### PR TITLE
Migrate from PyPDF2 to pypdf

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,5 +25,5 @@ colour-science>=0.4.2,<0.5
 coremltools>=7.0,<10
 psutil>=5.9.0,<8
 memory-profiler>=0.61.0,<1
-PyPDF2
+pypdf>=3.9.0
 types-PyYAML>=6.0.12

--- a/scripts/utilities/architectural_context_engine.py
+++ b/scripts/utilities/architectural_context_engine.py
@@ -301,10 +301,10 @@ class ArchitecturalContextExtractor:
 
         # Try to import PDF parsing libraries
         try:
-            import PyPDF2
+            from pypdf import PdfReader
 
             with open(pdf_path, 'rb') as f:
-                pdf = PyPDF2.PdfReader(f)
+                pdf = PdfReader(f)
 
                 # Extract text from first few pages
                 text = ""
@@ -325,7 +325,7 @@ class ArchitecturalContextExtractor:
                 context.design_intent.extend(design_intent)
 
         except ImportError:
-            logger.warning("PyPDF2 not installed. Install with: pip install PyPDF2")
+            logger.warning("pypdf not installed. Install with: pip install pypdf")
         except Exception as e:
             logger.warning(f"Error parsing PDF: {e}")
 

--- a/scripts/utilities/pdf_spec_parser.py
+++ b/scripts/utilities/pdf_spec_parser.py
@@ -3,7 +3,7 @@
 PDF Specification Parser for Architectural Submittals
 Extracts material specs, color palettes, and design intent from PDF documents
 
-Uses PyPDF2 for text extraction with pattern matching for common architectural specs
+Uses pypdf for text extraction with pattern matching for common architectural specs
 """
 
 import json
@@ -12,7 +12,7 @@ import re
 from dataclasses import dataclass, asdict
 from pathlib import Path
 from typing import Dict, List, Optional, Any, Tuple
-import PyPDF2
+from pypdf import PdfReader
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -86,7 +86,7 @@ class PDFSpecParser:
         all_text = []
         try:
             with open(self.pdf_path, 'rb') as f:
-                reader = PyPDF2.PdfReader(f)
+                reader = PdfReader(f)
                 total_pages = len(reader.pages)
                 logger.info(f"Processing {total_pages} pages")
 


### PR DESCRIPTION
- Update requirements.txt: PyPDF2 → pypdf>=3.9.0
- Update imports in pdf_spec_parser.py and architectural_context_engine.py
- Replace 'import PyPDF2' with 'from pypdf import PdfReader'
- Update all PyPDF2.PdfReader() calls to PdfReader()
- Update documentation and error messages

pypdf is the actively maintained successor to PyPDF2, providing the same API with better performance, bug fixes, and ongoing support.