### PR TITLE
Potential fix for code scanning alert no. 55: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   # Single lint job - no need to run on multiple Python versions
   lint:


### PR DESCRIPTION
Potential fix for [https://github.com/RC219805/Transformation_Portal/security/code-scanning/55](https://github.com/RC219805/Transformation_Portal/security/code-scanning/55)

To fix the problem, add a `permissions:` block at the workflow root (above `jobs:`) to set minimal required permissions, e.g., `contents: read`. This restricts GITHUB_TOKEN access for all jobs except those that request more privileges. If the workflow needs more permissions for a specific job (e.g., one that creates pull requests or modifies issues), add those keys specifically at the job level. In this code, no job apparently needs write permissions; thus, at minimum, add:
```yaml
permissions:
  contents: read
```
This block should be inserted after the top-level metadata (`name`, `on`, `concurrency`), before `jobs:`. No other code changes, imports, or definitions are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
