### PR TITLE
Potential fix for code scanning alert no. 49: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: CI (Lint, Tests & Manifest)
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/RC219805/Transformation_Portal/security/code-scanning/49](https://github.com/RC219805/Transformation_Portal/security/code-scanning/49)

To fix this, we should add an explicit `permissions` key to the workflow file to limit the GITHUB_TOKEN’s privileges. The safest way is to add it at the root of the workflow file, immediately below the workflow `name`, so all jobs inherit it unless they specifically need some write scopes (which in this workflow, they do not). The recommended minimal scope is `contents: read`, which is sufficient for actions like `actions/checkout`. No further permissions are needed unless writing to issues, PRs, packages, or use of deploy keys. Place the following block after the first line in `.github/workflows/build.yml`:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are needed—this is a YAML configuration change only.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
