### PR TITLE
Fix torch.backends attribute error in device detection

### DIFF
--- a/src/transformation_portal/pipelines/unified_luxury_pipeline.py
+++ b/src/transformation_portal/pipelines/unified_luxury_pipeline.py
@@ -313,7 +313,7 @@ class UnifiedLuxuryPipeline:
             if torch.cuda.is_available():
                 log.info("CUDA GPU detected")
                 return "cuda"
-            elif hasattr(torch.backends, 'mps') and torch.backends.mps.is_available():
+            elif hasattr(torch, 'backends') and hasattr(torch.backends, 'mps') and torch.backends.mps.is_available():
                 log.info("Apple Metal (MPS) detected")
                 return "mps"
         except ImportError:


### PR DESCRIPTION
The _detect_device method was attempting to access torch.backends.mps without first checking if the torch module has a 'backends' attribute. This caused an AttributeError on systems with older or minimal PyTorch installations.

Fixed by adding hasattr(torch, 'backends') check before accessing torch.backends.mps, ensuring graceful fallback to CPU when backends attribute is not available.

Fixes 28 failing tests in test_unified_luxury_pipeline.py