### PR TITLE
Add pytest-asyncio to CI workflows to fix async test failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -162,7 +162,7 @@ jobs:
           python -m pip install --upgrade pip wheel
           
           # Always install core test deps and runtime+CI deps
-          pip install --no-cache-dir pytest pytest-cov
+          pip install --no-cache-dir pytest pytest-cov pytest-asyncio
           pip install --no-cache-dir -r requirements-ci.txt
 
           # Clear cache and temp files immediately to save space

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -119,7 +119,7 @@ jobs:
         pip install --no-cache-dir "torch==2.5.1+cpu" "torchvision==0.20.1+cpu" --index-url https://download.pytorch.org/whl/cpu
 
         # Install core testing dependencies
-        pip install --no-cache-dir "pytest>=7.0" "pytest-cov>=4.0" coverage hypothesis
+        pip install --no-cache-dir "pytest>=7.0" "pytest-cov>=4.0" "pytest-asyncio>=0.23.0" coverage hypothesis
 
         # Install minimal required dependencies for CI (skip heavy optional deps)
         pip install --no-cache-dir numpy pillow scipy typer tqdm tifffile imagecodecs


### PR DESCRIPTION
The tests in test_async_pipeline.py use async def test functions which require pytest-asyncio to run. This was missing from both python-app.yml and build.yml CI workflows, causing all async tests to fail with: "async def functions are not natively supported"