### PR TITLE
fix(rag): export RAGSystem and RAGConfig from main module

### DIFF
--- a/.github/agents/rag_system/__init__.py
+++ b/.github/agents/rag_system/__init__.py
@@ -9,6 +9,7 @@ from .citation import CitationGenerator
 from .classifier import ArtifactClassifier, ArtifactType, PipelineType
 from .indexer import RepositoryIndexer
 from .knowledge_engine import KnowledgeIntegrationEngine, PatternAnalysis, Recommendation
+from .phase1_integration import RAGConfig, RAGSystem
 from .reranker import ResultReranker
 from .retriever import HybridRetriever
 
@@ -23,4 +24,6 @@ __all__ = [
     'KnowledgeIntegrationEngine',
     'PatternAnalysis',
     'Recommendation',
+    'RAGSystem',
+    'RAGConfig',
 ]


### PR DESCRIPTION
The unified RAGSystem interface was defined in phase1_integration.py but was not exported from the main __init__.py. This caused ImportError when trying to import RAGSystem from the rag_system package.

Added RAGSystem and RAGConfig to __all__ exports to enable proper usage of the unified RAG interface.