### PR TITLE
Potential fix for code scanning alert no. 57: Information exposure through an exception

### DIFF
--- a/lux_depth_v2/service.py
+++ b/lux_depth_v2/service.py
@@ -118,7 +118,7 @@ def run_service(cfg: PipelineConfig, host: str = "0.0.0.0", port: int = 8088, lo
                 return JSONResponse(rep)
             except Exception as e:
                 logger.exception(f"request failed: {req_id}: {e}")
-                return JSONResponse({"status": "error", "error": str(e)}, status_code=500)
+                return JSONResponse({"status": "error", "error": "An internal error has occurred."}, status_code=500)
 
     logger.info(f"Starting service on {host}:{port} | output_dir={cfg.output_dir}")
     logger.info(f"Security: Rate limiting enabled (10/min), max upload size: {MAX_UPLOAD_SIZE} bytes")


### PR DESCRIPTION
Potential fix for [https://github.com/RC219805/Transformation_Portal/security/code-scanning/57](https://github.com/RC219805/Transformation_Portal/security/code-scanning/57)

To fix the problem, the exception message (`str(e)`) should not be exposed in the HTTP response sent to the external user. Instead, a generic error message such as `"An internal error has occurred."` should be returned to the client, while the detailed error (including stack trace) is logged server-side for troubleshooting. 

In detail:
- In `run_service`, inside the except block at lines 119-121, replace the use of `str(e)` in the JSON response with a generic message (such as `"An internal error occurred."`).
- No changes are necessary in the logger call; it's correct and useful to retain `logger.exception(...)` for detailed logging on the server.
- No new imports or definitions are required, as all logging and response utilities are present in the shown code.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
