### PR TITLE
test: make pytest warning-clean under -W error (Hypothesis collection)

### DIFF
--- a/lux_depth_v2/pytest.ini
+++ b/lux_depth_v2/pytest.ini
@@ -32,7 +32,7 @@ markers =
 minversion = 3.10
 
 # Ignore patterns
-norecursedirs = .git .tox dist build *.egg __pycache__ .pytest_cache
+norecursedirs = .git .venv .hypothesis __pycache__ build dist .tox .pytest_cache *.egg *.egg-info
 
 # Logging
 log_cli = false

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,6 +5,7 @@ testpaths = tests
 python_files = test_*.py
 pythonpath = . src
 asyncio_mode = auto
+norecursedirs = .git .venv .hypothesis __pycache__ build dist .tox .pytest_cache *.egg *.egg-info
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')
     ml: marks tests requiring ML dependencies (torch, diffusers, etc.)


### PR DESCRIPTION
## Summary
Fix pytest UserWarning when running with `-W error` flag that causes collection to fail.

## Problem
Running `pytest -W error` produced:
```
UserWarning: Skipping collection of '.hypothesis' directory; configure norecursedirs
```
This causes pytest collection to fail before tests even run.

## Solution
Add `.hypothesis` and `.venv` to `norecursedirs` in both pytest.ini files:
- Root `pytest.ini`
- `lux_depth_v2/pytest.ini`

## Verification
```bash
# No more hypothesis collection warnings
pytest -q lux_depth_v2/tests/test_config.py -v 2>&1 | grep hypothesis
# Only shows: 'hypothesis profile default' (expected)
```

## Next Steps
**Note:** Full `-W error` support requires separate Pydantic V1→V2 migration:
- Convert `class Config:` → `model_config = ConfigDict(...)` in `src/transformation_portal/core/config/schemas.py`
- This PR only addresses the pytest/Hypothesis collection warning

Enables future CI hardening with strict warning enforcement.

Related: PR #591 (hardening sprint post-merge hygiene)