### PR TITLE
test(depth): cover AUTO strict_depth fail-fast vs non-strict continua…

### DIFF
--- a/lux_depth_v2/tests/test_depth_contract_guardrails.py
+++ b/lux_depth_v2/tests/test_depth_contract_guardrails.py
@@ -107,9 +107,6 @@ class TestDepthContractGuardrails:
         )
         config.depth.auto_model = custom_model  # Override default
         
-        # Capture create_tiled_estimator call
-        from lux_depth_v2.depth_inference import create_tiled_estimator
-        original_factory = create_tiled_estimator
         captured_kwargs = {}
         
         def spy_factory(**kwargs):
@@ -122,6 +119,9 @@ class TestDepthContractGuardrails:
         with patch('lux_depth_v2.depth_inference.create_tiled_estimator', side_effect=spy_factory):
             pipeline = LuxPipelineV2(config)
             result = pipeline.process_one(sample_image_file, depth_path=None)
+        
+        # Verify pipeline completed successfully
+        assert result["status"] == "ok", f"process_one failed: {result}"
         
         # Verify model_name was passed to factory
         assert "model_name" in captured_kwargs, "model_name not passed to create_tiled_estimator"


### PR DESCRIPTION
Summary

Adds regression tests to prevent AUTO + strict_depth contract regressions fixed in 0d23196.

Scope
	•	Type: tests-only (freeze-safe)
	•	Files: lux_depth_v2/tests/test_depth_contract_guardrails.py (+69)
	•	Risk: none (no production code changes)

Tests Added
	•	test_auto_model_is_plumbed_to_estimator
Ensures cfg.depth.auto_model is passed through to the depth estimator factory.
	•	test_auto_mode_importerror_does_not_raise_when_not_strict
Ensures AUTO mode continues when depth inference fails and strict_depth=False.
	•	test_auto_mode_missing_depth_fails_fast_when_strict_depth_true
Ensures AUTO mode fail-fast when depth is required and strict_depth=True.

Test Results

pytest -xvs lux_depth_v2/tests/test_depth_contract_guardrails.py -W ignore::DeprecationWarning
✅ 7 passed

Protects Against
	•	Auto-model plumbing regressions (prevents incorrect estimator selection / cache-key drift)
	•	Silent degradation in AUTO mode when dependencies are missing
	•	Strict depth enforcement regressions (fail-fast semantics)

Related
	•	0d23196 — fix(depth): plumb auto_model + enforce DepthMode.REQUIRED + cv2 optional
