### PR TITLE
fix(perf): align throughput tmp_path + memory metrics; cleanup

### DIFF
--- a/.github/workflows/ci-consolidated.yml
+++ b/.github/workflows/ci-consolidated.yml
@@ -553,7 +553,7 @@ jobs:
                 const metrics = JSON.parse(fs.readFileSync('bench/results/throughput_metrics.json', 'utf8'));
                 comment += '**Standard Quality (CPU)**\n\n';
                 comment += `- **Throughput:** ${metrics.images_per_hour?.toFixed(1) || 'N/A'} images/hour\n`;
-                comment += `- **Memory Peak:** ${metrics.memory_peak_mb?.toFixed(1) || 'N/A'} MB\n`;
+                comment += `- **Memory Peak:** ${(metrics.rss_final_mb ?? metrics.memory_peak_mb)?.toFixed(1) || 'N/A'} MB\n`;
                 comment += `- **Baseline:** 50 images/hour minimum\n\n`;
                 
                 if (metrics.images_per_hour >= 50) {

--- a/lux_depth_v2/edge_refinement.py
+++ b/lux_depth_v2/edge_refinement.py
@@ -430,7 +430,7 @@ def enhance_edges_with_guidance(
     # Soft gradient mask: 0 in flat regions, 1 at strong edges
     gradient_threshold = 0.02  # Tuned to preserve flats while enhancing edges
     gradient_mask = np.clip(
-        (gradient_mag - gradient_threshold) / max(gradient_threshold, 1e-6),
+        (gradient_mag - gradient_threshold) / gradient_threshold,
         0.0,
         1.0
     ).astype(np.float32)

--- a/scripts/validate_throughput.py
+++ b/scripts/validate_throughput.py
@@ -53,7 +53,7 @@ def validate_standard_quality(
     # Current format: direct metrics dict or pytest-benchmark format
     if "images_per_hour" in current:
         throughput = current["images_per_hour"]
-        memory_mb = current.get("memory_peak_mb", 0)
+        memory_mb = current.get("rss_final_mb", current.get("memory_peak_mb", 0))
     else:
         # Fallback for different formats
         warnings.append("⚠️  Could not parse throughput from current results")
@@ -114,7 +114,7 @@ def validate_max_quality(
     # Extract metrics
     if "images_per_hour" in current:
         throughput = current["images_per_hour"]
-        memory_mb = current.get("memory_peak_mb", 0)
+        memory_mb = current.get("rss_final_mb", current.get("memory_peak_mb", 0))
     else:
         warnings.append("⚠️  Could not parse throughput from current results")
         return False, warnings

--- a/tests/test_performance_throughput.py
+++ b/tests/test_performance_throughput.py
@@ -136,7 +136,10 @@ def measure_batch_throughput(
     Args:
         images: List of image paths to process
         config: Pipeline configuration
+        tmp_path: Temporary directory root for unique output dirs
+        batch_tag: Unique tag used to isolate output dir per run
         warmup: Number of warmup iterations
+        metrics_out: Optional path to write metrics JSON (direct dict format)
 
     Returns:
         Dict with throughput metrics:
@@ -144,7 +147,7 @@ def measure_batch_throughput(
         - seconds_per_image: Average time per image
         - total_time_s: Total processing time
         - num_images: Number of images processed
-        - rss_final_mb: Peak memory usage (if available)
+        - rss_final_mb: Peak RSS memory observed during run (MB)
     """
     import psutil
     import os
@@ -202,8 +205,6 @@ def measure_batch_throughput(
     
     # Write metrics JSON if requested
     if metrics_out:
-        from pathlib import Path
-        import json
         metrics_path = Path(metrics_out)
         metrics_path.parent.mkdir(parents=True, exist_ok=True)
         metrics_path.write_text(json.dumps(metrics, indent=2))
@@ -290,6 +291,8 @@ class TestThroughputPerformance:
         metrics = measure_batch_throughput(
             images=synthetic_test_images,
             config=pipeline_config_max,
+            tmp_path=tmp_path,
+            batch_tag="max_quality",
             warmup=1
         )
 


### PR DESCRIPTION
Fixes post-merge cleanups from #608:
- Add missing tmp_path in max-quality throughput call
- Align memory metric naming (use rss_final_mb with fallback) in validator + PR comment
- Include optional cleanups (redundant imports, docstring completeness, gradient divisor simplification)