### PR TITLE
chore(perf): default fail_on_unmatched_patterns to tolerant

### DIFF
--- a/scripts/validate_performance_budgets.py
+++ b/scripts/validate_performance_budgets.py
@@ -105,7 +105,7 @@ def main() -> int:
     settings = budgets_doc.get("settings", {})
     max_reg_pct = float(settings.get("max_regression_percent", 0))
     max_reg = max_reg_pct / 100.0 if max_reg_pct else None
-    fail_on_unmatched = settings.get("fail_on_unmatched_patterns", True)  # default strict
+    fail_on_unmatched = bool(settings.get("fail_on_unmatched_patterns", False))  # default tolerant
 
     budget_groups = budgets_doc.get("budgets", {})
     bench_map = budgets_doc.get("benchmark_map", {})


### PR DESCRIPTION
Aligns default behavior with documented policy:

Change:
  fail_on_unmatched = settings.get(..., True)  # default strict
To:
  fail_on_unmatched = bool(settings.get(..., False))  # default tolerant

Rationale:
- YAML config explicitly sets: fail_on_unmatched_patterns: false
- Default should match stated policy (tolerant)
- Prevents accidental strict mode if YAML key removed
- Safer: unmapped budgets warn instead of fail

Impact: None (YAML currently has explicit false setting)
Future-proof: Prevents regression to strict if key deleted

Follows up PR #611 (Copilot suggestion alignment).
