### PR TITLE
ci(deps): force CPU-only PyTorch index in dependency updates

### DIFF
--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -56,6 +56,8 @@ jobs:
       - name: Update dependencies
         env:
           PIP_NO_CACHE_DIR: "1"  # Disable pip caching to save disk space
+          PIP_INDEX_URL: "https://download.pytorch.org/whl/cpu"  # Force CPU-only PyTorch
+          PIP_EXTRA_INDEX_URL: "https://pypi.org/simple"  # Fallback to PyPI for non-torch packages
         run: |
           # Use the new layered requirements system
           if [ -d "requirements" ]; then


### PR DESCRIPTION
## Problem

PR #617 (automated dependency update) introduced ~16 NVIDIA CUDA packages (nvidia-cu12, triton, etc.), adding ~5-10GB of bloat and breaking macOS/CPU-only environments.

## Solution

Force pip-compile to resolve torch from the PyTorch CPU index during dependency updates:
- `PIP_INDEX_URL=https://download.pytorch.org/whl/cpu`
- `PIP_EXTRA_INDEX_URL=https://pypi.org/simple` (fallback for non-torch packages)

## Impact

- Prevents CUDA/NVIDIA bloat in future automated dependency PRs
- Maintains CPU-only torch compatibility (default for this repo)
- Keeps installation lightweight for development environments

## Testing

After merge: close #617, re-run dependency update workflow, verify new PR has no nvidia-cu12 packages.