### PR TITLE
fix(security): migrate security-scan workflow to Safety scan

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -152,18 +152,19 @@ jobs:
           python scripts/utilities/verify_no_basicsr_imports.py --check-pkg
 
       - name: Install Safety for Additional Scanning
-        run: pip install safety
+        run: python -m pip install -U safety==3.7.0
 
-      - name: Run Safety Check
+      - name: Run Safety Scan
         continue-on-error: true
         run: |
-          # Check all requirements for known vulnerabilities
-          safety check -r requirements/all.txt --json > safety-report.json || true
+          # Use Safety 3.x scan (replaces deprecated check)
+          # Scan canonical lockfile using policy file
+          safety scan --policy-file .safety-policy.yml --output json > safety-report.json || true
           
-          # Also check lux_depth_v2 dependencies
+          # Also check lux_depth_v2 dependencies if present
           if [ -f lux_depth_v2/requirements-repo.txt ]; then
             echo "Scanning lux_depth_v2/requirements-repo.txt..."
-            safety check --file lux_depth_v2/requirements-repo.txt --json > safety-lux-depth-v2.json || true
+            safety scan --target lux_depth_v2/requirements-repo.txt --output json > safety-lux-depth-v2.json || true
           fi
           
           # Display summary


### PR DESCRIPTION
## Problem

`.github/workflows/security-scan.yml` still uses deprecated `safety check` command (unsupported beyond June 2024).

## Changes

- **Replace**: `safety check` → `safety scan`
- **Pin**: `safety==3.7.0`
- **Policy**: Use `--policy-file .safety-policy.yml` for canonical lockfile
- **Target**: Use `--target` for lux_depth_v2 dependencies
- **Behavior**: Maintains `continue-on-error: true` (non-blocking)

## Completes Migration

This completes the Safety migration started in #620:
- ✅ #620: Migrated `dependency-update.yml`
- ✅ This PR: Migrates `security-scan.yml`

All workflows now use supported Safety 3.x API.

## Related

- Follows same pattern as #620
- Uses same `.safety-policy.yml`