### PR TITLE
fix(ci): make AI workflows fail-soft and conditional

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -17,7 +17,8 @@ jobs:
   ai-review:
     name: AI-Powered Code Review (GPT-4o Enhanced)
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
+    if: ${{ github.event.pull_request.draft == false && secrets.OPENAI_API_KEY != '' }}
+    continue-on-error: true
 
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/smart-issue-management.yml
+++ b/.github/workflows/smart-issue-management.yml
@@ -15,6 +15,8 @@ jobs:
   smart-triage:
     name: AI-Powered Issue Triage
     runs-on: ubuntu-latest
+    if: ${{ secrets.OPENAI_API_KEY != '' }}
+    continue-on-error: true
 
     steps:
       - name: Checkout code

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   summarize:
     runs-on: ubuntu-latest
+    if: ${{ secrets.OPENAI_API_KEY != '' }}
+    continue-on-error: true
     permissions:
       issues: write
       pull-requests: write


### PR DESCRIPTION
## Problem

AI workflows currently spam CI with noise:
- `OPENAI_API_KEY is not configured` warnings
- 429 rate limit errors
- Jobs appear as "failed" when they're just unavailable

## Solution

Add to all AI jobs:
```yaml
if: ${{ secrets.OPENAI_API_KEY != '' }}
continue-on-error: true
```

## Changes

- **Issue Summarizer** (`summary.yml`): Skip if no API key
- **AI Code Review** (`ai-code-review.yml`): Skip if no API key or PR is draft  
- **Smart Issue Triage** (`smart-issue-management.yml`): Skip if no API key

## Benefits

- ✅ Actions feed shows only real failures
- ✅ No spam warnings about missing keys
- ✅ 429 errors don't block CI
- ✅ Jobs skip silently when unavailable

## Freeze-Safe

This is pure CI hygiene - no feature changes, no logic changes. Makes CI signal cleaner and more trustworthy.