### PR TITLE
fix(hooks): allow .pre-commit-config.yaml in repository root

### DIFF
--- a/scripts/setup/pre-commit-check.sh
+++ b/scripts/setup/pre-commit-check.sh
@@ -48,6 +48,7 @@ ALLOWED_ROOT_FILES=(
     ".pylintrc"
     ".flake8"
     "mypy.ini"
+    ".pre-commit-config.yaml"  # Pre-commit framework config (must be in root)
     
     # Docker
     "Dockerfile"


### PR DESCRIPTION
## Problem

Pre-commit hook blocks `.pre-commit-config.yaml` in root with:
```
The following files should not be in the repository root:
  .pre-commit-config.yaml
```

## Why This Is Wrong

`.pre-commit-config.yaml` **MUST** be in repo root - this is required by the pre-commit framework for discovery. It's a standard Python/pre-commit convention, same as `.pylintrc`, `.flake8`, etc.

## Solution

Add `.pre-commit-config.yaml` to `ALLOWED_ROOT_FILES` whitelist in `scripts/setup/pre-commit-check.sh`.

## Impact

- Unblocks PR #625 (Quality Gate optimization)
- Allows standard pre-commit framework usage
- No --no-verify bypass needed

## Freeze-Safe

One-line allowlist addition - pure policy fix, no logic changes.