### PR TITLE
fix(lux-depth-v2): read 16-bit PNG depth maps

### DIFF
--- a/lux_depth_v2/io_utils.py
+++ b/lux_depth_v2/io_utils.py
@@ -110,15 +110,28 @@ def read_rgb_any(path: Path) -> Tuple[np.ndarray, ImageInfo]:
 
 
 def read_depth_u16(path: Path) -> np.ndarray:
-    """Read 16-bit depth TIFF into float32 0..1 normalized."""
+    """Read a depth map into float32 0..1 normalized.
+
+    Supports 16-bit depth TIFF and 16-bit grayscale PNG depth maps.
+    """
     ensure_deps()
     p = Path(path)
     if not p.exists():
         raise FileNotFoundError(str(p))
-    d = tifffile.imread(str(p))
+
+    if _is_tiff(p):
+        d = tifffile.imread(str(p))
+    else:
+        d = cv2.imread(str(p), cv2.IMREAD_UNCHANGED)
+        if d is None:
+            raise RuntimeError(f"Failed to read depth: {p}")
+
     if d.ndim != 2:
         d = d[..., 0]
-    if d.dtype != np.uint16:
+    if d.dtype == np.uint8:
+        # Promote 8-bit depth into 16-bit range for consistent percentile normalization.
+        d = (d.astype(np.uint16) * 257).astype(np.uint16)
+    elif d.dtype != np.uint16:
         d = d.astype(np.uint16)
     # robust percentile normalization (like V1)
     df = d.astype(np.float32)

--- a/lux_depth_v2/tests/test_io_utils.py
+++ b/lux_depth_v2/tests/test_io_utils.py
@@ -78,6 +78,25 @@ class TestReadDepthU16:
         assert np.all(depth >= 0.0)
         assert np.all(depth <= 1.0)
 
+    def test_read_depth_png16_matches_tiff(self, temp_dir):
+        """16-bit PNG depth should load equivalently to 16-bit TIFF depth."""
+        depth16 = np.linspace(0, 65535, 64 * 64, dtype=np.uint16).reshape(64, 64)
+
+        png_path = temp_dir / "test_depth.png"
+        tif_path = temp_dir / "test_depth.tif"
+
+        assert cv2.imwrite(str(png_path), depth16), "Failed to write 16-bit PNG depth"
+        tifffile.imwrite(str(tif_path), depth16)
+
+        depth_png = io_utils.read_depth_u16(png_path)
+        depth_tif = io_utils.read_depth_u16(tif_path)
+
+        assert depth_png.shape == (64, 64)
+        assert depth_png.dtype == np.float32
+        assert np.all(depth_png >= 0.0)
+        assert np.all(depth_png <= 1.0)
+        assert np.allclose(depth_png, depth_tif, atol=1e-6)
+
     def test_read_depth_nonexistent(self, temp_dir):
         """Test reading nonexistent depth file raises error."""
         fake_path = temp_dir / "nonexistent_depth.tif"


### PR DESCRIPTION
## Summary
  - V2 now reads 16‑bit *_depth.png directly via lux_depth_v2/io_utils.py:112 + test
    lux_depth_v2/tests/test_io_utils.py:81 (verified by running V2 with --depth-dir .cache/da3_to_v2_demo/
    da3_depth_png, report .cache/da3_to_v2_demo/v2_out_png_depth/750Picacho_Kitchen_16bit_report.json:1
    shows depth_source=file pointing at the PNG).

## Why
- Integrates DA3 + MaterialsV3 into R&D pipeline for quality ceiling exploration

## Scope
- [ ] additive
- [ ] breaking (requires explicit approval)

## Tests
- [ ] unit
- [ ] integration
- [ ] manual

## Notes
- Internal purposes/uses only (NOT FOR COMMERCIAL USE)
