### PR TITLE
fix(io): Option B Perfect — DA3 PNG depth ingestion + safe I/O hardening (#632)

### DIFF
--- a/lux_depth_v2/io_utils.py
+++ b/lux_depth_v2/io_utils.py
@@ -225,13 +225,15 @@ def read_depth_u16_with_info(
                 f"Depth must be uint16/uint8 integer, got floating point {d.dtype}: {p}. "
                 "Depth maps should be integer grayscale."
             )
+        # Cache min/max for performance (avoid multiple passes over large arrays)
+        d_min, d_max = d.min(), d.max()
         if np.issubdtype(d.dtype, np.signedinteger):
-            if d.min() < 0:
+            if d_min < 0:
                 raise ValueError(
-                    f"Depth has negative values (dtype={d.dtype}, min={d.min()}): {p}. Depth maps must be non-negative."
+                    f"Depth has negative values (dtype={d.dtype}, min={d_min}): {p}. Depth maps must be non-negative."
                 )
         # Prevent overflow when casting to uint16
-        max_val = int(d.max())
+        max_val = int(d_max)
         if max_val > 65535:
             raise ValueError(
                 f"Depth values exceed uint16 range (max={max_val} > 65535) for {p}. "
@@ -258,6 +260,10 @@ def read_depth_u16_with_info(
         else:
             depth01 = ((df - p1) / (p99 - p1)).clip(0.0, 1.0).astype(np.float32)
 
+    # Cache min/max for DepthInfo (reuse or compute once)
+    d_min_final = int(d.min()) if d.size else 0
+    d_max_final = int(d.max()) if d.size else 0
+
     info = DepthInfo(
         file_format=file_format,
         source_dtype=source_dtype,
@@ -265,8 +271,8 @@ def read_depth_u16_with_info(
         shape=(int(d.shape[0]), int(d.shape[1])),
         channels=int(channels),
         channel_collapsed=bool(channel_collapsed),
-        u16_min=int(np.min(d)) if d.size else 0,
-        u16_max=int(np.max(d)) if d.size else 0,
+        u16_min=d_min_final,
+        u16_max=d_max_final,
         p1=float(p1),
         p99=float(p99),
     )

--- a/lux_depth_v2/pipeline.py
+++ b/lux_depth_v2/pipeline.py
@@ -25,7 +25,6 @@ from . import material_profiles
 
 # Phase 2 Slice 2: ExportManager integration
 try:
-    import sys
     from pathlib import Path as _Path
 
     _repo_root = _Path(__file__).parent.parent
@@ -943,7 +942,8 @@ class LuxPipelineV2:
                 luma_diff = torch_ops.mean_abs_luma(base_up, ai_up)
                 if color_diff > cfg.ai_color_fail or luma_diff > cfg.ai_luma_fail:
                     self.logger.warning(
-                        f"AI drift FAIL {img_path.name}: rgb={color_diff:.4f} luma={luma_diff:.4f}; skipping AI detail transfer"
+                        f"AI drift FAIL {img_path.name}: rgb={color_diff:.4f} "
+                        f"luma={luma_diff:.4f}; skipping AI detail transfer"
                     )
                     use_ai_details = False
                 elif color_diff > cfg.ai_color_warn or luma_diff > cfg.ai_luma_warn:
@@ -1066,6 +1066,9 @@ class LuxPipelineV2:
             report["segmentation_v3"] = self.segmenter.get_segmentation_v3_report()
 
         # Always include depth provenance for observability (Commit 3)
+        # If depth_provenance is still empty, mark as error state for debugging
+        if not depth_provenance:
+            depth_provenance = {"source": "error"}
         report["depth"] = depth_provenance
 
         # Write report JSON only if enabled (after all fields added)

--- a/lux_depth_v2/tests/test_depth_hardening.py
+++ b/lux_depth_v2/tests/test_depth_hardening.py
@@ -16,7 +16,6 @@ import pytest
 from pathlib import Path
 
 from lux_depth_v2 import io_utils
-from lux_depth_v2.io_utils import DepthInfo
 
 try:
     import cv2  # type: ignore


### PR DESCRIPTION
* fix(lux-depth-v2): read 16-bit PNG depth maps

* fix(io): add validate_tiff_compression() to atomic_write_rgb16_tiff

- Add missing validate_tiff_compression() call in atomic_write_rgb16_tiff()
- Update IO_FEATURE_AUDIT.md to reflect actual temp file pattern (.tif.tmp)
- Fix glob pattern in test example to match implementation (*.tmp not *.tmp.tif)
- Verified all tests pass: test_io_utils.py, test_depth_hardening.py, test_hardening_safe_io.py
- Compression validation now enforced before atomic write (closes doc-code gap)

* style: apply ruff formatting to io_utils and pipeline

- Fix blank line spacing per ruff-format
- Fix line continuation formatting
- Remove trailing whitespace in IO_FEATURE_AUDIT.md
- All pre-commit checks passing (ruff, ruff-format, trailing-whitespace, end-of-files)
