### PR TITLE
fix(v3): DA3Config ctor does not accept preset kwarg

### DIFF
--- a/lux_depth_v3/enhance/orchestrator.py
+++ b/lux_depth_v3/enhance/orchestrator.py
@@ -172,10 +172,16 @@ class EnhanceOrchestrator:
             dir_path.mkdir(parents=True, exist_ok=True)
 
         # Initialize V3 inference engine
-        da3_config = DA3Config(
-            model_variant=config.model_variant,
-            preset=config.preset,
-        )
+        # DA3Config does not accept a `preset=` kwarg.
+        # If a preset is provided and a factory exists, build via factory.
+        # Otherwise construct directly from model_variant.
+        if config.preset is not None and hasattr(DA3Config, "from_preset"):
+            da3_config = DA3Config.from_preset(config.preset)
+            # Ensure explicit model selection wins if provided via EnhanceConfig
+            da3_config.model_variant = config.model_variant
+        else:
+            da3_config = DA3Config(model_variant=config.model_variant)
+
         da3_config.device.device = config.depth_device
 
         self.inference_engine = DA3InferenceEngine(


### PR DESCRIPTION
Summary
Fixes a hard runtime crash in lux_depth_v3/enhance/orchestrator.py where DA3Config was instantiated with an unsupported preset= keyword argument. DA3Config.__init__ does not accept preset, causing EnhanceOrchestrator to fail at init.

Change
- Replace DA3Config(model_variant=..., preset=...) with signature-correct construction:
  - If config.preset is set and DA3Config.from_preset exists, build via factory then re-assert model_variant
  - Else construct via DA3Config(model_variant=...)

Validation
- Local smoke init succeeded; pre-commit hooks passing.
