### PR TITLE
Potential fix for code scanning alert no. 56: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -1,4 +1,6 @@
 name: Quality Gate
+permissions:
+  contents: write
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/RC219805/Transformation_Portal/security/code-scanning/56](https://github.com/RC219805/Transformation_Portal/security/code-scanning/56)

To fix this problem, we need to explicitly set the permissions for the GITHUB_TOKEN used in this workflow to enforce least privilege. In the context of this workflow, which primarily reads repository contents and potentially makes commits (but does not need access to deployment keys, secrets, etc.), the best approach is to set `contents: write` (because committing changes is required) at the job (preferred for fine grain) or workflow level. 

The `permissions` block should be added at the top level of the workflow YAML if all jobs need these permissions, or specifically inside the `pre-commit-checks` job otherwise. Since there is only one job, either approach suffices, but adding it at the workflow root is simpler and more idiomatic.

The block to add is:
```yaml
permissions:
  contents: write
```

This should be inserted after the `name:` and before or after the `on:` block (conventionally right after `name:`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
