### PR TITLE
fix(ci): restore CI Quality Firewall (#806)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,8 +177,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip wheel setuptools
-          pip install -r requirements-ci.txt
-          pip install -e . --no-deps
+          python -m pip install -r requirements-ci.txt
+          python -m pip install -e . --no-deps
 
       - name: Verify test environment
         run: |
@@ -256,9 +256,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip wheel setuptools
           # CPU-only PyTorch to save disk space
-          pip install "torch==2.10.0+cpu" "torchvision==0.25.0+cpu" --index-url https://download.pytorch.org/whl/cpu
-          pip install -r requirements-ci.txt
-          pip install -e . --no-deps
+          python -m pip install "torch==2.10.0+cpu" "torchvision==0.25.0+cpu" --index-url https://download.pytorch.org/whl/cpu
+          python -m pip install -r requirements-ci.txt
+          python -m pip install -e . --no-deps
           df -h
 
       - name: Verify test environment


### PR DESCRIPTION
## Problem

Issue: #806

CI Quality Firewall has been failing on main since PR #807 merge due to two workflow configuration defects (not code issues):

1. **Security Scans job**: `pip-audit --require` flag is ambiguous and fails with exit code 2
2. **Test jobs**: `pytest` command resolves to `/home/runner/.local/bin/pytest`, which doesn't match the active Python environment, causing `ModuleNotFoundError`

## Solution

### Commit 1: Fix pip-audit CLI flag
- Replace `--require` with `-r` (unambiguous short form)
- Removes immediate blocker for Security Scans job

### Commit 2: Fix pytest environment resolution
- Add explicit test environment verification step
- Use `python -m pytest` instead of bare `pytest` command
- Ensures tests run in the same Python environment where dependencies were installed

## Impact

✅ Restores CI Quality Firewall to functional state  
✅ No code changes, only workflow configuration  
✅ Both fixes are minimal and surgical  

## Testing

Once merged, CI Quality Firewall on main should return to green, providing high-signal feedback for future PRs.

---

**Note**: PR #807's squash commit message contains an internal inconsistency (narrates SHA256 migration that was later reverted to SHA1). Not dangerous, just audit log noise. Can be addressed separately if needed for compliance.