### PR TITLE
fix(ci): resolve pytest shell PATH resolution issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,15 +187,7 @@ jobs:
 
       - name: Run core tests (no ML)
         run: |
-          python -m pytest -v tests/ \
-            -m "not ml and not slow" \
-            --cov=src/transformation_portal \
-            --cov-report=xml \
-            --cov-report=term \
-            --cov-report=html \
-            --cov-config=pyproject.toml \
-            --maxfail=3 \
-            --tb=short
+          python -m pytest -v tests/ -m "not ml and not slow" --cov=src/transformation_portal --cov-report=xml --cov-report=term --cov-report=html --cov-config=pyproject.toml --maxfail=3 --tb=short
         env:
           PYTHONPATH: ${{ github.workspace }}:${{ github.workspace }}/src
           PYTHONNOUSERSITE: 1
@@ -268,13 +260,7 @@ jobs:
 
       - name: Run ML tests
         run: |
-          python -m pytest -v tests/ \
-            -m "ml and not slow" \
-            --cov=src/transformation_portal \
-            --cov-report=xml \
-            --cov-report=term \
-            --maxfail=3 \
-            --tb=short
+          python -m pytest -v tests/ -m "ml and not slow" --cov=src/transformation_portal --cov-report=xml --cov-report=term --maxfail=3 --tb=short
         env:
           PYTHONPATH: ${{ github.workspace }}:${{ github.workspace }}/src
           PYTHONNOUSERSITE: 1


### PR DESCRIPTION
## Problem

PR #808 fixed pip-audit and changed test invocation to `python -m pytest`, but tests still fail with `/usr/bin/python: No module named pytest`.

Root cause: GitHub Actions' bash shell with `-e` flag doesn't properly resolve `python` from PATH when using backslash line continuations, falling back to `/usr/bin/python` instead of the setup-python installed version.

## Solution

Remove backslash continuations from pytest commands—collapse to single-line invocations.

## Testing

The verify step already showed pytest is correctly installed and importable. This change only fixes the shell PATH resolution issue during test execution.

Fixes: #806