### PR TITLE
fix(ci): Move disk cleanup before Python setup to prevent toolcache deletion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,18 +154,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }}
-        id: setup-python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-
       - name: Free disk space
         run: |
           sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/share/boost
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
           sudo docker image prune --all --force
           df -h
+
+      - name: Set up Python ${{ matrix.python-version }}
+        id: setup-python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
 
       - name: Cache pip packages
         uses: actions/cache@v4
@@ -293,18 +293,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.11
-        id: setup-python-ml
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
       - name: Free disk space
         run: |
           sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/share/boost
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
           sudo docker image prune --all --force
           df -h
+
+      - name: Set up Python 3.11
+        id: setup-python-ml
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
 
       - name: Cache pip packages
         uses: actions/cache@v4


### PR DESCRIPTION
## Summary

Fixes the root cause of #806 by reordering workflow steps so disk cleanup happens **before** Python installation, not after.

## Root Cause (Confirmed from CI Logs)

The `Free disk space` step was running **after** `actions/setup-python@v5`, executing:
```bash
sudo rm -rf "$AGENT_TOOLSDIRECTORY"
```

This deleted `/opt/hostedtoolcache`, which contains the just-installed Python interpreter.

Evidence from run 21651099423:
- setup-python completes, installs to `/opt/hostedtoolcache/Python/3.11.14/x64`
- Free disk space runs immediately after, deletes `$AGENT_TOOLSDIRECTORY`
- `pythonLocation` env var points to deleted directory
- All subsequent steps using `${{ steps.setup-python.outputs.python-path }}` fail with "No such file or directory"

## The Fix

**Move `Free disk space` step before `Set up Python` in both jobs:**
- `test-core` (Python 3.11, 3.12)
- `test-ml` (Python 3.11)

Now cleanup runs before Python is installed, so the interpreter remains intact.

## Changes
- Reordered 2 steps in `test-core` job
- Reordered 2 steps in `test-ml` job
- **Zero** logic changes

## Testing
- CI will run on this PR and should pass cleanly without fallback logic
- Once confirmed, #812's workaround can be removed in a follow-up cleanup PR

## Relationship to Other PRs
- **Resolves**: #806 (root cause fix)
- **Supersedes**: #812 (workaround/telemetry patch that stabilized main)
- **Follow-up**: Remove fallback logic from #812 once this is proven

## Risk Assessment
- **Risk**: Minimal (simple step reorder, no logic changes)
- **Blast radius**: CI only, no production code touched
- **Rollback**: Trivial (revert one commit)

---

Credit: Root cause identified by GitHub Copilot analysis of #812 telemetry.