### PR TITLE
chore(ci): Remove #812 diagnostic/fallback code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,86 +177,19 @@ jobs:
 
       - name: Install dependencies
         run: |
-          # Diagnostic: introspect python-path output and environment
-          echo "python-path output: ${{ steps.setup-python.outputs.python-path }}"
-          ls -la "$(dirname "${{ steps.setup-python.outputs.python-path }}")" || echo "Directory doesn't exist"
-          ls -la "${{ steps.setup-python.outputs.python-path }}" || echo "python-path file doesn't exist"
-          which -a python || echo "No 'python' in PATH"
-          which -a python3 || echo "No 'python3' in PATH"
-
-          # Guarded fallback: use python-path if it exists, else toolcache python3, else PATH python3
-          PY="${{ steps.setup-python.outputs.python-path }}"
-          if [ -x "$PY" ]; then
-            PYTHON="$PY"
-            echo "Using python-path: $PYTHON"
-          else
-            PYDIR="$(dirname "$PY")"
-            if [ -x "$PYDIR/python3" ]; then
-              PYTHON="$PYDIR/python3"
-              echo "Using toolcache python3: $PYTHON"
-            else
-              PYTHON="$(command -v python3 || true)"
-              if [ -z "$PYTHON" ]; then
-                echo "ERROR: No Python 3 interpreter found in any fallback location"
-                exit 1
-              fi
-              echo "Using PATH python3: $PYTHON"
-            fi
-          fi
-
-          "$PYTHON" -V
-          "$PYTHON" -c "import sys; print('sys.executable:', sys.executable)"
-          "$PYTHON" -m pip install --upgrade pip wheel setuptools
-          "$PYTHON" -m pip install -r requirements-ci.txt
-          "$PYTHON" -m pip install -e . --no-deps
+          python -m pip install --upgrade pip wheel setuptools
+          python -m pip install -r requirements-ci.txt
+          python -m pip install -e . --no-deps
 
       - name: Verify test environment
         run: |
-          # Use same fallback logic as install step
-          PY="${{ steps.setup-python.outputs.python-path }}"
-          if [ -x "$PY" ]; then
-            PYTHON="$PY"
-          else
-            PYDIR="$(dirname "$PY")"
-            if [ -x "$PYDIR/python3" ]; then
-              PYTHON="$PYDIR/python3"
-            else
-              PYTHON="$(command -v python3 || true)"
-              if [ -z "$PYTHON" ]; then
-                echo "ERROR: No Python 3 interpreter found in any fallback location"
-                exit 1
-              fi
-            fi
-          fi
-
-          echo "Verify using: $PYTHON"
-          "$PYTHON" -V
-          "$PYTHON" -c "import sys; print('sys.executable:', sys.executable)"
-          "$PYTHON" -c "import pytest; print('pytest', pytest.__version__)"
-          "$PYTHON" -m pytest --version
+          python --version
+          python -c "import pytest; print('pytest', pytest.__version__)"
+          python -m pytest --version
 
       - name: Run core tests (no ML)
         run: |
-          # Use same fallback logic
-          PY="${{ steps.setup-python.outputs.python-path }}"
-          if [ -x "$PY" ]; then
-            PYTHON="$PY"
-          else
-            PYDIR="$(dirname "$PY")"
-            if [ -x "$PYDIR/python3" ]; then
-              PYTHON="$PYDIR/python3"
-            else
-              PYTHON="$(command -v python3 || true)"
-              if [ -z "$PYTHON" ]; then
-                echo "ERROR: No Python 3 interpreter found in any fallback location"
-                exit 1
-              fi
-            fi
-          fi
-
-          echo "Running tests with: $PYTHON"
-          "$PYTHON" -c "import sys; print('sys.executable:', sys.executable)"
-          "$PYTHON" -m pytest -v tests/ \
+          python -m pytest -v tests/ \
             -m "not ml and not slow" \
             --cov=src/transformation_portal \
             --cov-report=xml \
@@ -324,85 +257,22 @@ jobs:
 
       - name: Install dependencies
         run: |
-          # Diagnostic: introspect python-path output and environment
-          echo "python-path output: ${{ steps.setup-python-ml.outputs.python-path }}"
-          ls -la "$(dirname "${{ steps.setup-python-ml.outputs.python-path }}")" || echo "Directory doesn't exist"
-          ls -la "${{ steps.setup-python-ml.outputs.python-path }}" || echo "python-path file doesn't exist"
-
-          # Guarded fallback
-          PY="${{ steps.setup-python-ml.outputs.python-path }}"
-          if [ -x "$PY" ]; then
-            PYTHON="$PY"
-            echo "Using python-path: $PYTHON"
-          else
-            PYDIR="$(dirname "$PY")"
-            if [ -x "$PYDIR/python3" ]; then
-              PYTHON="$PYDIR/python3"
-              echo "Using toolcache python3: $PYTHON"
-            else
-              PYTHON="$(command -v python3 || true)"
-              if [ -z "$PYTHON" ]; then
-                echo "ERROR: No Python 3 interpreter found in any fallback location"
-                exit 1
-              fi
-              echo "Using PATH python3: $PYTHON"
-            fi
-          fi
-
-          "$PYTHON" -V
-          "$PYTHON" -c "import sys; print('sys.executable:', sys.executable)"
-          "$PYTHON" -m pip install --upgrade pip wheel setuptools
+          python -m pip install --upgrade pip wheel setuptools
           # CPU-only PyTorch to save disk space
-          "$PYTHON" -m pip install "torch==2.10.0+cpu" "torchvision==0.25.0+cpu" --index-url https://download.pytorch.org/whl/cpu
-          "$PYTHON" -m pip install -r requirements-ci.txt
-          "$PYTHON" -m pip install -e . --no-deps
+          python -m pip install "torch==2.10.0+cpu" "torchvision==0.25.0+cpu" --index-url https://download.pytorch.org/whl/cpu
+          python -m pip install -r requirements-ci.txt
+          python -m pip install -e . --no-deps
           df -h
 
       - name: Verify test environment
         run: |
-          PY="${{ steps.setup-python-ml.outputs.python-path }}"
-          if [ -x "$PY" ]; then
-            PYTHON="$PY"
-          else
-            PYDIR="$(dirname "$PY")"
-            if [ -x "$PYDIR/python3" ]; then
-              PYTHON="$PYDIR/python3"
-            else
-              PYTHON="$(command -v python3 || true)"
-              if [ -z "$PYTHON" ]; then
-                echo "ERROR: No Python 3 interpreter found in any fallback location"
-                exit 1
-              fi
-            fi
-          fi
-
-          echo "Verify using: $PYTHON"
-          "$PYTHON" -V
-          "$PYTHON" -c "import sys; print('sys.executable:', sys.executable)"
-          "$PYTHON" -c "import pytest; print('pytest', pytest.__version__)"
-          "$PYTHON" -m pytest --version
+          python --version
+          python -c "import pytest; print('pytest', pytest.__version__)"
+          python -m pytest --version
 
       - name: Run ML tests
         run: |
-          PY="${{ steps.setup-python-ml.outputs.python-path }}"
-          if [ -x "$PY" ]; then
-            PYTHON="$PY"
-          else
-            PYDIR="$(dirname "$PY")"
-            if [ -x "$PYDIR/python3" ]; then
-              PYTHON="$PYDIR/python3"
-            else
-              PYTHON="$(command -v python3 || true)"
-              if [ -z "$PYTHON" ]; then
-                echo "ERROR: No Python 3 interpreter found in any fallback location"
-                exit 1
-              fi
-            fi
-          fi
-
-          echo "Running ML tests with: $PYTHON"
-          "$PYTHON" -c "import sys; print('sys.executable:', sys.executable)"
-          "$PYTHON" -m pytest -v tests/ \
+          python -m pytest -v tests/ \
             -m "ml and not slow" \
             --cov=src/transformation_portal \
             --cov-report=xml \


### PR DESCRIPTION
## Context

PR #813 fixed the root cause of CI issue #806 by moving disk cleanup **before** Python setup, preventing toolcache deletion. That fix has been verified in production (CI run 21652459975).

This PR removes the temporary diagnostic and fallback code from PR #812, which is no longer needed.

## Changes

- ✂️ Remove diagnostic introspection (`ls`, `which`, `sys.executable`)
- ✂️ Remove guarded Python fallback chains
- ✅ Restore clean, deterministic invocations: `python -m pip`, `python -m pytest`
- ✅ Preserve #813's step ordering fix (disk cleanup before Python setup)

## Result

- **130 lines removed** from `.github/workflows/ci.yml`
- Simpler, more maintainable workflow
- No masking behaviors or complexity debt

## Verification

CI will validate that the simplified workflow still works correctly with the #813 fix in place.

## References

- Closes: N/A (cleanup only)
- Related: #806, #812, #813