### PR TITLE
Polish: clean DA3 test docstrings and fix ADR-018 roadmap

### DIFF
--- a/docs/architecture/ADR-018-depth-pro-integration.md
+++ b/docs/architecture/ADR-018-depth-pro-integration.md
@@ -35,7 +35,7 @@ Apple's [Depth Pro](https://github.com/apple/ml-depth-pro) offers metric (absolu
 | Phase | PR | Scope | Status |
 |-------|-----|-------|--------|
 | **PR1: Stage** | #780 | Add `DepthProStage` class as isolated leaf stage with strict caching and provenance. | ✅ Merged |
-| **PR2: Wiring** | TBD | Wire stage into preset loader with `depth_backend` configuration key. | Planned |
+| **PR2: Wiring** | #859, ADR-019 | Wire backend via unified backend registry with `depth_backend: depth_pro` configuration. | ✅ Merged |
 | **PR3: Validation** | TBD | Integration tests with real checkpoint, benchmark against DA3. | Planned |
 
 ### Tier Classification
@@ -211,7 +211,6 @@ Cache invalidation triggers:
 1. **Manual Install:** Users must install `depth-pro` separately.
 2. **Large Checkpoint:** 1.9 GB download not bundled.
 3. **Experimental Status:** No stability guarantees.
-4. **Limited Wiring:** Not yet integrated into preset loader (PR2 pending).
 
 ### Neutral
 

--- a/tests/test_da3_backend.py
+++ b/tests/test_da3_backend.py
@@ -27,12 +27,11 @@ def test_da3_backend_implements_protocol():
 
 
 def test_da3_backend_availability():
-    """DA3Backend.ensure_available() raises ImportError when dependencies missing.
+    """DA3Backend has ensure_available() method.
 
-    Uses monkeypatch to force import failure, verifying error handling.
+    Verifies the method exists and is callable.
+    Actual error handling is tested in test_da3_backend_availability_missing_transformers.
     """
-    import importlib
-
     from transformation_portal.depth.backends.da3 import DA3Backend
 
     backend = DA3Backend()
@@ -45,35 +44,21 @@ def test_da3_backend_availability():
 def test_da3_backend_availability_missing_transformers(monkeypatch):
     """DA3Backend.ensure_available() detects missing transformers dependency.
 
-    Uses sys.modules patching to simulate ImportError during import statement.
+    Uses monkeypatch to manage sys.modules, simulating missing dependency.
     """
     import sys
 
     from transformation_portal.depth.backends.da3 import DA3Backend
 
-    # Temporarily remove transformers from sys.modules to force ImportError
-    # Save original value (if it exists)
-    original_transformers = sys.modules.get("transformers")
+    # Use monkeypatch to safely modify sys.modules
+    monkeypatch.delitem(sys.modules, "transformers", raising=False)
+    monkeypatch.setitem(sys.modules, "transformers", None)
 
-    try:
-        # Remove transformers from sys.modules
-        if "transformers" in sys.modules:
-            del sys.modules["transformers"]
+    backend = DA3Backend()
 
-        # Block future imports by setting to None
-        sys.modules["transformers"] = None
-
-        backend = DA3Backend()
-
-        # This should raise ImportError when ensure_available tries to import transformers
-        with pytest.raises(ImportError, match="transformers"):
-            backend.ensure_available()
-    finally:
-        # Restore original state
-        if original_transformers is not None:
-            sys.modules["transformers"] = original_transformers
-        elif "transformers" in sys.modules:
-            del sys.modules["transformers"]
+    # This should raise ImportError when ensure_available tries to import transformers
+    with pytest.raises(ImportError, match="transformers"):
+        backend.ensure_available()
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Follow-up to #862 - addresses lingering review comments with test cleanup and docs accuracy fixes. Pure polish, no functional changes.