### PR TITLE
fix(depth): use resolved backend in manifest, not config default (ADR-023)

### DIFF
--- a/src/transformation_portal/lux_depth_v3/orchestrator.py
+++ b/src/transformation_portal/lux_depth_v3/orchestrator.py
@@ -902,8 +902,14 @@ class EnhanceOrchestrator:
                     if _k in _md:
                         stats[_k] = _md[_k]
 
+                # CRITICAL FIX: Use resolved backend name, not config default
+                # This ensures depth.model matches what actually ran (backend_selection.resolved_backend)
+                # ADR-023 compliance: identity must match execution reality
+                resolved_backend = getattr(self, "_backend_metadata", None)
+                model_name = resolved_backend.resolved_backend if resolved_backend else self.config.model_variant.value.name
+
                 depth_metadata = DepthMetadata(
-                    model=self.config.model_variant.value.name,
+                    model=model_name,
                     depth_path=str(depth_path),
                     runtime_seconds=depth_runtime_s,
                     scaling=depth_stats._asdict(),

--- a/tests/test_orchestrator_backend_integration.py
+++ b/tests/test_orchestrator_backend_integration.py
@@ -152,3 +152,86 @@ def test_orchestrator_depth_pro_checkpoint_missing(tmp_path):
     assert orchestrator.depth_backend.name == "da3"
     assert orchestrator._backend_metadata.resolution_status == "fallback"
     assert "not found" in orchestrator._backend_metadata.resolution_reason
+
+
+def test_depth_metadata_uses_resolved_backend_not_config_default(tmp_path, mock_da3_available):
+    """REGRESSION TEST for ADR-023: depth.model must use resolved backend, not config default.
+
+    Bug: Previously used self.config.model_variant.value.name which shows config default
+    Fix: Now uses self._backend_metadata.resolved_backend which shows actual execution
+
+    This prevents manifest mismatches like:
+    - depth.model = "depth-anything-v3-metric-large" (config)
+    - backend_selection.resolved_backend = "depth_pro" (reality)
+
+    Critical for production debugging when fallbacks occur.
+    """
+    import json
+    from unittest.mock import patch
+
+    import numpy as np
+    from PIL import Image
+
+    from transformation_portal.depth.backends.protocol import DepthResult
+    from transformation_portal.lux_depth_v3.input_manager import ImageInput
+
+    # Create test image
+    test_image = tmp_path / "test.png"
+    img = Image.new("RGB", (64, 64), color="white")
+    img.save(test_image)
+
+    # Configure for DA3 backend
+    config = EnhanceConfig(
+        depth_backend="da3",
+        depth_device="cpu",
+        enable_v2=False,
+        enable_materials_v3=False,
+    )
+
+    orchestrator = EnhanceOrchestrator(config, tmp_path)
+
+    # Verify backend metadata was captured correctly
+    assert orchestrator._backend_metadata.requested_backend == "da3"
+    assert orchestrator._backend_metadata.resolved_backend == "da3"
+    assert orchestrator._backend_metadata.resolution_status == "success"
+
+    # Mock the depth backend compute to return synthetic result (fast test)
+    mock_depth_result = DepthResult(
+        depth_map=np.random.rand(64, 64).astype(np.float32),
+        original_image=np.array(img),
+        metadata={},
+        depth_units="relative",
+        backend_id="da3",
+        device="cpu",
+    )
+
+    with patch.object(orchestrator.depth_backend, "compute", return_value=mock_depth_result):
+        # Process single image to trigger depth metadata creation
+        image_input = ImageInput(path=test_image)
+        result = orchestrator.enhance_image(image_input)
+
+    # Verify manifest was created
+    manifest_path = result["manifest"]
+    assert Path(manifest_path).exists()
+
+    # Load and verify manifest
+    with open(manifest_path) as f:
+        manifest = json.load(f)
+
+    # CRITICAL ASSERTION: depth.model must match backend_selection.resolved_backend
+    assert "depth" in manifest
+    assert "backend_selection" in manifest
+
+    depth_model = manifest["depth"]["model"]
+    resolved_backend = manifest["backend_selection"]["resolved_backend"]
+
+    # This is the regression test: they must match!
+    assert depth_model == resolved_backend, (
+        f"ADR-023 violation: depth.model='{depth_model}' != "
+        f"backend_selection.resolved_backend='{resolved_backend}'. "
+        f"Depth metadata must use resolved backend, not config default."
+    )
+
+    # For DA3 backend, both should be "da3"
+    assert depth_model == "da3"
+    assert resolved_backend == "da3"


### PR DESCRIPTION
## Priority
⚡ **CRITICAL** - ADR-023 violation

## Extraction from PR #934
This is Phase 1 of the surgical extraction strategy from PR #934.

## Bug Description
Depth manifests showed **config default** instead of **actual resolved backend**:
```json
{
  "depth": {
    "model": "depth-anything-v3-metric-large"  // ❌ config default
  },
  "backend_selection": {
    "resolved_backend": "depth_pro"  // ✅ what actually ran
  }
}
```

This made production debugging impossible when fallbacks occurred.

## Root Cause
Line 906 in `orchestrator.py` used:
```python
model=self.config.model_variant.value.name  # ❌ Always returns config default
```

## Fix
Changed to use runtime-resolved backend:
```python
resolved_backend = getattr(self, '_backend_metadata', None)
model_name = (
    resolved_backend.resolved_backend
    if resolved_backend
    else self.config.model_variant.value.name  # Fallback for safety
)
```

## Testing
Added regression test:
- `test_depth_metadata_uses_resolved_backend_not_config_default`
- Verifies `depth.model == backend_selection.resolved_backend`
- Prevents future ADR-023 regressions

## Validation
✅ All backend integration tests pass (9/9)
✅ Manifest identity now matches execution reality
✅ Fallback scenarios properly tracked

## Impact
- **Surgical fix**: 6 lines added to orchestrator.py
- **No breaking changes**
- **Backward compatible** (uses config default if metadata unavailable)
- **Critical for production debugging**

## Related
- PR #934 (source of extraction)
- ADR-023 (Manifest accuracy requirement)