### PR TITLE
[codex] Escape backslash in sanitization docstring

### DIFF
--- a/src/transformation_portal/core/security/sanitization.py
+++ b/src/transformation_portal/core/security/sanitization.py
@@ -29,7 +29,7 @@ def sanitize_filename(filename: str, replacement: str = "_") -> str:
     """
     Make a string safe for use as a filename.
 
-    Removes dangerous characters like / \ : * ? " < > |
+    Removes dangerous characters like / \\ : * ? " < > |
     """
     # 1. Strip path components (we only want the name)
     name = Path(filename).name


### PR DESCRIPTION
## Summary
This change removes a Python 3.12 warning caused by an invalid escape sequence in a security-module docstring.

In Python 3.11, the `\ ` sequence can surface as a `DeprecationWarning` and is often hidden by default. In Python 3.12, the same pattern is treated as a `SyntaxWarning` and is emitted more aggressively during import, which makes it visible in CI. The result is warning noise in the `test (3.12, cpu, core)` job without any runtime behavior change.

## Root Cause
`src/transformation_portal/core/security/sanitization.py` documented dangerous filename characters using a literal backslash in a normal string/docstring context:

`/ \ : * ? " < > |`

The single backslash before a space (`\ `) is parsed as an invalid escape sequence.

## Fix
Escaped the literal backslash in the docstring:

- Before: `Removes dangerous characters like / \ : * ? " < > |` (single backslash in source)
- After: `Removes dangerous characters like / \\ : * ? " < > |`

This is a minimal, behavior-preserving fix that removes the warning while keeping the docs readable.

## User Impact
- Eliminates warning noise in Python 3.12 CI imports.
- Keeps test logs cleaner so real warnings are more visible.
- No functional change to sanitization logic or output.

## Validation
- Ran focused import check with warning promotion:
  - `python3 -W error::SyntaxWarning -c "from transformation_portal.core.security import sanitization"`
- Ran targeted tests:
  - `python3 -m pytest tests/test_lux_depth_v3_imports.py -q`
  - Result: `18 passed`

## Notes
This is a Python warning-behavior compatibility fix, not a determinism change.
