### PR TITLE
[codex] phase3.4 bundle root anchoring and notarization

### DIFF
--- a/.github/workflows/determinism-gate.yml
+++ b/.github/workflows/determinism-gate.yml
@@ -38,3 +38,7 @@ jobs:
       - name: FP-state invariance gate
         run: |
           pytest -v -m "not ml and not slow and not benchmark" tests/determinism/test_fpstate_invariance.py
+
+      - name: Bundle root determinism gate
+        run: |
+          pytest -v -m "not ml and not slow and not benchmark" tests/test_bundle_root.py

--- a/docs/archive/ARCHIVE_MANIFEST_PHASE3_EVIDENCE_BUNDLE.md
+++ b/docs/archive/ARCHIVE_MANIFEST_PHASE3_EVIDENCE_BUNDLE.md
@@ -1,33 +1,32 @@
-# Archive Manifest Phase 3.3 - Evidence Bundle Canonicalization
+# Archive Manifest Phase 3.4 - Bundle Root Anchoring and Notarization
 
 ## Status
-Proposed (Phase 3.3 - Evidence Bundle Layer)
+Proposed (Phase 3.4 - Bundle Root Layer)
 
 ## Context
 
-Phase 3 and later layers currently emit artifacts across integrity,
-attestation, and timestamp layers:
+Phase 3.3 introduced a portable canonical bundle manifest that binds these
+artifacts by SHA-256:
 
-- `hash_manifest.csv.gz` (deterministic hash manifest)
-- `hash_summary.json` (deterministic hash manifest summary)
-- `merkle_roots.json` (deterministic integrity)
-- `merkle_roots.sig.json` (detached attestation)
-- `merkle_roots.sig.tsr` or `merkle_roots.tsr` (detached timestamp)
+- `hash_manifest.csv.gz`
+- `hash_summary.json`
+- `merkle_roots.json`
+- `merkle_roots.sig.json`
+- `merkle_roots.sig.tsr` or `merkle_roots.tsr`
 
-These artifacts are independently verifiable but not yet tied together by a
-single canonical manifest contract.
-
-Phase 3.3 defines that contract.
+Phase 3.4 extends that contract with an externally anchorable
+`bundle_root_sha256` and an optional notarization layer. The extension is
+additive and does not weaken Phase 3.3 verification invariants.
 
 ---
 
 # Design Principles
 
-1. Bundle metadata is detached and additive.
+1. Bundle metadata remains detached and additive.
 2. Existing artifacts remain immutable inputs.
-3. The bundle contract is explicit, versioned, and schema-validated.
-4. The canonical signed object is a JSON manifest, not a container byte stream.
-5. The contract must support third-party offline verification.
+3. The bundle contract stays strict and schema-validated.
+4. Bundle root digest is deterministic across hosts and Python versions.
+5. Notarization artifacts are optional and re-anchorable.
 
 ---
 
@@ -61,10 +60,32 @@ evidence_bundle_manifest.json
 - `bundle_tool_name`
 - `bundle_tool_version`
 
+## Optional Phase 3.4 fields
+
+- `bundle_root_algorithm` (`"sha256"`)
+- `bundle_root_preimage_version` (`"1"`)
+- `bundle_root_sha256` (64 lowercase hex)
+- `notarization`
+
+All three `bundle_root_*` fields MUST appear together when present.
+
+### Optional notarization object
+
+`notarization` is an optional object with one or both providers:
+
+- `rfc3161`:
+  - `timestamp_path`
+  - `timestamp_sha256`
+- `sigstore`:
+  - `bundle_path`
+  - `bundle_sha256`
+
+Unknown fields are rejected.
+
 ## Field semantics
 
-- `bundle_version`: version for this bundle manifest contract.
-- `hash_algorithm`: digest algorithm used for manifest digests (`sha256`).
+- `bundle_version`: bundle manifest contract version (`"1"`).
+- `hash_algorithm`: digest algorithm for manifest digests (`"sha256"`).
 - `roots_path`: relative path of deterministic roots artifact.
 - `roots_sha256`: digest of exact `merkle_roots.json` bytes.
 - `hash_manifest_path`: relative path of deterministic hash manifest artifact.
@@ -76,19 +97,14 @@ evidence_bundle_manifest.json
 - `timestamp_target`: whether timestamp was taken over `roots` or `signature`.
 - `timestamp_path`: relative path of detached RFC 3161 response artifact.
 - `timestamp_sha256`: digest of exact `.tsr` bytes.
-- `merkle_leaf_count`: global leaf count from deterministic roots artifact
-  (`merkle_roots.json.global.leaf_count`).
-- `phase3_version`, `phase3_1_version`, `phase3_2_version`: non-empty contract
-  version strings used to produce and validate bundle members.
+- `merkle_leaf_count`: `merkle_roots.json.global.leaf_count`.
+- `phase3_version`, `phase3_1_version`, `phase3_2_version`: non-empty
+  contract version strings.
 - `bundle_tool_name`: identifier of bundle-manifest emitting tool.
 - `bundle_tool_version`: version of bundle-manifest emitting tool.
-
-## Recommended timestamp target
-
-For Phase 3.3 evidence bundles, timestamping the signature artifact is
-recommended (`timestamp_target = "signature"`), since identity and time are
-bound in the same detached chain. Signature artifacts are mandatory in this
-bundle contract.
+- `bundle_root_algorithm`: bundle root digest algorithm (`"sha256"`).
+- `bundle_root_preimage_version`: canonical preimage format version (`"1"`).
+- `bundle_root_sha256`: SHA-256 digest over canonical root preimage bytes.
 
 ---
 
@@ -102,62 +118,70 @@ bundle contract.
 - separators fixed to `(",", ": ")`
 - trailing newline
 
-This keeps emitted manifests deterministic across hosts and Python versions.
-
 ---
 
-# Example Manifest
+# Bundle Root Canonical Preimage (Normative)
 
-```json
-{
-  "bundle_version": "1",
-  "hash_algorithm": "sha256",
-  "phase3_1_version": "1",
-  "phase3_2_version": "1",
-  "phase3_version": "1",
-  "bundle_tool_name": "phase3_bundle_builder",
-  "bundle_tool_version": "1.0.0",
-  "merkle_leaf_count": 48291,
-  "hash_manifest_path": "hash_manifest.csv.gz",
-  "hash_manifest_sha256": "6cd77312a9ee3c11d73dbf17d02fd5f1e6e8cf70f92f9d0377ce4d79073e34ee",
-  "hash_summary_path": "hash_summary.json",
-  "hash_summary_sha256": "48ad5e285629f854ea5f93f3f0562ec3e13793a7a8ccf8a07c1f0bdd1818f26c",
-  "roots_path": "merkle_roots.json",
-  "roots_sha256": "2f44bcaee8cf9fc5fe91f8c9f8ce87b17cf5f6e11323191b37a89f2df5a37a99",
-  "signature_path": "merkle_roots.sig.json",
-  "signature_sha256": "2cc31d95be9b4ed8d8410fcf94fdc7a4a1034fd1433f20f8db1208149ca52e29",
-  "timestamp_path": "merkle_roots.sig.tsr",
-  "timestamp_sha256": "5b1fca7f20f6cca96c39f96d6fb2f7758867a2334df8459f39bc4826ce16d276",
-  "timestamp_target": "signature"
-}
+## Projection fields
+
+`bundle_root_sha256` is computed from a canonical projection using exactly these
+fields:
+
+- `bundle_version`
+- `hash_algorithm`
+- `roots_sha256`
+- `hash_manifest_sha256`
+- `hash_summary_sha256`
+- `signature_sha256`
+- `timestamp_target`
+- `timestamp_sha256`
+- `merkle_leaf_count`
+- `phase3_version`
+- `phase3_1_version`
+- `phase3_2_version`
+- `bundle_tool_name`
+- `bundle_tool_version`
+
+Path fields (`*_path`) and notarization fields are excluded from the root
+preimage.
+
+## Canonical preimage serialization
+
+Projection bytes (`preimage_v1`) MUST be serialized as canonical JSON with:
+
+- UTF-8
+- `sort_keys = true`
+- `separators = (",", ":")`
+- LF newline appended (`\n`)
+
+## Bundle root digest
+
+```text
+bundle_root_sha256 = sha256(preimage_v1)
 ```
 
 ---
 
 # Verification Contract
 
-Phase 3.3 bundle verification MUST:
+Bundle verification MUST:
 
-1. Load and schema-validate `evidence_bundle_manifest.json`.
-2. Recompute SHA-256 for each referenced artifact path:
-   - `merkle_roots.json`
-   - `hash_manifest.csv.gz`
-   - `hash_summary.json`
-   - `merkle_roots.sig.json`
-   - detached timestamp response (`.tsr`)
-3. Compare recomputed digests against manifest digest fields.
-4. Verify timestamp target consistency:
-   - `timestamp_target = "signature"` implies `timestamp_path = "merkle_roots.sig.tsr"`
-   - `timestamp_target = "roots"` implies `timestamp_path = "merkle_roots.tsr"`
-5. Verify `merkle_leaf_count` matches `merkle_roots.json.global.leaf_count`.
-6. Verify `bundle_tool_name` and `bundle_tool_version` are present and non-empty.
-7. Fail non-zero on any mismatch.
+1. Load and strict-validate `evidence_bundle_manifest.json`.
+2. Recompute SHA-256 for `merkle_roots.json`, `hash_manifest.csv.gz`,
+   `hash_summary.json`, `merkle_roots.sig.json`, and timestamp `.tsr` artifact.
+3. Verify `timestamp_target` to `timestamp_path` coupling.
+4. Verify `merkle_leaf_count` matches `merkle_roots.json.global.leaf_count`.
+5. Verify `bundle_tool_name` and `bundle_tool_version` are non-empty.
+6. If `bundle_root_sha256` is present, recompute canonical root and compare.
+7. If `notarization` is present, recompute SHA-256 of notarization artifacts and
+   compare against notarization digests.
+8. Fail non-zero on any mismatch.
 
 ---
 
 # CLI Interface
 
-Generate canonical bundle manifest:
+Generate canonical bundle manifest (Phase 3.3):
 
 ```bash
 python tools/generate_evidence_bundle_manifest.py \
@@ -173,6 +197,21 @@ python tools/generate_evidence_bundle_manifest.py \
   --bundle-tool-name phase3_bundle_builder \
   --bundle-tool-version 1.0.0 \
   --out /path/to/evidence_bundle_manifest.json
+```
+
+Compute bundle root only (no file mutation):
+
+```bash
+python tools/compute_bundle_root.py \
+  --bundle-manifest /path/to/evidence_bundle_manifest.json
+```
+
+Compute and write root fields into manifest:
+
+```bash
+python tools/compute_bundle_root.py \
+  --bundle-manifest /path/to/evidence_bundle_manifest.json \
+  --write
 ```
 
 Verify canonical bundle manifest:
@@ -192,6 +231,13 @@ Generate CLI (`generate_evidence_bundle_manifest.py`):
 - `0` = manifest generated successfully
 - `10` = bundle generation failure
 
+Compute root CLI (`compute_bundle_root.py`):
+
+- `0` = bundle root computed/written successfully
+- `21` = malformed manifest or invalid arguments
+- `22` = manifest write failure
+- `23` = existing `bundle_root_sha256` mismatches computed root
+
 Verify CLI (`verify_evidence_bundle_manifest.py`):
 
 - `0` = bundle manifest and referenced artifacts verified
@@ -204,30 +250,18 @@ Verify CLI (`verify_evidence_bundle_manifest.py`):
 
 Bundle transport MAY use zip/tar directories for convenience.
 
-The container bytes MUST NOT be treated as the signed object.
+Container bytes MUST NOT be treated as the signed object.
 
-Only `evidence_bundle_manifest.json` is the canonical representation of bundle
-membership. If signing is applied, sign the canonical manifest bytes.
-
----
-
-# Optional Detached Manifest Signature
-
-A future detached signature over `evidence_bundle_manifest.json` MAY be added as:
-
-```text
-evidence_bundle_manifest.sig.json
-```
-
-If present, it follows the same detached-envelope model used for
-`merkle_roots.sig.json`.
+`evidence_bundle_manifest.json` remains the canonical representation of bundle
+membership.
 
 ---
 
 # Non-Goals
 
-Phase 3.3 does not include:
+Phase 3.4 does not include:
 
+- public ledger integration in core repo
 - TSA certificate chain archival
 - long-term revocation evidence packaging
 - multi-signature policy orchestration

--- a/docs/archive/schemas/evidence_bundle_manifest.schema.json
+++ b/docs/archive/schemas/evidence_bundle_manifest.schema.json
@@ -102,7 +102,87 @@
     "bundle_tool_version": {
       "type": "string",
       "minLength": 1
+    },
+    "bundle_root_algorithm": {
+      "type": "string",
+      "const": "sha256"
+    },
+    "bundle_root_preimage_version": {
+      "type": "string",
+      "const": "1"
+    },
+    "bundle_root_sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "notarization": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "rfc3161": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "timestamp_path",
+            "timestamp_sha256"
+          ],
+          "properties": {
+            "timestamp_path": {
+              "type": "string",
+              "minLength": 1
+            },
+            "timestamp_sha256": {
+              "type": "string",
+              "pattern": "^[a-f0-9]{64}$"
+            }
+          }
+        },
+        "sigstore": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "bundle_path",
+            "bundle_sha256"
+          ],
+          "properties": {
+            "bundle_path": {
+              "type": "string",
+              "minLength": 1
+            },
+            "bundle_sha256": {
+              "type": "string",
+              "pattern": "^[a-f0-9]{64}$"
+            }
+          }
+        }
+      },
+      "anyOf": [
+        {
+          "required": [
+            "rfc3161"
+          ]
+        },
+        {
+          "required": [
+            "sigstore"
+          ]
+        }
+      ]
     }
+  },
+  "dependentRequired": {
+    "bundle_root_algorithm": [
+      "bundle_root_preimage_version",
+      "bundle_root_sha256"
+    ],
+    "bundle_root_preimage_version": [
+      "bundle_root_algorithm",
+      "bundle_root_sha256"
+    ],
+    "bundle_root_sha256": [
+      "bundle_root_algorithm",
+      "bundle_root_preimage_version"
+    ]
   },
   "allOf": [
     {

--- a/tests/test_bundle_root.py
+++ b/tests/test_bundle_root.py
@@ -1,0 +1,277 @@
+"""Tests for Phase 3.4 bundle root anchoring and notarization behavior."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+GENERATE_TOOL = PROJECT_ROOT / "tools" / "generate_evidence_bundle_manifest.py"
+VERIFY_TOOL = PROJECT_ROOT / "tools" / "verify_evidence_bundle_manifest.py"
+COMPUTE_ROOT_TOOL = PROJECT_ROOT / "tools" / "compute_bundle_root.py"
+
+pytestmark = [pytest.mark.regression]
+
+EXPECTED_GOLDEN_ROOT = "47c09af843470b891e8c33d614fb5b4a4399218fdc7b8461f5c6b11d1fa000ce"
+
+
+def _run_cli(command: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        cwd=str(PROJECT_ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _write_bundle_artifacts(tmp_path: Path, *, timestamp_target: str = "signature") -> dict[str, Path]:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+
+    roots_path = tmp_path / "merkle_roots.json"
+    roots_path.write_text(
+        json.dumps(
+            {
+                "hash_algorithm": "sha256",
+                "leaf_hash_algorithm": "sha256",
+                "leaf_format_version": "1",
+                "leaf_format": "v1",
+                "tree_method_version": "1",
+                "tree_method": "duplicate_last",
+                "partitions": [],
+                "global": {"leaf_count": 3, "root_sha256": "0" * 64},
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    hash_manifest_path = tmp_path / "hash_manifest.csv.gz"
+    hash_manifest_path.write_bytes(
+        b"# hash_algorithm=sha256\n"
+        b"origin_drive,partition,relpath,filesize_bytes,sha256,hash_status,error\n"
+        b"driveA,partA,a.jpg,5,abc,ok,\n"
+    )
+
+    hash_summary_path = tmp_path / "hash_summary.json"
+    hash_summary_path.write_text(
+        json.dumps(
+            {
+                "hash_algorithm": "sha256",
+                "hash_manifest_schema_version": "1",
+                "rows_total": 1,
+                "hashed_ok": 1,
+                "missing": 0,
+                "unreadable": 0,
+                "skipped": 0,
+                "total_bytes_hashed": 5,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    signature_path = tmp_path / "merkle_roots.sig.json"
+    signature_path.write_text(
+        json.dumps(
+            {
+                "envelope_version": "1",
+                "signature_algorithm": "ed25519",
+                "artifact_digest_algorithm": "sha256",
+                "signed_artifact": "merkle_roots.json",
+                "signed_artifact_sha256": hashlib.sha256(roots_path.read_bytes()).hexdigest(),
+                "signature_base64": "c2ln",
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    timestamp_filename = "merkle_roots.sig.tsr" if timestamp_target == "signature" else "merkle_roots.tsr"
+    timestamp_path = tmp_path / timestamp_filename
+    timestamp_path.write_bytes(b"\x30\x03\x30\x01\x00")
+
+    return {
+        "roots": roots_path,
+        "hash_manifest": hash_manifest_path,
+        "hash_summary": hash_summary_path,
+        "signature": signature_path,
+        "timestamp": timestamp_path,
+        "out": tmp_path / "evidence_bundle_manifest.json",
+    }
+
+
+def _generate_manifest(artifacts: dict[str, Path], *, timestamp_target: str = "signature") -> subprocess.CompletedProcess[str]:
+    return _run_cli(
+        [
+            sys.executable,
+            str(GENERATE_TOOL),
+            "--roots",
+            str(artifacts["roots"]),
+            "--hash-manifest",
+            str(artifacts["hash_manifest"]),
+            "--hash-summary",
+            str(artifacts["hash_summary"]),
+            "--signature",
+            str(artifacts["signature"]),
+            "--timestamp-target",
+            timestamp_target,
+            "--timestamp",
+            str(artifacts["timestamp"]),
+            "--out",
+            str(artifacts["out"]),
+        ]
+    )
+
+
+def _compute_root(manifest_path: Path, *, write: bool = False) -> subprocess.CompletedProcess[str]:
+    command = [
+        sys.executable,
+        str(COMPUTE_ROOT_TOOL),
+        "--bundle-manifest",
+        str(manifest_path),
+    ]
+    if write:
+        command.append("--write")
+    return _run_cli(command)
+
+
+def _verify_bundle(manifest_path: Path, bundle_dir: Path) -> subprocess.CompletedProcess[str]:
+    return _run_cli(
+        [
+            sys.executable,
+            str(VERIFY_TOOL),
+            "--bundle-manifest",
+            str(manifest_path),
+            "--bundle-dir",
+            str(bundle_dir),
+        ]
+    )
+
+
+def _load_manifest(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write_manifest(path: Path, payload: dict[str, object]) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def test_bundle_root_is_deterministic(tmp_path: Path) -> None:
+    artifacts = _write_bundle_artifacts(tmp_path / "bundle")
+    generated = _generate_manifest(artifacts, timestamp_target="signature")
+    assert generated.returncode == 0, generated.stderr
+
+    first = _compute_root(artifacts["out"])
+    second = _compute_root(artifacts["out"])
+    assert first.returncode == 0, first.stderr
+    assert second.returncode == 0, second.stderr
+
+    first_root = first.stdout.strip()
+    second_root = second.stdout.strip()
+    assert first_root == second_root
+    assert first_root == EXPECTED_GOLDEN_ROOT
+
+
+def test_bundle_root_is_invariant_under_bundle_relocation(tmp_path: Path) -> None:
+    artifacts_a = _write_bundle_artifacts(tmp_path / "layout_a" / "bundle")
+    artifacts_b = _write_bundle_artifacts(tmp_path / "layout_b" / "nested" / "bundle")
+    generated_a = _generate_manifest(artifacts_a, timestamp_target="signature")
+    generated_b = _generate_manifest(artifacts_b, timestamp_target="signature")
+    assert generated_a.returncode == 0, generated_a.stderr
+    assert generated_b.returncode == 0, generated_b.stderr
+
+    root_a = _compute_root(artifacts_a["out"])
+    root_b = _compute_root(artifacts_b["out"])
+    assert root_a.returncode == 0, root_a.stderr
+    assert root_b.returncode == 0, root_b.stderr
+    assert root_a.stdout.strip() == root_b.stdout.strip()
+
+
+def test_verify_fails_when_bundle_root_digest_mismatches(tmp_path: Path) -> None:
+    artifacts = _write_bundle_artifacts(tmp_path / "bundle")
+    generated = _generate_manifest(artifacts, timestamp_target="signature")
+    assert generated.returncode == 0, generated.stderr
+
+    written = _compute_root(artifacts["out"], write=True)
+    assert written.returncode == 0, written.stderr
+
+    manifest = _load_manifest(artifacts["out"])
+    manifest["bundle_root_sha256"] = "0" * 64
+    _write_manifest(artifacts["out"], manifest)
+
+    verify_result = _verify_bundle(artifacts["out"], artifacts["out"].parent)
+    assert verify_result.returncode == 11
+    assert "bundle_root_sha256 mismatch" in verify_result.stdout
+
+
+def test_verify_fails_when_notarization_artifact_digest_mismatches(tmp_path: Path) -> None:
+    artifacts = _write_bundle_artifacts(tmp_path / "bundle")
+    generated = _generate_manifest(artifacts, timestamp_target="signature")
+    assert generated.returncode == 0, generated.stderr
+
+    written = _compute_root(artifacts["out"], write=True)
+    assert written.returncode == 0, written.stderr
+
+    notarization_path = artifacts["out"].parent / "bundle_root.tsr"
+    notarization_path.write_bytes(b"\x30\x03\x30\x01\x7f")
+    notarization_digest = hashlib.sha256(notarization_path.read_bytes()).hexdigest()
+
+    manifest = _load_manifest(artifacts["out"])
+    manifest["notarization"] = {
+        "rfc3161": {
+            "timestamp_path": notarization_path.name,
+            "timestamp_sha256": notarization_digest,
+        }
+    }
+    _write_manifest(artifacts["out"], manifest)
+
+    verify_ok = _verify_bundle(artifacts["out"], artifacts["out"].parent)
+    assert verify_ok.returncode == 0, verify_ok.stderr
+
+    notarization_path.write_bytes(b"tampered")
+    verify_fail = _verify_bundle(artifacts["out"], artifacts["out"].parent)
+    assert verify_fail.returncode == 11
+    assert "notarization.rfc3161.timestamp_path" in verify_fail.stdout
+
+
+def test_compute_bundle_root_strict_mode_rejects_unknown_fields(tmp_path: Path) -> None:
+    artifacts = _write_bundle_artifacts(tmp_path / "bundle")
+    generated = _generate_manifest(artifacts, timestamp_target="signature")
+    assert generated.returncode == 0, generated.stderr
+
+    manifest = _load_manifest(artifacts["out"])
+    manifest["extra"] = "not-allowed"
+    _write_manifest(artifacts["out"], manifest)
+
+    compute_result = _compute_root(artifacts["out"])
+    assert compute_result.returncode == 21
+    assert "unexpected field(s): extra" in compute_result.stdout
+
+
+def test_compute_bundle_root_returns_mismatch_when_existing_root_is_stale(tmp_path: Path) -> None:
+    artifacts = _write_bundle_artifacts(tmp_path / "bundle")
+    generated = _generate_manifest(artifacts, timestamp_target="signature")
+    assert generated.returncode == 0, generated.stderr
+
+    written = _compute_root(artifacts["out"], write=True)
+    assert written.returncode == 0, written.stderr
+
+    manifest = _load_manifest(artifacts["out"])
+    manifest["phase3_version"] = "2"
+    _write_manifest(artifacts["out"], manifest)
+
+    compute_result = _compute_root(artifacts["out"])
+    assert compute_result.returncode == 23
+    assert "Bundle root mismatch" in compute_result.stdout

--- a/tools/bundle_root_common.py
+++ b/tools/bundle_root_common.py
@@ -1,0 +1,255 @@
+"""
+Common helpers for Phase 3.4 bundle root computation and validation.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Mapping
+
+BUNDLE_VERSION = "1"
+HASH_ALGORITHM = "sha256"
+BUNDLE_ROOT_ALGORITHM = "sha256"
+BUNDLE_ROOT_PREIMAGE_VERSION = "1"
+EXPECTED_MANIFEST_FILENAME = "evidence_bundle_manifest.json"
+EXPECTED_ROOTS_FILENAME = "merkle_roots.json"
+EXPECTED_HASH_MANIFEST_FILENAME = "hash_manifest.csv.gz"
+EXPECTED_HASH_SUMMARY_FILENAME = "hash_summary.json"
+EXPECTED_SIGNATURE_FILENAME = "merkle_roots.sig.json"
+TIMESTAMP_FILENAME_BY_TARGET = {
+    "roots": "merkle_roots.tsr",
+    "signature": "merkle_roots.sig.tsr",
+}
+HEX64_RE = re.compile(r"^[a-f0-9]{64}$")
+
+REQUIRED_FIELDS = {
+    "bundle_version",
+    "hash_algorithm",
+    "roots_path",
+    "roots_sha256",
+    "hash_manifest_path",
+    "hash_manifest_sha256",
+    "hash_summary_path",
+    "hash_summary_sha256",
+    "signature_path",
+    "signature_sha256",
+    "timestamp_target",
+    "timestamp_path",
+    "timestamp_sha256",
+    "merkle_leaf_count",
+    "phase3_version",
+    "phase3_1_version",
+    "phase3_2_version",
+    "bundle_tool_name",
+    "bundle_tool_version",
+}
+
+OPTIONAL_ROOT_FIELDS = {
+    "bundle_root_algorithm",
+    "bundle_root_preimage_version",
+    "bundle_root_sha256",
+}
+OPTIONAL_TOP_LEVEL_FIELDS = OPTIONAL_ROOT_FIELDS | {"notarization"}
+KNOWN_FIELDS = REQUIRED_FIELDS | OPTIONAL_TOP_LEVEL_FIELDS
+
+ROOT_PROJECTION_FIELDS = tuple(
+    sorted(
+        (
+            "bundle_version",
+            "hash_algorithm",
+            "roots_sha256",
+            "hash_manifest_sha256",
+            "hash_summary_sha256",
+            "signature_sha256",
+            "timestamp_target",
+            "timestamp_sha256",
+            "merkle_leaf_count",
+            "phase3_version",
+            "phase3_1_version",
+            "phase3_2_version",
+            "bundle_tool_name",
+            "bundle_tool_version",
+        )
+    )
+)
+
+_RFC3161_FIELDS = {"timestamp_path", "timestamp_sha256"}
+_SIGSTORE_FIELDS = {"bundle_path", "bundle_sha256"}
+
+
+def sha256_hexdigest(path: Path) -> str:
+    hasher = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def load_merkle_leaf_count(roots_path: Path) -> int:
+    roots_payload = json.loads(roots_path.read_text(encoding="utf-8"))
+    if not isinstance(roots_payload, dict):
+        raise ValueError(f"{EXPECTED_ROOTS_FILENAME} must be a JSON object")
+
+    global_block = roots_payload.get("global")
+    if not isinstance(global_block, dict):
+        raise ValueError(f"{EXPECTED_ROOTS_FILENAME} missing object field: global")
+
+    leaf_count = global_block.get("leaf_count")
+    if type(leaf_count) is not int or leaf_count < 0:
+        raise ValueError(f"{EXPECTED_ROOTS_FILENAME}.global.leaf_count must be a non-negative integer")
+    return leaf_count
+
+
+def require_string_field(manifest: Mapping[str, object], field: str) -> str:
+    value = manifest.get(field)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field} must be a non-empty string")
+    return value
+
+
+def require_hex_digest(manifest: Mapping[str, object], field: str) -> str:
+    value = require_string_field(manifest, field)
+    if HEX64_RE.fullmatch(value) is None:
+        raise ValueError(f"{field} must be 64 lowercase hex characters")
+    return value
+
+
+def _validate_notarization_subobject(
+    manifest: Mapping[str, object],
+    object_name: str,
+    required_fields: set[str],
+    digest_field: str,
+    strict: bool,
+) -> None:
+    block = manifest.get(object_name)
+    if block is None:
+        return
+    if not isinstance(block, dict):
+        raise ValueError(f"notarization.{object_name} must be an object")
+    if strict:
+        unexpected = sorted(set(block) - required_fields)
+        if unexpected:
+            raise ValueError(f"notarization.{object_name} has unexpected field(s): {', '.join(unexpected)}")
+    missing = sorted(required_fields - set(block))
+    if missing:
+        raise ValueError(f"notarization.{object_name} missing required field(s): {', '.join(missing)}")
+    for field in sorted(required_fields - {digest_field}):
+        value = block.get(field)
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(f"notarization.{object_name}.{field} must be a non-empty string")
+    digest_value = block.get(digest_field)
+    if not isinstance(digest_value, str) or HEX64_RE.fullmatch(digest_value) is None:
+        raise ValueError(f"notarization.{object_name}.{digest_field} must be 64 lowercase hex characters")
+
+
+def validate_manifest_structure(manifest: dict[str, object], *, strict: bool = True) -> None:
+    keys = set(manifest)
+    missing = sorted(REQUIRED_FIELDS - keys)
+    if missing:
+        raise ValueError(f"missing required field(s): {', '.join(missing)}")
+    if strict:
+        unexpected = sorted(keys - KNOWN_FIELDS)
+        if unexpected:
+            raise ValueError(f"unexpected field(s): {', '.join(unexpected)}")
+
+    if manifest["bundle_version"] != BUNDLE_VERSION:
+        raise ValueError(f"bundle_version must be {BUNDLE_VERSION!r}")
+    if manifest["hash_algorithm"] != HASH_ALGORITHM:
+        raise ValueError(f"hash_algorithm must be {HASH_ALGORITHM!r}")
+
+    if manifest["roots_path"] != EXPECTED_ROOTS_FILENAME:
+        raise ValueError(f"roots_path must be {EXPECTED_ROOTS_FILENAME!r}")
+    if manifest["hash_manifest_path"] != EXPECTED_HASH_MANIFEST_FILENAME:
+        raise ValueError(f"hash_manifest_path must be {EXPECTED_HASH_MANIFEST_FILENAME!r}")
+    if manifest["hash_summary_path"] != EXPECTED_HASH_SUMMARY_FILENAME:
+        raise ValueError(f"hash_summary_path must be {EXPECTED_HASH_SUMMARY_FILENAME!r}")
+    if manifest["signature_path"] != EXPECTED_SIGNATURE_FILENAME:
+        raise ValueError(f"signature_path must be {EXPECTED_SIGNATURE_FILENAME!r}")
+
+    timestamp_target = manifest["timestamp_target"]
+    if timestamp_target not in TIMESTAMP_FILENAME_BY_TARGET:
+        raise ValueError("timestamp_target must be 'roots' or 'signature'")
+    expected_timestamp_path = TIMESTAMP_FILENAME_BY_TARGET[str(timestamp_target)]
+    if manifest["timestamp_path"] != expected_timestamp_path:
+        raise ValueError(f"timestamp_path must be {expected_timestamp_path!r} for timestamp_target={timestamp_target!r}")
+
+    require_hex_digest(manifest, "roots_sha256")
+    require_hex_digest(manifest, "hash_manifest_sha256")
+    require_hex_digest(manifest, "hash_summary_sha256")
+    require_hex_digest(manifest, "signature_sha256")
+    require_hex_digest(manifest, "timestamp_sha256")
+
+    merkle_leaf_count = manifest["merkle_leaf_count"]
+    if type(merkle_leaf_count) is not int or merkle_leaf_count < 0:
+        raise ValueError("merkle_leaf_count must be a non-negative integer")
+
+    require_string_field(manifest, "phase3_version")
+    require_string_field(manifest, "phase3_1_version")
+    require_string_field(manifest, "phase3_2_version")
+    require_string_field(manifest, "bundle_tool_name")
+    require_string_field(manifest, "bundle_tool_version")
+
+    root_field_count = len(OPTIONAL_ROOT_FIELDS & keys)
+    if root_field_count not in (0, len(OPTIONAL_ROOT_FIELDS)):
+        raise ValueError("bundle_root fields must be provided together")
+    if root_field_count:
+        if manifest["bundle_root_algorithm"] != BUNDLE_ROOT_ALGORITHM:
+            raise ValueError(f"bundle_root_algorithm must be {BUNDLE_ROOT_ALGORITHM!r}")
+        if manifest["bundle_root_preimage_version"] != BUNDLE_ROOT_PREIMAGE_VERSION:
+            raise ValueError(f"bundle_root_preimage_version must be {BUNDLE_ROOT_PREIMAGE_VERSION!r}")
+        require_hex_digest(manifest, "bundle_root_sha256")
+
+    notarization_value = manifest.get("notarization")
+    if notarization_value is None:
+        return
+    if not isinstance(notarization_value, dict):
+        raise ValueError("notarization must be an object")
+
+    if strict:
+        unexpected_notarization = sorted(set(notarization_value) - {"rfc3161", "sigstore"})
+        if unexpected_notarization:
+            raise ValueError(f"notarization has unexpected field(s): {', '.join(unexpected_notarization)}")
+
+    if "rfc3161" not in notarization_value and "sigstore" not in notarization_value:
+        raise ValueError("notarization must include at least one provider: rfc3161 or sigstore")
+
+    _validate_notarization_subobject(
+        notarization_value,
+        "rfc3161",
+        _RFC3161_FIELDS,
+        "timestamp_sha256",
+        strict,
+    )
+    _validate_notarization_subobject(
+        notarization_value,
+        "sigstore",
+        _SIGSTORE_FIELDS,
+        "bundle_sha256",
+        strict,
+    )
+
+
+def build_bundle_root_projection(manifest: Mapping[str, object]) -> dict[str, object]:
+    projection: dict[str, object] = {}
+    for field in ROOT_PROJECTION_FIELDS:
+        if field not in manifest:
+            raise ValueError(f"missing required root projection field: {field}")
+        projection[field] = manifest[field]
+    return projection
+
+
+def canonical_root_preimage_bytes(manifest: Mapping[str, object]) -> bytes:
+    projection = build_bundle_root_projection(manifest)
+    payload = json.dumps(
+        projection,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return payload + b"\n"
+
+
+def compute_bundle_root_sha256(manifest: Mapping[str, object]) -> str:
+    return hashlib.sha256(canonical_root_preimage_bytes(manifest)).hexdigest()

--- a/tools/compute_bundle_root.py
+++ b/tools/compute_bundle_root.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""
+Phase 3.4 compute canonical evidence bundle root digest.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from uuid import uuid4
+
+from bundle_root_common import (
+    BUNDLE_ROOT_ALGORITHM,
+    BUNDLE_ROOT_PREIMAGE_VERSION,
+    EXPECTED_MANIFEST_FILENAME,
+    compute_bundle_root_sha256,
+    validate_manifest_structure,
+)
+
+EXIT_BUNDLE_MALFORMED = 21
+EXIT_BUNDLE_WRITE_FAILURE = 22
+EXIT_BUNDLE_ROOT_MISMATCH = 23
+
+
+def atomic_write(path: Path, data: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f".{path.name}.{uuid4().hex}.tmp")
+    try:
+        tmp.write_bytes(data)
+        tmp.replace(path)
+    finally:
+        if tmp.exists():
+            tmp.unlink()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bundle-manifest", required=True, help="Path to evidence_bundle_manifest.json")
+    parser.add_argument(
+        "--out",
+        default=None,
+        help="Output path for evidence_bundle_manifest.json (used only with --write)",
+    )
+    parser.add_argument("--write", action="store_true", help="Write bundle_root fields into output manifest")
+    parser.add_argument(
+        "--strict",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Reject unknown top-level fields (default: true)",
+    )
+    args = parser.parse_args()
+
+    manifest_path = Path(args.bundle_manifest)
+    if manifest_path.name != EXPECTED_MANIFEST_FILENAME:
+        print(f"Malformed manifest: --bundle-manifest must reference {EXPECTED_MANIFEST_FILENAME}")
+        return EXIT_BUNDLE_MALFORMED
+
+    if args.out is not None and not args.write:
+        print("Malformed manifest: --out requires --write")
+        return EXIT_BUNDLE_MALFORMED
+
+    out_path = manifest_path
+    if args.write and args.out is not None:
+        out_path = Path(args.out)
+    if args.write and out_path.name != EXPECTED_MANIFEST_FILENAME:
+        print(f"Malformed manifest: --out must reference {EXPECTED_MANIFEST_FILENAME}")
+        return EXIT_BUNDLE_MALFORMED
+
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        if not isinstance(manifest, dict):
+            raise ValueError("manifest must be a JSON object")
+        validate_manifest_structure(manifest, strict=args.strict)
+        computed_root = compute_bundle_root_sha256(manifest)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+        print(f"Malformed manifest: {exc}")
+        return EXIT_BUNDLE_MALFORMED
+
+    existing_root = manifest.get("bundle_root_sha256")
+    if existing_root is not None and existing_root != computed_root:
+        print("Bundle root mismatch: manifest bundle_root_sha256 does not match computed value")
+        return EXIT_BUNDLE_ROOT_MISMATCH
+
+    if not args.write:
+        print(computed_root)
+        return 0
+
+    manifest["bundle_root_algorithm"] = BUNDLE_ROOT_ALGORITHM
+    manifest["bundle_root_preimage_version"] = BUNDLE_ROOT_PREIMAGE_VERSION
+    manifest["bundle_root_sha256"] = computed_root
+
+    serialized = json.dumps(
+        manifest,
+        indent=2,
+        sort_keys=True,
+        separators=(",", ": "),
+    ).encode("utf-8")
+
+    try:
+        atomic_write(out_path, serialized + b"\n")
+    except OSError as exc:
+        print(f"Bundle root write failed: {exc}")
+        return EXIT_BUNDLE_WRITE_FAILURE
+
+    print(f"Bundle root written to {out_path}: {computed_root}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/verify_evidence_bundle_manifest.py
+++ b/tools/verify_evidence_bundle_manifest.py
@@ -6,131 +6,19 @@ Phase 3.3 Verify canonical evidence bundle manifest.
 from __future__ import annotations
 
 import argparse
-import hashlib
 import json
-import re
 from pathlib import Path
+
+from bundle_root_common import (
+    EXPECTED_MANIFEST_FILENAME,
+    compute_bundle_root_sha256,
+    load_merkle_leaf_count,
+    sha256_hexdigest,
+    validate_manifest_structure,
+)
 
 EXIT_BUNDLE_VERIFY_FAILURE = 11
 EXIT_BUNDLE_MALFORMED = 12
-BUNDLE_VERSION = "1"
-HASH_ALGORITHM = "sha256"
-EXPECTED_MANIFEST_FILENAME = "evidence_bundle_manifest.json"
-EXPECTED_ROOTS_FILENAME = "merkle_roots.json"
-EXPECTED_HASH_MANIFEST_FILENAME = "hash_manifest.csv.gz"
-EXPECTED_HASH_SUMMARY_FILENAME = "hash_summary.json"
-EXPECTED_SIGNATURE_FILENAME = "merkle_roots.sig.json"
-TIMESTAMP_FILENAME_BY_TARGET = {
-    "roots": "merkle_roots.tsr",
-    "signature": "merkle_roots.sig.tsr",
-}
-HEX64_RE = re.compile(r"^[a-f0-9]{64}$")
-
-REQUIRED_FIELDS = {
-    "bundle_version",
-    "hash_algorithm",
-    "roots_path",
-    "roots_sha256",
-    "hash_manifest_path",
-    "hash_manifest_sha256",
-    "hash_summary_path",
-    "hash_summary_sha256",
-    "signature_path",
-    "signature_sha256",
-    "timestamp_target",
-    "timestamp_path",
-    "timestamp_sha256",
-    "merkle_leaf_count",
-    "phase3_version",
-    "phase3_1_version",
-    "phase3_2_version",
-    "bundle_tool_name",
-    "bundle_tool_version",
-}
-
-
-def _sha256_hexdigest(path: Path) -> str:
-    hasher = hashlib.sha256()
-    with path.open("rb") as handle:
-        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
-            hasher.update(chunk)
-    return hasher.hexdigest()
-
-
-def _load_merkle_leaf_count(roots_path: Path) -> int:
-    roots_payload = json.loads(roots_path.read_text(encoding="utf-8"))
-    if not isinstance(roots_payload, dict):
-        raise ValueError(f"{EXPECTED_ROOTS_FILENAME} must be a JSON object")
-
-    global_block = roots_payload.get("global")
-    if not isinstance(global_block, dict):
-        raise ValueError(f"{EXPECTED_ROOTS_FILENAME} missing object field: global")
-
-    leaf_count = global_block.get("leaf_count")
-    if type(leaf_count) is not int or leaf_count < 0:
-        raise ValueError(f"{EXPECTED_ROOTS_FILENAME}.global.leaf_count must be a non-negative integer")
-    return leaf_count
-
-
-def _require_string_field(manifest: dict[str, object], field: str) -> str:
-    value = manifest.get(field)
-    if not isinstance(value, str) or not value.strip():
-        raise ValueError(f"{field} must be a non-empty string")
-    return value
-
-
-def _require_hex_digest(manifest: dict[str, object], field: str) -> str:
-    value = _require_string_field(manifest, field)
-    if HEX64_RE.fullmatch(value) is None:
-        raise ValueError(f"{field} must be 64 lowercase hex characters")
-    return value
-
-
-def _validate_manifest_structure(manifest: dict[str, object]) -> None:
-    keys = set(manifest)
-    missing = sorted(REQUIRED_FIELDS - keys)
-    if missing:
-        raise ValueError(f"missing required field(s): {', '.join(missing)}")
-    unexpected = sorted(keys - REQUIRED_FIELDS)
-    if unexpected:
-        raise ValueError(f"unexpected field(s): {', '.join(unexpected)}")
-
-    if manifest["bundle_version"] != BUNDLE_VERSION:
-        raise ValueError(f"bundle_version must be {BUNDLE_VERSION!r}")
-    if manifest["hash_algorithm"] != HASH_ALGORITHM:
-        raise ValueError(f"hash_algorithm must be {HASH_ALGORITHM!r}")
-
-    if manifest["roots_path"] != EXPECTED_ROOTS_FILENAME:
-        raise ValueError(f"roots_path must be {EXPECTED_ROOTS_FILENAME!r}")
-    if manifest["hash_manifest_path"] != EXPECTED_HASH_MANIFEST_FILENAME:
-        raise ValueError(f"hash_manifest_path must be {EXPECTED_HASH_MANIFEST_FILENAME!r}")
-    if manifest["hash_summary_path"] != EXPECTED_HASH_SUMMARY_FILENAME:
-        raise ValueError(f"hash_summary_path must be {EXPECTED_HASH_SUMMARY_FILENAME!r}")
-    if manifest["signature_path"] != EXPECTED_SIGNATURE_FILENAME:
-        raise ValueError(f"signature_path must be {EXPECTED_SIGNATURE_FILENAME!r}")
-
-    timestamp_target = manifest["timestamp_target"]
-    if timestamp_target not in TIMESTAMP_FILENAME_BY_TARGET:
-        raise ValueError("timestamp_target must be 'roots' or 'signature'")
-    expected_timestamp_path = TIMESTAMP_FILENAME_BY_TARGET[str(timestamp_target)]
-    if manifest["timestamp_path"] != expected_timestamp_path:
-        raise ValueError(f"timestamp_path must be {expected_timestamp_path!r} for timestamp_target={timestamp_target!r}")
-
-    _require_hex_digest(manifest, "roots_sha256")
-    _require_hex_digest(manifest, "hash_manifest_sha256")
-    _require_hex_digest(manifest, "hash_summary_sha256")
-    _require_hex_digest(manifest, "signature_sha256")
-    _require_hex_digest(manifest, "timestamp_sha256")
-
-    merkle_leaf_count = manifest["merkle_leaf_count"]
-    if type(merkle_leaf_count) is not int or merkle_leaf_count < 0:
-        raise ValueError("merkle_leaf_count must be a non-negative integer")
-
-    _require_string_field(manifest, "phase3_version")
-    _require_string_field(manifest, "phase3_1_version")
-    _require_string_field(manifest, "phase3_2_version")
-    _require_string_field(manifest, "bundle_tool_name")
-    _require_string_field(manifest, "bundle_tool_version")
 
 
 def main() -> int:
@@ -154,7 +42,7 @@ def main() -> int:
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
         if not isinstance(manifest, dict):
             raise ValueError("manifest must be a JSON object")
-        _validate_manifest_structure(manifest)
+        validate_manifest_structure(manifest, strict=True)
     except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
         print(f"Malformed manifest: {exc}")
         return EXIT_BUNDLE_MALFORMED
@@ -170,17 +58,40 @@ def main() -> int:
     try:
         for path_field, digest_field in digest_fields:
             artifact_path = bundle_dir / str(manifest[path_field])
-            computed = _sha256_hexdigest(artifact_path)
+            computed = sha256_hexdigest(artifact_path)
             expected = str(manifest[digest_field])
             if computed != expected:
                 print(f"Verification failed: digest mismatch for {path_field}")
                 return EXIT_BUNDLE_VERIFY_FAILURE
 
         roots_path = bundle_dir / str(manifest["roots_path"])
-        actual_leaf_count = _load_merkle_leaf_count(roots_path)
+        actual_leaf_count = load_merkle_leaf_count(roots_path)
         if actual_leaf_count != int(manifest["merkle_leaf_count"]):
             print("Verification failed: merkle_leaf_count mismatch")
             return EXIT_BUNDLE_VERIFY_FAILURE
+
+        if "bundle_root_sha256" in manifest:
+            computed_root = compute_bundle_root_sha256(manifest)
+            expected_root = str(manifest["bundle_root_sha256"])
+            if computed_root != expected_root:
+                print("Verification failed: bundle_root_sha256 mismatch")
+                return EXIT_BUNDLE_VERIFY_FAILURE
+
+        notarization_block = manifest.get("notarization")
+        if isinstance(notarization_block, dict):
+            rfc3161 = notarization_block.get("rfc3161")
+            if isinstance(rfc3161, dict):
+                timestamp_path = bundle_dir / str(rfc3161["timestamp_path"])
+                if sha256_hexdigest(timestamp_path) != str(rfc3161["timestamp_sha256"]):
+                    print("Verification failed: digest mismatch for notarization.rfc3161.timestamp_path")
+                    return EXIT_BUNDLE_VERIFY_FAILURE
+
+            sigstore = notarization_block.get("sigstore")
+            if isinstance(sigstore, dict):
+                bundle_path = bundle_dir / str(sigstore["bundle_path"])
+                if sha256_hexdigest(bundle_path) != str(sigstore["bundle_sha256"]):
+                    print("Verification failed: digest mismatch for notarization.sigstore.bundle_path")
+                    return EXIT_BUNDLE_VERIFY_FAILURE
 
         print("Evidence bundle manifest valid")
         return 0


### PR DESCRIPTION
## Summary
This PR implements Phase 3.4 bundle root anchoring and optional notarization support on top of the merged Phase 3.3 baseline (`main` @ #1012). It adds deterministic bundle-root computation, optional verification hooks for anchored/notarized bundles, schema updates, documentation updates, dedicated tests, and a lightweight CI determinism gate for the new behavior.

## Problem
Phase 3.3 produced a portable evidence bundle manifest with strict digest checks, but there was no single stable digest that represented the full bundle for external timestamping/signing/ledger anchoring workflows. That limited portability for downstream compliance and external attestation pipelines.

## Root Cause
The existing manifest format verified each artifact independently but did not define:
- a canonical projection for whole-bundle anchoring,
- a byte-level preimage contract for deterministic root computation,
- optional notarization fields bound to that root.

## What Changed
- Added `tools/compute_bundle_root.py` with explicit exit codes (`21/22/23`) and strict-mode manifest validation.
- Added `tools/bundle_root_common.py` to centralize:
  - strict manifest structure validation,
  - canonical root projection and preimage serialization,
  - deterministic bundle-root SHA-256 computation,
  - notarization shape validation.
- Extended `tools/verify_evidence_bundle_manifest.py` to:
  - validate optional `bundle_root_*` fields,
  - recompute and verify `bundle_root_sha256` when present,
  - verify optional notarization artifact digests for `rfc3161` and `sigstore` blocks.
- Updated `docs/archive/schemas/evidence_bundle_manifest.schema.json`:
  - added optional `bundle_root_*` fields,
  - added optional strict `notarization` sub-objects,
  - enforced root-field co-presence via `dependentRequired`.
- Updated `docs/archive/ARCHIVE_MANIFEST_PHASE3_EVIDENCE_BUNDLE.md` with the Phase 3.4 normative preimage specification, CLI usage, and updated verification semantics.
- Added `tests/test_bundle_root.py` covering determinism, relocation invariance, mismatch detection, notarization digest enforcement, strictness, and stale-root mismatch handling.
- Added `Bundle root determinism gate` step to `.github/workflows/determinism-gate.yml`.

## User Impact
Users can now compute and persist a deterministic bundle root digest from existing Phase 3.3 manifests, externally anchor that root, and optionally include notarization artifacts that the verifier enforces by digest.

## Validation
- `python3 -m pytest -q tests/test_bundle_root.py tests/test_evidence_bundle_manifest_cli.py`

All tests in these targeted suites passed locally (20 passed).
