### PR TITLE
[codex] phase3.7: add MetadataExtractionService ingest orchestration layer

### DIFF
--- a/src/transformation_portal/ingest/__init__.py
+++ b/src/transformation_portal/ingest/__init__.py
@@ -41,6 +41,14 @@ __all__ = [
     "capture_provenance",
     "write_sidecar",
     "load_sidecar",
+    "MetadataExtractionService",
+    "ExtractRequest",
+    "ExtractResult",
+    "ValidateRequest",
+    "ValidateResult",
+    "BatchExtractRequest",
+    "BatchItemResult",
+    "BatchExtractResult",
 ]
 
 
@@ -150,4 +158,36 @@ def __getattr__(name: str):
         from .sidecar import load_sidecar
 
         return load_sidecar
+    elif name == "MetadataExtractionService":
+        from .metadata_service import MetadataExtractionService
+
+        return MetadataExtractionService
+    elif name == "ExtractRequest":
+        from .metadata_service import ExtractRequest
+
+        return ExtractRequest
+    elif name == "ExtractResult":
+        from .metadata_service import ExtractResult
+
+        return ExtractResult
+    elif name == "ValidateRequest":
+        from .metadata_service import ValidateRequest
+
+        return ValidateRequest
+    elif name == "ValidateResult":
+        from .metadata_service import ValidateResult
+
+        return ValidateResult
+    elif name == "BatchExtractRequest":
+        from .metadata_service import BatchExtractRequest
+
+        return BatchExtractRequest
+    elif name == "BatchItemResult":
+        from .metadata_service import BatchItemResult
+
+        return BatchItemResult
+    elif name == "BatchExtractResult":
+        from .metadata_service import BatchExtractResult
+
+        return BatchExtractResult
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/transformation_portal/ingest/metadata_service.py
+++ b/src/transformation_portal/ingest/metadata_service.py
@@ -1,0 +1,238 @@
+"""Ingest orchestration service for provenance extraction and validation."""
+
+from __future__ import annotations
+
+import time
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Sequence
+
+from .errors import IngestError, IngestExitCode, OtherIngestFailure, aggregate_errors
+from .provenance import capture_provenance
+from .sidecar import write_sidecar
+from .validator import validate_schema_errors
+
+
+@dataclass(frozen=True)
+class ExtractRequest:
+    input_path: Path
+    output_path: Optional[Path] = None
+    output_dir: Optional[Path] = None
+    preset: Optional[str] = None
+    cli_args: Sequence[str] = ()
+    config_dict: Optional[Dict[str, Any]] = None
+    fsync: bool = False
+
+
+@dataclass(frozen=True)
+class ExtractResult:
+    path: Path
+    success: bool
+    output_path: Optional[Path]
+    elapsed_seconds: float
+    error: Optional[IngestError] = None
+
+
+@dataclass(frozen=True)
+class ValidateRequest:
+    sidecar_path: Path
+    schema_type: str = "provenance"
+    strict: bool = True
+
+
+@dataclass(frozen=True)
+class ValidateResult:
+    success: bool
+    errors: List[IngestError]
+    dominant_error: Optional[IngestError]
+
+
+@dataclass(frozen=True)
+class BatchExtractRequest:
+    input_paths: Sequence[Path]
+    output_dir: Path
+    preset: Optional[str] = None
+    cli_args: Sequence[str] = ()
+    config_dict: Optional[Dict[str, Any]] = None
+    fsync: bool = False
+    deterministic_order: bool = True
+
+
+@dataclass(frozen=True)
+class BatchItemResult:
+    path: Path
+    success: bool
+    output_path: Optional[Path]
+    elapsed_seconds: float
+    error: Optional[IngestError] = None
+
+
+@dataclass(frozen=True)
+class BatchExtractResult:
+    items: List[BatchItemResult]
+    total_elapsed: float
+    summary_counts: Dict[str, Any]
+    dominant_error: Optional[IngestError]
+
+    @property
+    def success(self) -> bool:
+        return self.dominant_error is None
+
+
+class MetadataExtractionService:
+    """Canonical ingest orchestration API for extraction and validation."""
+
+    def __init__(
+        self,
+        *,
+        capture_provenance_fn: Callable[..., Any] = capture_provenance,
+        write_sidecar_fn: Callable[..., Any] = write_sidecar,
+        validate_schema_errors_fn: Callable[..., List[IngestError]] = validate_schema_errors,
+        clock_fn: Callable[[], float] = time.perf_counter,
+    ) -> None:
+        self._capture_provenance = capture_provenance_fn
+        self._write_sidecar = write_sidecar_fn
+        self._validate_schema_errors = validate_schema_errors_fn
+        self._clock = clock_fn
+
+    def extract(self, req: ExtractRequest) -> ExtractResult:
+        """Extract provenance for a single input and write sidecar."""
+        start = self._clock()
+        try:
+            if not req.input_path.exists():
+                error = OtherIngestFailure(f"Input not found: {req.input_path}")
+                return ExtractResult(
+                    path=req.input_path,
+                    success=False,
+                    output_path=None,
+                    elapsed_seconds=self._clock() - start,
+                    error=error,
+                )
+
+            output_path = self._derive_output_path(req)
+            config_dict = req.config_dict if req.config_dict is not None else {"mode": "metadata_service", "phase": "3.7"}
+
+            sidecar = self._capture_provenance(
+                input_path=req.input_path,
+                cli_args=list(req.cli_args),
+                config_dict=config_dict,
+                preset=req.preset,
+            )
+            self._write_sidecar(sidecar, output_path, fsync=req.fsync)
+
+            return ExtractResult(
+                path=req.input_path,
+                success=True,
+                output_path=output_path,
+                elapsed_seconds=self._clock() - start,
+            )
+        except IngestError as error:
+            return ExtractResult(
+                path=req.input_path,
+                success=False,
+                output_path=None,
+                elapsed_seconds=self._clock() - start,
+                error=error,
+            )
+        except Exception as exc:  # noqa: BLE001 - service API returns typed failures
+            error = OtherIngestFailure(str(exc))
+            return ExtractResult(
+                path=req.input_path,
+                success=False,
+                output_path=None,
+                elapsed_seconds=self._clock() - start,
+                error=error,
+            )
+
+    def validate(self, req: ValidateRequest) -> ValidateResult:
+        """Validate a sidecar against the configured schema type."""
+        try:
+            errors = self._validate_schema_errors(
+                data=req.sidecar_path,
+                schema_type=req.schema_type,
+                strict_mode=req.strict,
+            )
+            dominant_error = aggregate_errors(errors)
+            return ValidateResult(success=dominant_error is None, errors=errors, dominant_error=dominant_error)
+        except IngestError as error:
+            return ValidateResult(success=False, errors=[error], dominant_error=error)
+        except Exception as exc:  # noqa: BLE001 - service API returns typed failures
+            error = OtherIngestFailure(str(exc))
+            return ValidateResult(success=False, errors=[error], dominant_error=error)
+
+    def batch_extract(self, req: BatchExtractRequest) -> BatchExtractResult:
+        """Run extract for each file and aggregate typed outcomes."""
+        start = self._clock()
+        paths = list(req.input_paths)
+        if req.deterministic_order:
+            paths = sorted(paths, key=lambda path: str(path))
+
+        items: List[BatchItemResult] = []
+        errors: List[IngestError] = []
+        by_exit = Counter()
+        success_count = 0
+        failure_count = 0
+
+        default_batch_config = {"mode": "batch_extraction", "phase": "3.7"}
+        config_dict = req.config_dict if req.config_dict is not None else default_batch_config
+
+        for path in paths:
+            result = self.extract(
+                ExtractRequest(
+                    input_path=path,
+                    output_dir=req.output_dir,
+                    preset=req.preset,
+                    cli_args=req.cli_args,
+                    config_dict=config_dict,
+                    fsync=req.fsync,
+                )
+            )
+            item = BatchItemResult(
+                path=result.path,
+                success=result.success,
+                output_path=result.output_path,
+                elapsed_seconds=result.elapsed_seconds,
+                error=result.error,
+            )
+            items.append(item)
+
+            if item.success:
+                success_count += 1
+                continue
+
+            failure_count += 1
+            if item.error is not None:
+                errors.append(item.error)
+                by_exit[item.error.exit_code] += 1
+            else:
+                by_exit[IngestExitCode.OTHER_FAILURE] += 1
+
+        dominant_error = aggregate_errors(errors)
+        summary = {
+            "total": len(items),
+            "success": success_count,
+            "failure": failure_count,
+            "by_exit_code": {
+                code.name: by_exit.get(code, 0)
+                for code in sorted(IngestExitCode, key=lambda code: code.value)
+                if code != IngestExitCode.SUCCESS
+            },
+        }
+        return BatchExtractResult(
+            items=items,
+            total_elapsed=self._clock() - start,
+            summary_counts=summary,
+            dominant_error=dominant_error,
+        )
+
+    def _derive_output_path(self, req: ExtractRequest) -> Path:
+        if req.output_path is not None:
+            return req.output_path
+
+        stem_name = f"{req.input_path.stem}.provenance.json"
+        if req.output_dir is not None:
+            req.output_dir.mkdir(parents=True, exist_ok=True)
+            return req.output_dir / stem_name
+
+        return req.input_path.with_name(stem_name)

--- a/tests/ingest/test_metadata_service.py
+++ b/tests/ingest/test_metadata_service.py
@@ -1,0 +1,185 @@
+"""Unit tests for ingest MetadataExtractionService orchestration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from transformation_portal.ingest.errors import (
+    BitDepthViolation,
+    IngestExitCode,
+    OtherIngestFailure,
+    SchemaDriftFailure,
+    SchemaValidationFailure,
+)
+from transformation_portal.ingest.metadata_service import (
+    BatchExtractRequest,
+    ExtractRequest,
+    ExtractResult,
+    MetadataExtractionService,
+    ValidateRequest,
+)
+
+
+def _clock() -> float:
+    return 100.0
+
+
+def test_batch_extract_delegates_per_file_to_extract(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    input_paths = [tmp_path / "b.cr2", tmp_path / "a.cr2", tmp_path / "c.cr2"]
+    for path in input_paths:
+        path.touch()
+
+    service = MetadataExtractionService(clock_fn=_clock)
+    calls: list[ExtractRequest] = []
+
+    def spy_extract(req: ExtractRequest) -> ExtractResult:
+        calls.append(req)
+        return ExtractResult(
+            path=req.input_path,
+            success=True,
+            output_path=req.output_dir / f"{req.input_path.stem}.provenance.json" if req.output_dir else None,
+            elapsed_seconds=0.1,
+        )
+
+    monkeypatch.setattr(service, "extract", spy_extract)
+
+    result = service.batch_extract(BatchExtractRequest(input_paths=input_paths, output_dir=tmp_path))
+
+    assert len(calls) == len(input_paths)
+    assert [call.input_path for call in calls] == sorted(input_paths, key=lambda path: str(path))
+    assert result.success
+
+
+def test_batch_extract_uses_priority_to_choose_dominant_error(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    input_paths = [tmp_path / "one.tif", tmp_path / "two.tif", tmp_path / "three.tif"]
+    for path in input_paths:
+        path.touch()
+
+    error_by_name = {
+        "one.tif": OtherIngestFailure("fallback failure"),
+        "two.tif": SchemaValidationFailure("schema failure"),
+        "three.tif": SchemaDriftFailure("drift failure"),
+    }
+
+    service = MetadataExtractionService(clock_fn=_clock)
+
+    def spy_extract(req: ExtractRequest) -> ExtractResult:
+        error = error_by_name[req.input_path.name]
+        return ExtractResult(
+            path=req.input_path,
+            success=False,
+            output_path=None,
+            elapsed_seconds=0.2,
+            error=error,
+        )
+
+    monkeypatch.setattr(service, "extract", spy_extract)
+
+    result = service.batch_extract(
+        BatchExtractRequest(input_paths=input_paths, output_dir=tmp_path, deterministic_order=False)
+    )
+
+    assert not result.success
+    assert isinstance(result.dominant_error, SchemaDriftFailure)
+
+
+def test_batch_extract_summary_counts_are_stable(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    input_paths = [tmp_path / "a.cr2", tmp_path / "b.cr2", tmp_path / "c.cr2", tmp_path / "d.cr2"]
+    for path in input_paths:
+        path.touch()
+
+    response_by_name = {
+        "a.cr2": ExtractResult(
+            path=input_paths[0], success=True, output_path=tmp_path / "a.provenance.json", elapsed_seconds=0.1
+        ),
+        "b.cr2": ExtractResult(
+            path=input_paths[1],
+            success=False,
+            output_path=None,
+            elapsed_seconds=0.1,
+            error=BitDepthViolation("8-bit violation"),
+        ),
+        "c.cr2": ExtractResult(
+            path=input_paths[2],
+            success=False,
+            output_path=None,
+            elapsed_seconds=0.1,
+            error=OtherIngestFailure("other failure"),
+        ),
+        "d.cr2": ExtractResult(
+            path=input_paths[3], success=True, output_path=tmp_path / "d.provenance.json", elapsed_seconds=0.1
+        ),
+    }
+
+    service = MetadataExtractionService(clock_fn=_clock)
+
+    def spy_extract(req: ExtractRequest) -> ExtractResult:
+        return response_by_name[req.input_path.name]
+
+    monkeypatch.setattr(service, "extract", spy_extract)
+
+    result = service.batch_extract(BatchExtractRequest(input_paths=input_paths, output_dir=tmp_path))
+
+    expected_exit_keys = [code.name for code in IngestExitCode if code != IngestExitCode.SUCCESS]
+    assert list(result.summary_counts["by_exit_code"].keys()) == expected_exit_keys
+    assert result.summary_counts["total"] == 4
+    assert result.summary_counts["success"] == 2
+    assert result.summary_counts["failure"] == 2
+    assert result.summary_counts["by_exit_code"]["BIT_DEPTH_VIOLATION"] == 1
+    assert result.summary_counts["by_exit_code"]["OTHER_FAILURE"] == 1
+
+
+def test_extract_wraps_unknown_exception_as_other_ingest_failure(tmp_path: Path) -> None:
+    input_path = tmp_path / "input.cr2"
+    input_path.touch()
+
+    def capture_raises(**_: object) -> object:
+        raise RuntimeError("boom")
+
+    service = MetadataExtractionService(
+        capture_provenance_fn=capture_raises,
+        write_sidecar_fn=lambda *_args, **_kwargs: None,
+        clock_fn=_clock,
+    )
+
+    result = service.extract(ExtractRequest(input_path=input_path, output_dir=tmp_path))
+
+    assert not result.success
+    assert result.error is not None
+    assert isinstance(result.error, OtherIngestFailure)
+    assert "boom" in str(result.error)
+
+
+def test_batch_extract_sorts_items_when_deterministic_order_enabled(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    input_paths = [tmp_path / "z.cr2", tmp_path / "a.cr2", tmp_path / "m.cr2"]
+    for path in input_paths:
+        path.touch()
+
+    service = MetadataExtractionService(clock_fn=_clock)
+
+    def spy_extract(req: ExtractRequest) -> ExtractResult:
+        return ExtractResult(
+            path=req.input_path,
+            success=True,
+            output_path=req.output_dir / f"{req.input_path.stem}.provenance.json" if req.output_dir else None,
+            elapsed_seconds=0.0,
+        )
+
+    monkeypatch.setattr(service, "extract", spy_extract)
+
+    result = service.batch_extract(BatchExtractRequest(input_paths=input_paths, output_dir=tmp_path, deterministic_order=True))
+
+    assert [item.path for item in result.items] == sorted(input_paths, key=lambda path: str(path))
+
+
+def test_validate_returns_typed_result_with_aggregated_dominance() -> None:
+    expected_errors = [SchemaValidationFailure("schema issue"), SchemaDriftFailure("drift issue")]
+    service = MetadataExtractionService(validate_schema_errors_fn=lambda **_: expected_errors, clock_fn=_clock)
+
+    result = service.validate(ValidateRequest(sidecar_path=Path("/tmp/sidecar.json")))
+
+    assert not result.success
+    assert result.errors == expected_errors
+    assert isinstance(result.dominant_error, SchemaDriftFailure)


### PR DESCRIPTION
## Summary
This PR introduces the Phase 2 ingest orchestration layer by adding `MetadataExtractionService` as the canonical programmatic API for metadata extraction and validation workflows. It centralizes ingest orchestration in the ingest package so downstream adapters can call a single service contract instead of re-implementing extraction and batch policy logic.

## Problem
Before this change, ingest had core primitives (`capture_provenance`, `write_sidecar`, schema validation, typed errors) but no dedicated service-layer API to orchestrate single-file extraction, validation, and batch execution with consistent result models. That made adapter code (including future CLI integration) responsible for orchestration concerns and increased the risk of duplicated logic and drift in error handling.

## Root Cause
The ingest package lacked an orchestration boundary that:
- standardized request/response shapes for extract/validate/batch operations,
- delegated batch execution through a single-file extraction path,
- consistently aggregated typed ingest errors via ingest-domain priority rules.

## Fix
This PR adds:
- `src/transformation_portal/ingest/metadata_service.py`
  - Frozen request/result dataclasses for `extract`, `validate`, and `batch_extract`.
  - `MetadataExtractionService.extract()` to perform existence checks, provenance capture, and sidecar writing with typed error wrapping.
  - `MetadataExtractionService.validate()` to run typed schema validation and compute dominant error via `aggregate_errors()`.
  - `MetadataExtractionService.batch_extract()` that enforces deterministic ordering by default and delegates per-file work through `self.extract()` (no direct batch calls to low-level capture/write primitives).
  - Deterministic summary accounting, including per-exit-code counts.
- `tests/ingest/test_metadata_service.py`
  - Unit coverage for batch delegation, dominant-error priority, stable summary schema/counts, unknown-exception wrapping, deterministic ordering, and validate dominance behavior.
- `src/transformation_portal/ingest/__init__.py`
  - Lazy exports for `MetadataExtractionService` and the new dataclasses.

## User Impact
Users and callers now have a stable ingest service API for:
- single-file extraction (`extract`),
- typed validation (`validate`),
- deterministic batch orchestration (`batch_extract`).

This sets up a clean Phase 3 adapter migration path without changing CLI behavior in this PR.

## Validation
I validated this change with:
- `pytest -q tests/ingest/test_metadata_service.py`
- repository pre-commit hooks executed during commit (`black`, `isort`, `flake8`-gated checks, and configured quality hooks), all passing.

## Scope / Boundary Notes
- No CLI code was modified.
- No schema contracts were changed.
- Existing transport compatibility behavior remains intact.
