### PR TITLE
feat(phase4): PR-4A contract surface schemas and governance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Phase 4 contract surfaces
-/schemas/phase4/metadata.schema.json @RC219805
+/schemas/phase4/*.schema.json @RC219805

--- a/docs/architecture/ADR-035-bundle-root-anchoring-invariants.md
+++ b/docs/architecture/ADR-035-bundle-root-anchoring-invariants.md
@@ -114,6 +114,10 @@ Phase 4 introduces additive, versioned contracts for capture provenance:
 - `tp.meta.provenance.v1` at `schemas/phase4/provenance_manifest.schema.json`
 - `tp.meta.provenance_merkle.v1` at `schemas/phase4/provenance_merkle.schema.json`
 
+The authoritative machine-readable Phase 4 contract location is
+`schemas/phase4/`. Documentation references under `docs/` are informative and
+must not be treated as canonical schema sources.
+
 These additions MUST NOT mutate Phase 3 artifact schemas or silently extend
 Evidence Bundle v1. Any incompatible contract change requires an explicit
 version bump and corresponding ADR update.

--- a/schemas/phase4/metadata.schema.json
+++ b/schemas/phase4/metadata.schema.json
@@ -32,8 +32,14 @@
       "type": "string",
       "minLength": 1,
       "maxLength": 4096,
-      "description": "Normalized relative path. Must use forward slashes, must not contain '..' segments, and must not begin with './'.",
+      "description": "Normalized relative path. Must be relative (not absolute or drive-qualified), must use forward slashes, must not contain '..' segments, and must not begin with './'.",
       "allOf": [
+        {
+          "pattern": "^(?!/).+"
+        },
+        {
+          "pattern": "^(?![A-Za-z]:[\\\\/]).+"
+        },
         {
           "pattern": "^(?!\\./).+"
         },

--- a/schemas/phase4/metadata_manifest.schema.json
+++ b/schemas/phase4/metadata_manifest.schema.json
@@ -22,6 +22,7 @@
     "entries": {
       "type": "array",
       "description": "Sorted by relative_path (generator responsibility).",
+      "minItems": 1,
       "items": {
         "type": "object",
         "additionalProperties": false,
@@ -34,7 +35,9 @@
           "relative_path": {
             "type": "string",
             "minLength": 1,
-            "maxLength": 4096
+            "maxLength": 4096,
+            "description": "Normalized, forward-slash-only relative path (no leading '/', no drive prefix, no backslashes, no '..' segments, no leading './').",
+            "pattern": "^(?!/)(?![A-Za-z]:[\\\\/])(?!\\./)(?!.*\\\\)(?!.*(^|/)\\.\\.(?:/|$)).+$"
           },
           "file_sha256": {
             "type": "string",

--- a/schemas/phase4/provenance_manifest.schema.json
+++ b/schemas/phase4/provenance_manifest.schema.json
@@ -22,6 +22,7 @@
     "entries": {
       "type": "array",
       "description": "Sorted by relative_path (generator responsibility).",
+      "minItems": 1,
       "items": {
         "type": "object",
         "additionalProperties": false,
@@ -35,7 +36,9 @@
           "relative_path": {
             "type": "string",
             "minLength": 1,
-            "maxLength": 4096
+            "maxLength": 4096,
+            "description": "Normalized, forward-slash-only relative path (no leading '/', no drive prefix, no backslashes, no '..' segments, no leading './').",
+            "pattern": "^(?!/)(?![A-Za-z]:[\\\\/])(?!\\./)(?!.*\\\\)(?!.*(^|/)\\.\\.(?:/|$)).+$"
           },
           "file_sha256": {
             "type": "string",

--- a/schemas/phase4/provenance_merkle.schema.json
+++ b/schemas/phase4/provenance_merkle.schema.json
@@ -22,6 +22,7 @@
     },
     "leaf_count": {
       "type": "integer",
+      "description": "Leaf count for sorted provenance entries. v1 assumes non-empty manifests and therefore requires at least one leaf.",
       "minimum": 1
     },
     "provenance_merkle_root": {


### PR DESCRIPTION
## Summary
- add Phase 4 contract schemas under `schemas/phase4/`:
  - `metadata.schema.json` (`tp.meta.capture.v1`)
  - `metadata_manifest.schema.json` (`tp.meta.capture_manifest.v1`)
  - `provenance_manifest.schema.json` (`tp.meta.provenance.v1`)
  - `provenance_merkle.schema.json` (`tp.meta.provenance_merkle.v1`)
- add CODEOWNERS governance entry for the Phase 4 metadata contract schema
- update ADR-035 with a Phase 4 addendum that freezes additive/versioned contract-surface rules and hash-convention governance

## Notes
- strict Draft 2020-12 schemas with `additionalProperties: false`
- deterministic ordering expectations remain generator/verifier invariants (documented in schema descriptions)
- this PR is contract/governance only; implementation and verifier wiring will follow in subsequent PRs
