### PR TITLE
security(deps): remediate starlette CVEs by upgrading fastapi lock chain

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     # Web stack ranges are intentionally bounded here.
     # Exact versions are enforced in requirements/base.in and compiled lockfiles.
     "fastapi>=0.120.0,<0.121",
+    "starlette>=0.47.2,<0.49",  # direct runtime import + patched multipart handling
     "uvicorn>=0.29.0,<0.30",
     "aiofiles>=23.2.1,<24",
     "tifffile>=2023.7.18,<2027",

--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -401,7 +401,9 @@ shellingham==1.5.4
 sortedcontainers==2.4.0
     # via hypothesis
 starlette==0.47.2
-    # via fastapi
+    # via
+    #   -r base.in
+    #   fastapi
 stevedore==5.6.0
     # via bandit
 sympy==1.14.0

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -16,6 +16,7 @@ tqdm>=4.66,<5              # progress bar utility
 # Web orchestration service stack (exact pins for API/UI parity)
 # Security: bump fastapi so resolver can use non-vulnerable Starlette (>=0.47.2)
 fastapi==0.120.0           # orchestrator API framework (security-patched dependency chain)
+starlette==0.47.2          # direct runtime import + security pin (CVE remediation)
 uvicorn==0.29.0            # ASGI server runtime pin
 aiofiles==23.2.1           # async file I/O support for FastAPI file responses
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -126,6 +126,7 @@ shellingham==1.5.4
 starlette==0.47.2
     # via
     #   -c all.txt
+    #   -r base.in
     #   fastapi
 threadpoolctl==3.6.0
     # via


### PR DESCRIPTION
Root cause fixed in code/deps.

**Root cause**
- `pip-audit -r requirements-ci.txt` failed because CI pulled `starlette==0.36.3` via `fastapi==0.110.0`, and that Starlette version is vulnerable (CVE-2024-47874, CVE-2025-54121).

**What I changed**
- Updated FastAPI pin to allow patched Starlette chain:
  - [requirements/base.in](/Users/rc/Projects/Transformation_Portal/requirements/base.in)
  - `fastapi==0.120.0`
- Synced package metadata range:
  - [pyproject.toml](/Users/rc/Projects/Transformation_Portal/pyproject.toml)
  - `fastapi>=0.120.0,<0.121`
- Updated lockfiles to patched Starlette:
  - [requirements/base.txt](/Users/rc/Projects/Transformation_Portal/requirements/base.txt)
  - [requirements/all.txt](/Users/rc/Projects/Transformation_Portal/requirements/all.txt)
  - `starlette==0.47.2` and `fastapi==0.120.0`

**Validation run locally**
- `bash scripts/validate_dependency_constraints.sh --verbose` ✅
- `.venv/bin/python -m pytest -q tests/test_app_orchestrator_runtime.py` ✅ (`16 passed`)