### PR TITLE
[codex] truth-sync frontdoor validation docs

### DIFF
--- a/docs/architecture/DNA_UX_UI_STRATEGY_REBASELINE_2026-04-08.md
+++ b/docs/architecture/DNA_UX_UI_STRATEGY_REBASELINE_2026-04-08.md
@@ -319,16 +319,22 @@ still pending:
   active implementation record for the UX tranche instead of opening a new
   frontdoor roadmap phase.
 - The local verification baseline on April 9, 2026 is:
-  - `make test-frontdoor-contract` passes locally under Node `22.22.2`;
-  - `make test-portal-contract` passes locally;
-  - live frontdoor browser validation still depends on a managed frontdoor
-    instance running with the expected local smoke credentials;
-  - live portal browser validation still depends on a backend instance that
-    accepts the configured `TP_API_KEY` for `/v1/config-preview`.
+  - `.venv/bin/python -m pytest -q tests/test_app_orchestrator_runtime.py tests/validation/test_portal_smoke_scripts.py`
+    passed in this workspace (`180 passed in 1.99s`);
+  - `.venv/bin/python scripts/validation/validate_portal_browser_smoke.py --spawn-local-backend --api-key contract-secret`
+    passed in this workspace;
+  - `make test-frontdoor-contract` passed after switching the frontdoor toolchain
+    to Node `22.22.2` and rebuilding native modules for that runtime;
+  - `make validate-frontdoor-browser` passed under the same Node `22.22.2`
+    environment;
+  - the default workspace runtime still resolves to Node `25.9.0`, so
+    frontdoor contract/build/browser commands must continue to switch to
+    Node `22.x` before validation.
 
-Phase 2B is now closed out. Phase 3 implementation is landed, and the only
-remaining close-out work is green live browser validation against known-good
-local managed frontdoor and backend instances.
+Phase 2B is now closed out. Phase 3 implementation and validation close-out
+are complete, and no open UX validation gate remains beyond rerunning the same
+contract/browser checks when homepage, login, portal, or managed frontdoor
+behavior changes.
 
 ### Phase 1: Accessibility and Token Alignment (Completed April 8, 2026)
 
@@ -372,7 +378,7 @@ Acceptance focus:
 Status:
 - Completed on April 8, 2026.
 
-### Phase 3: Cross-surface Visual Continuity (Validation Close-out April 9, 2026)
+### Phase 3: Cross-surface Visual Continuity (Completed April 9, 2026)
 
 Scope:
 - Harmonize CTA emphasis, empty/loading/error states, and premium polish across
@@ -398,8 +404,10 @@ Acceptance focus:
   environment.
 
 Status:
-- Implementation landed on April 9, 2026; completion remains gated on green
-  live browser validation for both frontdoor and portal.
+- Implementation and validation close-out completed on April 9, 2026. Portal
+  contract/runtime coverage, live portal browser smoke, frontdoor
+  contract/build verification, and live managed frontdoor browser smoke are
+  green when frontdoor commands run under Node `22.22.2`.
 
 ### Phase 4: Power-user Enhancements (Deferred)
 
@@ -465,25 +473,30 @@ The revised strategy is complete only if all of the following remain true:
 - Future-state items are clearly labeled as gated rather than implied defaults.
 - Desktop, mobile, keyboard-only, reduced-motion, and managed-login flows are
   explicitly covered.
+- Portal contract validation and live portal browser smoke are recorded as
+  complete rather than pending.
+- Managed frontdoor contract/build and live browser validation are recorded as
+  green when run under Node `22.x`, while unsupported runtimes remain
+  explicitly unsupported rather than treated as product regressions.
 
-Recommended validation commands for any implementation derived from this
-strategy:
+Portal truth-sync evidence already green as of April 9, 2026:
 
 ```bash
 make test-portal-contract
 make validate-portal-browser
 ```
 
-Run the frontdoor contract/browser checks only when homepage or login surfaces
-change in the same tranche:
+Managed frontdoor truth-sync evidence is also green as of April 9, 2026 when
+run under Node `22.22.2`:
 
 ```bash
 make test-frontdoor-contract
 make validate-frontdoor-browser
 ```
 
-`make test-frontdoor-contract` remains Node `22.x` only because the
-frontdoor package explicitly rejects unsupported runtimes.
+`make test-frontdoor-contract` and `make validate-frontdoor-browser` remain
+Node `22.x` only because the frontdoor package explicitly rejects unsupported
+runtimes and its native modules must be built against that ABI.
 
 Run `make test-orchestrator-contract` as well only if a UX change alters
 `/v1/*`, bootstrap behavior, or upstream portal semantics rather than pure
@@ -537,8 +550,8 @@ portal presentation and state handling.
 
 ### Proposed
 
-- Phase 3 completion gate once live browser validation is rerun against
-  known-good local managed frontdoor and backend instances
+- Routine rerun of portal/frontdoor contract and browser validation whenever
+  homepage, login, portal, or managed frontdoor behavior changes
 - Optional command-palette evaluation only after earlier IA improvements land
 
 ## Source Notes and Assumptions

--- a/docs/architecture/PORTAL_FRONTDOOR_ROADMAP.md
+++ b/docs/architecture/PORTAL_FRONTDOOR_ROADMAP.md
@@ -107,7 +107,7 @@ The following slices are already shipped and should remain closed:
 
 ## Roadmap Status
 
-- Once PR `#1375` lands, no queued phases remain for this roadmap horizon.
+- With PR `#1375` implemented, no queued phases remain for this roadmap horizon.
 - The only UX-adjacent close-out lane was rerunning managed frontdoor
   contract/build/browser validation under the enforced Node `22.x` runtime.
 - That close-out lane was completed on April 9, 2026:

--- a/docs/architecture/PORTAL_FRONTDOOR_ROADMAP.md
+++ b/docs/architecture/PORTAL_FRONTDOOR_ROADMAP.md
@@ -10,8 +10,9 @@ portal/orchestrator baseline is already re-baselined in
 `docs/architecture/PORTAL_ORCHESTRATOR_ROADMAP.md`.
 
 This roadmap is intentionally narrower than a full shell rewrite. The next
-delivery horizon is production hardening over the next 3-5 PRs, with FastAPI
-and `portal.html` remaining the operator-shell system of record.
+delivery horizon has already shipped; FastAPI and `portal.html` remain the
+operator-shell system of record, and this document now serves as a status and
+validation record rather than an active feature-phase plan.
 
 ## Completed Baseline
 
@@ -107,6 +108,15 @@ The following slices are already shipped and should remain closed:
 ## Roadmap Status
 
 - Once PR `#1375` lands, no queued phases remain for this roadmap horizon.
+- The only UX-adjacent close-out lane was rerunning managed frontdoor
+  contract/build/browser validation under the enforced Node `22.x` runtime.
+- That close-out lane was completed on April 9, 2026:
+  - `make test-frontdoor-contract` passed under Node `22.22.2`;
+  - `make validate-frontdoor-browser` passed under the same Node `22.22.2`
+    environment.
+- The default local workspace runtime may still resolve to Node `25.x`; treat
+  that as an unsupported toolchain posture, not as a frontdoor product
+  regression.
 
 ## Acceptance Gates
 
@@ -120,7 +130,7 @@ The following slices are already shipped and should remain closed:
   when unsupported multi-instance or ephemeral-runtime modes are declared
 - Local `make test-frontdoor-contract` verification must run under Node 22.x;
   the frontdoor package explicitly rejects unsupported runtimes such as the
-  current local Node 25.x toolchain.
+  default local Node 25.x toolchain.
 
 ## Explicit Non-Goals For This Horizon
 

--- a/docs/guides/PORTAL_SECURE_FRONTDOOR_QUICKSTART.md
+++ b/docs/guides/PORTAL_SECURE_FRONTDOOR_QUICKSTART.md
@@ -184,8 +184,9 @@ npm rebuild better-sqlite3 argon2
 ```
 
 - Run local browser smoke against `http://localhost`, not `http://127.0.0.1`,
-  because the development front door normalizes same-origin CSRF checks to
-  `localhost`.
+  because the browser-smoke harness defaults to `http://localhost:3000` and
+  same-origin CSRF validation requires the exact origin to match, so
+  `127.0.0.1` and `localhost` are different origins.
 - Treat Node `25.x` failures as unsupported-runtime/tooling failures unless the
   same command also fails under Node `22.x`.
 
@@ -248,9 +249,9 @@ front-door instead of `--spawn-local-frontdoor`, continue to pass
 `TP_FRONTDOOR_USERNAME` and `TP_FRONTDOOR_PASSWORD` explicitly.
 
 For local managed smoke validation, use `http://localhost:3000` rather than
-`http://127.0.0.1:3000`; the development front door normalizes same-origin CSRF
-checks to `localhost`, and the browser smoke is expected to exercise that exact
-origin.
+`http://127.0.0.1:3000`; the browser smoke defaults to that origin and the
+front door's same-origin CSRF validation requires an exact origin match, so
+`127.0.0.1:3000` and `localhost:3000` are different origins.
 
 For release validation, prefer running the browser smoke against
 `TP_NEXT_DIST_DIR=.next-build-verify npm run start` after building with the

--- a/docs/guides/PORTAL_SECURE_FRONTDOOR_QUICKSTART.md
+++ b/docs/guides/PORTAL_SECURE_FRONTDOOR_QUICKSTART.md
@@ -169,9 +169,32 @@ originRequest:
 
 ## Validation
 
+Validation prerequisites for every local managed frontdoor run:
+
+- Switch the frontdoor shell to Node `22.x` first. `web/secure-landing` ships
+  `.nvmrc` with `22`, and install/test/build/start all fail fast outside that
+  runtime.
+- If the shell previously used another Node major, rebuild the native modules
+  under Node `22.x` before running frontdoor checks:
+
+```bash
+cd web/secure-landing
+nvm use 22
+npm rebuild better-sqlite3 argon2
+```
+
+- Run local browser smoke against `http://localhost`, not `http://127.0.0.1`,
+  because the development front door normalizes same-origin CSRF checks to
+  `localhost`.
+- Treat Node `25.x` failures as unsupported-runtime/tooling failures unless the
+  same command also fails under Node `22.x`.
+
 Front door checks:
 
 ```bash
+cd web/secure-landing
+nvm use 22
+cd ../..
 make test-frontdoor-contract
 ```
 
@@ -195,6 +218,9 @@ Notes:
 Browser smoke with isolated local backend + managed front door:
 
 ```bash
+cd web/secure-landing
+nvm use 22
+cd ../..
 make validate-frontdoor-browser
 ```
 
@@ -223,7 +249,8 @@ front-door instead of `--spawn-local-frontdoor`, continue to pass
 
 For local managed smoke validation, use `http://localhost:3000` rather than
 `http://127.0.0.1:3000`; the development front door normalizes same-origin CSRF
-checks to `localhost`.
+checks to `localhost`, and the browser smoke is expected to exercise that exact
+origin.
 
 For release validation, prefer running the browser smoke against
 `TP_NEXT_DIST_DIR=.next-build-verify npm run start` after building with the


### PR DESCRIPTION
## Summary
- truth-sync the DNA UX rebaseline doc to record that Phase 3 validation closed on April 9, 2026
- update the frontdoor roadmap to treat the remaining Node 22.x validation lane as completed, not pending
- document the local managed-frontdoor validation prerequisites in the secure quickstart, including Node 22.x, native module rebuilds, and localhost browser-smoke origin expectations

## Validation
- `PRE_COMMIT_HOME=/tmp/pre-commit PATH="/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin:$PATH" TP_LINT_PYTHON=/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin/python .venv/bin/pre-commit run --all-files --show-diff-on-failure`

## Risk
- docs-only change; no product behavior changes