### PR TITLE
fix(portal): fail fast raw ingest and scope review artifacts

### DIFF
--- a/app.py
+++ b/app.py
@@ -600,6 +600,15 @@ class Job:
             self.logs_tail = self.logs_tail[-limit:]
 
 
+@dataclass(frozen=True)
+class JobRunMetadata:
+    output_dir: Path
+    run_card_path: Optional[Path] = None
+    run_card_payload: Optional[Dict[str, Any]] = None
+    batch_manifest_path: Optional[Path] = None
+    batch_manifest_payload: Optional[Dict[str, Any]] = None
+
+
 JOBS: Dict[str, Job] = {}
 EVENT_SUBSCRIBERS: Dict[str, Dict[str, "asyncio.Queue[Dict[str, Any]]"]] = {}
 RATE_LIMIT_BUCKETS: Dict[str, Deque[float]] = {}
@@ -3578,9 +3587,186 @@ def _artifact_recency_key(relative_path: str, artifact_path: Path) -> Tuple[str,
     return (batch_hint, modified_time, relative_path)
 
 
+def _find_newest_artifact_path(output_dir: Path, candidates: List[Path]) -> Optional[Path]:
+    normalized_candidates: List[Tuple[str, Path]] = []
+    for candidate in candidates:
+        try:
+            resolved = Path(os.path.realpath(candidate))
+        except OSError:
+            continue
+        if not resolved.exists() or not resolved.is_file():
+            continue
+        try:
+            relative_path = str(resolved.relative_to(output_dir))
+        except ValueError:
+            continue
+        normalized_candidates.append((relative_path, resolved))
+    if not normalized_candidates:
+        return None
+    _, artifact_path = max(
+        normalized_candidates,
+        key=lambda item: _artifact_recency_key(item[0], item[1]),
+    )
+    return artifact_path
+
+
+def _resolve_artifact_path_within_output_dir(
+    output_dir: Path,
+    relative_path: str,
+) -> Optional[Tuple[str, Path]]:
+    try:
+        normalized_relative_path = _normalize_artifact_relative_path(relative_path)
+    except ArtifactPathValidationError:
+        return None
+    resolved_candidate = Path(
+        os.path.realpath(
+            output_dir / Path(*PurePosixPath(normalized_relative_path).parts),
+        )
+    )
+    try:
+        canonical_relative_path = str(resolved_candidate.relative_to(output_dir))
+    except ValueError:
+        return None
+    if not resolved_candidate.exists() or not resolved_candidate.is_file():
+        return None
+    return canonical_relative_path, resolved_candidate
+
+
+def _resolve_job_run_metadata(job: Job) -> Optional[JobRunMetadata]:
+    output_dir = _job_output_dir(job)
+    if output_dir is None:
+        return None
+    output_dir = Path(os.path.realpath(output_dir.expanduser()))
+    if not output_dir.exists() or not output_dir.is_dir():
+        return None
+
+    run_card_path = _find_newest_artifact_path(
+        output_dir,
+        list(output_dir.glob("run_card_*.json")),
+    )
+    run_card_payload = _load_bounded_json_object(run_card_path) if run_card_path is not None else None
+
+    batch_manifest_path: Optional[Path] = None
+    batch_manifest_payload: Optional[Dict[str, Any]] = None
+    batch_manifest_dir = output_dir / "manifests"
+    if run_card_payload is not None:
+        batch_id = str(run_card_payload.get("batch_id") or "").strip()
+        if batch_id:
+            matching_manifest_path = batch_manifest_dir / f"batch_{batch_id}.json"
+            if matching_manifest_path.exists() and matching_manifest_path.is_file():
+                batch_manifest_path = Path(os.path.realpath(matching_manifest_path))
+                batch_manifest_payload = _load_bounded_json_object(batch_manifest_path)
+    elif batch_manifest_dir.exists() and batch_manifest_dir.is_dir():
+        batch_manifest_path = _find_newest_artifact_path(
+            output_dir,
+            list(batch_manifest_dir.glob("batch_*.json")),
+        )
+        if batch_manifest_path is not None:
+            batch_manifest_payload = _load_bounded_json_object(batch_manifest_path)
+
+    return JobRunMetadata(
+        output_dir=output_dir,
+        run_card_path=run_card_path,
+        run_card_payload=run_card_payload,
+        batch_manifest_path=batch_manifest_path,
+        batch_manifest_payload=batch_manifest_payload,
+    )
+
+
+def _build_scoped_job_artifacts(
+    *,
+    job: Job,
+    output_dir: Path,
+    candidate_paths: List[Path],
+) -> Tuple[List[Dict[str, Any]], Dict[str, Path], bool]:
+    artifact_lookup: Dict[str, Path] = {}
+    for candidate_path in candidate_paths:
+        try:
+            resolved_path = Path(os.path.realpath(candidate_path))
+        except OSError:
+            continue
+        if not resolved_path.exists() or not resolved_path.is_file():
+            continue
+        try:
+            relative_path = str(resolved_path.relative_to(output_dir))
+        except ValueError:
+            continue
+        artifact_lookup[relative_path] = resolved_path
+
+    ordered_candidates = sorted(
+        artifact_lookup.items(),
+        key=lambda item: (item[0].casefold(), item[0]),
+    )
+    truncated = len(ordered_candidates) > MAX_INDEXED_ARTIFACTS
+    selected_candidates = ordered_candidates[:MAX_INDEXED_ARTIFACTS]
+
+    items = [
+        _serialize_indexed_artifact(
+            job_id=job.id,
+            relative_path=relative_path,
+            path=path,
+        )
+        for relative_path, path in selected_candidates
+    ]
+    return items, artifact_lookup, truncated
+
+
+def _build_scoped_job_artifacts_from_run_metadata(
+    job: Job,
+    metadata: JobRunMetadata,
+) -> Optional[Tuple[List[Dict[str, Any]], Dict[str, Path], bool]]:
+    if metadata.run_card_path is not None and metadata.run_card_payload is not None:
+        artifact_index = metadata.run_card_payload.get("artifact_index")
+        if isinstance(artifact_index, list):
+            candidate_paths: List[Path] = [metadata.run_card_path]
+            for artifact_entry in artifact_index:
+                if not isinstance(artifact_entry, dict):
+                    continue
+                artifact_relative_path = artifact_entry.get("relative_path") or artifact_entry.get("path")
+                if not isinstance(artifact_relative_path, str) or not artifact_relative_path.strip():
+                    continue
+                resolved = _resolve_artifact_path_within_output_dir(
+                    metadata.output_dir,
+                    artifact_relative_path,
+                )
+                if resolved is None:
+                    continue
+                _, resolved_path = resolved
+                candidate_paths.append(resolved_path)
+            if len(candidate_paths) > 1:
+                return _build_scoped_job_artifacts(
+                    job=job,
+                    output_dir=metadata.output_dir,
+                    candidate_paths=candidate_paths,
+                )
+
+    if metadata.batch_manifest_path is not None:
+        candidate_paths = [metadata.batch_manifest_path]
+        if metadata.run_card_path is not None:
+            candidate_paths.insert(0, metadata.run_card_path)
+        return _build_scoped_job_artifacts(
+            job=job,
+            output_dir=metadata.output_dir,
+            candidate_paths=candidate_paths,
+        )
+
+    return None
+
+
 def _find_job_artifact_path(job: Job, predicate: Callable[[str], bool]) -> Optional[Path]:
-    lookup = job.artifact_lookup or _hydrate_artifact_lookup_from_items(job)
-    candidates = [(relative_path, lookup[relative_path]) for relative_path in lookup if predicate(relative_path)]
+    metadata = _resolve_job_run_metadata(job)
+    candidates: List[Tuple[str, Path]] = []
+    if metadata is not None:
+        if metadata.run_card_path is not None:
+            relative_path = str(metadata.run_card_path.relative_to(metadata.output_dir))
+            candidates.append((relative_path, metadata.run_card_path))
+        if metadata.batch_manifest_path is not None:
+            relative_path = str(metadata.batch_manifest_path.relative_to(metadata.output_dir))
+            candidates.append((relative_path, metadata.batch_manifest_path))
+    if not candidates:
+        lookup = job.artifact_lookup or _hydrate_artifact_lookup_from_items(job)
+        candidates = [(relative_path, lookup[relative_path]) for relative_path in lookup]
+    candidates = [candidate for candidate in candidates if predicate(candidate[0])]
     if not candidates:
         return None
     _, artifact_path = max(candidates, key=lambda item: _artifact_recency_key(item[0], item[1]))
@@ -3592,28 +3778,13 @@ def _refresh_job_run_summary(job: Job) -> Dict[str, Any]:
         return {}
 
     existing_summary = dict(job.run_summary) if isinstance(job.run_summary, dict) and job.run_summary else {}
-    run_card_path = _find_job_artifact_path(
-        job,
-        lambda relative_path: PurePosixPath(relative_path).name.startswith("run_card")
-        and relative_path.lower().endswith(".json"),
-    )
+    metadata = _resolve_job_run_metadata(job)
     summary: Dict[str, Any] = {}
-    if run_card_path is not None:
-        payload = _load_bounded_json_object(run_card_path)
-        if payload is not None:
-            summary = _summarize_run_card_payload(payload)
+    if metadata is not None and metadata.run_card_payload is not None:
+        summary = _summarize_run_card_payload(metadata.run_card_payload)
 
-    if not summary:
-        batch_manifest_path = _find_job_artifact_path(
-            job,
-            lambda relative_path: PurePosixPath(relative_path).parent.as_posix() == "manifests"
-            and PurePosixPath(relative_path).name.startswith("batch_")
-            and relative_path.lower().endswith(".json"),
-        )
-        if batch_manifest_path is not None:
-            payload = _load_bounded_json_object(batch_manifest_path)
-            if payload is not None:
-                summary = _summarize_batch_manifest_payload(payload)
+    if not summary and metadata is not None and metadata.batch_manifest_payload is not None:
+        summary = _summarize_batch_manifest_payload(metadata.batch_manifest_payload)
 
     if not summary and existing_summary:
         summary = existing_summary
@@ -3758,6 +3929,20 @@ def _index_job_artifacts(job: Job) -> List[Dict[str, Any]]:
         return []
 
     output_dir = Path(os.path.realpath(output_dir.expanduser()))
+    metadata = _resolve_job_run_metadata(job)
+    if metadata is not None:
+        scoped_artifacts = _build_scoped_job_artifacts_from_run_metadata(job, metadata)
+        if scoped_artifacts is not None:
+            items, artifact_lookup, truncated = scoped_artifacts
+            job.artifacts = {
+                "output_dir": str(output_dir),
+                "items": items,
+                "indexed_count": len(items),
+                "truncated": truncated,
+            }
+            job.artifact_lookup = artifact_lookup
+            return items
+
     selected: List[tuple[tuple[str, str], str, Path]] = []
     selected_keys: List[tuple[str, str]] = []
     artifact_lookup: Dict[str, Path] = {}

--- a/app.py
+++ b/app.py
@@ -3753,26 +3753,6 @@ def _build_scoped_job_artifacts_from_run_metadata(
     return None
 
 
-def _find_job_artifact_path(job: Job, predicate: Callable[[str], bool]) -> Optional[Path]:
-    metadata = _resolve_job_run_metadata(job)
-    candidates: List[Tuple[str, Path]] = []
-    if metadata is not None:
-        if metadata.run_card_path is not None:
-            relative_path = str(metadata.run_card_path.relative_to(metadata.output_dir))
-            candidates.append((relative_path, metadata.run_card_path))
-        if metadata.batch_manifest_path is not None:
-            relative_path = str(metadata.batch_manifest_path.relative_to(metadata.output_dir))
-            candidates.append((relative_path, metadata.batch_manifest_path))
-    if not candidates:
-        lookup = job.artifact_lookup or _hydrate_artifact_lookup_from_items(job)
-        candidates = [(relative_path, lookup[relative_path]) for relative_path in lookup]
-    candidates = [candidate for candidate in candidates if predicate(candidate[0])]
-    if not candidates:
-        return None
-    _, artifact_path = max(candidates, key=lambda item: _artifact_recency_key(item[0], item[1]))
-    return artifact_path
-
-
 def _refresh_job_run_summary(job: Job) -> Dict[str, Any]:
     if not job:
         return {}

--- a/src/transformation_portal/lux_depth_v3/README.md
+++ b/src/transformation_portal/lux_depth_v3/README.md
@@ -214,6 +214,22 @@ ERROR: V2 enhancement script not found: scripts/enhance_image.py
 
 **Why:** V2 is enabled by default and validates the enhancement script at startup. This is **correct fail-fast design** to prevent wasted processing. For PBR-only workflows, disable V2.
 
+### RAW Inputs Require Optional RAW Support
+
+**Error:**
+```
+RAW inputs detected but canonical RAW ingest is unavailable because rawpy is not installed.
+```
+
+**Fix:** Install the optional RAW dependency before dispatching RAW stills:
+```bash
+pip install -e ".[raw]"
+# or
+pip install rawpy
+```
+
+**Why:** Canonical RAW ingest stays deterministic and fail-closed. RAW batches are rejected before dispatch when `rawpy` is unavailable so the pipeline does not start a run that cannot satisfy the ingest contract.
+
 ### More Help
 
 - **Full Troubleshooting Guide:** [docs/guides/LUX_DEPTH_V3_TROUBLESHOOTING.md](../../../../docs/guides/LUX_DEPTH_V3_TROUBLESHOOTING.md)

--- a/src/transformation_portal/lux_depth_v3/__main__.py
+++ b/src/transformation_portal/lux_depth_v3/__main__.py
@@ -144,6 +144,7 @@ Troubleshooting:
 """
 
 import logging
+import os
 import sys
 from pathlib import Path
 from typing import Optional
@@ -159,6 +160,7 @@ except ImportError:
 
 from ._backend_contract import backend_alias_warning, is_legacy_backend_alias, normalize_backend_id
 from .config import EnhanceConfig, Preset
+from .ingest_adapter import RAW_PREVIEW_ESCAPE_ENV
 from .orchestrator import EnhanceOrchestrator
 
 logger = logging.getLogger(__name__)
@@ -176,6 +178,46 @@ def _parse_bool_flag(value: str) -> bool:
         return value
     normalized = value.lower().strip()
     return normalized in ("on", "true", "yes", "1")
+
+
+def _raw_preview_escape_enabled() -> bool:
+    raw_value = os.getenv(RAW_PREVIEW_ESCAPE_ENV, "0").strip().lower()
+    return raw_value in {"1", "true", "yes", "on"}
+
+
+def _canonical_raw_ingest_available() -> bool:
+    try:
+        import rawpy  # noqa: F401
+    except Exception:
+        return False
+    return True
+
+
+def _preflight_raw_ingest_requirements(image_files: list[Path], raw_ingest_mode: str) -> None:
+    from .raw_loader import is_raw_file
+
+    raw_inputs_detected = any(is_raw_file(image_path) for image_path in image_files)
+    if not raw_inputs_detected:
+        return
+
+    if raw_ingest_mode == "force_preview":
+        if _raw_preview_escape_enabled():
+            return
+        message = f"raw_ingest_mode=force_preview requires {RAW_PREVIEW_ESCAPE_ENV}=1 (debug-only escape hatch)."
+        logger.error(message)
+        print(message, file=sys.stdout)
+        raise typer.Exit(code=1)
+
+    if _canonical_raw_ingest_available():
+        return
+
+    message = (
+        "RAW inputs detected but canonical RAW ingest is unavailable because rawpy is not installed. "
+        'Install with: pip install -e ".[raw]" or pip install rawpy'
+    )
+    logger.error(message)
+    print(message, file=sys.stdout)
+    raise typer.Exit(code=1)
 
 
 def _configure_logging(
@@ -795,12 +837,6 @@ def main(
     if verify_images:
         setattr(config, "verify_images", verify_images)
 
-    # Create orchestrator
-    logger.info(
-        "Initializing orchestrator with" f" output dir: {output_dir}",
-    )
-    orchestrator = EnhanceOrchestrator(config=config, output_root=output_dir)
-
     # Discover images using same hygiene filters as orchestrator
     from .input_discovery import DiscoveryConfig, discover_images
     from .raw_loader import RAW_EXTENSIONS
@@ -831,6 +867,13 @@ def main(
         raise typer.Exit(code=1)
 
     logger.info(f"Found {len(image_files)} images to process")
+    _preflight_raw_ingest_requirements(image_files, raw_ingest_mode)
+
+    # Create orchestrator only after input discovery and RAW preflight succeed.
+    logger.info(
+        "Initializing orchestrator with" f" output dir: {output_dir}",
+    )
+    orchestrator = EnhanceOrchestrator(config=config, output_root=output_dir)
 
     # Process batch
     try:

--- a/src/transformation_portal/lux_depth_v3/__main__.py
+++ b/src/transformation_portal/lux_depth_v3/__main__.py
@@ -185,12 +185,20 @@ def _raw_preview_escape_enabled() -> bool:
     return raw_value in {"1", "true", "yes", "on"}
 
 
-def _canonical_raw_ingest_available() -> bool:
+def _canonical_raw_ingest_status() -> tuple[bool, Optional[str]]:
     try:
         import rawpy  # noqa: F401
+    except ImportError:
+        return False, "rawpy is not installed"
     except Exception:
-        return False
-    return True
+        logger.exception("Canonical RAW ingest is unavailable because rawpy failed to import cleanly")
+        return False, "rawpy is unavailable in this environment"
+    return True, None
+
+
+def _canonical_raw_ingest_available() -> bool:
+    available, _ = _canonical_raw_ingest_status()
+    return available
 
 
 def _preflight_raw_ingest_requirements(image_files: list[Path], raw_ingest_mode: str) -> None:
@@ -208,13 +216,17 @@ def _preflight_raw_ingest_requirements(image_files: list[Path], raw_ingest_mode:
         print(message, file=sys.stdout)
         raise typer.Exit(code=1)
 
-    if _canonical_raw_ingest_available():
+    raw_ingest_available, unavailable_reason = _canonical_raw_ingest_status()
+    if raw_ingest_available:
         return
 
     message = (
-        "RAW inputs detected but canonical RAW ingest is unavailable because rawpy is not installed. "
+        "RAW inputs detected but canonical RAW ingest is unavailable because "
+        f"{unavailable_reason or 'rawpy is unavailable in this environment'}. "
         'Install with: pip install -e ".[raw]" or pip install rawpy'
     )
+    if unavailable_reason != "rawpy is not installed":
+        message += " If rawpy is already installed, inspect the import/runtime error in the logs."
     logger.error(message)
     print(message, file=sys.stdout)
     raise typer.Exit(code=1)

--- a/tests/test_app_orchestrator_contract_http.py
+++ b/tests/test_app_orchestrator_contract_http.py
@@ -1076,6 +1076,80 @@ def test_partial_run_summary_prefers_newest_batch_manifest_when_run_card_missing
     assert job.state == "partial"
 
 
+def test_failed_run_summary_prefers_newest_all_error_run_card_when_output_dir_reused(tmp_path: Path) -> None:
+    output_dir = tmp_path / "out"
+    manifests_dir = output_dir / "manifests"
+    manifests_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "run_card_2026-04-06_232022.json").write_text(
+        json.dumps(
+            {
+                "batch_id": "2026-04-06_232022",
+                "total_images": 5,
+                "success_count": 4,
+                "error_count": 1,
+            }
+        ),
+        encoding="utf-8",
+    )
+    (manifests_dir / "batch_2026-04-09_132300.json").write_text(
+        json.dumps(
+            {
+                "batch_id": "2026-04-09_132300",
+                "results": [{"status": "error"}] * 6,
+                "stats": {"total_images": 6},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (output_dir / "run_card_2026-04-09_132300.json").write_text(
+        json.dumps(
+            {
+                "batch_id": "2026-04-09_132300",
+                "total_images": 6,
+                "success_count": 0,
+                "error_count": 6,
+                "artifact_index": [
+                    {
+                        "artifact_type": "batch_manifest",
+                        "path": "manifests/batch_2026-04-09_132300.json",
+                        "relative_path": "manifests/batch_2026-04-09_132300.json",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (output_dir / "stale_preview.png").write_bytes(b"stale-preview")
+
+    job = orchestrator_app.Job(
+        id="job_failed_reused_output_dir",
+        created_at=orchestrator_app._now(),
+        state="failed",
+        exit_code=1,
+        request={"pipeline": "lux-depth-v3", "args": {"output_dir": str(output_dir)}},
+        error={
+            "code": "RUNNER_EXIT_NONZERO",
+            "message": "runner exited with code 1",
+            "details": {"exit_code": 1},
+        },
+    )
+
+    indexed = orchestrator_app._index_job_artifacts(job)
+    summary = orchestrator_app._refresh_job_run_summary(job)
+
+    assert {item["path"] for item in indexed} == {
+        "manifests/batch_2026-04-09_132300.json",
+        "run_card_2026-04-09_132300.json",
+    }
+    assert summary["batch_id"] == "2026-04-09_132300"
+    assert summary["success_count"] == 0
+    assert summary["error_count"] == 6
+    assert summary["reviewable_outputs"] is False
+    assert summary["partial"] is False
+    assert job.state == "failed"
+    assert job.error["code"] == "RUNNER_EXIT_NONZERO"
+
+
 def test_jobs_list_and_detail_include_partial_run_summary(client: TestClient) -> None:
     job = orchestrator_app.Job(
         id="job_contract_partial",

--- a/tests/test_app_orchestrator_runtime.py
+++ b/tests/test_app_orchestrator_runtime.py
@@ -2905,6 +2905,170 @@ def test_index_job_artifacts_truncation_is_sorted_and_stable(tmp_path: Path) -> 
     assert job.artifacts["indexed_count"] == 2
 
 
+def test_index_job_artifacts_prefers_current_run_card_artifact_index(tmp_path: Path) -> None:
+    output_dir = tmp_path / "out"
+    depth_dir = output_dir / "depth"
+    manifests_dir = output_dir / "manifests"
+    depth_dir.mkdir(parents=True, exist_ok=True)
+    manifests_dir.mkdir(parents=True, exist_ok=True)
+
+    current_depth = depth_dir / "current_depth.png"
+    current_depth.write_bytes(b"current-depth")
+    (depth_dir / "stale_depth.png").write_bytes(b"stale-depth")
+    batch_manifest = manifests_dir / "batch_2026-04-09_132300.json"
+    batch_manifest.write_text(json.dumps({"batch_id": "2026-04-09_132300", "results": []}), encoding="utf-8")
+    run_card = output_dir / "run_card_2026-04-09_132300.json"
+    run_card.write_text(
+        json.dumps(
+            {
+                "batch_id": "2026-04-09_132300",
+                "success_count": 1,
+                "error_count": 0,
+                "artifact_index": [
+                    {"relative_path": "depth/current_depth.png"},
+                    {"relative_path": "manifests/batch_2026-04-09_132300.json"},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    job = orchestrator_app.Job(
+        id="job_artifacts_scoped_run_card",
+        created_at=orchestrator_app._now(),
+        request={"pipeline": "lux-depth-v3", "args": {"output_dir": str(output_dir)}},
+    )
+
+    indexed = orchestrator_app._index_job_artifacts(job)
+
+    assert {item["path"] for item in indexed} == {
+        "depth/current_depth.png",
+        "manifests/batch_2026-04-09_132300.json",
+        "run_card_2026-04-09_132300.json",
+    }
+    assert "depth/stale_depth.png" not in job.artifact_lookup
+
+
+def test_index_job_artifacts_uses_current_batch_manifest_when_run_card_lacks_artifact_index(tmp_path: Path) -> None:
+    output_dir = tmp_path / "out"
+    depth_dir = output_dir / "depth"
+    manifests_dir = output_dir / "manifests"
+    depth_dir.mkdir(parents=True, exist_ok=True)
+    manifests_dir.mkdir(parents=True, exist_ok=True)
+
+    (depth_dir / "stale_depth.png").write_bytes(b"stale-depth")
+    batch_manifest = manifests_dir / "batch_2026-04-09_132300.json"
+    batch_manifest.write_text(
+        json.dumps(
+            {
+                "batch_id": "2026-04-09_132300",
+                "results": [{"status": "error"}],
+                "stats": {"total_images": 1},
+            }
+        ),
+        encoding="utf-8",
+    )
+    run_card = output_dir / "run_card_2026-04-09_132300.json"
+    run_card.write_text(
+        json.dumps(
+            {
+                "batch_id": "2026-04-09_132300",
+                "success_count": 0,
+                "error_count": 1,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    job = orchestrator_app.Job(
+        id="job_artifacts_scoped_manifest",
+        created_at=orchestrator_app._now(),
+        request={"pipeline": "lux-depth-v3", "args": {"output_dir": str(output_dir)}},
+    )
+
+    indexed = orchestrator_app._index_job_artifacts(job)
+
+    assert {item["path"] for item in indexed} == {
+        "manifests/batch_2026-04-09_132300.json",
+        "run_card_2026-04-09_132300.json",
+    }
+    assert "depth/stale_depth.png" not in job.artifact_lookup
+
+
+def test_refresh_job_run_summary_uses_current_output_metadata_not_scoped_items(tmp_path: Path) -> None:
+    output_dir = tmp_path / "out"
+    manifests_dir = output_dir / "manifests"
+    manifests_dir.mkdir(parents=True, exist_ok=True)
+
+    old_run_card = output_dir / "run_card_2026-04-06_232022.json"
+    old_run_card.write_text(
+        json.dumps(
+            {
+                "batch_id": "2026-04-06_232022",
+                "total_images": 5,
+                "success_count": 4,
+                "error_count": 1,
+            }
+        ),
+        encoding="utf-8",
+    )
+    current_batch_manifest = manifests_dir / "batch_2026-04-09_132300.json"
+    current_batch_manifest.write_text(
+        json.dumps(
+            {
+                "batch_id": "2026-04-09_132300",
+                "results": [{"status": "error"}] * 6,
+                "stats": {"total_images": 6},
+            }
+        ),
+        encoding="utf-8",
+    )
+    current_run_card = output_dir / "run_card_2026-04-09_132300.json"
+    current_run_card.write_text(
+        json.dumps(
+            {
+                "batch_id": "2026-04-09_132300",
+                "total_images": 6,
+                "success_count": 0,
+                "error_count": 6,
+                "artifact_index": [
+                    {"relative_path": "manifests/batch_2026-04-09_132300.json"},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    job = orchestrator_app.Job(
+        id="job_run_summary_current_metadata",
+        created_at=orchestrator_app._now(),
+        state="failed",
+        exit_code=1,
+        request={"pipeline": "lux-depth-v3", "args": {"output_dir": str(output_dir)}},
+        artifacts={
+            "output_dir": str(output_dir),
+            "items": [{"path": "run_card_2026-04-06_232022.json", "relative_path": "run_card_2026-04-06_232022.json"}],
+            "indexed_count": 1,
+            "truncated": False,
+        },
+        error={
+            "code": "RUNNER_EXIT_NONZERO",
+            "message": "runner exited with code 1",
+            "details": {"exit_code": 1},
+        },
+    )
+
+    summary = orchestrator_app._refresh_job_run_summary(job)
+
+    assert summary["batch_id"] == "2026-04-09_132300"
+    assert summary["success_count"] == 0
+    assert summary["error_count"] == 6
+    assert summary["partial"] is False
+    assert summary["reviewable_outputs"] is False
+    assert job.state == "failed"
+    assert job.error["code"] == "RUNNER_EXIT_NONZERO"
+
+
 def test_create_job_validation_uses_typed_error_envelope() -> None:
     response = asyncio.run(orchestrator_app.create_job({"pipeline": "unsupported", "args": {}}))
     body = json.loads(response.body.decode("utf-8"))

--- a/tests/test_lux_depth_v3_cli.py
+++ b/tests/test_lux_depth_v3_cli.py
@@ -244,7 +244,10 @@ class TestCLIValidation:
                 raise AssertionError("orchestrator should not be constructed when RAW preflight fails")
 
         monkeypatch.setattr("transformation_portal.lux_depth_v3.__main__.EnhanceOrchestrator", FakeOrchestrator)
-        monkeypatch.setattr("transformation_portal.lux_depth_v3.__main__._canonical_raw_ingest_available", lambda: False)
+        monkeypatch.setattr(
+            "transformation_portal.lux_depth_v3.__main__._canonical_raw_ingest_status",
+            lambda: (False, "rawpy is not installed"),
+        )
 
         result = runner.invoke(
             app,
@@ -274,7 +277,10 @@ class TestCLIValidation:
                 return [{"status": "ok"}]
 
         monkeypatch.setattr("transformation_portal.lux_depth_v3.__main__.EnhanceOrchestrator", FakeOrchestrator)
-        monkeypatch.setattr("transformation_portal.lux_depth_v3.__main__._canonical_raw_ingest_available", lambda: False)
+        monkeypatch.setattr(
+            "transformation_portal.lux_depth_v3.__main__._canonical_raw_ingest_status",
+            lambda: (False, "rawpy is not installed"),
+        )
 
         result = runner.invoke(
             app,
@@ -316,6 +322,37 @@ class TestCLIValidation:
 
         assert result.exit_code == 1
         assert "tp_allow_raw_preview=1" in result.stdout.lower()
+
+    def test_raw_inputs_report_runtime_unavailability_without_claiming_rawpy_missing(self, monkeypatch, tmp_path):
+        """RAW preflight should distinguish missing rawpy from other import/runtime failures."""
+        input_dir = tmp_path / "input"
+        input_dir.mkdir()
+        (input_dir / "scene_01.DNG").write_bytes(b"raw-payload")
+
+        class FakeOrchestrator:
+            def __init__(self, *_args, **_kwargs):
+                raise AssertionError("orchestrator should not be constructed when RAW preflight fails")
+
+        monkeypatch.setattr("transformation_portal.lux_depth_v3.__main__.EnhanceOrchestrator", FakeOrchestrator)
+        monkeypatch.setattr(
+            "transformation_portal.lux_depth_v3.__main__._canonical_raw_ingest_status",
+            lambda: (False, "rawpy is unavailable in this environment"),
+        )
+
+        result = runner.invoke(
+            app,
+            [
+                "--input-dir",
+                str(input_dir),
+                "--output-dir",
+                str(tmp_path / "output"),
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "rawpy is unavailable in this environment" in result.stdout.lower()
+        assert "not installed" not in result.stdout.lower()
+        assert "inspect the import/runtime error in the logs" in result.stdout.lower()
 
     def test_apex_materials_v3_requires_segmentation_enabled(self, tmp_path):
         """APEX strict gate should require explicit segmentation when Materials V3 is on."""

--- a/tests/test_lux_depth_v3_cli.py
+++ b/tests/test_lux_depth_v3_cli.py
@@ -233,6 +233,90 @@ class TestCLIValidation:
         assert "raw-ingest-mode" in result.stdout.lower()
         assert "auto|force_rawpy|force_preview" in result.stdout
 
+    def test_raw_inputs_fail_fast_when_rawpy_unavailable(self, monkeypatch, tmp_path):
+        """RAW batches should fail before dispatch when canonical RAW support is unavailable."""
+        input_dir = tmp_path / "input"
+        input_dir.mkdir()
+        (input_dir / "scene_01.DNG").write_bytes(b"raw-payload")
+
+        class FakeOrchestrator:
+            def __init__(self, *_args, **_kwargs):
+                raise AssertionError("orchestrator should not be constructed when RAW preflight fails")
+
+        monkeypatch.setattr("transformation_portal.lux_depth_v3.__main__.EnhanceOrchestrator", FakeOrchestrator)
+        monkeypatch.setattr("transformation_portal.lux_depth_v3.__main__._canonical_raw_ingest_available", lambda: False)
+
+        result = runner.invoke(
+            app,
+            [
+                "--input-dir",
+                str(input_dir),
+                "--output-dir",
+                str(tmp_path / "output"),
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "raw inputs detected but canonical raw ingest is unavailable" in result.stdout.lower()
+        assert 'pip install -e ".[raw]"' in result.stdout
+
+    def test_non_raw_inputs_do_not_trigger_rawpy_preflight(self, monkeypatch, tmp_path):
+        """Non-RAW batches should not be blocked by the optional RAW dependency."""
+        input_dir = tmp_path / "input"
+        input_dir.mkdir()
+        (input_dir / "scene_01.png").write_bytes(b"png-payload")
+
+        class FakeOrchestrator:
+            def __init__(self, *_args, **_kwargs):
+                pass
+
+            def enhance_batch(self, *_args, **_kwargs):
+                return [{"status": "ok"}]
+
+        monkeypatch.setattr("transformation_portal.lux_depth_v3.__main__.EnhanceOrchestrator", FakeOrchestrator)
+        monkeypatch.setattr("transformation_portal.lux_depth_v3.__main__._canonical_raw_ingest_available", lambda: False)
+
+        result = runner.invoke(
+            app,
+            [
+                "--input-dir",
+                str(input_dir),
+                "--output-dir",
+                str(tmp_path / "output"),
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "raw inputs detected" not in result.stdout.lower()
+
+    def test_force_preview_requires_preview_escape_env_for_raw_inputs(self, monkeypatch, tmp_path):
+        """force_preview should still require the explicit preview escape hatch."""
+        input_dir = tmp_path / "input"
+        input_dir.mkdir()
+        (input_dir / "scene_01.DNG").write_bytes(b"raw-payload")
+
+        class FakeOrchestrator:
+            def __init__(self, *_args, **_kwargs):
+                raise AssertionError("orchestrator should not be constructed when preview escape is missing")
+
+        monkeypatch.setattr("transformation_portal.lux_depth_v3.__main__.EnhanceOrchestrator", FakeOrchestrator)
+        monkeypatch.delenv("TP_ALLOW_RAW_PREVIEW", raising=False)
+
+        result = runner.invoke(
+            app,
+            [
+                "--input-dir",
+                str(input_dir),
+                "--output-dir",
+                str(tmp_path / "output"),
+                "--raw-ingest-mode",
+                "force_preview",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "tp_allow_raw_preview=1" in result.stdout.lower()
+
     def test_apex_materials_v3_requires_segmentation_enabled(self, tmp_path):
         """APEX strict gate should require explicit segmentation when Materials V3 is on."""
         input_dir = tmp_path / "input"


### PR DESCRIPTION
## Summary
- fail fast before dispatch when RAW inputs are discovered without canonical rawpy support
- scope orchestrator artifact indexing and run-summary selection to the current batch metadata instead of the full reused output root
- add regression coverage for RAW preflight, scoped artifact indexing, and current-run summary selection plus README guidance for RAW requirements

## Validation
- PATH=/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin:$PATH PRE_COMMIT_HOME=/tmp/pre-commit ./.venv/bin/pre-commit run --files app.py src/transformation_portal/lux_depth_v3/README.md src/transformation_portal/lux_depth_v3/__main__.py tests/test_app_orchestrator_contract_http.py tests/test_app_orchestrator_runtime.py tests/test_lux_depth_v3_cli.py
- ./.venv/bin/python -m pytest -q -p no:rerunfailures tests/test_lux_depth_v3_cli.py
- ./.venv/bin/python -m pytest -q -p no:rerunfailures tests/lux_depth_v3/test_phase_c_raw_ingest.py
- ./.venv/bin/python -m pytest -q -p no:rerunfailures tests/test_app_orchestrator_runtime.py tests/test_app_orchestrator_contract_http.py
