### PR TITLE
[codex] style: satisfy pre-commit whitespace hooks

### DIFF
--- a/public/shared/tokens.css
+++ b/public/shared/tokens.css
@@ -31,7 +31,7 @@
     /* Focus ring — consistent across all surfaces */
     --tp-focus-ring: rgba(103, 232, 249, 0.96);
     --tp-focus-shadow: rgba(34, 211, 238, 0.24);
-    
+
     /* Minimum touch target size (WCAG 2.2 Target Size) */
     --tp-target-min-size: 44px;
 }
@@ -49,7 +49,7 @@
     --tp-text-xl: 1.25rem;      /* 20px */
     --tp-text-2xl: 1.5rem;      /* 24px */
     --tp-text-3xl: 1.875rem;    /* 30px */
-    
+
     /* Legacy aliases for backward compatibility */
     --tp-label-size: 0.8125rem; /* 13px */
     --tp-body-size: 1rem;
@@ -63,7 +63,7 @@
     /* Panel borders — consistent glass-like appearance */
     --tp-panel-border: rgba(148, 163, 184, 0.24);
     --tp-panel-border-strong: rgba(103, 232, 249, 0.28);
-    
+
     /* Continuity tokens — shared across frontdoor surfaces */
     --tp-continuity-panel: rgba(12, 18, 34, 0.76);
     --tp-continuity-panel-strong: rgba(7, 12, 26, 0.94);
@@ -80,11 +80,11 @@
     /* Primary accent — cyan/teal family */
     --tp-accent-primary: #22d3ee;     /* Cyan 400 */
     --tp-accent-primary-strong: #06b6d4; /* Cyan 500 */
-    
+
     /* Secondary accent — blue family */
     --tp-accent-secondary: #2563eb;   /* Blue 600 */
     --tp-accent-secondary-strong: #1d4ed8; /* Blue 700 */
-    
+
     /* Semantic colors */
     --tp-success: #34d399;            /* Emerald 400 */
     --tp-success-strong: #10b981;     /* Emerald 500 */
@@ -92,7 +92,7 @@
     --tp-warning-strong: #f59e0b;     /* Amber 500 */
     --tp-danger: #f87171;             /* Red 400 */
     --tp-danger-strong: #ef4444;      /* Red 500 */
-    
+
     /* Brand-specific */
     --tp-brand-azure: #56ccf2;
     --tp-brand-cyan: #2ac7ff;
@@ -109,7 +109,7 @@
     --tp-motion-duration-normal: 300ms;
     --tp-motion-duration-slow: 500ms;
     --tp-motion-duration-slower: 700ms;
-    
+
     /* Easing tokens */
     --tp-motion-easing-default: cubic-bezier(0.16, 1, 0.3, 1);
     --tp-motion-easing-bounce: cubic-bezier(0.34, 1.56, 0.64, 1);
@@ -136,7 +136,7 @@
     /* Soft shadows for panels */
     --tp-shadow-soft: 0 24px 60px rgba(2, 6, 23, 0.26);
     --tp-shadow-strong: 0 18px 40px rgba(37, 99, 235, 0.22);
-    
+
     /* Dark mode shadows */
     --tp-shadow-soft-dark: 0 24px 60px rgba(2, 6, 23, 0.52);
     --tp-shadow-strong-dark: 0 32px 90px rgba(2, 6, 23, 0.52);
@@ -193,7 +193,7 @@
 /* ============================================================================
  * Focus Behavior Utility
  * ============================================================================
- * 
+ *
  * Apply this to :focus-visible on interactive elements for consistent
  * focus indication across all surfaces.
  * ============================================================================ */

--- a/scripts/setup/ensure_node_version.sh
+++ b/scripts/setup/ensure_node_version.sh
@@ -52,7 +52,7 @@ if ! command -v node &> /dev/null; then
     echo ""
     log_info "Install Node.js ${REQUIRED_MAJOR}.x using one of these methods:"
     echo ""
-    
+
     # Check for version managers
     if command -v nvm &> /dev/null || [[ -d "$HOME/.nvm" ]]; then
         log_info "  nvm detected — run:"
@@ -94,7 +94,7 @@ fi
 # Validate version
 if [[ "$NODE_MAJOR" -eq "$REQUIRED_MAJOR" ]]; then
     log_success "Node.js ${NODE_VERSION} meets requirement (${REQUIRED_MAJOR}.x)"
-    
+
     # Show .nvmrc info if present
     if [[ -n "$NVMRC_VERSION" ]]; then
         log_info "  .nvmrc specifies: ${NVMRC_VERSION}"
@@ -103,13 +103,13 @@ if [[ "$NODE_MAJOR" -eq "$REQUIRED_MAJOR" ]]; then
 else
     log_error "Node.js ${NODE_VERSION} does not match required ${REQUIRED_MAJOR}.x"
     echo ""
-    
+
     # Provide specific guidance based on version manager
     if [[ -n "${NVM_DIR:-}" ]] || [[ -d "$HOME/.nvm" ]]; then
         log_info "nvm detected — switch version:"
         log_info "  nvm install ${REQUIRED_MAJOR}"
         log_info "  nvm use ${REQUIRED_MAJOR}"
-        
+
         # Check if the version is already installed
         if [[ -d "$HOME/.nvm/versions/node" ]]; then
             INSTALLED=$(ls "$HOME/.nvm/versions/node" 2>/dev/null | grep "^v${REQUIRED_MAJOR}" | head -1 || true)
@@ -131,11 +131,11 @@ else
         log_info "  Install a version manager like nvm, fnm, or volta"
         log_info "  Or download from https://nodejs.org/"
     fi
-    
+
     echo ""
     log_warning "The secure-landing frontdoor requires Node ${REQUIRED_MAJOR}.x"
     log_info "  Native dependencies (better-sqlite3, argon2) are ABI-sensitive"
     log_info "  See: web/secure-landing/package.json engines constraint"
-    
+
     exit 1
 fi

--- a/scripts/validation/check_local_environment.py
+++ b/scripts/validation/check_local_environment.py
@@ -242,9 +242,7 @@ def check_port_available(port: int, description: str) -> CheckResult:
 
 def check_ports_available() -> list[CheckResult]:
     """Check if all validation ports are available."""
-    return [
-        check_port_available(port, desc) for port, desc in VALIDATION_PORTS.items()
-    ]
+    return [check_port_available(port, desc) for port, desc in VALIDATION_PORTS.items()]
 
 
 def check_frontdoor_dependencies() -> CheckResult:
@@ -284,7 +282,7 @@ def check_env_vars() -> list[CheckResult]:
     results = []
     # Variables that should be masked when displaying their values
     sensitive_patterns = ("KEY", "PASSWORD", "SECRET", "TOKEN", "CREDENTIAL")
-    
+
     for var in CHECKED_ENV_VARS:
         value = os.environ.get(var)
         if value:
@@ -471,9 +469,7 @@ Examples:
             ],
             "exit_code": int(exit_code),
             "status": (
-                "pass"
-                if exit_code == ExitCode.PASS
-                else ("soft_fail" if exit_code == ExitCode.SOFT_FAIL else "hard_fail")
+                "pass" if exit_code == ExitCode.PASS else ("soft_fail" if exit_code == ExitCode.SOFT_FAIL else "hard_fail")
             ),
         }
         print(json.dumps(output, indent=2))

--- a/scripts/validation/check_worktree_clean.sh
+++ b/scripts/validation/check_worktree_clean.sh
@@ -108,17 +108,17 @@ if [[ -z "$STATUS" ]]; then
 else
     log_error "Worktree has uncommitted changes"
     echo ""
-    
+
     # Parse and display changes
     MODIFIED_COUNT=0
     ADDED_COUNT=0
     DELETED_COUNT=0
     UNTRACKED_COUNT=0
-    
+
     while IFS= read -r line; do
         status_code="${line:0:2}"
         file_path="${line:3}"
-        
+
         case "$status_code" in
             " M"|"M "|"MM")
                 ((++MODIFIED_COUNT))
@@ -141,21 +141,21 @@ else
                 ;;
         esac
     done <<< "$STATUS"
-    
+
     echo ""
     echo "Summary:"
     [[ $MODIFIED_COUNT -gt 0 ]] && echo "  Modified:  $MODIFIED_COUNT"
     [[ $ADDED_COUNT -gt 0 ]] && echo "  Added:     $ADDED_COUNT"
     [[ $DELETED_COUNT -gt 0 ]] && echo "  Deleted:   $DELETED_COUNT"
     [[ $UNTRACKED_COUNT -gt 0 ]] && echo "  Untracked: $UNTRACKED_COUNT"
-    
+
     if [[ "$SHOW_DIFF" == "true" ]]; then
         echo ""
         echo "Diff of tracked changes:"
         echo "─────────────────────────────────────────────────────────────"
         git diff
     fi
-    
+
     echo ""
     log_warning "Build artifacts may have dirtied the worktree"
     echo "  Check .gitignore to ensure build outputs are ignored"
@@ -166,6 +166,6 @@ else
     echo ""
     echo "  To reset: git checkout -- ."
     echo "  To see what changed: git diff"
-    
+
     exit 1
 fi

--- a/scripts/validation/run_full_validation_suite.sh
+++ b/scripts/validation/run_full_validation_suite.sh
@@ -135,9 +135,9 @@ run_step() {
     local step_name="$1"
     shift
     local step_start=$(date +%s)
-    
+
     log_step "$step_name"
-    
+
     if "$@"; then
         local step_end=$(date +%s)
         local duration=$((step_end - step_start))


### PR DESCRIPTION
## Summary
- remove trailing whitespace from tracked repo files that the canonical `make pre-commit` hook was auto-fixing
- keep the cleanup limited to the exact files the hook modified so the diff stays reviewable
- preserve the already-merged RAW-ingest/frontdoor work from `#1406`; this PR only captures the remaining hook-required hygiene

## Why
Running `make pre-commit` against the current checkout failed because the repository still had hook-fixable trailing whitespace in tracked files. That left the canonical local gate non-green even though the functional branch work had already been merged. This PR commits only those deterministic hook fixes so local and CI-aligned pre-commit runs stay clean.

## Validation
- `.venv/bin/python -m pytest -q tests/test_lux_depth_v3_cli.py tests/test_app_orchestrator_runtime.py tests/test_app_orchestrator_contract_http.py`
- `make pre-commit`

## Notes
- PR `#1406` (`fix(portal): fail fast raw ingest and scope review artifacts`) is already merged to `main`.
- Local untracked RAW workflow artifacts were intentionally left out of this PR.