### PR TITLE
feat(raw): isolate RAW ingest runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ requirements/.hash-pilot/
 .env
 .venv/
 .venv-da3/
+.venv-raw/
 .venv-lint/
 .runtime/
 env/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,7 @@ Quick reference for common workflows and commands in this repo.
 - `./scripts/pipelines/run_sealed_eval_72h.sh --archive-index <path> --archive-root <path>` run sealed pre/post fixity verification around an optional eval command and emit an audit package.
 - `./scripts/pipelines/hdr_production_pipeline.sh` interactive HDR video mastering workflow that pairs source footage with a 3D LUT and writes web deliverables.
 - `./scripts/setup/install_da3_runtime.sh` install the repo-local DA3 subprocess runtime (validated `.runtime/Depth-Anything-3` ref + auto-discovered `./.venv-da3/bin/python` contract + `.runtime/da3-pip-freeze.txt` snapshot).
+- `./scripts/setup/install_raw_runtime.sh` install the repo-local RAW subprocess runtime (auto-discovered `./.venv-raw/bin/python` contract + `.runtime/raw-pip-freeze.txt` snapshot).
 - `./scripts/setup/run_frontdoor_local.sh` start the local managed frontdoor only when the backend is ready, auth env is set, and `localhost:3000` is free.
 - `./scripts/test_v2_integration.sh` validate end-to-end lux-depth-v3 + V2 stage integration (`--verbose`, `--clean` available).
 - `./scripts/validate_dependency_constraints.sh` enforce dependency pinning rules used by repo policy (`--verbose` available).

--- a/README.md
+++ b/README.md
@@ -226,7 +226,22 @@ pip install -e ".[raw]"
 # or: pip install rawpy
 ```
 
-RAW inputs are auto-detected and converted into pipeline-ready RGB using LibRaw via `rawpy`. See [SETUP_GUIDE.md](docs/guides/SETUP_GUIDE.md) for environment details.
+RAW inputs are auto-detected and converted into pipeline-ready RGB using LibRaw via `rawpy`. If `./.venv-raw/bin/python` exists, Lux Depth V3 auto-discovers that repo-local RAW runtime before falling back to the main repo environment.
+
+**Recommended (RAW via isolated runtime):**
+```bash
+./scripts/setup/install_raw_runtime.sh
+
+lux-depth-v3 --input-dir ./input --output-dir ./output
+```
+
+Use `--raw-python` only when you want to override that repo-local runtime explicitly:
+
+```bash
+lux-depth-v3 --input-dir ./input --output-dir ./output --raw-python ~/venvs/raw/bin/python
+```
+
+See [SETUP_GUIDE.md](docs/guides/SETUP_GUIDE.md) for environment details.
 
 ---
 

--- a/docs/schemas/run_card/run_card.v1.schema.json
+++ b/docs/schemas/run_card/run_card.v1.schema.json
@@ -148,6 +148,12 @@
             "null"
           ]
         },
+        "raw_python_executable": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "da3_python_executable": {
           "type": [
             "string",

--- a/scripts/setup/README.md
+++ b/scripts/setup/README.md
@@ -51,6 +51,31 @@ lux-depth-v3 --input-dir ./input --output-dir ./output --da3-python ~/venvs/da3/
 - Git repository
 - Bash shell (Linux, macOS, or Windows with WSL/Git Bash)
 
+### `install_raw_runtime.sh`
+
+Bootstraps the repo-local RAW subprocess runtime used by the
+auto-discovered `./.venv-raw/bin/python` contract and by explicit
+`--raw-python` overrides.
+
+**Usage:**
+```bash
+./scripts/setup/install_raw_runtime.sh
+```
+
+**What it does:**
+- Creates the isolated RAW venv at `./.venv-raw`
+- Installs the local project with the `raw` extra into that venv
+- Captures a runtime package snapshot at `.runtime/raw-pip-freeze.txt`
+- Runs the RAW worker readiness check used by canonical ingest
+
+**Stable contract:**
+```bash
+lux-depth-v3 --input-dir ./input --output-dir ./output --raw-python ./.venv-raw/bin/python
+```
+
+If you want the repo-local runtime to be used automatically for RAW batches,
+just create `./.venv-raw/bin/python` with this script and omit `--raw-python`.
+
 ### `pre-commit-check.sh`
 
 Canonical root-placement validator used by the repository hook set and by the

--- a/scripts/setup/install_raw_runtime.sh
+++ b/scripts/setup/install_raw_runtime.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+#
+# install_raw_runtime.sh
+# Bootstrap a repo-local RAW ingest runtime for the subprocess-backed RAW adapter.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+VENV_DIR="${REPO_ROOT}/.venv-raw"
+RUNTIME_METADATA_DIR="${REPO_ROOT}/.runtime"
+RUNTIME_FREEZE_FILE="${RUNTIME_METADATA_DIR}/raw-pip-freeze.txt"
+DRY_RUN=false
+SKIP_VERIFY=false
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Install a stable repo-local RAW ingest runtime for:
+  --raw-python ./.venv-raw/bin/python
+
+Default paths:
+  venv: ${VENV_DIR}
+
+OPTIONS:
+  --venv-dir PATH       Override the isolated RAW venv path
+  --dry-run             Print commands without executing them
+  --skip-verify         Skip the RAW worker readiness check
+  --help                Show this help text
+EOF
+}
+
+log() {
+    printf '[INFO] %s\n' "$*"
+}
+
+run() {
+    if [[ "${DRY_RUN}" == "true" ]]; then
+        printf '+'
+        for arg in "$@"; do
+            printf ' %q' "${arg}"
+        done
+        printf '\n'
+        return 0
+    fi
+    "$@"
+}
+
+run_in_repo() {
+    if [[ "${DRY_RUN}" == "true" ]]; then
+        printf '+ (cd %q &&' "${REPO_ROOT}"
+        for arg in "$@"; do
+            printf ' %q' "${arg}"
+        done
+        printf ' )\n'
+        return 0
+    fi
+    (
+        cd "${REPO_ROOT}"
+        "$@"
+    )
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --venv-dir)
+            VENV_DIR="$2"
+            shift 2
+            ;;
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        --skip-verify)
+            SKIP_VERIFY=true
+            shift
+            ;;
+        --help)
+            usage
+            exit 0
+            ;;
+        *)
+            printf '[ERROR] Unknown argument: %s\n' "$1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+if ! command -v python3 >/dev/null 2>&1; then
+    printf '[ERROR] python3 is required but not available on PATH.\n' >&2
+    exit 1
+fi
+
+if [[ ! -d "${VENV_DIR}" ]]; then
+    log "Creating isolated RAW venv at ${VENV_DIR}"
+    run python3 -m venv "${VENV_DIR}"
+fi
+
+PYTHON_BIN="${VENV_DIR}/bin/python"
+
+log "Upgrading pip in ${VENV_DIR}"
+run "${PYTHON_BIN}" -m pip install --upgrade pip
+
+log "Installing Transformation Portal with RAW support into ${VENV_DIR}"
+run_in_repo "${PYTHON_BIN}" -m pip install -e ".[raw]"
+
+run mkdir -p "${RUNTIME_METADATA_DIR}"
+if [[ "${DRY_RUN}" == "true" ]]; then
+    log "Would capture RAW runtime package snapshot at ${RUNTIME_FREEZE_FILE}"
+else
+    log "Capturing RAW runtime package snapshot at ${RUNTIME_FREEZE_FILE}"
+    "${PYTHON_BIN}" -m pip freeze > "${RUNTIME_FREEZE_FILE}"
+fi
+
+if [[ "${SKIP_VERIFY}" != "true" ]]; then
+    log "Running RAW worker readiness check"
+    run env \
+        PYTHONPATH="${REPO_ROOT}/src${PYTHONPATH:+:${PYTHONPATH}}" \
+        "${PYTHON_BIN}" \
+        -m transformation_portal.spatial_ai.ingest.raw_worker \
+        --check
+fi
+
+cat <<EOF
+[INFO] RAW runtime ready.
+[INFO] Stable executable: ./.venv-raw/bin/python
+[INFO] Example:
+lux-depth-v3 --input-dir ./input --output-dir ./output --raw-python ./.venv-raw/bin/python
+EOF

--- a/scripts/verify_run_card_integrity.py
+++ b/scripts/verify_run_card_integrity.py
@@ -271,6 +271,7 @@ def _verify_config_fingerprint(run_card_payload: dict[str, Any], errors: list[st
         "raw_ingest_profile",
         "raw_ingest_settings_hash",
         "depth_pro_python_executable",
+        "raw_python_executable",
         "da3_python_executable",
     )
     present_optional_fields = tuple(field for field in optional_fields if field in config_fingerprint)

--- a/src/transformation_portal/core/raw_runtime.py
+++ b/src/transformation_portal/core/raw_runtime.py
@@ -24,6 +24,8 @@ _REPO_LOCAL_RAW_PYTHON_PARTS = (".venv-raw", "bin", "python")
 REPO_LOCAL_RAW_PYTHON = f"./{'/'.join(_REPO_LOCAL_RAW_PYTHON_PARTS)}"
 RAW_RUNTIME_ENV_VAR = "TRANSFORMATION_PORTAL_RAW_PYTHON"
 RAW_WORKER_MODULE = "transformation_portal.spatial_ai.ingest.raw_worker"
+RAW_RUNTIME_CHECK_TIMEOUT_SECONDS = 30
+RAW_WORKER_TIMEOUT_SECONDS = 300
 
 
 def repo_local_raw_python_path(start: Path) -> Optional[Path]:
@@ -102,6 +104,26 @@ def _format_subprocess_output(stdout: str, stderr: str) -> str:
     return "<no output>"
 
 
+def _build_subprocess_failure_message(
+    *,
+    title: str,
+    python_executable: str,
+    command: list[str],
+    stdout: str,
+    stderr: str,
+    timeout_seconds: int | None = None,
+) -> str:
+    """Build a deterministic subprocess failure message."""
+    timeout_line = f"Timeout: {timeout_seconds}s\n" if timeout_seconds is not None else ""
+    return (
+        f"{title}\n\n"
+        f"Python: {python_executable}\n"
+        f"Command: {' '.join(command)}\n"
+        f"{timeout_line}"
+        f"Output:\n{_format_subprocess_output(stdout, stderr)}"
+    )
+
+
 def check_raw_runtime(
     python_executable: str,
     *,
@@ -115,21 +137,36 @@ def check_raw_runtime(
         RAW_WORKER_MODULE,
         "--check",
     ]
-    result = subprocess.run(
-        command,
-        capture_output=True,
-        text=True,
-        cwd=_worker_cwd(start),
-        env=build_raw_worker_env(start),
-        check=False,
-    )
-    if result.returncode != 0:
-        output = _format_subprocess_output(result.stdout, result.stderr)
+    try:
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            cwd=_worker_cwd(start),
+            env=build_raw_worker_env(start),
+            check=False,
+            timeout=RAW_RUNTIME_CHECK_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
         raise RuntimeError(
-            "RAW subprocess environment is not ready.\n\n"
-            f"Python: {python_executable}\n"
-            f"Command: {' '.join(command)}\n"
-            f"Output:\n{output}"
+            _build_subprocess_failure_message(
+                title="RAW subprocess environment is not ready.",
+                python_executable=python_executable,
+                command=command,
+                stdout=exc.stdout or "",
+                stderr=exc.stderr or "",
+                timeout_seconds=RAW_RUNTIME_CHECK_TIMEOUT_SECONDS,
+            )
+        ) from exc
+    if result.returncode != 0:
+        raise RuntimeError(
+            _build_subprocess_failure_message(
+                title="RAW subprocess environment is not ready.",
+                python_executable=python_executable,
+                command=command,
+                stdout=result.stdout,
+                stderr=result.stderr,
+            )
         )
 
 
@@ -143,6 +180,7 @@ def run_raw_worker(
 ) -> tuple[np.ndarray, dict[str, Any]]:
     """Execute the RAW subprocess worker and return the array + metadata."""
     worker_python = resolve_raw_python_for_execution(python_executable, start=start)
+    resolved_input_path = Path(input_path).expanduser().resolve()
 
     with tempfile.TemporaryDirectory(prefix="tp-raw-worker-") as tmpdir:
         temp_root = Path(tmpdir)
@@ -167,7 +205,7 @@ def run_raw_worker(
             "--command",
             command_name,
             "--input-path",
-            str(input_path),
+            str(resolved_input_path),
             "--payload-json",
             str(payload_path),
             "--output-array",
@@ -175,21 +213,36 @@ def run_raw_worker(
             "--output-json",
             str(output_json_path),
         ]
-        result = subprocess.run(
-            command,
-            capture_output=True,
-            text=True,
-            cwd=_worker_cwd(start),
-            env=build_raw_worker_env(start),
-            check=False,
-        )
-        if result.returncode != 0:
-            output = _format_subprocess_output(result.stdout, result.stderr)
+        try:
+            result = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                cwd=_worker_cwd(start),
+                env=build_raw_worker_env(start),
+                check=False,
+                timeout=RAW_WORKER_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired as exc:
             raise RuntimeError(
-                "RAW subprocess worker failed.\n\n"
-                f"Python: {python_executable}\n"
-                f"Command: {' '.join(command)}\n"
-                f"Output:\n{output}"
+                _build_subprocess_failure_message(
+                    title="RAW subprocess worker failed.",
+                    python_executable=python_executable,
+                    command=command,
+                    stdout=exc.stdout or "",
+                    stderr=exc.stderr or "",
+                    timeout_seconds=RAW_WORKER_TIMEOUT_SECONDS,
+                )
+            ) from exc
+        if result.returncode != 0:
+            raise RuntimeError(
+                _build_subprocess_failure_message(
+                    title="RAW subprocess worker failed.",
+                    python_executable=python_executable,
+                    command=command,
+                    stdout=result.stdout,
+                    stderr=result.stderr,
+                )
             )
 
         array = np.load(output_array_path, allow_pickle=False)

--- a/src/transformation_portal/core/raw_runtime.py
+++ b/src/transformation_portal/core/raw_runtime.py
@@ -1,0 +1,198 @@
+"""Shared RAW runtime contract helpers.
+
+This module keeps the repo-local RAW subprocess contract lightweight so CLI
+preflight, config resolution, and ingest adapters can all resolve the same
+runtime path without importing heavier pipeline modules.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+import numpy as np
+
+from ..ingest.canonical_json import dump_json
+from .da3_runtime import find_repo_root
+
+_REPO_LOCAL_RAW_PYTHON_PARTS = (".venv-raw", "bin", "python")
+REPO_LOCAL_RAW_PYTHON = f"./{'/'.join(_REPO_LOCAL_RAW_PYTHON_PARTS)}"
+RAW_RUNTIME_ENV_VAR = "TRANSFORMATION_PORTAL_RAW_PYTHON"
+RAW_WORKER_MODULE = "transformation_portal.spatial_ai.ingest.raw_worker"
+
+
+def repo_local_raw_python_path(start: Path) -> Optional[Path]:
+    """Return the canonical repo-local RAW interpreter path when in a checkout."""
+    repo_root = find_repo_root(start)
+    if repo_root is None:
+        return None
+    return repo_root.joinpath(*_REPO_LOCAL_RAW_PYTHON_PARTS)
+
+
+def normalize_python_executable(value: Any) -> Optional[str]:
+    """Normalize Python executable configuration values."""
+    if value is None:
+        return None
+    try:
+        normalized = os.fspath(value).strip()
+    except TypeError:
+        normalized = str(value).strip()
+    return normalized or None
+
+
+def _worker_cwd(start: Path) -> Path:
+    """Choose a stable subprocess working directory."""
+    repo_root = find_repo_root(start)
+    if repo_root is not None:
+        return repo_root
+    return Path.cwd()
+
+
+def resolve_raw_python_for_execution(
+    python_executable: str,
+    *,
+    start: Path,
+) -> str:
+    """Resolve a configured RAW Python executable to an executable path."""
+    candidate = normalize_python_executable(python_executable)
+    if not candidate:
+        raise ValueError("RAW Python executable must be a non-empty string.")
+
+    has_separator = os.sep in candidate or (os.altsep is not None and os.altsep in candidate)
+    if candidate.startswith(".") or has_separator:
+        path = Path(candidate).expanduser()
+        if not path.is_absolute():
+            path = _worker_cwd(start) / path
+        if not path.exists():
+            raise FileNotFoundError(f"RAW Python executable not found: {path}")
+        return os.path.abspath(os.fspath(path))
+
+    resolved = shutil.which(candidate)
+    if resolved is None:
+        raise FileNotFoundError(f"RAW Python executable not found on PATH: {candidate}")
+    return resolved
+
+
+def build_raw_worker_env(start: Path) -> dict[str, str]:
+    """Build environment for the RAW subprocess worker."""
+    env = os.environ.copy()
+    repo_root = find_repo_root(start)
+    repo_src = repo_root / "src" if repo_root is not None else None
+    if repo_src is not None and repo_src.exists():
+        existing = env.get("PYTHONPATH")
+        env["PYTHONPATH"] = f"{repo_src}{os.pathsep}{existing}" if existing else str(repo_src)
+    return env
+
+
+def _format_subprocess_output(stdout: str, stderr: str) -> str:
+    """Format subprocess output for actionable error messages."""
+    stdout_clean = stdout.strip()
+    stderr_clean = stderr.strip()
+    if stdout_clean and stderr_clean:
+        return f"stdout:\n{stdout_clean}\n\nstderr:\n{stderr_clean}"
+    if stderr_clean:
+        return stderr_clean
+    if stdout_clean:
+        return stdout_clean
+    return "<no output>"
+
+
+def check_raw_runtime(
+    python_executable: str,
+    *,
+    start: Path,
+) -> None:
+    """Validate that the dedicated RAW subprocess environment is usable."""
+    worker_python = resolve_raw_python_for_execution(python_executable, start=start)
+    command = [
+        worker_python,
+        "-m",
+        RAW_WORKER_MODULE,
+        "--check",
+    ]
+    result = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        cwd=_worker_cwd(start),
+        env=build_raw_worker_env(start),
+        check=False,
+    )
+    if result.returncode != 0:
+        output = _format_subprocess_output(result.stdout, result.stderr)
+        raise RuntimeError(
+            "RAW subprocess environment is not ready.\n\n"
+            f"Python: {python_executable}\n"
+            f"Command: {' '.join(command)}\n"
+            f"Output:\n{output}"
+        )
+
+
+def run_raw_worker(
+    *,
+    python_executable: str,
+    command_name: str,
+    input_path: Path,
+    payload: Optional[Mapping[str, Any]] = None,
+    start: Path,
+) -> tuple[np.ndarray, dict[str, Any]]:
+    """Execute the RAW subprocess worker and return the array + metadata."""
+    worker_python = resolve_raw_python_for_execution(python_executable, start=start)
+
+    with tempfile.TemporaryDirectory(prefix="tp-raw-worker-") as tmpdir:
+        temp_root = Path(tmpdir)
+        payload_path = temp_root / "payload.json"
+        output_array_path = temp_root / "output.npy"
+        output_json_path = temp_root / "output.json"
+
+        with payload_path.open("w", encoding="utf-8") as handle:
+            dump_json(
+                dict(payload or {}),
+                handle,
+                indent=2,
+                sort_keys=True,
+                ensure_ascii=False,
+                allow_nan=False,
+            )
+
+        command = [
+            worker_python,
+            "-m",
+            RAW_WORKER_MODULE,
+            "--command",
+            command_name,
+            "--input-path",
+            str(input_path),
+            "--payload-json",
+            str(payload_path),
+            "--output-array",
+            str(output_array_path),
+            "--output-json",
+            str(output_json_path),
+        ]
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            cwd=_worker_cwd(start),
+            env=build_raw_worker_env(start),
+            check=False,
+        )
+        if result.returncode != 0:
+            output = _format_subprocess_output(result.stdout, result.stderr)
+            raise RuntimeError(
+                "RAW subprocess worker failed.\n\n"
+                f"Python: {python_executable}\n"
+                f"Command: {' '.join(command)}\n"
+                f"Output:\n{output}"
+            )
+
+        array = np.load(output_array_path, allow_pickle=False)
+        with output_json_path.open("r", encoding="utf-8") as handle:
+            metadata = json.load(handle)
+        return array, metadata

--- a/src/transformation_portal/lux_depth_v3/README.md
+++ b/src/transformation_portal/lux_depth_v3/README.md
@@ -228,6 +228,17 @@ pip install -e ".[raw]"
 pip install rawpy
 ```
 
+For deterministic isolation, bootstrap the repo-local RAW runtime and let the
+pipeline auto-discover `./.venv-raw/bin/python` for RAW batches:
+```bash
+./scripts/setup/install_raw_runtime.sh
+```
+
+You can also override the interpreter explicitly with:
+```bash
+--raw-python "./.venv-raw/bin/python"
+```
+
 **Why:** Canonical RAW ingest stays deterministic and fail-closed. RAW batches are rejected before dispatch when `rawpy` is unavailable so the pipeline does not start a run that cannot satisfy the ingest contract.
 
 ### More Help

--- a/src/transformation_portal/lux_depth_v3/__main__.py
+++ b/src/transformation_portal/lux_depth_v3/__main__.py
@@ -160,6 +160,7 @@ except ImportError:
 
 from ._backend_contract import backend_alias_warning, is_legacy_backend_alias, normalize_backend_id
 from .config import EnhanceConfig, Preset
+from .config_resolver import apply_effective_raw_runtime_config
 from .ingest_adapter import RAW_PREVIEW_ESCAPE_ENV
 from .orchestrator import EnhanceOrchestrator
 
@@ -185,7 +186,21 @@ def _raw_preview_escape_enabled() -> bool:
     return raw_value in {"1", "true", "yes", "on"}
 
 
-def _canonical_raw_ingest_status() -> tuple[bool, Optional[str]]:
+def _canonical_raw_ingest_status(
+    raw_python_executable: Optional[str] = None,
+) -> tuple[bool, Optional[str]]:
+    if raw_python_executable:
+        from transformation_portal.core.raw_runtime import check_raw_runtime
+
+        try:
+            check_raw_runtime(raw_python_executable, start=Path(__file__))
+        except FileNotFoundError as exc:
+            return False, str(exc)
+        except Exception:
+            logger.exception("Canonical RAW ingest is unavailable because the dedicated RAW runtime failed validation")
+            return False, "the dedicated RAW runtime is unavailable in this environment"
+        return True, None
+
     try:
         import rawpy  # noqa: F401
     except ImportError:
@@ -201,7 +216,11 @@ def _canonical_raw_ingest_available() -> bool:
     return available
 
 
-def _preflight_raw_ingest_requirements(image_files: list[Path], raw_ingest_mode: str) -> None:
+def _preflight_raw_ingest_requirements(
+    image_files: list[Path],
+    raw_ingest_mode: str,
+    raw_python_executable: Optional[str] = None,
+) -> None:
     from .raw_loader import is_raw_file
 
     raw_inputs_detected = any(is_raw_file(image_path) for image_path in image_files)
@@ -216,17 +235,23 @@ def _preflight_raw_ingest_requirements(image_files: list[Path], raw_ingest_mode:
         print(message, file=sys.stdout)
         raise typer.Exit(code=1)
 
-    raw_ingest_available, unavailable_reason = _canonical_raw_ingest_status()
+    raw_ingest_available, unavailable_reason = _canonical_raw_ingest_status(raw_python_executable)
     if raw_ingest_available:
         return
 
     message = (
         "RAW inputs detected but canonical RAW ingest is unavailable because "
-        f"{unavailable_reason or 'rawpy is unavailable in this environment'}. "
-        'Install with: pip install -e ".[raw]" or pip install rawpy'
+        f"{unavailable_reason or 'rawpy is unavailable in this environment'}."
     )
-    if unavailable_reason != "rawpy is not installed":
-        message += " If rawpy is already installed, inspect the import/runtime error in the logs."
+    if raw_python_executable:
+        message += (
+            " Rebuild that dedicated RAW runtime or point --raw-python / "
+            "TRANSFORMATION_PORTAL_RAW_PYTHON at a working interpreter."
+        )
+    else:
+        message += ' Install with: pip install -e ".[raw]" or pip install rawpy'
+        if unavailable_reason != "rawpy is not installed":
+            message += " If rawpy is already installed, inspect the import/runtime error in the logs."
     logger.error(message)
     print(message, file=sys.stdout)
     raise typer.Exit(code=1)
@@ -312,6 +337,16 @@ def main(
             "Use this to keep DA3 out of the main Transformation Portal venv or to override "
             "the auto-discovered repo-local runtime at ./.venv-da3/bin/python "
             "(bootstrap with ./scripts/setup/install_da3_runtime.sh)."
+        ),
+    ),
+    raw_python: Optional[str] = typer.Option(
+        None,
+        "--raw-python",
+        help=(
+            "Optional Python executable for an isolated RAW ingest environment. "
+            "Use this to keep rawpy/LibRaw out of the main Transformation Portal venv or to override "
+            "the auto-discovered repo-local runtime at ./.venv-raw/bin/python "
+            "(bootstrap with ./scripts/setup/install_raw_runtime.sh)."
         ),
     ),
     depth_device: str = typer.Option(
@@ -804,6 +839,7 @@ def main(
         accept_apple_depth_pro_research_license=enable_apple_license,
         accept_research_tools_license=enable_research_tools_license,
         depth_pro_python_executable=depth_pro_python,
+        raw_python_executable=raw_python,
         da3_python_executable=da3_python,
         force_depth=force_depth or overwrite,
         enable_depth_cache=enable_cache_depth,
@@ -835,6 +871,7 @@ def main(
         raw_demosaic=raw_demosaic_normalized,
         allow_semantic_fallback=allow_semantic_fallback,
     )
+    apply_effective_raw_runtime_config(config)
 
     # Forward-compatible knobs: apply via setattr
     # for non-breaking config evolution.
@@ -879,7 +916,11 @@ def main(
         raise typer.Exit(code=1)
 
     logger.info(f"Found {len(image_files)} images to process")
-    _preflight_raw_ingest_requirements(image_files, raw_ingest_mode)
+    _preflight_raw_ingest_requirements(
+        image_files,
+        raw_ingest_mode,
+        config.raw_python_executable,
+    )
 
     # Create orchestrator only after input discovery and RAW preflight succeed.
     logger.info(

--- a/src/transformation_portal/lux_depth_v3/__main__.py
+++ b/src/transformation_portal/lux_depth_v3/__main__.py
@@ -158,6 +158,7 @@ except ImportError:
     )
     sys.exit(1)
 
+from ..core.raw_runtime import RAW_RUNTIME_ENV_VAR
 from ._backend_contract import backend_alias_warning, is_legacy_backend_alias, normalize_backend_id
 from .config import EnhanceConfig, Preset
 from .config_resolver import apply_effective_raw_runtime_config
@@ -245,8 +246,7 @@ def _preflight_raw_ingest_requirements(
     )
     if raw_python_executable:
         message += (
-            " Rebuild that dedicated RAW runtime or point --raw-python / "
-            "TRANSFORMATION_PORTAL_RAW_PYTHON at a working interpreter."
+            " Rebuild that dedicated RAW runtime or point --raw-python / " f"{RAW_RUNTIME_ENV_VAR} at a working interpreter."
         )
     else:
         message += ' Install with: pip install -e ".[raw]" or pip install rawpy'

--- a/src/transformation_portal/lux_depth_v3/config.py
+++ b/src/transformation_portal/lux_depth_v3/config.py
@@ -1,7 +1,7 @@
-"""Configuration module for lux_depth_v3 pipeline.
+"""Lux Depth V3 configuration types and runtime defaults.
 
-STUB IMPLEMENTATION - Critical types to enable package imports.
-Full implementation pending.
+This module defines the typed configuration surface used by the CLI, portal
+preview layer, orchestrator, and reproducibility metadata.
 """
 
 from __future__ import annotations
@@ -225,6 +225,9 @@ class EnhanceConfig:
     # Optional Python executable for a
     # dedicated Depth Pro environment
     depth_pro_python_executable: Optional[str] = None
+    # Optional Python executable for a
+    # dedicated RAW ingest environment
+    raw_python_executable: Optional[str] = None
     # Optional Python executable for a
     # dedicated DA3 / depth-anything-3 environment
     da3_python_executable: Optional[str] = None

--- a/src/transformation_portal/lux_depth_v3/config_resolver.py
+++ b/src/transformation_portal/lux_depth_v3/config_resolver.py
@@ -40,7 +40,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from ..core.da3_runtime import REPO_LOCAL_DA3_PYTHON, find_repo_root, repo_local_da3_python_path
-from ..core.raw_runtime import REPO_LOCAL_RAW_PYTHON, repo_local_raw_python_path
+from ..core.raw_runtime import RAW_RUNTIME_ENV_VAR, REPO_LOCAL_RAW_PYTHON, repo_local_raw_python_path
 from ..ingest.canonical_json import canonicalize_json
 from .config import DA3Config, EnhanceConfig, ModelVariant, Preset
 from .manifest import ConfigFingerprint
@@ -119,14 +119,14 @@ def resolve_effective_raw_python_executable(
 
     Resolution precedence:
     1. Explicit config.raw_python_executable
-    2. TRANSFORMATION_PORTAL_RAW_PYTHON environment override
+    2. RAW runtime environment override
     3. Repo-local stable contract path when present
     """
     configured = _normalize_python_executable(getattr(config, "raw_python_executable", None))
     if configured:
         return configured
 
-    env_candidate = _normalize_python_executable(os.environ.get("TRANSFORMATION_PORTAL_RAW_PYTHON"))
+    env_candidate = _normalize_python_executable(os.environ.get(RAW_RUNTIME_ENV_VAR))
     if env_candidate:
         return env_candidate
 

--- a/src/transformation_portal/lux_depth_v3/config_resolver.py
+++ b/src/transformation_portal/lux_depth_v3/config_resolver.py
@@ -40,6 +40,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from ..core.da3_runtime import REPO_LOCAL_DA3_PYTHON, find_repo_root, repo_local_da3_python_path
+from ..core.raw_runtime import REPO_LOCAL_RAW_PYTHON, repo_local_raw_python_path
 from ..ingest.canonical_json import canonicalize_json
 from .config import DA3Config, EnhanceConfig, ModelVariant, Preset
 from .manifest import ConfigFingerprint
@@ -60,6 +61,11 @@ def _repo_local_depth_pro_python_path() -> Optional[Path]:
     if repo_root is None:
         return None
     return repo_root.joinpath(*_REPO_LOCAL_DEPTH_PRO_PYTHON_PARTS)
+
+
+def _repo_local_raw_python_path() -> Optional[Path]:
+    """Return the canonical repo-local RAW interpreter path."""
+    return repo_local_raw_python_path(Path(__file__))
 
 
 def _normalize_python_executable(value: Any) -> Optional[str]:
@@ -103,6 +109,39 @@ def apply_effective_da3_runtime_config(
 ) -> EnhanceConfig:
     """Persist the effective DA3 runtime choice onto the config object."""
     config.da3_python_executable = resolve_effective_da3_python_executable(config)
+    return config
+
+
+def resolve_effective_raw_python_executable(
+    config: EnhanceConfig,
+) -> Optional[str]:
+    """Resolve the effective RAW runtime executable for this config.
+
+    Resolution precedence:
+    1. Explicit config.raw_python_executable
+    2. TRANSFORMATION_PORTAL_RAW_PYTHON environment override
+    3. Repo-local stable contract path when present
+    """
+    configured = _normalize_python_executable(getattr(config, "raw_python_executable", None))
+    if configured:
+        return configured
+
+    env_candidate = _normalize_python_executable(os.environ.get("TRANSFORMATION_PORTAL_RAW_PYTHON"))
+    if env_candidate:
+        return env_candidate
+
+    repo_local_python = _repo_local_raw_python_path()
+    if repo_local_python is not None and repo_local_python.exists():
+        return REPO_LOCAL_RAW_PYTHON
+
+    return None
+
+
+def apply_effective_raw_runtime_config(
+    config: EnhanceConfig,
+) -> EnhanceConfig:
+    """Persist the effective RAW runtime choice onto the config object."""
+    config.raw_python_executable = resolve_effective_raw_python_executable(config)
     return config
 
 
@@ -389,6 +428,7 @@ def build_depth_cache_payload(
     if mv is None:
         mv = ModelVariant.METRIC_LARGE
     effective_da3_python = resolve_effective_da3_python_executable(config)
+    effective_raw_python = resolve_effective_raw_python_executable(config)
 
     return {
         "model_variant": mv.value.name,
@@ -397,6 +437,7 @@ def build_depth_cache_payload(
         "depth_backend": config.depth_backend,
         "depth_pro_checkpoint_path": config.depth_pro_checkpoint_path,
         "depth_pro_python_executable": config.depth_pro_python_executable,
+        "raw_python_executable": effective_raw_python,
         "da3_python_executable": effective_da3_python,
     }
 
@@ -421,6 +462,7 @@ def compute_config_fingerprint(
     if mv is None:
         mv = ModelVariant.METRIC_LARGE
     effective_da3_python = resolve_effective_da3_python_executable(config)
+    effective_raw_python = resolve_effective_raw_python_executable(config)
 
     return ConfigFingerprint(
         model_variant=mv.value.name,
@@ -433,6 +475,7 @@ def compute_config_fingerprint(
         depth_backend=config.depth_backend,
         depth_pro_checkpoint_path=config.depth_pro_checkpoint_path,
         depth_pro_python_executable=config.depth_pro_python_executable,
+        raw_python_executable=effective_raw_python,
         da3_python_executable=effective_da3_python,
         quality_tier=str(config.quality_tier),
         materials_config=build_materials_fingerprint_payload(config),
@@ -465,7 +508,10 @@ def build_run_card_config_fingerprint(
     from .ingest_adapter import raw_ingest_summary
 
     base = compute_config_fingerprint(config, model_variant)
-    raw_summary = raw_ingest_summary(config)
+    raw_summary = raw_ingest_summary(
+        config,
+        raw_python_executable=base.raw_python_executable,
+    )
 
     preset_requested = getattr(config, "preset_requested", None) or (config.preset.value if config.preset else None)
     preset_resolved = config.preset.value if config.preset else f"quality_tier:{config.quality_tier}"
@@ -490,6 +536,7 @@ def build_run_card_config_fingerprint(
         "v2_device": base.v2_device,
         "v2_upscaler_backend": base.v2_upscaler_backend,
         "depth_pro_python_executable": base.depth_pro_python_executable,
+        "raw_python_executable": base.raw_python_executable,
         "da3_python_executable": base.da3_python_executable,
         "preset_requested": preset_requested,
         "preset_resolved": preset_resolved,
@@ -566,6 +613,7 @@ class ConfigResolver:
         """
         # Resolve preset and model variant
         apply_effective_da3_runtime_config(config)
+        apply_effective_raw_runtime_config(config)
         da3_config, resolved_model = resolve_preset(
             config.preset,
             config.model_variant,

--- a/src/transformation_portal/lux_depth_v3/ingest_adapter.py
+++ b/src/transformation_portal/lux_depth_v3/ingest_adapter.py
@@ -83,6 +83,7 @@ def build_raw_ingest_options(
         )
         .strip()
         .upper(),
+        raw_python_executable=getattr(config, "raw_python_executable", None),
         no_auto_bright=True,
         no_auto_scale=True,
         gamma_mode="linear",
@@ -91,6 +92,8 @@ def build_raw_ingest_options(
 
 def raw_ingest_summary(
     config: "EnhanceConfig",
+    *,
+    raw_python_executable: str | None = None,
 ) -> Dict[str, Any]:
     """Return deterministic digest summary.
 
@@ -104,6 +107,7 @@ def raw_ingest_summary(
         "contract": options.contract,
         "wb_mode": options.wb_mode,
         "demosaic": options.demosaic,
+        "raw_python_executable": raw_python_executable or getattr(config, "raw_python_executable", None),
         "no_auto_bright": options.no_auto_bright,
         "no_auto_scale": options.no_auto_scale,
         "gamma_mode": options.gamma_mode,
@@ -137,7 +141,11 @@ def _is_camera_wb_metadata_failure(exc: Exception) -> bool:
     return RAW_CAMERA_WB_NON_POSITIVE_TOKEN in str(exc)
 
 
-def _decode_auto_wb_linear_rgb(path: Path) -> np.ndarray:
+def _decode_auto_wb_linear_rgb(
+    path: Path,
+    *,
+    python_executable: str | None,
+) -> np.ndarray:
     from .raw_loader import load_raw_as_rgb
 
     linear_rgb_u16 = load_raw_as_rgb(
@@ -146,6 +154,7 @@ def _decode_auto_wb_linear_rgb(path: Path) -> np.ndarray:
         half_size=False,
         output_bps=16,
         output_linear=True,
+        python_executable=python_executable,
     )
     return np.clip(linear_rgb_u16.astype(np.float32) / 65535.0, 0.0, 1.0).astype(np.float32)
 
@@ -195,7 +204,10 @@ def decode_for_lux_depth(
                 path.name,
             )
             try:
-                return _decode_auto_wb_linear_rgb(path)
+                return _decode_auto_wb_linear_rgb(
+                    path,
+                    python_executable=getattr(config, "raw_python_executable", None),
+                )
             except Exception as fallback_exc:
                 raise RawIngestError(
                     "Canonical RAW decode failed for {}: {}. "

--- a/src/transformation_portal/lux_depth_v3/input_manager.py
+++ b/src/transformation_portal/lux_depth_v3/input_manager.py
@@ -1,7 +1,7 @@
-"""Input management for lux_depth_v3 pipeline.
+"""Input modeling helpers for Lux Depth V3 batch execution.
 
-STUB IMPLEMENTATION - Critical types to enable package imports.
-Full implementation pending.
+This module keeps the lightweight input records shared by discovery,
+grouping, and orchestrator scheduling paths.
 """
 
 from __future__ import annotations

--- a/src/transformation_portal/lux_depth_v3/manifest.py
+++ b/src/transformation_portal/lux_depth_v3/manifest.py
@@ -1,7 +1,8 @@
-"""Manifest management for pipeline reproducibility.
+"""Lux Depth V3 manifest and reproducibility data models.
 
-STUB IMPLEMENTATION - Critical types to enable package imports.
-Full implementation pending.
+This module defines the typed manifest payloads written for per-image outputs,
+batch summaries, and config fingerprint material used by reuse and governance
+checks.
 """
 
 from __future__ import annotations
@@ -312,6 +313,7 @@ class ConfigFingerprint:
     depth_backend: Optional[str] = None
     depth_pro_checkpoint_path: Optional[str] = None
     depth_pro_python_executable: Optional[str] = None
+    raw_python_executable: Optional[str] = None
     da3_python_executable: Optional[str] = None
     quality_tier: Optional[str] = None
     materials_config: Optional[Dict[str, Any]] = None
@@ -336,6 +338,7 @@ class ConfigFingerprint:
             depth_backend=self.depth_backend,
             depth_pro_checkpoint_path=self.depth_pro_checkpoint_path,
             depth_pro_python_executable=self.depth_pro_python_executable,
+            raw_python_executable=self.raw_python_executable,
             da3_python_executable=self.da3_python_executable,
             quality_tier=self.quality_tier,
             materials_config=self.materials_config,
@@ -362,6 +365,7 @@ class ConfigFingerprint:
             depth_backend=None,
             depth_pro_checkpoint_path=None,
             depth_pro_python_executable=None,
+            raw_python_executable=None,
             da3_python_executable=None,
             quality_tier=None,
             materials_config=None,

--- a/src/transformation_portal/lux_depth_v3/orchestrator.py
+++ b/src/transformation_portal/lux_depth_v3/orchestrator.py
@@ -71,6 +71,7 @@ from .config_resolver import (
     PresetInfo,
     ResolvedConfig,
     apply_effective_da3_runtime_config,
+    apply_effective_raw_runtime_config,
     build_apex_depth_gate_fingerprint_payload,
     build_depth_cache_payload,
     build_materials_fingerprint_payload,
@@ -373,6 +374,7 @@ class EnhanceOrchestrator:
         _log_dependency_status()
 
         self.config = apply_effective_da3_runtime_config(config)
+        self.config = apply_effective_raw_runtime_config(self.config)
         self.output_root = Path(output_root)
         self.verify_outputs = verify_outputs
 

--- a/src/transformation_portal/lux_depth_v3/raw_loader.py
+++ b/src/transformation_portal/lux_depth_v3/raw_loader.py
@@ -22,10 +22,12 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Tuple
+from typing import Optional, Tuple
 
 import numpy as np
 from PIL import Image
+
+from transformation_portal.core.raw_runtime import run_raw_worker
 
 logger = logging.getLogger(__name__)
 
@@ -78,6 +80,7 @@ def load_raw_as_rgb(
     half_size: bool = False,
     output_bps: int = 8,
     output_linear: bool = False,
+    python_executable: Optional[str] = None,
 ) -> np.ndarray:
     """Load RAW camera file and convert to RGB numpy array.
 
@@ -92,6 +95,9 @@ def load_raw_as_rgb(
         output_linear: Output linear RGB (True) or gamma-encoded sRGB (False)
                       Default False for legacy compatibility
                       MUST be True for APEX pipeline
+        python_executable: Optional interpreter for an isolated RAW runtime.
+            When provided, the decode runs in a subprocess backed by that
+            interpreter instead of importing rawpy in-process.
 
     Returns:
         RGB numpy array (uint8 or uint16 depending on output_bps)
@@ -118,6 +124,23 @@ def load_raw_as_rgb(
         >>> print(rgb.shape, rgb.dtype)
         (4000, 6000, 3) uint16
     """
+    if python_executable is not None:
+        if not raw_path.exists():
+            raise FileNotFoundError(f"RAW file not found: {raw_path}")
+        rgb, _ = run_raw_worker(
+            python_executable=python_executable,
+            command_name="load_rgb",
+            input_path=raw_path,
+            payload={
+                "use_camera_wb": bool(use_camera_wb),
+                "half_size": bool(half_size),
+                "output_bps": int(output_bps),
+                "output_linear": bool(output_linear),
+            },
+            start=Path(__file__),
+        )
+        return np.asarray(rgb)
+
     try:
         import rawpy
     except ImportError as e:
@@ -180,6 +203,7 @@ def load_raw_as_pil(
     use_camera_wb: bool = True,
     half_size: bool = False,
     output_linear: bool = False,
+    python_executable: Optional[str] = None,
 ) -> Image.Image:
     """Load RAW camera file and convert to PIL Image.
 
@@ -196,6 +220,7 @@ def load_raw_as_pil(
         output_linear: Output linear RGB (True) or gamma-encoded sRGB (False)
                       Default False for legacy compatibility
                       MUST be True for APEX pipeline
+        python_executable: Optional interpreter for an isolated RAW runtime.
 
     Returns:
         PIL Image in RGB mode (uint8)
@@ -214,6 +239,7 @@ def load_raw_as_pil(
         half_size=half_size,
         output_bps=output_bps,
         output_linear=output_linear,
+        python_executable=python_executable,
     )
 
     # Convert to PIL Image with appropriate mode

--- a/src/transformation_portal/spatial_ai/ingest/contracts.py
+++ b/src/transformation_portal/spatial_ai/ingest/contracts.py
@@ -27,6 +27,7 @@ class IngestOptions:
     tensor_role: str = "xyz_d50_linear_fp32"
     wb_mode: Literal["none", "camera", "auto"] = "camera"
     demosaic: str = field(default="AHD")
+    raw_python_executable: str | None = None
     no_auto_bright: bool = True
     no_auto_scale: bool = True
     gamma_mode: Literal["linear"] = "linear"
@@ -60,6 +61,7 @@ def decode_contract(input_path: Path | str, opts: IngestOptions) -> np.ndarray:
             path=input_path,
             wb_mode=opts.wb_mode,
             demosaic=opts.demosaic,
+            raw_python_executable=opts.raw_python_executable,
         )
         return tensor
 
@@ -70,7 +72,11 @@ def decode_contract(input_path: Path | str, opts: IngestOptions) -> np.ndarray:
             raise ValueError("legacy_linear_srgb currently supports demosaic='AHD' only.")
         from .linear_decoder import LinearDecoder
 
-        result = LinearDecoder(gamma=1.0, strict_ingest=True).decode(input_path)
+        result = LinearDecoder(
+            gamma=1.0,
+            strict_ingest=True,
+            raw_python_executable=opts.raw_python_executable,
+        ).decode(input_path)
         return result.linear_rgb
 
     raise ValueError(

--- a/src/transformation_portal/spatial_ai/ingest/linear_decoder.py
+++ b/src/transformation_portal/spatial_ai/ingest/linear_decoder.py
@@ -41,6 +41,7 @@ from typing import Any, Dict, Optional, Tuple
 import numpy as np
 from PIL import Image
 
+from ...core.raw_runtime import run_raw_worker
 from ...ingest.canonical_json import dump_json
 from .exceptions import BitDepthViolationError, ColorSpaceError, UnsupportedFormatError
 from .provenance import ProvenanceCapture
@@ -184,6 +185,7 @@ class LinearDecoder:
         bit_depth: int = 32,
         strict_ingest: bool = False,
         telemetry: IngestTelemetry | None = None,
+        raw_python_executable: str | None = None,
     ):
         """Initialize linear decoder.
 
@@ -209,6 +211,7 @@ class LinearDecoder:
         self.bit_depth = bit_depth
         self.strict_ingest = strict_ingest
         self._telemetry: IngestTelemetry = telemetry or NullTelemetry()
+        self._raw_python_executable = raw_python_executable
 
     def _emit_telemetry(self, event: str, **fields: object) -> None:
         """Best-effort telemetry emission that never interrupts ingest flow."""
@@ -260,17 +263,20 @@ class LinearDecoder:
         format_str = self._detect_format(input_path)
         logger.debug(f"Detected format: {format_str}")
 
-        # Detect color space (especially for RAW files)
-        if format_str.startswith("RAW_"):
-            color_space = self._detect_raw_color_space(input_path)
+        if format_str.startswith("RAW_") and self._raw_python_executable is not None:
+            linear_rgb, input_size, ingest_fingerprint, color_space = self._decode_raw_via_subprocess(input_path)
         else:
-            # Non-RAW formats: assume linear_sRGB for Phase I
-            # (TIFF/PNG/EXR don't have embedded color matrices like RAW)
-            color_space = "linear_sRGB"
-        logger.debug(f"Color space: {color_space}")
+            # Detect color space (especially for RAW files)
+            if format_str.startswith("RAW_"):
+                color_space = self._detect_raw_color_space(input_path)
+            else:
+                # Non-RAW formats: assume linear_sRGB for Phase I
+                # (TIFF/PNG/EXR don't have embedded color matrices like RAW)
+                color_space = "linear_sRGB"
+            logger.debug(f"Color space: {color_space}")
 
-        # Decode to linear RGB
-        linear_rgb, input_size, ingest_fingerprint = self._decode_linear(input_path, format_str)
+            # Decode to linear RGB
+            linear_rgb, input_size, ingest_fingerprint = self._decode_linear(input_path, format_str)
 
         # Compute content hash
         content_hash = self._compute_content_hash(linear_rgb)
@@ -314,6 +320,36 @@ class LinearDecoder:
         )
 
         return result
+
+    def _decode_raw_via_subprocess(
+        self,
+        path: Path,
+    ) -> Tuple[np.ndarray, Tuple[int, int], Optional[str], str]:
+        """Decode RAW via an isolated subprocess runtime."""
+        if self._raw_python_executable is None:
+            raise RuntimeError("RAW subprocess decode requested without a Python executable.")
+
+        array, metadata = run_raw_worker(
+            python_executable=self._raw_python_executable,
+            command_name="linear_decode",
+            input_path=path,
+            payload={
+                "gamma": self.gamma,
+                "bit_depth": self.bit_depth,
+                "strict_ingest": self.strict_ingest,
+            },
+            start=Path(__file__),
+        )
+        linear_rgb = np.asarray(array, dtype=np.float32)
+        size_payload = metadata.get("input_size")
+        if not isinstance(size_payload, list) or len(size_payload) != 2:
+            raise RuntimeError(f"RAW worker returned invalid input_size metadata: {size_payload!r}")
+        input_size = (int(size_payload[0]), int(size_payload[1]))
+        color_space = str(metadata.get("color_space") or "linear_sRGB")
+        ingest_fingerprint = metadata.get("ingest_fingerprint")
+        if ingest_fingerprint is not None:
+            ingest_fingerprint = str(ingest_fingerprint)
+        return linear_rgb, input_size, ingest_fingerprint, color_space
 
     def _detect_format(self, path: Path) -> str:
         """Detect image format from file extension.
@@ -1004,6 +1040,7 @@ def decode(
     output_dir: Optional[Path | str] = None,
     emit_exr: bool = False,
     emit_provenance: bool = False,
+    raw_python_executable: str | None = None,
 ) -> LinearIngestResult:
     """Decode image to float32 linear light (convenience function).
 
@@ -1024,7 +1061,12 @@ def decode(
         >>> assert result.gamma == 1.0
         >>> assert result.linear_rgb.dtype == np.float32
     """
-    decoder = LinearDecoder(gamma=gamma, bit_depth=bit_depth, strict_ingest=strict_ingest)
+    decoder = LinearDecoder(
+        gamma=gamma,
+        bit_depth=bit_depth,
+        strict_ingest=strict_ingest,
+        raw_python_executable=raw_python_executable,
+    )
     return decoder.decode(
         input_path=input_path,
         output_dir=output_dir,

--- a/src/transformation_portal/spatial_ai/ingest/phase2_camera_native_linear.py
+++ b/src/transformation_portal/spatial_ai/ingest/phase2_camera_native_linear.py
@@ -86,6 +86,8 @@ def ingest_phase2_xyz_d50_linear_fp32(
     Returns (tensor, fingerprint) where fingerprint is schema-versioned provenance.
     """
     path = Path(path)
+    enforce_ftz_daz_disabled()
+
     if raw_python_executable is not None:
         tensor, metadata = run_raw_worker(
             python_executable=raw_python_executable,
@@ -107,8 +109,6 @@ def ingest_phase2_xyz_d50_linear_fp32(
                 f"got shape {tensor_f32.shape!r}"
             )
         return canonicalize_tensor_f32_le_c(tensor_f32), fingerprint
-
-    enforce_ftz_daz_disabled()
 
     try:
         import rawpy  # type: ignore

--- a/src/transformation_portal/spatial_ai/ingest/phase2_camera_native_linear.py
+++ b/src/transformation_portal/spatial_ai/ingest/phase2_camera_native_linear.py
@@ -18,6 +18,7 @@ from typing import Any, Dict, Literal, Optional
 
 import numpy as np
 
+from transformation_portal.core.raw_runtime import run_raw_worker
 from transformation_portal.determinism.fpstate import enforce_ftz_daz_disabled
 from transformation_portal.determinism.tensor import canonicalize_tensor_f32_le_c
 
@@ -77,6 +78,7 @@ def ingest_phase2_xyz_d50_linear_fp32(
     *,
     wb_mode: Literal["none", "camera", "auto"] = "camera",
     demosaic: str = "AHD",
+    raw_python_executable: str | None = None,
 ) -> tuple[np.ndarray, Dict[str, Any]]:
     """Certified Phase II decode: RAW -> camera RGB (linear) -> XYZ(D65) -> Bradford(D50) -> float32 HWC.
 
@@ -84,6 +86,22 @@ def ingest_phase2_xyz_d50_linear_fp32(
     Returns (tensor, fingerprint) where fingerprint is schema-versioned provenance.
     """
     path = Path(path)
+    if raw_python_executable is not None:
+        tensor, metadata = run_raw_worker(
+            python_executable=raw_python_executable,
+            command_name="phase2_decode",
+            input_path=path,
+            payload={
+                "wb_mode": wb_mode,
+                "demosaic": demosaic,
+            },
+            start=Path(__file__),
+        )
+        fingerprint = metadata.get("fingerprint")
+        if not isinstance(fingerprint, dict):
+            raise RuntimeError(f"RAW worker returned invalid Phase II fingerprint payload: {fingerprint!r}")
+        return np.asarray(tensor, dtype=np.float32), fingerprint
+
     enforce_ftz_daz_disabled()
 
     try:

--- a/src/transformation_portal/spatial_ai/ingest/phase2_camera_native_linear.py
+++ b/src/transformation_portal/spatial_ai/ingest/phase2_camera_native_linear.py
@@ -100,7 +100,13 @@ def ingest_phase2_xyz_d50_linear_fp32(
         fingerprint = metadata.get("fingerprint")
         if not isinstance(fingerprint, dict):
             raise RuntimeError(f"RAW worker returned invalid Phase II fingerprint payload: {fingerprint!r}")
-        return np.asarray(tensor, dtype=np.float32), fingerprint
+        tensor_f32 = np.asarray(tensor, dtype=np.float32)
+        if tensor_f32.ndim != 3 or tensor_f32.shape[2] != 3:
+            raise RuntimeError(
+                "RAW worker returned invalid Phase II tensor shape; expected float32 HWC with 3 channels, "
+                f"got shape {tensor_f32.shape!r}"
+            )
+        return canonicalize_tensor_f32_le_c(tensor_f32), fingerprint
 
     enforce_ftz_daz_disabled()
 

--- a/src/transformation_portal/spatial_ai/ingest/raw_worker.py
+++ b/src/transformation_portal/spatial_ai/ingest/raw_worker.py
@@ -1,0 +1,167 @@
+"""Subprocess worker for isolated RAW ingest operations."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+import numpy as np
+
+from ...ingest.canonical_json import dump_json
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run RAW ingest operations in an isolated Python environment.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Only validate that RAW ingest dependencies import cleanly.",
+    )
+    parser.add_argument(
+        "--command",
+        choices=("load_rgb", "linear_decode", "phase2_decode"),
+        help="RAW operation to execute.",
+    )
+    parser.add_argument(
+        "--input-path",
+        type=Path,
+        help="Input RAW image path.",
+    )
+    parser.add_argument(
+        "--payload-json",
+        type=Path,
+        help="JSON file with structured command options.",
+    )
+    parser.add_argument(
+        "--output-array",
+        type=Path,
+        help="Output .npy path for the array payload.",
+    )
+    parser.add_argument(
+        "--output-json",
+        type=Path,
+        help="Output JSON path for structured metadata.",
+    )
+    return parser
+
+
+def _load_payload(path: Path | None) -> Dict[str, Any]:
+    if path is None:
+        return {}
+    with path.open("r", encoding="utf-8") as handle:
+        loaded = json.load(handle)
+    if not isinstance(loaded, dict):
+        raise ValueError("RAW worker payload must be a JSON object.")
+    return loaded
+
+
+def _check_availability() -> int:
+    import rawpy  # noqa: F401
+
+    from ...lux_depth_v3.raw_loader import load_raw_as_rgb
+    from .linear_decoder import LinearDecoder
+    from .phase2_camera_native_linear import ingest_phase2_xyz_d50_linear_fp32
+
+    _ = (load_raw_as_rgb, LinearDecoder, ingest_phase2_xyz_d50_linear_fp32)
+    return 0
+
+
+def _run_load_rgb(input_path: Path, payload: Dict[str, Any]) -> tuple[np.ndarray, Dict[str, Any]]:
+    from ...lux_depth_v3.raw_loader import load_raw_as_rgb
+
+    array = load_raw_as_rgb(
+        input_path,
+        use_camera_wb=bool(payload.get("use_camera_wb", True)),
+        half_size=bool(payload.get("half_size", False)),
+        output_bps=int(payload.get("output_bps", 8)),
+        output_linear=bool(payload.get("output_linear", False)),
+        python_executable=None,
+    )
+    return array, {
+        "dtype": str(array.dtype),
+        "shape": [int(dim) for dim in array.shape],
+    }
+
+
+def _run_linear_decode(input_path: Path, payload: Dict[str, Any]) -> tuple[np.ndarray, Dict[str, Any]]:
+    from .linear_decoder import LinearDecoder
+
+    decoder = LinearDecoder(
+        gamma=float(payload.get("gamma", 1.0)),
+        bit_depth=int(payload.get("bit_depth", 32)),
+        strict_ingest=bool(payload.get("strict_ingest", False)),
+        raw_python_executable=None,
+    )
+    result = decoder.decode(input_path)
+    return result.linear_rgb, {
+        "input_size": [int(result.input_size[0]), int(result.input_size[1])],
+        "input_format": result.input_format,
+        "color_space": result.color_space,
+        "ingest_fingerprint": result.ingest_fingerprint,
+        "dtype": result.dtype,
+    }
+
+
+def _run_phase2_decode(input_path: Path, payload: Dict[str, Any]) -> tuple[np.ndarray, Dict[str, Any]]:
+    from .phase2_camera_native_linear import ingest_phase2_xyz_d50_linear_fp32
+
+    tensor, fingerprint = ingest_phase2_xyz_d50_linear_fp32(
+        input_path,
+        wb_mode=str(payload.get("wb_mode", "camera")),
+        demosaic=str(payload.get("demosaic", "AHD")),
+        raw_python_executable=None,
+    )
+    return tensor, {"fingerprint": fingerprint}
+
+
+def _write_outputs(output_array: Path, output_json: Path, array: np.ndarray, payload: Dict[str, Any]) -> int:
+    output_array.parent.mkdir(parents=True, exist_ok=True)
+    output_json.parent.mkdir(parents=True, exist_ok=True)
+    np.save(output_array, np.asarray(array), allow_pickle=False)
+    with output_json.open("w", encoding="utf-8") as handle:
+        dump_json(
+            payload,
+            handle,
+            indent=2,
+            sort_keys=True,
+            ensure_ascii=False,
+            allow_nan=False,
+        )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if args.check:
+        return _check_availability()
+
+    if args.command is None or args.input_path is None or args.output_array is None or args.output_json is None:
+        parser.error("--command, --input-path, --output-array, and --output-json are required unless --check is used.")
+
+    payload = _load_payload(args.payload_json)
+    input_path = args.input_path.expanduser()
+
+    if args.command == "load_rgb":
+        array, metadata = _run_load_rgb(input_path, payload)
+    elif args.command == "linear_decode":
+        array, metadata = _run_linear_decode(input_path, payload)
+    else:
+        array, metadata = _run_phase2_decode(input_path, payload)
+
+    return _write_outputs(
+        args.output_array.expanduser(),
+        args.output_json.expanduser(),
+        array,
+        metadata,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/transformation_portal/spatial_ai/ingest/raw_worker.py
+++ b/src/transformation_portal/spatial_ai/ingest/raw_worker.py
@@ -146,7 +146,7 @@ def main(argv: list[str] | None = None) -> int:
         parser.error("--command, --input-path, --output-array, and --output-json are required unless --check is used.")
 
     payload = _load_payload(args.payload_json)
-    input_path = args.input_path.expanduser()
+    input_path = args.input_path.expanduser().resolve()
 
     if args.command == "load_rgb":
         array, metadata = _run_load_rgb(input_path, payload)

--- a/tests/lux_depth_v3/test_config_resolver.py
+++ b/tests/lux_depth_v3/test_config_resolver.py
@@ -235,6 +235,61 @@ class TestEffectiveDepthProRuntimeResolution:
         assert resolve_effective_depth_pro_python_executable(EnhanceConfig()) == REPO_LOCAL_DEPTH_PRO_PYTHON
 
 
+class TestEffectiveRawRuntimeResolution:
+    """Test effective RAW runtime resolution."""
+
+    def test_auto_discovers_repo_local_contract(self, monkeypatch, tmp_path):
+        """Repo-local RAW runtime should resolve to the stable contract path."""
+        from transformation_portal.lux_depth_v3.config import EnhanceConfig
+        from transformation_portal.lux_depth_v3.config_resolver import (
+            REPO_LOCAL_RAW_PYTHON,
+            resolve_effective_raw_python_executable,
+        )
+
+        discovered_python = tmp_path / "bin" / "python"
+        discovered_python.parent.mkdir(parents=True)
+        discovered_python.write_text("#!/bin/sh\n", encoding="utf-8")
+        monkeypatch.delenv("TRANSFORMATION_PORTAL_RAW_PYTHON", raising=False)
+        monkeypatch.setattr(
+            "transformation_portal.lux_depth_v3.config_resolver._repo_local_raw_python_path",
+            lambda: discovered_python,
+        )
+
+        assert resolve_effective_raw_python_executable(EnhanceConfig()) == REPO_LOCAL_RAW_PYTHON
+
+    def test_prefers_explicit_config(self, monkeypatch, tmp_path):
+        """Explicit RAW config should win over env and repo-local discovery."""
+        from transformation_portal.lux_depth_v3.config import EnhanceConfig
+        from transformation_portal.lux_depth_v3.config_resolver import resolve_effective_raw_python_executable
+
+        discovered_python = tmp_path / "bin" / "python"
+        discovered_python.parent.mkdir(parents=True)
+        discovered_python.write_text("#!/bin/sh\n", encoding="utf-8")
+        monkeypatch.setenv("TRANSFORMATION_PORTAL_RAW_PYTHON", "/env/raw-python")
+        monkeypatch.setattr(
+            "transformation_portal.lux_depth_v3.config_resolver._repo_local_raw_python_path",
+            lambda: discovered_python,
+        )
+
+        config = EnhanceConfig(raw_python_executable="/config/raw-python")
+
+        assert resolve_effective_raw_python_executable(config) == "/config/raw-python"
+
+    def test_uses_env_when_config_unset(self, monkeypatch, tmp_path):
+        """Environment override should win when RAW config is unset."""
+        from transformation_portal.lux_depth_v3.config import EnhanceConfig
+        from transformation_portal.lux_depth_v3.config_resolver import resolve_effective_raw_python_executable
+
+        missing_python = tmp_path / "missing" / "python"
+        monkeypatch.setenv("TRANSFORMATION_PORTAL_RAW_PYTHON", "/env/raw-python")
+        monkeypatch.setattr(
+            "transformation_portal.lux_depth_v3.config_resolver._repo_local_raw_python_path",
+            lambda: missing_python,
+        )
+
+        assert resolve_effective_raw_python_executable(EnhanceConfig()) == "/env/raw-python"
+
+
 class TestComputeConfigFingerprint:
     """Test configuration fingerprint computation."""
 
@@ -326,6 +381,27 @@ class TestComputeConfigFingerprint:
         fingerprint = compute_config_fingerprint(EnhanceConfig())
 
         assert fingerprint.da3_python_executable == REPO_LOCAL_DA3_PYTHON
+
+    def test_fingerprint_records_auto_discovered_raw_runtime(self, monkeypatch, tmp_path):
+        """Fingerprint should capture the effective repo-local RAW runtime."""
+        from transformation_portal.lux_depth_v3.config import EnhanceConfig
+        from transformation_portal.lux_depth_v3.config_resolver import (
+            REPO_LOCAL_RAW_PYTHON,
+            compute_config_fingerprint,
+        )
+
+        discovered_python = tmp_path / "bin" / "python"
+        discovered_python.parent.mkdir(parents=True)
+        discovered_python.write_text("#!/bin/sh\n", encoding="utf-8")
+        monkeypatch.delenv("TRANSFORMATION_PORTAL_RAW_PYTHON", raising=False)
+        monkeypatch.setattr(
+            "transformation_portal.lux_depth_v3.config_resolver._repo_local_raw_python_path",
+            lambda: discovered_python,
+        )
+
+        fingerprint = compute_config_fingerprint(EnhanceConfig())
+
+        assert fingerprint.raw_python_executable == REPO_LOCAL_RAW_PYTHON
 
 
 class TestBuildFingerprintPayloads:
@@ -448,6 +524,27 @@ class TestBuildRunCardConfigFingerprint:
 
         assert fingerprint["da3_python_executable"] == REPO_LOCAL_DA3_PYTHON
 
+    def test_run_card_fingerprint_records_auto_discovered_raw_runtime(self, monkeypatch, tmp_path):
+        """Run-card fingerprint should record the effective repo-local RAW runtime."""
+        from transformation_portal.lux_depth_v3.config import EnhanceConfig
+        from transformation_portal.lux_depth_v3.config_resolver import (
+            REPO_LOCAL_RAW_PYTHON,
+            build_run_card_config_fingerprint,
+        )
+
+        discovered_python = tmp_path / "bin" / "python"
+        discovered_python.parent.mkdir(parents=True)
+        discovered_python.write_text("#!/bin/sh\n", encoding="utf-8")
+        monkeypatch.delenv("TRANSFORMATION_PORTAL_RAW_PYTHON", raising=False)
+        monkeypatch.setattr(
+            "transformation_portal.lux_depth_v3.config_resolver._repo_local_raw_python_path",
+            lambda: discovered_python,
+        )
+
+        fingerprint = build_run_card_config_fingerprint(EnhanceConfig())
+
+        assert fingerprint["raw_python_executable"] == REPO_LOCAL_RAW_PYTHON
+
 
 class TestConfigResolverClass:
     """Test the ConfigResolver class interface."""
@@ -494,6 +591,26 @@ class TestConfigResolverClass:
         assert resolved.enhance_config is config
         assert resolved.da3_config is not None
         assert resolved.fingerprint is not None
+
+    def test_resolver_persists_auto_discovered_raw_runtime(self, monkeypatch, tmp_path):
+        """Resolver should persist the effective RAW runtime on config."""
+        from transformation_portal.lux_depth_v3.config import EnhanceConfig
+        from transformation_portal.lux_depth_v3.config_resolver import REPO_LOCAL_RAW_PYTHON, ConfigResolver
+
+        discovered_python = tmp_path / "bin" / "python"
+        discovered_python.parent.mkdir(parents=True)
+        discovered_python.write_text("#!/bin/sh\n", encoding="utf-8")
+        monkeypatch.delenv("TRANSFORMATION_PORTAL_RAW_PYTHON", raising=False)
+        monkeypatch.setattr(
+            "transformation_portal.lux_depth_v3.config_resolver._repo_local_raw_python_path",
+            lambda: discovered_python,
+        )
+
+        config = EnhanceConfig()
+        resolved = ConfigResolver().resolve(config)
+
+        assert resolved.enhance_config.raw_python_executable == REPO_LOCAL_RAW_PYTHON
+        assert resolved.enhance_config is config
 
     def test_resolver_resolve_with_preset(self):
         """Test resolver resolve with preset."""

--- a/tests/lux_depth_v3/test_phase_c_raw_ingest.py
+++ b/tests/lux_depth_v3/test_phase_c_raw_ingest.py
@@ -168,6 +168,7 @@ def test_auto_mode_retries_non_positive_camera_wb_with_rawpy_auto_wb(
         "half_size": False,
         "output_bps": 16,
         "output_linear": True,
+        "python_executable": None,
     }
 
 

--- a/tests/lux_depth_v3/validators/test_run_card_validator.py
+++ b/tests/lux_depth_v3/validators/test_run_card_validator.py
@@ -112,6 +112,7 @@ def _minimal_valid_payload() -> Dict[str, Any]:
         "v2_device": "cpu",
         "v2_upscaler_backend": "realesrgan",
         "depth_pro_python_executable": None,
+        "raw_python_executable": None,
         "da3_python_executable": None,
     }
     canonical_json = json.dumps(
@@ -136,6 +137,7 @@ def _minimal_valid_payload() -> Dict[str, Any]:
                 "strict_segmentation",
                 "apex_strict_mode",
                 "depth_pro_python_executable",
+                "raw_python_executable",
                 "da3_python_executable",
             )
         },

--- a/tests/spatial_ai/ingest/test_contracts_dispatcher.py
+++ b/tests/spatial_ai/ingest/test_contracts_dispatcher.py
@@ -24,10 +24,11 @@ def test_decode_contract_camera_native_linear_forwards_params(monkeypatch):
     captured = {}
     expected = np.ones((2, 2, 3), dtype=np.float32)
 
-    def _fake_ingest(path, *, wb_mode, demosaic):  # noqa: ANN001
+    def _fake_ingest(path, *, wb_mode, demosaic, raw_python_executable):  # noqa: ANN001
         captured["path"] = path
         captured["wb_mode"] = wb_mode
         captured["demosaic"] = demosaic
+        captured["raw_python_executable"] = raw_python_executable
         return expected, {"contract": "camera_native_linear"}
 
     monkeypatch.setattr(
@@ -35,7 +36,12 @@ def test_decode_contract_camera_native_linear_forwards_params(monkeypatch):
         _fake_ingest,
     )
 
-    opts = IngestOptions(contract="camera_native_linear", wb_mode="auto", demosaic="AHD")
+    opts = IngestOptions(
+        contract="camera_native_linear",
+        wb_mode="auto",
+        demosaic="AHD",
+        raw_python_executable="./.venv-raw/bin/python",
+    )
     out = decode_contract("example.CR3", opts)
 
     assert out.dtype == np.float32
@@ -43,15 +49,17 @@ def test_decode_contract_camera_native_linear_forwards_params(monkeypatch):
     assert np.allclose(out, expected)
     assert captured["wb_mode"] == "auto"
     assert captured["demosaic"] == "AHD"
+    assert captured["raw_python_executable"] == "./.venv-raw/bin/python"
 
 
 def test_decode_contract_accepts_path_like_input(monkeypatch):
     captured = {}
 
-    def _fake_ingest(path, *, wb_mode, demosaic):  # noqa: ANN001
+    def _fake_ingest(path, *, wb_mode, demosaic, raw_python_executable):  # noqa: ANN001
         captured["path"] = path
         captured["wb_mode"] = wb_mode
         captured["demosaic"] = demosaic
+        captured["raw_python_executable"] = raw_python_executable
         return np.ones((1, 1, 3), dtype=np.float32), {"contract": "camera_native_linear"}
 
     monkeypatch.setattr(
@@ -66,22 +74,27 @@ def test_decode_contract_accepts_path_like_input(monkeypatch):
     assert captured["path"] == Path("example.CR3")
     assert captured["wb_mode"] == "camera"
     assert captured["demosaic"] == "AHD"
+    assert captured["raw_python_executable"] is None
 
 
 def test_decode_contract_legacy_linear_srgb_returns_linear_rgb(monkeypatch):
     expected = np.full((4, 4, 3), 0.25, dtype=np.float32)
 
     class _FakeDecoder:
-        def __init__(self, gamma, strict_ingest):  # noqa: ANN001
+        def __init__(self, gamma, strict_ingest, raw_python_executable):  # noqa: ANN001
             assert gamma == 1.0
             assert strict_ingest is True
+            assert raw_python_executable == "./.venv-raw/bin/python"
 
         def decode(self, input_path):  # noqa: ANN001
             assert input_path == "legacy_input.tiff"
             return types.SimpleNamespace(linear_rgb=expected)
 
     monkeypatch.setattr("transformation_portal.spatial_ai.ingest.linear_decoder.LinearDecoder", _FakeDecoder)
-    opts = IngestOptions(contract="legacy_linear_srgb")
+    opts = IngestOptions(
+        contract="legacy_linear_srgb",
+        raw_python_executable="./.venv-raw/bin/python",
+    )
     out = decode_contract("legacy_input.tiff", opts)
 
     assert out.dtype == np.float32

--- a/tests/spatial_ai/ingest/test_linear_decoder.py
+++ b/tests/spatial_ai/ingest/test_linear_decoder.py
@@ -202,6 +202,53 @@ class TestLinearDecoder:
         with pytest.raises((RuntimeError, ColorSpaceError, ImportError)):
             decoder.decode(raw_path)
 
+    def test_raw_format_uses_dedicated_runtime_when_configured(self, tmp_path: Path, monkeypatch):
+        """Configured RAW runtime should dispatch through the subprocess worker."""
+        raw_path = tmp_path / "test.cr2"
+        raw_path.write_text("dummy")
+
+        fake_linear = np.full((4, 5, 3), 0.25, dtype=np.float32)
+        captured: dict[str, object] = {}
+
+        def fake_run_raw_worker(*, python_executable, command_name, input_path, payload, start):
+            captured["python_executable"] = python_executable
+            captured["command_name"] = command_name
+            captured["input_path"] = input_path
+            captured["payload"] = payload
+            captured["start"] = start
+            return fake_linear, {
+                "input_size": [4, 5],
+                "input_format": "RAW_CR2",
+                "color_space": "linear_sRGB",
+                "ingest_fingerprint": "f" * 64,
+                "dtype": "float32",
+            }
+
+        monkeypatch.setattr(
+            "transformation_portal.spatial_ai.ingest.linear_decoder.run_raw_worker",
+            fake_run_raw_worker,
+        )
+
+        result = LinearDecoder(
+            gamma=1.0,
+            bit_depth=32,
+            strict_ingest=True,
+            raw_python_executable="./.venv-raw/bin/python",
+        ).decode(raw_path)
+
+        assert np.array_equal(result.linear_rgb, fake_linear)
+        assert result.input_size == (4, 5)
+        assert result.color_space == "linear_sRGB"
+        assert result.ingest_fingerprint == "f" * 64
+        assert captured["python_executable"] == "./.venv-raw/bin/python"
+        assert captured["command_name"] == "linear_decode"
+        assert captured["input_path"] == raw_path
+        assert captured["payload"] == {
+            "gamma": 1.0,
+            "bit_depth": 32,
+            "strict_ingest": True,
+        }
+
     def test_content_hash_reproducible(self, tmp_path: Path):
         """Test that content hash is deterministic."""
         # Create test image

--- a/tests/spatial_ai/ingest/test_phase2_camera_native_linear.py
+++ b/tests/spatial_ai/ingest/test_phase2_camera_native_linear.py
@@ -130,6 +130,7 @@ def test_ingest_phase2_fails_closed_when_fpstate_enforcement_fails(monkeypatch):
 
 def test_ingest_phase2_uses_dedicated_raw_runtime(monkeypatch):
     captured: dict[str, object] = {}
+    enforced = {"called": False}
     fake_tensor = np.asfortranarray(np.full((2, 2, 3), 0.5, dtype=np.float64))
     fake_fingerprint = {
         "schema_version": "1.0.0",
@@ -146,11 +147,7 @@ def test_ingest_phase2_uses_dedicated_raw_runtime(monkeypatch):
         return fake_tensor, {"fingerprint": fake_fingerprint}
 
     monkeypatch.setattr(phase2, "run_raw_worker", fake_run_raw_worker)
-    monkeypatch.setattr(
-        phase2,
-        "enforce_ftz_daz_disabled",
-        lambda: (_ for _ in ()).throw(AssertionError("in-process Phase II path should not run")),
-    )
+    monkeypatch.setattr(phase2, "enforce_ftz_daz_disabled", lambda: enforced.__setitem__("called", True))
 
     tensor, fingerprint = phase2.ingest_phase2_xyz_d50_linear_fp32(
         Path("sample.CR3"),
@@ -159,6 +156,7 @@ def test_ingest_phase2_uses_dedicated_raw_runtime(monkeypatch):
         raw_python_executable="./.venv-raw/bin/python",
     )
 
+    assert enforced["called"] is True
     assert np.array_equal(tensor, fake_tensor.astype(np.float32))
     assert tensor.dtype == np.float32
     assert tensor.flags["C_CONTIGUOUS"]
@@ -170,6 +168,24 @@ def test_ingest_phase2_uses_dedicated_raw_runtime(monkeypatch):
         "wb_mode": "auto",
         "demosaic": "AHD",
     }
+
+
+def test_ingest_phase2_subprocess_branch_fails_closed_before_dispatch(monkeypatch):
+    def _raise() -> None:
+        raise RuntimeError("fpstate violation")
+
+    monkeypatch.setattr(phase2, "enforce_ftz_daz_disabled", _raise)
+    monkeypatch.setattr(
+        phase2,
+        "run_raw_worker",
+        lambda **_kwargs: (_ for _ in ()).throw(AssertionError("subprocess dispatch should not run")),
+    )
+
+    with pytest.raises(RuntimeError, match="fpstate violation"):
+        phase2.ingest_phase2_xyz_d50_linear_fp32(
+            Path("sample.CR3"),
+            raw_python_executable="./.venv-raw/bin/python",
+        )
 
 
 def test_ingest_phase2_rejects_invalid_subprocess_tensor_shape(monkeypatch):

--- a/tests/spatial_ai/ingest/test_phase2_camera_native_linear.py
+++ b/tests/spatial_ai/ingest/test_phase2_camera_native_linear.py
@@ -130,7 +130,7 @@ def test_ingest_phase2_fails_closed_when_fpstate_enforcement_fails(monkeypatch):
 
 def test_ingest_phase2_uses_dedicated_raw_runtime(monkeypatch):
     captured: dict[str, object] = {}
-    fake_tensor = np.full((2, 2, 3), 0.5, dtype=np.float32)
+    fake_tensor = np.asfortranarray(np.full((2, 2, 3), 0.5, dtype=np.float64))
     fake_fingerprint = {
         "schema_version": "1.0.0",
         "contract": "camera_native_linear",
@@ -159,7 +159,9 @@ def test_ingest_phase2_uses_dedicated_raw_runtime(monkeypatch):
         raw_python_executable="./.venv-raw/bin/python",
     )
 
-    assert np.array_equal(tensor, fake_tensor)
+    assert np.array_equal(tensor, fake_tensor.astype(np.float32))
+    assert tensor.dtype == np.float32
+    assert tensor.flags["C_CONTIGUOUS"]
     assert fingerprint == fake_fingerprint
     assert captured["python_executable"] == "./.venv-raw/bin/python"
     assert captured["command_name"] == "phase2_decode"
@@ -168,3 +170,17 @@ def test_ingest_phase2_uses_dedicated_raw_runtime(monkeypatch):
         "wb_mode": "auto",
         "demosaic": "AHD",
     }
+
+
+def test_ingest_phase2_rejects_invalid_subprocess_tensor_shape(monkeypatch):
+    def fake_run_raw_worker(*, python_executable, command_name, input_path, payload, start):
+        del python_executable, command_name, input_path, payload, start
+        return np.zeros((4, 4), dtype=np.float32), {"fingerprint": {"schema_version": "1.0.0"}}
+
+    monkeypatch.setattr(phase2, "run_raw_worker", fake_run_raw_worker)
+
+    with pytest.raises(RuntimeError, match="invalid Phase II tensor shape"):
+        phase2.ingest_phase2_xyz_d50_linear_fp32(
+            Path("sample.CR3"),
+            raw_python_executable="./.venv-raw/bin/python",
+        )

--- a/tests/spatial_ai/ingest/test_phase2_camera_native_linear.py
+++ b/tests/spatial_ai/ingest/test_phase2_camera_native_linear.py
@@ -126,3 +126,45 @@ def test_ingest_phase2_fails_closed_when_fpstate_enforcement_fails(monkeypatch):
     monkeypatch.setattr(phase2, "enforce_ftz_daz_disabled", _raise)
     with pytest.raises(RuntimeError, match="fpstate violation"):
         phase2.ingest_phase2_xyz_d50_linear_fp32(Path("sample.CR3"))
+
+
+def test_ingest_phase2_uses_dedicated_raw_runtime(monkeypatch):
+    captured: dict[str, object] = {}
+    fake_tensor = np.full((2, 2, 3), 0.5, dtype=np.float32)
+    fake_fingerprint = {
+        "schema_version": "1.0.0",
+        "contract": "camera_native_linear",
+        "input_path": "sample.CR3",
+    }
+
+    def fake_run_raw_worker(*, python_executable, command_name, input_path, payload, start):
+        captured["python_executable"] = python_executable
+        captured["command_name"] = command_name
+        captured["input_path"] = input_path
+        captured["payload"] = payload
+        captured["start"] = start
+        return fake_tensor, {"fingerprint": fake_fingerprint}
+
+    monkeypatch.setattr(phase2, "run_raw_worker", fake_run_raw_worker)
+    monkeypatch.setattr(
+        phase2,
+        "enforce_ftz_daz_disabled",
+        lambda: (_ for _ in ()).throw(AssertionError("in-process Phase II path should not run")),
+    )
+
+    tensor, fingerprint = phase2.ingest_phase2_xyz_d50_linear_fp32(
+        Path("sample.CR3"),
+        wb_mode="auto",
+        demosaic="AHD",
+        raw_python_executable="./.venv-raw/bin/python",
+    )
+
+    assert np.array_equal(tensor, fake_tensor)
+    assert fingerprint == fake_fingerprint
+    assert captured["python_executable"] == "./.venv-raw/bin/python"
+    assert captured["command_name"] == "phase2_decode"
+    assert captured["input_path"] == Path("sample.CR3")
+    assert captured["payload"] == {
+        "wb_mode": "auto",
+        "demosaic": "AHD",
+    }

--- a/tests/spatial_ai/ingest/test_raw_worker.py
+++ b/tests/spatial_ai/ingest/test_raw_worker.py
@@ -1,0 +1,51 @@
+"""Unit tests for the isolated RAW ingest worker entrypoint."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from transformation_portal.spatial_ai.ingest import raw_worker
+
+pytestmark = [pytest.mark.unit]
+
+
+def test_main_resolves_relative_input_path_before_dispatch(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    input_path = tmp_path / "inputs" / "sample.cr2"
+    input_path.parent.mkdir(parents=True)
+    input_path.write_bytes(b"raw")
+    payload_path = tmp_path / "payload.json"
+    payload_path.write_text("{}", encoding="utf-8")
+
+    captured: dict[str, Path] = {}
+
+    def fake_run_load_rgb(resolved_input_path: Path, payload: dict[str, object]):
+        captured["input_path"] = resolved_input_path
+        captured["payload"] = payload
+        return np.zeros((1, 1, 3), dtype=np.uint8), {"dtype": "uint8"}
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(raw_worker, "_run_load_rgb", fake_run_load_rgb)
+    monkeypatch.setattr(raw_worker, "_write_outputs", lambda *args, **kwargs: 0)
+
+    exit_code = raw_worker.main(
+        [
+            "--command",
+            "load_rgb",
+            "--input-path",
+            "inputs/sample.cr2",
+            "--payload-json",
+            str(payload_path),
+            "--output-array",
+            "out.npy",
+            "--output-json",
+            "out.json",
+        ]
+    )
+
+    assert exit_code == 0
+    assert captured["input_path"] == input_path.resolve()
+    assert captured["input_path"].is_absolute()
+    assert captured["payload"] == {}

--- a/tests/test_lux_depth_v3_cli.py
+++ b/tests/test_lux_depth_v3_cli.py
@@ -246,7 +246,7 @@ class TestCLIValidation:
         monkeypatch.setattr("transformation_portal.lux_depth_v3.__main__.EnhanceOrchestrator", FakeOrchestrator)
         monkeypatch.setattr(
             "transformation_portal.lux_depth_v3.__main__._canonical_raw_ingest_status",
-            lambda: (False, "rawpy is not installed"),
+            lambda *_args: (False, "rawpy is not installed"),
         )
 
         result = runner.invoke(
@@ -279,7 +279,7 @@ class TestCLIValidation:
         monkeypatch.setattr("transformation_portal.lux_depth_v3.__main__.EnhanceOrchestrator", FakeOrchestrator)
         monkeypatch.setattr(
             "transformation_portal.lux_depth_v3.__main__._canonical_raw_ingest_status",
-            lambda: (False, "rawpy is not installed"),
+            lambda *_args: (False, "rawpy is not installed"),
         )
 
         result = runner.invoke(
@@ -336,7 +336,7 @@ class TestCLIValidation:
         monkeypatch.setattr("transformation_portal.lux_depth_v3.__main__.EnhanceOrchestrator", FakeOrchestrator)
         monkeypatch.setattr(
             "transformation_portal.lux_depth_v3.__main__._canonical_raw_ingest_status",
-            lambda: (False, "rawpy is unavailable in this environment"),
+            lambda *_args: (False, "rawpy is unavailable in this environment"),
         )
 
         result = runner.invoke(
@@ -851,6 +851,79 @@ class TestCLIConfiguration:
 
         assert captured_config is not None
         assert captured_config.da3_python_executable == "./.venv-da3/bin/python"
+
+    def test_raw_python_flag_sets_config(self, tmp_path):
+        """--raw-python should be forwarded into EnhanceConfig."""
+        from unittest.mock import MagicMock, patch
+
+        input_dir = tmp_path / "input"
+        input_dir.mkdir()
+        (input_dir / "test.jpg").touch()
+
+        captured_config = None
+
+        def mock_orch_init(config, output_root):
+            nonlocal captured_config
+            captured_config = config
+            mock_orch = MagicMock()
+            mock_orch.enhance_batch.return_value = {"total": 0, "succeeded": 0}
+            return mock_orch
+
+        with patch(
+            "transformation_portal.lux_depth_v3.__main__.EnhanceOrchestrator",
+            side_effect=mock_orch_init,
+        ):
+            _result = runner.invoke(
+                app,
+                [
+                    "--input-dir",
+                    str(input_dir),
+                    "--output-dir",
+                    str(tmp_path / "output"),
+                    "--raw-python",
+                    "./.venv-raw/bin/python",
+                ],
+            )
+
+        assert captured_config is not None
+        assert captured_config.raw_python_executable == "./.venv-raw/bin/python"
+
+    def test_raw_preflight_uses_dedicated_raw_runtime(self, monkeypatch, tmp_path):
+        """RAW preflight should validate the dedicated RAW runtime when configured."""
+        input_dir = tmp_path / "input"
+        input_dir.mkdir()
+        (input_dir / "scene_01.DNG").write_bytes(b"raw-payload")
+
+        captured: dict[str, str | None] = {"raw_python": None}
+
+        class FakeOrchestrator:
+            def __init__(self, *_args, **_kwargs):
+                pass
+
+            def enhance_batch(self, *_args, **_kwargs):
+                return [{"status": "ok"}]
+
+        def fake_status(raw_python_executable=None):
+            captured["raw_python"] = raw_python_executable
+            return True, None
+
+        monkeypatch.setattr("transformation_portal.lux_depth_v3.__main__.EnhanceOrchestrator", FakeOrchestrator)
+        monkeypatch.setattr("transformation_portal.lux_depth_v3.__main__._canonical_raw_ingest_status", fake_status)
+
+        result = runner.invoke(
+            app,
+            [
+                "--input-dir",
+                str(input_dir),
+                "--output-dir",
+                str(tmp_path / "output"),
+                "--raw-python",
+                "./.venv-raw/bin/python",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert captured["raw_python"] == "./.venv-raw/bin/python"
 
     def test_save_float_depth_defaults_false(self, tmp_path):
         """save_float_depth should default to False when flag is omitted."""

--- a/tests/test_orchestrator_backend_integration.py
+++ b/tests/test_orchestrator_backend_integration.py
@@ -146,6 +146,39 @@ def test_orchestrator_explicit_depth_pro_auto_discovers_repo_runtime(tmp_path, m
     assert backend_calls == [("depth_pro", REPO_LOCAL_DEPTH_PRO_PYTHON)]
 
 
+def test_orchestrator_auto_discovers_repo_raw_runtime(tmp_path, monkeypatch):
+    """Orchestrator should persist the repo-local RAW subprocess contract when available."""
+    from transformation_portal.lux_depth_v3.config_resolver import REPO_LOCAL_RAW_PYTHON
+
+    discovered_python = tmp_path / ".venv-raw" / "bin" / "python"
+    discovered_python.parent.mkdir(parents=True)
+    discovered_python.write_text("#!/bin/sh\n", encoding="utf-8")
+    monkeypatch.delenv("TRANSFORMATION_PORTAL_RAW_PYTHON", raising=False)
+    monkeypatch.setattr(
+        "transformation_portal.lux_depth_v3.config_resolver._repo_local_raw_python_path",
+        lambda: discovered_python,
+    )
+
+    class FakeBackend:
+        name = "da3"
+
+        def ensure_available(self):
+            return None
+
+    with patch(
+        "transformation_portal.depth.backends.registry.DepthBackendRegistry.get_backend",
+        return_value=FakeBackend(),
+    ):
+        config = EnhanceConfig(
+            depth_backend="da3",
+            depth_device="cpu",
+            enable_v2=False,
+        )
+        orchestrator = EnhanceOrchestrator(config, tmp_path)
+
+    assert orchestrator.config.raw_python_executable == REPO_LOCAL_RAW_PYTHON
+
+
 def test_orchestrator_explicit_da3_unavailable_fails_without_fallback(tmp_path):
     """Explicit DA3 should fail fast instead of silently selecting DA2."""
     backend_calls = []

--- a/tests/test_raw_loader.py
+++ b/tests/test_raw_loader.py
@@ -101,6 +101,47 @@ class TestRawpyNotInstalled:
             error_msg = str(exc_info.value)
             assert "rawpy required" in error_msg or "pip install rawpy" in error_msg
 
+    def test_load_raw_as_rgb_uses_dedicated_runtime_when_configured(self, tmp_path, monkeypatch):
+        """Configured RAW runtime should dispatch through the subprocess worker."""
+        raw_file = tmp_path / "test.cr2"
+        raw_file.write_bytes(b"fake raw data")
+
+        fake_rgb = np.full((8, 8, 3), 1024, dtype=np.uint16)
+        captured: dict[str, object] = {}
+
+        def fake_run_raw_worker(*, python_executable, command_name, input_path, payload, start):
+            captured["python_executable"] = python_executable
+            captured["command_name"] = command_name
+            captured["input_path"] = input_path
+            captured["payload"] = payload
+            captured["start"] = start
+            return fake_rgb, {"dtype": "uint16", "shape": [8, 8, 3]}
+
+        monkeypatch.setattr(
+            "transformation_portal.lux_depth_v3.raw_loader.run_raw_worker",
+            fake_run_raw_worker,
+        )
+
+        rgb = load_raw_as_rgb(
+            raw_file,
+            use_camera_wb=False,
+            half_size=True,
+            output_bps=16,
+            output_linear=True,
+            python_executable="./.venv-raw/bin/python",
+        )
+
+        assert np.array_equal(rgb, fake_rgb)
+        assert captured["python_executable"] == "./.venv-raw/bin/python"
+        assert captured["command_name"] == "load_rgb"
+        assert captured["input_path"] == raw_file
+        assert captured["payload"] == {
+            "use_camera_wb": False,
+            "half_size": True,
+            "output_bps": 16,
+            "output_linear": True,
+        }
+
     def test_load_raw_as_pil_missing_rawpy(self, tmp_path):
         """load_raw_as_pil should also fail gracefully when rawpy missing."""
         raw_file = tmp_path / "test.nef"

--- a/tests/test_raw_runtime.py
+++ b/tests/test_raw_runtime.py
@@ -1,0 +1,114 @@
+"""Unit tests for the shared RAW subprocess runtime helpers."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from transformation_portal.core import raw_runtime
+
+pytestmark = [pytest.mark.unit]
+
+
+def test_check_raw_runtime_timeout_surfaces_output(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        raw_runtime,
+        "resolve_raw_python_for_execution",
+        lambda python_executable, start: "/tmp/raw-python",
+    )
+    monkeypatch.setattr(raw_runtime, "build_raw_worker_env", lambda start: {})
+    monkeypatch.setattr(raw_runtime, "_worker_cwd", lambda start: Path("/tmp/repo"))
+
+    timeout_exc = subprocess.TimeoutExpired(
+        cmd=["/tmp/raw-python", "-m", raw_runtime.RAW_WORKER_MODULE, "--check"],
+        timeout=raw_runtime.RAW_RUNTIME_CHECK_TIMEOUT_SECONDS,
+        output="partial stdout",
+        stderr="partial stderr",
+    )
+
+    with patch("subprocess.run", side_effect=timeout_exc) as mock_run:
+        with pytest.raises(RuntimeError, match="RAW subprocess environment is not ready") as exc_info:
+            raw_runtime.check_raw_runtime("./.venv-raw/bin/python", start=Path(__file__))
+
+    assert mock_run.call_args.kwargs["timeout"] == raw_runtime.RAW_RUNTIME_CHECK_TIMEOUT_SECONDS
+    message = str(exc_info.value)
+    assert f"Timeout: {raw_runtime.RAW_RUNTIME_CHECK_TIMEOUT_SECONDS}s" in message
+    assert "partial stdout" in message
+    assert "partial stderr" in message
+
+
+def test_run_raw_worker_resolves_relative_input_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    input_path = tmp_path / "inputs" / "sample.cr2"
+    input_path.parent.mkdir(parents=True)
+    input_path.write_bytes(b"raw")
+    monkeypatch.chdir(tmp_path)
+
+    monkeypatch.setattr(
+        raw_runtime,
+        "resolve_raw_python_for_execution",
+        lambda python_executable, start: "/tmp/raw-python",
+    )
+    monkeypatch.setattr(raw_runtime, "build_raw_worker_env", lambda start: {})
+    monkeypatch.setattr(raw_runtime, "_worker_cwd", lambda start: tmp_path)
+
+    expected_array = np.full((2, 3, 3), 0.5, dtype=np.float32)
+    expected_metadata = {"dtype": "float32", "shape": [2, 3, 3]}
+
+    def fake_run(command, **kwargs):
+        assert kwargs["timeout"] == raw_runtime.RAW_WORKER_TIMEOUT_SECONDS
+        input_index = command.index("--input-path") + 1
+        output_array_index = command.index("--output-array") + 1
+        output_json_index = command.index("--output-json") + 1
+        assert command[input_index] == str(input_path.resolve())
+        np.save(command[output_array_index], expected_array, allow_pickle=False)
+        Path(command[output_json_index]).write_text(json.dumps(expected_metadata), encoding="utf-8")
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    with patch("subprocess.run", side_effect=fake_run):
+        array, metadata = raw_runtime.run_raw_worker(
+            python_executable="./.venv-raw/bin/python",
+            command_name="load_rgb",
+            input_path=Path("inputs/sample.cr2"),
+            payload={"output_bps": 16},
+            start=Path(__file__),
+        )
+
+    assert np.array_equal(array, expected_array)
+    assert metadata == expected_metadata
+
+
+def test_run_raw_worker_timeout_surfaces_output(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        raw_runtime,
+        "resolve_raw_python_for_execution",
+        lambda python_executable, start: "/tmp/raw-python",
+    )
+    monkeypatch.setattr(raw_runtime, "build_raw_worker_env", lambda start: {})
+    monkeypatch.setattr(raw_runtime, "_worker_cwd", lambda start: Path("/tmp/repo"))
+
+    timeout_exc = subprocess.TimeoutExpired(
+        cmd=["/tmp/raw-python", "-m", raw_runtime.RAW_WORKER_MODULE, "--command", "load_rgb"],
+        timeout=raw_runtime.RAW_WORKER_TIMEOUT_SECONDS,
+        output="worker stdout",
+        stderr="worker stderr",
+    )
+
+    with patch("subprocess.run", side_effect=timeout_exc):
+        with pytest.raises(RuntimeError, match="RAW subprocess worker failed") as exc_info:
+            raw_runtime.run_raw_worker(
+                python_executable="./.venv-raw/bin/python",
+                command_name="load_rgb",
+                input_path=Path("sample.cr2"),
+                payload={},
+                start=Path(__file__),
+            )
+
+    message = str(exc_info.value)
+    assert f"Timeout: {raw_runtime.RAW_WORKER_TIMEOUT_SECONDS}s" in message
+    assert "worker stdout" in message
+    assert "worker stderr" in message

--- a/tests/test_run_card_schema.py
+++ b/tests/test_run_card_schema.py
@@ -48,6 +48,7 @@ def _valid_run_card_payload() -> dict:
         "v2_device": "cpu",
         "v2_upscaler_backend": "realesrgan",
         "depth_pro_python_executable": None,
+        "raw_python_executable": None,
         "da3_python_executable": None,
     }
     canonical_json = json.dumps(
@@ -72,6 +73,7 @@ def _valid_run_card_payload() -> dict:
                 "strict_segmentation",
                 "apex_strict_mode",
                 "depth_pro_python_executable",
+                "raw_python_executable",
                 "da3_python_executable",
             )
         },

--- a/tests/test_verify_run_card_integrity.py
+++ b/tests/test_verify_run_card_integrity.py
@@ -59,6 +59,7 @@ def _valid_run_card_payload(module) -> dict:
         "v2_device": "cpu",
         "v2_upscaler_backend": "realesrgan",
         "depth_pro_python_executable": None,
+        "raw_python_executable": None,
         "da3_python_executable": None,
     }
     canonical_json = json.dumps(
@@ -83,6 +84,7 @@ def _valid_run_card_payload(module) -> dict:
                 "strict_segmentation",
                 "apex_strict_mode",
                 "depth_pro_python_executable",
+                "raw_python_executable",
                 "da3_python_executable",
             )
         },
@@ -324,6 +326,7 @@ def test_verify_run_card_integrity_accepts_config_fingerprint_with_raw_ingest_fi
         "v2_device",
         "v2_upscaler_backend",
         "depth_pro_python_executable",
+        "raw_python_executable",
         "da3_python_executable",
         "preset_requested",
         "preset_resolved",


### PR DESCRIPTION
## Summary
- add a dedicated RAW subprocess runtime contract with repo-local auto-discovery of `./.venv-raw/bin/python`, plus explicit `--raw-python` and `TRANSFORMATION_PORTAL_RAW_PYTHON` support
- route RAW decode call sites through an isolated worker when that runtime is configured, while preserving the existing in-process path when it is not
- persist `raw_python_executable` in Lux Depth V3 config fingerprints and run-card metadata, and update docs, bootstrap tooling, schema coverage, and focused tests
- replace stale Lux Depth V3 module docstrings that still described live modules as stub implementations

## Validation
- `PRE_COMMIT_HOME=/tmp/pre-commit PATH=/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin:$PATH TP_LINT_PYTHON=/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin/python .venv/bin/pre-commit run --show-diff-on-failure --files $(git diff --name-only --diff-filter=ACM) $(git ls-files --others --exclude-standard)`
- `PYTHONDONTWRITEBYTECODE=1 TMPDIR=/tmp .venv/bin/python -m pytest -p no:cacheprovider tests/lux_depth_v3/test_config_resolver.py tests/test_lux_depth_v3_cli.py tests/lux_depth_v3/test_phase_c_raw_ingest.py tests/test_raw_loader.py tests/spatial_ai/ingest/test_linear_decoder.py tests/spatial_ai/ingest/test_phase2_camera_native_linear.py tests/test_run_card_schema.py tests/test_verify_run_card_integrity.py tests/test_orchestrator_backend_integration.py`
- commit-time pre-commit hook passed cleanly on the staged branch contents

## Notes
- `make pre-commit` is not green as a portable entry point in this environment because the target shells out to `pre-commit` on `PATH`; I used the repo-local `.venv/bin/pre-commit` binary instead
- the focused pytest slice required an unsandboxed rerun because `pytest-rerunfailures` binds a localhost coordination socket during startup