### PR TITLE
feat(portal): fingerprint assets and cache static homepage

### DIFF
--- a/app.py
+++ b/app.py
@@ -54,6 +54,13 @@ class PortalAssetBundle:
     urls: Dict[str, str]
 
 
+@dataclass(frozen=True)
+class PortalRenderedTextAsset:
+    text: str
+    content_bytes: bytes
+    fingerprint: str
+
+
 def _env_csv(name: str, default: List[str]) -> List[str]:
     raw = os.getenv(name)
     if raw is None:
@@ -165,16 +172,6 @@ def _portal_asset_signature(path: Path) -> Tuple[str, int, int]:
     return str(path), stat_result.st_mtime_ns, stat_result.st_size
 
 
-def _portal_bundle_signature() -> Tuple[Tuple[str, int, int], ...]:
-    source_paths = [
-        PORTAL_HTML,
-        PORTAL_CSS_TEMPLATE_PATH,
-        *(PORTAL_ASSET_PATHS[asset_name] for asset_name in PORTAL_DIRECT_FINGERPRINT_ASSET_NAMES),
-    ]
-    deduped_paths = list(dict.fromkeys(source_paths))
-    return tuple(_portal_asset_signature(path) for path in deduped_paths)
-
-
 def _fingerprint_bytes(payload: bytes) -> str:
     return hashlib.sha256(payload).hexdigest()[:PORTAL_ASSET_FINGERPRINT_LENGTH]
 
@@ -201,24 +198,74 @@ def _render_portal_template(template_text: str, replacements: Mapping[str, str],
     return rendered
 
 
-@lru_cache(maxsize=4)
-def _build_portal_asset_bundle(_: Tuple[Tuple[str, int, int], ...]) -> PortalAssetBundle:
-    fingerprints: Dict[str, str] = {}
-    for asset_name in PORTAL_DIRECT_FINGERPRINT_ASSET_NAMES:
-        fingerprints[asset_name] = _fingerprint_bytes(PORTAL_ASSET_PATHS[asset_name].read_bytes())
+def _portal_direct_asset_signature(asset_name: str) -> Tuple[str, int, int]:
+    return _portal_asset_signature(PORTAL_ASSET_PATHS[asset_name])
 
+
+@lru_cache(maxsize=16)
+def _build_portal_direct_asset_fingerprint(asset_name: str, _: Tuple[str, int, int]) -> str:
+    return _fingerprint_bytes(PORTAL_ASSET_PATHS[asset_name].read_bytes())
+
+
+def _get_portal_direct_asset_fingerprint(asset_name: str) -> str:
+    return _build_portal_direct_asset_fingerprint(asset_name, _portal_direct_asset_signature(asset_name))
+
+
+def _portal_css_signature() -> Tuple[object, ...]:
+    return (
+        _portal_asset_signature(PORTAL_CSS_TEMPLATE_PATH),
+        ("fonts/portal-sans.woff2", _get_portal_direct_asset_fingerprint("fonts/portal-sans.woff2")),
+        ("fonts/portal-mono.woff2", _get_portal_direct_asset_fingerprint("fonts/portal-mono.woff2")),
+    )
+
+
+@lru_cache(maxsize=4)
+def _build_portal_css_asset(_: Tuple[object, ...]) -> PortalRenderedTextAsset:
+    font_fingerprints = {
+        "fonts/portal-sans.woff2": _get_portal_direct_asset_fingerprint("fonts/portal-sans.woff2"),
+        "fonts/portal-mono.woff2": _get_portal_direct_asset_fingerprint("fonts/portal-mono.woff2"),
+    }
     css_template = PORTAL_CSS_TEMPLATE_PATH.read_text(encoding="utf-8")
     css_render = _render_portal_template(
         css_template,
         {
-            token: _portal_asset_versioned_url(asset_name, fingerprints[asset_name])
+            token: _portal_asset_versioned_url(asset_name, font_fingerprint)
             for token, asset_name in PORTAL_CSS_TEMPLATE_TOKENS.items()
+            for font_fingerprint in [font_fingerprints[asset_name]]
         },
         template_name="portal.css",
     )
     css_bytes = css_render.encode("utf-8")
-    fingerprints["portal.css"] = _fingerprint_bytes(css_bytes)
+    return PortalRenderedTextAsset(
+        text=css_render,
+        content_bytes=css_bytes,
+        fingerprint=_fingerprint_bytes(css_bytes),
+    )
 
+
+def _get_portal_css_asset() -> PortalRenderedTextAsset:
+    return _build_portal_css_asset(_portal_css_signature())
+
+
+def _portal_html_signature() -> Tuple[object, ...]:
+    css_asset = _get_portal_css_asset()
+    return (
+        _portal_asset_signature(PORTAL_HTML),
+        ("portal.css", css_asset.fingerprint),
+        *(
+            (asset_name, _get_portal_direct_asset_fingerprint(asset_name))
+            for asset_name in ("portal.js", "brand/dna-symbol-dark.svg", "brand/dna-symbol-light.svg")
+        ),
+    )
+
+
+@lru_cache(maxsize=4)
+def _build_portal_asset_bundle(_: Tuple[object, ...]) -> PortalAssetBundle:
+    css_asset = _get_portal_css_asset()
+    fingerprints = {
+        asset_name: _get_portal_direct_asset_fingerprint(asset_name) for asset_name in PORTAL_DIRECT_FINGERPRINT_ASSET_NAMES
+    }
+    fingerprints["portal.css"] = css_asset.fingerprint
     urls = {
         asset_name: _portal_asset_versioned_url(asset_name, fingerprint) for asset_name, fingerprint in fingerprints.items()
     }
@@ -232,23 +279,22 @@ def _build_portal_asset_bundle(_: Tuple[Tuple[str, int, int], ...]) -> PortalAss
     return PortalAssetBundle(
         html=html_render,
         html_bytes=html_bytes,
-        css=css_render,
-        css_bytes=css_bytes,
+        css=css_asset.text,
+        css_bytes=css_asset.content_bytes,
         fingerprints=fingerprints,
         urls=urls,
     )
 
 
 def _get_portal_asset_bundle() -> PortalAssetBundle:
-    return _build_portal_asset_bundle(_portal_bundle_signature())
+    return _build_portal_asset_bundle(_portal_html_signature())
 
 
 def _requested_portal_asset_fingerprint(request: Request) -> str:
     return str(request.query_params.get(PORTAL_ASSET_FINGERPRINT_PARAM, "")).strip()
 
 
-def _portal_asset_cache_control(asset_name: str, requested_fingerprint: str) -> str:
-    current_fingerprint = _get_portal_asset_bundle().fingerprints[asset_name]
+def _portal_asset_cache_control(current_fingerprint: str, requested_fingerprint: str) -> str:
     if requested_fingerprint and hmac.compare_digest(requested_fingerprint, current_fingerprint):
         return PORTAL_IMMUTABLE_ASSET_CACHE_CONTROL
     return PORTAL_ASSET_CACHE_CONTROL
@@ -5400,24 +5446,27 @@ async def serve_portal_asset(asset_path: str, request: Request) -> Response:
     except FileNotFoundError as exc:
         raise HTTPException(status_code=404, detail="portal asset not found") from exc
 
-    cache_control = _portal_asset_cache_control(asset_path, _requested_portal_asset_fingerprint(request))
+    requested_fingerprint = _requested_portal_asset_fingerprint(request)
     if asset_path == "portal.css":
-        bundle = _get_portal_asset_bundle()
+        css_asset = _get_portal_css_asset()
+        cache_control = _portal_asset_cache_control(css_asset.fingerprint, requested_fingerprint)
         return Response(
-            content=bundle.css_bytes,
+            content=css_asset.content_bytes,
             headers={
                 "Cache-Control": cache_control,
                 "Content-Type": resolved_asset.media_type,
-                "ETag": f'"{bundle.fingerprints[asset_path]}"',
+                "ETag": f'"{css_asset.fingerprint}"',
             },
         )
 
+    direct_fingerprint = _get_portal_direct_asset_fingerprint(asset_path)
+    cache_control = _portal_asset_cache_control(direct_fingerprint, requested_fingerprint)
     return FileResponse(
         str(resolved_asset.path),
         media_type=resolved_asset.media_type,
         headers={
             "Cache-Control": cache_control,
-            "ETag": f'"{_get_portal_asset_bundle().fingerprints[asset_path]}"',
+            "ETag": f'"{direct_fingerprint}"',
         },
     )
 

--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import hmac
 import json
 import logging
@@ -15,6 +16,7 @@ import uuid
 from bisect import bisect_left
 from collections import deque
 from dataclasses import dataclass, field
+from functools import lru_cache
 from importlib.util import find_spec
 from pathlib import Path, PurePosixPath
 from typing import Any, AsyncGenerator, Callable, Deque, Dict, List, Mapping, Optional, Tuple
@@ -40,6 +42,16 @@ LOGGER = logging.getLogger(__name__)
 class PortalAssetSpec:
     path: Path
     media_type: str
+
+
+@dataclass(frozen=True)
+class PortalAssetBundle:
+    html: str
+    html_bytes: bytes
+    css: str
+    css_bytes: bytes
+    fingerprints: Dict[str, str]
+    urls: Dict[str, str]
 
 
 def _env_csv(name: str, default: List[str]) -> List[str]:
@@ -87,6 +99,27 @@ PORTAL_ASSET_MANIFEST_PATH = REPO_ROOT / "config" / "portal_asset_manifest.json"
 PORTAL_VIDEO_ASSET_NAME = "dna-portal-video-2.mp4"
 PORTAL_VIDEO_PATH = REPO_ROOT / "public" / "video" / PORTAL_VIDEO_ASSET_NAME
 PORTAL_ASSET_CACHE_CONTROL = "no-store"
+PORTAL_IMMUTABLE_ASSET_CACHE_CONTROL = "public, max-age=31536000, immutable"
+PORTAL_ASSET_FINGERPRINT_PARAM = "v"
+PORTAL_ASSET_FINGERPRINT_LENGTH = 12
+PORTAL_CSS_TEMPLATE_PATH = PORTAL_ASSETS_DIR / "portal.css"
+PORTAL_DIRECT_FINGERPRINT_ASSET_NAMES = (
+    "portal.js",
+    "fonts/portal-sans.woff2",
+    "fonts/portal-mono.woff2",
+    "brand/dna-symbol-dark.svg",
+    "brand/dna-symbol-light.svg",
+)
+PORTAL_CSS_TEMPLATE_TOKENS = {
+    "__PORTAL_FONT_SANS_URL__": "fonts/portal-sans.woff2",
+    "__PORTAL_FONT_MONO_URL__": "fonts/portal-mono.woff2",
+}
+PORTAL_HTML_TEMPLATE_TOKENS = {
+    "__PORTAL_CSS_URL__": "portal.css",
+    "__PORTAL_JS_URL__": "portal.js",
+    "__PORTAL_BRAND_LIGHT_URL__": "brand/dna-symbol-light.svg",
+    "__PORTAL_BRAND_DARK_URL__": "brand/dna-symbol-dark.svg",
+}
 
 
 def _load_portal_asset_manifest() -> Dict[str, PortalAssetSpec]:
@@ -125,6 +158,102 @@ def _load_portal_asset_manifest() -> Dict[str, PortalAssetSpec]:
 PORTAL_ASSET_MANIFEST = _load_portal_asset_manifest()
 PORTAL_ASSET_PATHS = {name: asset.path for name, asset in PORTAL_ASSET_MANIFEST.items()}
 PORTAL_ASSET_MEDIA_TYPES = {name: asset.media_type for name, asset in PORTAL_ASSET_MANIFEST.items()}
+
+
+def _portal_asset_signature(path: Path) -> Tuple[str, int, int]:
+    stat_result = path.stat()
+    return str(path), stat_result.st_mtime_ns, stat_result.st_size
+
+
+def _portal_bundle_signature() -> Tuple[Tuple[str, int, int], ...]:
+    source_paths = [
+        PORTAL_HTML,
+        PORTAL_CSS_TEMPLATE_PATH,
+        *(PORTAL_ASSET_PATHS[asset_name] for asset_name in PORTAL_DIRECT_FINGERPRINT_ASSET_NAMES),
+    ]
+    deduped_paths = list(dict.fromkeys(source_paths))
+    return tuple(_portal_asset_signature(path) for path in deduped_paths)
+
+
+def _fingerprint_bytes(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()[:PORTAL_ASSET_FINGERPRINT_LENGTH]
+
+
+def _portal_asset_route_path(asset_name: str) -> str:
+    encoded_parts = [quote(part, safe="") for part in asset_name.split("/")]
+    return "/portal/assets/" + "/".join(encoded_parts)
+
+
+def _portal_asset_versioned_url(asset_name: str, fingerprint: str) -> str:
+    return f"{_portal_asset_route_path(asset_name)}?{PORTAL_ASSET_FINGERPRINT_PARAM}={fingerprint}"
+
+
+def _render_portal_template(template_text: str, replacements: Mapping[str, str], *, template_name: str) -> str:
+    rendered = template_text
+    for token, value in replacements.items():
+        if token not in rendered:
+            raise RuntimeError(f"{template_name} is missing required token {token}")
+        rendered = rendered.replace(token, value)
+
+    unresolved = sorted(set(re.findall(r"__PORTAL_[A-Z0-9_]+__", rendered)))
+    if unresolved:
+        raise RuntimeError(f"{template_name} has unresolved tokens: {', '.join(unresolved)}")
+    return rendered
+
+
+@lru_cache(maxsize=4)
+def _build_portal_asset_bundle(_: Tuple[Tuple[str, int, int], ...]) -> PortalAssetBundle:
+    fingerprints: Dict[str, str] = {}
+    for asset_name in PORTAL_DIRECT_FINGERPRINT_ASSET_NAMES:
+        fingerprints[asset_name] = _fingerprint_bytes(PORTAL_ASSET_PATHS[asset_name].read_bytes())
+
+    css_template = PORTAL_CSS_TEMPLATE_PATH.read_text(encoding="utf-8")
+    css_render = _render_portal_template(
+        css_template,
+        {
+            token: _portal_asset_versioned_url(asset_name, fingerprints[asset_name])
+            for token, asset_name in PORTAL_CSS_TEMPLATE_TOKENS.items()
+        },
+        template_name="portal.css",
+    )
+    css_bytes = css_render.encode("utf-8")
+    fingerprints["portal.css"] = _fingerprint_bytes(css_bytes)
+
+    urls = {
+        asset_name: _portal_asset_versioned_url(asset_name, fingerprint) for asset_name, fingerprint in fingerprints.items()
+    }
+    html_template = PORTAL_HTML.read_text(encoding="utf-8")
+    html_render = _render_portal_template(
+        html_template,
+        {token: urls[asset_name] for token, asset_name in PORTAL_HTML_TEMPLATE_TOKENS.items()},
+        template_name="portal.html",
+    )
+    html_bytes = html_render.encode("utf-8")
+    return PortalAssetBundle(
+        html=html_render,
+        html_bytes=html_bytes,
+        css=css_render,
+        css_bytes=css_bytes,
+        fingerprints=fingerprints,
+        urls=urls,
+    )
+
+
+def _get_portal_asset_bundle() -> PortalAssetBundle:
+    return _build_portal_asset_bundle(_portal_bundle_signature())
+
+
+def _requested_portal_asset_fingerprint(request: Request) -> str:
+    return str(request.query_params.get(PORTAL_ASSET_FINGERPRINT_PARAM, "")).strip()
+
+
+def _portal_asset_cache_control(asset_name: str, requested_fingerprint: str) -> str:
+    current_fingerprint = _get_portal_asset_bundle().fingerprints[asset_name]
+    if requested_fingerprint and hmac.compare_digest(requested_fingerprint, current_fingerprint):
+        return PORTAL_IMMUTABLE_ASSET_CACHE_CONTROL
+    return PORTAL_ASSET_CACHE_CONTROL
+
+
 ARCHIVE_GOVERNANCE_SCRIPT = REPO_ROOT / "tools" / "archive_governance.py"
 LUX_DEPTH_MODULE = "transformation_portal.lux_depth_v3"
 APP_VERSION = "0.3.0"
@@ -5253,26 +5382,43 @@ async def serve_ui() -> Response:
             status_code=500,
             detail="portal.html is missing",
         )
-    return FileResponse(
-        str(PORTAL_HTML),
+    bundle = _get_portal_asset_bundle()
+    return Response(
+        content=bundle.html_bytes,
         headers={
             "Cache-Control": "no-store",
             "Pragma": "no-cache",
+            "Content-Type": "text/html; charset=utf-8",
         },
     )
 
 
 @app.get("/portal/assets/{asset_path:path}")
-async def serve_portal_asset(asset_path: str) -> Response:
+async def serve_portal_asset(asset_path: str, request: Request) -> Response:
     try:
         resolved_asset = _resolve_portal_asset(asset_path)
     except FileNotFoundError as exc:
         raise HTTPException(status_code=404, detail="portal asset not found") from exc
 
+    cache_control = _portal_asset_cache_control(asset_path, _requested_portal_asset_fingerprint(request))
+    if asset_path == "portal.css":
+        bundle = _get_portal_asset_bundle()
+        return Response(
+            content=bundle.css_bytes,
+            headers={
+                "Cache-Control": cache_control,
+                "Content-Type": resolved_asset.media_type,
+                "ETag": f'"{bundle.fingerprints[asset_path]}"',
+            },
+        )
+
     return FileResponse(
         str(resolved_asset.path),
         media_type=resolved_asset.media_type,
-        headers={"Cache-Control": PORTAL_ASSET_CACHE_CONTROL},
+        headers={
+            "Cache-Control": cache_control,
+            "ETag": f'"{_get_portal_asset_bundle().fingerprints[asset_path]}"',
+        },
     )
 
 

--- a/portal.html
+++ b/portal.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Transformation Portal — Orchestrator</title>
-    <link rel="stylesheet" href="/portal/assets/portal.css" />
+    <link rel="stylesheet" href="__PORTAL_CSS_URL__" />
 </head>
 <!--
 ============================================================================
@@ -47,14 +47,14 @@ Contract notes:
                 <div class="portal-brand-mark flex h-12 w-12 items-center justify-center rounded-2xl text-sm font-black tracking-[0.24em] shadow-soft">
                     <img
                         class="portal-brand-asset portal-brand-asset--light"
-                        src="/portal/assets/brand/dna-symbol-light.svg"
+                        src="__PORTAL_BRAND_LIGHT_URL__"
                         alt=""
                         decoding="async"
                         aria-hidden="true"
                     />
                     <img
                         class="portal-brand-asset portal-brand-asset--dark"
-                        src="/portal/assets/brand/dna-symbol-dark.svg"
+                        src="__PORTAL_BRAND_DARK_URL__"
                         alt=""
                         decoding="async"
                         aria-hidden="true"
@@ -1512,6 +1512,6 @@ Contract notes:
 
     <!-- Toast Container -->
     <div id="toastContainer" class="fixed bottom-6 right-6 z-50 flex flex-col gap-3 w-full max-w-sm pointer-events-none" aria-live="polite"></div>
-    <script src="/portal/assets/portal.js" defer></script>
+    <script src="__PORTAL_JS_URL__" defer></script>
 </body>
 </html>

--- a/public/portal-assets/portal.css
+++ b/public/portal-assets/portal.css
@@ -27,13 +27,13 @@
 
 @font-face {
     font-family: "Portal Sans";
-    src: url("/portal/assets/fonts/portal-sans.woff2") format("woff2");
+    src: url("__PORTAL_FONT_SANS_URL__") format("woff2");
     font-display: swap;
 }
 
 @font-face {
     font-family: "Portal Mono";
-    src: url("/portal/assets/fonts/portal-mono.woff2") format("woff2");
+    src: url("__PORTAL_FONT_MONO_URL__") format("woff2");
     font-display: swap;
 }
 

--- a/tests/test_app_orchestrator_contract_http.py
+++ b/tests/test_app_orchestrator_contract_http.py
@@ -113,6 +113,7 @@ def test_portal_bootstrap_reports_direct_debug_mode(client: TestClient) -> None:
 
 
 def test_root_ui_response_is_not_cached(client: TestClient) -> None:
+    bundle = orchestrator_app._get_portal_asset_bundle()
     response = client.get("/")
     assert response.status_code == 200
     csp = response.headers.get("Content-Security-Policy")
@@ -146,8 +147,8 @@ def test_root_ui_response_is_not_cached(client: TestClient) -> None:
     assert "https://cdn.tailwindcss.com" not in response.text
     assert "https://fonts.googleapis.com" not in response.text
     assert "https://fonts.gstatic.com" not in response.text
-    assert '<link rel="stylesheet" href="/portal/assets/portal.css"' in response.text
-    assert '<script src="/portal/assets/portal.js" defer></script>' in response.text
+    assert f'<link rel="stylesheet" href="{bundle.urls["portal.css"]}"' in response.text
+    assert f'<script src="{bundle.urls["portal.js"]}" defer></script>' in response.text
     assert "<style>" not in response.text
     assert "<script>" not in response.text
     assert "Content-Security-Policy" not in response.text
@@ -156,29 +157,44 @@ def test_root_ui_response_is_not_cached(client: TestClient) -> None:
 
 
 def test_portal_asset_endpoint_serves_css_and_js(client: TestClient) -> None:
-    css_response = client.get("/portal/assets/portal.css")
-    js_response = client.get("/portal/assets/portal.js")
+    bundle = orchestrator_app._get_portal_asset_bundle()
+    css_response = client.get(bundle.urls["portal.css"])
+    js_response = client.get(bundle.urls["portal.js"])
 
     assert css_response.status_code == 200
-    assert css_response.headers["Cache-Control"] == orchestrator_app.PORTAL_ASSET_CACHE_CONTROL
+    assert css_response.headers["Cache-Control"] == orchestrator_app.PORTAL_IMMUTABLE_ASSET_CACHE_CONTROL
     assert css_response.headers["content-type"] == orchestrator_app.PORTAL_ASSET_MEDIA_TYPES["portal.css"]
     assert "@font-face" in css_response.text
     assert "Portal Sans" in css_response.text
+    assert bundle.urls["fonts/portal-sans.woff2"] in css_response.text
+    assert bundle.urls["fonts/portal-mono.woff2"] in css_response.text
     assert "https://fonts.googleapis.com" not in css_response.text
 
     assert js_response.status_code == 200
-    assert js_response.headers["Cache-Control"] == orchestrator_app.PORTAL_ASSET_CACHE_CONTROL
+    assert js_response.headers["Cache-Control"] == orchestrator_app.PORTAL_IMMUTABLE_ASSET_CACHE_CONTROL
     assert js_response.headers["content-type"] == orchestrator_app.PORTAL_ASSET_MEDIA_TYPES["portal.js"]
     assert "const BOOTSTRAP_TIMEOUT_MS = 3500;" in js_response.text
 
 
 def test_portal_asset_endpoint_serves_repo_local_fonts(client: TestClient) -> None:
-    response = client.get("/portal/assets/fonts/portal-sans.woff2")
+    bundle = orchestrator_app._get_portal_asset_bundle()
+    response = client.get(bundle.urls["fonts/portal-sans.woff2"])
+
+    assert response.status_code == 200
+    assert response.headers["Cache-Control"] == orchestrator_app.PORTAL_IMMUTABLE_ASSET_CACHE_CONTROL
+    assert response.headers["content-type"] == orchestrator_app.PORTAL_ASSET_MEDIA_TYPES["fonts/portal-sans.woff2"]
+    assert response.content
+
+
+def test_portal_asset_endpoint_keeps_unversioned_and_stale_requests_backward_compatible(client: TestClient) -> None:
+    response = client.get("/portal/assets/portal.css")
+    stale_response = client.get("/portal/assets/portal.css", params={"v": "stale-version"})
 
     assert response.status_code == 200
     assert response.headers["Cache-Control"] == orchestrator_app.PORTAL_ASSET_CACHE_CONTROL
-    assert response.headers["content-type"] == orchestrator_app.PORTAL_ASSET_MEDIA_TYPES["fonts/portal-sans.woff2"]
-    assert response.content
+    assert stale_response.status_code == 200
+    assert stale_response.headers["Cache-Control"] == orchestrator_app.PORTAL_ASSET_CACHE_CONTROL
+    assert response.text == stale_response.text
 
 
 def test_portal_asset_endpoint_rejects_path_traversal(client: TestClient) -> None:

--- a/tests/test_app_orchestrator_contract_http.py
+++ b/tests/test_app_orchestrator_contract_http.py
@@ -197,6 +197,39 @@ def test_portal_asset_endpoint_keeps_unversioned_and_stale_requests_backward_com
     assert response.text == stale_response.text
 
 
+def test_portal_css_endpoint_does_not_depend_on_html_bundle_inputs(
+    client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    css_asset = orchestrator_app._get_portal_css_asset()
+    monkeypatch.setattr(orchestrator_app, "PORTAL_HTML", tmp_path / "missing-portal.html")
+    orchestrator_app._build_portal_asset_bundle.cache_clear()
+
+    response = client.get("/portal/assets/portal.css", params={"v": css_asset.fingerprint})
+
+    assert response.status_code == 200
+    assert response.headers["Cache-Control"] == orchestrator_app.PORTAL_IMMUTABLE_ASSET_CACHE_CONTROL
+    assert response.headers["ETag"] == f'"{css_asset.fingerprint}"'
+    assert response.text == css_asset.text
+
+
+def test_portal_direct_asset_endpoint_does_not_depend_on_html_bundle_inputs(
+    client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    current_fingerprint = orchestrator_app._get_portal_direct_asset_fingerprint("fonts/portal-sans.woff2")
+    monkeypatch.setattr(orchestrator_app, "PORTAL_HTML", tmp_path / "missing-portal.html")
+    orchestrator_app._build_portal_asset_bundle.cache_clear()
+
+    response = client.get(
+        "/portal/assets/fonts/portal-sans.woff2",
+        params={"v": current_fingerprint},
+    )
+
+    assert response.status_code == 200
+    assert response.headers["Cache-Control"] == orchestrator_app.PORTAL_IMMUTABLE_ASSET_CACHE_CONTROL
+    assert response.headers["ETag"] == f'"{current_fingerprint}"'
+    assert response.content
+
+
 def test_portal_asset_endpoint_rejects_path_traversal(client: TestClient) -> None:
     response = client.get("/portal/assets/../portal.html")
 

--- a/tests/test_app_orchestrator_runtime.py
+++ b/tests/test_app_orchestrator_runtime.py
@@ -16,6 +16,7 @@ from functools import lru_cache
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Dict
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 from starlette.requests import Request as StarletteRequest
@@ -45,7 +46,7 @@ def _flag_value(argv: list[str], flag: str) -> str:
 
 @lru_cache(maxsize=1)
 def _portal_html_content() -> str:
-    return PORTAL_HTML_PATH.read_text(encoding="utf-8")
+    return orchestrator_app._get_portal_asset_bundle().html
 
 
 @lru_cache(maxsize=1)
@@ -59,12 +60,24 @@ def _portal_asset_urls_from_css() -> set[str]:
 
 
 def _portal_asset_path(asset_url: str) -> Path:
-    if not asset_url.startswith("/portal/assets/"):
+    parsed = urlparse(asset_url)
+    if not parsed.path.startswith("/portal/assets/"):
         raise AssertionError(f"unexpected portal asset url: {asset_url}")
-    candidate = PORTAL_ASSET_ROOT / asset_url.removeprefix("/portal/assets/")
+    candidate = PORTAL_ASSET_ROOT / parsed.path.removeprefix("/portal/assets/")
     if not candidate.is_file():
         raise AssertionError(f"portal asset missing: {candidate}")
     return candidate
+
+
+def _portal_asset_name(asset_url: str) -> str:
+    parsed = urlparse(asset_url)
+    if not parsed.path.startswith("/portal/assets/"):
+        raise AssertionError(f"unexpected portal asset url: {asset_url}")
+    return parsed.path.removeprefix("/portal/assets/")
+
+
+def _portal_asset_version(asset_url: str) -> str:
+    return parse_qs(urlparse(asset_url).query).get("v", [""])[0]
 
 
 @lru_cache(maxsize=1)
@@ -73,7 +86,7 @@ def _portal_css_content() -> str:
     match = re.search(r'<link rel="stylesheet" href="(/portal/assets/[^"]+)"\s*/?>', html)
     if match is None:
         raise AssertionError("portal stylesheet link not found")
-    return _portal_asset_path(match.group(1)).read_text(encoding="utf-8")
+    return orchestrator_app._get_portal_asset_bundle().css
 
 
 @lru_cache(maxsize=1)
@@ -420,9 +433,10 @@ def test_portal_phase1_accessibility_tokens_align_focus_and_target_size() -> Non
 def test_portal_html_externalizes_direct_debug_assets_without_third_party_hosts() -> None:
     html_content = _portal_html_content()
     css_content = _portal_css_content()
+    bundle = orchestrator_app._get_portal_asset_bundle()
 
-    assert 'href="/portal/assets/portal.css"' in html_content
-    assert 'src="/portal/assets/portal.js"' in html_content
+    assert f'href="{bundle.urls["portal.css"]}"' in html_content
+    assert f'src="{bundle.urls["portal.js"]}"' in html_content
     assert "<style>" not in html_content
     assert "<script>" not in html_content
     assert "https://cdn.tailwindcss.com" not in html_content
@@ -479,27 +493,33 @@ def test_portal_asset_manifest_rejects_paths_outside_portal_assets_dir(
 
 
 def test_portal_html_asset_references_are_covered_by_manifest() -> None:
+    bundle = orchestrator_app._get_portal_asset_bundle()
     html_asset_urls = _portal_asset_urls_from_html()
     bundled_asset_urls = html_asset_urls | _portal_asset_urls_from_css()
     manifest_asset_urls = {f"/portal/assets/{asset_name}" for asset_name in orchestrator_app.PORTAL_ASSET_MANIFEST.keys()}
+    normalized_asset_urls = {urlparse(asset_url).path for asset_url in bundled_asset_urls}
 
     assert html_asset_urls
-    assert html_asset_urls <= manifest_asset_urls
-    assert bundled_asset_urls == manifest_asset_urls
+    assert {urlparse(asset_url).path for asset_url in html_asset_urls} <= manifest_asset_urls
+    assert normalized_asset_urls == manifest_asset_urls
     for asset_url in bundled_asset_urls:
+        asset_name = _portal_asset_name(asset_url)
+        assert _portal_asset_version(asset_url) == bundle.fingerprints[asset_name]
         _portal_asset_path(asset_url)
 
 
 def test_portal_brand_asset_references_are_manifest_backed_and_repo_local() -> None:
+    bundle = orchestrator_app._get_portal_asset_bundle()
     brand_asset_urls = {url for url in _portal_asset_urls_from_html() if url.startswith("/portal/assets/brand/")}
     manifest_asset_urls = {f"/portal/assets/{asset_name}" for asset_name in orchestrator_app.PORTAL_ASSET_MANIFEST.keys()}
 
     assert brand_asset_urls == {
-        "/portal/assets/brand/dna-symbol-dark.svg",
-        "/portal/assets/brand/dna-symbol-light.svg",
+        bundle.urls["brand/dna-symbol-dark.svg"],
+        bundle.urls["brand/dna-symbol-light.svg"],
     }
-    assert brand_asset_urls <= manifest_asset_urls
+    assert {urlparse(asset_url).path for asset_url in brand_asset_urls} <= manifest_asset_urls
     for asset_url in brand_asset_urls:
+        assert _portal_asset_version(asset_url) == bundle.fingerprints[_portal_asset_name(asset_url)]
         assert _portal_asset_path(asset_url).is_relative_to(orchestrator_app.PORTAL_ASSETS_DIR)
 
 

--- a/web/secure-landing/app/portal/assets/[...path]/route.js
+++ b/web/secure-landing/app/portal/assets/[...path]/route.js
@@ -114,7 +114,10 @@ async function proxyPortalAsset(request, { params }) {
   try {
     ({ upstream, usedGetFallback } = await fetchUpstreamAsset(
       request,
-      buildUpstreamUrl(`/portal/assets/${assetPath.split("/").map(encodeURIComponent).join("/")}`),
+      buildUpstreamUrl(
+        `/portal/assets/${assetPath.split("/").map(encodeURIComponent).join("/")}`,
+        request.nextUrl.search
+      ),
       upstreamHeaders
     ));
   } catch (error) {

--- a/web/secure-landing/app/route.js
+++ b/web/secure-landing/app/route.js
@@ -1,21 +1,20 @@
 import { NextResponse } from "next/server.js";
 
-import { getSessionFromRequest } from "../lib/sessions.js";
 import { applySecurityHeaders, FRONTDOOR_CSP } from "../lib/http.js";
 import { renderHomepage } from "../lib/homepage.js";
 
 export const runtime = "nodejs";
-export const dynamic = "force-dynamic";
+export const dynamic = "force-static";
 
-export async function GET(request) {
-  const session = getSessionFromRequest(request, { touch: false });
-  const hasAuthenticatedSessionHint = Boolean(session?.authenticated);
-  const html = renderHomepage({ hasAuthenticatedSessionHint });
+const HOMEPAGE_CACHE_CONTROL = "public, max-age=300, must-revalidate";
+
+export async function GET() {
+  const html = renderHomepage();
   const response = new NextResponse(html, {
     status: 200,
     headers: {
       "Content-Type": "text/html; charset=utf-8",
-      "Cache-Control": "no-store"
+      "Cache-Control": HOMEPAGE_CACHE_CONTROL
     }
   });
   return applySecurityHeaders(response, { csp: FRONTDOOR_CSP });

--- a/web/secure-landing/lib/homepage.js
+++ b/web/secure-landing/lib/homepage.js
@@ -411,10 +411,7 @@ function renderReleaseBundlePreview() {
   </section>`;
 }
 
-export function renderHomepage({ hasAuthenticatedSessionHint }) {
-  const utilityHref = hasAuthenticatedSessionHint ? "/portal" : "/login";
-  const utilityLabel = hasAuthenticatedSessionHint ? "Open Console" : "Operator Access";
-
+export function renderHomepage() {
   return `<!DOCTYPE html>
 <html lang="en">
   <head>
@@ -467,7 +464,7 @@ export function renderHomepage({ hasAuthenticatedSessionHint }) {
 
         <div class="site-actions">
           <a class="site-link" href="/login" data-ui="homepage-operator-link">Operator Login</a>
-          <a class="site-cta site-cta--ghost" href="${escapeHtml(utilityHref)}" data-ui="homepage-utility-cta">${escapeHtml(utilityLabel)}</a>
+          <a class="site-cta site-cta--ghost" href="/login" data-ui="homepage-utility-cta">Operator Access</a>
         </div>
 
         <details class="site-mobile-menu">
@@ -478,7 +475,7 @@ export function renderHomepage({ hasAuthenticatedSessionHint }) {
             </nav>
             <div class="site-mobile-menu__actions">
               <a class="site-link site-link--mobile" href="/login" data-ui="homepage-mobile-operator-link">Operator Login</a>
-              <a class="site-cta site-cta--ghost site-cta--mobile" href="${escapeHtml(utilityHref)}" data-ui="homepage-mobile-utility-cta">${escapeHtml(utilityLabel)}</a>
+              <a class="site-cta site-cta--ghost site-cta--mobile" href="/login" data-ui="homepage-mobile-utility-cta">Operator Access</a>
             </div>
           </div>
         </details>

--- a/web/secure-landing/tests/routes.test.mjs
+++ b/web/secure-landing/tests/routes.test.mjs
@@ -413,9 +413,12 @@ test("homepage GET serves the public DNA landing page instead of redirecting", a
     const response = await GET(request);
     const html = await response.text();
     const sessionCountAfter = db.prepare("SELECT COUNT(*) AS count FROM sessions").get().count;
+    const cacheControl = response.headers.get("cache-control") || "";
 
     assert.equal(response.status, 200);
-    assert.equal(response.headers.get("cache-control"), "no-store");
+    assert.doesNotMatch(cacheControl, /no-store/i);
+    assert.match(cacheControl, /\bpublic\b/i);
+    assert.match(cacheControl, /\bmax-age=/i);
     assert.match(response.headers.get("content-security-policy") || "", /default-src 'self'/);
     assert.match(response.headers.get("content-security-policy") || "", /script-src 'none'/);
     assert.equal(response.headers.get("set-cookie"), null);
@@ -451,12 +454,13 @@ test("homepage GET serves the public DNA landing page instead of redirecting", a
   }
 });
 
-test("homepage GET keeps authenticated operators on the public landing page while surfacing console entry", async () => {
+test("homepage route is explicitly static and ignores authenticated session hints", async () => {
   const env = withTempEnvironment();
 
   try {
     const sessions = await importFresh("../lib/sessions.js");
     const db = getDb(env.dbPath);
+    const routeSource = readFileSync(path.resolve(process.cwd(), "app", "route.js"), "utf-8");
     const { GET } = await importFresh("../app/route.js");
     const authenticatedSession = sessions.rotateAuthenticatedSession(
       sessions.createAnonymousSession(),
@@ -482,10 +486,11 @@ test("homepage GET keeps authenticated operators on the public landing page whil
       .prepare("SELECT last_seen_at, idle_expires_at FROM sessions WHERE id = ?")
       .get(authenticatedSession.id);
 
+    assert.match(routeSource, /dynamic = "force-static"/);
     assert.equal(response.status, 200);
     assert.equal(response.headers.get("set-cookie"), null);
-    assert.match(html, /(?:data-ui="homepage-utility-cta"[^>]*href="\/portal"|href="\/portal"[^>]*data-ui="homepage-utility-cta")/);
-    assert.match(html, />Open Console</);
+    assert.match(html, /(?:data-ui="homepage-utility-cta"[^>]*href="\/login"|href="\/login"[^>]*data-ui="homepage-utility-cta")/);
+    assert.match(html, />Operator Access</);
     assert.match(html, /(?:data-ui="homepage-primary-cta"[^>]*href="\/login"|href="\/login"[^>]*data-ui="homepage-primary-cta")/);
     assert.equal(after.last_seen_at, before.last_seen_at);
     assert.equal(after.idle_expires_at, before.idle_expires_at);
@@ -517,7 +522,7 @@ test("homepage GET succeeds without backend coupling or fetch side effects", asy
   }
 });
 
-test("homepage GET may prune expired sessions without setting cookies", async () => {
+test("homepage GET does not touch session state even when a stale cookie is present", async () => {
   const env = withTempEnvironment();
 
   try {
@@ -540,10 +545,11 @@ test("homepage GET may prune expired sessions without setting cookies", async ()
 
     const response = await GET(request);
     const html = await response.text();
+    const persisted = db.prepare("SELECT id FROM sessions WHERE id = ?").get(expiredSession.id);
 
     assert.equal(response.status, 200);
     assert.equal(response.headers.get("set-cookie"), null);
-    assert.equal(sessions.getSessionById(expiredSession.id, { touch: false }), null);
+    assert.equal(persisted.id, expiredSession.id);
     assert.match(html, />Operator Access</);
   } finally {
     env.cleanup();
@@ -1358,7 +1364,7 @@ test("portal asset proxy preserves content type and strips browser cookies", asy
 
     const originalFetch = global.fetch;
     global.fetch = async (url, init) => {
-      assert.equal(String(url), "http://127.0.0.1:8000/portal/assets/portal.css");
+      assert.equal(String(url), "http://127.0.0.1:8000/portal/assets/portal.css?v=portal-css-v1");
       assert.equal(init.method, "GET");
       assert.equal(init.headers.get("Authorization"), "Bearer backend-secret");
       assert.equal(init.headers.get("x-api-key"), "backend-secret");
@@ -1376,7 +1382,7 @@ test("portal asset proxy preserves content type and strips browser cookies", asy
     };
 
     try {
-      const request = buildRequest("https://portal.example.com/portal/assets/portal.css", {
+      const request = buildRequest("https://portal.example.com/portal/assets/portal.css?v=portal-css-v1", {
         method: "GET",
         headers: new Headers({
           accept: "text/css",
@@ -1442,7 +1448,7 @@ test("portal asset proxy supports nested asset paths and HEAD fallback", async (
     const originalFetch = global.fetch;
     global.fetch = async (url, init) => {
       fetchCalls.push({ url: String(url), method: init.method });
-      assert.equal(String(url), "http://127.0.0.1:8000/portal/assets/fonts/portal-sans.woff2");
+      assert.equal(String(url), "http://127.0.0.1:8000/portal/assets/fonts/portal-sans.woff2?v=font-v1");
       assert.equal(init.headers.get("Authorization"), "Bearer backend-secret");
       assert.equal(init.headers.get("x-api-key"), "backend-secret");
       if (init.method === "HEAD") {
@@ -1471,7 +1477,7 @@ test("portal asset proxy supports nested asset paths and HEAD fallback", async (
     };
 
     try {
-      const request = buildRequest("https://portal.example.com/portal/assets/fonts/portal-sans.woff2", {
+      const request = buildRequest("https://portal.example.com/portal/assets/fonts/portal-sans.woff2?v=font-v1", {
         method: "HEAD"
       });
 
@@ -1484,11 +1490,11 @@ test("portal asset proxy supports nested asset paths and HEAD fallback", async (
       assert.equal(response.headers.get("cache-control"), "public, max-age=3600");
       assert.deepEqual(fetchCalls, [
         {
-          url: "http://127.0.0.1:8000/portal/assets/fonts/portal-sans.woff2",
+          url: "http://127.0.0.1:8000/portal/assets/fonts/portal-sans.woff2?v=font-v1",
           method: "HEAD"
         },
         {
-          url: "http://127.0.0.1:8000/portal/assets/fonts/portal-sans.woff2",
+          url: "http://127.0.0.1:8000/portal/assets/fonts/portal-sans.woff2?v=font-v1",
           method: "GET"
         }
       ]);
@@ -1511,7 +1517,7 @@ test("portal asset proxy preserves upstream cache headers for 304 responses", as
 
     const originalFetch = global.fetch;
     global.fetch = async (url, init) => {
-      assert.equal(String(url), "http://127.0.0.1:8000/portal/assets/portal.js");
+      assert.equal(String(url), "http://127.0.0.1:8000/portal/assets/portal.js?v=portal-js-v1");
       assert.equal(init.method, "GET");
       assert.equal(init.headers.get("if-none-match"), '"portal-js-v1"');
       return new Response(null, {
@@ -1524,7 +1530,7 @@ test("portal asset proxy preserves upstream cache headers for 304 responses", as
     };
 
     try {
-      const request = buildRequest("https://portal.example.com/portal/assets/portal.js", {
+      const request = buildRequest("https://portal.example.com/portal/assets/portal.js?v=portal-js-v1", {
         method: "GET",
         headers: new Headers({
           "if-none-match": '"portal-js-v1"'


### PR DESCRIPTION
## Summary
- fingerprint FastAPI-served portal assets with canonical `?v=` URLs and immutable caching for current versions
- keep `/portal/assets/{path}` manifest-backed and backward-compatible by serving missing or stale versions with `no-store`
- make the managed frontdoor homepage session-agnostic and cacheable while preserving `/login` as the single operator entry point

## Implementation
- render `portal.html` and `portal.css` from tokenized templates in the FastAPI backend so HTML, CSS, font, JS, and brand asset URLs stay version-aligned
- serve rendered portal CSS from memory with a content-derived fingerprint and cache policy, while leaving JS, fonts, and SVGs file-backed
- forward frontdoor portal asset query strings upstream and update the homepage route to `force-static` with explicit cache headers
- update Python and Node contract coverage to assert rendered asset URLs, immutable-vs-`no-store` caching behavior, and the new static homepage contract

## Validation
- `PATH=/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin:$PATH ./.venv/bin/pre-commit run --all-files --show-diff-on-failure`
- `./.venv/bin/pytest -q tests/test_app_orchestrator_runtime.py tests/test_app_orchestrator_contract_http.py`
- `make test-orchestrator-contract`
- `make test-frontdoor-contract`
- `make validate-frontdoor-browser`
- `make test-fast`

## Follow-up
- measured fresh-load transfer still shows the shared background video dominates first-visit bytes even after the asset-cache fix
- homepage: `2,867,544` encoded bytes total, `2,854,035` from `/video/dna-loop.mp4`
- login: `2,862,438` encoded bytes total, `2,854,035` from `/video/dna-loop.mp4`
- that exceeds the 500 KB threshold from the perf plan, so video loading behavior should be the next targeted perf pass rather than revisiting portal asset caching
