### PR TITLE
[codex] Harden skill progression automation evidence collection

### DIFF
--- a/docs/guides/CUSTOM_AGENT_GUIDE.md
+++ b/docs/guides/CUSTOM_AGENT_GUIDE.md
@@ -200,6 +200,14 @@ contract test and sync the supporting agent docs
 that docs-and-tests sync
 ```
 
+### Automation Support
+
+For recurring review-pattern analysis, use the skill progression automation guide:
+
+- [Skill progression automation](./SKILL_PROGRESSION_AUTOMATION.md)
+
+It documents the GitHub-first evidence flow, the repo-local collector, the ranking rubric, and the required degraded-mode behavior when review-thread data or memory writes fail.
+
 The agent follows a structured response pattern:
 
 1. **Context**: "I understand you're working with [component]..."

--- a/docs/guides/SKILL_PROGRESSION_AUTOMATION.md
+++ b/docs/guides/SKILL_PROGRESSION_AUTOMATION.md
@@ -1,0 +1,136 @@
+# Skill Progression Automation
+
+## Purpose
+
+`skill-progression-map` is a recurring automation that reviews recent authored pull requests and review feedback, then ranks the next skills worth deepening.
+
+The workflow is intentionally evidence-first:
+
+1. Read automation memory from `$CODEX_HOME/automations/skill-progression-map/memory.md`.
+2. Prefer GitHub connector data when the automation can fetch recent PRs and review threads directly.
+3. If connector review-thread data is missing or unavailable, run the repo-local helper:
+
+```bash
+python scripts/automation/skill_progression_map.py --json
+```
+
+4. Fall back to local git history only when both connector and `gh`-backed collection fail.
+
+The automation should not claim review threads were unreachable unless both GitHub tiers fail.
+
+## Repo-Local Helper
+
+The helper lives in:
+
+- `src/transformation_portal/dev/skill_progression_map.py`
+- `scripts/automation/skill_progression_map.py`
+
+Stable CLI flags:
+
+- `--repo`
+- `--author`
+- `--since`
+- `--limit`
+- `--json`
+
+Default behavior:
+
+- repo: resolve from `git remote.origin.url`
+- author: resolve from active `gh auth status`
+- since: latest timestamp in automation memory, otherwise trailing 7 days
+- limit: `10`
+
+## Evidence Sources
+
+The helper emits one normalized report with a `source_status` block so the automation can explain evidence quality without guessing.
+
+Primary evidence sources:
+
+- `gh pr list` for recent authored PR discovery
+- `gh pr view` for changed files and review summaries
+- `gh api graphql` for inline review threads
+
+Degraded evidence source:
+
+- local `git log` plus changed-file inspection when GitHub evidence cannot be collected
+
+The helper ignores non-actionable GitHub noise such as AI rate-limit comments from `github-actions` and `chatgpt-codex-connector`.
+
+## Ranking Rubric
+
+Evidence is normalized into:
+
+- PR number, title, date, and URL
+- file path and line when available
+- review-thread status
+- concise comment summary
+- subsystem tag
+- issue-class tag
+
+Required issue classes:
+
+- `contract parity`
+- `fail-closed behavior`
+- `timeout/runtime guard`
+- `path normalization`
+- `deterministic validation/preflight`
+- `atomicity/concurrency`
+- `optional-dependency/runtime isolation`
+
+Theme scores are fixed-weight and deterministic:
+
+- review threads score higher than review summaries
+- review summaries score higher than changed-file-only signals
+- local git fallback scores lowest
+- recent evidence gets a higher multiplier
+- repeated PR recurrence and review-thread density add explicit bonuses
+
+This keeps genuine review pressure above raw file-touch counts.
+
+## Output Contract
+
+JSON output includes:
+
+- repo, author, and analysis window
+- `source_status`
+- inspected PRs
+- fallback commits when GitHub collection fails
+- normalized evidence records
+- ranked themes with numeric scores
+- `top_skills` as the top five themes
+
+Automation prose should turn that into:
+
+1. the top five ranked skills
+2. two concrete evidence anchors per skill
+3. two training tasks per skill
+4. one short confidence or evidence-quality line
+
+The helper does not write training tasks itself. It provides the ranked evidence for the automation prompt to summarize.
+
+## Memory and Failure Handling
+
+Memory remains external to the repo:
+
+- `$CODEX_HOME/automations/skill-progression-map/memory.md`
+
+On a successful automation run, append a concise dated summary and current run time there.
+
+If memory write fails:
+
+- state the failure explicitly in the automation output
+- do not redirect memory into the repo
+- keep the ranked report visible so the run still provides value
+
+## Manual Dry Run
+
+For a recent validation pass against the April 2026 PR cluster:
+
+```bash
+python scripts/automation/skill_progression_map.py \
+  --repo RC219805/Transformation_Portal \
+  --author RC219805 \
+  --since 2026-04-03T00:00:00Z \
+  --limit 5 \
+  --json
+```

--- a/scripts/automation/skill_progression_map.py
+++ b/scripts/automation/skill_progression_map.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""Thin CLI wrapper for the skill progression map collector."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from transformation_portal.dev.skill_progression_map import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/transformation_portal/dev/skill_progression_map.py
+++ b/src/transformation_portal/dev/skill_progression_map.py
@@ -1,0 +1,1201 @@
+"""Collect and rank recent PR/review evidence for skill progression mapping.
+
+This module is designed for automation use. It prefers GitHub PR/review
+evidence via the local ``gh`` CLI and falls back to local git history only when
+GitHub evidence cannot be collected.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+from transformation_portal.ingest.canonical_json import dumps_json
+
+AUTOMATION_ID = "skill-progression-map"
+DEFAULT_LIMIT = 10
+FALLBACK_WINDOW_DAYS = 7
+GITHUB_COMMAND_TIMEOUT_SECONDS = 30
+GRAPHQL_TIMEOUT_SECONDS = 45
+LOCAL_GIT_TIMEOUT_SECONDS = 15
+TOP_EVIDENCE_PER_THEME = 2
+MAX_GH_PR_FETCH = 50
+MAX_LOCAL_COMMITS = 50
+
+LOCAL_TZ = datetime.now().astimezone().tzinfo or UTC
+GITHUB_NOISE_AUTHORS = frozenset({"github-actions", "chatgpt-codex-connector"})
+
+REVIEW_SOURCE_WEIGHT = 3.0
+REVIEW_SUMMARY_WEIGHT = 2.0
+CHANGED_FILE_WEIGHT = 0.6
+LOCAL_COMMIT_WEIGHT = 0.5
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    """Structured subprocess result for deterministic command handling."""
+
+    command: tuple[str, ...]
+    returncode: int
+    stdout: str
+    stderr: str
+    timed_out: bool = False
+    error: str | None = None
+
+
+def _run_command(
+    command: Sequence[str],
+    *,
+    cwd: Path,
+    timeout: int,
+) -> CommandResult:
+    """Run a command and capture structured output without raising."""
+
+    try:
+        completed = subprocess.run(
+            list(command),
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+        return CommandResult(
+            command=tuple(command),
+            returncode=completed.returncode,
+            stdout=completed.stdout,
+            stderr=completed.stderr,
+        )
+    except subprocess.TimeoutExpired as exc:
+        return CommandResult(
+            command=tuple(command),
+            returncode=124,
+            stdout=exc.stdout or "",
+            stderr=exc.stderr or "",
+            timed_out=True,
+            error=f"Timed out after {timeout}s",
+        )
+    except OSError as exc:
+        return CommandResult(
+            command=tuple(command),
+            returncode=127,
+            stdout="",
+            stderr="",
+            error=str(exc),
+        )
+
+
+def _codex_home() -> Path:
+    """Return Codex home, falling back to ~/.codex when env is unset."""
+
+    configured = os.environ.get("CODEX_HOME", "").strip()
+    if configured:
+        return Path(configured).expanduser().resolve()
+    return (Path.home() / ".codex").resolve()
+
+
+def default_memory_path(automation_id: str = AUTOMATION_ID) -> Path:
+    """Return the default memory path for the automation."""
+
+    return _codex_home() / "automations" / automation_id / "memory.md"
+
+
+def _parse_iso8601(timestamp: str) -> datetime | None:
+    value = timestamp.strip()
+    if not value:
+        return None
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=LOCAL_TZ)
+    return parsed.astimezone(UTC)
+
+
+def parse_memory_timestamps(memory_text: str) -> list[datetime]:
+    """Extract timestamps from automation memory."""
+
+    timestamps: list[datetime] = []
+
+    for match in re.finditer(r"\b\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\b", memory_text):
+        parsed = _parse_iso8601(match.group(0))
+        if parsed is not None:
+            timestamps.append(parsed)
+
+    for match in re.finditer(
+        r"^##\s+(?P<stamp>\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})(?:\s+[A-Z]{2,4})?$",
+        memory_text,
+        flags=re.MULTILINE,
+    ):
+        try:
+            parsed = datetime.strptime(match.group("stamp"), "%Y-%m-%d %H:%M:%S")
+        except ValueError:
+            continue
+        timestamps.append(parsed.replace(tzinfo=LOCAL_TZ))
+
+    return sorted(timestamps)
+
+
+def resolve_since(
+    memory_path: Path | None = None,
+    *,
+    now: datetime | None = None,
+) -> tuple[datetime, dict[str, Any]]:
+    """Resolve the default analysis window start from memory or fallback."""
+
+    current_time = (now or datetime.now(UTC)).astimezone(UTC)
+    resolved_memory_path = memory_path or default_memory_path()
+    memory_meta: dict[str, Any] = {
+        "path": str(resolved_memory_path),
+        "loaded": False,
+        "timestamp_found": False,
+        "last_run": None,
+    }
+
+    if resolved_memory_path.exists():
+        content = resolved_memory_path.read_text(encoding="utf-8")
+        memory_meta["loaded"] = True
+        parsed_timestamps = parse_memory_timestamps(content)
+        if parsed_timestamps:
+            latest = parsed_timestamps[-1].astimezone(UTC)
+            memory_meta["timestamp_found"] = True
+            memory_meta["last_run"] = latest.isoformat().replace("+00:00", "Z")
+            return latest, memory_meta
+
+    fallback = current_time - timedelta(days=FALLBACK_WINDOW_DAYS)
+    return fallback, memory_meta
+
+
+def _normalize_slug(remote_url: str) -> str | None:
+    match = re.search(r"github\.com[:/](?P<owner>[^/]+)/(?P<repo>[^/.]+)(?:\.git)?$", remote_url.strip())
+    if not match:
+        return None
+    return f"{match.group('owner')}/{match.group('repo')}"
+
+
+def resolve_repo_slug(repo_root: Path) -> str:
+    """Resolve owner/repo from the current git checkout."""
+
+    for command in (
+        ("git", "remote", "get-url", "origin"),
+        ("git", "config", "--get", "remote.origin.url"),
+    ):
+        result = _run_command(command, cwd=repo_root, timeout=5)
+        if result.returncode != 0 or not result.stdout.strip():
+            continue
+        slug = _normalize_slug(result.stdout.strip())
+        if slug:
+            return slug
+    raise RuntimeError("Could not resolve GitHub repository from git remote.origin.url")
+
+
+def parse_github_login(auth_status_output: str) -> str | None:
+    """Extract the active GitHub login from `gh auth status` output."""
+
+    match = re.search(r"Logged in to github\.com account (?P<login>[A-Za-z0-9-]+)", auth_status_output)
+    if match:
+        return match.group("login")
+    return None
+
+
+def resolve_github_login(repo_root: Path) -> str:
+    """Resolve the active GitHub login via the local gh CLI."""
+
+    result = _run_command(("gh", "auth", "status"), cwd=repo_root, timeout=10)
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.error or "gh auth status failed"
+        raise RuntimeError(detail)
+    login = parse_github_login(result.stdout)
+    if not login:
+        raise RuntimeError("Could not parse active GitHub login from `gh auth status` output")
+    return login
+
+
+def _safe_json_loads(text: str) -> Any:
+    payload = text.strip()
+    if not payload:
+        return None
+    return json.loads(payload)
+
+
+def _normalize_datetime_string(value: str | None) -> str | None:
+    if not value:
+        return None
+    parsed = _parse_iso8601(value)
+    if parsed is None:
+        return None
+    return parsed.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _summary_from_text(text: str) -> str:
+    collapsed = re.sub(r"\s+", " ", re.sub(r"```.*?```", " ", text, flags=re.DOTALL)).strip()
+    if not collapsed:
+        return ""
+    sentence = re.split(r"(?<=[.!?])\s+", collapsed, maxsplit=1)[0].strip()
+    if len(sentence) > 220:
+        return sentence[:217].rstrip() + "..."
+    return sentence
+
+
+def _classify_subsystem(path: str | None) -> str:
+    if not path:
+        return "repository"
+
+    normalized = path.replace("\\", "/")
+    if normalized.startswith("web/secure-landing/"):
+        return "frontdoor"
+    if normalized in {"app.py", "portal.html"} or normalized.startswith("public/portal-assets/"):
+        return "portal"
+    if normalized.startswith("scripts/validation/") or normalized.startswith("tests/validation/"):
+        return "validation"
+    if any(token in normalized for token in ("raw_runtime", "raw_worker", "raw_loader")):
+        return "raw-runtime"
+    if "artifact_store" in normalized or "orchestration/graph" in normalized:
+        return "artifact-store"
+    if "/ingest/" in normalized or normalized.startswith("tests/spatial_ai/ingest/"):
+        return "ingest"
+    if "/depth/backends/" in normalized or normalized.startswith("tests/test_da2_backend.py"):
+        return "depth-runtime"
+    if normalized.startswith(".github/workflows/") or normalized.startswith("docs/ci/"):
+        return "github-workflows"
+    if normalized.startswith("src/transformation_portal/"):
+        parts = Path(normalized).parts
+        if len(parts) >= 3:
+            return parts[2].replace("_", "-")
+    if normalized.startswith("docs/"):
+        return "documentation"
+    if normalized.startswith("tests/"):
+        return "tests"
+    return Path(normalized).parts[0]
+
+
+def _matches_any(text: str, patterns: Iterable[str]) -> bool:
+    for pattern in patterns:
+        if re.fullmatch(r"[a-z0-9_]+", pattern):
+            if re.search(rf"\b{re.escape(pattern)}\b", text):
+                return True
+            continue
+        if pattern in text:
+            return True
+    return False
+
+
+def _classify_issue_class(text: str, path: str | None) -> str:
+    normalized_path = (path or "").replace("\\", "/").lower()
+    normalized_text = f"{normalized_path} {text.lower()}"
+
+    if _matches_any(
+        normalized_text,
+        (
+            "atomic",
+            "concurrent",
+            "multiprocess",
+            "partial write",
+            "partial writes",
+            "race",
+            "lock",
+            "fsync",
+            "rename",
+            "transactional visibility",
+            "reader never sees partial",
+        ),
+    ):
+        return "atomicity/concurrency"
+
+    if _matches_any(
+        normalized_text,
+        (
+            "fail closed",
+            "fail-closed",
+            "reject",
+            "required",
+            "missing_access",
+            "missing_backend_api_key",
+            "auth",
+            "healthz",
+            "access_config",
+            "session_store",
+            "session_scaling",
+            "deployment gate",
+            "protected deployment",
+        ),
+    ):
+        return "fail-closed behavior"
+
+    if _matches_any(
+        normalized_text,
+        (
+            "timeout",
+            "timed out",
+            "hang",
+            "stuck",
+            "watchdog",
+            "indefinite",
+            "subprocess.run without a timeout",
+        ),
+    ):
+        return "timeout/runtime guard"
+
+    if _matches_any(
+        normalized_text,
+        (
+            "relative path",
+            "absolute path",
+            "resolved path",
+            "cwd differs",
+            "cwd",
+            "normalize input_path",
+            "resolve it in the worker",
+            "path normalization",
+        ),
+    ):
+        return "path normalization"
+
+    if _matches_any(
+        normalized_text,
+        (
+            "lazy import",
+            "torch-free",
+            "optional dependency",
+            "optional dependencies",
+            "subprocess runtime",
+            "isolated runtime",
+            "openmp",
+            "rawpy",
+            "transformers",
+            "import boundary",
+            "eager torch import",
+        ),
+    ):
+        return "optional-dependency/runtime isolation"
+
+    if _matches_any(
+        normalized_text,
+        (
+            "preflight",
+            "validation",
+            "deterministic",
+            "smoke",
+            "environment",
+            "node version",
+            "readiness",
+            "preview",
+            "ci gate",
+            "gate",
+            "check_local_environment",
+        ),
+    ):
+        return "deterministic validation/preflight"
+
+    if _matches_any(
+        normalized_text,
+        (
+            "contract",
+            "payload",
+            "envelope",
+            "selector",
+            "dom marker",
+            "route shape",
+            "review status",
+            "compare state",
+            "surface",
+            "schema",
+        ),
+    ):
+        return "contract parity"
+
+    if normalized_path.startswith("scripts/validation/") or normalized_path.startswith("tests/validation/"):
+        return "deterministic validation/preflight"
+    if normalized_path.startswith("web/secure-landing/") and "healthz" in normalized_path:
+        return "fail-closed behavior"
+    if "artifact_store" in normalized_path:
+        return "atomicity/concurrency"
+    if any(token in normalized_path for token in ("raw_runtime", "raw_worker", "depth/backends", "raw_loader")):
+        return "optional-dependency/runtime isolation"
+    if normalized_path in {"app.py", "portal.html"} or normalized_path.startswith("public/portal-assets/"):
+        return "contract parity"
+
+    return "general review pressure"
+
+
+def _theme_catalog(theme_id: str, issue_class: str, subsystem: str) -> tuple[str, str]:
+    if issue_class == "atomicity/concurrency":
+        return theme_id, "Concurrency-safe storage and atomic commit semantics"
+
+    if subsystem == "frontdoor" and issue_class in {
+        "fail-closed behavior",
+        "deterministic validation/preflight",
+    }:
+        return theme_id, "Fail-closed frontdoor operations"
+
+    if issue_class == "contract parity" and subsystem in {"portal", "frontdoor"}:
+        return theme_id, "Contract-driven portal/frontdoor state modeling"
+
+    if issue_class == "deterministic validation/preflight":
+        return theme_id, "Deterministic validation-system design"
+
+    if issue_class in {
+        "optional-dependency/runtime isolation",
+        "timeout/runtime guard",
+        "path normalization",
+    } and subsystem in {"raw-runtime", "ingest", "depth-runtime"}:
+        return theme_id, "ML/runtime isolation and subprocess contract design"
+
+    subsystem_label = subsystem.replace("-", " ").title()
+    issue_label = issue_class.replace("/", " / ").title()
+    return theme_id, f"{issue_label} in {subsystem_label}"
+
+
+def _theme_id(issue_class: str, subsystem: str) -> str:
+    if issue_class == "atomicity/concurrency":
+        return "concurrency_safe_storage"
+    if subsystem == "frontdoor" and issue_class in {
+        "fail-closed behavior",
+        "deterministic validation/preflight",
+    }:
+        return "fail_closed_frontdoor_operations"
+    if issue_class == "contract parity" and subsystem in {"portal", "frontdoor"}:
+        return "contract_driven_portal_frontdoor_state_modeling"
+    if issue_class == "deterministic validation/preflight":
+        return "deterministic_validation_system_design"
+    if issue_class in {
+        "optional-dependency/runtime isolation",
+        "timeout/runtime guard",
+        "path normalization",
+    } and subsystem in {"raw-runtime", "ingest", "depth-runtime"}:
+        return "ml_runtime_isolation_and_subprocess_contract_design"
+    normalized = re.sub(r"[^a-z0-9]+", "_", f"{issue_class}_{subsystem}".lower()).strip("_")
+    return normalized or "general_review_pressure"
+
+
+def _recency_multiplier(updated_at: str | None, *, now: datetime) -> float:
+    normalized = _normalize_datetime_string(updated_at)
+    if normalized is None:
+        return 1.0
+    parsed = _parse_iso8601(normalized)
+    if parsed is None:
+        return 1.0
+    age = max((now - parsed.astimezone(UTC)).days, 0)
+    if age <= 1:
+        return 1.5
+    if age <= 3:
+        return 1.3
+    if age <= 7:
+        return 1.1
+    if age <= 14:
+        return 1.0
+    return 0.8
+
+
+def _make_pr_summary(pr_payload: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "number": pr_payload["number"],
+        "title": pr_payload["title"],
+        "state": pr_payload.get("state", "UNKNOWN"),
+        "url": pr_payload.get("url"),
+        "updated_at": _normalize_datetime_string(pr_payload.get("updatedAt")),
+        "merged_at": _normalize_datetime_string(pr_payload.get("mergedAt")),
+        "review_thread_count": 0,
+        "changed_file_count": 0,
+    }
+
+
+def _make_evidence_record(
+    *,
+    evidence_id: str,
+    source: str,
+    pr_summary: dict[str, Any] | None,
+    path: str | None,
+    line: int | None,
+    status: str,
+    summary: str,
+    issue_class: str,
+    subsystem: str,
+    base_weight: float,
+    review_comment_count: int = 1,
+    now: datetime,
+) -> dict[str, Any]:
+    updated_at = pr_summary.get("updated_at") if pr_summary else None
+    recency = _recency_multiplier(updated_at, now=now)
+    intensity = 1.0 + max(review_comment_count - 1, 0) * 0.2
+    score = round(base_weight * recency * intensity, 3)
+    theme_id = _theme_id(issue_class, subsystem)
+    _, theme_label = _theme_catalog(theme_id, issue_class, subsystem)
+    return {
+        "id": evidence_id,
+        "theme_id": theme_id,
+        "theme_label": theme_label,
+        "source": source,
+        "pr_number": pr_summary.get("number") if pr_summary else None,
+        "pr_title": pr_summary.get("title") if pr_summary else None,
+        "pr_url": pr_summary.get("url") if pr_summary else None,
+        "updated_at": updated_at,
+        "path": path,
+        "line": line,
+        "thread_status": status,
+        "summary": summary,
+        "subsystem_tag": subsystem,
+        "issue_class_tag": issue_class,
+        "review_comment_count": review_comment_count,
+        "score": score,
+    }
+
+
+def _normalize_review_threads(
+    *,
+    pr_summary: dict[str, Any],
+    threads_payload: dict[str, Any],
+    author_login: str,
+    now: datetime,
+) -> list[dict[str, Any]]:
+    nodes = (
+        threads_payload.get("data", {}).get("repository", {}).get("pullRequest", {}).get("reviewThreads", {}).get("nodes", [])
+    )
+    evidence_records: list[dict[str, Any]] = []
+    for index, thread in enumerate(nodes, start=1):
+        comments = thread.get("comments", {}).get("nodes", [])
+        actionable = [
+            comment
+            for comment in comments
+            if comment.get("author", {}).get("login") not in GITHUB_NOISE_AUTHORS
+            and comment.get("author", {}).get("login") != author_login
+        ]
+        if not actionable:
+            continue
+
+        primary = actionable[0]
+        path = primary.get("path")
+        summary_text = " ".join(comment.get("body", "") for comment in actionable[:2])
+        summary = _summary_from_text(summary_text)
+        subsystem = _classify_subsystem(path)
+        issue_class = _classify_issue_class(summary_text, path)
+        line = primary.get("line") or primary.get("originalLine")
+        thread_status = "resolved" if thread.get("isResolved") else "open"
+        if thread.get("isOutdated"):
+            thread_status = "outdated" if thread_status != "open" else "open-outdated"
+        evidence_records.append(
+            _make_evidence_record(
+                evidence_id=f"pr-{pr_summary['number']}-thread-{index}",
+                source="review_thread",
+                pr_summary=pr_summary,
+                path=path,
+                line=line,
+                status=thread_status,
+                summary=summary,
+                issue_class=issue_class,
+                subsystem=subsystem,
+                base_weight=REVIEW_SOURCE_WEIGHT,
+                review_comment_count=len(actionable),
+                now=now,
+            )
+        )
+
+    return evidence_records
+
+
+def _normalize_review_summaries(
+    *,
+    pr_summary: dict[str, Any],
+    reviews: list[dict[str, Any]],
+    author_login: str,
+    now: datetime,
+) -> list[dict[str, Any]]:
+    evidence_records: list[dict[str, Any]] = []
+    review_index = 0
+    for review in reviews:
+        body = str(review.get("body") or "").strip()
+        reviewer = review.get("author", {}).get("login")
+        if not body or reviewer in GITHUB_NOISE_AUTHORS or reviewer == author_login:
+            continue
+        issue_class = _classify_issue_class(body, None)
+        if issue_class == "general review pressure":
+            continue
+        review_index += 1
+        evidence_records.append(
+            _make_evidence_record(
+                evidence_id=f"pr-{pr_summary['number']}-review-{review_index}",
+                source="review_summary",
+                pr_summary=pr_summary,
+                path=None,
+                line=None,
+                status=str(review.get("state") or "commented").lower(),
+                summary=_summary_from_text(body),
+                issue_class=issue_class,
+                subsystem="repository",
+                base_weight=REVIEW_SUMMARY_WEIGHT,
+                now=now,
+            )
+        )
+    return evidence_records
+
+
+def _normalize_changed_files(
+    *,
+    pr_summary: dict[str, Any],
+    files: list[dict[str, Any]],
+    now: datetime,
+) -> list[dict[str, Any]]:
+    seen_keys: set[tuple[str, str]] = set()
+    evidence_records: list[dict[str, Any]] = []
+    for index, file_info in enumerate(files, start=1):
+        path = file_info.get("path")
+        subsystem = _classify_subsystem(path)
+        issue_class = _classify_issue_class("", path)
+        if issue_class == "general review pressure":
+            continue
+        dedupe_key = (subsystem, issue_class)
+        if dedupe_key in seen_keys:
+            continue
+        seen_keys.add(dedupe_key)
+        change_type = str(file_info.get("changeType") or "MODIFIED").lower()
+        summary = f"{change_type} file in recurring {subsystem} surface."
+        evidence_records.append(
+            _make_evidence_record(
+                evidence_id=f"pr-{pr_summary['number']}-file-{index}",
+                source="changed_file",
+                pr_summary=pr_summary,
+                path=path,
+                line=None,
+                status=change_type,
+                summary=summary,
+                issue_class=issue_class,
+                subsystem=subsystem,
+                base_weight=CHANGED_FILE_WEIGHT,
+                now=now,
+            )
+        )
+    return evidence_records
+
+
+def _collect_gh_prs(
+    *,
+    repo: str,
+    author: str,
+    since: datetime,
+    limit: int,
+    repo_root: Path,
+    now: datetime,
+) -> dict[str, Any]:
+    source_status = {
+        "connector": "not-run-by-helper",
+        "gh_cli": {
+            "auth": "unknown",
+            "pr_list": "unknown",
+            "review_threads": "unknown",
+            "notes": [],
+        },
+        "local_git": {"used": False, "status": "not-used", "notes": []},
+        "memory": {},
+        "degraded": False,
+        "evidence_quality": "unknown",
+    }
+
+    auth_result = _run_command(("gh", "auth", "status"), cwd=repo_root, timeout=10)
+    if auth_result.returncode != 0:
+        source_status["gh_cli"]["auth"] = "failed"
+        source_status["gh_cli"]["notes"].append(auth_result.stderr.strip() or auth_result.error or "gh auth status failed")
+        source_status["degraded"] = True
+        source_status["evidence_quality"] = "low"
+        return {
+            "success": False,
+            "inspected_prs": [],
+            "evidence_records": [],
+            "source_status": source_status,
+        }
+    source_status["gh_cli"]["auth"] = "ok"
+
+    fetch_count = min(max(limit * 4, limit), MAX_GH_PR_FETCH)
+    list_command = (
+        "gh",
+        "pr",
+        "list",
+        "--repo",
+        repo,
+        "--author",
+        author,
+        "--state",
+        "all",
+        "--limit",
+        str(fetch_count),
+        "--json",
+        "number,title,state,url,isDraft,updatedAt,mergedAt",
+    )
+    list_result = _run_command(list_command, cwd=repo_root, timeout=GITHUB_COMMAND_TIMEOUT_SECONDS)
+    if list_result.returncode != 0:
+        source_status["gh_cli"]["pr_list"] = "failed"
+        source_status["gh_cli"]["notes"].append(list_result.stderr.strip() or list_result.error or "gh pr list failed")
+        source_status["degraded"] = True
+        source_status["evidence_quality"] = "low"
+        return {
+            "success": False,
+            "inspected_prs": [],
+            "evidence_records": [],
+            "source_status": source_status,
+        }
+    source_status["gh_cli"]["pr_list"] = "ok"
+
+    raw_prs = _safe_json_loads(list_result.stdout) or []
+    since_utc = since.astimezone(UTC)
+    filtered_prs = []
+    for pr in raw_prs:
+        updated_at = _parse_iso8601(str(pr.get("updatedAt") or ""))
+        if updated_at is None or updated_at.astimezone(UTC) < since_utc:
+            continue
+        filtered_prs.append(pr)
+    filtered_prs.sort(key=lambda item: str(item.get("updatedAt") or ""), reverse=True)
+    filtered_prs = filtered_prs[:limit]
+
+    inspected_prs: list[dict[str, Any]] = []
+    evidence_records: list[dict[str, Any]] = []
+    thread_failures = 0
+    thread_successes = 0
+
+    for pr in filtered_prs:
+        number = int(pr["number"])
+        summary = _make_pr_summary(pr)
+        inspected_prs.append(summary)
+
+        detail_command = (
+            "gh",
+            "pr",
+            "view",
+            str(number),
+            "--repo",
+            repo,
+            "--json",
+            "number,title,state,url,updatedAt,mergedAt,files,reviews",
+        )
+        detail_result = _run_command(detail_command, cwd=repo_root, timeout=GITHUB_COMMAND_TIMEOUT_SECONDS)
+        if detail_result.returncode != 0:
+            source_status["gh_cli"]["notes"].append(
+                f"Failed to inspect PR #{number}: {detail_result.stderr.strip() or detail_result.error or 'unknown error'}"
+            )
+            source_status["degraded"] = True
+            continue
+
+        detail_payload = _safe_json_loads(detail_result.stdout) or {}
+        summary["changed_file_count"] = len(detail_payload.get("files", []))
+
+        threads_payload: dict[str, Any] | None = None
+        graphql_query = (
+            "query($owner:String!, $repo:String!, $number:Int!){ "
+            "repository(owner:$owner, name:$repo){ "
+            "pullRequest(number:$number){ "
+            "number title reviewThreads(first:50){ "
+            "nodes { "
+            "isResolved isOutdated "
+            "comments(first:20){ nodes { author { login } body path line originalLine createdAt } } "
+            "} } } } }"
+        )
+        owner, repo_name = repo.split("/", maxsplit=1)
+        graphql_command = (
+            "gh",
+            "api",
+            "graphql",
+            "-f",
+            f"query={graphql_query}",
+            "-F",
+            f"owner={owner}",
+            "-F",
+            f"repo={repo_name}",
+            "-F",
+            f"number={number}",
+        )
+        thread_result = _run_command(graphql_command, cwd=repo_root, timeout=GRAPHQL_TIMEOUT_SECONDS)
+        if thread_result.returncode == 0:
+            threads_payload = _safe_json_loads(thread_result.stdout) or {}
+            thread_records = _normalize_review_threads(
+                pr_summary=summary,
+                threads_payload=threads_payload,
+                author_login=author,
+                now=now,
+            )
+            evidence_records.extend(thread_records)
+            summary["review_thread_count"] = len(thread_records)
+            thread_successes += 1
+        else:
+            thread_failures += 1
+            source_status["degraded"] = True
+            source_status["gh_cli"]["notes"].append(
+                f"Failed to fetch review threads for PR #{number}: "
+                f"{thread_result.stderr.strip() or thread_result.error or 'unknown error'}"
+            )
+
+        if summary["review_thread_count"] == 0:
+            evidence_records.extend(
+                _normalize_review_summaries(
+                    pr_summary=summary,
+                    reviews=detail_payload.get("reviews", []),
+                    author_login=author,
+                    now=now,
+                )
+            )
+
+        evidence_records.extend(
+            _normalize_changed_files(
+                pr_summary=summary,
+                files=detail_payload.get("files", []),
+                now=now,
+            )
+        )
+
+    if filtered_prs:
+        if thread_failures == 0:
+            source_status["gh_cli"]["review_threads"] = "ok"
+            source_status["evidence_quality"] = "high"
+        elif thread_successes > 0:
+            source_status["gh_cli"]["review_threads"] = "partial"
+            source_status["evidence_quality"] = "medium"
+        else:
+            source_status["gh_cli"]["review_threads"] = "failed"
+            source_status["evidence_quality"] = "medium" if evidence_records else "low"
+    else:
+        source_status["gh_cli"]["review_threads"] = "no-prs"
+        source_status["evidence_quality"] = "low"
+
+    return {
+        "success": True,
+        "inspected_prs": inspected_prs,
+        "evidence_records": evidence_records,
+        "source_status": source_status,
+    }
+
+
+def _collect_local_git_fallback(
+    *,
+    author: str,
+    since: datetime,
+    limit: int,
+    repo_root: Path,
+    now: datetime,
+) -> dict[str, Any]:
+    source_status = {
+        "connector": "not-run-by-helper",
+        "gh_cli": {
+            "auth": "unavailable",
+            "pr_list": "unavailable",
+            "review_threads": "unavailable",
+            "notes": ["Using degraded local git fallback."],
+        },
+        "local_git": {"used": True, "status": "unknown", "notes": []},
+        "memory": {},
+        "degraded": True,
+        "evidence_quality": "low",
+    }
+
+    log_command = (
+        "git",
+        "log",
+        "--since",
+        since.astimezone(UTC).isoformat().replace("+00:00", "Z"),
+        "--author",
+        author,
+        "--pretty=format:%H%x09%aI%x09%s",
+        f"--max-count={min(max(limit * 5, limit), MAX_LOCAL_COMMITS)}",
+    )
+    log_result = _run_command(log_command, cwd=repo_root, timeout=LOCAL_GIT_TIMEOUT_SECONDS)
+    if log_result.returncode != 0:
+        source_status["local_git"]["status"] = "failed"
+        source_status["local_git"]["notes"].append(log_result.stderr.strip() or log_result.error or "git log failed")
+        return {
+            "success": False,
+            "fallback_commits": [],
+            "evidence_records": [],
+            "source_status": source_status,
+        }
+
+    fallback_commits: list[dict[str, Any]] = []
+    evidence_records: list[dict[str, Any]] = []
+
+    for index, line in enumerate(filter(None, log_result.stdout.splitlines()), start=1):
+        if index > limit:
+            break
+        try:
+            commit_sha, authored_at, subject = line.split("\t", maxsplit=2)
+        except ValueError:
+            continue
+        commit_payload = {
+            "sha": commit_sha,
+            "subject": subject,
+            "updated_at": _normalize_datetime_string(authored_at),
+        }
+        fallback_commits.append(commit_payload)
+
+        show_result = _run_command(
+            ("git", "show", "--name-only", "--format=", commit_sha),
+            cwd=repo_root,
+            timeout=LOCAL_GIT_TIMEOUT_SECONDS,
+        )
+        if show_result.returncode != 0:
+            source_status["local_git"]["notes"].append(
+                f"Failed to inspect commit {commit_sha[:8]}: {show_result.stderr.strip() or show_result.error or 'unknown error'}"
+            )
+            continue
+
+        seen_keys: set[tuple[str, str]] = set()
+        for file_index, path in enumerate(filter(None, (entry.strip() for entry in show_result.stdout.splitlines())), start=1):
+            subsystem = _classify_subsystem(path)
+            issue_class = _classify_issue_class(subject, path)
+            if issue_class == "general review pressure":
+                continue
+            dedupe_key = (subsystem, issue_class)
+            if dedupe_key in seen_keys:
+                continue
+            seen_keys.add(dedupe_key)
+            pr_summary = {
+                "number": None,
+                "title": subject,
+                "url": None,
+                "updated_at": commit_payload["updated_at"],
+            }
+            evidence_records.append(
+                _make_evidence_record(
+                    evidence_id=f"commit-{commit_sha[:8]}-file-{file_index}",
+                    source="local_commit",
+                    pr_summary=pr_summary,
+                    path=path,
+                    line=None,
+                    status="local-commit",
+                    summary=_summary_from_text(subject),
+                    issue_class=issue_class,
+                    subsystem=subsystem,
+                    base_weight=LOCAL_COMMIT_WEIGHT,
+                    now=now,
+                )
+            )
+
+    source_status["local_git"]["status"] = "ok" if fallback_commits else "no-data"
+    return {
+        "success": bool(fallback_commits),
+        "fallback_commits": fallback_commits,
+        "evidence_records": evidence_records,
+        "source_status": source_status,
+    }
+
+
+def rank_themes(evidence_records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Rank synthesized skill themes from normalized evidence."""
+
+    grouped: dict[str, dict[str, Any]] = {}
+    for record in evidence_records:
+        theme_id = record["theme_id"]
+        grouped.setdefault(
+            theme_id,
+            {
+                "theme_id": theme_id,
+                "label": record["theme_label"],
+                "score": 0.0,
+                "evidence": [],
+                "pr_numbers": set(),
+                "issue_classes": set(),
+                "subsystems": set(),
+                "review_thread_count": 0,
+            },
+        )
+        bucket = grouped[theme_id]
+        bucket["score"] += float(record["score"])
+        bucket["evidence"].append(record)
+        if record.get("pr_number") is not None:
+            bucket["pr_numbers"].add(record["pr_number"])
+        bucket["issue_classes"].add(record["issue_class_tag"])
+        bucket["subsystems"].add(record["subsystem_tag"])
+        if record["source"] == "review_thread":
+            bucket["review_thread_count"] += 1
+
+    ranked: list[dict[str, Any]] = []
+    for bucket in grouped.values():
+        distinct_prs = len(bucket["pr_numbers"])
+        review_thread_bonus = max(bucket["review_thread_count"] - 1, 0) * 1.0
+        recurrence_bonus = max(distinct_prs - 1, 0) * 1.5
+        final_score = round(bucket["score"] + recurrence_bonus + review_thread_bonus, 3)
+        ordered_evidence = sorted(
+            bucket["evidence"],
+            key=lambda item: (float(item["score"]), item.get("updated_at") or ""),
+            reverse=True,
+        )
+        ranked.append(
+            {
+                "theme_id": bucket["theme_id"],
+                "label": bucket["label"],
+                "score": final_score,
+                "evidence_count": len(bucket["evidence"]),
+                "distinct_pr_count": distinct_prs,
+                "review_thread_count": bucket["review_thread_count"],
+                "issue_class_tags": sorted(bucket["issue_classes"]),
+                "subsystem_tags": sorted(bucket["subsystems"]),
+                "top_evidence": ordered_evidence[:TOP_EVIDENCE_PER_THEME],
+            }
+        )
+
+    ranked.sort(key=lambda item: (item["score"], item["review_thread_count"], item["distinct_pr_count"]), reverse=True)
+    return ranked
+
+
+def build_skill_progression_report(
+    *,
+    repo: str | None = None,
+    author: str | None = None,
+    since: datetime | None = None,
+    limit: int = DEFAULT_LIMIT,
+    repo_root: Path | None = None,
+    memory_path: Path | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Build a deterministic skill-progression report."""
+
+    if limit <= 0:
+        raise ValueError("limit must be positive")
+
+    resolved_repo_root = (repo_root or Path.cwd()).resolve()
+    current_time = (now or datetime.now(UTC)).astimezone(UTC)
+    resolved_repo = repo or resolve_repo_slug(resolved_repo_root)
+    resolved_author = author or resolve_github_login(resolved_repo_root)
+    resolved_since, memory_meta = (
+        resolve_since(memory_path, now=current_time)
+        if since is None
+        else (
+            since.astimezone(UTC),
+            {
+                "path": str(memory_path or default_memory_path()),
+                "loaded": memory_path.exists() if memory_path else default_memory_path().exists(),
+                "timestamp_found": False,
+                "last_run": None,
+            },
+        )
+    )
+
+    gh_report = _collect_gh_prs(
+        repo=resolved_repo,
+        author=resolved_author,
+        since=resolved_since,
+        limit=limit,
+        repo_root=resolved_repo_root,
+        now=current_time,
+    )
+    gh_report["source_status"]["memory"] = memory_meta
+
+    fallback_commits: list[dict[str, Any]] = []
+    evidence_records = gh_report["evidence_records"]
+    source_status = gh_report["source_status"]
+    inspected_prs = gh_report["inspected_prs"]
+
+    if not gh_report["success"]:
+        fallback_report = _collect_local_git_fallback(
+            author=resolved_author,
+            since=resolved_since,
+            limit=limit,
+            repo_root=resolved_repo_root,
+            now=current_time,
+        )
+        fallback_report["source_status"]["memory"] = memory_meta
+        source_status = fallback_report["source_status"]
+        evidence_records = fallback_report["evidence_records"]
+        fallback_commits = fallback_report["fallback_commits"]
+        inspected_prs = []
+
+    ranked_themes = rank_themes(evidence_records)
+    top_skills = ranked_themes[:5]
+
+    return {
+        "report_version": "skill-progression-map.v1",
+        "repo": resolved_repo,
+        "author": resolved_author,
+        "window": {
+            "since": resolved_since.astimezone(UTC).isoformat().replace("+00:00", "Z"),
+            "until": current_time.astimezone(UTC).isoformat().replace("+00:00", "Z"),
+            "limit": limit,
+        },
+        "source_status": source_status,
+        "inspected_prs": inspected_prs,
+        "fallback_commits": fallback_commits,
+        "evidence_records": evidence_records,
+        "ranked_themes": ranked_themes,
+        "top_skills": top_skills,
+    }
+
+
+def render_text_report(report: dict[str, Any]) -> str:
+    """Render a compact human-readable report."""
+
+    lines = [
+        f"Skill progression map for {report['author']} in {report['repo']}",
+        f"Window: {report['window']['since']} -> {report['window']['until']}",
+        f"Evidence quality: {report['source_status']['evidence_quality']}",
+    ]
+    if not report["top_skills"]:
+        lines.append("No ranked themes found.")
+        return "\n".join(lines)
+
+    for index, theme in enumerate(report["top_skills"], start=1):
+        lines.append(f"{index}. {theme['label']} (score {theme['score']:.2f})")
+        for evidence in theme["top_evidence"]:
+            anchor = f"PR #{evidence['pr_number']}" if evidence.get("pr_number") else evidence["source"]
+            if evidence.get("path"):
+                anchor = f"{anchor} {evidence['path']}"
+            lines.append(f"   - {anchor}: {evidence['summary']}")
+    return "\n".join(lines)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", help="GitHub repository in owner/name format.")
+    parser.add_argument("--author", help="GitHub login to analyze.")
+    parser.add_argument(
+        "--since",
+        help="Analysis window start in ISO-8601 format (defaults to automation memory, then trailing 7 days).",
+    )
+    parser.add_argument(
+        "--limit", type=int, default=DEFAULT_LIMIT, help=f"Maximum recent PRs to inspect (default: {DEFAULT_LIMIT})."
+    )
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """CLI entrypoint used by automation and manual dry runs."""
+
+    parser = _build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    since = None
+    if args.since:
+        since = _parse_iso8601(args.since)
+        if since is None:
+            parser.error("--since must be a valid ISO-8601 timestamp")
+
+    try:
+        report = build_skill_progression_report(
+            repo=args.repo,
+            author=args.author,
+            since=since,
+            limit=args.limit,
+        )
+    except Exception as exc:  # pragma: no cover - CLI boundary
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(dumps_json(report, indent=2, sort_keys=True, ensure_ascii=False, allow_nan=False))
+    else:
+        print(render_text_report(report))
+
+    if report["top_skills"]:
+        return 0
+    if report["source_status"]["evidence_quality"] == "low":
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/transformation_portal/dev/skill_progression_map.py
+++ b/src/transformation_portal/dev/skill_progression_map.py
@@ -134,7 +134,7 @@ def parse_memory_timestamps(memory_text: str) -> list[datetime]:
             timestamps.append(parsed)
 
     for match in re.finditer(
-        r"^##\s+(?P<stamp>\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})(?:\s+[A-Z]{2,4})?$",
+        r"^##\s+(?P<stamp>\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})(?:\s+(?P<tz>[A-Z]{2,4}))?$",
         memory_text,
         flags=re.MULTILINE,
     ):
@@ -142,7 +142,12 @@ def parse_memory_timestamps(memory_text: str) -> list[datetime]:
             parsed = datetime.strptime(match.group("stamp"), "%Y-%m-%d %H:%M:%S")
         except ValueError:
             continue
-        timestamps.append(parsed.replace(tzinfo=LOCAL_TZ))
+        tz_suffix = match.group("tz")
+        if tz_suffix == "UTC":
+            timestamps.append(parsed.replace(tzinfo=UTC))
+        else:
+            # Treat missing or unrecognized timezone suffix as local time
+            timestamps.append(parsed.replace(tzinfo=LOCAL_TZ))
 
     return sorted(timestamps)
 

--- a/src/transformation_portal/dev/skill_progression_map.py
+++ b/src/transformation_portal/dev/skill_progression_map.py
@@ -14,7 +14,7 @@ import re
 import subprocess
 import sys
 from dataclasses import dataclass
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Iterable, Sequence
 
@@ -32,6 +32,18 @@ MAX_LOCAL_COMMITS = 50
 
 LOCAL_TZ = datetime.now().astimezone().tzinfo or UTC
 GITHUB_NOISE_AUTHORS = frozenset({"github-actions", "chatgpt-codex-connector"})
+MEMORY_HEADING_TZINFOS = {
+    "UTC": UTC,
+    "GMT": UTC,
+    "PST": timezone(timedelta(hours=-8), "PST"),
+    "PDT": timezone(timedelta(hours=-7), "PDT"),
+    "MST": timezone(timedelta(hours=-7), "MST"),
+    "MDT": timezone(timedelta(hours=-6), "MDT"),
+    "CST": timezone(timedelta(hours=-6), "CST"),
+    "CDT": timezone(timedelta(hours=-5), "CDT"),
+    "EST": timezone(timedelta(hours=-5), "EST"),
+    "EDT": timezone(timedelta(hours=-4), "EDT"),
+}
 
 REVIEW_SOURCE_WEIGHT = 3.0
 REVIEW_SUMMARY_WEIGHT = 2.0
@@ -143,11 +155,10 @@ def parse_memory_timestamps(memory_text: str) -> list[datetime]:
         except ValueError:
             continue
         tz_suffix = match.group("tz")
-        if tz_suffix == "UTC":
-            timestamps.append(parsed.replace(tzinfo=UTC))
-        else:
-            # Treat missing or unrecognized timezone suffix as local time
-            timestamps.append(parsed.replace(tzinfo=LOCAL_TZ))
+        if tz_suffix:
+            timestamps.append(parsed.replace(tzinfo=MEMORY_HEADING_TZINFOS.get(tz_suffix, LOCAL_TZ)))
+            continue
+        timestamps.append(parsed.replace(tzinfo=LOCAL_TZ))
 
     return sorted(timestamps)
 

--- a/src/transformation_portal/dev/skill_progression_map.py
+++ b/src/transformation_portal/dev/skill_progression_map.py
@@ -172,22 +172,32 @@ def resolve_since(
 
     current_time = (now or datetime.now(UTC)).astimezone(UTC)
     resolved_memory_path = memory_path or default_memory_path()
+    memory_exists = resolved_memory_path.exists()
     memory_meta: dict[str, Any] = {
         "path": str(resolved_memory_path),
+        "exists": memory_exists,
         "loaded": False,
         "timestamp_found": False,
         "last_run": None,
+        "status": "missing",
+        "notes": None,
     }
 
-    if resolved_memory_path.exists():
-        content = resolved_memory_path.read_text(encoding="utf-8")
-        memory_meta["loaded"] = True
-        parsed_timestamps = parse_memory_timestamps(content)
-        if parsed_timestamps:
-            latest = parsed_timestamps[-1].astimezone(UTC)
-            memory_meta["timestamp_found"] = True
-            memory_meta["last_run"] = latest.isoformat().replace("+00:00", "Z")
-            return latest, memory_meta
+    if memory_exists:
+        try:
+            content = resolved_memory_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            memory_meta["status"] = "read_error"
+            memory_meta["notes"] = f"{type(exc).__name__}: {exc}"
+        else:
+            memory_meta["loaded"] = True
+            memory_meta["status"] = "loaded"
+            parsed_timestamps = parse_memory_timestamps(content)
+            if parsed_timestamps:
+                latest = parsed_timestamps[-1].astimezone(UTC)
+                memory_meta["timestamp_found"] = True
+                memory_meta["last_run"] = latest.isoformat().replace("+00:00", "Z")
+                return latest, memory_meta
 
     fallback = current_time - timedelta(days=FALLBACK_WINDOW_DAYS)
     return fallback, memory_meta
@@ -238,11 +248,69 @@ def resolve_github_login(repo_root: Path) -> str:
     return login
 
 
-def _safe_json_loads(text: str) -> Any:
+def _safe_json_loads(
+    text: str,
+    *,
+    notes: list[str] | None = None,
+    context: str | None = None,
+) -> Any:
     payload = text.strip()
     if not payload:
         return None
-    return json.loads(payload)
+    try:
+        return json.loads(payload)
+    except json.JSONDecodeError as exc:
+        if notes is not None:
+            label = context or "JSON payload"
+            notes.append(f"{label} was not valid JSON: {exc.msg} (line {exc.lineno}, column {exc.colno}).")
+        return None
+
+
+def _normalize_author_token(value: str | None) -> str | None:
+    if value is None:
+        return None
+    normalized = value.strip().casefold()
+    return normalized or None
+
+
+def _collect_git_author_filters(repo_root: Path, author: str) -> set[str]:
+    filters: set[str] = set()
+
+    def add(value: str | None) -> None:
+        normalized = _normalize_author_token(value)
+        if not normalized:
+            return
+        filters.add(normalized)
+        if "@" in normalized:
+            filters.add(normalized.split("@", maxsplit=1)[0])
+
+    add(author)
+
+    for command in (
+        ("git", "config", "--get", "user.name"),
+        ("git", "config", "--get", "user.email"),
+    ):
+        result = _run_command(command, cwd=repo_root, timeout=5)
+        if result.returncode == 0:
+            add(result.stdout.strip())
+
+    return filters
+
+
+def _commit_matches_git_author(filters: set[str], author_name: str, author_email: str) -> bool:
+    if not filters:
+        return True
+
+    candidates: set[str] = set()
+    for value in (author_name, author_email, f"{author_name} <{author_email}>"):
+        normalized = _normalize_author_token(value)
+        if not normalized:
+            continue
+        candidates.add(normalized)
+        if "@" in normalized:
+            candidates.add(normalized.split("@", maxsplit=1)[0])
+
+    return bool(filters.intersection(candidates))
 
 
 def _normalize_datetime_string(value: str | None) -> str | None:
@@ -761,7 +829,21 @@ def _collect_gh_prs(
         }
     source_status["gh_cli"]["pr_list"] = "ok"
 
-    raw_prs = _safe_json_loads(list_result.stdout) or []
+    raw_prs = _safe_json_loads(
+        list_result.stdout,
+        notes=source_status["gh_cli"]["notes"],
+        context="`gh pr list` output",
+    )
+    if not isinstance(raw_prs, list):
+        source_status["gh_cli"]["pr_list"] = "failed"
+        source_status["degraded"] = True
+        source_status["evidence_quality"] = "low"
+        return {
+            "success": False,
+            "inspected_prs": [],
+            "evidence_records": [],
+            "source_status": source_status,
+        }
     since_utc = since.astimezone(UTC)
     filtered_prs = []
     for pr in raw_prs:
@@ -801,7 +883,16 @@ def _collect_gh_prs(
             thread_failures += 1
             continue
 
-        detail_payload = _safe_json_loads(detail_result.stdout) or {}
+        detail_payload = _safe_json_loads(
+            detail_result.stdout,
+            notes=source_status["gh_cli"]["notes"],
+            context=f"`gh pr view` output for PR #{number}",
+        )
+        if not isinstance(detail_payload, dict):
+            source_status["gh_cli"]["notes"].append(f"Failed to parse PR #{number} detail payload.")
+            source_status["degraded"] = True
+            thread_failures += 1
+            continue
         summary["changed_file_count"] = len(detail_payload.get("files", []))
 
         threads_payload: dict[str, Any] | None = None
@@ -831,16 +922,26 @@ def _collect_gh_prs(
         )
         thread_result = _run_command(graphql_command, cwd=repo_root, timeout=GRAPHQL_TIMEOUT_SECONDS)
         if thread_result.returncode == 0:
-            threads_payload = _safe_json_loads(thread_result.stdout) or {}
-            thread_records = _normalize_review_threads(
-                pr_summary=summary,
-                threads_payload=threads_payload,
-                author_login=author,
-                now=now,
+            threads_payload = _safe_json_loads(
+                thread_result.stdout,
+                notes=source_status["gh_cli"]["notes"],
+                context=f"GraphQL review thread payload for PR #{number}",
             )
-            evidence_records.extend(thread_records)
-            summary["review_thread_count"] = len(thread_records)
-            thread_successes += 1
+            if not isinstance(threads_payload, dict):
+                thread_failures += 1
+                source_status["degraded"] = True
+                source_status["gh_cli"]["notes"].append(f"Failed to parse review thread payload for PR #{number}.")
+                threads_payload = None
+            else:
+                thread_records = _normalize_review_threads(
+                    pr_summary=summary,
+                    threads_payload=threads_payload,
+                    author_login=author,
+                    now=now,
+                )
+                evidence_records.extend(thread_records)
+                summary["review_thread_count"] = len(thread_records)
+                thread_successes += 1
         else:
             thread_failures += 1
             source_status["degraded"] = True
@@ -911,15 +1012,14 @@ def _collect_local_git_fallback(
         "evidence_quality": "low",
     }
 
+    author_filters = _collect_git_author_filters(repo_root, author)
     log_command = (
         "git",
         "log",
         "--since",
         since.astimezone(UTC).isoformat().replace("+00:00", "Z"),
-        "--author",
-        author,
-        "--pretty=format:%H%x09%aI%x09%s",
-        f"--max-count={min(max(limit * 5, limit), MAX_LOCAL_COMMITS)}",
+        "--pretty=format:%H%x09%aI%x09%an%x09%ae%x09%s",
+        f"--max-count={min(max(limit * 10, limit), MAX_LOCAL_COMMITS)}",
     )
     log_result = _run_command(log_command, cwd=repo_root, timeout=LOCAL_GIT_TIMEOUT_SECONDS)
     if log_result.returncode != 0:
@@ -935,12 +1035,12 @@ def _collect_local_git_fallback(
     fallback_commits: list[dict[str, Any]] = []
     evidence_records: list[dict[str, Any]] = []
 
-    for index, line in enumerate(filter(None, log_result.stdout.splitlines()), start=1):
-        if index > limit:
-            break
+    for line in filter(None, log_result.stdout.splitlines()):
         try:
-            commit_sha, authored_at, subject = line.split("\t", maxsplit=2)
+            commit_sha, authored_at, commit_author_name, commit_author_email, subject = line.split("\t", maxsplit=4)
         except ValueError:
+            continue
+        if not _commit_matches_git_author(author_filters, commit_author_name, commit_author_email):
             continue
         commit_payload = {
             "sha": commit_sha,
@@ -992,6 +1092,11 @@ def _collect_local_git_fallback(
                 )
             )
 
+        if len(fallback_commits) >= limit:
+            break
+
+    if not fallback_commits:
+        source_status["local_git"]["notes"].append("No local commits matched the resolved git author filters.")
     source_status["local_git"]["status"] = "ok" if fallback_commits else "no-data"
     return {
         "success": bool(fallback_commits),
@@ -1078,16 +1183,20 @@ def build_skill_progression_report(
     current_time = (now or datetime.now(UTC)).astimezone(UTC)
     resolved_repo = repo or resolve_repo_slug(resolved_repo_root)
     resolved_author = author or resolve_github_login(resolved_repo_root)
+    resolved_memory_path = memory_path or default_memory_path()
     resolved_since, memory_meta = (
-        resolve_since(memory_path, now=current_time)
+        resolve_since(resolved_memory_path, now=current_time)
         if since is None
         else (
             since.astimezone(UTC),
             {
-                "path": str(memory_path or default_memory_path()),
-                "loaded": memory_path.exists() if memory_path else default_memory_path().exists(),
+                "path": str(resolved_memory_path),
+                "exists": resolved_memory_path.exists(),
+                "loaded": False,
                 "timestamp_found": False,
                 "last_run": None,
+                "status": "not-read",
+                "notes": "Memory was not read because since was provided explicitly.",
             },
         )
     )

--- a/src/transformation_portal/dev/skill_progression_map.py
+++ b/src/transformation_portal/dev/skill_progression_map.py
@@ -782,6 +782,7 @@ def _collect_gh_prs(
                 f"Failed to inspect PR #{number}: {detail_result.stderr.strip() or detail_result.error or 'unknown error'}"
             )
             source_status["degraded"] = True
+            thread_failures += 1
             continue
 
         detail_payload = _safe_json_loads(detail_result.stdout) or {}

--- a/tests/dev/test_skill_progression_map.py
+++ b/tests/dev/test_skill_progression_map.py
@@ -1,0 +1,282 @@
+"""Tests for the skill progression map collector."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from transformation_portal.dev import skill_progression_map as module
+
+pytestmark = pytest.mark.unit
+
+
+def test_resolve_since_falls_back_to_trailing_seven_days_when_memory_missing(tmp_path: Path) -> None:
+    fixed_now = datetime(2026, 4, 10, 18, 0, 0, tzinfo=UTC)
+    since, metadata = module.resolve_since(tmp_path / "missing-memory.md", now=fixed_now)
+
+    assert since == fixed_now - timedelta(days=7)
+    assert metadata["loaded"] is False
+    assert metadata["timestamp_found"] is False
+    assert metadata["last_run"] is None
+
+
+def test_normalize_review_threads_tags_timeout_issue_for_raw_runtime() -> None:
+    pr_summary = {
+        "number": 1408,
+        "title": "feat(raw): isolate RAW ingest runtime",
+        "url": "https://github.com/RC219805/Transformation_Portal/pull/1408",
+        "updated_at": "2026-04-10T17:22:23Z",
+    }
+    threads_payload = {
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "reviewThreads": {
+                        "nodes": [
+                            {
+                                "isResolved": True,
+                                "isOutdated": False,
+                                "comments": {
+                                    "nodes": [
+                                        {
+                                            "author": {"login": "copilot-pull-request-reviewer"},
+                                            "body": (
+                                                "Both the RAW runtime readiness check and the RAW worker "
+                                                "invocation call subprocess.run without a timeout."
+                                            ),
+                                            "path": "src/transformation_portal/core/raw_runtime.py",
+                                            "line": 209,
+                                            "originalLine": 171,
+                                            "createdAt": "2026-04-10T16:23:49Z",
+                                        }
+                                    ]
+                                },
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }
+
+    records = module._normalize_review_threads(
+        pr_summary=pr_summary,
+        threads_payload=threads_payload,
+        author_login="RC219805",
+        now=datetime(2026, 4, 10, 18, 0, 0, tzinfo=UTC),
+    )
+
+    assert len(records) == 1
+    assert records[0]["issue_class_tag"] == "timeout/runtime guard"
+    assert records[0]["subsystem_tag"] == "raw-runtime"
+    assert records[0]["theme_id"] == "ml_runtime_isolation_and_subprocess_contract_design"
+
+
+def test_classify_issue_class_does_not_treat_block_as_lock() -> None:
+    issue_class = module._classify_issue_class(
+        "A stuck worker here would block CLI preflight and ingest indefinitely without a timeout.",
+        "src/transformation_portal/core/raw_runtime.py",
+    )
+
+    assert issue_class == "timeout/runtime guard"
+
+
+def test_collect_gh_prs_marks_degraded_when_review_threads_fail(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    commands: list[tuple[str, ...]] = []
+
+    def fake_run(command: tuple[str, ...], *, cwd: Path, timeout: int) -> module.CommandResult:
+        commands.append(tuple(command))
+        if command[:3] == ("gh", "auth", "status"):
+            return module.CommandResult(
+                command=tuple(command),
+                returncode=0,
+                stdout="github.com\n  ✓ Logged in to github.com account RC219805 (keyring)\n",
+                stderr="",
+            )
+        if command[:3] == ("gh", "pr", "list"):
+            payload = [
+                {
+                    "number": 1408,
+                    "title": "feat(raw): isolate RAW ingest runtime",
+                    "state": "MERGED",
+                    "url": "https://github.com/RC219805/Transformation_Portal/pull/1408",
+                    "updatedAt": "2026-04-10T17:22:23Z",
+                    "mergedAt": "2026-04-10T17:22:23Z",
+                    "isDraft": False,
+                }
+            ]
+            return module.CommandResult(tuple(command), 0, json.dumps(payload), "")
+        if command[:3] == ("gh", "pr", "view"):
+            payload = {
+                "number": 1408,
+                "title": "feat(raw): isolate RAW ingest runtime",
+                "state": "MERGED",
+                "url": "https://github.com/RC219805/Transformation_Portal/pull/1408",
+                "updatedAt": "2026-04-10T17:22:23Z",
+                "mergedAt": "2026-04-10T17:22:23Z",
+                "files": [
+                    {
+                        "path": "src/transformation_portal/core/raw_runtime.py",
+                        "changeType": "MODIFIED",
+                    }
+                ],
+                "reviews": [],
+            }
+            return module.CommandResult(tuple(command), 0, json.dumps(payload), "")
+        if command[:3] == ("gh", "api", "graphql"):
+            return module.CommandResult(tuple(command), 1, "", "GraphQL unavailable")
+        raise AssertionError(f"Unexpected command: {command}")
+
+    monkeypatch.setattr(module, "_run_command", fake_run)
+
+    report = module._collect_gh_prs(
+        repo="RC219805/Transformation_Portal",
+        author="RC219805",
+        since=datetime(2026, 4, 3, 0, 0, 0, tzinfo=UTC),
+        limit=5,
+        repo_root=tmp_path,
+        now=datetime(2026, 4, 10, 18, 0, 0, tzinfo=UTC),
+    )
+
+    assert report["success"] is True
+    assert report["source_status"]["degraded"] is True
+    assert report["source_status"]["gh_cli"]["review_threads"] == "failed"
+    assert report["source_status"]["evidence_quality"] == "medium"
+    assert report["evidence_records"]
+    assert report["evidence_records"][0]["source"] == "changed_file"
+    assert any(command[:3] == ("gh", "api", "graphql") for command in commands)
+
+
+def test_rank_themes_prioritizes_recent_review_threads_over_changed_file_volume() -> None:
+    now = datetime(2026, 4, 10, 18, 0, 0, tzinfo=UTC)
+    recent_pr = {
+        "number": 1408,
+        "title": "feat(raw): isolate RAW ingest runtime",
+        "url": "https://github.com/RC219805/Transformation_Portal/pull/1408",
+        "updated_at": "2026-04-10T17:22:23Z",
+    }
+    older_pr = {
+        "number": 1396,
+        "title": "feat(portal): close out Phase 2B hierarchy and context polish",
+        "url": "https://github.com/RC219805/Transformation_Portal/pull/1396",
+        "updated_at": "2026-04-01T17:22:23Z",
+    }
+
+    evidence = [
+        module._make_evidence_record(
+            evidence_id="review-1",
+            source="review_thread",
+            pr_summary=recent_pr,
+            path="src/transformation_portal/core/raw_runtime.py",
+            line=100,
+            status="resolved",
+            summary="RAW worker invocation calls subprocess.run without a timeout.",
+            issue_class="timeout/runtime guard",
+            subsystem="raw-runtime",
+            base_weight=module.REVIEW_SOURCE_WEIGHT,
+            review_comment_count=2,
+            now=now,
+        ),
+        module._make_evidence_record(
+            evidence_id="review-2",
+            source="review_thread",
+            pr_summary=recent_pr,
+            path="src/transformation_portal/core/raw_runtime.py",
+            line=209,
+            status="resolved",
+            summary="Normalize input_path to an absolute path before dispatching to the worker.",
+            issue_class="path normalization",
+            subsystem="raw-runtime",
+            base_weight=module.REVIEW_SOURCE_WEIGHT,
+            review_comment_count=1,
+            now=now,
+        ),
+    ]
+
+    for index in range(6):
+        evidence.append(
+            module._make_evidence_record(
+                evidence_id=f"file-{index}",
+                source="changed_file",
+                pr_summary=older_pr,
+                path="portal.html",
+                line=None,
+                status="modified",
+                summary="modified file in recurring portal surface.",
+                issue_class="contract parity",
+                subsystem="portal",
+                base_weight=module.CHANGED_FILE_WEIGHT,
+                now=now,
+            )
+        )
+
+    ranked = module.rank_themes(evidence)
+
+    assert ranked[0]["theme_id"] == "ml_runtime_isolation_and_subprocess_contract_design"
+    assert ranked[0]["score"] > ranked[1]["score"]
+
+
+def test_main_json_output_contains_ranked_themes_and_source_status(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    def fake_report(**_: object) -> dict[str, object]:
+        return {
+            "report_version": "skill-progression-map.v1",
+            "repo": "RC219805/Transformation_Portal",
+            "author": "RC219805",
+            "window": {
+                "since": "2026-04-03T14:00:29Z",
+                "until": "2026-04-10T19:00:00Z",
+                "limit": 10,
+            },
+            "source_status": {
+                "connector": "not-run-by-helper",
+                "gh_cli": {"auth": "ok", "pr_list": "ok", "review_threads": "partial", "notes": []},
+                "local_git": {"used": False, "status": "not-used", "notes": []},
+                "memory": {"path": "/tmp/memory.md", "loaded": False, "timestamp_found": False, "last_run": None},
+                "degraded": True,
+                "evidence_quality": "medium",
+            },
+            "inspected_prs": [],
+            "fallback_commits": [],
+            "evidence_records": [],
+            "ranked_themes": [
+                {
+                    "theme_id": "deterministic_validation_system_design",
+                    "label": "Deterministic validation-system design",
+                    "score": 6.5,
+                    "evidence_count": 2,
+                    "distinct_pr_count": 1,
+                    "review_thread_count": 1,
+                    "issue_class_tags": ["deterministic validation/preflight"],
+                    "subsystem_tags": ["validation"],
+                    "top_evidence": [],
+                }
+            ],
+            "top_skills": [
+                {
+                    "theme_id": "deterministic_validation_system_design",
+                    "label": "Deterministic validation-system design",
+                    "score": 6.5,
+                    "evidence_count": 2,
+                    "distinct_pr_count": 1,
+                    "review_thread_count": 1,
+                    "issue_class_tags": ["deterministic validation/preflight"],
+                    "subsystem_tags": ["validation"],
+                    "top_evidence": [],
+                }
+            ],
+        }
+
+    monkeypatch.setattr(module, "build_skill_progression_report", fake_report)
+
+    exit_code = module.main(["--json"])
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert exit_code == 0
+    assert payload["top_skills"][0]["label"] == "Deterministic validation-system design"
+    assert payload["source_status"]["gh_cli"]["review_threads"] == "partial"

--- a/tests/dev/test_skill_progression_map.py
+++ b/tests/dev/test_skill_progression_map.py
@@ -23,6 +23,60 @@ def test_resolve_since_falls_back_to_trailing_seven_days_when_memory_missing(tmp
     assert metadata["last_run"] is None
 
 
+def test_parse_memory_timestamps_handles_utc_suffix_correctly() -> None:
+    """Timestamp headings with 'UTC' suffix must be interpreted as UTC, not local time."""
+
+    memory_text = """\
+# Skill Progression Run
+
+## 2026-04-10 14:30:00 UTC
+
+Some notes from the run.
+
+## 2026-04-09 10:00:00
+
+Earlier local run.
+"""
+    timestamps = module.parse_memory_timestamps(memory_text)
+
+    assert len(timestamps) == 2
+
+    # Find timestamp by naive value (date + time) to isolate which is which
+    ts_apr10 = next(
+        (ts for ts in timestamps if ts.year == 2026 and ts.month == 4 and ts.day == 10),
+        None,
+    )
+    ts_apr9 = next(
+        (ts for ts in timestamps if ts.year == 2026 and ts.month == 4 and ts.day == 9),
+        None,
+    )
+
+    assert ts_apr10 is not None, "Expected 2026-04-10 timestamp"
+    assert ts_apr9 is not None, "Expected 2026-04-09 timestamp"
+
+    # The UTC-suffixed timestamp must have exactly UTC timezone
+    assert ts_apr10.tzinfo == UTC, f"Expected UTC for '2026-04-10 14:30:00 UTC', got {ts_apr10.tzinfo}"
+    assert ts_apr10.hour == 14 and ts_apr10.minute == 30 and ts_apr10.second == 0
+
+    # The unsuffixed timestamp must have LOCAL_TZ (which may be UTC in CI)
+    assert ts_apr9.tzinfo == module.LOCAL_TZ, f"Expected LOCAL_TZ for unsuffixed timestamp, got {ts_apr9.tzinfo}"
+    assert ts_apr9.hour == 10 and ts_apr9.minute == 0 and ts_apr9.second == 0
+
+
+def test_parse_memory_timestamps_treats_unknown_timezone_suffix_as_local() -> None:
+    """Unknown timezone suffixes (e.g., PST) should be treated as local time."""
+
+    memory_text = """\
+## 2026-04-10 09:00:00 PST
+"""
+    timestamps = module.parse_memory_timestamps(memory_text)
+
+    assert len(timestamps) == 1
+    # Unknown suffix → treated as local time
+    assert timestamps[0].tzinfo == module.LOCAL_TZ
+    assert timestamps[0].hour == 9
+
+
 def test_normalize_review_threads_tags_timeout_issue_for_raw_runtime() -> None:
     pr_summary = {
         "number": 1408,

--- a/tests/dev/test_skill_progression_map.py
+++ b/tests/dev/test_skill_progression_map.py
@@ -150,6 +150,55 @@ def test_collect_gh_prs_marks_degraded_when_review_threads_fail(monkeypatch: pyt
     assert any(command[:3] == ("gh", "api", "graphql") for command in commands)
 
 
+def test_collect_gh_prs_marks_degraded_when_detail_fetch_fails(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """PR detail (gh pr view) failure must degrade review_threads and evidence_quality."""
+
+    def fake_run(command: tuple[str, ...], *, cwd: Path, timeout: int) -> module.CommandResult:
+        if command[:3] == ("gh", "auth", "status"):
+            return module.CommandResult(
+                command=tuple(command),
+                returncode=0,
+                stdout="github.com\n  ✓ Logged in to github.com account RC219805 (keyring)\n",
+                stderr="",
+            )
+        if command[:3] == ("gh", "pr", "list"):
+            payload = [
+                {
+                    "number": 1409,
+                    "title": "feat(portal): fingerprint assets",
+                    "state": "MERGED",
+                    "url": "https://github.com/RC219805/Transformation_Portal/pull/1409",
+                    "updatedAt": "2026-04-10T17:22:23Z",
+                    "mergedAt": "2026-04-10T17:22:23Z",
+                    "isDraft": False,
+                }
+            ]
+            return module.CommandResult(tuple(command), 0, json.dumps(payload), "")
+        if command[:3] == ("gh", "pr", "view"):
+            # Simulate a failed detail fetch
+            return module.CommandResult(tuple(command), 1, "", "gh: PR not found")
+        raise AssertionError(f"Unexpected command: {command}")
+
+    monkeypatch.setattr(module, "_run_command", fake_run)
+
+    report = module._collect_gh_prs(
+        repo="RC219805/Transformation_Portal",
+        author="RC219805",
+        since=datetime(2026, 4, 3, 0, 0, 0, tzinfo=UTC),
+        limit=5,
+        repo_root=tmp_path,
+        now=datetime(2026, 4, 10, 18, 0, 0, tzinfo=UTC),
+    )
+
+    assert report["success"] is True
+    assert report["source_status"]["degraded"] is True
+    # detail failure must count as a thread failure → not "ok"
+    assert report["source_status"]["gh_cli"]["review_threads"] != "ok"
+    # evidence_quality must not be "high" when all detail fetches failed
+    assert report["source_status"]["evidence_quality"] != "high"
+    assert any("Failed to inspect PR" in note for note in report["source_status"]["gh_cli"]["notes"])
+
+
 def test_rank_themes_prioritizes_recent_review_threads_over_changed_file_volume() -> None:
     now = datetime(2026, 4, 10, 18, 0, 0, tzinfo=UTC)
     recent_pr = {

--- a/tests/dev/test_skill_progression_map.py
+++ b/tests/dev/test_skill_progression_map.py
@@ -63,16 +63,36 @@ Earlier local run.
     assert ts_apr9.hour == 10 and ts_apr9.minute == 0 and ts_apr9.second == 0
 
 
-def test_parse_memory_timestamps_treats_unknown_timezone_suffix_as_local() -> None:
-    """Unknown timezone suffixes (e.g., PST) should be treated as local time."""
+def test_parse_memory_timestamps_handles_common_us_timezone_suffixes() -> None:
+    """Known timezone suffixes should use deterministic fixed offsets."""
 
     memory_text = """\
 ## 2026-04-10 09:00:00 PST
+
+## 2026-04-10 10:00:00 PDT
+    """
+    timestamps = module.parse_memory_timestamps(memory_text)
+
+    assert len(timestamps) == 2
+
+    pst_timestamp = next((ts for ts in timestamps if ts.hour == 9), None)
+    pdt_timestamp = next((ts for ts in timestamps if ts.hour == 10), None)
+
+    assert pst_timestamp is not None
+    assert pdt_timestamp is not None
+    assert pst_timestamp.tzinfo == module.MEMORY_HEADING_TZINFOS["PST"]
+    assert pdt_timestamp.tzinfo == module.MEMORY_HEADING_TZINFOS["PDT"]
+
+
+def test_parse_memory_timestamps_treats_unknown_timezone_suffix_as_local() -> None:
+    """Unknown timezone suffixes should still fall back to local time."""
+
+    memory_text = """\
+## 2026-04-10 09:00:00 FOO
 """
     timestamps = module.parse_memory_timestamps(memory_text)
 
     assert len(timestamps) == 1
-    # Unknown suffix → treated as local time
     assert timestamps[0].tzinfo == module.LOCAL_TZ
     assert timestamps[0].hour == 9
 

--- a/tests/dev/test_skill_progression_map.py
+++ b/tests/dev/test_skill_progression_map.py
@@ -23,6 +23,19 @@ def test_resolve_since_falls_back_to_trailing_seven_days_when_memory_missing(tmp
     assert metadata["last_run"] is None
 
 
+def test_resolve_since_falls_back_when_memory_cannot_be_decoded(tmp_path: Path) -> None:
+    fixed_now = datetime(2026, 4, 10, 18, 0, 0, tzinfo=UTC)
+    memory_path = tmp_path / "memory.md"
+    memory_path.write_bytes(b"\xff\xfe\x00")
+
+    since, metadata = module.resolve_since(memory_path, now=fixed_now)
+
+    assert since == fixed_now - timedelta(days=7)
+    assert metadata["loaded"] is False
+    assert metadata["status"] == "read_error"
+    assert "UnicodeDecodeError" in str(metadata["notes"])
+
+
 def test_parse_memory_timestamps_handles_utc_suffix_correctly() -> None:
     """Timestamp headings with 'UTC' suffix must be interpreted as UTC, not local time."""
 
@@ -158,6 +171,45 @@ def test_classify_issue_class_does_not_treat_block_as_lock() -> None:
     assert issue_class == "timeout/runtime guard"
 
 
+def test_safe_json_loads_returns_none_and_records_note_on_invalid_json() -> None:
+    notes: list[str] = []
+
+    result = module._safe_json_loads("not-json", notes=notes, context="test payload")
+
+    assert result is None
+    assert notes
+    assert "test payload was not valid JSON" in notes[0]
+
+
+def test_collect_gh_prs_fails_closed_on_invalid_pr_list_json(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    def fake_run(command: tuple[str, ...], *, cwd: Path, timeout: int) -> module.CommandResult:
+        if command[:3] == ("gh", "auth", "status"):
+            return module.CommandResult(
+                command=tuple(command),
+                returncode=0,
+                stdout="github.com\n  ✓ Logged in to github.com account RC219805 (keyring)\n",
+                stderr="",
+            )
+        if command[:3] == ("gh", "pr", "list"):
+            return module.CommandResult(tuple(command), 0, "not-json", "")
+        raise AssertionError(f"Unexpected command: {command}")
+
+    monkeypatch.setattr(module, "_run_command", fake_run)
+
+    report = module._collect_gh_prs(
+        repo="RC219805/Transformation_Portal",
+        author="RC219805",
+        since=datetime(2026, 4, 3, 0, 0, 0, tzinfo=UTC),
+        limit=5,
+        repo_root=tmp_path,
+        now=datetime(2026, 4, 10, 18, 0, 0, tzinfo=UTC),
+    )
+
+    assert report["success"] is False
+    assert report["source_status"]["gh_cli"]["pr_list"] == "failed"
+    assert any("not valid JSON" in note for note in report["source_status"]["gh_cli"]["notes"])
+
+
 def test_collect_gh_prs_marks_degraded_when_review_threads_fail(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     commands: list[tuple[str, ...]] = []
 
@@ -273,6 +325,45 @@ def test_collect_gh_prs_marks_degraded_when_detail_fetch_fails(monkeypatch: pyte
     assert any("Failed to inspect PR" in note for note in report["source_status"]["gh_cli"]["notes"])
 
 
+def test_collect_local_git_fallback_matches_git_config_author_when_login_differs(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    commands: list[tuple[str, ...]] = []
+
+    def fake_run(command: tuple[str, ...], *, cwd: Path, timeout: int) -> module.CommandResult:
+        commands.append(tuple(command))
+        if command[:4] == ("git", "config", "--get", "user.name"):
+            return module.CommandResult(tuple(command), 0, "Richard Cheetham\n", "")
+        if command[:4] == ("git", "config", "--get", "user.email"):
+            return module.CommandResult(tuple(command), 0, "richard@example.com\n", "")
+        if command[:2] == ("git", "log"):
+            assert "--author" not in command
+            stdout = "\n".join(
+                (
+                    "abc12345\t2026-04-10T18:00:00+00:00\tRichard Cheetham\trichard@example.com\tfeat: matching commit",
+                    "def67890\t2026-04-10T17:00:00+00:00\tSomeone Else\tother@example.com\tfeat: other commit",
+                )
+            )
+            return module.CommandResult(tuple(command), 0, stdout, "")
+        if command[:3] == ("git", "show", "--name-only"):
+            return module.CommandResult(tuple(command), 0, "src/transformation_portal/dev/skill_progression_map.py\n", "")
+        raise AssertionError(f"Unexpected command: {command}")
+
+    monkeypatch.setattr(module, "_run_command", fake_run)
+
+    report = module._collect_local_git_fallback(
+        author="RC219805",
+        since=datetime(2026, 4, 3, 0, 0, 0, tzinfo=UTC),
+        limit=5,
+        repo_root=tmp_path,
+        now=datetime(2026, 4, 10, 18, 0, 0, tzinfo=UTC),
+    )
+
+    assert report["success"] is True
+    assert len(report["fallback_commits"]) == 1
+    assert report["fallback_commits"][0]["sha"] == "abc12345"
+
+
 def test_rank_themes_prioritizes_recent_review_threads_over_changed_file_volume() -> None:
     now = datetime(2026, 4, 10, 18, 0, 0, tzinfo=UTC)
     recent_pr = {
@@ -340,6 +431,42 @@ def test_rank_themes_prioritizes_recent_review_threads_over_changed_file_volume(
 
     assert ranked[0]["theme_id"] == "ml_runtime_isolation_and_subprocess_contract_design"
     assert ranked[0]["score"] > ranked[1]["score"]
+
+
+def test_build_report_marks_memory_not_read_when_since_explicit(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    memory_path = tmp_path / "memory.md"
+    memory_path.write_text("## 2026-04-10 10:00:00 UTC\n", encoding="utf-8")
+
+    def fake_collect_gh_prs(**_: object) -> dict[str, object]:
+        return {
+            "success": True,
+            "inspected_prs": [],
+            "evidence_records": [],
+            "source_status": {
+                "connector": "not-run-by-helper",
+                "gh_cli": {"auth": "ok", "pr_list": "ok", "review_threads": "no-prs", "notes": []},
+                "local_git": {"used": False, "status": "not-used", "notes": []},
+                "memory": {},
+                "degraded": False,
+                "evidence_quality": "low",
+            },
+        }
+
+    monkeypatch.setattr(module, "_collect_gh_prs", fake_collect_gh_prs)
+
+    report = module.build_skill_progression_report(
+        repo="RC219805/Transformation_Portal",
+        author="RC219805",
+        since=datetime(2026, 4, 10, 18, 0, 0, tzinfo=UTC),
+        limit=1,
+        repo_root=tmp_path,
+        memory_path=memory_path,
+        now=datetime(2026, 4, 10, 18, 0, 0, tzinfo=UTC),
+    )
+
+    assert report["source_status"]["memory"]["exists"] is True
+    assert report["source_status"]["memory"]["loaded"] is False
+    assert report["source_status"]["memory"]["status"] == "not-read"
 
 
 def test_main_json_output_contains_ranked_themes_and_source_status(


### PR DESCRIPTION
## Summary

- add a deterministic `skill_progression_map` collector that prefers GitHub PR and review-thread evidence and only falls back to local git after both GitHub tiers fail
- add a thin CLI wrapper, focused unit coverage, and repo docs for the automation workflow, ranking rubric, output contract, and degraded-evidence behavior
- link the new automation guide from the custom agent guide so recurring review-pattern analysis has a documented entry point

## Root Cause

The existing automation reasoning was too prompt-only and could degrade into local-only evidence gathering without a deterministic, testable collector. That made ranking harder to validate, weakened review-thread grounding, and left fallback behavior under-specified.

## What Changed

- added `src/transformation_portal/dev/skill_progression_map.py` for repo/author/since resolution, `gh` PR and GraphQL review-thread collection, evidence normalization, issue tagging, deterministic scoring, and JSON report generation
- added `scripts/automation/skill_progression_map.py` as the stable CLI entrypoint
- added `tests/dev/test_skill_progression_map.py` to cover memory fallback, review-thread normalization, degraded-source handling, ranking pressure, and JSON output shape
- added `docs/guides/SKILL_PROGRESSION_AUTOMATION.md` and linked it from `docs/guides/CUSTOM_AGENT_GUIDE.md`

## Validation

- `PRE_COMMIT_HOME=/tmp/pre-commit PATH=/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin:$PATH TP_LINT_PYTHON=/opt/homebrew/bin/python3.12 make pre-commit`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin/python -m pytest tests/dev/test_skill_progression_map.py -q`

## Notes

- Homebrew `python@3.12` was installed locally to satisfy the repo's CI-parity lint runtime contract during `pre-commit`
- the external automation prompt and memory were updated locally outside the repo; this PR contains the repo-side helper, tests, and docs only
