### PR TITLE
[codex] Add RAW ingest sidecar integration

### DIFF
--- a/src/transformation_portal/ingest/metadata_service.py
+++ b/src/transformation_portal/ingest/metadata_service.py
@@ -158,10 +158,13 @@ class MetadataExtractionService:
             )
 
             if should_emit_raw_sidecar and resolved_raw_sidecar_path is not None:
+                precomputed_file_sha256, precomputed_file_size = self._extract_precomputed_file_integrity(sidecar)
                 try:
                     raw_result = self._generate_raw_sidecar(
                         req.input_path,
                         output_path=resolved_raw_sidecar_path,
+                        file_sha256=precomputed_file_sha256,
+                        file_size_bytes=precomputed_file_size,
                         fsync=req.fsync,
                     )
                     raw_sidecar_path = raw_result.output_path
@@ -436,3 +439,18 @@ class MetadataExtractionService:
             return
         except OSError:
             return
+
+    def _extract_precomputed_file_integrity(
+        self,
+        sidecar: Any,
+    ) -> tuple[Optional[str], Optional[int]]:
+        file_integrity = getattr(sidecar, "file_integrity", None)
+        if file_integrity is None:
+            return None, None
+
+        sha256 = getattr(file_integrity, "sha256", None)
+        size_bytes = getattr(file_integrity, "size_bytes", None)
+        return (
+            str(sha256) if isinstance(sha256, str) else None,
+            int(size_bytes) if isinstance(size_bytes, int) else None,
+        )

--- a/src/transformation_portal/ingest/metadata_service.py
+++ b/src/transformation_portal/ingest/metadata_service.py
@@ -6,6 +6,7 @@ import hashlib
 import os
 import time
 from collections import Counter
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Sequence
@@ -134,7 +135,6 @@ class MetadataExtractionService:
             should_emit_raw_sidecar = req.emit_raw_sidecar and is_raw_image_path(req.input_path)
             resolved_raw_sidecar_path = (
                 self._derive_raw_sidecar_output_path(
-                    input_path=req.input_path,
                     provenance_output_path=output_path,
                     explicit_output_path=req.raw_sidecar_output_path,
                 )
@@ -159,12 +159,16 @@ class MetadataExtractionService:
 
             if should_emit_raw_sidecar and resolved_raw_sidecar_path is not None:
                 precomputed_file_sha256, precomputed_file_size = self._extract_precomputed_file_integrity(sidecar)
+                precomputed_exiftool_payload = self._extract_precomputed_exiftool_payload(sidecar)
+                precomputed_exiftool_version = self._extract_precomputed_exiftool_version(sidecar)
                 try:
                     raw_result = self._generate_raw_sidecar(
                         req.input_path,
                         output_path=resolved_raw_sidecar_path,
                         file_sha256=precomputed_file_sha256,
                         file_size_bytes=precomputed_file_size,
+                        precomputed_exiftool_payload=precomputed_exiftool_payload,
+                        precomputed_exiftool_version=precomputed_exiftool_version,
                         fsync=req.fsync,
                     )
                     raw_sidecar_path = raw_result.output_path
@@ -418,7 +422,6 @@ class MetadataExtractionService:
     def _derive_raw_sidecar_output_path(
         self,
         *,
-        input_path: Path,
         provenance_output_path: Path,
         explicit_output_path: Optional[Path],
     ) -> Path:
@@ -430,7 +433,7 @@ class MetadataExtractionService:
         if provenance_name.endswith(suffix):
             base_name = provenance_name[: -len(suffix)]
             return provenance_output_path.with_name(f"{base_name}.raw.sidecar.json")
-        return provenance_output_path.with_name(f"{input_path.stem}.raw.sidecar.json")
+        return provenance_output_path.with_name(f"{provenance_output_path.stem}.raw.sidecar.json")
 
     def _remove_if_exists(self, path: Path) -> None:
         try:
@@ -454,3 +457,36 @@ class MetadataExtractionService:
             str(sha256) if isinstance(sha256, str) else None,
             int(size_bytes) if isinstance(size_bytes, int) else None,
         )
+
+    def _extract_precomputed_exiftool_payload(
+        self,
+        sidecar: Any,
+    ) -> Optional[Dict[str, Any]]:
+        exif = getattr(sidecar, "exif", None)
+        if exif is None:
+            return None
+
+        all_tags = getattr(exif, "all_tags", None)
+        if isinstance(all_tags, Mapping):
+            return dict(all_tags)
+        return None
+
+    def _extract_precomputed_exiftool_version(
+        self,
+        sidecar: Any,
+    ) -> Optional[str]:
+        toolchain = getattr(sidecar, "toolchain", None)
+        if not isinstance(toolchain, (list, tuple)):
+            return None
+
+        for tool in toolchain:
+            if isinstance(tool, Mapping):
+                tool_name = tool.get("name")
+                tool_version = tool.get("version")
+            else:
+                tool_name = getattr(tool, "name", None)
+                tool_version = getattr(tool, "version", None)
+
+            if tool_name == "exiftool" and tool_version is not None:
+                return str(tool_version)
+        return None

--- a/src/transformation_portal/ingest/metadata_service.py
+++ b/src/transformation_portal/ingest/metadata_service.py
@@ -12,6 +12,7 @@ from typing import Any, Callable, Dict, List, Optional, Sequence
 
 from .errors import IngestError, IngestExitCode, OtherIngestFailure, aggregate_errors
 from .provenance import capture_provenance
+from .raw_sidecar import generate_raw_sidecar, is_raw_image_path
 from .sidecar import write_sidecar
 from .validator import validate_schema_errors
 
@@ -25,6 +26,9 @@ class ExtractRequest:
     cli_args: Sequence[str] = ()
     config_dict: Optional[Dict[str, Any]] = None
     fsync: bool = False
+    emit_raw_sidecar: bool = True
+    raw_sidecar_output_path: Optional[Path] = None
+    raw_sidecar_strict: bool = False
 
 
 @dataclass(frozen=True)
@@ -34,6 +38,8 @@ class ExtractResult:
     output_path: Optional[Path]
     elapsed_seconds: float
     error: Optional[IngestError] = None
+    raw_sidecar_path: Optional[Path] = None
+    raw_sidecar_error: Optional[str] = None
 
 
 @dataclass(frozen=True)
@@ -62,6 +68,8 @@ class BatchExtractRequest:
     fail_fast: bool = False
     preserve_structure: bool = True
     input_root: Optional[Path] = None
+    emit_raw_sidecar: bool = True
+    raw_sidecar_strict: bool = False
 
 
 @dataclass(frozen=True)
@@ -71,6 +79,8 @@ class BatchItemResult:
     output_path: Optional[Path]
     elapsed_seconds: float
     error: Optional[IngestError] = None
+    raw_sidecar_path: Optional[Path] = None
+    raw_sidecar_error: Optional[str] = None
 
 
 @dataclass(frozen=True)
@@ -94,16 +104,21 @@ class MetadataExtractionService:
         capture_provenance_fn: Callable[..., Any] = capture_provenance,
         write_sidecar_fn: Callable[..., Any] = write_sidecar,
         validate_schema_errors_fn: Callable[..., List[IngestError]] = validate_schema_errors,
+        generate_raw_sidecar_fn: Callable[..., Any] = generate_raw_sidecar,
         clock_fn: Callable[[], float] = time.perf_counter,
     ) -> None:
         self._capture_provenance = capture_provenance_fn
         self._write_sidecar = write_sidecar_fn
         self._validate_schema_errors = validate_schema_errors_fn
+        self._generate_raw_sidecar = generate_raw_sidecar_fn
         self._clock = clock_fn
 
     def extract(self, req: ExtractRequest) -> ExtractResult:
         """Extract provenance for a single input and write sidecar."""
         start = self._clock()
+        raw_sidecar_path: Optional[Path] = None
+        raw_sidecar_error: Optional[str] = None
+        raw_sidecar_written = False
         try:
             if not req.input_path.exists():
                 not_found_err = OtherIngestFailure(f"Input not found: {req.input_path}")
@@ -116,6 +131,16 @@ class MetadataExtractionService:
                 )
 
             output_path = self._derive_output_path(req)
+            should_emit_raw_sidecar = req.emit_raw_sidecar and is_raw_image_path(req.input_path)
+            resolved_raw_sidecar_path = (
+                self._derive_raw_sidecar_output_path(
+                    input_path=req.input_path,
+                    provenance_output_path=output_path,
+                    explicit_output_path=req.raw_sidecar_output_path,
+                )
+                if should_emit_raw_sidecar
+                else None
+            )
             config_dict = (
                 req.config_dict
                 if req.config_dict is not None
@@ -131,13 +156,37 @@ class MetadataExtractionService:
                 config_dict=config_dict,
                 preset=req.preset,
             )
-            self._write_sidecar(sidecar, output_path, fsync=req.fsync)
+
+            if should_emit_raw_sidecar and resolved_raw_sidecar_path is not None:
+                try:
+                    raw_result = self._generate_raw_sidecar(
+                        req.input_path,
+                        output_path=resolved_raw_sidecar_path,
+                        fsync=req.fsync,
+                    )
+                    raw_sidecar_path = raw_result.output_path
+                    raw_sidecar_error = raw_result.rawpy_error
+                    raw_sidecar_written = True
+                except Exception as exc:  # noqa: BLE001
+                    raw_sidecar_error = str(exc)
+                    if req.raw_sidecar_strict:
+                        raise OtherIngestFailure(f"RAW sidecar generation failed for {req.input_path}: {exc}") from exc
+
+            try:
+                self._write_sidecar(sidecar, output_path, fsync=req.fsync)
+            except Exception:
+                if raw_sidecar_written and raw_sidecar_path is not None:
+                    self._remove_if_exists(raw_sidecar_path)
+                    raw_sidecar_path = None
+                raise
 
             return ExtractResult(
                 path=req.input_path,
                 success=True,
                 output_path=output_path,
                 elapsed_seconds=self._clock() - start,
+                raw_sidecar_path=raw_sidecar_path,
+                raw_sidecar_error=raw_sidecar_error,
             )
         except IngestError as error:
             return ExtractResult(
@@ -146,6 +195,8 @@ class MetadataExtractionService:
                 output_path=None,
                 elapsed_seconds=self._clock() - start,
                 error=error,
+                raw_sidecar_path=raw_sidecar_path,
+                raw_sidecar_error=raw_sidecar_error,
             )
         except Exception as exc:  # noqa: BLE001
             wrapped_error = OtherIngestFailure(str(exc))
@@ -155,6 +206,8 @@ class MetadataExtractionService:
                 output_path=None,
                 elapsed_seconds=self._clock() - start,
                 error=wrapped_error,
+                raw_sidecar_path=raw_sidecar_path,
+                raw_sidecar_error=raw_sidecar_error,
             )
 
     def validate(self, req: ValidateRequest) -> ValidateResult:
@@ -222,6 +275,8 @@ class MetadataExtractionService:
                     cli_args=req.cli_args,
                     config_dict=config_dict,
                     fsync=req.fsync,
+                    emit_raw_sidecar=req.emit_raw_sidecar,
+                    raw_sidecar_strict=req.raw_sidecar_strict,
                 )
             )
             item = BatchItemResult(
@@ -230,6 +285,8 @@ class MetadataExtractionService:
                 output_path=result.output_path,
                 elapsed_seconds=result.elapsed_seconds,
                 error=result.error,
+                raw_sidecar_path=result.raw_sidecar_path,
+                raw_sidecar_error=result.raw_sidecar_error,
             )
             items.append(item)
 
@@ -354,3 +411,28 @@ class MetadataExtractionService:
             return req.output_dir / stem_name
 
         return req.input_path.with_name(stem_name)
+
+    def _derive_raw_sidecar_output_path(
+        self,
+        *,
+        input_path: Path,
+        provenance_output_path: Path,
+        explicit_output_path: Optional[Path],
+    ) -> Path:
+        if explicit_output_path is not None:
+            return explicit_output_path
+
+        provenance_name = provenance_output_path.name
+        suffix = ".provenance.json"
+        if provenance_name.endswith(suffix):
+            base_name = provenance_name[: -len(suffix)]
+            return provenance_output_path.with_name(f"{base_name}.raw.sidecar.json")
+        return provenance_output_path.with_name(f"{input_path.stem}.raw.sidecar.json")
+
+    def _remove_if_exists(self, path: Path) -> None:
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            return
+        except OSError:
+            return

--- a/src/transformation_portal/ingest/raw_sidecar.py
+++ b/src/transformation_portal/ingest/raw_sidecar.py
@@ -13,6 +13,8 @@ from pathlib import Path
 from types import ModuleType
 from typing import Any, Dict, Optional
 
+from .canonical_json import dumps_json
+
 RAW_EXTENSIONS = {
     ".cr2",
     ".cr3",
@@ -61,7 +63,7 @@ def _sha256_file(path: Path, *, chunk_size: int = 1024 * 1024) -> str:
 
 
 def _canonical_json(payload: Dict[str, Any]) -> str:
-    return json.dumps(
+    return dumps_json(
         payload,
         indent=2,
         sort_keys=True,

--- a/src/transformation_portal/ingest/raw_sidecar.py
+++ b/src/transformation_portal/ingest/raw_sidecar.py
@@ -1,0 +1,280 @@
+"""RAW metadata sidecar generation helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+RAW_EXTENSIONS = {
+    ".cr2",
+    ".cr3",
+    ".nef",
+    ".nrw",
+    ".arw",
+    ".srf",
+    ".dng",
+    ".raf",
+    ".orf",
+    ".rw2",
+    ".pef",
+    ".srw",
+}
+RAW_SIDECAR_SCHEMA = "raw-image-sidecar/v2"
+EXIFTOOL_VERSION_TIMEOUT_SECONDS = 5
+EXIFTOOL_METADATA_TIMEOUT_SECONDS = 30
+_VOLATILE_EXIFTOOL_KEYS = {
+    "FileAccessDate",
+    "FileInodeChangeDate",
+}
+
+
+@dataclass(frozen=True)
+class RawSidecarResult:
+    input_path: Path
+    output_path: Path
+    rawpy_available: bool
+    rawpy_ok: bool
+    rawpy_error: Optional[str] = None
+
+
+def is_raw_image_path(path: Path) -> bool:
+    return path.suffix.lower() in RAW_EXTENSIONS
+
+
+def _sha256_file(path: Path, *, chunk_size: int = 1024 * 1024) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while True:
+            chunk = handle.read(chunk_size)
+            if not chunk:
+                break
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _canonical_json(payload: Dict[str, Any]) -> str:
+    return json.dumps(payload, indent=2, sort_keys=True, ensure_ascii=True, allow_nan=False) + "\n"
+
+
+def _write_json_atomic(payload: Dict[str, Any], output_path: Path, *, fsync: bool) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_fd: Optional[int] = None
+    tmp_name: Optional[str] = None
+    try:
+        tmp_fd, tmp_name = tempfile.mkstemp(
+            prefix=f".{output_path.name}.",
+            suffix=".tmp",
+            dir=str(output_path.parent),
+        )
+        with os.fdopen(tmp_fd, "w", encoding="utf-8") as handle:
+            tmp_fd = None
+            handle.write(_canonical_json(payload))
+            if fsync:
+                handle.flush()
+                os.fsync(handle.fileno())
+        Path(tmp_name).replace(output_path)
+    finally:
+        if tmp_fd is not None:
+            os.close(tmp_fd)
+        if tmp_name is not None:
+            tmp_path = Path(tmp_name)
+            if tmp_path.exists():
+                try:
+                    tmp_path.unlink()
+                except OSError:
+                    pass
+
+
+def _sanitize_exiftool_payload(raw_payload: Dict[str, Any]) -> Dict[str, Any]:
+    cleaned: Dict[str, Any] = {}
+    for key, value in raw_payload.items():
+        terminal_key = key.split(":")[-1]
+        if terminal_key in _VOLATILE_EXIFTOOL_KEYS:
+            continue
+        cleaned[key] = value
+    return cleaned
+
+
+def _get_exiftool_version(exiftool_path: str) -> str:
+    completed = subprocess.run(
+        [exiftool_path, "-ver"],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=EXIFTOOL_VERSION_TIMEOUT_SECONDS,
+    )
+    return completed.stdout.strip()
+
+
+def _run_exiftool_json(input_path: Path, exiftool_path: str) -> Dict[str, Any]:
+    completed = subprocess.run(
+        [exiftool_path, "-json", "-G1", "-a", "-u", "-n", str(input_path)],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=EXIFTOOL_METADATA_TIMEOUT_SECONDS,
+    )
+    payload = json.loads(completed.stdout)
+    if not isinstance(payload, list) or not payload or not isinstance(payload[0], dict):
+        raise ValueError("Unexpected exiftool JSON payload shape")
+    return _sanitize_exiftool_payload(payload[0])
+
+
+def _rawpy_status_payload() -> tuple[Optional[Dict[str, Any]], Dict[str, Any]]:
+    try:
+        import rawpy  # type: ignore
+    except Exception as exc:  # noqa: BLE001
+        return None, {
+            "available": False,
+            "ok": False,
+            "error": str(exc),
+            "version": None,
+            "libraw_version": None,
+        }
+
+    rawpy_version = getattr(rawpy, "__version__", None)
+    libraw_version = getattr(rawpy, "libraw_version", None)
+    if isinstance(libraw_version, (tuple, list)):
+        libraw_version = ".".join(str(part) for part in libraw_version)
+    elif libraw_version is not None:
+        libraw_version = str(libraw_version)
+
+    return rawpy, {
+        "available": True,
+        "ok": True,
+        "error": None,
+        "version": str(rawpy_version) if rawpy_version is not None else None,
+        "libraw_version": libraw_version,
+    }
+
+
+def _read_rawpy_metadata(input_path: Path) -> tuple[Optional[Dict[str, Any]], Dict[str, Any]]:
+    rawpy_module, status = _rawpy_status_payload()
+    if rawpy_module is None:
+        return None, status
+
+    try:
+        with rawpy_module.imread(str(input_path)) as raw:
+            payload = {
+                "raw_type": str(raw.raw_type),
+                "sizes": {
+                    "raw_height": raw.sizes.raw_height,
+                    "raw_width": raw.sizes.raw_width,
+                    "height": raw.sizes.height,
+                    "width": raw.sizes.width,
+                    "top_margin": raw.sizes.top_margin,
+                    "left_margin": raw.sizes.left_margin,
+                    "iheight": raw.sizes.iheight,
+                    "iwidth": raw.sizes.iwidth,
+                    "pixel_aspect": raw.sizes.pixel_aspect,
+                    "flip": raw.sizes.flip,
+                    "crop_left_margin": raw.sizes.crop_left_margin,
+                    "crop_top_margin": raw.sizes.crop_top_margin,
+                    "crop_width": raw.sizes.crop_width,
+                    "crop_height": raw.sizes.crop_height,
+                },
+                "color_desc": (
+                    raw.color_desc.decode("ascii", errors="replace")
+                    if raw.color_desc is not None
+                    else None
+                ),
+                "num_colors": raw.num_colors,
+                "black_level_per_channel": (
+                    list(raw.black_level_per_channel)
+                    if raw.black_level_per_channel is not None
+                    else None
+                ),
+                "white_level": raw.white_level,
+                "camera_whitebalance": (
+                    list(raw.camera_whitebalance)
+                    if raw.camera_whitebalance is not None
+                    else None
+                ),
+                "daylight_whitebalance": (
+                    list(raw.daylight_whitebalance)
+                    if raw.daylight_whitebalance is not None
+                    else None
+                ),
+                "raw_pattern": raw.raw_pattern.tolist() if raw.raw_pattern is not None else None,
+            }
+            return payload, status
+    except Exception as exc:  # noqa: BLE001
+        failed_status = dict(status)
+        failed_status["ok"] = False
+        failed_status["error"] = str(exc)
+        return None, failed_status
+
+
+def _build_file_metadata(input_path: Path) -> Dict[str, Any]:
+    stat = input_path.stat()
+    return {
+        "source_file": str(input_path.resolve()),
+        "file_name": input_path.name,
+        "suffix": input_path.suffix.lower(),
+        "size_bytes": stat.st_size,
+        "sha256": _sha256_file(input_path),
+    }
+
+
+def build_raw_sidecar_payload(
+    input_path: Path,
+    *,
+    exiftool_path: Optional[str] = None,
+) -> Dict[str, Any]:
+    resolved_exiftool = exiftool_path or shutil.which("exiftool")
+    if not resolved_exiftool:
+        raise FileNotFoundError("exiftool not found on PATH")
+
+    exiftool_version = _get_exiftool_version(resolved_exiftool)
+    exiftool_payload = _sanitize_exiftool_payload(_run_exiftool_json(input_path, resolved_exiftool))
+    rawpy_payload, rawpy_status = _read_rawpy_metadata(input_path)
+
+    return {
+        "sidecar_schema": RAW_SIDECAR_SCHEMA,
+        "source_file": str(input_path.resolve()),
+        "file": _build_file_metadata(input_path),
+        "capture_status": {
+            "exiftool": {
+                "available": True,
+                "ok": True,
+                "error": None,
+                "version": exiftool_version,
+            },
+            "rawpy": rawpy_status,
+        },
+        "metadata_exiftool": exiftool_payload,
+        "metadata_rawpy": rawpy_payload,
+    }
+
+
+def generate_raw_sidecar(
+    input_path: Path,
+    *,
+    output_path: Optional[Path] = None,
+    exiftool_path: Optional[str] = None,
+    fsync: bool = False,
+) -> RawSidecarResult:
+    if not input_path.exists():
+        raise FileNotFoundError(f"Input not found: {input_path}")
+    if not input_path.is_file():
+        raise ValueError(f"Input path is not a file: {input_path}")
+
+    resolved_output = output_path or input_path.with_name(f"{input_path.stem}.raw.sidecar.json")
+    payload = build_raw_sidecar_payload(input_path, exiftool_path=exiftool_path)
+    _write_json_atomic(payload, resolved_output, fsync=fsync)
+
+    rawpy_status = payload["capture_status"]["rawpy"]
+    return RawSidecarResult(
+        input_path=input_path,
+        output_path=resolved_output,
+        rawpy_available=bool(rawpy_status.get("available", False)),
+        rawpy_ok=bool(rawpy_status.get("ok", False)),
+        rawpy_error=rawpy_status.get("error"),
+    )

--- a/src/transformation_portal/ingest/raw_sidecar.py
+++ b/src/transformation_portal/ingest/raw_sidecar.py
@@ -10,6 +10,7 @@ import subprocess
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
+from types import ModuleType
 from typing import Any, Dict, Optional
 
 RAW_EXTENSIONS = {
@@ -60,7 +61,14 @@ def _sha256_file(path: Path, *, chunk_size: int = 1024 * 1024) -> str:
 
 
 def _canonical_json(payload: Dict[str, Any]) -> str:
-    return json.dumps(payload, indent=2, sort_keys=True, ensure_ascii=True, allow_nan=False) + "\n"
+    return json.dumps(
+        payload,
+        indent=2,
+        sort_keys=True,
+        ensure_ascii=False,
+        allow_nan=False,
+        separators=(",", ": "),
+    )
 
 
 def _write_json_atomic(payload: Dict[str, Any], output_path: Path, *, fsync: bool) -> None:
@@ -124,10 +132,10 @@ def _run_exiftool_json(input_path: Path, exiftool_path: str) -> Dict[str, Any]:
     payload = json.loads(completed.stdout)
     if not isinstance(payload, list) or not payload or not isinstance(payload[0], dict):
         raise ValueError("Unexpected exiftool JSON payload shape")
-    return _sanitize_exiftool_payload(payload[0])
+    return payload[0]
 
 
-def _rawpy_status_payload() -> tuple[Optional[Dict[str, Any]], Dict[str, Any]]:
+def _rawpy_status_payload() -> tuple[Optional[ModuleType], Dict[str, Any]]:
     try:
         import rawpy  # type: ignore
     except Exception as exc:  # noqa: BLE001
@@ -180,28 +188,14 @@ def _read_rawpy_metadata(input_path: Path) -> tuple[Optional[Dict[str, Any]], Di
                     "crop_width": raw.sizes.crop_width,
                     "crop_height": raw.sizes.crop_height,
                 },
-                "color_desc": (
-                    raw.color_desc.decode("ascii", errors="replace")
-                    if raw.color_desc is not None
-                    else None
-                ),
+                "color_desc": (raw.color_desc.decode("ascii", errors="replace") if raw.color_desc is not None else None),
                 "num_colors": raw.num_colors,
                 "black_level_per_channel": (
-                    list(raw.black_level_per_channel)
-                    if raw.black_level_per_channel is not None
-                    else None
+                    list(raw.black_level_per_channel) if raw.black_level_per_channel is not None else None
                 ),
                 "white_level": raw.white_level,
-                "camera_whitebalance": (
-                    list(raw.camera_whitebalance)
-                    if raw.camera_whitebalance is not None
-                    else None
-                ),
-                "daylight_whitebalance": (
-                    list(raw.daylight_whitebalance)
-                    if raw.daylight_whitebalance is not None
-                    else None
-                ),
+                "camera_whitebalance": (list(raw.camera_whitebalance) if raw.camera_whitebalance is not None else None),
+                "daylight_whitebalance": (list(raw.daylight_whitebalance) if raw.daylight_whitebalance is not None else None),
                 "raw_pattern": raw.raw_pattern.tolist() if raw.raw_pattern is not None else None,
             }
             return payload, status
@@ -212,14 +206,19 @@ def _read_rawpy_metadata(input_path: Path) -> tuple[Optional[Dict[str, Any]], Di
         return None, failed_status
 
 
-def _build_file_metadata(input_path: Path) -> Dict[str, Any]:
+def _build_file_metadata(
+    input_path: Path,
+    *,
+    size_bytes: Optional[int] = None,
+    sha256: Optional[str] = None,
+) -> Dict[str, Any]:
     stat = input_path.stat()
     return {
         "source_file": str(input_path.resolve()),
         "file_name": input_path.name,
         "suffix": input_path.suffix.lower(),
-        "size_bytes": stat.st_size,
-        "sha256": _sha256_file(input_path),
+        "size_bytes": stat.st_size if size_bytes is None else size_bytes,
+        "sha256": _sha256_file(input_path) if sha256 is None else sha256,
     }
 
 
@@ -227,6 +226,8 @@ def build_raw_sidecar_payload(
     input_path: Path,
     *,
     exiftool_path: Optional[str] = None,
+    file_size_bytes: Optional[int] = None,
+    file_sha256: Optional[str] = None,
 ) -> Dict[str, Any]:
     resolved_exiftool = exiftool_path or shutil.which("exiftool")
     if not resolved_exiftool:
@@ -239,7 +240,11 @@ def build_raw_sidecar_payload(
     return {
         "sidecar_schema": RAW_SIDECAR_SCHEMA,
         "source_file": str(input_path.resolve()),
-        "file": _build_file_metadata(input_path),
+        "file": _build_file_metadata(
+            input_path,
+            size_bytes=file_size_bytes,
+            sha256=file_sha256,
+        ),
         "capture_status": {
             "exiftool": {
                 "available": True,
@@ -259,6 +264,8 @@ def generate_raw_sidecar(
     *,
     output_path: Optional[Path] = None,
     exiftool_path: Optional[str] = None,
+    file_size_bytes: Optional[int] = None,
+    file_sha256: Optional[str] = None,
     fsync: bool = False,
 ) -> RawSidecarResult:
     if not input_path.exists():
@@ -267,7 +274,12 @@ def generate_raw_sidecar(
         raise ValueError(f"Input path is not a file: {input_path}")
 
     resolved_output = output_path or input_path.with_name(f"{input_path.stem}.raw.sidecar.json")
-    payload = build_raw_sidecar_payload(input_path, exiftool_path=exiftool_path)
+    payload = build_raw_sidecar_payload(
+        input_path,
+        exiftool_path=exiftool_path,
+        file_size_bytes=file_size_bytes,
+        file_sha256=file_sha256,
+    )
     _write_json_atomic(payload, resolved_output, fsync=fsync)
 
     rawpy_status = payload["capture_status"]["rawpy"]

--- a/src/transformation_portal/ingest/raw_sidecar.py
+++ b/src/transformation_portal/ingest/raw_sidecar.py
@@ -4,10 +4,8 @@ from __future__ import annotations
 
 import hashlib
 import json
-import os
 import shutil
 import subprocess
-import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from types import ModuleType
@@ -75,31 +73,22 @@ def _canonical_json(payload: Dict[str, Any]) -> str:
 
 def _write_json_atomic(payload: Dict[str, Any], output_path: Path, *, fsync: bool) -> None:
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_fd: Optional[int] = None
-    tmp_name: Optional[str] = None
+    temp_path = output_path.with_suffix(output_path.suffix + ".tmp")
     try:
-        tmp_fd, tmp_name = tempfile.mkstemp(
-            prefix=f".{output_path.name}.",
-            suffix=".tmp",
-            dir=str(output_path.parent),
-        )
-        with os.fdopen(tmp_fd, "w", encoding="utf-8") as handle:
-            tmp_fd = None
+        with temp_path.open("w", encoding="utf-8") as handle:
             handle.write(_canonical_json(payload))
             if fsync:
                 handle.flush()
+                import os
+
                 os.fsync(handle.fileno())
-        Path(tmp_name).replace(output_path)
+        temp_path.replace(output_path)
     finally:
-        if tmp_fd is not None:
-            os.close(tmp_fd)
-        if tmp_name is not None:
-            tmp_path = Path(tmp_name)
-            if tmp_path.exists():
-                try:
-                    tmp_path.unlink()
-                except OSError:
-                    pass
+        if temp_path.exists():
+            try:
+                temp_path.unlink()
+            except OSError:
+                pass
 
 
 def _sanitize_exiftool_payload(raw_payload: Dict[str, Any]) -> Dict[str, Any]:
@@ -216,7 +205,7 @@ def _build_file_metadata(
 ) -> Dict[str, Any]:
     stat = input_path.stat()
     return {
-        "source_file": str(input_path.resolve()),
+        "source_file": str(input_path),
         "file_name": input_path.name,
         "suffix": input_path.suffix.lower(),
         "size_bytes": stat.st_size if size_bytes is None else size_bytes,
@@ -230,18 +219,27 @@ def build_raw_sidecar_payload(
     exiftool_path: Optional[str] = None,
     file_size_bytes: Optional[int] = None,
     file_sha256: Optional[str] = None,
+    precomputed_exiftool_payload: Optional[Dict[str, Any]] = None,
+    precomputed_exiftool_version: Optional[str] = None,
 ) -> Dict[str, Any]:
     resolved_exiftool = exiftool_path or shutil.which("exiftool")
-    if not resolved_exiftool:
-        raise FileNotFoundError("exiftool not found on PATH")
+    if precomputed_exiftool_version is None or precomputed_exiftool_payload is None:
+        if not resolved_exiftool:
+            raise FileNotFoundError("exiftool not found on PATH")
 
-    exiftool_version = _get_exiftool_version(resolved_exiftool)
-    exiftool_payload = _sanitize_exiftool_payload(_run_exiftool_json(input_path, resolved_exiftool))
+    exiftool_version = (
+        precomputed_exiftool_version if precomputed_exiftool_version is not None else _get_exiftool_version(resolved_exiftool)
+    )
+    exiftool_payload = _sanitize_exiftool_payload(
+        precomputed_exiftool_payload
+        if precomputed_exiftool_payload is not None
+        else _run_exiftool_json(input_path, resolved_exiftool)
+    )
     rawpy_payload, rawpy_status = _read_rawpy_metadata(input_path)
 
     return {
         "sidecar_schema": RAW_SIDECAR_SCHEMA,
-        "source_file": str(input_path.resolve()),
+        "source_file": str(input_path),
         "file": _build_file_metadata(
             input_path,
             size_bytes=file_size_bytes,
@@ -268,6 +266,8 @@ def generate_raw_sidecar(
     exiftool_path: Optional[str] = None,
     file_size_bytes: Optional[int] = None,
     file_sha256: Optional[str] = None,
+    precomputed_exiftool_payload: Optional[Dict[str, Any]] = None,
+    precomputed_exiftool_version: Optional[str] = None,
     fsync: bool = False,
 ) -> RawSidecarResult:
     if not input_path.exists():
@@ -281,6 +281,8 @@ def generate_raw_sidecar(
         exiftool_path=exiftool_path,
         file_size_bytes=file_size_bytes,
         file_sha256=file_sha256,
+        precomputed_exiftool_payload=precomputed_exiftool_payload,
+        precomputed_exiftool_version=precomputed_exiftool_version,
     )
     _write_json_atomic(payload, resolved_output, fsync=fsync)
 

--- a/src/transformation_portal/ingest/service.py
+++ b/src/transformation_portal/ingest/service.py
@@ -120,6 +120,7 @@ class MetadataExtractionService:
             config_dict = None
 
         output_path = self._as_path(request.args.get("output_path"))
+        raw_sidecar_output_path = self._as_path(request.args.get("raw_sidecar_output_path"))
         output_dir = self._as_path(request.output_dir)
         cli_args, cli_args_error = self._normalize_cli_args(
             request.args.get("cli_args"),
@@ -139,6 +140,9 @@ class MetadataExtractionService:
                 cli_args=cli_args,
                 config_dict=config_dict,
                 fsync=bool(request.args.get("fsync", False)),
+                emit_raw_sidecar=bool(request.args.get("emit_raw_sidecar", True)),
+                raw_sidecar_output_path=raw_sidecar_output_path,
+                raw_sidecar_strict=bool(request.args.get("raw_sidecar_strict", False)),
             )
         )
 
@@ -212,6 +216,8 @@ class MetadataExtractionService:
                 fail_fast=bool(request.args.get("fail_fast", False)),
                 preserve_structure=True,
                 input_root=input_dir,
+                emit_raw_sidecar=bool(request.args.get("emit_raw_sidecar", True)),
+                raw_sidecar_strict=bool(request.args.get("raw_sidecar_strict", False)),
             )
         )
 

--- a/tests/ingest/test_machine_output.py
+++ b/tests/ingest/test_machine_output.py
@@ -51,6 +51,8 @@ def test_extract_result_to_dict_shape() -> None:
         output_path=None,
         elapsed_seconds=1.25,
         error=OtherIngestFailure("boom"),
+        raw_sidecar_path=Path("/tmp/input.raw.sidecar.json"),
+        raw_sidecar_error="rawpy missing",
     )
 
     payload = extract_result_to_dict(result, preset="luxury")
@@ -60,6 +62,8 @@ def test_extract_result_to_dict_shape() -> None:
     assert payload["output_path"] is None
     assert payload["preset"] == "luxury"
     assert payload["error"]["type"] == "OtherIngestFailure"
+    assert "raw_sidecar_path" not in payload
+    assert "raw_sidecar_error" not in payload
 
 
 def test_validate_result_to_dict_serializes_typed_errors() -> None:
@@ -151,6 +155,27 @@ def test_batch_item_to_dict_handles_none_values() -> None:
     }
 
 
+def test_batch_item_to_dict_ignores_raw_sidecar_fields() -> None:
+    item = BatchItemResult(
+        path=Path("/tmp/input.cr2"),
+        success=True,
+        output_path=Path("/tmp/input.provenance.json"),
+        elapsed_seconds=0.0,
+        raw_sidecar_path=Path("/tmp/input.raw.sidecar.json"),
+        raw_sidecar_error="rawpy missing",
+    )
+
+    payload = batch_item_to_dict(item)
+
+    assert payload == {
+        "path": "/tmp/input.cr2",
+        "success": True,
+        "output_path": "/tmp/input.provenance.json",
+        "elapsed_seconds": 0.0,
+        "error": None,
+    }
+
+
 def test_batch_result_to_dict_includes_unknown_exit_code_names() -> None:
     result = BatchExtractResult(
         items=[],
@@ -204,6 +229,8 @@ def test_golden_contract_extract_result_canonical_output() -> None:
         output_path=None,
         elapsed_seconds=1.5,
         error=SchemaValidationFailure("golden test error"),
+        raw_sidecar_path=Path("/tmp/test.raw.sidecar.json"),
+        raw_sidecar_error="rawpy missing",
     )
 
     payload = extract_result_to_dict(result, preset="stable")

--- a/tests/ingest/test_metadata_service_raw_sidecar.py
+++ b/tests/ingest/test_metadata_service_raw_sidecar.py
@@ -23,13 +23,20 @@ def test_extract_generates_raw_sidecar_for_raw_inputs_and_records_path(tmp_path:
     output_dir = tmp_path / "out"
 
     written_paths: list[Path] = []
-    raw_sidecar_calls: list[tuple[Path, Path, bool]] = []
+    raw_sidecar_calls: list[tuple[Path, Path, bool, str | None, int | None]] = []
 
     def fake_write_sidecar(_sidecar: object, output_path: Path, fsync: bool = False) -> None:
         written_paths.append(output_path)
 
-    def fake_generate_raw_sidecar(input_path_arg: Path, *, output_path: Path, fsync: bool = False) -> RawSidecarResult:
-        raw_sidecar_calls.append((input_path_arg, output_path, fsync))
+    def fake_generate_raw_sidecar(
+        input_path_arg: Path,
+        *,
+        output_path: Path,
+        fsync: bool = False,
+        file_sha256: str | None = None,
+        file_size_bytes: int | None = None,
+    ) -> RawSidecarResult:
+        raw_sidecar_calls.append((input_path_arg, output_path, fsync, file_sha256, file_size_bytes))
         return RawSidecarResult(
             input_path=input_path_arg,
             output_path=output_path,
@@ -52,7 +59,7 @@ def test_extract_generates_raw_sidecar_for_raw_inputs_and_records_path(tmp_path:
     assert result.raw_sidecar_path == output_dir / "sample.raw.sidecar.json"
     assert result.raw_sidecar_error is None
     assert written_paths == [output_dir / "sample.provenance.json"]
-    assert raw_sidecar_calls == [(input_path, output_dir / "sample.raw.sidecar.json", False)]
+    assert raw_sidecar_calls == [(input_path, output_dir / "sample.raw.sidecar.json", False, None, None)]
 
 
 def test_extract_non_raw_input_does_not_attempt_raw_sidecar(tmp_path: Path) -> None:
@@ -60,7 +67,14 @@ def test_extract_non_raw_input_does_not_attempt_raw_sidecar(tmp_path: Path) -> N
     input_path.touch()
     raw_sidecar_calls: list[Path] = []
 
-    def fake_generate_raw_sidecar(input_path_arg: Path, *, output_path: Path, fsync: bool = False) -> RawSidecarResult:
+    def fake_generate_raw_sidecar(
+        input_path_arg: Path,
+        *,
+        output_path: Path,
+        fsync: bool = False,
+        file_sha256: str | None = None,
+        file_size_bytes: int | None = None,
+    ) -> RawSidecarResult:
         raw_sidecar_calls.append(input_path_arg)
         return RawSidecarResult(
             input_path=input_path_arg,
@@ -89,7 +103,14 @@ def test_extract_can_disable_raw_sidecar_generation(tmp_path: Path) -> None:
     input_path.touch()
     raw_sidecar_calls: list[Path] = []
 
-    def fake_generate_raw_sidecar(input_path_arg: Path, *, output_path: Path, fsync: bool = False) -> RawSidecarResult:
+    def fake_generate_raw_sidecar(
+        input_path_arg: Path,
+        *,
+        output_path: Path,
+        fsync: bool = False,
+        file_sha256: str | None = None,
+        file_size_bytes: int | None = None,
+    ) -> RawSidecarResult:
         raw_sidecar_calls.append(input_path_arg)
         return RawSidecarResult(
             input_path=input_path_arg,
@@ -123,7 +144,14 @@ def test_extract_raw_sidecar_failure_soft_fails_by_default(tmp_path: Path) -> No
     input_path = tmp_path / "sample.dng"
     input_path.touch()
 
-    def fail_generate_raw_sidecar(_input_path: Path, *, output_path: Path, fsync: bool = False) -> RawSidecarResult:
+    def fail_generate_raw_sidecar(
+        _input_path: Path,
+        *,
+        output_path: Path,
+        fsync: bool = False,
+        file_sha256: str | None = None,
+        file_size_bytes: int | None = None,
+    ) -> RawSidecarResult:
         raise RuntimeError(f"boom: {output_path.name}")
 
     service = MetadataExtractionService(
@@ -151,7 +179,14 @@ def test_extract_raw_sidecar_failure_can_be_strict_and_writes_no_provenance(tmp_
         written_paths.append(output_path)
         output_path.write_text("should-not-exist", encoding="utf-8")
 
-    def fail_generate_raw_sidecar(_input_path: Path, *, output_path: Path, fsync: bool = False) -> RawSidecarResult:
+    def fail_generate_raw_sidecar(
+        _input_path: Path,
+        *,
+        output_path: Path,
+        fsync: bool = False,
+        file_sha256: str | None = None,
+        file_size_bytes: int | None = None,
+    ) -> RawSidecarResult:
         raise RuntimeError("strict failure")
 
     service = MetadataExtractionService(
@@ -183,7 +218,14 @@ def test_extract_provenance_write_failure_removes_generated_raw_sidecar(tmp_path
     input_path.touch()
     output_dir = tmp_path / "out"
 
-    def fake_generate_raw_sidecar(input_path_arg: Path, *, output_path: Path, fsync: bool = False) -> RawSidecarResult:
+    def fake_generate_raw_sidecar(
+        input_path_arg: Path,
+        *,
+        output_path: Path,
+        fsync: bool = False,
+        file_sha256: str | None = None,
+        file_size_bytes: int | None = None,
+    ) -> RawSidecarResult:
         output_path.parent.mkdir(parents=True, exist_ok=True)
         output_path.write_text("{}", encoding="utf-8")
         return RawSidecarResult(
@@ -218,13 +260,62 @@ def test_extract_provenance_write_failure_removes_generated_raw_sidecar(tmp_path
     assert not (output_dir / "sample.raw.sidecar.json").exists()
 
 
+def test_extract_reuses_precomputed_file_integrity_for_raw_sidecar(tmp_path: Path) -> None:
+    input_path = tmp_path / "sample.dng"
+    input_path.write_bytes(b"raw-bytes")
+    output_dir = tmp_path / "out"
+    raw_sidecar_calls: list[tuple[str | None, int | None]] = []
+
+    class _FileIntegrity:
+        sha256 = "a" * 64
+        size_bytes = 12345
+
+    class _Sidecar:
+        file_integrity = _FileIntegrity()
+
+    def fake_generate_raw_sidecar(
+        input_path_arg: Path,
+        *,
+        output_path: Path,
+        fsync: bool = False,
+        file_sha256: str | None = None,
+        file_size_bytes: int | None = None,
+    ) -> RawSidecarResult:
+        raw_sidecar_calls.append((file_sha256, file_size_bytes))
+        return RawSidecarResult(
+            input_path=input_path_arg,
+            output_path=output_path,
+            rawpy_available=True,
+            rawpy_ok=True,
+        )
+
+    service = MetadataExtractionService(
+        capture_provenance_fn=lambda **_: _Sidecar(),
+        write_sidecar_fn=lambda *_args, **_kwargs: None,
+        generate_raw_sidecar_fn=fake_generate_raw_sidecar,
+        clock_fn=_clock,
+    )
+
+    result = service.extract(ExtractRequest(input_path=input_path, output_dir=output_dir))
+
+    assert result.success is True
+    assert raw_sidecar_calls == [("a" * 64, 12345)]
+
+
 def test_extract_respects_explicit_raw_sidecar_output_path(tmp_path: Path) -> None:
     input_path = tmp_path / "sample.cr3"
     input_path.touch()
     explicit_output_path = tmp_path / "custom" / "sample.custom.raw.sidecar.json"
     raw_sidecar_calls: list[Path] = []
 
-    def fake_generate_raw_sidecar(input_path_arg: Path, *, output_path: Path, fsync: bool = False) -> RawSidecarResult:
+    def fake_generate_raw_sidecar(
+        input_path_arg: Path,
+        *,
+        output_path: Path,
+        fsync: bool = False,
+        file_sha256: str | None = None,
+        file_size_bytes: int | None = None,
+    ) -> RawSidecarResult:
         raw_sidecar_calls.append(output_path)
         return RawSidecarResult(
             input_path=input_path_arg,
@@ -267,7 +358,7 @@ def test_batch_extract_preserves_disambiguated_raw_sidecar_paths(tmp_path: Path)
     service = MetadataExtractionService(
         capture_provenance_fn=lambda **_: object(),
         write_sidecar_fn=lambda *_args, **_kwargs: None,
-        generate_raw_sidecar_fn=lambda input_path_arg, *, output_path, fsync=False: RawSidecarResult(
+        generate_raw_sidecar_fn=lambda input_path_arg, *, output_path, fsync=False, file_sha256=None, file_size_bytes=None: RawSidecarResult(
             input_path=input_path_arg,
             output_path=output_path,
             rawpy_available=True,

--- a/tests/ingest/test_metadata_service_raw_sidecar.py
+++ b/tests/ingest/test_metadata_service_raw_sidecar.py
@@ -1,0 +1,295 @@
+"""Tests for RAW-sidecar integration in MetadataExtractionService."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from transformation_portal.ingest.errors import OtherIngestFailure
+from transformation_portal.ingest.metadata_service import BatchExtractRequest, ExtractRequest, MetadataExtractionService
+from transformation_portal.ingest.raw_sidecar import RawSidecarResult
+
+pytestmark = pytest.mark.unit
+
+
+def _clock() -> float:
+    return 100.0
+
+
+def test_extract_generates_raw_sidecar_for_raw_inputs_and_records_path(tmp_path: Path) -> None:
+    input_path = tmp_path / "sample.cr2"
+    input_path.touch()
+    output_dir = tmp_path / "out"
+
+    written_paths: list[Path] = []
+    raw_sidecar_calls: list[tuple[Path, Path, bool]] = []
+
+    def fake_write_sidecar(_sidecar: object, output_path: Path, fsync: bool = False) -> None:
+        written_paths.append(output_path)
+
+    def fake_generate_raw_sidecar(input_path_arg: Path, *, output_path: Path, fsync: bool = False) -> RawSidecarResult:
+        raw_sidecar_calls.append((input_path_arg, output_path, fsync))
+        return RawSidecarResult(
+            input_path=input_path_arg,
+            output_path=output_path,
+            rawpy_available=True,
+            rawpy_ok=True,
+            rawpy_error=None,
+        )
+
+    service = MetadataExtractionService(
+        capture_provenance_fn=lambda **_: object(),
+        write_sidecar_fn=fake_write_sidecar,
+        generate_raw_sidecar_fn=fake_generate_raw_sidecar,
+        clock_fn=_clock,
+    )
+
+    result = service.extract(ExtractRequest(input_path=input_path, output_dir=output_dir))
+
+    assert result.success is True
+    assert result.output_path == output_dir / "sample.provenance.json"
+    assert result.raw_sidecar_path == output_dir / "sample.raw.sidecar.json"
+    assert result.raw_sidecar_error is None
+    assert written_paths == [output_dir / "sample.provenance.json"]
+    assert raw_sidecar_calls == [(input_path, output_dir / "sample.raw.sidecar.json", False)]
+
+
+def test_extract_non_raw_input_does_not_attempt_raw_sidecar(tmp_path: Path) -> None:
+    input_path = tmp_path / "sample.jpg"
+    input_path.touch()
+    raw_sidecar_calls: list[Path] = []
+
+    def fake_generate_raw_sidecar(input_path_arg: Path, *, output_path: Path, fsync: bool = False) -> RawSidecarResult:
+        raw_sidecar_calls.append(input_path_arg)
+        return RawSidecarResult(
+            input_path=input_path_arg,
+            output_path=output_path,
+            rawpy_available=True,
+            rawpy_ok=True,
+        )
+
+    service = MetadataExtractionService(
+        capture_provenance_fn=lambda **_: object(),
+        write_sidecar_fn=lambda *_args, **_kwargs: None,
+        generate_raw_sidecar_fn=fake_generate_raw_sidecar,
+        clock_fn=_clock,
+    )
+
+    result = service.extract(ExtractRequest(input_path=input_path, output_dir=tmp_path / "out"))
+
+    assert result.success is True
+    assert result.raw_sidecar_path is None
+    assert result.raw_sidecar_error is None
+    assert raw_sidecar_calls == []
+
+
+def test_extract_can_disable_raw_sidecar_generation(tmp_path: Path) -> None:
+    input_path = tmp_path / "sample.dng"
+    input_path.touch()
+    raw_sidecar_calls: list[Path] = []
+
+    def fake_generate_raw_sidecar(input_path_arg: Path, *, output_path: Path, fsync: bool = False) -> RawSidecarResult:
+        raw_sidecar_calls.append(input_path_arg)
+        return RawSidecarResult(
+            input_path=input_path_arg,
+            output_path=output_path,
+            rawpy_available=True,
+            rawpy_ok=True,
+        )
+
+    service = MetadataExtractionService(
+        capture_provenance_fn=lambda **_: object(),
+        write_sidecar_fn=lambda *_args, **_kwargs: None,
+        generate_raw_sidecar_fn=fake_generate_raw_sidecar,
+        clock_fn=_clock,
+    )
+
+    result = service.extract(
+        ExtractRequest(
+            input_path=input_path,
+            output_dir=tmp_path / "out",
+            emit_raw_sidecar=False,
+        )
+    )
+
+    assert result.success is True
+    assert result.raw_sidecar_path is None
+    assert result.raw_sidecar_error is None
+    assert raw_sidecar_calls == []
+
+
+def test_extract_raw_sidecar_failure_soft_fails_by_default(tmp_path: Path) -> None:
+    input_path = tmp_path / "sample.dng"
+    input_path.touch()
+
+    def fail_generate_raw_sidecar(_input_path: Path, *, output_path: Path, fsync: bool = False) -> RawSidecarResult:
+        raise RuntimeError(f"boom: {output_path.name}")
+
+    service = MetadataExtractionService(
+        capture_provenance_fn=lambda **_: object(),
+        write_sidecar_fn=lambda *_args, **_kwargs: None,
+        generate_raw_sidecar_fn=fail_generate_raw_sidecar,
+        clock_fn=_clock,
+    )
+
+    result = service.extract(ExtractRequest(input_path=input_path, output_dir=tmp_path / "out"))
+
+    assert result.success is True
+    assert result.raw_sidecar_path is None
+    assert result.raw_sidecar_error is not None
+    assert "boom: sample.raw.sidecar.json" in result.raw_sidecar_error
+
+
+def test_extract_raw_sidecar_failure_can_be_strict_and_writes_no_provenance(tmp_path: Path) -> None:
+    input_path = tmp_path / "sample.dng"
+    input_path.touch()
+    output_dir = tmp_path / "out"
+    written_paths: list[Path] = []
+
+    def fake_write_sidecar(_sidecar: object, output_path: Path, fsync: bool = False) -> None:
+        written_paths.append(output_path)
+        output_path.write_text("should-not-exist", encoding="utf-8")
+
+    def fail_generate_raw_sidecar(_input_path: Path, *, output_path: Path, fsync: bool = False) -> RawSidecarResult:
+        raise RuntimeError("strict failure")
+
+    service = MetadataExtractionService(
+        capture_provenance_fn=lambda **_: object(),
+        write_sidecar_fn=fake_write_sidecar,
+        generate_raw_sidecar_fn=fail_generate_raw_sidecar,
+        clock_fn=_clock,
+    )
+
+    result = service.extract(
+        ExtractRequest(
+            input_path=input_path,
+            output_dir=output_dir,
+            raw_sidecar_strict=True,
+        )
+    )
+
+    assert result.success is False
+    assert isinstance(result.error, OtherIngestFailure)
+    assert "RAW sidecar generation failed" in str(result.error)
+    assert result.raw_sidecar_path is None
+    assert result.raw_sidecar_error == "strict failure"
+    assert written_paths == []
+    assert not (output_dir / "sample.provenance.json").exists()
+
+
+def test_extract_provenance_write_failure_removes_generated_raw_sidecar(tmp_path: Path) -> None:
+    input_path = tmp_path / "sample.dng"
+    input_path.touch()
+    output_dir = tmp_path / "out"
+
+    def fake_generate_raw_sidecar(input_path_arg: Path, *, output_path: Path, fsync: bool = False) -> RawSidecarResult:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text("{}", encoding="utf-8")
+        return RawSidecarResult(
+            input_path=input_path_arg,
+            output_path=output_path,
+            rawpy_available=True,
+            rawpy_ok=True,
+            rawpy_error=None,
+        )
+
+    def fake_write_sidecar_raises(*_args: object, **_kwargs: object) -> None:
+        raise OSError("disk full")
+
+    service = MetadataExtractionService(
+        capture_provenance_fn=lambda **_: object(),
+        write_sidecar_fn=fake_write_sidecar_raises,
+        generate_raw_sidecar_fn=fake_generate_raw_sidecar,
+        clock_fn=_clock,
+    )
+
+    result = service.extract(
+        ExtractRequest(
+            input_path=input_path,
+            output_dir=output_dir,
+            raw_sidecar_strict=True,
+        )
+    )
+
+    assert result.success is False
+    assert isinstance(result.error, OtherIngestFailure)
+    assert result.raw_sidecar_path is None
+    assert not (output_dir / "sample.raw.sidecar.json").exists()
+
+
+def test_extract_respects_explicit_raw_sidecar_output_path(tmp_path: Path) -> None:
+    input_path = tmp_path / "sample.cr3"
+    input_path.touch()
+    explicit_output_path = tmp_path / "custom" / "sample.custom.raw.sidecar.json"
+    raw_sidecar_calls: list[Path] = []
+
+    def fake_generate_raw_sidecar(input_path_arg: Path, *, output_path: Path, fsync: bool = False) -> RawSidecarResult:
+        raw_sidecar_calls.append(output_path)
+        return RawSidecarResult(
+            input_path=input_path_arg,
+            output_path=output_path,
+            rawpy_available=True,
+            rawpy_ok=True,
+        )
+
+    service = MetadataExtractionService(
+        capture_provenance_fn=lambda **_: object(),
+        write_sidecar_fn=lambda *_args, **_kwargs: None,
+        generate_raw_sidecar_fn=fake_generate_raw_sidecar,
+        clock_fn=_clock,
+    )
+
+    result = service.extract(
+        ExtractRequest(
+            input_path=input_path,
+            output_dir=tmp_path / "out",
+            raw_sidecar_output_path=explicit_output_path,
+        )
+    )
+
+    assert result.success is True
+    assert result.raw_sidecar_path == explicit_output_path
+    assert raw_sidecar_calls == [explicit_output_path]
+
+
+def test_batch_extract_preserves_disambiguated_raw_sidecar_paths(tmp_path: Path) -> None:
+    input_root = tmp_path / "inputs"
+    first_dir = input_root / "first"
+    second_dir = input_root / "second"
+    first_dir.mkdir(parents=True)
+    second_dir.mkdir(parents=True)
+    first = first_dir / "image.cr2"
+    second = second_dir / "image.cr2"
+    first.touch()
+    second.touch()
+
+    service = MetadataExtractionService(
+        capture_provenance_fn=lambda **_: object(),
+        write_sidecar_fn=lambda *_args, **_kwargs: None,
+        generate_raw_sidecar_fn=lambda input_path_arg, *, output_path, fsync=False: RawSidecarResult(
+            input_path=input_path_arg,
+            output_path=output_path,
+            rawpy_available=True,
+            rawpy_ok=True,
+        ),
+        clock_fn=_clock,
+    )
+
+    result = service.batch_extract(
+        BatchExtractRequest(
+            input_paths=[first, second],
+            output_dir=tmp_path / "out",
+            preserve_structure=False,
+            deterministic_order=False,
+        )
+    )
+
+    assert result.success is True
+    assert len(result.items) == 2
+    raw_names = [item.raw_sidecar_path.name if item.raw_sidecar_path is not None else None for item in result.items]
+    assert raw_names[0] == "image.cr2.raw.sidecar.json"
+    assert raw_names[1] is not None
+    assert raw_names[1] != raw_names[0]
+    assert raw_names[1].startswith("image.cr2.")
+    assert raw_names[1].endswith(".raw.sidecar.json")

--- a/tests/ingest/test_metadata_service_raw_sidecar.py
+++ b/tests/ingest/test_metadata_service_raw_sidecar.py
@@ -35,6 +35,8 @@ def test_extract_generates_raw_sidecar_for_raw_inputs_and_records_path(tmp_path:
         fsync: bool = False,
         file_sha256: str | None = None,
         file_size_bytes: int | None = None,
+        precomputed_exiftool_payload: dict[str, object] | None = None,
+        precomputed_exiftool_version: str | None = None,
     ) -> RawSidecarResult:
         raw_sidecar_calls.append((input_path_arg, output_path, fsync, file_sha256, file_size_bytes))
         return RawSidecarResult(
@@ -74,6 +76,8 @@ def test_extract_non_raw_input_does_not_attempt_raw_sidecar(tmp_path: Path) -> N
         fsync: bool = False,
         file_sha256: str | None = None,
         file_size_bytes: int | None = None,
+        precomputed_exiftool_payload: dict[str, object] | None = None,
+        precomputed_exiftool_version: str | None = None,
     ) -> RawSidecarResult:
         raw_sidecar_calls.append(input_path_arg)
         return RawSidecarResult(
@@ -110,6 +114,8 @@ def test_extract_can_disable_raw_sidecar_generation(tmp_path: Path) -> None:
         fsync: bool = False,
         file_sha256: str | None = None,
         file_size_bytes: int | None = None,
+        precomputed_exiftool_payload: dict[str, object] | None = None,
+        precomputed_exiftool_version: str | None = None,
     ) -> RawSidecarResult:
         raw_sidecar_calls.append(input_path_arg)
         return RawSidecarResult(
@@ -151,6 +157,8 @@ def test_extract_raw_sidecar_failure_soft_fails_by_default(tmp_path: Path) -> No
         fsync: bool = False,
         file_sha256: str | None = None,
         file_size_bytes: int | None = None,
+        precomputed_exiftool_payload: dict[str, object] | None = None,
+        precomputed_exiftool_version: str | None = None,
     ) -> RawSidecarResult:
         raise RuntimeError(f"boom: {output_path.name}")
 
@@ -186,6 +194,8 @@ def test_extract_raw_sidecar_failure_can_be_strict_and_writes_no_provenance(tmp_
         fsync: bool = False,
         file_sha256: str | None = None,
         file_size_bytes: int | None = None,
+        precomputed_exiftool_payload: dict[str, object] | None = None,
+        precomputed_exiftool_version: str | None = None,
     ) -> RawSidecarResult:
         raise RuntimeError("strict failure")
 
@@ -225,6 +235,8 @@ def test_extract_provenance_write_failure_removes_generated_raw_sidecar(tmp_path
         fsync: bool = False,
         file_sha256: str | None = None,
         file_size_bytes: int | None = None,
+        precomputed_exiftool_payload: dict[str, object] | None = None,
+        precomputed_exiftool_version: str | None = None,
     ) -> RawSidecarResult:
         output_path.parent.mkdir(parents=True, exist_ok=True)
         output_path.write_text("{}", encoding="utf-8")
@@ -280,6 +292,8 @@ def test_extract_reuses_precomputed_file_integrity_for_raw_sidecar(tmp_path: Pat
         fsync: bool = False,
         file_sha256: str | None = None,
         file_size_bytes: int | None = None,
+        precomputed_exiftool_payload: dict[str, object] | None = None,
+        precomputed_exiftool_version: str | None = None,
     ) -> RawSidecarResult:
         raw_sidecar_calls.append((file_sha256, file_size_bytes))
         return RawSidecarResult(
@@ -302,6 +316,54 @@ def test_extract_reuses_precomputed_file_integrity_for_raw_sidecar(tmp_path: Pat
     assert raw_sidecar_calls == [("a" * 64, 12345)]
 
 
+def test_extract_reuses_precomputed_exiftool_metadata_for_raw_sidecar(tmp_path: Path) -> None:
+    input_path = tmp_path / "sample.dng"
+    input_path.write_bytes(b"raw-bytes")
+    output_dir = tmp_path / "out"
+    raw_sidecar_calls: list[tuple[dict[str, object] | None, str | None]] = []
+
+    class _Exif:
+        all_tags = {"EXIF:ISO": 100}
+
+    class _ToolchainEntry:
+        name = "exiftool"
+        version = "13.55"
+
+    class _Sidecar:
+        exif = _Exif()
+        toolchain = [_ToolchainEntry()]
+
+    def fake_generate_raw_sidecar(
+        input_path_arg: Path,
+        *,
+        output_path: Path,
+        fsync: bool = False,
+        file_sha256: str | None = None,
+        file_size_bytes: int | None = None,
+        precomputed_exiftool_payload: dict[str, object] | None = None,
+        precomputed_exiftool_version: str | None = None,
+    ) -> RawSidecarResult:
+        raw_sidecar_calls.append((precomputed_exiftool_payload, precomputed_exiftool_version))
+        return RawSidecarResult(
+            input_path=input_path_arg,
+            output_path=output_path,
+            rawpy_available=True,
+            rawpy_ok=True,
+        )
+
+    service = MetadataExtractionService(
+        capture_provenance_fn=lambda **_: _Sidecar(),
+        write_sidecar_fn=lambda *_args, **_kwargs: None,
+        generate_raw_sidecar_fn=fake_generate_raw_sidecar,
+        clock_fn=_clock,
+    )
+
+    result = service.extract(ExtractRequest(input_path=input_path, output_dir=output_dir))
+
+    assert result.success is True
+    assert raw_sidecar_calls == [({"EXIF:ISO": 100}, "13.55")]
+
+
 def test_extract_respects_explicit_raw_sidecar_output_path(tmp_path: Path) -> None:
     input_path = tmp_path / "sample.cr3"
     input_path.touch()
@@ -315,6 +377,8 @@ def test_extract_respects_explicit_raw_sidecar_output_path(tmp_path: Path) -> No
         fsync: bool = False,
         file_sha256: str | None = None,
         file_size_bytes: int | None = None,
+        precomputed_exiftool_payload: dict[str, object] | None = None,
+        precomputed_exiftool_version: str | None = None,
     ) -> RawSidecarResult:
         raw_sidecar_calls.append(output_path)
         return RawSidecarResult(
@@ -344,6 +408,50 @@ def test_extract_respects_explicit_raw_sidecar_output_path(tmp_path: Path) -> No
     assert raw_sidecar_calls == [explicit_output_path]
 
 
+def test_extract_derives_raw_sidecar_name_from_custom_provenance_output_path(tmp_path: Path) -> None:
+    input_path = tmp_path / "sample.cr3"
+    input_path.touch()
+    custom_provenance_output_path = tmp_path / "out" / "custom.prov.json"
+    raw_sidecar_calls: list[Path] = []
+
+    def fake_generate_raw_sidecar(
+        input_path_arg: Path,
+        *,
+        output_path: Path,
+        fsync: bool = False,
+        file_sha256: str | None = None,
+        file_size_bytes: int | None = None,
+        precomputed_exiftool_payload: dict[str, object] | None = None,
+        precomputed_exiftool_version: str | None = None,
+    ) -> RawSidecarResult:
+        raw_sidecar_calls.append(output_path)
+        return RawSidecarResult(
+            input_path=input_path_arg,
+            output_path=output_path,
+            rawpy_available=True,
+            rawpy_ok=True,
+        )
+
+    service = MetadataExtractionService(
+        capture_provenance_fn=lambda **_: object(),
+        write_sidecar_fn=lambda *_args, **_kwargs: None,
+        generate_raw_sidecar_fn=fake_generate_raw_sidecar,
+        clock_fn=_clock,
+    )
+
+    result = service.extract(
+        ExtractRequest(
+            input_path=input_path,
+            output_path=custom_provenance_output_path,
+        )
+    )
+
+    assert result.success is True
+    assert result.output_path == custom_provenance_output_path
+    assert result.raw_sidecar_path == tmp_path / "out" / "custom.prov.raw.sidecar.json"
+    assert raw_sidecar_calls == [tmp_path / "out" / "custom.prov.raw.sidecar.json"]
+
+
 def test_batch_extract_preserves_disambiguated_raw_sidecar_paths(tmp_path: Path) -> None:
     input_root = tmp_path / "inputs"
     first_dir = input_root / "first"
@@ -355,15 +463,27 @@ def test_batch_extract_preserves_disambiguated_raw_sidecar_paths(tmp_path: Path)
     first.touch()
     second.touch()
 
-    service = MetadataExtractionService(
-        capture_provenance_fn=lambda **_: object(),
-        write_sidecar_fn=lambda *_args, **_kwargs: None,
-        generate_raw_sidecar_fn=lambda input_path_arg, *, output_path, fsync=False, file_sha256=None, file_size_bytes=None: RawSidecarResult(
+    def fake_generate_raw_sidecar(
+        input_path_arg: Path,
+        *,
+        output_path: Path,
+        fsync: bool = False,
+        file_sha256: str | None = None,
+        file_size_bytes: int | None = None,
+        precomputed_exiftool_payload: dict[str, object] | None = None,
+        precomputed_exiftool_version: str | None = None,
+    ) -> RawSidecarResult:
+        return RawSidecarResult(
             input_path=input_path_arg,
             output_path=output_path,
             rawpy_available=True,
             rawpy_ok=True,
-        ),
+        )
+
+    service = MetadataExtractionService(
+        capture_provenance_fn=lambda **_: object(),
+        write_sidecar_fn=lambda *_args, **_kwargs: None,
+        generate_raw_sidecar_fn=fake_generate_raw_sidecar,
         clock_fn=_clock,
     )
 

--- a/tests/ingest/test_raw_sidecar.py
+++ b/tests/ingest/test_raw_sidecar.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import stat
 import subprocess
 from pathlib import Path
 
@@ -146,6 +147,73 @@ def test_build_raw_sidecar_payload_uses_precomputed_file_integrity(
     assert payload["file"]["sha256"] == "b" * 64
 
 
+def test_build_raw_sidecar_payload_reuses_precomputed_exiftool_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    input_path = tmp_path / "frame.dng"
+    input_path.write_bytes(b"raw-bytes")
+
+    monkeypatch.setattr(
+        raw_sidecar_module,
+        "_get_exiftool_version",
+        lambda _path: (_ for _ in ()).throw(AssertionError("should not read live exiftool version")),
+    )
+    monkeypatch.setattr(
+        raw_sidecar_module,
+        "_run_exiftool_json",
+        lambda _input_path, _exiftool_path: (_ for _ in ()).throw(AssertionError("should not re-run exiftool")),
+    )
+    monkeypatch.setattr(
+        raw_sidecar_module,
+        "_read_rawpy_metadata",
+        lambda _input_path: (
+            None,
+            {"available": False, "ok": False, "error": "rawpy missing", "version": None, "libraw_version": None},
+        ),
+    )
+
+    payload = raw_sidecar_module.build_raw_sidecar_payload(
+        input_path,
+        precomputed_exiftool_version="13.55",
+        precomputed_exiftool_payload={"File:FileAccessDate": "volatile", "EXIF:ISO": 100},
+    )
+
+    assert payload["capture_status"]["exiftool"]["version"] == "13.55"
+    assert payload["metadata_exiftool"] == {"EXIF:ISO": 100}
+
+
+def test_build_raw_sidecar_payload_preserves_input_path_semantics(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    nested_dir = tmp_path / "nested"
+    nested_dir.mkdir()
+    input_path = Path("nested/frame.dng")
+    (nested_dir / "frame.dng").write_bytes(b"raw-bytes")
+    monkeypatch.chdir(tmp_path)
+
+    monkeypatch.setattr(raw_sidecar_module, "_get_exiftool_version", lambda _path: "13.55")
+    monkeypatch.setattr(
+        raw_sidecar_module,
+        "_run_exiftool_json",
+        lambda _input_path, _exiftool_path: {"EXIF:ISO": 100},
+    )
+    monkeypatch.setattr(
+        raw_sidecar_module,
+        "_read_rawpy_metadata",
+        lambda _input_path: (
+            None,
+            {"available": False, "ok": False, "error": "rawpy missing", "version": None, "libraw_version": None},
+        ),
+    )
+
+    payload = raw_sidecar_module.build_raw_sidecar_payload(input_path, exiftool_path="exiftool")
+
+    assert payload["source_file"] == "nested/frame.dng"
+    assert payload["file"]["source_file"] == "nested/frame.dng"
+
+
 def test_generate_raw_sidecar_propagates_exiftool_timeout(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -166,3 +234,35 @@ def test_generate_raw_sidecar_propagates_exiftool_timeout(
             output_path=tmp_path / "frame.raw.sidecar.json",
             exiftool_path="exiftool",
         )
+
+
+def test_generate_raw_sidecar_matches_default_file_permissions(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    input_path = tmp_path / "frame.cr2"
+    input_path.write_bytes(b"raw-bytes")
+
+    baseline_path = tmp_path / "baseline.txt"
+    baseline_path.write_text("baseline", encoding="utf-8")
+    baseline_mode = stat.S_IMODE(baseline_path.stat().st_mode)
+
+    monkeypatch.setattr(raw_sidecar_module, "_get_exiftool_version", lambda _path: "13.55")
+    monkeypatch.setattr(
+        raw_sidecar_module,
+        "_run_exiftool_json",
+        lambda _input_path, _exiftool_path: {"EXIF:ISO": 200},
+    )
+    monkeypatch.setattr(
+        raw_sidecar_module,
+        "_read_rawpy_metadata",
+        lambda _input_path: (
+            None,
+            {"available": False, "ok": False, "error": "rawpy missing", "version": None, "libraw_version": None},
+        ),
+    )
+
+    output_path = tmp_path / "frame.raw.sidecar.json"
+    raw_sidecar_module.generate_raw_sidecar(input_path, output_path=output_path, exiftool_path="exiftool")
+
+    assert stat.S_IMODE(output_path.stat().st_mode) == baseline_mode

--- a/tests/ingest/test_raw_sidecar.py
+++ b/tests/ingest/test_raw_sidecar.py
@@ -1,0 +1,104 @@
+"""Tests for raw_sidecar helpers."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from transformation_portal.ingest import raw_sidecar as raw_sidecar_module
+
+pytestmark = pytest.mark.unit
+
+
+def test_build_raw_sidecar_payload_sanitizes_volatile_exif_fields(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    input_path = tmp_path / "frame.dng"
+    input_path.write_bytes(b"raw-bytes")
+
+    monkeypatch.setattr(raw_sidecar_module, "_get_exiftool_version", lambda _path: "13.55")
+    monkeypatch.setattr(
+        raw_sidecar_module,
+        "_run_exiftool_json",
+        lambda _input_path, _exiftool_path: {
+            "File:FileName": "frame.dng",
+            "File:FileAccessDate": "volatile",
+            "EXIF:ISO": 100,
+        },
+    )
+    monkeypatch.setattr(
+        raw_sidecar_module,
+        "_read_rawpy_metadata",
+        lambda _input_path: (
+            {"white_level": 16383},
+            {"available": True, "ok": True, "error": None, "version": "0.26.1", "libraw_version": "0.21.4"},
+        ),
+    )
+
+    payload = raw_sidecar_module.build_raw_sidecar_payload(input_path, exiftool_path="exiftool")
+
+    assert payload["sidecar_schema"] == raw_sidecar_module.RAW_SIDECAR_SCHEMA
+    assert payload["metadata_exiftool"]["EXIF:ISO"] == 100
+    assert "File:FileAccessDate" not in payload["metadata_exiftool"]
+    assert payload["metadata_rawpy"]["white_level"] == 16383
+
+
+def test_generate_raw_sidecar_writes_json_and_preserves_rawpy_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    input_path = tmp_path / "frame.cr2"
+    input_path.write_bytes(b"raw-bytes")
+
+    monkeypatch.setattr(raw_sidecar_module, "_get_exiftool_version", lambda _path: "13.55")
+    monkeypatch.setattr(
+        raw_sidecar_module,
+        "_run_exiftool_json",
+        lambda _input_path, _exiftool_path: {"File:FileName": "frame.cr2", "EXIF:ISO": 200},
+    )
+    monkeypatch.setattr(
+        raw_sidecar_module,
+        "_read_rawpy_metadata",
+        lambda _input_path: (
+            None,
+            {"available": False, "ok": False, "error": "rawpy missing", "version": None, "libraw_version": None},
+        ),
+    )
+
+    output_path = tmp_path / "frame.raw.sidecar.json"
+    result = raw_sidecar_module.generate_raw_sidecar(input_path, output_path=output_path, exiftool_path="exiftool")
+
+    assert result.output_path == output_path
+    assert result.rawpy_available is False
+    assert result.rawpy_ok is False
+    assert result.rawpy_error == "rawpy missing"
+
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert payload["capture_status"]["rawpy"]["error"] == "rawpy missing"
+    assert payload["metadata_rawpy"] is None
+
+
+def test_generate_raw_sidecar_propagates_exiftool_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    input_path = tmp_path / "frame.cr2"
+    input_path.write_bytes(b"raw-bytes")
+
+    monkeypatch.setattr(raw_sidecar_module, "_get_exiftool_version", lambda _path: "13.55")
+    monkeypatch.setattr(
+        raw_sidecar_module,
+        "_run_exiftool_json",
+        lambda _input_path, _exiftool_path: (_ for _ in ()).throw(subprocess.TimeoutExpired("exiftool", 30)),
+    )
+
+    with pytest.raises(subprocess.TimeoutExpired):
+        raw_sidecar_module.generate_raw_sidecar(
+            input_path,
+            output_path=tmp_path / "frame.raw.sidecar.json",
+            exiftool_path="exiftool",
+        )

--- a/tests/ingest/test_raw_sidecar.py
+++ b/tests/ingest/test_raw_sidecar.py
@@ -82,6 +82,70 @@ def test_generate_raw_sidecar_writes_json_and_preserves_rawpy_failure(
     assert payload["metadata_rawpy"] is None
 
 
+def test_generate_raw_sidecar_uses_existing_ingest_json_style(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    input_path = tmp_path / "frame.cr2"
+    input_path.write_bytes(b"raw-bytes")
+
+    monkeypatch.setattr(raw_sidecar_module, "_get_exiftool_version", lambda _path: "13.55")
+    monkeypatch.setattr(
+        raw_sidecar_module,
+        "_run_exiftool_json",
+        lambda _input_path, _exiftool_path: {"EXIF:LensModel": "Café Lens"},
+    )
+    monkeypatch.setattr(
+        raw_sidecar_module,
+        "_read_rawpy_metadata",
+        lambda _input_path: (
+            None,
+            {"available": False, "ok": False, "error": "rawpy missing", "version": None, "libraw_version": None},
+        ),
+    )
+
+    output_path = tmp_path / "frame.raw.sidecar.json"
+    raw_sidecar_module.generate_raw_sidecar(input_path, output_path=output_path, exiftool_path="exiftool")
+
+    text = output_path.read_text(encoding="utf-8")
+    assert "Café Lens" in text
+    assert "\\u00e9" not in text
+    assert not text.endswith("\n")
+
+
+def test_build_raw_sidecar_payload_uses_precomputed_file_integrity(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    input_path = tmp_path / "frame.dng"
+    input_path.write_bytes(b"raw-bytes")
+
+    monkeypatch.setattr(raw_sidecar_module, "_get_exiftool_version", lambda _path: "13.55")
+    monkeypatch.setattr(
+        raw_sidecar_module,
+        "_run_exiftool_json",
+        lambda _input_path, _exiftool_path: {"EXIF:ISO": 100},
+    )
+    monkeypatch.setattr(
+        raw_sidecar_module,
+        "_read_rawpy_metadata",
+        lambda _input_path: (
+            None,
+            {"available": False, "ok": False, "error": "rawpy missing", "version": None, "libraw_version": None},
+        ),
+    )
+
+    payload = raw_sidecar_module.build_raw_sidecar_payload(
+        input_path,
+        exiftool_path="exiftool",
+        file_size_bytes=4321,
+        file_sha256="b" * 64,
+    )
+
+    assert payload["file"]["size_bytes"] == 4321
+    assert payload["file"]["sha256"] == "b" * 64
+
+
 def test_generate_raw_sidecar_propagates_exiftool_timeout(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/ingest/test_service_orchestration.py
+++ b/tests/ingest/test_service_orchestration.py
@@ -151,6 +151,38 @@ def test_run_extract_cli_args_none_normalizes_to_empty_sequence(tmp_path: Path) 
     assert delegated.cli_args == []
 
 
+def test_run_extract_passes_raw_sidecar_args_to_core_service(tmp_path: Path) -> None:
+    input_path = tmp_path / "sample.cr2"
+    input_path.touch()
+    raw_sidecar_output_path = tmp_path / "sidecars" / "sample.raw.sidecar.json"
+    stub = _StubCoreService()
+    stub.extract_result = CoreExtractResult(
+        path=input_path,
+        success=True,
+        output_path=tmp_path / "sample.provenance.json",
+        elapsed_seconds=0.1,
+    )
+    service = MetadataExtractionService(metadata_service=stub)  # type: ignore[arg-type]
+
+    result = service.run(
+        ServiceRunRequest(
+            command="extract",
+            input_path=input_path,
+            args={
+                "emit_raw_sidecar": False,
+                "raw_sidecar_strict": True,
+                "raw_sidecar_output_path": str(raw_sidecar_output_path),
+            },
+        )
+    )
+
+    assert result.success is True
+    delegated = stub.extract_requests[0]
+    assert delegated.emit_raw_sidecar is False
+    assert delegated.raw_sidecar_strict is True
+    assert delegated.raw_sidecar_output_path == raw_sidecar_output_path
+
+
 def test_run_extract_with_invalid_cli_args_type_returns_other_failure(tmp_path: Path) -> None:
     input_path = tmp_path / "sample.cr2"
     input_path.touch()
@@ -263,6 +295,47 @@ def test_run_extract_batch_preserves_core_default_config_and_normalizes_paths(tm
     assert delegated.input_root == input_dir
     assert list(delegated.input_paths) == [image_path]
     assert delegated.config_dict is None
+
+
+def test_run_extract_batch_passes_raw_sidecar_args_to_core_service(tmp_path: Path) -> None:
+    input_dir = tmp_path / "inputs"
+    input_dir.mkdir(parents=True)
+    image_path = input_dir / "a.cr2"
+    image_path.touch()
+
+    summary = {
+        "total": 1,
+        "success": 1,
+        "failure": 0,
+        "by_exit_code": {
+            code.name: 0 for code in sorted(IngestExitCode, key=lambda code: code.value) if code != IngestExitCode.SUCCESS
+        },
+    }
+    stub = _StubCoreService()
+    stub.batch_result = BatchExtractResult(
+        items=[],
+        total_elapsed=0.01,
+        summary_counts=summary,
+        dominant_error=None,
+    )
+    service = MetadataExtractionService(metadata_service=stub)  # type: ignore[arg-type]
+
+    result = service.run(
+        ServiceRunRequest(
+            command="extract-batch",
+            input_path=input_dir,
+            input_paths=[image_path],
+            args={
+                "emit_raw_sidecar": False,
+                "raw_sidecar_strict": True,
+            },
+        )
+    )
+
+    assert result.success is True
+    delegated = stub.batch_requests[0]
+    assert delegated.emit_raw_sidecar is False
+    assert delegated.raw_sidecar_strict is True
 
 
 def test_run_extract_batch_with_invalid_input_paths_fails_without_silent_drop(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add deterministic RAW-sidecar generation helpers for RAW metadata capture
- integrate RAW sidecar emission into `MetadataExtractionService.extract()` and `batch_extract()` with soft-fail default behavior and strict fail-closed mode
- pass the new controls through the ingest orchestration surface and add regression coverage to keep `tp.meta.machine.v1` unchanged

## Root Cause
- the ingest seam only emitted provenance sidecars, so RAW-specific metadata had no additive sidecar path
- there was no request-level strict mode that treated RAW-sidecar generation as part of the extract contract without leaving partial artifacts behind on failure
- the orchestration layer had no way to pass RAW-sidecar controls through to the core metadata service

## Impact
- RAW inputs can now emit companion `*.raw.sidecar.json` artifacts using the finalized provenance output path for naming, so existing batch collision/disambiguation behavior is preserved
- non-RAW ingest behavior remains unchanged
- machine-mode serialization remains unchanged under `tp.meta.machine.v1`
- callers can enable or disable RAW-sidecar generation and opt into strict fail-closed behavior through `ServiceRunRequest.args`

## Validation
- `PATH=/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin:$PATH .venv/bin/pre-commit run --all-files --show-diff-on-failure`
- `.venv/bin/pytest tests/ingest/test_metadata_service.py tests/ingest/test_metadata_service_raw_sidecar.py tests/ingest/test_raw_sidecar.py tests/ingest/test_service_orchestration.py tests/ingest/test_machine_output.py tests/ingest/test_provenance_capture.py -q`
- `.venv/bin/python scripts/test_metadata_extraction.py extract /tmp/raw-sidecar-smoke.N5AWAC/DJI_0018.DNG --output /tmp/raw-sidecar-smoke.N5AWAC/DJI_0018.provenance.json`
- verified the smoke output included both `DJI_0018.provenance.json` and `DJI_0018.raw.sidecar.json`