### PR TITLE
fix(apex): preserve gate diagnostics and align v2 handoff

### DIFF
--- a/.github/workflows/ingest_contract_validation.yml
+++ b/.github/workflows/ingest_contract_validation.yml
@@ -48,6 +48,12 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Disable broken Azure CLI apt source when present
+        run: |
+          if ls /etc/apt/sources.list.d/azure-cli*.list >/dev/null 2>&1; then
+            sudo rm -f /etc/apt/sources.list.d/azure-cli*.list
+          fi
+
       - name: Install exiftool
         run: |
           sudo apt-get update

--- a/src/transformation_portal/lux_depth_v3/orchestrator.py
+++ b/src/transformation_portal/lux_depth_v3/orchestrator.py
@@ -3021,6 +3021,8 @@ class EnhanceOrchestrator:
         materials_v3_result: Optional[dict],
     ) -> None:
         """Fail early when APEX strict violates handoff."""
+        if not self.config.enable_v2 or self.v2_runner is None:
+            return
         if not self._is_apex_materials_gate_enabled():
             return
         if not depth_path or not depth_path.exists():

--- a/src/transformation_portal/lux_depth_v3/orchestrator.py
+++ b/src/transformation_portal/lux_depth_v3/orchestrator.py
@@ -955,6 +955,17 @@ class EnhanceOrchestrator:
             return "MPS_UNAVAILABLE"
         return "BACKEND_RUNTIME_ERROR"
 
+    def _set_active_depth_state(
+        self,
+        backend_metadata: Optional[BackendSelectionMetadata],
+        depth_attempts: List[Dict[str, Any]],
+        selected_attempt_index: Optional[int],
+    ) -> None:
+        """Persist per-image depth state for downstream error/reporting paths."""
+        self._active_backend_metadata = backend_metadata
+        self._active_depth_attempts = list(depth_attempts)
+        self._active_selected_attempt_index = selected_attempt_index
+
     def _build_backend_metadata_for_attempts(
         self,
         selected_backend: str,
@@ -1739,6 +1750,7 @@ class EnhanceOrchestrator:
                 depth_validity_metrics = None
                 selected_backend_id = _primary_backend_name
                 selected_attempt_index: Optional[int] = None
+                native_depth_shape: Optional[tuple[int, int]] = None
                 last_error: Optional[Exception] = None
                 attempt_offset = len(depth_attempts)
 
@@ -1882,8 +1894,6 @@ class EnhanceOrchestrator:
                         if isinstance(result_device, str) and result_device:
                             attempt_record["device"] = result_device
 
-                        # CRITICAL FIX (#2): Resize depth
-                        # back to original dimensions
                         depth_candidate = (
                             result_candidate.depth_map
                             if hasattr(
@@ -1892,43 +1902,11 @@ class EnhanceOrchestrator:
                             )
                             else result_candidate.depth
                         )
-                        current_shape = depth_candidate.shape[:2]
-                        if current_shape != original_shape:
-                            from PIL import Image as PILImage
-
-                            logger.debug(
-                                "Resizing depth map" " from %s back to" " original %s",
-                                current_shape,
-                                original_shape,
-                            )
-                            # Preserve raw numeric depth
-                            # semantics during resize.
-                            depth_pil = PILImage.fromarray(
-                                np.asarray(
-                                    depth_candidate,
-                                    dtype=np.float32,
-                                ),
-                                mode="F",
-                            )
-                            depth_pil_resized = depth_pil.resize(
-                                (
-                                    original_shape[1],
-                                    original_shape[0],
-                                ),
-                                PILImage.Resampling.BILINEAR,
-                            )
-                            depth_candidate = np.array(
-                                depth_pil_resized,
-                                dtype=np.float32,
-                            )
-                            if hasattr(result_candidate, "depth_map"):
-                                result_candidate.depth_map = depth_candidate
-                            else:
-                                object.__setattr__(
-                                    result_candidate,
-                                    "depth",
-                                    depth_candidate,
-                                )
+                        native_depth_map = np.asarray(
+                            depth_candidate,
+                            dtype=np.float32,
+                        )
+                        current_shape = tuple(int(value) for value in native_depth_map.shape[:2])
 
                         result_metadata = dict(
                             getattr(
@@ -1976,13 +1954,50 @@ class EnhanceOrchestrator:
                         # 2b. APEX depth validity gate
                         # (plateau/saturation guardrails)
                         gate_result = self._enforce_apex_depth_validity_gate(
-                            depth_candidate,
+                            native_depth_map,
                             depth_units=getattr(
                                 result_candidate,
                                 "depth_units",
                                 None,
                             ),
+                            native_shape=current_shape,
+                            artifact_shape=original_shape,
                         )
+
+                        artifact_depth_map = native_depth_map
+                        if current_shape != original_shape:
+                            from PIL import Image as PILImage
+
+                            logger.debug(
+                                "Resizing depth map" " from %s back to" " original %s",
+                                current_shape,
+                                original_shape,
+                            )
+                            # Preserve raw numeric depth
+                            # semantics during resize.
+                            depth_pil = PILImage.fromarray(
+                                native_depth_map,
+                                mode="F",
+                            )
+                            depth_pil_resized = depth_pil.resize(
+                                (
+                                    original_shape[1],
+                                    original_shape[0],
+                                ),
+                                PILImage.Resampling.BILINEAR,
+                            )
+                            artifact_depth_map = np.array(
+                                depth_pil_resized,
+                                dtype=np.float32,
+                            )
+                            if hasattr(result_candidate, "depth_map"):
+                                result_candidate.depth_map = artifact_depth_map
+                            else:
+                                object.__setattr__(
+                                    result_candidate,
+                                    "depth",
+                                    artifact_depth_map,
+                                )
 
                         attempt_record.update(
                             {
@@ -2000,10 +2015,11 @@ class EnhanceOrchestrator:
                         depth_attempts.append(attempt_record)
 
                         result = result_candidate
-                        depth_map = depth_candidate
+                        depth_map = native_depth_map
                         depth_validity_metrics = gate_result
                         selected_backend_id = backend_id
                         selected_attempt_index = attempt_slot
+                        native_depth_shape = current_shape
                         break
 
                     except LicenseRestrictionError as license_error:
@@ -2094,9 +2110,11 @@ class EnhanceOrchestrator:
                     ),
                     selected_attempt_index=(selected_attempt_index),
                 )
-                self._active_backend_metadata = active_backend_metadata
-                self._active_depth_attempts = depth_attempts
-                self._active_selected_attempt_index = selected_attempt_index
+                self._set_active_depth_state(
+                    active_backend_metadata,
+                    depth_attempts,
+                    selected_attempt_index,
+                )
 
                 # 2c. Materials V3 Processing (if enabled)
                 if self.materials_v3_engine:
@@ -2108,6 +2126,7 @@ class EnhanceOrchestrator:
                         preprocessed_array=preprocessed_array,
                         depth_map=depth_map,
                         output_key=output_key,
+                        artifact_shape=tuple(int(value) for value in result.depth.shape[:2]),
                     )
 
                 # 3. Write quantized depth (PNG 16-bit)
@@ -2134,6 +2153,10 @@ class EnhanceOrchestrator:
                     "non_commercial_ok": self.config.non_commercial_ok,
                     "dtype": "uint16",
                     "shape": list(result.depth.shape[:2]),
+                    "native_shape": (
+                        list(native_depth_shape) if native_depth_shape is not None else list(result.depth.shape[:2])
+                    ),
+                    "artifact_shape": list(result.depth.shape[:2]),
                     "representation": "depth",
                     "convention": "higher_is_farther",
                     "unit": (
@@ -2189,6 +2212,11 @@ class EnhanceOrchestrator:
                 }
                 if depth_validity_metrics:
                     stats["apex_depth_validity"] = depth_validity_metrics
+                    shape_context = depth_validity_metrics.get("shape_context")
+                    if isinstance(shape_context, dict):
+                        gate_shape = shape_context.get("gate_evaluated_shape")
+                        if isinstance(gate_shape, list):
+                            stats["gate_evaluated_shape"] = gate_shape
 
                 # Merge inference provenance into depth stats
                 _md = getattr(result, "metadata", None) or {}
@@ -2247,6 +2275,11 @@ class EnhanceOrchestrator:
 
             except Exception as e:
                 logger.error(f"Depth failed: {e}")
+                self._set_active_depth_state(
+                    active_backend_metadata,
+                    depth_attempts,
+                    selected_attempt_index,
+                )
                 if isinstance(e, ApexStrictGateError):
                     logger.error(
                         "APEX strict gate failure:" " code=%s details=%s",
@@ -2257,8 +2290,6 @@ class EnhanceOrchestrator:
                 if self.config.depth_fallback == "fail":
                     raise
                 elif self.config.depth_fallback == "skip":
-                    self._active_backend_metadata = active_backend_metadata
-                    self._active_depth_attempts = depth_attempts
                     return (
                         None,
                         0.0,
@@ -2275,8 +2306,6 @@ class EnhanceOrchestrator:
                     )
                     if depth_path.exists():
                         depth_path.unlink()
-                    self._active_backend_metadata = active_backend_metadata
-                    self._active_depth_attempts = depth_attempts
                     return (
                         None,
                         0.0,
@@ -2471,6 +2500,141 @@ class EnhanceOrchestrator:
         """Return canonical segmentation mask path."""
         return self.segmentation_dir / output_key.parent / f"{output_key.stem}" "_materials_v3_masks.npz"
 
+    @staticmethod
+    def _resize_float_array_to_shape(
+        array: np.ndarray,
+        target_shape: tuple[int, int],
+        *,
+        resample: Any,
+    ) -> np.ndarray:
+        """Resize 2D or RGB float arrays deterministically."""
+        from PIL import Image as PILImage
+
+        float_array = np.asarray(array, dtype=np.float32)
+        if float_array.shape[:2] == target_shape:
+            return float_array.astype(np.float32, copy=False)
+
+        if float_array.ndim == 2:
+            image = PILImage.fromarray(float_array, mode="F")
+            resized = image.resize(
+                (target_shape[1], target_shape[0]),
+                resample=resample,
+            )
+            return np.asarray(resized, dtype=np.float32)
+
+        if float_array.ndim == 3 and float_array.shape[2] == 3:
+            channels = [
+                EnhanceOrchestrator._resize_float_array_to_shape(
+                    float_array[..., channel_index],
+                    target_shape,
+                    resample=resample,
+                )
+                for channel_index in range(float_array.shape[2])
+            ]
+            return np.stack(channels, axis=-1).astype(np.float32)
+
+        raise ValueError(f"Expected 2D mask or RGB image for handoff resize, got shape {float_array.shape}")
+
+    def _align_materials_v3_handoff_payload(
+        self,
+        materials_v3_result: Dict[str, Any],
+        *,
+        artifact_shape: tuple[int, int],
+        processing_shape: tuple[int, int],
+    ) -> Dict[str, Any]:
+        """Resize Materials V3 handoff artifacts to the depth artifact shape."""
+        from PIL import Image as PILImage
+
+        target_shape = tuple(int(value) for value in artifact_shape)
+        processing_shape_list = [int(value) for value in processing_shape]
+        handoff_shape_list = [int(value) for value in target_shape]
+
+        enhanced_image = materials_v3_result.get("enhanced_image")
+        if enhanced_image is not None:
+            materials_v3_result["enhanced_image"] = self._resize_float_array_to_shape(
+                np.asarray(enhanced_image, dtype=np.float32),
+                target_shape,
+                resample=PILImage.Resampling.BILINEAR,
+            )
+
+        material_masks = materials_v3_result.get("material_masks")
+        if isinstance(material_masks, dict) and material_masks:
+            aligned_masks: Dict[str, np.ndarray] = {}
+            for material_name, mask in material_masks.items():
+                aligned_masks[material_name] = self._resize_float_array_to_shape(
+                    np.asarray(mask, dtype=np.float32),
+                    target_shape,
+                    resample=PILImage.Resampling.NEAREST,
+                )
+            materials_v3_result["material_masks"] = aligned_masks
+
+        materials_v3_metadata = materials_v3_result.setdefault(
+            "materials_v3_metadata",
+            {},
+        )
+        if not isinstance(materials_v3_metadata, dict):
+            materials_v3_metadata = {}
+            materials_v3_result["materials_v3_metadata"] = materials_v3_metadata
+
+        segmentation_metadata = materials_v3_metadata.get(
+            "segmentation_metadata",
+        )
+        segmentation_metadata = dict(segmentation_metadata) if isinstance(segmentation_metadata, dict) else {}
+        segmentation_metadata["processing_shape"] = processing_shape_list
+        segmentation_metadata["v2_handoff_shape"] = handoff_shape_list
+        materials_v3_metadata["segmentation_metadata"] = segmentation_metadata
+        return materials_v3_result
+
+    @staticmethod
+    def _artifact_image_shape(image_path: Path) -> tuple[int, int]:
+        """Read image artifact dimensions as (height, width)."""
+        from PIL import Image as PILImage
+
+        with PILImage.open(image_path) as image:
+            return int(image.size[1]), int(image.size[0])
+
+    def _material_mask_shape(
+        self,
+        materials_v3_result: Optional[dict],
+    ) -> Optional[tuple[int, int]]:
+        """Resolve a common material mask shape from in-memory or persisted artifacts."""
+        if not isinstance(materials_v3_result, dict):
+            return None
+
+        material_masks = materials_v3_result.get("material_masks")
+        if isinstance(material_masks, dict) and material_masks:
+            resolved_shape: Optional[tuple[int, int]] = None
+            for mask in material_masks.values():
+                mask_shape = tuple(int(value) for value in np.asarray(mask).shape[:2])
+                if resolved_shape is None:
+                    resolved_shape = mask_shape
+                    continue
+                if resolved_shape != mask_shape:
+                    raise RuntimeError(
+                        "Materials V3 mask handoff uses inconsistent mask shapes: " f"{resolved_shape} vs {mask_shape}"
+                    )
+            return resolved_shape
+
+        mask_artifact_path = self._persisted_material_mask_artifact_path(
+            materials_v3_result,
+        )
+        if mask_artifact_path is None:
+            return None
+
+        with np.load(mask_artifact_path) as data:
+            resolved_shape = None
+            for mask_name in data.files:
+                mask_shape = tuple(int(value) for value in np.asarray(data[mask_name]).shape[:2])
+                if resolved_shape is None:
+                    resolved_shape = mask_shape
+                    continue
+                if resolved_shape != mask_shape:
+                    raise RuntimeError(
+                        "Materials V3 persisted mask artifact uses inconsistent mask shapes: "
+                        f"{resolved_shape} vs {mask_shape}"
+                    )
+        return resolved_shape
+
     def _persist_material_masks_artifact(
         self,
         masks: Dict[str, np.ndarray],
@@ -2495,6 +2659,7 @@ class EnhanceOrchestrator:
         preprocessed_array: np.ndarray,
         depth_map: np.ndarray,
         output_key: Path,
+        artifact_shape: Optional[tuple[int, int]] = None,
     ) -> tuple[Optional[dict], float, Optional[Path]]:
         """Run Materials V3 stage and persist artifacts."""
         if not self.materials_v3_engine:
@@ -2552,6 +2717,13 @@ class EnhanceOrchestrator:
             runtime_s = time.time() - t_materials_start
 
             if materials_v3_result:
+                if artifact_shape is not None:
+                    materials_v3_result = self._align_materials_v3_handoff_payload(
+                        materials_v3_result,
+                        artifact_shape=artifact_shape,
+                        processing_shape=tuple(int(value) for value in preprocessed_array.shape[:2]),
+                    )
+
                 material_masks = materials_v3_result.get("material_masks")
                 if isinstance(material_masks, dict) and material_masks:
                     mask_artifact_path = self._persist_material_masks_artifact(
@@ -2580,6 +2752,9 @@ class EnhanceOrchestrator:
                             mask_artifact_path,
                         )
                         segmentation_metadata["mask_artifact_format"] = "npz"
+                        segmentation_metadata["mask_artifact_shape"] = list(
+                            np.asarray(next(iter(material_masks.values()))).shape[:2]
+                        )
                         materials_v3_metadata["segmentation_metadata"] = segmentation_metadata
 
                 enhanced_image = materials_v3_result.get("enhanced_image")
@@ -2798,6 +2973,7 @@ class EnhanceOrchestrator:
                 dtype=np.float32,
             ),
             output_key=output_key,
+            artifact_shape=tuple(int(value) for value in np.asarray(depth_for_materials).shape[:2]),
         )
 
         has_recomputed_masks = bool(
@@ -2864,6 +3040,21 @@ class EnhanceOrchestrator:
         )
 
         if actual_path_resolved == expected_path_resolved and expected_path.exists() and has_masks:
+            depth_shape = self._artifact_image_shape(depth_path)
+            v2_input_shape = self._artifact_image_shape(Path(v2_input_path))
+            mask_shape = self._material_mask_shape(materials_v3_result)
+            if v2_input_shape != depth_shape or mask_shape != depth_shape:
+                raise ApexStrictGateError(
+                    "APEX_V2_HANDOFF_DIMENSION_DRIFT",
+                    "APEX strict mode forbids V2 handoff dimension drift.",
+                    details={
+                        "depth_path": str(depth_path),
+                        "v2_input_path": str(v2_input_path),
+                        "depth_shape": list(depth_shape),
+                        "v2_input_shape": list(v2_input_shape),
+                        "mask_shape": list(mask_shape) if mask_shape is not None else None,
+                    },
+                )
             return
 
         raise ApexStrictGateError(
@@ -4046,10 +4237,40 @@ class EnhanceOrchestrator:
             "gate_normalization": normalization,
         }
 
+    @staticmethod
+    def _shape_list(shape: Any) -> Optional[List[int]]:
+        """Normalize an arbitrary HxW shape payload to a JSON-safe list."""
+        if isinstance(shape, (tuple, list)) and len(shape) >= 2:
+            try:
+                return [int(shape[0]), int(shape[1])]
+            except (TypeError, ValueError):
+                return None
+        return None
+
+    def _build_apex_depth_shape_context(
+        self,
+        *,
+        gate_evaluated_shape: Any,
+        native_shape: Any,
+        artifact_shape: Any,
+    ) -> Dict[str, Optional[List[int]]]:
+        """Build explicit shape context for APEX gate telemetry."""
+        gate_shape = self._shape_list(gate_evaluated_shape)
+        native_shape_list = self._shape_list(native_shape) or gate_shape
+        artifact_shape_list = self._shape_list(artifact_shape) or native_shape_list
+        return {
+            "gate_evaluated_shape": gate_shape,
+            "native_shape": native_shape_list,
+            "artifact_shape": artifact_shape_list,
+        }
+
     def _enforce_apex_depth_validity_gate(
         self,
         depth_map: np.ndarray,
         depth_units: Optional[str] = None,
+        *,
+        native_shape: Optional[Any] = None,
+        artifact_shape: Optional[Any] = None,
     ) -> Optional[Dict[str, Any]]:
         """APEX-only depth quality gate."""
         if not self._is_apex_tier():
@@ -4058,6 +4279,11 @@ class EnhanceOrchestrator:
         metrics = self._compute_depth_validity_metrics(
             depth_map,
             depth_units=depth_units,
+        )
+        shape_context = self._build_apex_depth_shape_context(
+            gate_evaluated_shape=np.asarray(depth_map).shape[:2],
+            native_shape=native_shape or np.asarray(depth_map).shape[:2],
+            artifact_shape=artifact_shape or native_shape or np.asarray(depth_map).shape[:2],
         )
 
         _cfg = self.config
@@ -4191,6 +4417,7 @@ class EnhanceOrchestrator:
                 "failure_codes": failure_codes,
                 "metrics": metrics,
                 "thresholds": thresholds,
+                "shape_context": shape_context,
             }
             raise ApexStrictGateError(
                 failure_codes[0] if len(failure_codes) == 1 else "APEX_DEPTH_INVALID",
@@ -4214,6 +4441,7 @@ class EnhanceOrchestrator:
             "warnings": warnings,
             "metrics": metrics,
             "thresholds": thresholds,
+            "shape_context": shape_context,
         }
 
     def _enforce_apex_materials_gate(

--- a/src/transformation_portal/lux_depth_v3/orchestrator.py
+++ b/src/transformation_portal/lux_depth_v3/orchestrator.py
@@ -2627,14 +2627,21 @@ class EnhanceOrchestrator:
         material_masks = materials_v3_result.get("material_masks")
         if isinstance(material_masks, dict) and material_masks:
             resolved_shape: Optional[tuple[int, int]] = None
-            for mask in material_masks.values():
+            for material_key, mask in material_masks.items():
                 mask_shape = _shape_2d(np.asarray(mask))
                 if resolved_shape is None:
                     resolved_shape = mask_shape
                     continue
                 if resolved_shape != mask_shape:
-                    raise RuntimeError(
-                        "Materials V3 mask handoff uses inconsistent mask shapes: " f"{resolved_shape} vs {mask_shape}"
+                    raise ApexStrictGateError(
+                        "APEX_MATERIAL_MASK_SHAPE_MISMATCH",
+                        "APEX strict mode requires consistent Materials V3 mask shapes before V2 handoff.",
+                        details={
+                            "source": "material_masks",
+                            "material_key": str(material_key),
+                            "expected_mask_shape": list(resolved_shape),
+                            "observed_mask_shape": list(mask_shape),
+                        },
                     )
             return resolved_shape
 
@@ -2652,9 +2659,16 @@ class EnhanceOrchestrator:
                     resolved_shape = mask_shape
                     continue
                 if resolved_shape != mask_shape:
-                    raise RuntimeError(
-                        "Materials V3 persisted mask artifact uses inconsistent mask shapes: "
-                        f"{resolved_shape} vs {mask_shape}"
+                    raise ApexStrictGateError(
+                        "APEX_MATERIAL_MASK_SHAPE_MISMATCH",
+                        "APEX strict mode requires consistent Materials V3 mask shapes before V2 handoff.",
+                        details={
+                            "source": "mask_artifact",
+                            "mask_artifact_path": str(mask_artifact_path),
+                            "material_key": str(mask_name),
+                            "expected_mask_shape": list(resolved_shape),
+                            "observed_mask_shape": list(mask_shape),
+                        },
                     )
         return resolved_shape
 
@@ -3059,8 +3073,11 @@ class EnhanceOrchestrator:
         enhanced_path_resolved = enhanced_image_path.resolve() if enhanced_image_path else None
         has_masks = bool(
             materials_v3_result
-            and materials_v3_result.get(
-                "material_masks",
+            and (
+                materials_v3_result.get(
+                    "material_masks",
+                )
+                or self._persisted_material_mask_artifact_path(materials_v3_result) is not None
             )
         )
 

--- a/src/transformation_portal/lux_depth_v3/orchestrator.py
+++ b/src/transformation_portal/lux_depth_v3/orchestrator.py
@@ -219,7 +219,20 @@ def _shape_2d(arr: np.ndarray) -> tuple[int, int]:
     to satisfy mypy's strict tuple type checking. Without this, the
     generator expression `tuple(int(v) for v in arr.shape[:2])` produces
     `tuple[int, ...]` which is incompatible with `tuple[int, int]`.
+
+    Args:
+        arr: A numpy array with at least 2 dimensions (depth maps, masks, images).
+
+    Returns:
+        A tuple of (height, width) representing the first two dimensions.
+
+    Raises:
+        IndexError: If the array has fewer than 2 dimensions.
     """
+    if arr.ndim < 2:
+        raise IndexError(
+            f"_shape_2d requires an array with at least 2 dimensions, got {arr.ndim}D array"
+        )
     height, width = int(arr.shape[0]), int(arr.shape[1])
     return (height, width)
 

--- a/src/transformation_portal/lux_depth_v3/orchestrator.py
+++ b/src/transformation_portal/lux_depth_v3/orchestrator.py
@@ -212,6 +212,18 @@ class _MaskSerializationRejected(RuntimeError):
     """Internal signal for non-fatal mask serialization rejection."""
 
 
+def _shape_2d(arr: np.ndarray) -> tuple[int, int]:
+    """Extract 2D shape from array as properly typed tuple[int, int].
+
+    This helper converts numpy shape slices into typed 2-element tuples
+    to satisfy mypy's strict tuple type checking. Without this, the
+    generator expression `tuple(int(v) for v in arr.shape[:2])` produces
+    `tuple[int, ...]` which is incompatible with `tuple[int, int]`.
+    """
+    height, width = int(arr.shape[0]), int(arr.shape[1])
+    return (height, width)
+
+
 def _log_dependency_status() -> dict:
     """Log startup dependency availability report.
 
@@ -1906,7 +1918,7 @@ class EnhanceOrchestrator:
                             depth_candidate,
                             dtype=np.float32,
                         )
-                        current_shape = tuple(int(value) for value in native_depth_map.shape[:2])
+                        current_shape = _shape_2d(native_depth_map)
 
                         result_metadata = dict(
                             getattr(
@@ -2126,7 +2138,7 @@ class EnhanceOrchestrator:
                         preprocessed_array=preprocessed_array,
                         depth_map=depth_map,
                         output_key=output_key,
-                        artifact_shape=tuple(int(value) for value in result.depth.shape[:2]),
+                        artifact_shape=_shape_2d(result.depth),
                     )
 
                 # 3. Write quantized depth (PNG 16-bit)
@@ -2545,9 +2557,9 @@ class EnhanceOrchestrator:
         """Resize Materials V3 handoff artifacts to the depth artifact shape."""
         from PIL import Image as PILImage
 
-        target_shape = tuple(int(value) for value in artifact_shape)
-        processing_shape_list = [int(value) for value in processing_shape]
-        handoff_shape_list = [int(value) for value in target_shape]
+        target_shape: tuple[int, int] = artifact_shape
+        processing_shape_list = [processing_shape[0], processing_shape[1]]
+        handoff_shape_list = [target_shape[0], target_shape[1]]
 
         enhanced_image = materials_v3_result.get("enhanced_image")
         if enhanced_image is not None:
@@ -2605,7 +2617,7 @@ class EnhanceOrchestrator:
         if isinstance(material_masks, dict) and material_masks:
             resolved_shape: Optional[tuple[int, int]] = None
             for mask in material_masks.values():
-                mask_shape = tuple(int(value) for value in np.asarray(mask).shape[:2])
+                mask_shape = _shape_2d(np.asarray(mask))
                 if resolved_shape is None:
                     resolved_shape = mask_shape
                     continue
@@ -2624,7 +2636,7 @@ class EnhanceOrchestrator:
         with np.load(mask_artifact_path) as data:
             resolved_shape = None
             for mask_name in data.files:
-                mask_shape = tuple(int(value) for value in np.asarray(data[mask_name]).shape[:2])
+                mask_shape = _shape_2d(np.asarray(data[mask_name]))
                 if resolved_shape is None:
                     resolved_shape = mask_shape
                     continue
@@ -2721,7 +2733,7 @@ class EnhanceOrchestrator:
                     materials_v3_result = self._align_materials_v3_handoff_payload(
                         materials_v3_result,
                         artifact_shape=artifact_shape,
-                        processing_shape=tuple(int(value) for value in preprocessed_array.shape[:2]),
+                        processing_shape=_shape_2d(preprocessed_array),
                     )
 
                 material_masks = materials_v3_result.get("material_masks")
@@ -2973,7 +2985,7 @@ class EnhanceOrchestrator:
                 dtype=np.float32,
             ),
             output_key=output_key,
-            artifact_shape=tuple(int(value) for value in np.asarray(depth_for_materials).shape[:2]),
+            artifact_shape=_shape_2d(np.asarray(depth_for_materials)),
         )
 
         has_recomputed_masks = bool(

--- a/src/transformation_portal/lux_depth_v3/orchestrator.py
+++ b/src/transformation_portal/lux_depth_v3/orchestrator.py
@@ -230,9 +230,7 @@ def _shape_2d(arr: np.ndarray) -> tuple[int, int]:
         IndexError: If the array has fewer than 2 dimensions.
     """
     if arr.ndim < 2:
-        raise IndexError(
-            f"_shape_2d requires an array with at least 2 dimensions, got {arr.ndim}D array"
-        )
+        raise IndexError(f"_shape_2d requires an array with at least 2 dimensions, got {arr.ndim}D array")
     height, width = int(arr.shape[0]), int(arr.shape[1])
     return (height, width)
 

--- a/src/transformation_portal/lux_depth_v3/provenance.py
+++ b/src/transformation_portal/lux_depth_v3/provenance.py
@@ -34,6 +34,7 @@ import json
 import logging
 import os
 import platform
+import re
 import subprocess
 import sys
 from dataclasses import asdict, dataclass
@@ -161,6 +162,78 @@ def extract_exif_metadata(image_path: Path) -> Dict[str, Any]:
         raise ProvenanceError("Failed to parse exiftool" f" JSON output: {e}") from e
     except subprocess.TimeoutExpired as e:
         raise ProvenanceError("exiftool timed out after 30s") from e
+
+
+_BENIGN_EXIFTOOL_WARNING_PATTERNS = (
+    (
+        "EXIFTOOL_MAKERNOTE_OFFSET_WARNING",
+        re.compile(
+            r"^\[minor\]\s+Possibly incorrect maker notes offsets\b",
+            re.IGNORECASE,
+        ),
+    ),
+)
+
+
+def _normalize_exiftool_warning_messages(exif_metadata: Dict[str, Any]) -> list[str]:
+    """Normalize ExifTool warning payloads into a list of strings."""
+    raw_warning = exif_metadata.get("ExifTool:Warning")
+    if isinstance(raw_warning, str):
+        warning = raw_warning.strip()
+        return [warning] if warning else []
+    if isinstance(raw_warning, list):
+        warnings = []
+        for value in raw_warning:
+            if not isinstance(value, str):
+                continue
+            warning = value.strip()
+            if warning:
+                warnings.append(warning)
+        return warnings
+    return []
+
+
+def _classify_exiftool_warnings(exif_metadata: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Classify raw ExifTool warnings without mutating the captured EXIF payload."""
+    warnings = _normalize_exiftool_warning_messages(exif_metadata)
+    if not warnings:
+        return None
+
+    benign = []
+    actionable = []
+    for warning in warnings:
+        matched_code = None
+        for code, pattern in _BENIGN_EXIFTOOL_WARNING_PATTERNS:
+            if pattern.search(warning):
+                matched_code = code
+                break
+        entry = {
+            "tag": "ExifTool:Warning",
+            "message": warning,
+        }
+        if matched_code is not None:
+            benign.append(
+                {
+                    **entry,
+                    "code": matched_code,
+                    "classification": "benign",
+                }
+            )
+        else:
+            actionable.append(
+                {
+                    **entry,
+                    "code": "EXIFTOOL_WARNING_UNCLASSIFIED",
+                    "classification": "actionable",
+                }
+            )
+
+    return {
+        "exiftool": {
+            "benign": benign,
+            "actionable": actionable,
+        }
+    }
 
 
 def get_toolchain_versions() -> Dict[str, Optional[str]]:
@@ -314,6 +387,7 @@ class ProvenanceMetadata:
     exif: Dict[str, Any]
     toolchain: Dict[str, Optional[str]]
     ingest_context: IngestContext
+    warning_classification: Optional[Dict[str, Any]] = None
 
     def validate_required_fields(self) -> None:
         """Validate that all required fields are present and well-formed.
@@ -373,6 +447,7 @@ class ProvenanceMetadata:
             "exif": self.exif,
             "toolchain": self.toolchain,
             "ingest_context": self.ingest_context.to_dict(),
+            **({"warning_classification": self.warning_classification} if self.warning_classification is not None else {}),
         }
 
     def to_json(self, indent: int = 2) -> str:
@@ -456,6 +531,7 @@ class ProvenanceMetadata:
             schema_version=schema_version,
             input=InputFileMetadata(**data["input"]),
             exif=data["exif"],
+            warning_classification=data.get("warning_classification"),
             toolchain=data["toolchain"],
             ingest_context=IngestContext(**data["ingest_context"]),
         )
@@ -580,6 +656,7 @@ def capture_provenance(
         schema_version=PROVENANCE_SCHEMA_VERSION,
         input=input_metadata,
         exif=exif_metadata,
+        warning_classification=_classify_exiftool_warnings(exif_metadata),
         toolchain=toolchain,
         ingest_context=ingest_context,
     )

--- a/tests/lux_depth_v3/test_orchestrator_smoke.py
+++ b/tests/lux_depth_v3/test_orchestrator_smoke.py
@@ -12,6 +12,54 @@ from PIL import Image
 
 pytestmark = pytest.mark.unit
 
+
+class TestShape2dHelper:
+    """Unit tests for the _shape_2d helper function."""
+
+    def test_shape_2d_with_2d_array(self) -> None:
+        """_shape_2d extracts correct shape from 2D array."""
+        from transformation_portal.lux_depth_v3.orchestrator import _shape_2d
+
+        arr = np.zeros((100, 200), dtype=np.float32)
+        result = _shape_2d(arr)
+        assert result == (100, 200)
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+
+    def test_shape_2d_with_3d_array(self) -> None:
+        """_shape_2d extracts first two dimensions from 3D array."""
+        from transformation_portal.lux_depth_v3.orchestrator import _shape_2d
+
+        arr = np.zeros((100, 200, 3), dtype=np.float32)
+        result = _shape_2d(arr)
+        assert result == (100, 200)
+
+    def test_shape_2d_returns_int_types(self) -> None:
+        """_shape_2d returns Python ints, not numpy int types."""
+        from transformation_portal.lux_depth_v3.orchestrator import _shape_2d
+
+        arr = np.zeros((100, 200), dtype=np.float32)
+        height, width = _shape_2d(arr)
+        assert type(height) is int
+        assert type(width) is int
+
+    def test_shape_2d_rejects_1d_array(self) -> None:
+        """_shape_2d raises IndexError for 1D array."""
+        from transformation_portal.lux_depth_v3.orchestrator import _shape_2d
+
+        arr = np.zeros((100,), dtype=np.float32)
+        with pytest.raises(IndexError, match="at least 2 dimensions"):
+            _shape_2d(arr)
+
+    def test_shape_2d_rejects_0d_array(self) -> None:
+        """_shape_2d raises IndexError for 0D (scalar) array."""
+        from transformation_portal.lux_depth_v3.orchestrator import _shape_2d
+
+        arr = np.array(5.0)
+        with pytest.raises(IndexError, match="at least 2 dimensions"):
+            _shape_2d(arr)
+
+
 PIPELINE_PACKAGE = "transformation_portal.lux_depth_v3"
 ORCHESTRATOR_MODULE = "transformation_portal.lux_depth_v3.orchestrator"
 

--- a/tests/materials/test_materials_v3_orchestrator_integration.py
+++ b/tests/materials/test_materials_v3_orchestrator_integration.py
@@ -114,8 +114,12 @@ def test_materials_v3_process_integration(tmp_path, mock_depth_backend, mock_da3
     assert "timing_ms" in pixel_ops
 
 
-def test_run_materials_v3_stage_persists_mask_artifact_and_sets_metadata(tmp_path, mock_depth_backend, mock_da3_available):
-    """Materials V3 stage should persist segmentation mask artifacts and merge metadata."""
+def test_run_materials_v3_stage_aligns_v2_handoff_artifacts_and_sets_metadata(
+    tmp_path,
+    mock_depth_backend,
+    mock_da3_available,
+):
+    """Materials V3 stage should align persisted handoff artifacts to the depth artifact shape."""
     config = EnhanceConfig(
         enable_materials_v3=True,
         apply_pixel_ops=True,
@@ -127,10 +131,11 @@ def test_run_materials_v3_stage_persists_mask_artifact_and_sets_metadata(tmp_pat
     preprocessed_array = np.zeros((8, 8, 3), dtype=np.float32)
     depth_map = np.ones((8, 8), dtype=np.float32)
     glass_mask = np.ones((8, 8), dtype=np.float32)
+    enhanced_image = np.linspace(0.0, 1.0, 8 * 8 * 3, dtype=np.float32).reshape(8, 8, 3)
     output_key = Path("nested/image_01")
 
     materials_result = {
-        "enhanced_image": None,
+        "enhanced_image": enhanced_image,
         "materials_v3_response_plan": {"per_class": {}},
         "materials_v3_pixel_ops": {"applied": [], "blocked": []},
         "materials_v3_metadata": {
@@ -152,14 +157,24 @@ def test_run_materials_v3_stage_persists_mask_artifact_and_sets_metadata(tmp_pat
                     preprocessed_array=preprocessed_array,
                     depth_map=depth_map,
                     output_key=output_key,
+                    artifact_shape=(10, 12),
                 )
 
     assert result is materials_result
-    assert enhanced_path is None
+    assert enhanced_path is not None
+    assert enhanced_path.exists()
+
+    from PIL import Image
+
+    with Image.open(enhanced_path) as enhanced_image_file:
+        assert enhanced_image_file.size == (12, 10)
 
     segmentation_metadata = result["materials_v3_metadata"]["segmentation_metadata"]
     assert segmentation_metadata["clip_runtime"]["weights_source"] == "cache_path"
     assert segmentation_metadata["mask_artifact_format"] == "npz"
+    assert segmentation_metadata["processing_shape"] == [8, 8]
+    assert segmentation_metadata["v2_handoff_shape"] == [10, 12]
+    assert segmentation_metadata["mask_artifact_shape"] == [10, 12]
 
     mask_artifact_path = Path(segmentation_metadata["mask_artifact_path"])
     assert mask_artifact_path == orchestrator._segmentation_mask_artifact_path(output_key)
@@ -169,9 +184,10 @@ def test_run_materials_v3_stage_persists_mask_artifact_and_sets_metadata(tmp_pat
         assert set(data.files) == {"glass"}
         loaded_mask = np.asarray(data["glass"])
 
-    assert loaded_mask.shape == glass_mask.shape
+    assert loaded_mask.shape == (10, 12)
     assert loaded_mask.dtype == np.float32
-    assert np.array_equal(loaded_mask, glass_mask)
+    assert result["material_masks"]["glass"].shape == (10, 12)
+    assert float(loaded_mask.mean()) == pytest.approx(1.0, rel=1e-6, abs=1e-6)
 
 
 def test_materials_v3_manifest_integration(tmp_path, mock_depth_backend, mock_da3_available):
@@ -406,6 +422,8 @@ def test_apex_v2_preflight_rejects_non_canonical_fastpath(tmp_path, mock_depth_b
 
 def test_apex_v2_preflight_accepts_canonical_handoff(tmp_path, mock_depth_backend, mock_da3_available):
     """APEX strict mode should allow V2 preflight only with canonical enhanced input + masks."""
+    from PIL import Image
+
     config = EnhanceConfig(
         quality_tier="apex",
         enable_materials_v3=True,
@@ -420,19 +438,53 @@ def test_apex_v2_preflight_accepts_canonical_handoff(tmp_path, mock_depth_backen
     output_key = Path("image_01")
     depth_path = tmp_path / "depth" / "image_depth.png"
     depth_path.parent.mkdir(parents=True, exist_ok=True)
-    depth_path.write_bytes(b"depth")
+    Image.fromarray(np.full((8, 8), 128, dtype=np.uint8), mode="L").save(depth_path)
 
     expected_path = orchestrator._expected_materials_v3_enhanced_path(output_key)
     expected_path.parent.mkdir(parents=True, exist_ok=True)
-    expected_path.write_bytes(b"enhanced")
+    Image.fromarray(np.full((8, 8, 3), 64, dtype=np.uint8), mode="RGB").save(expected_path)
 
     orchestrator._enforce_apex_v2_canonical_input_preflight(
         depth_path=depth_path,
         output_key=output_key,
         v2_input_path=expected_path,
         enhanced_image_path=expected_path,
-        materials_v3_result={"material_masks": {"glass": np.ones((2, 2), dtype=np.float32)}},
+        materials_v3_result={"material_masks": {"glass": np.ones((8, 8), dtype=np.float32)}},
     )
+
+
+def test_apex_v2_preflight_rejects_dimension_drift(tmp_path, mock_depth_backend, mock_da3_available):
+    """APEX strict mode should fail before V2 when image, depth, and mask shapes drift."""
+    from PIL import Image
+
+    config = EnhanceConfig(
+        quality_tier="apex",
+        enable_materials_v3=True,
+        enable_material_segmentation=True,
+        material_segmentation_backend="efficientsam",
+        strict_backend=True,
+        depth_device="cpu",
+        enable_v2=False,
+    )
+    orchestrator = EnhanceOrchestrator(config, tmp_path)
+
+    output_key = Path("image_01")
+    depth_path = tmp_path / "depth" / "image_depth.png"
+    depth_path.parent.mkdir(parents=True, exist_ok=True)
+    Image.fromarray(np.full((8, 8), 128, dtype=np.uint8), mode="L").save(depth_path)
+
+    expected_path = orchestrator._expected_materials_v3_enhanced_path(output_key)
+    expected_path.parent.mkdir(parents=True, exist_ok=True)
+    Image.fromarray(np.full((6, 6, 3), 64, dtype=np.uint8), mode="RGB").save(expected_path)
+
+    with pytest.raises(RuntimeError, match="dimension drift"):
+        orchestrator._enforce_apex_v2_canonical_input_preflight(
+            depth_path=depth_path,
+            output_key=output_key,
+            v2_input_path=expected_path,
+            enhanced_image_path=expected_path,
+            materials_v3_result={"material_masks": {"glass": np.ones((8, 8), dtype=np.float32)}},
+        )
 
 
 def test_apex_cached_depth_recomputes_materials_for_canonical_handoff(tmp_path, mock_depth_backend, mock_da3_available):
@@ -467,7 +519,8 @@ def test_apex_cached_depth_recomputes_materials_for_canonical_handoff(tmp_path, 
         "materials_v3_metadata": {"version": "3.1"},
     }
 
-    def _run_stage(*, preprocessed_array, depth_map, output_key):  # noqa: ARG001
+    def _run_stage(*, preprocessed_array, depth_map, output_key, artifact_shape):  # noqa: ARG001
+        assert artifact_shape == (4, 4)
         expected_path.write_bytes(b"enhanced")
         return recomputed_result, 0.321, expected_path
 

--- a/tests/materials/test_materials_v3_orchestrator_integration.py
+++ b/tests/materials/test_materials_v3_orchestrator_integration.py
@@ -521,6 +521,120 @@ def test_apex_v2_preflight_rejects_dimension_drift(tmp_path, mock_depth_backend,
         )
 
 
+def test_apex_v2_preflight_rejects_in_memory_mask_shape_drift_with_structured_gate_error(
+    tmp_path,
+    mock_depth_backend,
+    mock_da3_available,
+):
+    """APEX strict mode should surface inconsistent in-memory mask shapes as structured gate errors."""
+    from PIL import Image
+
+    config = EnhanceConfig(
+        quality_tier="apex",
+        enable_materials_v3=True,
+        enable_material_segmentation=True,
+        material_segmentation_backend="efficientsam",
+        strict_backend=True,
+        depth_device="cpu",
+        enable_v2=True,
+    )
+    orchestrator = EnhanceOrchestrator(config, tmp_path)
+    orchestrator.v2_runner = MagicMock()
+
+    output_key = Path("image_01")
+    depth_path = tmp_path / "depth" / "image_depth.png"
+    depth_path.parent.mkdir(parents=True, exist_ok=True)
+    Image.fromarray(np.full((8, 8), 128, dtype=np.uint8), mode="L").save(depth_path)
+
+    expected_path = orchestrator._expected_materials_v3_enhanced_path(output_key)
+    expected_path.parent.mkdir(parents=True, exist_ok=True)
+    Image.fromarray(np.full((8, 8, 3), 64, dtype=np.uint8), mode="RGB").save(expected_path)
+
+    with pytest.raises(ApexStrictGateError) as exc_info:
+        orchestrator._enforce_apex_v2_canonical_input_preflight(
+            depth_path=depth_path,
+            output_key=output_key,
+            v2_input_path=expected_path,
+            enhanced_image_path=expected_path,
+            materials_v3_result={
+                "material_masks": {
+                    "glass": np.ones((8, 8), dtype=np.float32),
+                    "metal": np.ones((6, 6), dtype=np.float32),
+                }
+            },
+        )
+
+    assert exc_info.value.code == "APEX_MATERIAL_MASK_SHAPE_MISMATCH"
+    assert exc_info.value.details == {
+        "source": "material_masks",
+        "material_key": "metal",
+        "expected_mask_shape": [8, 8],
+        "observed_mask_shape": [6, 6],
+    }
+
+
+def test_apex_v2_preflight_rejects_persisted_mask_shape_drift_with_structured_gate_error(
+    tmp_path,
+    mock_depth_backend,
+    mock_da3_available,
+):
+    """APEX strict mode should surface persisted mask-shape drift as structured gate errors."""
+    from PIL import Image
+
+    config = EnhanceConfig(
+        quality_tier="apex",
+        enable_materials_v3=True,
+        enable_material_segmentation=True,
+        material_segmentation_backend="efficientsam",
+        strict_backend=True,
+        depth_device="cpu",
+        enable_v2=True,
+    )
+    orchestrator = EnhanceOrchestrator(config, tmp_path)
+    orchestrator.v2_runner = MagicMock()
+
+    output_key = Path("image_01")
+    depth_path = tmp_path / "depth" / "image_depth.png"
+    depth_path.parent.mkdir(parents=True, exist_ok=True)
+    Image.fromarray(np.full((8, 8), 128, dtype=np.uint8), mode="L").save(depth_path)
+
+    expected_path = orchestrator._expected_materials_v3_enhanced_path(output_key)
+    expected_path.parent.mkdir(parents=True, exist_ok=True)
+    Image.fromarray(np.full((8, 8, 3), 64, dtype=np.uint8), mode="RGB").save(expected_path)
+
+    mask_artifact_path = tmp_path / "materials" / "mask_bundle.npz"
+    mask_artifact_path.parent.mkdir(parents=True, exist_ok=True)
+    np.savez(
+        mask_artifact_path,
+        glass=np.ones((8, 8), dtype=np.float32),
+        metal=np.ones((6, 6), dtype=np.float32),
+    )
+
+    with pytest.raises(ApexStrictGateError) as exc_info:
+        orchestrator._enforce_apex_v2_canonical_input_preflight(
+            depth_path=depth_path,
+            output_key=output_key,
+            v2_input_path=expected_path,
+            enhanced_image_path=expected_path,
+            materials_v3_result={
+                "materials_v3_metadata": {
+                    "segmentation_metadata": {
+                        "mask_artifact_path": str(mask_artifact_path),
+                    }
+                }
+            },
+        )
+
+    assert exc_info.value.code == "APEX_MATERIAL_MASK_SHAPE_MISMATCH"
+    assert exc_info.value.details == {
+        "source": "mask_artifact",
+        "mask_artifact_path": str(mask_artifact_path),
+        "material_key": "metal",
+        "expected_mask_shape": [8, 8],
+        "observed_mask_shape": [6, 6],
+    }
+
+
 def test_apex_cached_depth_recomputes_materials_for_canonical_handoff(tmp_path, mock_depth_backend, mock_da3_available):
     """APEX strict mode should recompute Materials V3 when cached depth lacks canonical handoff artifacts."""
     config = EnhanceConfig(

--- a/tests/materials/test_materials_v3_orchestrator_integration.py
+++ b/tests/materials/test_materials_v3_orchestrator_integration.py
@@ -389,8 +389,8 @@ def test_apex_strict_gate_not_applied_outside_apex(tmp_path, mock_depth_backend,
     orchestrator._enforce_apex_materials_gate({"materials": {}})
 
 
-def test_apex_v2_preflight_rejects_non_canonical_fastpath(tmp_path, mock_depth_backend, mock_da3_available):
-    """APEX strict mode should fail before V2 when cached fast-path drifts from canonical stem."""
+def test_apex_v2_preflight_skips_when_v2_disabled(tmp_path, mock_depth_backend, mock_da3_available):
+    """APEX+Materials flows with V2 disabled must not fail on the V2-only preflight invariant."""
     config = EnhanceConfig(
         quality_tier="apex",
         enable_materials_v3=True,
@@ -401,6 +401,38 @@ def test_apex_v2_preflight_rejects_non_canonical_fastpath(tmp_path, mock_depth_b
         enable_v2=False,
     )
     orchestrator = EnhanceOrchestrator(config, tmp_path)
+
+    depth_path = tmp_path / "depth" / "image_depth.png"
+    depth_path.parent.mkdir(parents=True, exist_ok=True)
+    depth_path.write_bytes(b"depth")
+
+    non_canonical_input = tmp_path / "input" / "image.png"
+    non_canonical_input.parent.mkdir(parents=True, exist_ok=True)
+    non_canonical_input.write_bytes(b"raw")
+
+    # Must not raise even though the input is not canonical: V2 is disabled.
+    orchestrator._enforce_apex_v2_canonical_input_preflight(
+        depth_path=depth_path,
+        output_key=Path("image_01"),
+        v2_input_path=non_canonical_input,
+        enhanced_image_path=None,
+        materials_v3_result={"materials_v3_metadata": {"version": "3.1"}},
+    )
+
+
+def test_apex_v2_preflight_rejects_non_canonical_fastpath(tmp_path, mock_depth_backend, mock_da3_available):
+    """APEX strict mode should fail before V2 when cached fast-path drifts from canonical stem."""
+    config = EnhanceConfig(
+        quality_tier="apex",
+        enable_materials_v3=True,
+        enable_material_segmentation=True,
+        material_segmentation_backend="efficientsam",
+        strict_backend=True,
+        depth_device="cpu",
+        enable_v2=True,
+    )
+    orchestrator = EnhanceOrchestrator(config, tmp_path)
+    orchestrator.v2_runner = MagicMock()
 
     depth_path = tmp_path / "depth" / "image_depth.png"
     depth_path.parent.mkdir(parents=True, exist_ok=True)
@@ -431,9 +463,10 @@ def test_apex_v2_preflight_accepts_canonical_handoff(tmp_path, mock_depth_backen
         material_segmentation_backend="efficientsam",
         strict_backend=True,
         depth_device="cpu",
-        enable_v2=False,
+        enable_v2=True,
     )
     orchestrator = EnhanceOrchestrator(config, tmp_path)
+    orchestrator.v2_runner = MagicMock()
 
     output_key = Path("image_01")
     depth_path = tmp_path / "depth" / "image_depth.png"
@@ -464,9 +497,10 @@ def test_apex_v2_preflight_rejects_dimension_drift(tmp_path, mock_depth_backend,
         material_segmentation_backend="efficientsam",
         strict_backend=True,
         depth_device="cpu",
-        enable_v2=False,
+        enable_v2=True,
     )
     orchestrator = EnhanceOrchestrator(config, tmp_path)
+    orchestrator.v2_runner = MagicMock()
 
     output_key = Path("image_01")
     depth_path = tmp_path / "depth" / "image_depth.png"

--- a/tests/test_batch_processing.py
+++ b/tests/test_batch_processing.py
@@ -1141,3 +1141,79 @@ class TestEnhanceBatch:
                     assert result["status"] == "error"
                     assert result["error_code"] == "APEX_DEPTH_SATURATION_HIGH"
                     assert result["error_details"] == expected_details
+
+    def test_enhance_batch_sequential_preserves_attempt_history_for_apex_gate_failures(self, batch_temp_workspace):
+        """Sequential batch errors should retain the failed attempt provenance from Stage A."""
+        import numpy as np
+
+        from transformation_portal.depth.backends.protocol import DepthResult
+
+        config = EnhanceConfig(
+            model_variant=ModelVariant.METRIC_LARGE,
+            depth_backend="da3",
+            depth_device="cpu",
+            quality_tier="apex",
+            enable_v2=False,
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+
+            with patch("transformation_portal.lux_depth_v3.orchestrator.DepthBackendRegistry") as mock_registry_class:
+                mock_backend = Mock()
+                mock_backend.ensure_available.return_value = None
+                mock_backend.name = "da3"
+                mock_backend.compute.return_value = DepthResult(
+                    depth_map=np.ones((64, 64), dtype=np.float32),
+                    original_image=np.ones((64, 64, 3), dtype=np.uint8),
+                    metadata={},
+                    depth_units="relative",
+                    backend_id="da3",
+                    device="cpu",
+                )
+
+                mock_registry = Mock()
+                mock_registry.get_backend.return_value = mock_backend
+                mock_registry_class.return_value = mock_registry
+
+                orchestrator = EnhanceOrchestrator(
+                    config=config,
+                    output_root=tmpdir_path,
+                )
+                orchestrator._use_parallel = False
+                orchestrator.postprocessor = Mock(process=lambda result: result)
+
+                expected_details = {
+                    "passed": False,
+                    "failure_codes": ["APEX_DEPTH_SATURATION_LOW"],
+                    "metrics": {"saturation_low_fraction": 0.031},
+                    "thresholds": {"saturation_low_fraction_max": 0.02},
+                    "shape_context": {
+                        "gate_evaluated_shape": [64, 64],
+                        "native_shape": [64, 64],
+                        "artifact_shape": [100, 100],
+                    },
+                }
+
+                with patch.object(
+                    orchestrator,
+                    "_enforce_apex_depth_validity_gate",
+                    side_effect=ApexStrictGateError(
+                        "APEX_DEPTH_SATURATION_LOW",
+                        "APEX depth validity gate failed: APEX_DEPTH_SATURATION_LOW",
+                        details=expected_details,
+                    ),
+                ):
+                    results = orchestrator.enhance_batch(batch_temp_workspace["input_dir"])
+
+                assert len(results) == 3
+                for result in results:
+                    assert result["status"] == "error"
+                    assert result["error_code"] == "APEX_DEPTH_SATURATION_LOW"
+                    assert result["error_details"] == expected_details
+                    assert result["selected_attempt_index"] is None
+                    assert len(result["attempts"]) == 1
+                    assert result["attempts"][0]["backend"] == "da3"
+                    assert result["attempts"][0]["failure_kind"] == "semantic"
+                    assert result["attempts"][0]["error_code"] == "APEX_DEPTH_SATURATION_LOW"
+                    assert result["attempts"][0]["error_details"] == expected_details

--- a/tests/test_orchestrator_backend_integration.py
+++ b/tests/test_orchestrator_backend_integration.py
@@ -671,6 +671,65 @@ def test_enhance_image_reuses_initialized_backend_metadata_without_recapture(tmp
     capture_mock.assert_not_called()
 
 
+def test_apex_gate_evaluates_native_depth_grid_before_artifact_resize(tmp_path, mock_da3_available):
+    """APEX gate should inspect the backend/native grid, not the resized depth artifact."""
+    import json
+
+    from PIL import Image
+
+    from transformation_portal.lux_depth_v3.input_manager import ImageInput
+
+    test_image = tmp_path / "native_grid_gate.png"
+    Image.new("RGB", (65, 65), color="white").save(test_image)
+
+    config = EnhanceConfig(
+        depth_backend="da3",
+        depth_device="cpu",
+        enable_v2=False,
+        quality_tier="apex",
+    )
+    orchestrator = EnhanceOrchestrator(config, tmp_path)
+    orchestrator.postprocessor = Mock(process=lambda result: result)
+
+    seen: dict[str, tuple[int, int] | None] = {
+        "gate_shape": None,
+        "native_shape": None,
+        "artifact_shape": None,
+    }
+
+    def _capture_gate(depth_map, depth_units=None, *, native_shape=None, artifact_shape=None):  # noqa: ARG001
+        seen["gate_shape"] = tuple(int(value) for value in depth_map.shape[:2])
+        seen["native_shape"] = tuple(int(value) for value in native_shape)
+        seen["artifact_shape"] = tuple(int(value) for value in artifact_shape)
+        return {
+            "passed": True,
+            "failure_codes": [],
+            "warnings": [],
+            "metrics": {},
+            "thresholds": {},
+            "shape_context": {
+                "gate_evaluated_shape": list(seen["gate_shape"]),
+                "native_shape": list(seen["native_shape"]),
+                "artifact_shape": list(seen["artifact_shape"]),
+            },
+        }
+
+    with patch.object(orchestrator.depth_backend, "compute", return_value=_make_depth_result(width=56, height=56)):
+        with patch.object(orchestrator, "_enforce_apex_depth_validity_gate", side_effect=_capture_gate):
+            result = orchestrator.enhance_image(ImageInput(path=test_image))
+
+    assert result["status"] == "ok"
+    assert seen["gate_shape"] == (56, 56)
+    assert seen["native_shape"] == (56, 56)
+    assert seen["artifact_shape"] == (65, 65)
+
+    manifest = json.loads(Path(result["manifest"]).read_text())
+    depth_stats = manifest["depth"]["stats"]
+    assert depth_stats["native_shape"] == [56, 56]
+    assert depth_stats["artifact_shape"] == [65, 65]
+    assert depth_stats["gate_evaluated_shape"] == [56, 56]
+
+
 def test_runtime_operational_failure_falls_back_to_da2_with_attempt_provenance(tmp_path):
     """Operational failure should fallback to DA2 and persist attempts in metadata."""
     import json

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -503,6 +503,28 @@ class TestJSONSerialization:
         assert restored.input.file_path == valid_provenance_metadata.input.file_path
         assert restored.exif == valid_provenance_metadata.exif
 
+    def test_roundtrip_serialization_preserves_warning_classification(
+        self,
+        valid_provenance_metadata: ProvenanceMetadata,
+    ):
+        """Optional warning classification metadata should survive serialization roundtrip."""
+        valid_provenance_metadata.warning_classification = {
+            "exiftool": {
+                "benign": [
+                    {
+                        "tag": "ExifTool:Warning",
+                        "message": "[minor] Possibly incorrect maker notes offsets (fix by -71244?)",
+                        "code": "EXIFTOOL_MAKERNOTE_OFFSET_WARNING",
+                        "classification": "benign",
+                    }
+                ],
+                "actionable": [],
+            }
+        }
+
+        restored = ProvenanceMetadata.from_dict(valid_provenance_metadata.to_dict())
+        assert restored.warning_classification == valid_provenance_metadata.warning_classification
+
 
 # =============================================================================
 # Test: Sidecar File Writing & Reading
@@ -651,6 +673,33 @@ class TestProvenanceCapture:
             assert provenance.exif  # Should have EXIF data
             assert provenance.toolchain["python_version"]
             assert provenance.ingest_context.config_fingerprint == config_fingerprint
+
+    def test_capture_provenance_classifies_benign_exiftool_warning_without_mutating_exif(
+        self,
+        sample_tiff_image: Path,
+        mock_exiftool_available,
+    ):
+        """Known minor maker-note warnings should be classified as benign without altering raw EXIF."""
+        warning_message = "[minor] Possibly incorrect maker notes offsets (fix by -71244?)"
+        exif_payload = {
+            "ExifTool:Warning": warning_message,
+            "EXIF:Make": "DJI",
+            "EXIF:Model": "FC9113",
+        }
+
+        with patch("transformation_portal.lux_depth_v3.provenance.extract_exif_metadata", return_value=exif_payload):
+            provenance = capture_provenance(
+                image_path=sample_tiff_image,
+                config_fingerprint="sha256:" + "f" * 64,
+                repo_root=None,
+            )
+
+        assert provenance.exif["ExifTool:Warning"] == warning_message
+        assert provenance.warning_classification is not None
+        classified = provenance.warning_classification["exiftool"]
+        assert classified["actionable"] == []
+        assert classified["benign"][0]["code"] == "EXIFTOOL_MAKERNOTE_OFFSET_WARNING"
+        assert classified["benign"][0]["message"] == warning_message
 
     def test_capture_provenance_file_not_found(self, tmp_path: Path):
         """Test provenance capture fails on non-existent file."""


### PR DESCRIPTION
## Summary
- evaluate the APEX depth validity gate on the native backend grid while preserving source-sized depth artifacts
- retain depth attempt diagnostics and selected attempt state on Stage A failures
- align Materials V3 image and mask handoff artifacts to the canonical depth dimensions before V2 and fail fast on drift
- classify the known benign DJI ExifTool maker-note warning without dropping the raw EXIF payload

## Validation
- `PRE_COMMIT_HOME=/tmp/pre-commit PATH=/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin:$PATH pre-commit run --files src/transformation_portal/lux_depth_v3/orchestrator.py src/transformation_portal/lux_depth_v3/provenance.py tests/materials/test_materials_v3_orchestrator_integration.py tests/test_batch_processing.py tests/test_orchestrator_backend_integration.py tests/test_provenance.py --show-diff-on-failure`
- `pytest tests/materials/test_materials_v3_orchestrator_integration.py tests/test_orchestrator_backend_integration.py tests/test_batch_processing.py tests/test_provenance.py`
- `make test-fast`

## Notes
- reproduced `DJI_0025 2.DNG` end to end with aligned Materials V3 -> V2 handoff and benign warning classification in provenance
- reproduced `DJI_0018.DNG` on April 10, 2026 and it still fails `APEX_DEPTH_SATURATION_LOW` on the native grid, so this PR fixes telemetry and handoff drift but does not relax the gate