### PR TITLE
fix: harden Python bootstrap and env recovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,9 +3,10 @@
 Quick reference for common workflows and commands in this repo.
 
 ## Common commands (Makefile)
-- `make venv` create local `.venv` if missing.
+- `make venv` create local `.venv` with a Python 3.11+ interpreter, or fail closed if an existing `.venv` is unsupported.
 - `make setup` install package in editable mode.
-- `make install-core` install core runtime + dev tooling dependencies (with constraints if present).
+- `make install-core` install the pinned core runtime + dev tooling lockfiles into `.venv`, install the project editable with `--no-deps`, and run `pip check`.
+- `make repair-core-venv` recreate `.venv`, reinstall the pinned core environment, and re-run `pip check`.
 - `make install-ml` disabled; no trusted checked-in umbrella ML lockfile contract.
 - `make install-ml-core` install the platform-specific checked-in ML core baseline selected from the local OS/architecture.
 - `make install-ml-raw` disabled; no trusted checked-in RAW lockfile contract.
@@ -44,7 +45,7 @@ Quick reference for common workflows and commands in this repo.
 - `make quality-check` run lint + workflow validation + the root-file placement check.
 - `make fix-quality` auto-fix quality issues (`scripts/auto_fix_quality.py --fix-all`).
 - `make check-quality` dry-run quality auto-fix checks (`scripts/auto_fix_quality.py --dry-run`).
-- `make check-environment` run pre-flight environment validation (`scripts/validation/check_local_environment.py`).
+- `make check-environment` run pre-flight environment validation through the resolved repo interpreter.
 - `make check-worktree` check if git worktree is clean after builds (`scripts/validation/check_worktree_clean.sh`).
 - `make validate-ci` validate GitHub Actions configs plus dependency-update and Dependabot contracts.
 - `make check-json-serialization` fail when raw `json.dump`/`json.dumps` usage is detected outside approved modules.
@@ -72,10 +73,12 @@ Quick reference for common workflows and commands in this repo.
 - `make docs-clean` remove generated docs output.
 
 ## Environment Validation Scripts
-- `./scripts/validation/check_local_environment.py` unified pre-flight validation for Python, Node, Chrome, and port availability.
-- `./scripts/validation/check_local_environment.py --strict` treat soft failures as hard failures.
-- `./scripts/validation/check_local_environment.py --check python` check only Python version.
-- `./scripts/validation/check_local_environment.py --check node` check only Node.js version (22.x required).
+- `make check-environment` run the canonical pre-flight validation flow.
+- `./.venv/bin/python scripts/validation/check_local_environment.py` run the pre-flight validation script directly when you need a specific check.
+- `./.venv/bin/python scripts/validation/check_local_environment.py --strict` treat soft failures as hard failures.
+- `./.venv/bin/python scripts/validation/check_local_environment.py --check python` check only Python version.
+- `./.venv/bin/python scripts/validation/check_local_environment.py --check node` check only Node.js version (22.x required).
+- `./.venv/bin/python scripts/validation/check_local_environment.py --check dependency-health` run `pip check` for the active interpreter.
 - `./scripts/setup/ensure_node_version.sh` Node version enforcement wrapper with version manager detection.
 - `./scripts/validation/run_full_validation_suite.sh` all-in-one validation orchestrator.
 - `./scripts/validation/run_full_validation_suite.sh --quick` skip browser smokes for faster iteration.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 SHELL := /bin/sh
 
-# Resolve a Python interpreter: prefer local venv, otherwise fall back to python3
-PY := $(shell if [ -x .venv/bin/python ]; then echo .venv/bin/python; else command -v python3 || command -v python; fi)
+# Resolve Python interpreters at recipe runtime so targets that create or repair
+# .venv immediately switch to the repo interpreter on subsequent lines.
+BOOTSTRAP_PY = $$(./scripts/setup/resolve_python_311.sh)
+PY = $$(if [ -x .venv/bin/python ] && ./.venv/bin/python -c 'import sys; raise SystemExit(0 if sys.version_info[:2] >= (3, 11) else 1)' >/dev/null 2>&1; then printf '%s' .venv/bin/python; else ./scripts/setup/resolve_python_311.sh; fi)
 
 # Common subsets (fast tests avoid heavy/optional paths)
 FAST_TESTS := \
@@ -24,7 +26,7 @@ PHASE6_SMOKE_TESTS := \
 	tests/test_lux_render_pipeline_smoke.py \
 	tests/lux_depth_v3/test_orchestrator_smoke.py
 
-.PHONY: help test-fast test-novideo test-full test-integration test-structure test-utils test-orchestrator-contract test-orchestrator-http-contract test-portal-contract test-frontdoor-contract seed-frontdoor-user run-frontdoor-local validate-orchestrator-http validate-portal-browser validate-frontdoor-browser validate-frontdoor-deployment-gate audit-pipeline-readiness coverage-fast-scope venv setup clean \
+.PHONY: help test-fast test-novideo test-full test-integration test-structure test-utils test-orchestrator-contract test-orchestrator-http-contract test-portal-contract test-frontdoor-contract seed-frontdoor-user run-frontdoor-local validate-orchestrator-http validate-portal-browser validate-frontdoor-browser validate-frontdoor-deployment-gate audit-pipeline-readiness coverage-fast-scope venv repair-core-venv setup clean \
         lint lint-parity ci ci-full pre-commit install-hooks quality-check fix-quality validate-ci organize-docs check-json-serialization check-piptools-cache \
         check-yaml-governance check-stale-docs lock lock-prod lock-ci lock-dev install-core install-ml install-ml-core install-ml-raw install-ml-sam2 install-ml-coreml docs docs-clean \
         check-test-markers check-ci-sync check-environment validate-full validate-quick clean-frontdoor clean-all check-worktree
@@ -32,7 +34,8 @@ PHASE6_SMOKE_TESTS := \
 help:
 	@echo "Targets:"
 	@echo "  setup              Install package in editable mode (pip install -e .)"
-	@echo "  install-core       Install core dependencies with constraints"
+	@echo "  install-core       Install pinned core runtime + dev tooling dependencies into .venv"
+	@echo "  repair-core-venv   Recreate .venv and reinstall the pinned core environment"
 	@echo "  install-ml         Disabled: no trusted umbrella ML lockfile contract"
 	@echo "  install-ml-core    Install ML core layer only (cross-platform baseline)"
 	@echo "  install-ml-raw     Disabled: no trusted checked-in RAW lockfile contract"
@@ -94,10 +97,22 @@ help:
 	@echo "  docs-clean         Clean generated documentation files"
 
 venv:
-	@if [ ! -x .venv/bin/python ]; then \
-		"$(PY)" -m venv .venv && echo "Created .venv"; \
+	@if [ -x .venv/bin/python ]; then \
+		if ./.venv/bin/python -c 'import sys; raise SystemExit(0 if sys.version_info[:2] >= (3, 11) else 1)' >/dev/null 2>&1; then \
+			echo ".venv already present"; \
+		else \
+			venv_version="$$(./.venv/bin/python -V 2>&1 || echo 'Python version unavailable')"; \
+			echo "Error: existing .venv is not using Python 3.11+ ($$venv_version)."; \
+			echo "Error: run 'make repair-core-venv' to recreate the repo environment."; \
+			exit 1; \
+		fi; \
+	elif [ -d .venv ]; then \
+		echo "Error: .venv exists but is missing a usable Python interpreter."; \
+		echo "Error: run 'make repair-core-venv' to recreate the repo environment."; \
+		exit 1; \
 	else \
-		echo ".venv already present"; \
+		bootstrap_py="$(BOOTSTRAP_PY)"; \
+		"$$bootstrap_py" -m venv .venv && echo "Created .venv with $$bootstrap_py"; \
 	fi
 
 setup: venv
@@ -105,13 +120,21 @@ setup: venv
 	@"$(PY)" -m pip install -e .
 
 install-core: venv
-	@echo "Installing core dependencies with constraints..."
-	@if [ -f requirements/constraints.txt ]; then \
-		"$(PY)" -m pip install -e ".[dev]" -c requirements/constraints.txt; \
-	else \
-		echo "Warning: requirements/constraints.txt not found, installing without constraints"; \
-		"$(PY)" -m pip install -e ".[dev]"; \
-	fi
+	@echo "Installing pinned core dependencies into .venv..."
+	@./.venv/bin/python -m pip install -r requirements/base.txt -r requirements/dev.txt -c requirements/constraints.txt
+	@./.venv/bin/python -m pip install -e . --no-deps
+	@./.venv/bin/python -m pip check
+
+repair-core-venv:
+	@echo "Recreating repo .venv with a Python 3.11+ interpreter..."
+	@rm -rf .venv
+	@bootstrap_py="$(BOOTSTRAP_PY)"; \
+		"$$bootstrap_py" -m venv .venv
+	@./.venv/bin/python -m pip install -r requirements/base.txt -r requirements/dev.txt -c requirements/constraints.txt
+	@./.venv/bin/python -m pip install -e . --no-deps
+	@./.venv/bin/python -m pip check
+	@echo "Repo .venv repaired."
+	@echo "Reminder: install Depth Anything 3 into .venv-da3 with ./scripts/setup/install_da3_runtime.sh"
 
 # ML Layer Install Targets
 # These support fine-grained ML capability installation per the layered strategy.

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL := /bin/sh
 # Resolve Python interpreters at recipe runtime so targets that create or repair
 # .venv immediately switch to the repo interpreter on subsequent lines.
 BOOTSTRAP_PY = $$(./scripts/setup/resolve_python_311.sh)
-PY = $$(if [ -x .venv/bin/python ] && ./.venv/bin/python -c 'import sys; raise SystemExit(0 if sys.version_info[:2] >= (3, 11) else 1)' >/dev/null 2>&1; then printf '%s' .venv/bin/python; else ./scripts/setup/resolve_python_311.sh; fi)
+PY = $$(./scripts/setup/resolve_python_311.sh)
 
 # Common subsets (fast tests avoid heavy/optional paths)
 FAST_TESTS := \
@@ -97,11 +97,17 @@ help:
 	@echo "  docs-clean         Clean generated documentation files"
 
 venv:
-	@if [ -x .venv/bin/python ]; then \
-		if ./.venv/bin/python -c 'import sys; raise SystemExit(0 if sys.version_info[:2] >= (3, 11) else 1)' >/dev/null 2>&1; then \
+	@repo_venv_py=""; \
+	if [ -x .venv/bin/python ]; then \
+		repo_venv_py=.venv/bin/python; \
+	elif [ -x .venv/Scripts/python.exe ]; then \
+		repo_venv_py=.venv/Scripts/python.exe; \
+	fi; \
+	if [ -n "$$repo_venv_py" ]; then \
+		if "$$repo_venv_py" -c 'import sys; raise SystemExit(0 if sys.version_info[:2] >= (3, 11) else 1)' >/dev/null 2>&1; then \
 			echo ".venv already present"; \
 		else \
-			venv_version="$$(./.venv/bin/python -V 2>&1 || echo 'Python version unavailable')"; \
+			venv_version="$$("$$repo_venv_py" -V 2>&1 || echo 'Python version unavailable')"; \
 			echo "Error: existing .venv is not using Python 3.11+ ($$venv_version)."; \
 			echo "Error: run 'make repair-core-venv' to recreate the repo environment."; \
 			exit 1; \
@@ -121,18 +127,18 @@ setup: venv
 
 install-core: venv
 	@echo "Installing pinned core dependencies into .venv..."
-	@./.venv/bin/python -m pip install -r requirements/base.txt -r requirements/dev.txt -c requirements/constraints.txt
-	@./.venv/bin/python -m pip install -e . --no-deps
-	@./.venv/bin/python -m pip check
+	@"$(PY)" -m pip install -r requirements/base.txt -r requirements/dev.txt -c requirements/constraints.txt
+	@"$(PY)" -m pip install -e . --no-deps
+	@"$(PY)" -m pip check
 
 repair-core-venv:
 	@echo "Recreating repo .venv with a Python 3.11+ interpreter..."
 	@rm -rf .venv
 	@bootstrap_py="$(BOOTSTRAP_PY)"; \
 		"$$bootstrap_py" -m venv .venv
-	@./.venv/bin/python -m pip install -r requirements/base.txt -r requirements/dev.txt -c requirements/constraints.txt
-	@./.venv/bin/python -m pip install -e . --no-deps
-	@./.venv/bin/python -m pip check
+	@"$(PY)" -m pip install -r requirements/base.txt -r requirements/dev.txt -c requirements/constraints.txt
+	@"$(PY)" -m pip install -e . --no-deps
+	@"$(PY)" -m pip check
 	@echo "Repo .venv repaired."
 	@echo "Reminder: install Depth Anything 3 into .venv-da3 with ./scripts/setup/install_da3_runtime.sh"
 

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ help:
 	@echo "  validate-full      Run the full validation suite (all checks + browser smokes)"
 	@echo "  validate-quick     Run quick validation (skip browser smokes)"
 	@echo "  audit-pipeline-readiness  Run the local four-pipeline readiness audit"
-	@echo "  venv               Create local .venv if missing"
+	@echo "  venv               Create or validate .venv with Python 3.11+; fail on unsupported or broken environments"
 	@echo "  clean              Remove Python cache files and build artifacts"
 	@echo "  clean-frontdoor    Remove frontdoor build artifacts (.next)"
 	@echo "  clean-all          Remove all build artifacts (Python + Node)"

--- a/README.md
+++ b/README.md
@@ -250,7 +250,9 @@ See [SETUP_GUIDE.md](docs/guides/SETUP_GUIDE.md) for environment details.
 Use `depth_pro` when you need metric depth and are operating in an explicit research-only workflow.
 
 ```bash
-python3.11 -m venv .venv-depth-pro
+# Use any Python 3.11+ interpreter (e.g., python3.11, python3.12, python3.13)
+# The resolver picks a compatible one automatically:
+"$(./scripts/setup/resolve_python_311.sh)" -m venv .venv-depth-pro
 ./.venv-depth-pro/bin/python -m pip install --upgrade pip depth-pro
 mkdir -p checkpoints
 curl -L https://ml-site.cdn-apple.com/models/depth-pro/depth_pro.pt -o checkpoints/depth_pro.pt

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ See [SETUP_GUIDE.md](docs/guides/SETUP_GUIDE.md) for environment details.
 Use `depth_pro` when you need metric depth and are operating in an explicit research-only workflow.
 
 ```bash
-python3 -m venv .venv-depth-pro
+python3.11 -m venv .venv-depth-pro
 ./.venv-depth-pro/bin/python -m pip install --upgrade pip depth-pro
 mkdir -p checkpoints
 curl -L https://ml-site.cdn-apple.com/models/depth-pro/depth_pro.pt -o checkpoints/depth_pro.pt
@@ -310,6 +310,7 @@ cd Transformation_Portal
 make venv
 source .venv/bin/activate  # Windows: .venv\Scripts\activate
 make install-core
+make check-environment
 lux-depth-v3 --help
 ```
 

--- a/docs/depth_pipeline/DEPTH_PRO_QUICKSTART.md
+++ b/docs/depth_pipeline/DEPTH_PRO_QUICKSTART.md
@@ -7,7 +7,7 @@ This guide helps you get started with Apple's Depth Pro for metric depth estimat
 ### 1. Create a Dedicated Depth Pro Environment
 
 ```bash
-python3 -m venv .venv-depth-pro
+python3.11 -m venv .venv-depth-pro
 ./.venv-depth-pro/bin/python -m pip install --upgrade pip
 ./.venv-depth-pro/bin/python -m pip install depth-pro
 ```

--- a/docs/depth_pipeline/DEPTH_PRO_QUICKSTART.md
+++ b/docs/depth_pipeline/DEPTH_PRO_QUICKSTART.md
@@ -7,7 +7,9 @@ This guide helps you get started with Apple's Depth Pro for metric depth estimat
 ### 1. Create a Dedicated Depth Pro Environment
 
 ```bash
-python3.11 -m venv .venv-depth-pro
+# Use any Python 3.11+ interpreter (e.g., python3.11, python3.12, python3.13).
+# The resolver picks a compatible one automatically:
+"$(./scripts/setup/resolve_python_311.sh)" -m venv .venv-depth-pro
 ./.venv-depth-pro/bin/python -m pip install --upgrade pip
 ./.venv-depth-pro/bin/python -m pip install depth-pro
 ```

--- a/docs/guides/LOCAL_VALIDATION_QUICKSTART.md
+++ b/docs/guides/LOCAL_VALIDATION_QUICKSTART.md
@@ -17,7 +17,7 @@ This guide covers the canonical workflow for validating the Transformation Porta
 Run the pre-flight check to verify your environment:
 
 ```bash
-python scripts/validation/check_local_environment.py
+make check-environment
 ```
 
 This validates:
@@ -221,6 +221,31 @@ Chrome or Chromium not found
 export TP_PORTAL_BROWSER_BINARY="/path/to/chrome"
 ```
 
+### Python Snippet Pasted Into zsh
+
+If you need to run an ad hoc Python snippet, execute it through the repo interpreter instead of pasting raw Python into the shell:
+
+```bash
+.venv/bin/python - <<'PY'
+print("run Python here")
+PY
+```
+
+### Repo venv Drift or Wrong Interpreter
+
+If pre-flight reports the wrong interpreter or `pip check` dependency conflicts, rebuild the core repo environment:
+
+```bash
+make repair-core-venv
+make check-environment
+```
+
+If the conflict mentions `depth-anything-3`, keep DA3 isolated and reinstall it separately:
+
+```bash
+./scripts/setup/install_da3_runtime.sh
+```
+
 ### Build Dirties Worktree
 
 If `make test-frontdoor-contract` or other builds dirty the worktree:
@@ -239,7 +264,7 @@ The frontdoor build should use `TP_NEXT_DIST_DIR=.next-build-verify` for isolati
 
 ```bash
 # Pre-flight check
-python scripts/validation/check_local_environment.py
+make check-environment
 
 # Node version check
 ./scripts/setup/ensure_node_version.sh

--- a/docs/guides/SETUP_GUIDE.md
+++ b/docs/guides/SETUP_GUIDE.md
@@ -19,16 +19,15 @@ This guide walks you through setting up the Transformation Portal with all requi
 git clone https://github.com/RC219805/Transformation_Portal.git
 cd Transformation_Portal
 
-# 2. Create virtual environment (recommended)
-python3 -m venv .venv
+# 2. Create the repo virtual environment
+make venv
 source .venv/bin/activate  # On Windows: .venv\Scripts\activate
 
-# 3. Install core dependencies and CLI
-pip install -r requirements.txt
-pip install -e .
+# 3. Install pinned core dependencies and CLI
+make install-core
 
-# 4. Verify installation
-python scripts/verification/verify_core.py
+# 4. Verify the environment
+make check-environment
 ```
 
 ---
@@ -47,8 +46,8 @@ python scripts/verification/verify_core.py
 Install the core packages required for basic image processing:
 
 ```bash
-pip install -r requirements.txt
-# or from repo root (preferred for contributors):
+make venv
+source .venv/bin/activate
 make install-core
 ```
 
@@ -57,6 +56,7 @@ This installs:
 - **Pillow**: Image I/O and manipulation
 - **scipy**: Scientific computing
 - **typer**: CLI framework and other pinned core utilities
+- the local project in editable mode without re-resolving dependencies outside the checked-in lockfiles
 
 ### Step 2: ML Dependencies (Optional)
 

--- a/scripts/bootstrap/install_ml_stack.sh
+++ b/scripts/bootstrap/install_ml_stack.sh
@@ -71,6 +71,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 REQUIREMENTS_DIR="${REPO_ROOT}/requirements"
+PYTHON_RESOLVER="${REPO_ROOT}/scripts/setup/resolve_python_311.sh"
+PYTHON_BIN=""
 
 # Colors for output
 RED='\033[0;31m'
@@ -168,14 +170,15 @@ check_prerequisites() {
     # Note: Bash version check is handled by auto-exec at script start.
     # If we reach here, bash 4.3+ is guaranteed.
 
-    # Check Python is available
-    if ! command -v python3 &> /dev/null; then
-        log_error "Python 3 is required but not found."
+    if [[ ! -x "${PYTHON_RESOLVER}" ]]; then
+        log_error "Python resolver missing: ${PYTHON_RESOLVER}"
         exit 1
     fi
 
+    PYTHON_BIN="$("${PYTHON_RESOLVER}")"
+
     # Check pip is available
-    if ! python3 -m pip --version &> /dev/null; then
+    if ! "${PYTHON_BIN}" -m pip --version &> /dev/null; then
         log_error "pip is required but not found."
         exit 1
     fi
@@ -199,7 +202,7 @@ check_lockfile() {
 # Build pip command as array for safe quoting
 build_pip_cmd() {
     local -n cmd_array=$1
-    cmd_array=(python3 -m pip install)
+    cmd_array=("${PYTHON_BIN}" -m pip install)
 
     # Add verbose flag if enabled
     if [[ "${VERBOSE}" == "true" ]]; then
@@ -224,12 +227,12 @@ normalize_arch() {
 }
 
 python_platform_os() {
-    python3 -c 'import platform; print(platform.system())'
+    "${PYTHON_BIN}" -c 'import platform; print(platform.system())'
 }
 
 python_platform_arch() {
     local arch
-    arch="$(python3 -c 'import platform; print(platform.machine())')"
+    arch="$("${PYTHON_BIN}" -c 'import platform; print(platform.machine())')"
     normalize_arch "${arch}"
 }
 
@@ -482,6 +485,8 @@ main() {
         log_info "Verbose mode enabled"
     fi
 
+    log_verbose "Using bootstrap/runtime interpreter: ${PYTHON_BIN}"
+
     # Parse and install profiles
     IFS=',' read -ra PROFILES <<< "${PROFILE}"
 
@@ -499,7 +504,7 @@ main() {
 
     log_info "ML stack installation complete!"
     if [[ "${DRY_RUN}" != "true" ]]; then
-        log_info "Verify with: python3 -c 'import torch; print(torch.__version__)'"
+        log_info "Verify with: ${PYTHON_BIN} -c 'import torch; print(torch.__version__)'"
     fi
 }
 

--- a/scripts/setup/README.md
+++ b/scripts/setup/README.md
@@ -32,6 +32,7 @@ the auto-discovered `./.venv-da3/bin/python` contract and by explicit
 **What it does:**
 - Clones Depth Anything 3 into `.runtime/Depth-Anything-3` if it is missing
 - Synchronizes that checkout to the validated default ref unless `--ref` overrides it
+- Resolves a Python 3.11+ bootstrap interpreter (preferring the repo `.venv` when available)
 - Creates the isolated DA3 venv at `./.venv-da3`
 - Installs a pinned DA3-compatible dependency set without upstream `xformers`
 - Captures a runtime package snapshot at `.runtime/da3-pip-freeze.txt`
@@ -63,6 +64,7 @@ auto-discovered `./.venv-raw/bin/python` contract and by explicit
 ```
 
 **What it does:**
+- Resolves a Python 3.11+ bootstrap interpreter (preferring the repo `.venv` when available)
 - Creates the isolated RAW venv at `./.venv-raw`
 - Installs the local project with the `raw` extra into that venv
 - Captures a runtime package snapshot at `.runtime/raw-pip-freeze.txt`

--- a/scripts/setup/install_da3_runtime.sh
+++ b/scripts/setup/install_da3_runtime.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+PYTHON_RESOLVER="${REPO_ROOT}/scripts/setup/resolve_python_311.sh"
 
 CHECKOUT_DIR="${REPO_ROOT}/.runtime/Depth-Anything-3"
 VENV_DIR="${REPO_ROOT}/.venv-da3"
@@ -94,10 +95,12 @@ if ! command -v git >/dev/null 2>&1; then
     exit 1
 fi
 
-if ! command -v python3 >/dev/null 2>&1; then
-    printf '[ERROR] python3 is required but not available on PATH.\n' >&2
+if [[ ! -x "${PYTHON_RESOLVER}" ]]; then
+    printf '[ERROR] Python resolver missing: %s\n' "${PYTHON_RESOLVER}" >&2
     exit 1
 fi
+
+BOOTSTRAP_PYTHON="$("${PYTHON_RESOLVER}")"
 
 mkdir -p "$(dirname "${CHECKOUT_DIR}")"
 
@@ -116,7 +119,8 @@ run git -C "${CHECKOUT_DIR}" clean -fd
 
 if [[ ! -d "${VENV_DIR}" ]]; then
     log "Creating isolated DA3 venv at ${VENV_DIR}"
-    run python3 -m venv "${VENV_DIR}"
+    log "Using bootstrap interpreter: ${BOOTSTRAP_PYTHON}"
+    run "${BOOTSTRAP_PYTHON}" -m venv "${VENV_DIR}"
 fi
 
 PYTHON_BIN="${VENV_DIR}/bin/python"

--- a/scripts/setup/install_raw_runtime.sh
+++ b/scripts/setup/install_raw_runtime.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+PYTHON_RESOLVER="${REPO_ROOT}/scripts/setup/resolve_python_311.sh"
 
 VENV_DIR="${REPO_ROOT}/.venv-raw"
 RUNTIME_METADATA_DIR="${REPO_ROOT}/.runtime"
@@ -89,14 +90,17 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-if ! command -v python3 >/dev/null 2>&1; then
-    printf '[ERROR] python3 is required but not available on PATH.\n' >&2
+if [[ ! -x "${PYTHON_RESOLVER}" ]]; then
+    printf '[ERROR] Python resolver missing: %s\n' "${PYTHON_RESOLVER}" >&2
     exit 1
 fi
 
+BOOTSTRAP_PYTHON="$("${PYTHON_RESOLVER}")"
+
 if [[ ! -d "${VENV_DIR}" ]]; then
     log "Creating isolated RAW venv at ${VENV_DIR}"
-    run python3 -m venv "${VENV_DIR}"
+    log "Using bootstrap interpreter: ${BOOTSTRAP_PYTHON}"
+    run "${BOOTSTRAP_PYTHON}" -m venv "${VENV_DIR}"
 fi
 
 PYTHON_BIN="${VENV_DIR}/bin/python"

--- a/scripts/setup/resolve_python_311.sh
+++ b/scripts/setup/resolve_python_311.sh
@@ -30,9 +30,11 @@ emit_guidance() {
 [ERROR] Transformation Portal requires Python ${MIN_MAJOR}.${MIN_MINOR}+.
 [ERROR] Checked candidates:
 [ERROR]   1. ${REPO_VENV_PYTHON}
-[ERROR]   2. python3.11
-[ERROR]   3. python3
-[ERROR]   4. python
+[ERROR]   2. python3.13
+[ERROR]   3. python3.12
+[ERROR]   4. python3.11
+[ERROR]   5. python3
+[ERROR]   6. python
 [ERROR]
 [ERROR] Install Python ${MIN_MAJOR}.${MIN_MINOR}+ and retry, then run:
 [ERROR]   make venv
@@ -45,6 +47,8 @@ main() {
     local candidate
     for candidate in \
         "${REPO_VENV_PYTHON}" \
+        python3.13 \
+        python3.12 \
         python3.11 \
         python3 \
         python; do

--- a/scripts/setup/resolve_python_311.sh
+++ b/scripts/setup/resolve_python_311.sh
@@ -7,16 +7,10 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
-
-# Platform-aware repo venv interpreter path
-# On Windows (Git Bash/MSYS/Cygwin), check both layouts
-if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" || "$OSTYPE" == "win32" ]]; then
-    REPO_VENV_PYTHON="${REPO_ROOT}/.venv/Scripts/python.exe"
-    REPO_VENV_PYTHON_ALT="${REPO_ROOT}/.venv/bin/python"
-else
-    REPO_VENV_PYTHON="${REPO_ROOT}/.venv/bin/python"
-    REPO_VENV_PYTHON_ALT=""
-fi
+REPO_VENV_CANDIDATES=(
+    "${REPO_ROOT}/.venv/bin/python"
+    "${REPO_ROOT}/.venv/Scripts/python.exe"
+)
 
 MIN_MAJOR=3
 MIN_MINOR=11
@@ -38,45 +32,62 @@ emit_guidance() {
     cat >&2 <<EOF
 [ERROR] Transformation Portal requires Python ${MIN_MAJOR}.${MIN_MINOR}+.
 [ERROR] Checked candidates (in order):
-[ERROR]   1. ${REPO_VENV_PYTHON}
-[ERROR]   2. python3.15, python3.14, python3.13, python3.12, python3.11
-[ERROR]   3. python3
-[ERROR]   4. python
+[ERROR]   1. ${REPO_VENV_CANDIDATES[0]}
+[ERROR]   2. ${REPO_VENV_CANDIDATES[1]}
+[ERROR]   3. versioned python3.N commands on PATH (newest supported first)
+[ERROR]   4. python3
+[ERROR]   5. python
 [ERROR]
 [ERROR] Install Python ${MIN_MAJOR}.${MIN_MINOR}+ and retry, then run:
 [ERROR]   make venv
-[ERROR] If you need to bootstrap manually, use any available Python ${MIN_MAJOR}.${MIN_MINOR}+ interpreter:
+[ERROR] If you need to bootstrap manually, use any available Python ${MIN_MAJOR}.${MIN_MINOR}+ interpreter, for example:
 [ERROR]   python3.13 -m venv .venv
 [ERROR]   python3.12 -m venv .venv
 [ERROR]   python3.11 -m venv .venv
 EOF
 }
 
+discover_versioned_python_candidates() {
+    local path_dir candidate candidate_name minor
+    local discovered=()
+
+    IFS=: read -r -a path_dirs <<< "${PATH:-}"
+    for path_dir in "${path_dirs[@]}"; do
+        [[ -d "$path_dir" ]] || continue
+        for candidate in "$path_dir"/python3.*; do
+            [[ -e "$candidate" ]] || continue
+            candidate_name="${candidate##*/}"
+            if [[ "$candidate_name" =~ ^python3\.([0-9]+)(\.exe)?$ ]]; then
+                minor="${BASH_REMATCH[1]}"
+                (( minor < MIN_MINOR )) && continue
+                discovered+=("${minor}:${candidate_name}")
+            fi
+        done
+    done
+
+    if ((${#discovered[@]})); then
+        printf '%s\n' "${discovered[@]}" | sort -t: -k1,1nr -k2,2 | awk -F: '!seen[$2]++ { print $2 }'
+    fi
+}
+
 main() {
     local candidate
 
-    # First check repo venv (platform-specific path)
-    if is_supported_python "${REPO_VENV_PYTHON}"; then
-        printf '%s\n' "${REPO_VENV_PYTHON}"
-        return 0
-    fi
-
-    # On Windows, also check the alternative layout
-    if [[ -n "${REPO_VENV_PYTHON_ALT:-}" ]] && is_supported_python "${REPO_VENV_PYTHON_ALT}"; then
-        printf '%s\n' "${REPO_VENV_PYTHON_ALT}"
-        return 0
-    fi
-
-    # Probe versioned interpreters from newest to oldest (3.15 down to 3.11)
-    # This future-proofs against newer Python releases
-    for candidate in python3.15 python3.14 python3.13 python3.12 python3.11; do
+    for candidate in "${REPO_VENV_CANDIDATES[@]}"; do
         if is_supported_python "$candidate"; then
-            command -v "$candidate"
+            printf '%s\n' "$candidate"
             return 0
         fi
     done
 
-    # Fallback to generic python3/python if they meet the version requirement
+    while IFS= read -r candidate; do
+        [[ -n "$candidate" ]] || continue
+        if is_supported_python "$candidate"; then
+            command -v "$candidate"
+            return 0
+        fi
+    done < <(discover_versioned_python_candidates)
+
     for candidate in python3 python; do
         if is_supported_python "$candidate"; then
             command -v "$candidate"

--- a/scripts/setup/resolve_python_311.sh
+++ b/scripts/setup/resolve_python_311.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# resolve_python_311.sh
+# Print a usable Python 3.11+ interpreter for this repository.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+REPO_VENV_PYTHON="${REPO_ROOT}/.venv/bin/python"
+
+MIN_MAJOR=3
+MIN_MINOR=11
+
+is_supported_python() {
+    local candidate="$1"
+
+    if [[ "$candidate" == */* ]]; then
+        [[ -x "$candidate" ]] || return 1
+    else
+        candidate="$(command -v "$candidate" 2>/dev/null || true)"
+        [[ -n "$candidate" ]] || return 1
+    fi
+
+    "$candidate" -c 'import sys; raise SystemExit(0 if sys.version_info[:2] >= (3, 11) else 1)' >/dev/null 2>&1
+}
+
+emit_guidance() {
+    cat >&2 <<EOF
+[ERROR] Transformation Portal requires Python ${MIN_MAJOR}.${MIN_MINOR}+.
+[ERROR] Checked candidates:
+[ERROR]   1. ${REPO_VENV_PYTHON}
+[ERROR]   2. python3.11
+[ERROR]   3. python3
+[ERROR]   4. python
+[ERROR]
+[ERROR] Install Python ${MIN_MAJOR}.${MIN_MINOR}+ and retry, then run:
+[ERROR]   make venv
+[ERROR] If you need to bootstrap manually:
+[ERROR]   python3.11 -m venv .venv
+EOF
+}
+
+main() {
+    local candidate
+    for candidate in \
+        "${REPO_VENV_PYTHON}" \
+        python3.11 \
+        python3 \
+        python; do
+        if is_supported_python "$candidate"; then
+            if [[ "$candidate" == */* ]]; then
+                printf '%s\n' "$candidate"
+            else
+                command -v "$candidate"
+            fi
+            return 0
+        fi
+    done
+
+    emit_guidance
+    return 1
+}
+
+main "$@"

--- a/scripts/setup/resolve_python_311.sh
+++ b/scripts/setup/resolve_python_311.sh
@@ -7,7 +7,16 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
-REPO_VENV_PYTHON="${REPO_ROOT}/.venv/bin/python"
+
+# Platform-aware repo venv interpreter path
+# On Windows (Git Bash/MSYS/Cygwin), check both layouts
+if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" || "$OSTYPE" == "win32" ]]; then
+    REPO_VENV_PYTHON="${REPO_ROOT}/.venv/Scripts/python.exe"
+    REPO_VENV_PYTHON_ALT="${REPO_ROOT}/.venv/bin/python"
+else
+    REPO_VENV_PYTHON="${REPO_ROOT}/.venv/bin/python"
+    REPO_VENV_PYTHON_ALT=""
+fi
 
 MIN_MAJOR=3
 MIN_MINOR=11
@@ -28,36 +37,49 @@ is_supported_python() {
 emit_guidance() {
     cat >&2 <<EOF
 [ERROR] Transformation Portal requires Python ${MIN_MAJOR}.${MIN_MINOR}+.
-[ERROR] Checked candidates:
+[ERROR] Checked candidates (in order):
 [ERROR]   1. ${REPO_VENV_PYTHON}
-[ERROR]   2. python3.13
-[ERROR]   3. python3.12
-[ERROR]   4. python3.11
-[ERROR]   5. python3
-[ERROR]   6. python
+[ERROR]   2. python3.15, python3.14, python3.13, python3.12, python3.11
+[ERROR]   3. python3
+[ERROR]   4. python
 [ERROR]
 [ERROR] Install Python ${MIN_MAJOR}.${MIN_MINOR}+ and retry, then run:
 [ERROR]   make venv
-[ERROR] If you need to bootstrap manually:
+[ERROR] If you need to bootstrap manually, use any available Python ${MIN_MAJOR}.${MIN_MINOR}+ interpreter:
+[ERROR]   python3.13 -m venv .venv
+[ERROR]   python3.12 -m venv .venv
 [ERROR]   python3.11 -m venv .venv
 EOF
 }
 
 main() {
     local candidate
-    for candidate in \
-        "${REPO_VENV_PYTHON}" \
-        python3.13 \
-        python3.12 \
-        python3.11 \
-        python3 \
-        python; do
+
+    # First check repo venv (platform-specific path)
+    if is_supported_python "${REPO_VENV_PYTHON}"; then
+        printf '%s\n' "${REPO_VENV_PYTHON}"
+        return 0
+    fi
+
+    # On Windows, also check the alternative layout
+    if [[ -n "${REPO_VENV_PYTHON_ALT:-}" ]] && is_supported_python "${REPO_VENV_PYTHON_ALT}"; then
+        printf '%s\n' "${REPO_VENV_PYTHON_ALT}"
+        return 0
+    fi
+
+    # Probe versioned interpreters from newest to oldest (3.15 down to 3.11)
+    # This future-proofs against newer Python releases
+    for candidate in python3.15 python3.14 python3.13 python3.12 python3.11; do
         if is_supported_python "$candidate"; then
-            if [[ "$candidate" == */* ]]; then
-                printf '%s\n' "$candidate"
-            else
-                command -v "$candidate"
-            fi
+            command -v "$candidate"
+            return 0
+        fi
+    done
+
+    # Fallback to generic python3/python if they meet the version requirement
+    for candidate in python3 python; do
+        if is_supported_python "$candidate"; then
+            command -v "$candidate"
             return 0
         fi
     done

--- a/scripts/validation/check_local_environment.py
+++ b/scripts/validation/check_local_environment.py
@@ -11,12 +11,14 @@ Exit codes:
     2 - Hard failure: environment cannot run validation targets
 
 Usage:
-    python scripts/validation/check_local_environment.py
-    python scripts/validation/check_local_environment.py --strict
-    python scripts/validation/check_local_environment.py --check python
-    python scripts/validation/check_local_environment.py --check node
-    python scripts/validation/check_local_environment.py --check chrome
-    python scripts/validation/check_local_environment.py --check ports
+    make check-environment
+    .venv/bin/python scripts/validation/check_local_environment.py
+    .venv/bin/python scripts/validation/check_local_environment.py --strict
+    .venv/bin/python scripts/validation/check_local_environment.py --check python
+    .venv/bin/python scripts/validation/check_local_environment.py --check node
+    .venv/bin/python scripts/validation/check_local_environment.py --check chrome
+    .venv/bin/python scripts/validation/check_local_environment.py --check ports
+    .venv/bin/python scripts/validation/check_local_environment.py --check dependency-health
 """
 
 from __future__ import annotations
@@ -55,6 +57,7 @@ class CheckResult:
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 FRONTDOOR_ROOT = REPO_ROOT / "web" / "secure-landing"
+REPO_VENV_PYTHON = REPO_ROOT / ".venv" / "bin" / "python"
 
 # Required Python version
 MIN_PYTHON_VERSION = (3, 11)
@@ -75,6 +78,12 @@ CHECKED_ENV_VARS = [
     "TP_FRONTDOOR_USERNAME",
     "TP_FRONTDOOR_PASSWORD",
 ]
+
+DA3_CONTAMINATION_MARKERS = (
+    "depth-anything-3",
+    "xformers",
+    "numpy<2",
+)
 
 
 def check_python_version() -> CheckResult:
@@ -309,24 +318,120 @@ def check_env_vars() -> list[CheckResult]:
     return results
 
 
+def _is_virtualenv_interpreter() -> bool:
+    """Return whether the active interpreter is running from a virtualenv."""
+    if os.environ.get("VIRTUAL_ENV"):
+        return True
+    if hasattr(sys, "real_prefix"):
+        return True
+    return getattr(sys, "base_prefix", sys.prefix) != sys.prefix
+
+
+def _repo_venv_matches_current_interpreter() -> bool:
+    """Return whether the active interpreter matches the repo-local .venv."""
+    if not REPO_VENV_PYTHON.exists():
+        return False
+
+    current_executable = Path(sys.executable)
+    if not current_executable.exists():
+        return False
+
+    try:
+        return current_executable.samefile(REPO_VENV_PYTHON)
+    except OSError:
+        return False
+
+
 def check_venv_active() -> CheckResult:
     """Check if a virtual environment is active."""
-    venv_path = os.environ.get("VIRTUAL_ENV")
-    if venv_path:
+    if REPO_VENV_PYTHON.exists() and not _repo_venv_matches_current_interpreter():
+        return CheckResult(
+            name="Python venv",
+            passed=False,
+            message=(
+                f"Repo venv exists at {REPO_VENV_PYTHON}, but the current interpreter is {sys.executable}"
+            ),
+            guidance=(
+                "Use `.venv/bin/python ...` or `source .venv/bin/activate`. "
+                "If `.venv` is broken, run `make repair-core-venv`."
+            ),
+        )
+
+    if _is_virtualenv_interpreter():
         return CheckResult(
             name="Python venv",
             passed=True,
-            message=f"Active: {venv_path}",
+            message=f"Active: {os.environ.get('VIRTUAL_ENV') or sys.prefix}",
             is_hard_requirement=False,
         )
-    else:
+
+    return CheckResult(
+        name="Python venv",
+        passed=True,
+        message="No venv active (using system Python)",
+        is_hard_requirement=False,
+        guidance="Consider: make venv && source .venv/bin/activate",
+    )
+
+
+def _summarize_pip_check_output(output: str) -> str:
+    """Collapse pip check output into a compact single-line summary."""
+    lines = [line.strip() for line in output.splitlines() if line.strip()]
+    if not lines:
+        return "pip check reported dependency issues"
+    return "; ".join(lines[:2])
+
+
+def _dependency_health_guidance(output: str) -> str:
+    """Return actionable dependency-health guidance."""
+    combined = output.lower()
+    if any(marker in combined for marker in DA3_CONTAMINATION_MARKERS):
+        return (
+            "Repair the core repo environment with `make repair-core-venv`, then reinstall "
+            "the isolated DA3 runtime with `./scripts/setup/install_da3_runtime.sh`."
+        )
+    return "Repair the repo environment with `make repair-core-venv`, then rerun this pre-flight check."
+
+
+def check_dependency_health() -> CheckResult:
+    """Check whether the active interpreter has a consistent dependency graph."""
+    try:
+        result = subprocess.run(
+            [sys.executable, "-m", "pip", "check"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
         return CheckResult(
-            name="Python venv",
-            passed=True,
-            message="No venv active (using system Python)",
-            is_hard_requirement=False,
-            guidance="Consider: make venv && source .venv/bin/activate",
+            name="Python dependency health",
+            passed=False,
+            message="`python -m pip check` timed out",
+            guidance="Repair the repo environment with `make repair-core-venv`, then retry.",
         )
+    except Exception as exc:
+        return CheckResult(
+            name="Python dependency health",
+            passed=False,
+            message=f"Could not run `{sys.executable} -m pip check`: {exc}",
+            guidance="Repair the repo environment with `make repair-core-venv`, then retry.",
+        )
+
+    combined_output = "\n".join(part for part in (result.stdout, result.stderr) if part).strip()
+    if result.returncode == 0:
+        return CheckResult(
+            name="Python dependency health",
+            passed=True,
+            message=f"`{sys.executable} -m pip check` passed",
+        )
+
+    return CheckResult(
+        name="Python dependency health",
+        passed=False,
+        message=_summarize_pip_check_output(combined_output),
+        guidance=_dependency_health_guidance(combined_output),
+    )
 
 
 def run_all_checks(
@@ -342,6 +447,7 @@ def run_all_checks(
         "ports": check_ports_available,
         "frontdoor": check_frontdoor_dependencies,
         "venv": check_venv_active,
+        "dependency-health": check_dependency_health,
         "env": check_env_vars,
     }
 
@@ -421,6 +527,7 @@ Examples:
     %(prog)s --check node    Check only Node.js version
     %(prog)s --check chrome  Check only Chrome availability
     %(prog)s --check ports   Check only port availability
+    %(prog)s --check dependency-health  Check pip dependency health
     %(prog)s --quiet         Only output failures
         """,
     )
@@ -431,7 +538,7 @@ Examples:
     )
     parser.add_argument(
         "--check",
-        choices=["python", "node", "chrome", "ports", "frontdoor", "venv", "env"],
+        choices=["python", "node", "chrome", "ports", "frontdoor", "venv", "dependency-health", "env"],
         action="append",
         help="Run only specified check(s)",
     )

--- a/scripts/validation/check_local_environment.py
+++ b/scripts/validation/check_local_environment.py
@@ -57,7 +57,11 @@ class CheckResult:
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 FRONTDOOR_ROOT = REPO_ROOT / "web" / "secure-landing"
-REPO_VENV_PYTHON = REPO_ROOT / ".venv" / "bin" / "python"
+# Platform-aware venv interpreter path
+if sys.platform == "win32":
+    REPO_VENV_PYTHON = REPO_ROOT / ".venv" / "Scripts" / "python.exe"
+else:
+    REPO_VENV_PYTHON = REPO_ROOT / ".venv" / "bin" / "python"
 
 # Required Python version
 MIN_PYTHON_VERSION = (3, 11)
@@ -348,9 +352,7 @@ def check_venv_active() -> CheckResult:
         return CheckResult(
             name="Python venv",
             passed=False,
-            message=(
-                f"Repo venv exists at {REPO_VENV_PYTHON}, but the current interpreter is {sys.executable}"
-            ),
+            message=(f"Repo venv exists at {REPO_VENV_PYTHON}, but the current interpreter is {sys.executable}"),
             guidance=(
                 "Use `.venv/bin/python ...` or `source .venv/bin/activate`. "
                 "If `.venv` is broken, run `make repair-core-venv`."

--- a/scripts/validation/check_local_environment.py
+++ b/scripts/validation/check_local_environment.py
@@ -153,7 +153,8 @@ def check_node_version() -> CheckResult:
                 name="Node.js version",
                 passed=False,
                 message=f"Node.js {version_str} does not match required {REQUIRED_NODE_MAJOR}.x",
-                guidance=f"Switch to Node {REQUIRED_NODE_MAJOR}.x: nvm use {REQUIRED_NODE_MAJOR} / fnm use {REQUIRED_NODE_MAJOR}",
+                guidance=f"Switch to Node {REQUIRED_NODE_MAJOR}.x: nvm use {REQUIRED_NODE_MAJOR} / fnm use "
+                f"{REQUIRED_NODE_MAJOR}",
             )
     except subprocess.TimeoutExpired:
         return CheckResult(
@@ -491,7 +492,6 @@ def print_results(results: list[CheckResult], exit_code: ExitCode) -> None:
 
     # Group results
     passed = [r for r in results if r.passed]
-    failed = [r for r in results if not r.passed]
 
     for result in results:
         status = "✓" if result.passed else "✗"

--- a/scripts/validation/check_local_environment.py
+++ b/scripts/validation/check_local_environment.py
@@ -12,13 +12,12 @@ Exit codes:
 
 Usage:
     make check-environment
-    .venv/bin/python scripts/validation/check_local_environment.py
-    .venv/bin/python scripts/validation/check_local_environment.py --strict
-    .venv/bin/python scripts/validation/check_local_environment.py --check python
-    .venv/bin/python scripts/validation/check_local_environment.py --check node
-    .venv/bin/python scripts/validation/check_local_environment.py --check chrome
-    .venv/bin/python scripts/validation/check_local_environment.py --check ports
-    .venv/bin/python scripts/validation/check_local_environment.py --check dependency-health
+    make check-environment CHECK_ENV_ARGS="--strict"
+    make check-environment CHECK_ENV_ARGS="--check python"
+    make check-environment CHECK_ENV_ARGS="--check node"
+    make check-environment CHECK_ENV_ARGS="--check chrome"
+    make check-environment CHECK_ENV_ARGS="--check ports"
+    make check-environment CHECK_ENV_ARGS="--check dependency-health"
 """
 
 from __future__ import annotations

--- a/scripts/validation/check_local_environment.py
+++ b/scripts/validation/check_local_environment.py
@@ -60,8 +60,12 @@ FRONTDOOR_ROOT = REPO_ROOT / "web" / "secure-landing"
 # Platform-aware venv interpreter path
 if sys.platform == "win32":
     REPO_VENV_PYTHON = REPO_ROOT / ".venv" / "Scripts" / "python.exe"
+    _VENV_PYTHON_REL = r".venv\Scripts\python.exe"
+    _VENV_ACTIVATE_CMD = r".venv\Scripts\activate"
 else:
     REPO_VENV_PYTHON = REPO_ROOT / ".venv" / "bin" / "python"
+    _VENV_PYTHON_REL = ".venv/bin/python"
+    _VENV_ACTIVATE_CMD = "source .venv/bin/activate"
 
 # Required Python version
 MIN_PYTHON_VERSION = (3, 11)
@@ -355,7 +359,7 @@ def check_venv_active() -> CheckResult:
             passed=False,
             message=(f"Repo venv exists at {REPO_VENV_PYTHON}, but the current interpreter is {sys.executable}"),
             guidance=(
-                "Use `.venv/bin/python ...` or `source .venv/bin/activate`. "
+                f"Use `{_VENV_PYTHON_REL} ...` or `{_VENV_ACTIVATE_CMD}`. "
                 "If `.venv` is broken, run `make repair-core-venv`."
             ),
         )
@@ -373,7 +377,7 @@ def check_venv_active() -> CheckResult:
         passed=True,
         message="No venv active (using system Python)",
         is_hard_requirement=False,
-        guidance="Consider: make venv && source .venv/bin/activate",
+        guidance=f"Consider: make venv && {_VENV_ACTIVATE_CMD}",
     )
 
 

--- a/scripts/validation/run_full_validation_suite.sh
+++ b/scripts/validation/run_full_validation_suite.sh
@@ -22,6 +22,40 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 PYTHON_RESOLVER="${REPO_ROOT}/scripts/setup/resolve_python_311.sh"
 
+# Handle --help early so it works even if the resolver is missing
+for arg in "$@"; do
+    case "${arg}" in
+        -h|--help)
+            cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+All-in-one validation orchestrator for local development.
+
+Options:
+    --quick           Run quick validation (skip browser smokes)
+    --skip-browser    Skip browser smoke tests
+    --skip-frontdoor  Skip frontdoor validation (Node/npm)
+    --verbose         Show verbose output
+    -h, --help        Show this help message
+
+Validation sequence:
+    1. Environment pre-flight checks
+    2. Fast Python tests (make test-fast)
+    3. Orchestrator contract tests (make test-orchestrator-contract)
+    4. Frontdoor contract tests (make test-frontdoor-contract)
+    5. Portal browser smoke (make validate-portal-browser)
+    6. Frontdoor browser smoke (make validate-frontdoor-browser)
+
+Examples:
+    $(basename "$0")                  # Full validation suite
+    $(basename "$0") --quick          # Skip browser smokes
+    $(basename "$0") --skip-frontdoor # Python-only validation
+EOF
+            exit 0
+            ;;
+    esac
+done
+
 if [[ ! -x "${PYTHON_RESOLVER}" ]]; then
     echo "[ERROR] Python resolver missing: ${PYTHON_RESOLVER}" >&2
     exit 1
@@ -71,35 +105,7 @@ log_info() {
     echo "  $1"
 }
 
-usage() {
-    cat <<EOF
-Usage: $(basename "$0") [OPTIONS]
-
-All-in-one validation orchestrator for local development.
-
-Options:
-    --quick           Run quick validation (skip browser smokes)
-    --skip-browser    Skip browser smoke tests
-    --skip-frontdoor  Skip frontdoor validation (Node/npm)
-    --verbose         Show verbose output
-    -h, --help        Show this help message
-
-Validation sequence:
-    1. Environment pre-flight checks
-    2. Fast Python tests (make test-fast)
-    3. Orchestrator contract tests (make test-orchestrator-contract)
-    4. Frontdoor contract tests (make test-frontdoor-contract)
-    5. Portal browser smoke (make validate-portal-browser)
-    6. Frontdoor browser smoke (make validate-frontdoor-browser)
-
-Examples:
-    $(basename "$0")                  # Full validation suite
-    $(basename "$0") --quick          # Skip browser smokes
-    $(basename "$0") --skip-frontdoor # Python-only validation
-EOF
-}
-
-# Parse arguments
+# Parse arguments (--help already handled above)
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --quick)
@@ -119,13 +125,9 @@ while [[ $# -gt 0 ]]; do
             VERBOSE=true
             shift
             ;;
-        -h|--help)
-            usage
-            exit 0
-            ;;
         *)
-            echo "Unknown option: $1"
-            usage
+            echo "Unknown option: $1" >&2
+            echo "Use --help for usage information." >&2
             exit 1
             ;;
     esac

--- a/scripts/validation/run_full_validation_suite.sh
+++ b/scripts/validation/run_full_validation_suite.sh
@@ -20,6 +20,14 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+PYTHON_RESOLVER="${REPO_ROOT}/scripts/setup/resolve_python_311.sh"
+
+if [[ ! -x "${PYTHON_RESOLVER}" ]]; then
+    echo "[ERROR] Python resolver missing: ${PYTHON_RESOLVER}" >&2
+    exit 1
+fi
+
+PYTHON_BIN="$("${PYTHON_RESOLVER}")"
 
 # Options
 QUICK_MODE=false
@@ -169,7 +177,7 @@ fi
 # Step 1: Environment pre-flight
 log_step "Step 1/6: Environment Pre-flight Checks"
 if [[ "$SKIP_FRONTDOOR" == "true" ]]; then
-    if python3 "${SCRIPT_DIR}/check_local_environment.py" --check python --check venv; then
+    if "${PYTHON_BIN}" "${SCRIPT_DIR}/check_local_environment.py" --check python --check venv --check dependency-health; then
         log_success "Environment checks passed"
     else
         PREFLIGHT_STATUS=$?
@@ -188,7 +196,7 @@ if [[ "$SKIP_FRONTDOOR" == "true" ]]; then
         esac
     fi
 else
-    if python3 "${SCRIPT_DIR}/check_local_environment.py"; then
+    if "${PYTHON_BIN}" "${SCRIPT_DIR}/check_local_environment.py"; then
         log_success "Environment checks passed"
     else
         PREFLIGHT_STATUS=$?

--- a/scripts/validation/run_full_validation_suite.sh
+++ b/scripts/validation/run_full_validation_suite.sh
@@ -27,8 +27,6 @@ if [[ ! -x "${PYTHON_RESOLVER}" ]]; then
     exit 1
 fi
 
-PYTHON_BIN="$("${PYTHON_RESOLVER}")"
-
 # Options
 QUICK_MODE=false
 SKIP_BROWSER=false
@@ -132,6 +130,8 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
+
+PYTHON_BIN="$("${PYTHON_RESOLVER}")"
 
 cd "$REPO_ROOT"
 

--- a/tests/validation/test_environment_preflight.py
+++ b/tests/validation/test_environment_preflight.py
@@ -114,6 +114,32 @@ class TestCheckLocalEnvironment:
         assert result.is_hard_requirement is True
         assert "make repair-core-venv" in (result.guidance or "")
 
+    def test_check_venv_guidance_is_platform_aware(self, env_module, monkeypatch, tmp_path):
+        """Venv guidance should use platform-appropriate paths."""
+        repo_python = tmp_path / ".venv" / "bin" / "python"
+        repo_python.parent.mkdir(parents=True, exist_ok=True)
+        repo_python.write_text("", encoding="utf-8")
+        current_python = tmp_path / "bin" / "python"
+        current_python.parent.mkdir(parents=True, exist_ok=True)
+        current_python.write_text("", encoding="utf-8")
+
+        monkeypatch.setattr(env_module, "REPO_ROOT", tmp_path)
+        monkeypatch.setattr(env_module, "REPO_VENV_PYTHON", repo_python)
+        monkeypatch.setattr(env_module.sys, "executable", str(current_python))
+        monkeypatch.setattr(env_module.sys, "prefix", str(tmp_path / "system"))
+        monkeypatch.setattr(env_module.sys, "base_prefix", str(tmp_path / "system"))
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+
+        # Set POSIX-style guidance constants
+        monkeypatch.setattr(env_module, "_VENV_PYTHON_REL", ".venv/bin/python")
+        monkeypatch.setattr(env_module, "_VENV_ACTIVATE_CMD", "source .venv/bin/activate")
+
+        result = env_module.check_venv_active()
+
+        # Guidance should use the platform-appropriate paths
+        assert ".venv/bin/python" in (result.guidance or "")
+        assert "source .venv/bin/activate" in (result.guidance or "")
+
     def test_dependency_health_check_surfaces_da3_contamination_guidance(self, env_module, monkeypatch):
         """DA3 contamination should point operators to the repair and isolated-runtime paths."""
         completed = subprocess.CompletedProcess(

--- a/tests/validation/test_environment_preflight.py
+++ b/tests/validation/test_environment_preflight.py
@@ -72,6 +72,71 @@ class TestCheckLocalEnvironment:
         assert hasattr(result, "passed")
         assert result.is_hard_requirement is False  # Venv is optional
 
+    def test_check_venv_active_detects_venv_without_virtual_env_envvar(self, env_module, monkeypatch, tmp_path):
+        """Interpreter-based venv detection should work without VIRTUAL_ENV."""
+        monkeypatch.setattr(env_module, "REPO_ROOT", tmp_path)
+        monkeypatch.setattr(env_module, "REPO_VENV_PYTHON", tmp_path / ".venv" / "bin" / "python")
+        monkeypatch.setattr(env_module.sys, "prefix", str(tmp_path / ".venv"))
+        monkeypatch.setattr(env_module.sys, "base_prefix", str(tmp_path / "python-base"))
+        monkeypatch.setattr(env_module.sys, "executable", str(tmp_path / ".venv" / "bin" / "python"))
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+
+        result = env_module.check_venv_active()
+
+        assert result.passed is True
+        assert result.is_hard_requirement is False
+        assert "Active:" in result.message
+
+    def test_check_venv_active_hard_fails_when_repo_venv_exists_but_interpreter_differs(
+        self,
+        env_module,
+        monkeypatch,
+        tmp_path,
+    ):
+        """Preflight should fail closed when the repo venv exists but is not in use."""
+        repo_python = tmp_path / ".venv" / "bin" / "python"
+        repo_python.parent.mkdir(parents=True, exist_ok=True)
+        repo_python.write_text("", encoding="utf-8")
+        current_python = tmp_path / "bin" / "python"
+        current_python.parent.mkdir(parents=True, exist_ok=True)
+        current_python.write_text("", encoding="utf-8")
+
+        monkeypatch.setattr(env_module, "REPO_ROOT", tmp_path)
+        monkeypatch.setattr(env_module, "REPO_VENV_PYTHON", repo_python)
+        monkeypatch.setattr(env_module.sys, "executable", str(current_python))
+        monkeypatch.setattr(env_module.sys, "prefix", str(tmp_path / "system"))
+        monkeypatch.setattr(env_module.sys, "base_prefix", str(tmp_path / "system"))
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+
+        result = env_module.check_venv_active()
+
+        assert result.passed is False
+        assert result.is_hard_requirement is True
+        assert "make repair-core-venv" in (result.guidance or "")
+
+    def test_dependency_health_check_surfaces_da3_contamination_guidance(self, env_module, monkeypatch):
+        """DA3 contamination should point operators to the repair and isolated-runtime paths."""
+        completed = subprocess.CompletedProcess(
+            args=[sys.executable, "-m", "pip", "check"],
+            returncode=1,
+            stdout=(
+                "depth-anything-3 0.0.0 requires xformers, which is not installed.\n"
+                "depth-anything-3 0.0.0 has requirement numpy<2, but you have numpy 2.4.4.\n"
+            ),
+            stderr="",
+        )
+
+        monkeypatch.setattr(env_module.sys, "executable", "/tmp/repo/.venv/bin/python")
+        monkeypatch.setattr(env_module.subprocess, "run", lambda *args, **kwargs: completed)
+
+        result = env_module.check_dependency_health()
+
+        assert result.passed is False
+        assert result.is_hard_requirement is True
+        assert "depth-anything-3" in result.message
+        assert "make repair-core-venv" in (result.guidance or "")
+        assert "./scripts/setup/install_da3_runtime.sh" in (result.guidance or "")
+
     def test_run_all_checks_returns_results_and_exit_code(self, env_module):
         """run_all_checks should return results and exit code."""
         results, exit_code = env_module.run_all_checks()
@@ -157,6 +222,19 @@ class TestCheckLocalEnvironmentCLI:
         output = json.loads(result.stdout)
         # Should only have Python-related checks
         assert len(output["results"]) == 1
+
+    def test_script_check_specific_dependency_health(self):
+        """Script should accept dependency-health as a specific check."""
+        result = subprocess.run(
+            [sys.executable, str(CHECK_LOCAL_ENVIRONMENT_PATH), "--check", "dependency-health", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode in (0, 2)
+        output = json.loads(result.stdout)
+        assert len(output["results"]) == 1
+        assert output["results"][0]["name"] == "Python dependency health"
 
     def test_script_quiet_mode(self):
         """Quiet mode should reduce output."""

--- a/tests/validation/test_python_bootstrap_scripts.py
+++ b/tests/validation/test_python_bootstrap_scripts.py
@@ -82,8 +82,8 @@ def test_resolver_falls_back_to_python311_when_repo_venv_missing(tmp_path: Path)
     fakebin = tmp_path / "fakebin"
     python311 = _write_fake_python(fakebin / "python3.11", version="3.11.15", real_python=sys.executable)
     # Provide fake python3.12/3.13 that report unsupported versions to isolate from system
-    _write_fake_python(fakebin / "python3.13", version="3.10.0", real_python=sys.executable)
-    _write_fake_python(fakebin / "python3.12", version="3.10.0", real_python=sys.executable)
+    _write_fake_python(fakebin / "python3.13", version="3.9.0", real_python=sys.executable)
+    _write_fake_python(fakebin / "python3.12", version="3.9.0", real_python=sys.executable)
     _write_fake_python(fakebin / "python3", version="3.9.6", real_python=sys.executable)
     _write_fake_python(fakebin / "python", version="3.9.6", real_python=sys.executable)
 
@@ -146,8 +146,8 @@ def test_validation_suite_uses_resolved_python_for_preflight(tmp_path: Path) -> 
     fakebin = tmp_path / "fakebin"
     python311 = _write_fake_python(fakebin / "python3.11", version="3.11.15", real_python=sys.executable)
     # Provide fake python3.12/3.13 that report unsupported versions to isolate from system
-    _write_fake_python(fakebin / "python3.13", version="3.10.0", real_python=sys.executable)
-    _write_fake_python(fakebin / "python3.12", version="3.10.0", real_python=sys.executable)
+    _write_fake_python(fakebin / "python3.13", version="3.9.0", real_python=sys.executable)
+    _write_fake_python(fakebin / "python3.12", version="3.9.0", real_python=sys.executable)
     _write_fake_python(fakebin / "python3", version="3.9.6", real_python=sys.executable)
     _write_fake_python(fakebin / "python", version="3.9.6", real_python=sys.executable)
     _write_executable(
@@ -178,8 +178,8 @@ def test_install_da3_runtime_uses_resolved_python_for_venv_creation(tmp_path: Pa
     fakebin = tmp_path / "fakebin"
     python311 = _write_fake_python(fakebin / "python3.11", version="3.11.15", real_python=sys.executable)
     # Provide fake python3.12/3.13 that report unsupported versions to isolate from system
-    _write_fake_python(fakebin / "python3.13", version="3.10.0", real_python=sys.executable)
-    _write_fake_python(fakebin / "python3.12", version="3.10.0", real_python=sys.executable)
+    _write_fake_python(fakebin / "python3.13", version="3.9.0", real_python=sys.executable)
+    _write_fake_python(fakebin / "python3.12", version="3.9.0", real_python=sys.executable)
     _write_fake_python(fakebin / "python3", version="3.9.6", real_python=sys.executable)
     _write_fake_python(fakebin / "python", version="3.9.6", real_python=sys.executable)
 
@@ -216,8 +216,8 @@ def test_install_raw_runtime_uses_resolved_python_for_venv_creation(tmp_path: Pa
     fakebin = tmp_path / "fakebin"
     python311 = _write_fake_python(fakebin / "python3.11", version="3.11.15", real_python=sys.executable)
     # Provide fake python3.12/3.13 that report unsupported versions to isolate from system
-    _write_fake_python(fakebin / "python3.13", version="3.10.0", real_python=sys.executable)
-    _write_fake_python(fakebin / "python3.12", version="3.10.0", real_python=sys.executable)
+    _write_fake_python(fakebin / "python3.13", version="3.9.0", real_python=sys.executable)
+    _write_fake_python(fakebin / "python3.12", version="3.9.0", real_python=sys.executable)
     _write_fake_python(fakebin / "python3", version="3.9.6", real_python=sys.executable)
     _write_fake_python(fakebin / "python", version="3.9.6", real_python=sys.executable)
 

--- a/tests/validation/test_python_bootstrap_scripts.py
+++ b/tests/validation/test_python_bootstrap_scripts.py
@@ -170,6 +170,19 @@ def test_make_venv_refuses_wrong_version_existing_repo_venv(tmp_path: Path) -> N
     assert "make repair-core-venv" in (result.stdout + result.stderr)
 
 
+def test_make_venv_accepts_supported_windows_repo_venv_layout(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    _copy_repo_file(MAKEFILE_PATH, repo_root / "Makefile")
+    _copy_repo_file(RESOLVER_PATH, repo_root / "scripts" / "setup" / "resolve_python_311.sh")
+    _write_fake_python(repo_root / ".venv" / "Scripts" / "python.exe", version="3.12.4", real_python=sys.executable)
+
+    env = {**os.environ, "PATH": "/usr/bin:/bin"}
+    result = subprocess.run(["make", "venv"], cwd=repo_root, env=env, capture_output=True, text=True, check=False)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert ".venv already present" in result.stdout
+
+
 def test_validation_suite_uses_resolved_python_for_preflight(tmp_path: Path) -> None:
     repo_root = tmp_path / "repo"
     _copy_repo_file(VALIDATION_SUITE_PATH, repo_root / "scripts" / "validation" / "run_full_validation_suite.sh")
@@ -212,6 +225,29 @@ def test_validation_suite_uses_resolved_python_for_preflight(tmp_path: Path) -> 
 
     assert result.returncode == 0, result.stdout + result.stderr
     assert marker_path.read_text(encoding="utf-8").strip() == str(python311)
+
+
+def test_validation_suite_help_skips_python_resolution(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    _copy_repo_file(VALIDATION_SUITE_PATH, repo_root / "scripts" / "validation" / "run_full_validation_suite.sh")
+    _write_executable(
+        repo_root / "scripts" / "setup" / "resolve_python_311.sh",
+        "#!/bin/sh\n" "echo missing-python >&2\n" "exit 1\n",
+    )
+
+    env = {**os.environ, "PATH": "/usr/bin:/bin"}
+    result = subprocess.run(
+        ["bash", str(repo_root / "scripts" / "validation" / "run_full_validation_suite.sh"), "--help"],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Usage" in result.stdout
+    assert "missing-python" not in result.stderr
 
 
 def test_install_da3_runtime_uses_resolved_python_for_venv_creation(tmp_path: Path) -> None:

--- a/tests/validation/test_python_bootstrap_scripts.py
+++ b/tests/validation/test_python_bootstrap_scripts.py
@@ -36,7 +36,10 @@ def _copy_repo_file(source: Path, destination: Path) -> Path:
 
 
 def _write_fake_python(path: Path, *, version: str, real_python: str) -> Path:
-    supported = version.startswith(("3.11", "3.12", "3.13", "3.14", "3.15"))
+    version_parts = version.split(".")
+    major = int(version_parts[0])
+    minor = int(version_parts[1])
+    supported = (major, minor) >= (3, 11)
     exit_code = "0" if supported else "1"
     script = f"""#!/bin/sh
 REAL_PYTHON={shlex.quote(real_python)}
@@ -95,6 +98,39 @@ def test_resolver_falls_back_to_python311_when_repo_venv_missing(tmp_path: Path)
 
     assert result.returncode == 0, result.stdout + result.stderr
     assert result.stdout.strip() == str(python311)
+
+
+def test_resolver_discovers_newer_versioned_python_commands(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    script_path = _copy_repo_file(RESOLVER_PATH, repo_root / "scripts" / "setup" / "resolve_python_311.sh")
+    fakebin = tmp_path / "fakebin"
+    python316 = _write_fake_python(fakebin / "python3.16", version="3.16.0", real_python=sys.executable)
+    _write_fake_python(fakebin / "python3.15", version="3.15.2", real_python=sys.executable)
+    _write_fake_python(fakebin / "python3.11", version="3.11.15", real_python=sys.executable)
+    _write_fake_python(fakebin / "python3", version="3.9.6", real_python=sys.executable)
+    _write_fake_python(fakebin / "python", version="3.9.6", real_python=sys.executable)
+
+    env = {**os.environ, "PATH": f"{fakebin}:/usr/bin:/bin"}
+    result = subprocess.run(["bash", str(script_path)], cwd=repo_root, env=env, capture_output=True, text=True, check=False)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert result.stdout.strip() == str(python316)
+
+
+def test_resolver_prefers_windows_repo_venv_layout(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    script_path = _copy_repo_file(RESOLVER_PATH, repo_root / "scripts" / "setup" / "resolve_python_311.sh")
+    repo_python = _write_fake_python(
+        repo_root / ".venv" / "Scripts" / "python.exe",
+        version="3.12.4",
+        real_python=sys.executable,
+    )
+
+    env = {**os.environ, "PATH": "/usr/bin:/bin"}
+    result = subprocess.run(["bash", str(script_path)], cwd=repo_root, env=env, capture_output=True, text=True, check=False)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert result.stdout.strip() == str(repo_python)
 
 
 def test_resolver_rejects_old_python_candidates(tmp_path: Path) -> None:

--- a/tests/validation/test_python_bootstrap_scripts.py
+++ b/tests/validation/test_python_bootstrap_scripts.py
@@ -81,8 +81,13 @@ def test_resolver_falls_back_to_python311_when_repo_venv_missing(tmp_path: Path)
     script_path = _copy_repo_file(RESOLVER_PATH, repo_root / "scripts" / "setup" / "resolve_python_311.sh")
     fakebin = tmp_path / "fakebin"
     python311 = _write_fake_python(fakebin / "python3.11", version="3.11.15", real_python=sys.executable)
+    # Provide fake python3.12/3.13 that report unsupported versions to isolate from system
+    _write_fake_python(fakebin / "python3.13", version="3.10.0", real_python=sys.executable)
+    _write_fake_python(fakebin / "python3.12", version="3.10.0", real_python=sys.executable)
     _write_fake_python(fakebin / "python3", version="3.9.6", real_python=sys.executable)
+    _write_fake_python(fakebin / "python", version="3.9.6", real_python=sys.executable)
 
+    # fakebin first so our fake pythons are found; /usr/bin for bash and other utilities
     env = {**os.environ, "PATH": f"{fakebin}:/usr/bin:/bin"}
     result = subprocess.run(["bash", str(script_path)], cwd=repo_root, env=env, capture_output=True, text=True, check=False)
 
@@ -94,9 +99,14 @@ def test_resolver_rejects_old_python_candidates(tmp_path: Path) -> None:
     repo_root = tmp_path / "repo"
     script_path = _copy_repo_file(RESOLVER_PATH, repo_root / "scripts" / "setup" / "resolve_python_311.sh")
     fakebin = tmp_path / "fakebin"
+    # All candidates report old unsupported versions
+    _write_fake_python(fakebin / "python3.13", version="3.9.0", real_python=sys.executable)
+    _write_fake_python(fakebin / "python3.12", version="3.9.0", real_python=sys.executable)
+    _write_fake_python(fakebin / "python3.11", version="3.9.0", real_python=sys.executable)
     _write_fake_python(fakebin / "python3", version="3.9.6", real_python=sys.executable)
     _write_fake_python(fakebin / "python", version="3.10.14", real_python=sys.executable)
 
+    # fakebin first so our fake pythons are found; /usr/bin for bash and other utilities
     env = {**os.environ, "PATH": f"{fakebin}:/usr/bin:/bin"}
     result = subprocess.run(["bash", str(script_path)], cwd=repo_root, env=env, capture_output=True, text=True, check=False)
 
@@ -135,13 +145,17 @@ def test_validation_suite_uses_resolved_python_for_preflight(tmp_path: Path) -> 
 
     fakebin = tmp_path / "fakebin"
     python311 = _write_fake_python(fakebin / "python3.11", version="3.11.15", real_python=sys.executable)
+    # Provide fake python3.12/3.13 that report unsupported versions to isolate from system
+    _write_fake_python(fakebin / "python3.13", version="3.10.0", real_python=sys.executable)
+    _write_fake_python(fakebin / "python3.12", version="3.10.0", real_python=sys.executable)
     _write_fake_python(fakebin / "python3", version="3.9.6", real_python=sys.executable)
+    _write_fake_python(fakebin / "python", version="3.9.6", real_python=sys.executable)
     _write_executable(
         fakebin / "make",
-        "#!/bin/sh\n"
-        "exit 0\n",
+        "#!/bin/sh\n" "exit 0\n",
     )
 
+    # fakebin first so our fake pythons are found; /usr/bin for bash and other utilities
     env = {**os.environ, "PATH": f"{fakebin}:/usr/bin:/bin"}
     result = subprocess.run(
         ["bash", str(repo_root / "scripts" / "validation" / "run_full_validation_suite.sh"), "--quick", "--skip-frontdoor"],
@@ -163,8 +177,13 @@ def test_install_da3_runtime_uses_resolved_python_for_venv_creation(tmp_path: Pa
 
     fakebin = tmp_path / "fakebin"
     python311 = _write_fake_python(fakebin / "python3.11", version="3.11.15", real_python=sys.executable)
+    # Provide fake python3.12/3.13 that report unsupported versions to isolate from system
+    _write_fake_python(fakebin / "python3.13", version="3.10.0", real_python=sys.executable)
+    _write_fake_python(fakebin / "python3.12", version="3.10.0", real_python=sys.executable)
     _write_fake_python(fakebin / "python3", version="3.9.6", real_python=sys.executable)
+    _write_fake_python(fakebin / "python", version="3.9.6", real_python=sys.executable)
 
+    # fakebin first so our fake pythons are found; /usr/bin for bash, git, and other utilities
     env = {**os.environ, "PATH": f"{fakebin}:/usr/bin:/bin"}
     result = subprocess.run(
         [
@@ -196,8 +215,13 @@ def test_install_raw_runtime_uses_resolved_python_for_venv_creation(tmp_path: Pa
 
     fakebin = tmp_path / "fakebin"
     python311 = _write_fake_python(fakebin / "python3.11", version="3.11.15", real_python=sys.executable)
+    # Provide fake python3.12/3.13 that report unsupported versions to isolate from system
+    _write_fake_python(fakebin / "python3.13", version="3.10.0", real_python=sys.executable)
+    _write_fake_python(fakebin / "python3.12", version="3.10.0", real_python=sys.executable)
     _write_fake_python(fakebin / "python3", version="3.9.6", real_python=sys.executable)
+    _write_fake_python(fakebin / "python", version="3.9.6", real_python=sys.executable)
 
+    # fakebin first so our fake pythons are found; /usr/bin for bash and other utilities
     env = {**os.environ, "PATH": f"{fakebin}:/usr/bin:/bin"}
     result = subprocess.run(
         [

--- a/tests/validation/test_python_bootstrap_scripts.py
+++ b/tests/validation/test_python_bootstrap_scripts.py
@@ -81,7 +81,9 @@ def test_resolver_falls_back_to_python311_when_repo_venv_missing(tmp_path: Path)
     script_path = _copy_repo_file(RESOLVER_PATH, repo_root / "scripts" / "setup" / "resolve_python_311.sh")
     fakebin = tmp_path / "fakebin"
     python311 = _write_fake_python(fakebin / "python3.11", version="3.11.15", real_python=sys.executable)
-    # Provide fake python3.12/3.13 that report unsupported versions to isolate from system
+    # Provide fake python3.12-3.15 that report unsupported versions to isolate from system
+    _write_fake_python(fakebin / "python3.15", version="3.9.0", real_python=sys.executable)
+    _write_fake_python(fakebin / "python3.14", version="3.9.0", real_python=sys.executable)
     _write_fake_python(fakebin / "python3.13", version="3.9.0", real_python=sys.executable)
     _write_fake_python(fakebin / "python3.12", version="3.9.0", real_python=sys.executable)
     _write_fake_python(fakebin / "python3", version="3.9.6", real_python=sys.executable)
@@ -100,6 +102,8 @@ def test_resolver_rejects_old_python_candidates(tmp_path: Path) -> None:
     script_path = _copy_repo_file(RESOLVER_PATH, repo_root / "scripts" / "setup" / "resolve_python_311.sh")
     fakebin = tmp_path / "fakebin"
     # All candidates report old unsupported versions
+    _write_fake_python(fakebin / "python3.15", version="3.9.0", real_python=sys.executable)
+    _write_fake_python(fakebin / "python3.14", version="3.9.0", real_python=sys.executable)
     _write_fake_python(fakebin / "python3.13", version="3.9.0", real_python=sys.executable)
     _write_fake_python(fakebin / "python3.12", version="3.9.0", real_python=sys.executable)
     _write_fake_python(fakebin / "python3.11", version="3.9.0", real_python=sys.executable)
@@ -112,7 +116,9 @@ def test_resolver_rejects_old_python_candidates(tmp_path: Path) -> None:
 
     assert result.returncode == 1
     assert "make venv" in result.stderr
-    assert "python3.11 -m venv .venv" in result.stderr
+    # Updated guidance now includes multiple Python version examples
+    assert "python3.13 -m venv .venv" in result.stderr
+    assert "python3.12 -m venv .venv" in result.stderr
 
 
 def test_make_venv_refuses_wrong_version_existing_repo_venv(tmp_path: Path) -> None:
@@ -145,7 +151,9 @@ def test_validation_suite_uses_resolved_python_for_preflight(tmp_path: Path) -> 
 
     fakebin = tmp_path / "fakebin"
     python311 = _write_fake_python(fakebin / "python3.11", version="3.11.15", real_python=sys.executable)
-    # Provide fake python3.12/3.13 that report unsupported versions to isolate from system
+    # Provide fake python3.12-3.15 that report unsupported versions to isolate from system
+    _write_fake_python(fakebin / "python3.15", version="3.9.0", real_python=sys.executable)
+    _write_fake_python(fakebin / "python3.14", version="3.9.0", real_python=sys.executable)
     _write_fake_python(fakebin / "python3.13", version="3.9.0", real_python=sys.executable)
     _write_fake_python(fakebin / "python3.12", version="3.9.0", real_python=sys.executable)
     _write_fake_python(fakebin / "python3", version="3.9.6", real_python=sys.executable)
@@ -177,7 +185,9 @@ def test_install_da3_runtime_uses_resolved_python_for_venv_creation(tmp_path: Pa
 
     fakebin = tmp_path / "fakebin"
     python311 = _write_fake_python(fakebin / "python3.11", version="3.11.15", real_python=sys.executable)
-    # Provide fake python3.12/3.13 that report unsupported versions to isolate from system
+    # Provide fake python3.12-3.15 that report unsupported versions to isolate from system
+    _write_fake_python(fakebin / "python3.15", version="3.9.0", real_python=sys.executable)
+    _write_fake_python(fakebin / "python3.14", version="3.9.0", real_python=sys.executable)
     _write_fake_python(fakebin / "python3.13", version="3.9.0", real_python=sys.executable)
     _write_fake_python(fakebin / "python3.12", version="3.9.0", real_python=sys.executable)
     _write_fake_python(fakebin / "python3", version="3.9.6", real_python=sys.executable)
@@ -215,7 +225,9 @@ def test_install_raw_runtime_uses_resolved_python_for_venv_creation(tmp_path: Pa
 
     fakebin = tmp_path / "fakebin"
     python311 = _write_fake_python(fakebin / "python3.11", version="3.11.15", real_python=sys.executable)
-    # Provide fake python3.12/3.13 that report unsupported versions to isolate from system
+    # Provide fake python3.12-3.15 that report unsupported versions to isolate from system
+    _write_fake_python(fakebin / "python3.15", version="3.9.0", real_python=sys.executable)
+    _write_fake_python(fakebin / "python3.14", version="3.9.0", real_python=sys.executable)
     _write_fake_python(fakebin / "python3.13", version="3.9.0", real_python=sys.executable)
     _write_fake_python(fakebin / "python3.12", version="3.9.0", real_python=sys.executable)
     _write_fake_python(fakebin / "python3", version="3.9.6", real_python=sys.executable)
@@ -242,3 +254,26 @@ def test_install_raw_runtime_uses_resolved_python_for_venv_creation(tmp_path: Pa
     assert result.returncode == 0, result.stdout + result.stderr
     assert f"Using bootstrap interpreter: {python311}" in result.stdout
     assert f"+ {python311} -m venv {repo_root / '.venv-raw'}" in result.stdout
+
+
+def test_resolver_prefers_python314_over_python311(tmp_path: Path) -> None:
+    """Test that resolver prefers newer Python versions (e.g., 3.14) over 3.11."""
+    repo_root = tmp_path / "repo"
+    script_path = _copy_repo_file(RESOLVER_PATH, repo_root / "scripts" / "setup" / "resolve_python_311.sh")
+    fakebin = tmp_path / "fakebin"
+    # Python 3.14 is available and supported
+    python314 = _write_fake_python(fakebin / "python3.14", version="3.14.0", real_python=sys.executable)
+    # Python 3.11 is also available but should not be preferred
+    _write_fake_python(fakebin / "python3.11", version="3.11.15", real_python=sys.executable)
+    # Other candidates report unsupported versions
+    _write_fake_python(fakebin / "python3.15", version="3.9.0", real_python=sys.executable)
+    _write_fake_python(fakebin / "python3.13", version="3.9.0", real_python=sys.executable)
+    _write_fake_python(fakebin / "python3.12", version="3.9.0", real_python=sys.executable)
+    _write_fake_python(fakebin / "python3", version="3.9.6", real_python=sys.executable)
+    _write_fake_python(fakebin / "python", version="3.9.6", real_python=sys.executable)
+
+    env = {**os.environ, "PATH": f"{fakebin}:/usr/bin:/bin"}
+    result = subprocess.run(["bash", str(script_path)], cwd=repo_root, env=env, capture_output=True, text=True, check=False)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert result.stdout.strip() == str(python314)

--- a/tests/validation/test_python_bootstrap_scripts.py
+++ b/tests/validation/test_python_bootstrap_scripts.py
@@ -1,0 +1,220 @@
+"""Tests for Python bootstrap and validation shell entrypoints."""
+
+from __future__ import annotations
+
+import os
+import shlex
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+MAKEFILE_PATH = PROJECT_ROOT / "Makefile"
+RESOLVER_PATH = PROJECT_ROOT / "scripts" / "setup" / "resolve_python_311.sh"
+DA3_RUNTIME_INSTALLER_PATH = PROJECT_ROOT / "scripts" / "setup" / "install_da3_runtime.sh"
+RAW_RUNTIME_INSTALLER_PATH = PROJECT_ROOT / "scripts" / "setup" / "install_raw_runtime.sh"
+VALIDATION_SUITE_PATH = PROJECT_ROOT / "scripts" / "validation" / "run_full_validation_suite.sh"
+
+
+def _write_executable(path: Path, content: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return path
+
+
+def _copy_repo_file(source: Path, destination: Path) -> Path:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
+    destination.chmod(source.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return destination
+
+
+def _write_fake_python(path: Path, *, version: str, real_python: str) -> Path:
+    supported = version.startswith(("3.11", "3.12", "3.13", "3.14", "3.15"))
+    exit_code = "0" if supported else "1"
+    script = f"""#!/bin/sh
+REAL_PYTHON={shlex.quote(real_python)}
+FAKE_VERSION={shlex.quote(version)}
+if [ "$1" = "-c" ]; then
+    exit {exit_code}
+fi
+if [ "$1" = "-V" ] || [ "$1" = "--version" ]; then
+    echo "Python $FAKE_VERSION"
+    exit 0
+fi
+if [ "$1" = "-m" ] && [ "$2" = "pip" ] && [ "$3" = "--version" ]; then
+    echo "pip 24.0 from fake ($FAKE_VERSION)"
+    exit 0
+fi
+export FAKE_PYTHON_LAUNCHER="$0"
+exec "$REAL_PYTHON" "$@"
+"""
+    return _write_executable(path, script)
+
+
+def test_resolver_prefers_repo_venv(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    script_path = _copy_repo_file(RESOLVER_PATH, repo_root / "scripts" / "setup" / "resolve_python_311.sh")
+    repo_python = _write_fake_python(
+        repo_root / ".venv" / "bin" / "python",
+        version="3.11.15",
+        real_python=sys.executable,
+    )
+    fakebin = tmp_path / "fakebin"
+    _write_fake_python(fakebin / "python3.11", version="3.12.0", real_python=sys.executable)
+
+    env = {**os.environ, "PATH": f"{fakebin}:/usr/bin:/bin"}
+    result = subprocess.run(["bash", str(script_path)], cwd=repo_root, env=env, capture_output=True, text=True, check=False)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert result.stdout.strip() == str(repo_python)
+
+
+def test_resolver_falls_back_to_python311_when_repo_venv_missing(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    script_path = _copy_repo_file(RESOLVER_PATH, repo_root / "scripts" / "setup" / "resolve_python_311.sh")
+    fakebin = tmp_path / "fakebin"
+    python311 = _write_fake_python(fakebin / "python3.11", version="3.11.15", real_python=sys.executable)
+    _write_fake_python(fakebin / "python3", version="3.9.6", real_python=sys.executable)
+
+    env = {**os.environ, "PATH": f"{fakebin}:/usr/bin:/bin"}
+    result = subprocess.run(["bash", str(script_path)], cwd=repo_root, env=env, capture_output=True, text=True, check=False)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert result.stdout.strip() == str(python311)
+
+
+def test_resolver_rejects_old_python_candidates(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    script_path = _copy_repo_file(RESOLVER_PATH, repo_root / "scripts" / "setup" / "resolve_python_311.sh")
+    fakebin = tmp_path / "fakebin"
+    _write_fake_python(fakebin / "python3", version="3.9.6", real_python=sys.executable)
+    _write_fake_python(fakebin / "python", version="3.10.14", real_python=sys.executable)
+
+    env = {**os.environ, "PATH": f"{fakebin}:/usr/bin:/bin"}
+    result = subprocess.run(["bash", str(script_path)], cwd=repo_root, env=env, capture_output=True, text=True, check=False)
+
+    assert result.returncode == 1
+    assert "make venv" in result.stderr
+    assert "python3.11 -m venv .venv" in result.stderr
+
+
+def test_make_venv_refuses_wrong_version_existing_repo_venv(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    _copy_repo_file(MAKEFILE_PATH, repo_root / "Makefile")
+    _copy_repo_file(RESOLVER_PATH, repo_root / "scripts" / "setup" / "resolve_python_311.sh")
+    _write_fake_python(repo_root / ".venv" / "bin" / "python", version="3.9.6", real_python=sys.executable)
+
+    env = {**os.environ, "PATH": "/usr/bin:/bin"}
+    result = subprocess.run(["make", "venv"], cwd=repo_root, env=env, capture_output=True, text=True, check=False)
+
+    assert result.returncode != 0
+    assert "make repair-core-venv" in (result.stdout + result.stderr)
+
+
+def test_validation_suite_uses_resolved_python_for_preflight(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    _copy_repo_file(VALIDATION_SUITE_PATH, repo_root / "scripts" / "validation" / "run_full_validation_suite.sh")
+    _copy_repo_file(RESOLVER_PATH, repo_root / "scripts" / "setup" / "resolve_python_311.sh")
+    marker_path = repo_root / "preflight_python.txt"
+    _write_executable(
+        repo_root / "scripts" / "validation" / "check_local_environment.py",
+        (
+            "#!/usr/bin/env python3\n"
+            "import os\n"
+            "from pathlib import Path\n"
+            f"Path({str(marker_path)!r}).write_text(os.environ.get('FAKE_PYTHON_LAUNCHER', ''), encoding='utf-8')\n"
+        ),
+    )
+
+    fakebin = tmp_path / "fakebin"
+    python311 = _write_fake_python(fakebin / "python3.11", version="3.11.15", real_python=sys.executable)
+    _write_fake_python(fakebin / "python3", version="3.9.6", real_python=sys.executable)
+    _write_executable(
+        fakebin / "make",
+        "#!/bin/sh\n"
+        "exit 0\n",
+    )
+
+    env = {**os.environ, "PATH": f"{fakebin}:/usr/bin:/bin"}
+    result = subprocess.run(
+        ["bash", str(repo_root / "scripts" / "validation" / "run_full_validation_suite.sh"), "--quick", "--skip-frontdoor"],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert marker_path.read_text(encoding="utf-8").strip() == str(python311)
+
+
+def test_install_da3_runtime_uses_resolved_python_for_venv_creation(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    script_path = _copy_repo_file(DA3_RUNTIME_INSTALLER_PATH, repo_root / "scripts" / "setup" / "install_da3_runtime.sh")
+    _copy_repo_file(RESOLVER_PATH, repo_root / "scripts" / "setup" / "resolve_python_311.sh")
+
+    fakebin = tmp_path / "fakebin"
+    python311 = _write_fake_python(fakebin / "python3.11", version="3.11.15", real_python=sys.executable)
+    _write_fake_python(fakebin / "python3", version="3.9.6", real_python=sys.executable)
+
+    env = {**os.environ, "PATH": f"{fakebin}:/usr/bin:/bin"}
+    result = subprocess.run(
+        [
+            "bash",
+            str(script_path),
+            "--dry-run",
+            "--skip-verify",
+            "--checkout-dir",
+            str(repo_root / ".runtime" / "Depth-Anything-3"),
+            "--venv-dir",
+            str(repo_root / ".venv-da3"),
+        ],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert f"Using bootstrap interpreter: {python311}" in result.stdout
+    assert f"+ {python311} -m venv {repo_root / '.venv-da3'}" in result.stdout
+
+
+def test_install_raw_runtime_uses_resolved_python_for_venv_creation(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    script_path = _copy_repo_file(RAW_RUNTIME_INSTALLER_PATH, repo_root / "scripts" / "setup" / "install_raw_runtime.sh")
+    _copy_repo_file(RESOLVER_PATH, repo_root / "scripts" / "setup" / "resolve_python_311.sh")
+
+    fakebin = tmp_path / "fakebin"
+    python311 = _write_fake_python(fakebin / "python3.11", version="3.11.15", real_python=sys.executable)
+    _write_fake_python(fakebin / "python3", version="3.9.6", real_python=sys.executable)
+
+    env = {**os.environ, "PATH": f"{fakebin}:/usr/bin:/bin"}
+    result = subprocess.run(
+        [
+            "bash",
+            str(script_path),
+            "--dry-run",
+            "--skip-verify",
+            "--venv-dir",
+            str(repo_root / ".venv-raw"),
+        ],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert f"Using bootstrap interpreter: {python311}" in result.stdout
+    assert f"+ {python311} -m venv {repo_root / '.venv-raw'}" in result.stdout


### PR DESCRIPTION
## Summary
- add a shared Python 3.11+ resolver and route setup, validation, and runtime bootstrap scripts through it
- make repo `.venv` creation and core installs deterministic, plus add a canonical `make repair-core-venv` recovery path
- harden environment preflight for repo-interpreter mismatch, `pip check` dependency contamination, and update docs/tests accordingly

## Root Cause
Local setup paths were still willing to trust the ambient shell interpreter. On this machine, `python3` resolves to Python 3.9.6 even though `python3.11` and the repo `.venv` are both 3.11.15. That let preflight run against the wrong interpreter, and the old core install path could re-resolve dependencies in ways that hid DA3 contamination inside the main repo environment.

## What Changed
- added `scripts/setup/resolve_python_311.sh` with explicit resolution order and operator guidance
- updated `Makefile` so `make venv` fails closed on unsupported repo envs, `make install-core` uses the checked-in locked inputs plus `pip check`, and `make repair-core-venv` rebuilds the canonical core env
- updated `scripts/validation/check_local_environment.py` to detect active venvs from the interpreter itself, fail when a repo `.venv` exists but is not in use, and add a hard `dependency-health` check backed by `pip check`
- updated `scripts/validation/run_full_validation_suite.sh`, `scripts/setup/install_da3_runtime.sh`, `scripts/setup/install_raw_runtime.sh`, and `scripts/bootstrap/install_ml_stack.sh` to use the shared resolver instead of bare `python3`
- refreshed setup and validation docs to point operators at `make venv`, `make check-environment`, and `python - <<'PY'` for ad hoc snippets
- added focused tests for the new preflight behavior and Python bootstrap script behavior

## Validation
- `bash -n scripts/setup/resolve_python_311.sh`
- `bash -n scripts/validation/run_full_validation_suite.sh`
- `bash -n scripts/setup/install_da3_runtime.sh`
- `bash -n scripts/setup/install_raw_runtime.sh`
- `bash -n scripts/bootstrap/install_ml_stack.sh`
- `.venv/bin/pytest -q tests/validation/test_environment_preflight.py tests/validation/test_python_bootstrap_scripts.py`
- `make repair-core-venv`
- `.venv/bin/python -m pip check`
- `make check-environment`
- `./scripts/setup/install_da3_runtime.sh --dry-run --skip-verify --checkout-dir /tmp/tp-da3-checkout --venv-dir /tmp/tp-da3-venv`
- `./scripts/setup/install_raw_runtime.sh --dry-run --skip-verify --venv-dir /tmp/tp-raw-venv`
- `./scripts/validation/run_full_validation_suite.sh --quick`

## Notes
- `python3 scripts/validation/check_local_environment.py --json` now intentionally hard-fails when the repo `.venv` exists but the active interpreter is outside it.
- The quick validation suite passed after rerunning outside the sandbox, because the sandboxed `pytest-rerunfailures` path could not bind a localhost socket.
