### PR TITLE
[codex] Fix DSSE release assessment binding validation

### DIFF
--- a/src/transformation_portal/attestation/run_card_intoto.py
+++ b/src/transformation_portal/attestation/run_card_intoto.py
@@ -217,11 +217,13 @@ def validate_run_card_statement_binding(
         release_assessment = predicate["release_assessment"]
         if not isinstance(release_assessment, Mapping):
             raise ValueError("Statement predicate release_assessment must be an object when present")
-        sha256_value = release_assessment.get("sha256")
+        if "sha256" not in release_assessment:
+            raise ValueError("Statement predicate release_assessment.sha256 is required")
+        sha256_value = release_assessment["sha256"]
         if not _is_sha256_digest(sha256_value):
             raise ValueError("Statement predicate release_assessment.sha256 must be a sha256 digest")
         if "status" not in release_assessment:
-            raise ValueError("Statement predicate release_assessment.status must be present")
+            raise ValueError("Statement predicate release_assessment.status is required")
         status_value = release_assessment["status"]
         if status_value is not None and not isinstance(status_value, str):
             raise ValueError("Statement predicate release_assessment.status must be a string or null")

--- a/tests/attestation/test_run_card_attestation.py
+++ b/tests/attestation/test_run_card_attestation.py
@@ -223,7 +223,7 @@ def test_dsse_statement_rejects_missing_release_assessment_status() -> None:
     )
     del statement["predicate"]["release_assessment"]["status"]
 
-    with pytest.raises(ValueError, match="release_assessment.status must be present"):
+    with pytest.raises(ValueError, match="release_assessment.status is required"):
         validate_run_card_statement_binding(
             statement,
             run_card_path=Path("run_card_2026-04-10_120000.json"),

--- a/tests/attestation/test_verify_run_card_attestation_cli.py
+++ b/tests/attestation/test_verify_run_card_attestation_cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import hashlib
 import json
 import os
@@ -309,6 +310,22 @@ def test_verify_cli_rejects_missing_explicit_sigstore_bundle_path(tmp_path: Path
 
     assert result.returncode == 5
     assert f"Sigstore bundle not found: {bundle_path}" in result.stderr
+
+
+def test_verify_cli_rejects_dsse_release_assessment_missing_status(tmp_path: Path) -> None:
+    run_card_path, _, dsse_path, _ = _build_inputs(tmp_path)
+    dsse_attestation = json.loads(dsse_path.read_text(encoding="utf-8"))
+    statement = json.loads(base64.b64decode(dsse_attestation["payload"]).decode("utf-8"))
+    statement["predicate"]["release_assessment"] = {"sha256": "c" * 64}
+    dsse_attestation["payload"] = base64.b64encode(
+        json.dumps(statement, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    ).decode("ascii")
+    dsse_path.write_text(json.dumps(dsse_attestation), encoding="utf-8")
+
+    result = _run_tool("--run-card", str(run_card_path), "--require-dsse")
+
+    assert result.returncode == 5
+    assert "release_assessment.status is required" in result.stderr
 
 
 def test_verify_cli_runs_from_source_checkout_without_pyproject_install(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- require `release_assessment.sha256` and `release_assessment.status` explicitly when a DSSE run-card predicate includes `release_assessment`
- keep the binding validator fail-closed with a clearer required-field error surface
- add CLI coverage proving `tools/verify_run_card_attestation.py` rejects DSSE statements that omit `release_assessment.status`

## Root cause
The DSSE binding path validated `release_assessment.status` only after reading the field, but the end-to-end verifier lacked a regression test for an omitted status field. This made the helper contract easier to drift from the predicate schema requirement that both `sha256` and `status` be present.

## Validation
- `/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin/pytest tests/attestation/test_run_card_attestation.py tests/attestation/test_verify_run_card_attestation_cli.py tests/validation/test_assess_run_card_release.py`