### PR TITLE
fix(bootstrap): guard SAM2 return trap cleanup

### DIFF
--- a/scripts/bootstrap/install_ml_stack.sh
+++ b/scripts/bootstrap/install_ml_stack.sh
@@ -395,17 +395,23 @@ install_profile() {
             else
                 # Create secure temporary file for error logging
                 local error_log
+                local cleanup_trap
                 error_log="$(mktemp)"
-                trap 'if [[ -n "${error_log:-}" ]]; then rm -f "${error_log}"; fi' RETURN
+                cleanup_trap="$(printf 'rm -f %q' "${error_log}")"
+                trap "${cleanup_trap}" RETURN
 
                 # Try standard install first
                 log_info "Attempting standard SAM2 install..."
                 log_verbose "Using PyTorch index: ${PYTORCH_INDEX}"
                 if "${pip_cmd[@]}" --extra-index-url "${PYTORCH_INDEX}" sam2==1.1.0 2>"${error_log}"; then
+                    rm -f "${error_log}"
+                    trap - RETURN
                     log_info "SAM2 installed successfully via standard path."
                 else
                     log_warn "Standard install failed. Error log:"
                     cat "${error_log}" >&2
+                    rm -f "${error_log}"
+                    trap - RETURN
                     log_warn "Retrying with --no-build-isolation (torch must be pre-installed)..."
                     if "${pip_cmd[@]}" --extra-index-url "${PYTORCH_INDEX}" --no-build-isolation sam2==1.1.0; then
                         log_info "SAM2 installed successfully with --no-build-isolation."

--- a/scripts/bootstrap/install_ml_stack.sh
+++ b/scripts/bootstrap/install_ml_stack.sh
@@ -396,7 +396,7 @@ install_profile() {
                 # Create secure temporary file for error logging
                 local error_log
                 error_log="$(mktemp)"
-                trap 'rm -f "${error_log}"' RETURN
+                trap 'if [[ -n "${error_log:-}" ]]; then rm -f "${error_log}"; fi' RETURN
 
                 # Try standard install first
                 log_info "Attempting standard SAM2 install..."

--- a/tests/validation/test_python_bootstrap_scripts.py
+++ b/tests/validation/test_python_bootstrap_scripts.py
@@ -446,6 +446,8 @@ def test_install_ml_stack_sam2_success_does_not_fail_on_return_trap(tmp_path: Pa
     script_path = _copy_repo_file(ML_STACK_INSTALLER_PATH, repo_root / "scripts" / "bootstrap" / "install_ml_stack.sh")
     resolver_path = repo_root / "scripts" / "setup" / "resolve_python_311.sh"
     pip_log_path = repo_root / "pip-install.log"
+    fakebin = tmp_path / "fakebin"
+    error_log_path = tmp_path / "sam2-error.log"
     fake_python = _write_fake_ml_core_python(
         repo_root / ".venv" / "bin" / "python",
         version="3.11.15",
@@ -454,9 +456,19 @@ def test_install_ml_stack_sam2_success_does_not_fail_on_return_trap(tmp_path: Pa
         pip_log_path=pip_log_path,
     )
     _write_executable(resolver_path, f"#!/bin/sh\nprintf '%s\\n' {shlex.quote(str(fake_python))}\n")
+    _write_executable(
+        fakebin / "mktemp",
+        (
+            "#!/bin/sh\n"
+            f"tmp={shlex.quote(str(error_log_path))}\n"
+            'rm -f "$tmp"\n'
+            'touch "$tmp"\n'
+            "printf '%s\\n' \"$tmp\"\n"
+        ),
+    )
     (repo_root / "requirements").mkdir(parents=True, exist_ok=True)
 
-    env = {**os.environ, "PATH": "/usr/bin:/bin"}
+    env = {**os.environ, "PATH": f"{fakebin}:/usr/bin:/bin"}
     result = subprocess.run(
         ["bash", str(script_path), "--profile", "sam2"],
         cwd=repo_root,
@@ -469,6 +481,7 @@ def test_install_ml_stack_sam2_success_does_not_fail_on_return_trap(tmp_path: Pa
     assert result.returncode == 0, result.stdout + result.stderr
     assert "SAM2 installed successfully via standard path." in result.stdout
     assert "unbound variable" not in (result.stdout + result.stderr)
+    assert not error_log_path.exists()
     pip_commands = pip_log_path.read_text(encoding="utf-8")
     assert "-m pip install --extra-index-url https://download.pytorch.org/whl/cpu sam2==1.1.0" in pip_commands
 

--- a/tests/validation/test_python_bootstrap_scripts.py
+++ b/tests/validation/test_python_bootstrap_scripts.py
@@ -441,6 +441,38 @@ def test_install_raw_runtime_uses_resolved_python_for_venv_creation(tmp_path: Pa
     assert f"+ {python311} -m venv {repo_root / '.venv-raw'}" in result.stdout
 
 
+def test_install_ml_stack_sam2_success_does_not_fail_on_return_trap(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    script_path = _copy_repo_file(ML_STACK_INSTALLER_PATH, repo_root / "scripts" / "bootstrap" / "install_ml_stack.sh")
+    resolver_path = repo_root / "scripts" / "setup" / "resolve_python_311.sh"
+    pip_log_path = repo_root / "pip-install.log"
+    fake_python = _write_fake_ml_core_python(
+        repo_root / ".venv" / "bin" / "python",
+        version="3.11.15",
+        platform_system="Darwin",
+        platform_machine="arm64",
+        pip_log_path=pip_log_path,
+    )
+    _write_executable(resolver_path, f"#!/bin/sh\nprintf '%s\\n' {shlex.quote(str(fake_python))}\n")
+    (repo_root / "requirements").mkdir(parents=True, exist_ok=True)
+
+    env = {**os.environ, "PATH": "/usr/bin:/bin"}
+    result = subprocess.run(
+        ["bash", str(script_path), "--profile", "sam2"],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "SAM2 installed successfully via standard path." in result.stdout
+    assert "unbound variable" not in (result.stdout + result.stderr)
+    pip_commands = pip_log_path.read_text(encoding="utf-8")
+    assert "-m pip install --extra-index-url https://download.pytorch.org/whl/cpu sam2==1.1.0" in pip_commands
+
+
 def test_resolver_prefers_python314_over_python311(tmp_path: Path) -> None:
     """Test that resolver prefers newer Python versions (e.g., 3.14) over 3.11."""
     repo_root = tmp_path / "repo"


### PR DESCRIPTION
## Summary
- guard the SAM2 standard-install RETURN trap so a successful path does not fail on an unset `error_log`
- add a regression test that proves the Darwin arm64 SAM2 success path stays zero-exit and does not emit an `unbound variable` failure

## Validation
- `bash -n scripts/bootstrap/install_ml_stack.sh`
- `TMPDIR=/private/tmp /Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin/pytest -q tests/validation/test_python_bootstrap_scripts.py -k return_trap --basetemp=/private/tmp/tp-pytest-return-trap`
- `PRE_COMMIT_HOME=/tmp/pre-commit PATH=/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin:$PATH TP_LINT_PYTHON=/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin/python /Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin/pre-commit run --files scripts/bootstrap/install_ml_stack.sh tests/validation/test_python_bootstrap_scripts.py`

## Scope
- only `scripts/bootstrap/install_ml_stack.sh`
- only `tests/validation/test_python_bootstrap_scripts.py`
