### PR TITLE
chore(requirements): refresh generic layered locks

### DIFF
--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -53,9 +53,7 @@ colorama==0.4.6
 coverage[toml]==7.13.4
     # via pytest-cov
 cryptography==46.0.7
-    # via
-    #   -r dev.in
-    #   secretstorage
+    # via -r dev.in
 dill==0.4.1
     # via pylint
 distlib==0.4.0
@@ -106,10 +104,6 @@ jaraco-context==6.1.0
     # via keyring
 jaraco-functools==4.4.0
     # via keyring
-jeepney==0.9.0
-    # via
-    #   keyring
-    #   secretstorage
 joblib==1.5.3
     # via scikit-learn
 jsonschema==4.26.0
@@ -268,8 +262,6 @@ scipy==1.17.1
     # via
     #   -r base.in
     #   scikit-learn
-secretstorage==3.5.0
-    # via keyring
 shellingham==1.5.4
     # via typer
 sortedcontainers==2.4.0

--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -53,7 +53,9 @@ colorama==0.4.6
 coverage[toml]==7.13.4
     # via pytest-cov
 cryptography==46.0.7
-    # via -r dev.in
+    # via
+    #   -r dev.in
+    #   secretstorage
 dill==0.4.1
     # via pylint
 distlib==0.4.0
@@ -104,6 +106,10 @@ jaraco-context==6.1.0
     # via keyring
 jaraco-functools==4.4.0
     # via keyring
+jeepney==0.9.0
+    # via
+    #   keyring
+    #   secretstorage
 joblib==1.5.3
     # via scikit-learn
 jsonschema==4.26.0
@@ -262,6 +268,8 @@ scipy==1.17.1
     # via
     #   -r base.in
     #   scikit-learn
+secretstorage==3.5.0
+    # via keyring
 shellingham==1.5.4
     # via typer
 sortedcontainers==2.4.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,37 +5,162 @@
 #    pip-compile --constraint=all.txt --output-file=base.txt base.in
 #
 aiofiles==25.1.0
+    # via
+    #   -c all.txt
+    #   -r base.in
 annotated-doc==0.0.4
+    # via
+    #   -c all.txt
+    #   fastapi
+    #   typer
 annotated-types==0.7.0
+    # via
+    #   -c all.txt
+    #   pydantic
 anyio==4.12.1
+    # via
+    #   -c all.txt
+    #   starlette
 attrs==25.4.0
+    # via
+    #   -c all.txt
+    #   jsonschema
+    #   referencing
 click==8.3.1
+    # via
+    #   -c all.txt
+    #   typer
+    #   uvicorn
 fastapi==0.135.3
+    # via
+    #   -c all.txt
+    #   -r base.in
 h11==0.16.0
+    # via
+    #   -c all.txt
+    #   uvicorn
 idna==3.11
+    # via
+    #   -c all.txt
+    #   anyio
 imagecodecs==2026.3.6
+    # via
+    #   -c all.txt
+    #   -r base.in
 joblib==1.5.3
+    # via
+    #   -c all.txt
+    #   scikit-learn
 jsonschema==4.26.0
+    # via
+    #   -c all.txt
+    #   -r base.in
 jsonschema-specifications==2025.9.1
+    # via
+    #   -c all.txt
+    #   jsonschema
 markdown-it-py==4.0.0
+    # via
+    #   -c all.txt
+    #   rich
 mdurl==0.1.2
+    # via
+    #   -c all.txt
+    #   markdown-it-py
 numpy==2.4.3
+    # via
+    #   -c all.txt
+    #   -r base.in
+    #   imagecodecs
+    #   opencv-python
+    #   scikit-learn
+    #   scipy
+    #   tifffile
 opencv-python==4.13.0.92
+    # via
+    #   -c all.txt
+    #   -r base.in
 pillow==12.1.1
+    # via
+    #   -c all.txt
+    #   -r base.in
 pydantic==2.12.5
+    # via
+    #   -c all.txt
+    #   -r base.in
+    #   fastapi
 pydantic-core==2.41.5
+    # via
+    #   -c all.txt
+    #   pydantic
 pygments==2.20.0
+    # via
+    #   -c all.txt
+    #   rich
 referencing==0.37.0
+    # via
+    #   -c all.txt
+    #   jsonschema
+    #   jsonschema-specifications
 rich==14.3.3
+    # via
+    #   -c all.txt
+    #   typer
 rpds-py==0.30.0
+    # via
+    #   -c all.txt
+    #   jsonschema
+    #   referencing
 scikit-learn==1.8.0
+    # via
+    #   -c all.txt
+    #   -r base.in
 scipy==1.17.1
+    # via
+    #   -c all.txt
+    #   -r base.in
+    #   scikit-learn
 shellingham==1.5.4
+    # via
+    #   -c all.txt
+    #   typer
 starlette==1.0.0
+    # via
+    #   -c all.txt
+    #   -r base.in
+    #   fastapi
 threadpoolctl==3.6.0
+    # via
+    #   -c all.txt
+    #   scikit-learn
 tifffile==2026.3.3
+    # via
+    #   -c all.txt
+    #   -r base.in
 tqdm==4.67.3
+    # via
+    #   -c all.txt
+    #   -r base.in
 typer==0.24.1
+    # via
+    #   -c all.txt
+    #   -r base.in
 typing-extensions==4.15.0
+    # via
+    #   -c all.txt
+    #   anyio
+    #   fastapi
+    #   pydantic
+    #   pydantic-core
+    #   referencing
+    #   starlette
+    #   typing-inspection
 typing-inspection==0.4.2
+    # via
+    #   -c all.txt
+    #   fastapi
+    #   pydantic
 uvicorn==0.42.0
+    # via
+    #   -c all.txt
+    #   -r base.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -24,6 +24,10 @@ certifi==2026.2.25
     # via
     #   -c all.txt
     #   requests
+cffi==2.0.0
+    # via
+    #   -c all.txt
+    #   cryptography
 charset-normalizer==3.4.4
     # via
     #   -c all.txt
@@ -32,6 +36,10 @@ colorama==0.4.6
     # via
     #   -c all.txt
     #   tox
+cryptography==46.0.7
+    # via
+    #   -c all.txt
+    #   secretstorage
 distlib==0.4.0
     # via
     #   -c all.txt
@@ -70,6 +78,11 @@ jaraco-functools==4.4.0
     # via
     #   -c all.txt
     #   keyring
+jeepney==0.9.0
+    # via
+    #   -c all.txt
+    #   keyring
+    #   secretstorage
 keyring==25.7.0
     # via
     #   -c all.txt
@@ -108,6 +121,10 @@ pluggy==1.6.0
     # via
     #   -c all.txt
     #   tox
+pycparser==3.0
+    # via
+    #   -c all.txt
+    #   cffi
 pygments==2.20.0
     # via
     #   -c all.txt
@@ -156,6 +173,10 @@ rich==14.3.3
     #   -c all.txt
     #   bandit
     #   twine
+secretstorage==3.5.0
+    # via
+    #   -c all.txt
+    #   keyring
 stevedore==5.7.0
     # via
     #   -c all.txt

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -5,49 +5,184 @@
 #    pip-compile --constraint=all.txt --output-file=ci.txt ci.in
 #
 backports-tarfile==1.2.0
+    # via
+    #   -c all.txt
+    #   jaraco-context
 bandit==1.9.4
+    # via
+    #   -c all.txt
+    #   -r ci.in
 build==1.4.2
+    # via
+    #   -c all.txt
+    #   -r ci.in
 cachetools==7.0.5
+    # via
+    #   -c all.txt
+    #   tox
 certifi==2026.2.25
-cffi==2.0.0
+    # via
+    #   -c all.txt
+    #   requests
 charset-normalizer==3.4.4
+    # via
+    #   -c all.txt
+    #   requests
 colorama==0.4.6
-cryptography==46.0.7
+    # via
+    #   -c all.txt
+    #   tox
 distlib==0.4.0
+    # via
+    #   -c all.txt
+    #   virtualenv
 docutils==0.22.4
+    # via
+    #   -c all.txt
+    #   readme-renderer
 filelock==3.25.0
+    # via
+    #   -c all.txt
+    #   python-discovery
+    #   tox
+    #   virtualenv
 id==1.6.1
+    # via
+    #   -c all.txt
+    #   twine
 idna==3.11
+    # via
+    #   -c all.txt
+    #   requests
 importlib-metadata==8.7.1
+    # via
+    #   -c all.txt
+    #   keyring
 jaraco-classes==3.4.0
+    # via
+    #   -c all.txt
+    #   keyring
 jaraco-context==6.1.0
+    # via
+    #   -c all.txt
+    #   keyring
 jaraco-functools==4.4.0
-jeepney==0.9.0
+    # via
+    #   -c all.txt
+    #   keyring
 keyring==25.7.0
+    # via
+    #   -c all.txt
+    #   twine
 markdown-it-py==4.0.0
+    # via
+    #   -c all.txt
+    #   rich
 mdurl==0.1.2
+    # via
+    #   -c all.txt
+    #   markdown-it-py
 more-itertools==10.8.0
+    # via
+    #   -c all.txt
+    #   jaraco-classes
+    #   jaraco-functools
 nh3==0.3.3
+    # via
+    #   -c all.txt
+    #   readme-renderer
 packaging==26.0
+    # via
+    #   -c all.txt
+    #   build
+    #   pyproject-api
+    #   tox
+    #   twine
 platformdirs==4.9.6
+    # via
+    #   -c all.txt
+    #   python-discovery
+    #   tox
+    #   virtualenv
 pluggy==1.6.0
-pycparser==3.0
+    # via
+    #   -c all.txt
+    #   tox
 pygments==2.20.0
+    # via
+    #   -c all.txt
+    #   readme-renderer
+    #   rich
 pypdf==6.10.0
+    # via
+    #   -c all.txt
+    #   -r ci.in
 pyproject-api==1.10.0
+    # via
+    #   -c all.txt
+    #   tox
 pyproject-hooks==1.2.0
+    # via
+    #   -c all.txt
+    #   build
 python-discovery==1.2.2
+    # via
+    #   -c all.txt
+    #   tox
+    #   virtualenv
 pyyaml==6.0.3
+    # via
+    #   -c all.txt
+    #   bandit
 readme-renderer==44.0
+    # via
+    #   -c all.txt
+    #   twine
 requests==2.33.0
+    # via
+    #   -c all.txt
+    #   requests-toolbelt
+    #   twine
 requests-toolbelt==1.0.0
+    # via
+    #   -c all.txt
+    #   twine
 rfc3986==2.0.0
+    # via
+    #   -c all.txt
+    #   twine
 rich==14.3.3
-secretstorage==3.5.0
+    # via
+    #   -c all.txt
+    #   bandit
+    #   twine
 stevedore==5.7.0
+    # via
+    #   -c all.txt
+    #   bandit
 tomli-w==1.2.0
+    # via
+    #   -c all.txt
+    #   tox
 tox==4.52.0
+    # via
+    #   -c all.txt
+    #   -r ci.in
 twine==6.2.0
+    # via
+    #   -c all.txt
+    #   -r ci.in
 urllib3==2.6.3
+    # via
+    #   -c all.txt
+    #   id
+    #   requests
+    #   twine
 virtualenv==21.1.0
+    # via
+    #   -c all.txt
+    #   tox
 zipp==3.23.0
+    # via
+    #   -c all.txt
+    #   importlib-metadata

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,53 +5,229 @@
 #    pip-compile --constraint=all.txt --output-file=dev.txt dev.in
 #
 anyio==4.12.1
+    # via
+    #   -c all.txt
+    #   httpx
 astroid==4.0.4
+    # via
+    #   -c all.txt
+    #   pylint
 attrs==25.4.0
+    # via
+    #   -c all.txt
+    #   jsonschema
+    #   referencing
 autopep8==2.3.2
+    # via
+    #   -c all.txt
+    #   -r dev.in
 black==26.3.1
+    # via
+    #   -c all.txt
+    #   -r dev.in
 certifi==2026.2.25
+    # via
+    #   -c all.txt
+    #   httpcore
+    #   httpx
 cffi==2.0.0
+    # via
+    #   -c all.txt
+    #   cryptography
 click==8.3.1
+    # via
+    #   -c all.txt
+    #   black
 coverage[toml]==7.13.4
+    # via
+    #   -c all.txt
+    #   pytest-cov
 cryptography==46.0.7
+    # via
+    #   -c all.txt
+    #   -r dev.in
 dill==0.4.1
+    # via
+    #   -c all.txt
+    #   pylint
 execnet==2.1.2
+    # via
+    #   -c all.txt
+    #   pytest-xdist
 flake8==7.3.0
+    # via
+    #   -c all.txt
+    #   -r dev.in
 h11==0.16.0
+    # via
+    #   -c all.txt
+    #   httpcore
 httpcore==1.0.9
+    # via
+    #   -c all.txt
+    #   httpx
 httpx==0.28.1
+    # via
+    #   -c all.txt
+    #   -r dev.in
 hypothesis==6.151.12
+    # via
+    #   -c all.txt
+    #   -r dev.in
 idna==3.11
+    # via
+    #   -c all.txt
+    #   anyio
+    #   httpx
 iniconfig==2.3.0
+    # via
+    #   -c all.txt
+    #   pytest
 isort==7.0.0
+    # via
+    #   -c all.txt
+    #   -r dev.in
+    #   pylint
 jsonschema==4.26.0
+    # via
+    #   -c all.txt
+    #   -r dev.in
 jsonschema-specifications==2025.9.1
+    # via
+    #   -c all.txt
+    #   jsonschema
 libcst==1.8.6
+    # via
+    #   -c all.txt
+    #   -r dev.in
 librt==0.8.1
+    # via
+    #   -c all.txt
+    #   mypy
 mccabe==0.7.0
+    # via
+    #   -c all.txt
+    #   flake8
+    #   pylint
 mypy==1.19.1
+    # via
+    #   -c all.txt
+    #   -r dev.in
 mypy-extensions==1.1.0
+    # via
+    #   -c all.txt
+    #   black
+    #   mypy
 packaging==26.0
+    # via
+    #   -c all.txt
+    #   black
+    #   pytest
+    #   pytest-rerunfailures
 pathspec==1.0.4
-platformdirs==4.9.2
+    # via
+    #   -c all.txt
+    #   black
+    #   mypy
+platformdirs==4.9.6
+    # via
+    #   -c all.txt
+    #   black
+    #   pylint
 pluggy==1.6.0
+    # via
+    #   -c all.txt
+    #   pytest
+    #   pytest-cov
 pycodestyle==2.14.0
+    # via
+    #   -c all.txt
+    #   autopep8
+    #   flake8
 pycparser==3.0
+    # via
+    #   -c all.txt
+    #   cffi
 pyflakes==3.4.0
+    # via
+    #   -c all.txt
+    #   flake8
 pygments==2.20.0
+    # via
+    #   -c all.txt
+    #   pytest
 pylint==4.0.5
+    # via
+    #   -c all.txt
+    #   -r dev.in
 pytest==9.0.3
+    # via
+    #   -c all.txt
+    #   -r dev.in
+    #   pytest-asyncio
+    #   pytest-cov
+    #   pytest-json-report
+    #   pytest-metadata
+    #   pytest-rerunfailures
+    #   pytest-xdist
 pytest-asyncio==1.3.0
+    # via
+    #   -c all.txt
+    #   -r dev.in
 pytest-cov==7.1.0
+    # via
+    #   -c all.txt
+    #   -r dev.in
 pytest-json-report==1.5.0
+    # via
+    #   -c all.txt
+    #   -r dev.in
 pytest-metadata==3.1.1
+    # via
+    #   -c all.txt
+    #   pytest-json-report
 pytest-rerunfailures==16.1
+    # via
+    #   -c all.txt
+    #   -r dev.in
 pytest-xdist==3.8.0
+    # via
+    #   -c all.txt
+    #   -r dev.in
 pytokens==0.4.1
+    # via
+    #   -c all.txt
+    #   black
 pyyaml==6.0.3
+    # via
+    #   -c all.txt
+    #   libcst
 referencing==0.37.0
+    # via
+    #   -c all.txt
+    #   jsonschema
+    #   jsonschema-specifications
 rpds-py==0.30.0
+    # via
+    #   -c all.txt
+    #   jsonschema
+    #   referencing
 sortedcontainers==2.4.0
+    # via
+    #   -c all.txt
+    #   hypothesis
 tomlkit==0.14.0
+    # via
+    #   -c all.txt
+    #   pylint
 types-pyyaml==6.0.12.20250915
+    # via
+    #   -c all.txt
+    #   -r dev.in
 typing-extensions==4.15.0
+    # via
+    #   -c all.txt
+    #   anyio
+    #   mypy
+    #   pytest-asyncio
+    #   referencing

--- a/requirements/tools-archive.txt
+++ b/requirements/tools-archive.txt
@@ -6,39 +6,57 @@
 #
 attrs==25.4.0
     # via
+    #   -c all.txt
     #   jsonschema
     #   referencing
 bagit==1.9.0
     # via -r tools-archive.in
 cffi==2.0.0
-    # via cryptography
+    # via
+    #   -c all.txt
+    #   cryptography
 cryptography==46.0.7
-    # via -r tools-archive.in
+    # via
+    #   -c all.txt
+    #   -r tools-archive.in
 jsonschema==4.26.0
-    # via -r tools-archive.in
+    # via
+    #   -c all.txt
+    #   -r tools-archive.in
 jsonschema-specifications==2025.9.1
-    # via jsonschema
+    # via
+    #   -c all.txt
+    #   jsonschema
 numpy==2.4.3
     # via
+    #   -c all.txt
     #   -r tools-archive.in
     #   pandas
 pandas==3.0.1
     # via -r tools-archive.in
 pycparser==3.0
-    # via cffi
+    # via
+    #   -c all.txt
+    #   cffi
 python-dateutil==2.9.0.post0
     # via pandas
 pyyaml==6.0.3
-    # via -r tools-archive.in
+    # via
+    #   -c all.txt
+    #   -r tools-archive.in
 referencing==0.37.0
     # via
+    #   -c all.txt
     #   jsonschema
     #   jsonschema-specifications
 rpds-py==0.30.0
     # via
+    #   -c all.txt
     #   jsonschema
     #   referencing
 six==1.17.0
     # via python-dateutil
 typing-extensions==4.15.0
-    # via referencing
+    # via
+    #   -c all.txt
+    #   referencing

--- a/scripts/validation/check_requirements_lock_contract.py
+++ b/scripts/validation/check_requirements_lock_contract.py
@@ -107,6 +107,10 @@ DARWIN_ARM64_COREML_PATTERN = re.compile(r"^coremltools\b[^\n]*$", re.IGNORECASE
 LINUX_TRANSFORMERS_GUARD_PATTERN = re.compile(r"^transformers[^#\n]*<\s*5(?:\.0+)?(?:\s|$)", re.IGNORECASE)
 DARWIN_LOCKFILE_FORBIDDEN_PACKAGES = ("triton",)
 DARWIN_LOCKFILE_FORBIDDEN_PREFIXES = ("nvidia-",)
+GENERIC_LINUX_KEYRING_REQUIRED_PACKAGES = {
+    "all.txt": ("jeepney", "secretstorage"),
+    "ci.txt": ("cffi", "cryptography", "jeepney", "pycparser", "secretstorage"),
+}
 # Note: [^\n]* (not [^#\n]*) intentionally matches lines that carry inline comments,
 # because ml-core-darwin-arm64.in declares coremltools with a trailing # comment.
 # The x86 guard patterns check stripped non-comment lines, so they use [^#\n]*.
@@ -266,6 +270,31 @@ def _read_pinned_packages(lock_path: Path) -> dict[str, str]:
         if match:
             packages[_normalize_package_name(match.group(1))] = match.group(2)
     return packages
+
+
+def validate_generic_linux_keyring_pins() -> list[str]:
+    """Ensure generic locks keep the Linux keyring backend pinned."""
+    errors: list[str] = []
+
+    for lock_name, required_packages in GENERIC_LINUX_KEYRING_REQUIRED_PACKAGES.items():
+        lock_path = REQUIREMENTS_DIR / lock_name
+        if not lock_path.is_file():
+            continue
+
+        packages = _read_pinned_packages(lock_path)
+        if "keyring" not in packages:
+            continue
+
+        missing = [package for package in required_packages if package not in packages]
+        if missing:
+            missing_text = ", ".join(repr(package) for package in missing)
+            errors.append(
+                f"{lock_path} pins keyring=={packages['keyring']} but is missing Linux keyring-chain packages "
+                f"{missing_text}. Regenerate the generic lock on ubuntu-x64-generic or restore the pinned "
+                "Linux transitive dependencies explicitly."
+            )
+
+    return errors
 
 
 def validate_darwin_lock_purity() -> list[str]:
@@ -444,6 +473,7 @@ def main() -> int:
     errors.extend(validate_lock_ownership_manifest())
     errors.extend(validate_lockfile_headers(expected_python))
     errors.extend(validate_noncore_optional_lockfiles_absent())
+    errors.extend(validate_generic_linux_keyring_pins())
     errors.extend(validate_platform_lock_markers())
     errors.extend(validate_darwin_input_guards())
     errors.extend(validate_linux_input_guards())

--- a/tests/test_check_requirements_lock_contract.py
+++ b/tests/test_check_requirements_lock_contract.py
@@ -180,6 +180,59 @@ def test_noncore_optional_lockfile_is_reported(isolated_repo: Path) -> None:
     ]
 
 
+def test_generic_lock_requires_linux_keyring_transitives_in_all_lock(isolated_repo: Path) -> None:
+    write_lockfile(
+        isolated_repo,
+        "all.txt",
+        "3.11",
+        body="keyring==25.7.0\ncryptography==46.0.7\ncffi==2.0.0\npycparser==3.0\n",
+    )
+
+    errors = contract.validate_generic_linux_keyring_pins()
+
+    assert errors == [
+        f"{isolated_repo / 'requirements' / 'all.txt'} pins keyring==25.7.0 but is missing Linux keyring-chain packages "
+        "'jeepney', 'secretstorage'. Regenerate the generic lock on ubuntu-x64-generic or restore the pinned "
+        "Linux transitive dependencies explicitly."
+    ]
+
+
+def test_generic_lock_requires_linux_keyring_transitives_in_ci_lock(isolated_repo: Path) -> None:
+    write_lockfile(
+        isolated_repo,
+        "ci.txt",
+        "3.11",
+        body="keyring==25.7.0\njeepney==0.9.0\nsecretstorage==3.5.0\n",
+    )
+
+    errors = contract.validate_generic_linux_keyring_pins()
+
+    assert errors == [
+        f"{isolated_repo / 'requirements' / 'ci.txt'} pins keyring==25.7.0 but is missing Linux keyring-chain packages "
+        "'cffi', 'cryptography', 'pycparser'. Regenerate the generic lock on ubuntu-x64-generic or restore the pinned "
+        "Linux transitive dependencies explicitly."
+    ]
+
+
+def test_generic_lock_accepts_complete_linux_keyring_chain(isolated_repo: Path) -> None:
+    write_lockfile(
+        isolated_repo,
+        "all.txt",
+        "3.11",
+        body="keyring==25.7.0\njeepney==0.9.0\nsecretstorage==3.5.0\ncryptography==46.0.7\ncffi==2.0.0\npycparser==3.0\n",
+    )
+    write_lockfile(
+        isolated_repo,
+        "ci.txt",
+        "3.11",
+        body="keyring==25.7.0\njeepney==0.9.0\nsecretstorage==3.5.0\ncryptography==46.0.7\ncffi==2.0.0\npycparser==3.0\n",
+    )
+
+    errors = contract.validate_generic_linux_keyring_pins()
+
+    assert errors == []
+
+
 def test_platform_lock_wrong_os_marker_is_reported(isolated_repo: Path) -> None:
     write_lockfile(
         isolated_repo,


### PR DESCRIPTION
## Summary
- refresh the generic layered lockfiles so repo-level `make check` is green again on the M4 Max
- keep the #1422 authority model intact by touching only the generic layered set and leaving target-owned ML lockfiles unchanged
- preserve the Linux `keyring` backend chain in the generic locks and add contract enforcement so off-lane refreshes cannot silently drop those transitive pins again

## Changed Files
- `requirements/all.txt`
- `requirements/base.txt`
- `requirements/ci.txt`
- `requirements/dev.txt`
- `requirements/tools-archive.txt`
- `scripts/validation/check_requirements_lock_contract.py`
- `tests/test_check_requirements_lock_contract.py`

## Validation
- `cd requirements && PATH=/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin:$PATH make compile LOCK_PYTHON_VERSION=3.11`
- `cd requirements && PATH=/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin:$PATH make check LOCK_PYTHON_VERSION=3.11`
- `PATH=/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin:$PATH make check`
- `PATH=/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin:$PATH /Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin/python scripts/validation/check_dependency_update_workflow.py`
- `PATH=/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin:$PATH /Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin/python scripts/validation/check_requirements_lock_contract.py`
- `/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin/pytest -o cache_dir=/tmp/pytest-cache tests/test_check_requirements_lock_contract.py tests/test_check_lock_ownership.py`
- `PRE_COMMIT_HOME=/tmp/pre-commit PATH=/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin:$PATH TP_LINT_PYTHON=/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin/python /Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin/pre-commit run --files requirements/all.txt requirements/base.txt requirements/ci.txt requirements/dev.txt requirements/tools-archive.txt scripts/validation/check_requirements_lock_contract.py tests/test_check_requirements_lock_contract.py`

## Ownership Boundary
- no `requirements/ml-core-*.txt` file changed
- Darwin arm64 remains local-only authoritative
- Linux x86_64 remains CI/native-Linux authoritative
- Darwin x86_64 remains frozen
