### PR TITLE
fix(ci): pin dependency-update lock toolchain

### DIFF
--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -51,10 +51,10 @@ jobs:
 
       - name: Install lock generation tools
         run: |
-          python -m pip install --upgrade pip
-          pip install "pip-tools==7.5.2"
+          python -m pip install --upgrade "pip<26"
+          python -m pip install "pip-tools==7.5.2"
           # Install pip-audit from governed security lockfile
-          pip install -r requirements/security.txt
+          python -m pip install -r requirements/security.txt
 
       - name: Update dependencies
         env:

--- a/scripts/validation/check_dependency_update_workflow.py
+++ b/scripts/validation/check_dependency_update_workflow.py
@@ -64,6 +64,12 @@ REQUIRED_WORKFLOW_SNIPPETS = (
     "requirements/ml-core-darwin-x86_64.txt",
 )
 
+REQUIRED_INSTALL_TOOLCHAIN_SNIPPETS = (
+    'python -m pip install --upgrade "pip<26"',
+    'python -m pip install "pip-tools==7.5.2"',
+    "python -m pip install -r requirements/security.txt",
+)
+
 FORBIDDEN_WORKFLOW_SNIPPETS = (
     "make update LOCK_PYTHON_VERSION=3.11",
     "make check LOCK_PYTHON_VERSION=3.11",
@@ -149,6 +155,10 @@ def validate_dependency_update_workflow(text: str) -> list[str]:
     for snippet in REQUIRED_WORKFLOW_SNIPPETS:
         if snippet not in text:
             errors.append(f"dependency-update workflow must include snippet {snippet!r}")
+
+    for snippet in REQUIRED_INSTALL_TOOLCHAIN_SNIPPETS:
+        if snippet not in text:
+            errors.append(f"dependency-update workflow must include install-tool snippet {snippet!r}")
 
     for snippet in FORBIDDEN_WORKFLOW_SNIPPETS:
         if snippet in text:

--- a/tests/test_check_dependency_update_workflow.py
+++ b/tests/test_check_dependency_update_workflow.py
@@ -18,7 +18,13 @@ def valid_workflow_text() -> str:
     required_pr_refs = "\n".join(f"          {ref}" for ref in workflow_contract.REQUIRED_PR_BODY_REFERENCES)
     required_pr_snippets = "\n".join(f"          {snippet}" for snippet in workflow_contract.REQUIRED_PR_BODY_SNIPPETS)
     required_workflow_snippets = "\n".join(f"        {snippet}" for snippet in workflow_contract.REQUIRED_WORKFLOW_SNIPPETS)
+    required_install_snippets = "\n".join(
+        f"        {snippet}" for snippet in workflow_contract.REQUIRED_INSTALL_TOOLCHAIN_SNIPPETS
+    )
     return f"""
+    - name: Install lock generation tools
+      run: |
+{required_install_snippets}
     - name: Update dependencies
       run: |
 {required_workflow_snippets}
@@ -43,7 +49,10 @@ def remove_from_pr_body(text: str, needle: str) -> str:
 
 
 def remove_from_audit_targets(text: str, needle: str) -> str:
-    return text.replace(f"{needle}\n", "", 1)
+    before_block, rest = text.split("        audit_targets=(\n", maxsplit=1)
+    audit_targets_block, after_block = rest.split("        )\n", maxsplit=1)
+    audit_targets_block = audit_targets_block.replace(f"{needle}\n", "", 1)
+    return f"{before_block}        audit_targets=(\n{audit_targets_block}        )\n{after_block}"
 
 
 def remove_audit_targets_block(text: str) -> str:
@@ -90,6 +99,14 @@ def test_missing_required_workflow_snippet_is_reported() -> None:
     assert (
         "dependency-update workflow must include snippet " "'make update-ml-linux-x86_64 LOCK_PYTHON_VERSION=3.11'"
     ) in errors
+
+
+def test_missing_required_install_toolchain_snippet_is_reported() -> None:
+    broken = remove_workflow_snippet(valid_workflow_text(), 'python -m pip install --upgrade "pip<26"')
+    errors = workflow_contract.validate_dependency_update_workflow(broken)
+    assert (
+        "dependency-update workflow must include install-tool snippet 'python -m pip install --upgrade \"pip<26\"'" in errors
+    )
 
 
 def test_forbidden_target_agnostic_update_command_is_reported() -> None:


### PR DESCRIPTION
## Summary
- pin the dependency-update workflow to pip less than 26 while keeping pip-tools 7.5.2
- switch the install step to python -m pip consistently so the runner uses the configured interpreter
- extend the dependency-update workflow contract validator and tests so this compatibility requirement stays enforced

## Why
A manual Linux lane dispatch from the M4 Max reached the workflow boundary and then failed inside Update dependencies with an AttributeError from pip-tools against the hosted runner pip stack. The repo already documents the compatible pairing as pip less than 26 plus pip-tools 7.5.2.

## Validation
- /Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin/python scripts/validation/check_dependency_update_workflow.py
- TMPDIR=/private/tmp /Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin/pytest -q tests/test_check_dependency_update_workflow.py --basetemp=/private/tmp/tp-pytest-dependency-update
- PRE_COMMIT_HOME=/tmp/pre-commit PATH=/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin:$PATH TP_LINT_PYTHON=/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin/python /Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin/pre-commit run --files .github/workflows/dependency-update.yml scripts/validation/check_dependency_update_workflow.py tests/test_check_dependency_update_workflow.py
