### PR TITLE
fix(v2): enforce emitted artifact naming contract

### DIFF
--- a/scripts/enhance_image.py
+++ b/scripts/enhance_image.py
@@ -28,7 +28,13 @@ from pathlib import Path
 from typing import Any
 
 # Import V2 enhancement implementation
-from transformation_portal.lux_depth_v3.v2_enhance import V2EnhancementError, enhance_image, find_depth_map
+from transformation_portal.lux_depth_v3.v2_enhance import (
+    V2EnhancementError,
+    enhance_image,
+    find_depth_map,
+    infer_v2_output_bit_depth,
+    resolve_v2_emitted_artifact_path,
+)
 from transformation_portal.lux_depth_v3.v2_presets import V2EnhancementConfig
 
 logger = logging.getLogger("lux_depth_v2_enhance")
@@ -291,8 +297,14 @@ def run_v2_enhancement(
     depth_dir = validate_depth_dir(depth_dir)
     output_dir = validate_output_dir(output_dir)
 
-    # Use only filename to avoid leaking directory structure into output paths
-    output_path = safe_join_under(output_dir, input_path.name)
+    # Build emitted artifact path from canonical identity rather than source suffix.
+    lookup_key = resolve_asset_key(asset_key, input_path.stem)
+    candidate_bit_depth = infer_v2_output_bit_depth(input_path, allow_8bit_output=allow_8bit)
+    output_path = resolve_v2_emitted_artifact_path(
+        safe_join_under(output_dir, lookup_key),
+        bit_depth=candidate_bit_depth,
+        identity=lookup_key,
+    )
 
     # Prevent no-op/self-copy edge case
     if input_path == output_path:
@@ -310,7 +322,6 @@ def run_v2_enhancement(
     # Find depth map if depth_dir provided
     # Use canonical asset key for depth lookup to align with orchestrator naming
     # Validate asset_key to prevent path traversal (important for direct CLI invocation)
-    lookup_key = resolve_asset_key(asset_key, input_path.stem)
     depth_map_path = None
     if depth_dir:
         depth_map_path = find_depth_map(depth_dir, lookup_key)
@@ -337,7 +348,7 @@ def run_v2_enhancement(
     report["upscaler"] = upscaler
 
     # Add identity metadata for provenance/debugging
-    report["asset_key"] = asset_key if asset_key else input_path.stem
+    report["asset_key"] = lookup_key
     report["input_stem"] = input_path.stem
 
     # Enrich depth block with lookup_key (computed at this layer)

--- a/src/transformation_portal/lux_depth_v3/v2_enhance.py
+++ b/src/transformation_portal/lux_depth_v3/v2_enhance.py
@@ -65,6 +65,66 @@ _KNOWN_IMAGE_EXTENSIONS = (
     ".exr",
 )
 
+_RAW_SOURCE_EXTENSIONS = {
+    ".3fr",
+    ".arw",
+    ".cr2",
+    ".cr3",
+    ".crw",
+    ".dng",
+    ".iiq",
+    ".nef",
+    ".nrw",
+    ".orf",
+    ".pef",
+    ".raf",
+    ".rw2",
+    ".sr2",
+    ".srf",
+    ".srw",
+}
+
+
+def emitted_v2_suffix_for_bit_depth(bit_depth: int) -> str:
+    """Return the canonical emitted suffix for a V2 artifact."""
+    return ".tif" if int(bit_depth) >= 16 else ".png"
+
+
+def resolve_v2_emitted_artifact_path(
+    output_path: Path,
+    *,
+    bit_depth: int,
+    identity: str | None = None,
+) -> Path:
+    """Normalize a V2 emitted artifact path to the canonical basename and suffix."""
+    candidate_path = Path(output_path)
+    normalized_identity = canonical_asset_stem(identity) if identity else canonical_asset_stem(candidate_path.stem)
+    if not normalized_identity:
+        normalized_identity = "artifact"
+    emitted_name = f"{normalized_identity}_materials_v3_enhanced{emitted_v2_suffix_for_bit_depth(bit_depth)}"
+    return candidate_path.with_name(emitted_name)
+
+
+def infer_v2_output_bit_depth(input_path: Path, *, allow_8bit_output: bool = False) -> int:
+    """Infer the likely emitted V2 bit depth before enhancement runs."""
+    if allow_8bit_output:
+        return 8
+
+    input_path = Path(input_path)
+    if input_path.suffix.lower() in _RAW_SOURCE_EXTENSIONS:
+        return 16
+
+    try:
+        with Image.open(input_path) as pil_image:
+            return 16 if detect_input_bit_depth(pil_image) == 16 else 8
+    except Exception as exc:  # pragma: no cover - best-effort inference fallback
+        logger.debug("Could not inspect input bit depth for %s: %s", input_path, exc)
+
+    if input_path.suffix.lower() in {".tif", ".tiff"}:
+        return 16
+
+    return 8
+
 
 def _coerce_to_stem_preserving_dots(input_path_or_stem: str) -> str:
     """Treat value as a stem by default; only strip extensions for path-like inputs."""
@@ -552,7 +612,10 @@ def enhance_image(
                 raise V2EnhancementError(f"Unsupported dtype conversion: {enhanced_image.dtype} → {target_dtype}")
 
         # Ensure output directory exists
-        output_path = Path(output_path)
+        output_path = resolve_v2_emitted_artifact_path(
+            output_path,
+            bit_depth=target_bits,
+        )
         output_path.parent.mkdir(parents=True, exist_ok=True)
 
         # Save enhanced image with metadata preservation and correct bit-depth

--- a/tests/test_enhance_image_script_contract.py
+++ b/tests/test_enhance_image_script_contract.py
@@ -1,0 +1,111 @@
+"""Contract tests for the standalone V2 enhancement script naming behavior."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+from PIL import Image
+
+pytestmark = pytest.mark.unit
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "enhance_image.py"
+RAW_SUFFIXES = (".dng", ".cr2", ".nef", ".arw")
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location("tp_v2_enhance_script_contract", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_input_fixture(path: Path) -> None:
+    if path.suffix.lower() in {".png", ".jpg", ".jpeg"}:
+        data = np.full((8, 8, 3), 96, dtype=np.uint8)
+        Image.fromarray(data, mode="RGB").save(path)
+        return
+
+    path.write_bytes(b"raw-input-fixture")
+
+
+@pytest.mark.parametrize(
+    ("input_name", "asset_key", "expected_name"),
+    [
+        ("scene.DNG", None, "scene_materials_v3_enhanced.tif"),
+        ("scene.CR2", "scene_hash", "scene_hash_materials_v3_enhanced.tif"),
+        ("scene.jpg", None, "scene_materials_v3_enhanced.png"),
+        ("scene.png", "scene_hash", "scene_hash_materials_v3_enhanced.png"),
+    ],
+)
+def test_run_v2_enhancement_uses_canonical_emitted_artifact_name(
+    tmp_path: Path,
+    input_name: str,
+    asset_key: str | None,
+    expected_name: str,
+) -> None:
+    module = _load_script_module()
+
+    input_path = tmp_path / input_name
+    output_dir = tmp_path / "output"
+    _write_input_fixture(input_path)
+
+    def _fake_enhance_image(
+        *,
+        input_path: Path,
+        output_path: Path,
+        depth_map_path: Path | None,
+        material_masks: dict[str, Any] | None,
+        config: Any,
+        device: str,
+        allow_8bit_output: bool,
+    ) -> dict[str, Any]:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(b"enhanced")
+        return {
+            "status": "success",
+            "implementation": "v2_enhance",
+            "input": str(input_path),
+            "output": str(output_path),
+            "depth_map": str(depth_map_path) if depth_map_path else None,
+            "depth_consumed": False,
+            "preset": config.preset,
+            "runtime_s": 0.01,
+            "timestamp": 0.0,
+            "depth": {
+                "requested": False,
+                "resolved_path": None,
+                "loaded": False,
+                "supplied_to_stage": False,
+                "consumed": False,
+                "consumption_source": "not_requested",
+                "stage_has_depth": None,
+            },
+        }
+
+    with patch.object(module, "enhance_image", side_effect=_fake_enhance_image):
+        report = module.run_v2_enhancement(
+            input_path=input_path,
+            depth_dir=None,
+            output_dir=output_dir,
+            preset="default",
+            device="cpu",
+            upscaler="default",
+            allow_8bit=False,
+            masks_file=None,
+            asset_key=asset_key,
+        )
+
+    emitted_output = Path(report["output"])
+    assert emitted_output.name == expected_name
+    assert emitted_output.parent == output_dir
+    assert report["asset_key"] == (asset_key or input_path.stem)
+    assert report["input_stem"] == input_path.stem
+    assert emitted_output.exists()
+    assert all(not report["output"].lower().endswith(raw_suffix) for raw_suffix in RAW_SUFFIXES)

--- a/tests/test_lux_depth_v3_critical_fixes.py
+++ b/tests/test_lux_depth_v3_critical_fixes.py
@@ -22,7 +22,7 @@ from PIL import Image, ImageOps
 from transformation_portal.lux_depth_v3.batch_stats import compute_batch_runtime_stats, detect_runtime_outliers
 from transformation_portal.lux_depth_v3.input_discovery import DiscoveryConfig, discover_images
 from transformation_portal.lux_depth_v3.preprocessing import preprocess_image
-from transformation_portal.lux_depth_v3.v2_enhance import enhance_image
+from transformation_portal.lux_depth_v3.v2_enhance import enhance_image, resolve_v2_emitted_artifact_path
 
 pytestmark = pytest.mark.unit
 
@@ -67,12 +67,14 @@ class TestFix1DoubleEXIFRotation:
 
             # Run enhancement
             result = enhance_image(input_path, output_path, config=None)
+            emitted_output = resolve_v2_emitted_artifact_path(output_path, bit_depth=8)
 
             assert result["status"] == "success"
-            assert output_path.exists()
+            assert Path(result["output"]) == emitted_output
+            assert emitted_output.exists()
 
             # Load output and check that EXIF is not present or orientation is reset
-            output_img = Image.open(output_path)
+            output_img = Image.open(emitted_output)
             exif_data = output_img.info.get("exif")
 
             # After fix: EXIF should be None (stripped) to prevent double rotation
@@ -99,6 +101,7 @@ class TestFix1DoubleEXIFRotation:
 
             result = enhance_image(input_path, output_path, config=None)
             assert result["status"] == "success"
+            assert Path(result["output"]) == resolve_v2_emitted_artifact_path(output_path, bit_depth=8)
 
 
 class TestFix2DimensionMismatch:
@@ -275,12 +278,14 @@ class TestFix5AlphaChannelSafety:
 
             # Run enhancement - should not crash despite dimension mismatch
             result = enhance_image(input_path, output_path, config=None)
+            emitted_output = resolve_v2_emitted_artifact_path(output_path, bit_depth=8)
 
             assert result["status"] == "success"
-            assert output_path.exists()
+            assert Path(result["output"]) == emitted_output
+            assert emitted_output.exists()
 
             # Verify output has alpha channel and correct dimensions
-            output_img = Image.open(output_path)
+            output_img = Image.open(emitted_output)
             assert output_img.mode == "RGBA", "Output should preserve RGBA mode"
             # Output should match enhanced dimensions (80, 60), not original (100, 50)
             assert output_img.size == (60, 80), f"Output should match enhanced dimensions (60, 80), got {output_img.size}"
@@ -308,9 +313,11 @@ class TestFix5AlphaChannelSafety:
             mock_instance.compute.return_value = mock_result
 
             result = enhance_image(input_path, output_path, config=None)
+            emitted_output = resolve_v2_emitted_artifact_path(output_path, bit_depth=8)
             assert result["status"] == "success"
+            assert Path(result["output"]) == emitted_output
 
-            output_img = Image.open(output_path)
+            output_img = Image.open(emitted_output)
             assert output_img.mode == "RGBA"
             assert output_img.size == (100, 50)
 

--- a/tests/test_v2_enhance.py
+++ b/tests/test_v2_enhance.py
@@ -15,9 +15,11 @@ from PIL import Image
 from transformation_portal.lux_depth_v3.v2_enhance import (
     V2EnhancementError,
     canonical_asset_stem,
+    emitted_v2_suffix_for_bit_depth,
     enhance_image,
     find_depth_map,
     load_depth_map,
+    resolve_v2_emitted_artifact_path,
 )
 from transformation_portal.lux_depth_v3.v2_presets import V2EnhancementConfig
 from transformation_portal.stage_graph.stage import StageStatus
@@ -114,6 +116,33 @@ class TestFindDepthMap:
         assert find_depth_map(Path("/nonexistent"), "test") is None
 
 
+class TestEmittedArtifactPath:
+    """Test canonical emitted V2 artifact naming."""
+
+    @pytest.mark.parametrize(
+        ("candidate_name", "bit_depth", "expected_name"),
+        [
+            ("scene.DNG", 16, "scene_materials_v3_enhanced.tif"),
+            ("scene.CR2", 16, "scene_materials_v3_enhanced.tif"),
+            ("scene_materials_v3_enhanced.nef", 16, "scene_materials_v3_enhanced.tif"),
+            ("scene.jpg", 8, "scene_materials_v3_enhanced.png"),
+        ],
+    )
+    def test_resolve_v2_emitted_artifact_path_normalizes_basename_and_suffix(
+        self,
+        tmp_path,
+        candidate_name,
+        bit_depth,
+        expected_name,
+    ):
+        candidate_path = tmp_path / candidate_name
+
+        resolved = resolve_v2_emitted_artifact_path(candidate_path, bit_depth=bit_depth)
+
+        assert resolved == tmp_path / expected_name
+        assert resolved.suffix == emitted_v2_suffix_for_bit_depth(bit_depth)
+
+
 class TestLoadDepthMap:
     """Test depth map loading and normalization."""
 
@@ -192,6 +221,7 @@ class TestEnhanceImage:
         Image.fromarray(test_image, mode="RGB").save(input_path)
 
         output_path = tmp_path / "output.png"
+        expected_output = resolve_v2_emitted_artifact_path(output_path, bit_depth=8)
 
         # Mock EnhancementStage to avoid actual processing
         with patch("transformation_portal.lux_depth_v3.v2_enhance.EnhancementStage") as mock_stage_cls:
@@ -214,11 +244,11 @@ class TestEnhanceImage:
             # Verify report
             assert report["status"] == "success"
             assert report["input"] == str(input_path)
-            assert report["output"] == str(output_path)
+            assert report["output"] == str(expected_output)
             assert report["preset"] == "default"
             assert report["depth_consumed"] is False
             assert "runtime_s" in report
-            assert output_path.exists()
+            assert expected_output.exists()
 
     def test_enhance_image_with_depth_map(self, tmp_path):
         """Test enhancement with depth map."""
@@ -268,6 +298,7 @@ class TestEnhanceImage:
         Image.fromarray(depth_data, mode="L").save(depth_path)
 
         output_path = tmp_path / "output.png"
+        expected_output = resolve_v2_emitted_artifact_path(output_path, bit_depth=8)
         config = V2EnhancementConfig(
             preset="default",
             enhancement_strength=0.7,
@@ -279,9 +310,9 @@ class TestEnhanceImage:
 
         assert report["status"] == "success"
         assert report["depth_consumed"] is True
-        assert output_path.exists()
+        assert expected_output.exists()
 
-        output_image = Image.open(output_path)
+        output_image = Image.open(expected_output)
         assert output_image.size == (100, 80)
 
     def test_enhance_image_depth_consumed_prefers_stage_metadata(self, tmp_path):
@@ -468,6 +499,32 @@ class TestEnhanceImage:
             # Verify output file exists (copied from input)
             assert output_path.exists()
 
+    def test_enhance_image_normalizes_inherited_raw_suffix_for_8bit_output(self, tmp_path):
+        """8-bit enhancement should overwrite inherited RAW suffixes before save."""
+        input_path = tmp_path / "input.png"
+        test_image = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
+        Image.fromarray(test_image, mode="RGB").save(input_path)
+
+        raw_suffix_output = tmp_path / "input.DNG"
+        expected_output = tmp_path / "input_materials_v3_enhanced.png"
+
+        with patch("transformation_portal.lux_depth_v3.v2_enhance.EnhancementStage") as mock_stage_cls:
+            mock_stage = Mock()
+            mock_stage_cls.return_value = mock_stage
+
+            mock_result = Mock()
+            mock_result.status = StageStatus.COMPLETED
+            mock_result.artifacts = {"enhanced_image": test_image}
+            mock_result.metadata = {}
+            mock_stage.compute.return_value = mock_result
+
+            report = enhance_image(input_path, raw_suffix_output)
+
+        assert report["status"] == "success"
+        assert report["output"] == str(expected_output)
+        assert expected_output.exists()
+        assert not raw_suffix_output.exists()
+
     def test_enhance_image_input_not_found(self, tmp_path):
         """Test error handling for nonexistent input."""
         input_path = tmp_path / "nonexistent.png"
@@ -505,6 +562,7 @@ class TestEnhanceImage:
 
         # Output path in non-existent directory
         output_path = tmp_path / "subdir" / "nested" / "output.png"
+        expected_output = resolve_v2_emitted_artifact_path(output_path, bit_depth=8)
 
         with patch("transformation_portal.lux_depth_v3.v2_enhance.EnhancementStage") as mock_stage_cls:
             mock_stage = Mock()
@@ -520,7 +578,7 @@ class TestEnhanceImage:
 
             # Verify output directory was created
             assert output_path.parent.exists()
-            assert output_path.exists()
+            assert expected_output.exists()
 
     def test_enhance_image_device_selection(self, tmp_path):
         """Test that device parameter is passed to stage context."""
@@ -553,6 +611,7 @@ class TestEnhanceImage:
         """Test that RGBA inputs preserve alpha channel byte-for-byte."""
         input_path = tmp_path / "input.png"
         output_path = tmp_path / "output.png"
+        expected_output = resolve_v2_emitted_artifact_path(output_path, bit_depth=8)
 
         # Create RGBA test image with distinct alpha channel
         rgb = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
@@ -577,7 +636,7 @@ class TestEnhanceImage:
             report = enhance_image(input_path, output_path)
 
             # Verify output is RGBA
-            output_image = Image.open(output_path)
+            output_image = Image.open(expected_output)
             assert output_image.mode == "RGBA"
 
             # Verify alpha channel preserved byte-for-byte
@@ -595,6 +654,7 @@ class TestEnhanceImage:
         """Test that enhancement never changes spatial dimensions."""
         input_path = tmp_path / "input.png"
         output_path = tmp_path / "output.png"
+        expected_output = resolve_v2_emitted_artifact_path(output_path, bit_depth=8)
 
         # Test with various image sizes
         test_sizes = [(100, 100), (640, 480), (1920, 1080), (99, 157)]  # Including odd dimensions
@@ -616,7 +676,7 @@ class TestEnhanceImage:
                 enhance_image(input_path, output_path)
 
                 # Verify spatial dimensions preserved
-                output_image = Image.open(output_path)
+                output_image = Image.open(expected_output)
                 assert output_image.size == (width, height), f"Dimensions changed for {width}x{height}"
 
     def test_enhance_image_passthrough_sha256_identical(self, tmp_path):
@@ -625,6 +685,7 @@ class TestEnhanceImage:
 
         input_path = tmp_path / "input.jpg"
         output_path = tmp_path / "output.jpg"
+        expected_output = resolve_v2_emitted_artifact_path(output_path, bit_depth=8)
 
         # Create test JPEG with EXIF and ICC profile
         test_image = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
@@ -658,6 +719,7 @@ class TestEnhanceImage:
         """Test that ICC color profiles are preserved in enhanced images."""
         input_path = tmp_path / "input.jpg"
         output_path = tmp_path / "output.jpg"
+        expected_output = resolve_v2_emitted_artifact_path(output_path, bit_depth=8)
 
         # Create test image with ICC profile
         test_image = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
@@ -679,11 +741,40 @@ class TestEnhanceImage:
             enhance_image(input_path, output_path)
 
             # Verify ICC profile preserved
-            output_image = Image.open(output_path)
+            output_image = Image.open(expected_output)
             output_icc = output_image.info.get("icc_profile")
 
             assert output_icc is not None, "ICC profile was not preserved"
             assert output_icc == icc_profile, "ICC profile data differs"
+
+    def test_enhance_image_normalizes_inherited_raw_suffix_for_16bit_output(self, tmp_path):
+        """16-bit enhancement should overwrite inherited RAW suffixes before save."""
+        tifffile = pytest.importorskip("tifffile")
+
+        input_path = tmp_path / "input_16bit.tif"
+        output_path = tmp_path / "input.CR2"
+        expected_output = tmp_path / "input_materials_v3_enhanced.tif"
+
+        test_image_16 = np.random.randint(0, 65536, (32, 32, 3), dtype=np.uint16)
+        tifffile.imwrite(input_path, test_image_16, photometric="rgb", compression=None)
+
+        with patch("transformation_portal.lux_depth_v3.v2_enhance.EnhancementStage") as mock_stage_cls:
+            mock_stage = Mock()
+            mock_stage_cls.return_value = mock_stage
+
+            mock_result = Mock()
+            mock_result.status = StageStatus.COMPLETED
+            mock_result.artifacts = {"enhanced_image": test_image_16}
+            mock_result.metadata = {}
+            mock_stage.compute.return_value = mock_result
+
+            report = enhance_image(input_path, output_path, allow_8bit_output=False)
+
+        assert report["status"] == "success"
+        assert report["output"] == str(expected_output)
+        assert Path(report["output"]) == expected_output
+        assert expected_output.exists()
+        assert not output_path.exists()
 
     def test_enhance_image_preserves_icc_profile_16bit_tiff(self, tmp_path):
         """Test that ICC profiles are preserved in 16-bit TIFF output via tifffile.

--- a/tests/unit/lux_depth_v3/test_v2_enhance_quality_firewall.py
+++ b/tests/unit/lux_depth_v3/test_v2_enhance_quality_firewall.py
@@ -17,7 +17,12 @@ from PIL import Image
 
 pytestmark = [pytest.mark.unit]
 
-from transformation_portal.lux_depth_v3.v2_enhance import V2EnhancementError, enhance_image, load_image_preserve_bit_depth
+from transformation_portal.lux_depth_v3.v2_enhance import (
+    V2EnhancementError,
+    enhance_image,
+    load_image_preserve_bit_depth,
+    resolve_v2_emitted_artifact_path,
+)
 from transformation_portal.stage_graph.stage import StageStatus
 
 
@@ -194,10 +199,12 @@ class TestRealProcessing:
 
             # Run enhancement
             result = enhance_image(temp_8bit_tiff, output_path, allow_8bit_output=False)
+            emitted_output = resolve_v2_emitted_artifact_path(output_path, bit_depth=8)
 
             # Verify success
             assert result["status"] == "success"
-            assert output_path.exists()
+            assert Path(result["output"]) == emitted_output
+            assert emitted_output.exists()
             assert result["bit_depth"]["input_bits_per_sample"] == 8
             assert result["bit_depth"]["output_bits_per_sample"] == 8
 


### PR DESCRIPTION
## Summary
- canonicalize V2 emitted artifact names from asset identity and output bit depth
- make the core V2 write boundary authoritative for final suffix normalization and reported output paths
- add script-level and core-level regression coverage for RAW-suffixed candidate outputs

## Root Cause
- `scripts/enhance_image.py` seeded fallback output candidates from `input_path.name`
- when canonical Materials V3 handoff was unavailable, RAW source suffixes like `.dng` and `.cr2` survived into the V2 save boundary
- the core V2 layer then reached PIL with unsupported output suffixes even though historical successful RAW-source runs emitted `.tif`

## Contract
- 16-bit V2 outputs emit `<identity>_materials_v3_enhanced.tif`
- 8-bit V2 outputs emit `<identity>_materials_v3_enhanced.png`
- RAW source suffixes never appear in emitted V2 artifact paths or `report["output"]`
- the writer return path and reported output path are the same normalized path

## Validation
- `pre-commit install -f`
- `pre-commit run --files scripts/enhance_image.py src/transformation_portal/lux_depth_v3/v2_enhance.py tests/test_v2_enhance.py tests/test_enhance_image_script_contract.py --show-diff-on-failure`
- `TMPDIR=/tmp PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=/Users/richardcheetham/Desktop/Transformation_Portal_pr_v2_output_contract/src /Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin/pytest -p no:cacheprovider tests/test_enhance_image_script_contract.py tests/test_v2_enhance.py tests/test_v2_runner.py tests/materials/test_materials_v3_orchestrator_integration.py`
- `make test-fast PY=/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin/python`

## Notes
- `Transformation_Portal_accept_main/checkpoints/` was repaired locally with existing checkpoint binaries to unblock acceptance validation; binaries are not part of this PR
- `pre-commit run --all-files` is still blocked by pre-existing ADR-044 marker debt already present on `main` in `tests/lux_depth_v3/test_artifact_tree.py`, `tests/crypto/test_ct_merkle.py`, and `tests/validation/test_assess_run_card_release.py`
