### PR TITLE
[codex] Upgrade portal operator UX briefing

### DIFF
--- a/portal.html
+++ b/portal.html
@@ -284,23 +284,23 @@ Contract notes:
                 <p id="consoleViewMeta" class="portal-context-meta text-[11px] font-mono text-slate-500 dark:text-slate-400">View routing stays client-side to preserve the live orchestrator contract.</p>
             </div>
             <div id="consoleContextRibbon" class="console-context-ribbon portal-context-ribbon mt-4 hidden" data-ui="console-context-ribbon" aria-live="polite">
-                <div class="console-context-card">
-                    <p class="console-context-label">Job</p>
+                <div id="contextRibbonCard1" class="console-context-card" data-tone="info">
+                    <p id="contextRibbonCard1Label" class="console-context-label">Job</p>
                     <p id="contextRibbonJob" class="console-context-value">No job selected</p>
                     <p id="contextRibbonJobMeta" class="console-context-meta">Choose a run in operate or review to pin context here.</p>
                 </div>
-                <div class="console-context-card">
-                    <p class="console-context-label">State</p>
+                <div id="contextRibbonCard2" class="console-context-card" data-tone="info">
+                    <p id="contextRibbonCard2Label" class="console-context-label">State</p>
                     <p id="contextRibbonState" class="console-context-value">Idle</p>
                     <p id="contextRibbonFreshness" class="console-context-meta">No live telemetry</p>
                 </div>
-                <div class="console-context-card">
-                    <p class="console-context-label">Artifact</p>
+                <div id="contextRibbonCard3" class="console-context-card" data-tone="info">
+                    <p id="contextRibbonCard3Label" class="console-context-label">Artifact</p>
                     <p id="contextRibbonArtifact" class="console-context-value">Awaiting selection</p>
                     <p id="contextRibbonArtifactMeta" class="console-context-meta">Review context will show the active artifact path here.</p>
                 </div>
-                <div class="console-context-card">
-                    <p class="console-context-label">Compare</p>
+                <div id="contextRibbonCard4" class="console-context-card" data-tone="info">
+                    <p id="contextRibbonCard4Label" class="console-context-label">Compare</p>
                     <p id="contextRibbonCompare" class="console-context-value">No compare pair</p>
                     <p id="contextRibbonCompareMeta" class="console-context-meta">No paired comparison is available for the current artifact.</p>
                 </div>
@@ -433,6 +433,28 @@ Contract notes:
                             <button id="buildStepNextBtn" type="button" class="stepper-nav-btn stepper-nav-btn-primary focus:outline-none focus:ring-2 focus:ring-cyan-500">
                                 Next
                             </button>
+                        </div>
+                    </div>
+                    <div id="buildPulseGrid" class="build-pulse-grid mt-5" data-ui="build-step-pulse">
+                        <div id="buildPulseDraftCard" class="build-pulse-card" data-tone="info">
+                            <p class="build-pulse-label">Draft</p>
+                            <p id="buildPulseDraft" class="build-pulse-value">premium</p>
+                            <p id="buildPulseDraftMeta" class="build-pulse-meta">lux-depth-v3 draft is staged for preview-backed dispatch.</p>
+                        </div>
+                        <div id="buildPulseStepCard" class="build-pulse-card" data-tone="info">
+                            <p class="build-pulse-label">Current Focus</p>
+                            <p id="buildPulseStep" class="build-pulse-value">1 of 4 · Configure</p>
+                            <p id="buildPulseStepMeta" class="build-pulse-meta">Pipeline and preset posture.</p>
+                        </div>
+                        <div id="buildPulsePreviewCard" class="build-pulse-card" data-tone="info">
+                            <p class="build-pulse-label">Preview</p>
+                            <p id="buildPulsePreview" class="build-pulse-value">Refreshing</p>
+                            <p id="buildPulsePreviewMeta" class="build-pulse-meta">Preview-backed validation will summarize the draft here.</p>
+                        </div>
+                        <div id="buildPulseDispatchCard" class="build-pulse-card" data-tone="info">
+                            <p class="build-pulse-label">Dispatch</p>
+                            <p id="buildPulseDispatch" class="build-pulse-value">Review dispatch posture</p>
+                            <p id="buildPulseDispatchMeta" class="build-pulse-meta">The next operator action stays pinned here while the draft changes.</p>
                         </div>
                     </div>
                     <div id="buildStepTabs" class="build-step-tabs mt-5" role="tablist" aria-label="Build steps">

--- a/public/portal-assets/portal.css
+++ b/public/portal-assets/portal.css
@@ -720,14 +720,95 @@ progress::-moz-progress-bar { background-color: #4f46e5; transition: width 0.3s 
 }
 
 .console-context-card {
+    position: relative;
     border: 1px solid var(--shell-border);
-    border-radius: 1.15rem;
+    border-radius: 8px;
     background: rgba(255, 255, 255, 0.62);
     padding: 0.85rem 0.9rem;
+    box-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.22),
+        0 10px 24px rgba(15, 23, 42, 0.04);
 }
 
 .dark .console-context-card {
     background: rgba(15, 23, 42, 0.58);
+    box-shadow:
+        inset 0 1px 0 rgba(148, 163, 184, 0.04),
+        0 12px 26px rgba(2, 6, 23, 0.18);
+}
+
+.console-context-card::before,
+.build-pulse-card::before {
+    content: "";
+    position: absolute;
+    inset: 0 auto auto 0;
+    width: 100%;
+    height: 2px;
+    border-radius: 999px;
+    background: rgba(8, 145, 178, 0.18);
+}
+
+.console-context-card[data-tone="ready"],
+.build-pulse-card[data-tone="ready"] {
+    border-color: rgba(13, 148, 136, 0.18);
+    background:
+        linear-gradient(180deg, rgba(240, 253, 250, 0.94), rgba(255, 255, 255, 0.7)),
+        rgba(255, 255, 255, 0.62);
+}
+
+.console-context-card[data-tone="ready"]::before,
+.build-pulse-card[data-tone="ready"]::before {
+    background: rgba(13, 148, 136, 0.82);
+}
+
+.console-context-card[data-tone="warning"],
+.build-pulse-card[data-tone="warning"] {
+    border-color: rgba(217, 119, 6, 0.18);
+    background:
+        linear-gradient(180deg, rgba(255, 251, 235, 0.96), rgba(255, 255, 255, 0.7)),
+        rgba(255, 255, 255, 0.62);
+}
+
+.console-context-card[data-tone="warning"]::before,
+.build-pulse-card[data-tone="warning"]::before {
+    background: rgba(217, 119, 6, 0.82);
+}
+
+.console-context-card[data-tone="blocked"],
+.build-pulse-card[data-tone="blocked"] {
+    border-color: rgba(220, 38, 38, 0.18);
+    background:
+        linear-gradient(180deg, rgba(254, 242, 242, 0.94), rgba(255, 255, 255, 0.7)),
+        rgba(255, 255, 255, 0.62);
+}
+
+.console-context-card[data-tone="blocked"]::before,
+.build-pulse-card[data-tone="blocked"]::before {
+    background: rgba(220, 38, 38, 0.82);
+}
+
+.dark .console-context-card[data-tone="ready"],
+.dark .build-pulse-card[data-tone="ready"] {
+    border-color: rgba(45, 212, 191, 0.24);
+    background:
+        linear-gradient(180deg, rgba(15, 118, 110, 0.18), rgba(15, 23, 42, 0.76)),
+        rgba(15, 23, 42, 0.58);
+}
+
+.dark .console-context-card[data-tone="warning"],
+.dark .build-pulse-card[data-tone="warning"] {
+    border-color: rgba(251, 191, 36, 0.24);
+    background:
+        linear-gradient(180deg, rgba(120, 53, 15, 0.24), rgba(15, 23, 42, 0.76)),
+        rgba(15, 23, 42, 0.58);
+}
+
+.dark .console-context-card[data-tone="blocked"],
+.dark .build-pulse-card[data-tone="blocked"] {
+    border-color: rgba(248, 113, 113, 0.24);
+    background:
+        linear-gradient(180deg, rgba(127, 29, 29, 0.24), rgba(15, 23, 42, 0.76)),
+        rgba(15, 23, 42, 0.58);
 }
 
 .console-context-label {
@@ -751,6 +832,54 @@ progress::-moz-progress-bar { background-color: #4f46e5; transition: width 0.3s 
     margin-top: 0.35rem;
     font-size: 10.5px;
     line-height: 1.45;
+    color: var(--shell-muted);
+}
+
+.build-pulse-grid {
+    display: grid;
+    gap: 0.75rem;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.build-pulse-card {
+    position: relative;
+    min-height: 100%;
+    border: 1px solid var(--shell-border);
+    border-radius: 8px;
+    background: rgba(255, 255, 255, 0.68);
+    padding: 0.85rem 0.95rem;
+    box-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.22),
+        0 10px 24px rgba(15, 23, 42, 0.04);
+}
+
+.dark .build-pulse-card {
+    background: rgba(15, 23, 42, 0.64);
+    box-shadow:
+        inset 0 1px 0 rgba(148, 163, 184, 0.04),
+        0 12px 26px rgba(2, 6, 23, 0.18);
+}
+
+.build-pulse-label {
+    font-size: 10px;
+    font-weight: 800;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--shell-muted);
+}
+
+.build-pulse-value {
+    margin-top: 0.45rem;
+    font-size: 13px;
+    font-weight: 800;
+    line-height: 1.4;
+    color: var(--shell-ink);
+}
+
+.build-pulse-meta {
+    margin-top: 0.4rem;
+    font-size: 11px;
+    line-height: 1.55;
     color: var(--shell-muted);
 }
 

--- a/public/portal-assets/portal.js
+++ b/public/portal-assets/portal.js
@@ -1331,16 +1331,15 @@ function renderConsoleContextRibbon() {
     els.consoleContextRibbon.classList.toggle('hidden', !ribbonVisible);
     if (!ribbonVisible) return;
 
-    const currentPayload = generatePayload();
-    const selected = state.jobs.find((job) => job.id === state.selectedJobId) || null;
-    const artifacts = Array.isArray(selected?.artifacts) ? rankArtifactsForDisplay(selected.artifacts) : [];
-    const selectedArtifact = selected ? _selectedArtifactForJob(selected) : null;
-    const compareCandidate = selected ? findCompareArtifact(selectedArtifact, artifacts) : null;
-    const compareEnabled = Boolean(selected && compareCandidate && state.artifactUi.compareByJob[String(selected.id || '')]);
-    const artifactCount = artifacts.length;
-    const compareCopy = _compareSurfaceCopy(selectedArtifact, compareCandidate, compareEnabled);
-
     if (state.currentView === 'operate' || state.currentView === 'review') {
+        const selected = state.jobs.find((job) => job.id === state.selectedJobId) || null;
+        const artifacts = Array.isArray(selected?.artifacts) ? rankArtifactsForDisplay(selected.artifacts) : [];
+        const selectedArtifact = selected ? _selectedArtifactForJob(selected) : null;
+        const compareCandidate = selected ? findCompareArtifact(selectedArtifact, artifacts) : null;
+        const compareEnabled = Boolean(selected && compareCandidate && state.artifactUi.compareByJob[String(selected.id || '')]);
+        const artifactCount = artifacts.length;
+        const compareCopy = _compareSurfaceCopy(selectedArtifact, compareCandidate, compareEnabled);
+
         _setSummaryCard(els.contextRibbonCard1, els.contextRibbonCard1Label, els.contextRibbonJob, els.contextRibbonJobMeta, {
             label: 'Job',
             value: selected ? String(selected.id || 'unknown') : 'No job selected',
@@ -1372,6 +1371,7 @@ function renderConsoleContextRibbon() {
         return;
     }
 
+    const currentPayload = generatePayload();
     const activeJob = _latestActiveJob();
     const reviewJob = _latestReviewableJob();
     const activeJobTone = activeJob ? _jobSurfaceTone(activeJob) : (state.backendOk ? 'info' : 'blocked');

--- a/public/portal-assets/portal.js
+++ b/public/portal-assets/portal.js
@@ -262,12 +262,20 @@ const els = {
     consoleViewSummary: document.getElementById('consoleViewSummary'),
     consoleViewMeta: document.getElementById('consoleViewMeta'),
     consoleContextRibbon: document.getElementById('consoleContextRibbon'),
+    contextRibbonCard1: document.getElementById('contextRibbonCard1'),
+    contextRibbonCard1Label: document.getElementById('contextRibbonCard1Label'),
     contextRibbonJob: document.getElementById('contextRibbonJob'),
     contextRibbonJobMeta: document.getElementById('contextRibbonJobMeta'),
+    contextRibbonCard2: document.getElementById('contextRibbonCard2'),
+    contextRibbonCard2Label: document.getElementById('contextRibbonCard2Label'),
     contextRibbonState: document.getElementById('contextRibbonState'),
     contextRibbonFreshness: document.getElementById('contextRibbonFreshness'),
+    contextRibbonCard3: document.getElementById('contextRibbonCard3'),
+    contextRibbonCard3Label: document.getElementById('contextRibbonCard3Label'),
     contextRibbonArtifact: document.getElementById('contextRibbonArtifact'),
     contextRibbonArtifactMeta: document.getElementById('contextRibbonArtifactMeta'),
+    contextRibbonCard4: document.getElementById('contextRibbonCard4'),
+    contextRibbonCard4Label: document.getElementById('contextRibbonCard4Label'),
     contextRibbonCompare: document.getElementById('contextRibbonCompare'),
     contextRibbonCompareMeta: document.getElementById('contextRibbonCompareMeta'),
     heroRunBtn: document.getElementById('heroRunBtn'),
@@ -302,6 +310,18 @@ const els = {
     buildStepTab2: document.getElementById('buildStepTab2'),
     buildStepTab3: document.getElementById('buildStepTab3'),
     buildStepTab4: document.getElementById('buildStepTab4'),
+    buildPulseDraftCard: document.getElementById('buildPulseDraftCard'),
+    buildPulseDraft: document.getElementById('buildPulseDraft'),
+    buildPulseDraftMeta: document.getElementById('buildPulseDraftMeta'),
+    buildPulseStepCard: document.getElementById('buildPulseStepCard'),
+    buildPulseStep: document.getElementById('buildPulseStep'),
+    buildPulseStepMeta: document.getElementById('buildPulseStepMeta'),
+    buildPulsePreviewCard: document.getElementById('buildPulsePreviewCard'),
+    buildPulsePreview: document.getElementById('buildPulsePreview'),
+    buildPulsePreviewMeta: document.getElementById('buildPulsePreviewMeta'),
+    buildPulseDispatchCard: document.getElementById('buildPulseDispatchCard'),
+    buildPulseDispatch: document.getElementById('buildPulseDispatch'),
+    buildPulseDispatchMeta: document.getElementById('buildPulseDispatchMeta'),
 
     pipelineSelect: document.getElementById('pipelineSelect'),
     presetSelect: document.getElementById('presetSelect'),
@@ -1178,12 +1198,140 @@ function updateConsoleViewContext() {
         : `Transformation Portal — ${viewMeta.title}`;
 }
 
+function _summaryTone(value) {
+    const tone = String(value || '').trim().toLowerCase();
+    return ['ready', 'warning', 'blocked', 'info'].includes(tone) ? tone : 'info';
+}
+
+function _setSummaryCard(card, labelElement, valueElement, metaElement, summary) {
+    if (!valueElement || !metaElement) return;
+    const nextSummary = summary && typeof summary === 'object' ? summary : {};
+    if (labelElement) labelElement.textContent = String(nextSummary.label || '');
+    valueElement.textContent = String(nextSummary.value || '');
+    metaElement.textContent = String(nextSummary.meta || '');
+    if (card) {
+        card.dataset.tone = _summaryTone(nextSummary.tone);
+    }
+}
+
+function _jobSurfaceTone(job) {
+    const stateLabel = String(job?.state || '').trim().toLowerCase();
+    if (['succeeded', 'ready', 'partial'].includes(stateLabel)) return 'ready';
+    if (['failed', 'canceled', 'offline'].includes(stateLabel)) return 'blocked';
+    return 'info';
+}
+
+function _previewSurfaceSummary(payload = null) {
+    const currentPayload = payload || generatePayload();
+    const preview = _currentPreviewForPayload(currentPayload);
+    if (!state.backendOk) {
+        return {
+            value: 'Backend offline',
+            meta: 'Preview-backed validation resumes when the orchestrator backend becomes reachable again.',
+            tone: 'blocked'
+        };
+    }
+    if (!preview) {
+        return {
+            value: 'Refreshing',
+            meta: 'Preview-backed validation is hydrating the current draft.',
+            tone: 'info'
+        };
+    }
+    if (preview.status === 'loading') {
+        return {
+            value: 'Refreshing',
+            meta: 'Preview-backed validation is recalculating the active draft.',
+            tone: 'info'
+        };
+    }
+    if (preview.status === 'error') {
+        const details = _previewFailureDetails(preview);
+        const message = currentPayload.pipeline === 'lux-depth-v3'
+            ? String(details.luxBlockedMessage || '').replace(/^BLOCKED:\s*/i, '')
+            : String(details.archiveWarningMessage || '').replace(/^WARNING:\s*/i, '');
+        return {
+            value: details.summaryLabel,
+            meta: message || 'Preview-backed validation needs operator attention.',
+            tone: currentPayload.pipeline === 'lux-depth-v3' ? 'blocked' : 'warning'
+        };
+    }
+    if (preview.status === 'ready') {
+        const errors = Array.isArray(preview.field_errors) ? preview.field_errors.length : 0;
+        const warnings = Array.isArray(preview.field_warnings) ? preview.field_warnings.length : 0;
+        if (errors > 0) {
+            return {
+                value: 'Preview invalid',
+                meta: `${errors} blocking issue${errors === 1 ? '' : 's'} need resolution before dispatch.`,
+                tone: 'blocked'
+            };
+        }
+        if (warnings > 0) {
+            return {
+                value: 'Preview ready with warnings',
+                meta: `${warnings} warning${warnings === 1 ? '' : 's'} remain visible before dispatch.`,
+                tone: 'warning'
+            };
+        }
+        return {
+            value: 'Preview ready',
+            meta: 'Preview-backed validation and normalized arguments are aligned with the current draft.',
+            tone: 'ready'
+        };
+    }
+    if (preview.status === 'offline' || preview.status === 'local_fallback') {
+        return {
+            value: 'Local fallback',
+            meta: 'Local rendering is standing in while preview-backed validation is unavailable.',
+            tone: 'warning'
+        };
+    }
+    return {
+        value: _formatPreviewStateLabel(currentPayload),
+        meta: 'Preview-backed validation will summarize the active draft here.',
+        tone: 'info'
+    };
+}
+
+function renderBuildStepPulse(payload = null) {
+    const currentPayload = payload || generatePayload();
+    const activeStep = resolveBuildStep(state.portalUi.buildStep);
+    const stepContent = _currentBuildStepContent();
+    const activeStepContent = stepContent[activeStep - 1] || BUILD_STEP_CONTENT.lux[activeStep - 1];
+    const nextAction = _effectiveNextBestAction(currentPayload);
+    const previewSummary = _previewSurfaceSummary(currentPayload);
+    const draftValue = state.pipeline === 'lux-depth-v3'
+        ? String(currentPayload?.args?.preset || state.config.preset || 'custom')
+        : canonicalArchiveCommand(state.pipeline) || 'archive';
+    const draftMeta = state.pipeline === 'lux-depth-v3'
+        ? `${String(state.pipeline || 'lux-depth-v3')} • ${titleCaseToken(currentPayload?.args?.quality_tier || state.config.qualityTier || 'premium', 'Premium')} posture`
+        : `${String(state.pipeline || 'archive')} • deterministic archive stage`;
+
+    _setSummaryCard(els.buildPulseDraftCard, null, els.buildPulseDraft, els.buildPulseDraftMeta, {
+        value: draftValue,
+        meta: draftMeta,
+        tone: state.backendOk ? 'ready' : 'info'
+    });
+    _setSummaryCard(els.buildPulseStepCard, null, els.buildPulseStep, els.buildPulseStepMeta, {
+        value: `${activeStep} of 4 · ${String(activeStepContent?.label || 'Focus')}`,
+        meta: String(activeStepContent?.summary || activeStepContent?.meta || 'Build focus is pinned here.'),
+        tone: 'info'
+    });
+    _setSummaryCard(els.buildPulsePreviewCard, null, els.buildPulsePreview, els.buildPulsePreviewMeta, previewSummary);
+    _setSummaryCard(els.buildPulseDispatchCard, null, els.buildPulseDispatch, els.buildPulseDispatchMeta, {
+        value: String(nextAction?.label || 'Review dispatch posture'),
+        meta: String(nextAction?.detail || 'The next operator action stays pinned here while the draft changes.'),
+        tone: String(nextAction?.tone || 'info')
+    });
+}
+
 function renderConsoleContextRibbon() {
     if (!els.consoleContextRibbon) return;
-    const ribbonVisible = state.currentView === 'operate' || state.currentView === 'review';
+    const ribbonVisible = ['overview', 'build', 'operate', 'review'].includes(state.currentView);
     els.consoleContextRibbon.classList.toggle('hidden', !ribbonVisible);
     if (!ribbonVisible) return;
 
+    const currentPayload = generatePayload();
     const selected = state.jobs.find((job) => job.id === state.selectedJobId) || null;
     const artifacts = Array.isArray(selected?.artifacts) ? rankArtifactsForDisplay(selected.artifacts) : [];
     const selectedArtifact = selected ? _selectedArtifactForJob(selected) : null;
@@ -1192,34 +1340,90 @@ function renderConsoleContextRibbon() {
     const artifactCount = artifacts.length;
     const compareCopy = _compareSurfaceCopy(selectedArtifact, compareCandidate, compareEnabled);
 
-    if (els.contextRibbonJob) {
-        els.contextRibbonJob.textContent = selected ? String(selected.id || 'unknown') : 'No job selected';
+    if (state.currentView === 'operate' || state.currentView === 'review') {
+        _setSummaryCard(els.contextRibbonCard1, els.contextRibbonCard1Label, els.contextRibbonJob, els.contextRibbonJobMeta, {
+            label: 'Job',
+            value: selected ? String(selected.id || 'unknown') : 'No job selected',
+            meta: selected
+                ? `${String(selected.pipeline || 'unknown')} • ${artifactCount} artifact${artifactCount === 1 ? '' : 's'} indexed`
+                : 'Choose a run in operate or review to pin context here.',
+            tone: selected ? _jobSurfaceTone(selected) : 'info'
+        });
+        _setSummaryCard(els.contextRibbonCard2, els.contextRibbonCard2Label, els.contextRibbonState, els.contextRibbonFreshness, {
+            label: 'State',
+            value: selected ? titleCaseToken(selected.state, 'Unknown') : 'Idle',
+            meta: _jobFreshnessLabel(selected),
+            tone: selected ? _jobSurfaceTone(selected) : 'info'
+        });
+        _setSummaryCard(els.contextRibbonCard3, els.contextRibbonCard3Label, els.contextRibbonArtifact, els.contextRibbonArtifactMeta, {
+            label: 'Artifact',
+            value: selectedArtifact ? artifactLabel(selectedArtifact) : 'Awaiting selection',
+            meta: selectedArtifact
+                ? `${artifactDisplayLabel(selectedArtifact)}${compareCandidate ? ' • paired comparison available' : ' • single artifact context'}`
+                : 'Review context will show the active artifact path here.',
+            tone: selectedArtifact ? 'ready' : 'info'
+        });
+        _setSummaryCard(els.contextRibbonCard4, els.contextRibbonCard4Label, els.contextRibbonCompare, els.contextRibbonCompareMeta, {
+            label: 'Compare',
+            value: selected ? compareCopy.ribbonValue : 'No compare pair',
+            meta: selected ? compareCopy.ribbonMeta : 'Deep-linkable review context stays aligned with the URL.',
+            tone: selected && compareEnabled ? 'ready' : 'info'
+        });
+        return;
     }
-    if (els.contextRibbonJobMeta) {
-        els.contextRibbonJobMeta.textContent = selected
-            ? `${String(selected.pipeline || 'unknown')} • ${artifactCount} artifact${artifactCount === 1 ? '' : 's'} indexed`
-            : 'Choose a run in operate or review to pin context here.';
-    }
-    if (els.contextRibbonState) {
-        els.contextRibbonState.textContent = selected ? titleCaseToken(selected.state, 'Unknown') : 'Idle';
-    }
-    if (els.contextRibbonFreshness) {
-        els.contextRibbonFreshness.textContent = _jobFreshnessLabel(selected);
-    }
-    if (els.contextRibbonArtifact) {
-        els.contextRibbonArtifact.textContent = selectedArtifact ? artifactLabel(selectedArtifact) : 'Awaiting selection';
-    }
-    if (els.contextRibbonArtifactMeta) {
-        els.contextRibbonArtifactMeta.textContent = selectedArtifact
-            ? `${artifactDisplayLabel(selectedArtifact)}${compareCandidate ? ' • paired comparison available' : ' • single artifact context'}`
-            : 'Review context will show the active artifact path here.';
-    }
-    if (els.contextRibbonCompare) {
-        els.contextRibbonCompare.textContent = selected ? compareCopy.ribbonValue : 'No compare pair';
-    }
-    if (els.contextRibbonCompareMeta) {
-        els.contextRibbonCompareMeta.textContent = selected ? compareCopy.ribbonMeta : 'Deep-linkable review context stays aligned with the URL.';
-    }
+
+    const activeJob = _latestActiveJob();
+    const reviewJob = _latestReviewableJob();
+    const activeJobTone = activeJob ? _jobSurfaceTone(activeJob) : (state.backendOk ? 'info' : 'blocked');
+    const reviewJobTone = reviewJob ? _jobSurfaceTone(reviewJob) : 'info';
+    const nextAction = _effectiveNextBestAction(currentPayload);
+    const stepContent = _currentBuildStepContent();
+    const activeStep = resolveBuildStep(state.portalUi.buildStep);
+    const activeStepContent = stepContent[activeStep - 1] || BUILD_STEP_CONTENT.lux[activeStep - 1];
+    const draftValue = state.pipeline === 'lux-depth-v3'
+        ? String(currentPayload?.args?.preset || state.config.preset || 'custom')
+        : canonicalArchiveCommand(state.pipeline) || 'archive';
+
+    _setSummaryCard(els.contextRibbonCard1, els.contextRibbonCard1Label, els.contextRibbonJob, els.contextRibbonJobMeta, {
+        label: 'Live lane',
+        value: activeJob
+            ? `${titleCaseToken(activeJob.state, 'Unknown')} • ${Math.max(0, Math.min(100, Number(activeJob.progress) || 0))}%`
+            : state.backendOk
+                ? 'No live run'
+                : 'Backend offline',
+        meta: activeJob
+            ? `${String(activeJob.pipeline || 'unknown')} • ${_jobFreshnessLabel(activeJob)}`
+            : state.backendOk
+                ? 'Dispatch from Build to watch live progress here.'
+                : 'Restore the orchestrator connection to unlock preview-backed dispatch.',
+        tone: activeJobTone
+    });
+    _setSummaryCard(els.contextRibbonCard2, els.contextRibbonCard2Label, els.contextRibbonState, els.contextRibbonFreshness, {
+        label: 'Review lane',
+        value: reviewJob
+            ? (jobOutcomeSummary(reviewJob) || 'Review available')
+            : 'No review target',
+        meta: reviewJob
+            ? `${Array.isArray(reviewJob.artifacts) ? reviewJob.artifacts.length : 0} artifact${Array.isArray(reviewJob.artifacts) && reviewJob.artifacts.length === 1 ? '' : 's'} indexed • open Review to inspect the latest output.`
+            : 'Completed or partial outputs will appear here when the current draft finishes.',
+        tone: reviewJobTone
+    });
+    _setSummaryCard(els.contextRibbonCard3, els.contextRibbonCard3Label, els.contextRibbonArtifact, els.contextRibbonArtifactMeta, {
+        label: 'Dispatch lane',
+        value: String(nextAction?.label || 'Review dispatch posture'),
+        meta: String(nextAction?.detail || 'Preview guidance will summarize the clearest next step for this draft.'),
+        tone: String(nextAction?.tone || 'info')
+    });
+    _setSummaryCard(els.contextRibbonCard4, els.contextRibbonCard4Label, els.contextRibbonCompare, els.contextRibbonCompareMeta, {
+        label: state.currentView === 'build' ? 'Current focus' : 'Draft',
+        value: state.currentView === 'build'
+            ? `${activeStep} of 4 · ${String(activeStepContent?.label || 'Focus')}`
+            : draftValue,
+        meta: state.currentView === 'build'
+            ? String(activeStepContent?.summary || activeStepContent?.meta || 'Build focus is pinned here.')
+            : `${String(state.pipeline || 'lux-depth-v3')} • ${state.backendOk ? 'live backend connected' : 'dispatch paused until the backend recovers'}.`,
+        tone: 'info'
+    });
 }
 
 function applyConsoleViewLayout() {
@@ -1469,6 +1673,8 @@ function syncBuildStepUi() {
         els.buildStepNextBtn.disabled = activeStep >= 4;
         els.buildStepNextBtn.textContent = activeStep >= 4 ? 'Dispatch Ready' : 'Next';
     }
+
+    renderBuildStepPulse(generatePayload());
 }
 
 function setBuildStep(nextStep, options = {}) {
@@ -2535,6 +2741,8 @@ function renderMissionControl(payload = null) {
     renderPresetIntelligence(currentPayload);
     renderGovernanceBanner(currentPayload);
     syncDisclosurePanels(currentPayload);
+    renderBuildStepPulse(currentPayload);
+    renderConsoleContextRibbon();
     _syncOverviewBuildLoadingState(currentPayload);
 }
 

--- a/tests/test_app_orchestrator_runtime.py
+++ b/tests/test_app_orchestrator_runtime.py
@@ -1183,14 +1183,15 @@ def test_portal_console_context_ribbon_tracks_selected_job_and_review_state() ->
     assert 'id="contextRibbonFreshness"' in content
     assert 'id="contextRibbonArtifact"' in content
     assert 'id="contextRibbonCompare"' in content
-    assert "const ribbonVisible = state.currentView === 'operate' || state.currentView === 'review';" in ribbon_body
+    assert "const ribbonVisible = ['overview', 'build', 'operate', 'review'].includes(state.currentView);" in ribbon_body
     assert "els.consoleContextRibbon.classList.toggle('hidden', !ribbonVisible);" in ribbon_body
     assert (
-        "els.contextRibbonArtifact.textContent = selectedArtifact ? artifactLabel(selectedArtifact) : 'Awaiting selection';"
+        "_setSummaryCard(els.contextRibbonCard1, els.contextRibbonCard1Label, els.contextRibbonJob, els.contextRibbonJobMeta, {"
         in ribbon_body
     )
     assert "const compareCopy = _compareSurfaceCopy(selectedArtifact, compareCandidate, compareEnabled);" in ribbon_body
-    assert "els.contextRibbonCompare.textContent = selected ? compareCopy.ribbonValue : 'No compare pair';" in ribbon_body
+    assert "label: 'Artifact'," in ribbon_body
+    assert "value: selected ? compareCopy.ribbonValue : 'No compare pair'" in ribbon_body
     assert "renderConsoleContextRibbon();" in apply_view_body
     assert "renderConsoleContextRibbon();" in inspector_body
     assert "renderConsoleContextRibbon();" in artifact_body
@@ -1991,6 +1992,30 @@ def test_portal_surfaces_pre_run_diagnostics_and_expected_outputs() -> None:
     assert "_normalizeNextBestAction(currentPreview?.next_best_action)" in content
     assert "Wait for preview to refresh" in local_next_action_body
     assert "Restore backend connection" in local_next_action_body
+
+
+def test_portal_operator_briefing_and_build_pulse_surfaces_are_present() -> None:
+    content = _portal_bundle_content()
+    ribbon_body = _extract_js_function_body(content, "renderConsoleContextRibbon")
+    pulse_body = _extract_js_function_body(content, "renderBuildStepPulse")
+    mission_body = _extract_js_function_body(content, "renderMissionControl")
+    stepper_body = _extract_js_function_body(content, "syncBuildStepUi")
+
+    assert 'id="contextRibbonCard1Label"' in content
+    assert 'id="contextRibbonCard4Label"' in content
+    assert 'id="buildPulseDraft"' in content
+    assert 'id="buildPulsePreview"' in content
+    assert 'id="buildPulseDispatch"' in content
+    assert 'data-ui="build-step-pulse"' in content
+    assert "label: 'Live lane'" in ribbon_body
+    assert "label: 'Review lane'" in ribbon_body
+    assert "label: 'Dispatch lane'" in ribbon_body
+    assert "state.currentView === 'build' ? 'Current focus' : 'Draft'" in ribbon_body
+    assert "_previewSurfaceSummary(currentPayload)" in pulse_body
+    assert "_effectiveNextBestAction(currentPayload)" in pulse_body
+    assert "renderBuildStepPulse(currentPayload);" in mission_body
+    assert "renderConsoleContextRibbon();" in mission_body
+    assert "renderBuildStepPulse(generatePayload());" in stepper_body
 
 
 def test_portal_exposes_run_card_quick_actions() -> None:

--- a/tests/test_app_orchestrator_runtime.py
+++ b/tests/test_app_orchestrator_runtime.py
@@ -1176,6 +1176,10 @@ def test_portal_console_context_ribbon_tracks_selected_job_and_review_state() ->
     apply_view_body = _extract_js_function_body(content, "applyConsoleViewLayout")
     inspector_body = _extract_js_function_body(content, "renderSelectedJobInspector")
     artifact_body = _extract_js_function_body(content, "renderArtifactPanel")
+    operate_branch_idx = ribbon_body.index("if (state.currentView === 'operate' || state.currentView === 'review') {")
+    operate_return_idx = ribbon_body.index("        return;", operate_branch_idx)
+    selected_idx = ribbon_body.index("const selected = state.jobs.find((job) => job.id === state.selectedJobId) || null;")
+    current_payload_idx = ribbon_body.index("const currentPayload = generatePayload();")
 
     assert 'id="consoleContextRibbon"' in content
     assert 'id="contextRibbonJob"' in content
@@ -1192,6 +1196,8 @@ def test_portal_console_context_ribbon_tracks_selected_job_and_review_state() ->
     assert "const compareCopy = _compareSurfaceCopy(selectedArtifact, compareCandidate, compareEnabled);" in ribbon_body
     assert "label: 'Artifact'," in ribbon_body
     assert "value: selected ? compareCopy.ribbonValue : 'No compare pair'" in ribbon_body
+    assert selected_idx > operate_branch_idx
+    assert current_payload_idx > operate_return_idx
     assert "renderConsoleContextRibbon();" in apply_view_body
     assert "renderConsoleContextRibbon();" in inspector_body
     assert "renderConsoleContextRibbon();" in artifact_body


### PR DESCRIPTION
## Summary
- add an always-on operator briefing ribbon so overview and build keep live lane, review lane, dispatch posture, and draft focus visible at a glance
- add a build-step pulse strip that keeps the active draft, current step, preview state, and next dispatch action pinned through the build flow
- extend portal runtime contract coverage so the new briefing surfaces stay locked to the static portal bundle

## Why
The operator shell already had the right data, but the most useful context moved around between views. This change makes blocked dispatch posture, current draft state, and review readiness visible in the first scan without changing route shape, managed access behavior, or portal asset contracts.

## Impact
- faster operator orientation on overview and build
- clearer blocked versus ready posture before dispatch
- no auth, frontdoor, or proxy contract changes

## Validation
- scoped pre-commit on the changed files with the repo-local Python environment
- `./.venv/bin/pytest tests/test_app_orchestrator_runtime.py tests/test_app_orchestrator_contract_http.py -k portal`
- headless Chrome screenshots against the local backend for `/` and `/?view=build`

## Notes
- left the unrelated existing change in `web/secure-landing/package-lock.json` out of this PR
