### PR TITLE
[codex] Clarify portal runtime posture and recovery UX

### DIFF
--- a/app.py
+++ b/app.py
@@ -2188,6 +2188,126 @@ def _lux_config_metadata() -> Dict[str, Any]:
             "gpu_pressure": ["low", "medium", "high"],
             "research_risk": ["none", "research_only", "experimental"],
         },
+        "backend_catalog": {
+            "da3": {
+                "label": "DA3",
+                "kind": "depth_backend",
+                "operator_summary": ("Default managed depth backend for standard Lux runs."),
+                "policy_posture": {
+                    "code": "governed_default",
+                    "label": "Governed default",
+                    "detail": (
+                        "Treat the managed preset and backend-owned release" " policy as the operator source of truth."
+                    ),
+                },
+                "required_acknowledgments": [],
+                "checkpoint_expectation": {
+                    "required": False,
+                    "field": None,
+                    "detail": (
+                        "Prefers the repo-local canary runtime when it is"
+                        " available, but base readiness is evaluated"
+                        " separately."
+                    ),
+                },
+                "model_provider_label": "Depth Anything",
+                "model_display_label": "Depth Anything v3",
+            },
+            "depth_pro": {
+                "label": "Depth Pro",
+                "kind": "depth_backend",
+                "operator_summary": (
+                    "Metric depth backend reserved for research-oriented runs" " and higher-cost validation."
+                ),
+                "policy_posture": {
+                    "code": "research_only",
+                    "label": "Research only",
+                    "detail": (
+                        "This backend stays behind explicit" " non-commercial and Apple research-license" " acknowledgments."
+                    ),
+                },
+                "required_acknowledgments": [
+                    {
+                        "field": "non_commercial_ok",
+                        "label": "Non-commercial acknowledgment",
+                    },
+                    {
+                        "field": "accept_apple_depth_pro_research_license",
+                        "label": "Apple Depth Pro research license",
+                    },
+                ],
+                "checkpoint_expectation": {
+                    "required": True,
+                    "field": None,
+                    "detail": ("Requires a local Depth Pro checkpoint in the active" " runtime before execution."),
+                },
+                "model_provider_label": "Apple",
+                "model_display_label": "Depth Pro",
+            },
+            "efficientsam": {
+                "label": "EfficientSAM",
+                "kind": "segmentation_backend",
+                "operator_summary": (
+                    "Lighter segmentation backend for managed runs that need" " masks without the heaviest research posture."
+                ),
+                "policy_posture": {
+                    "code": "managed_optional",
+                    "label": "Managed optional",
+                    "detail": (
+                        "Suitable for standard segmentation coverage when the" " run contract does not require the SAM2 path."
+                    ),
+                },
+                "required_acknowledgments": [],
+                "checkpoint_expectation": {
+                    "required": False,
+                    "field": None,
+                    "detail": "No explicit checkpoint path is required.",
+                },
+                "model_provider_label": "EfficientSAM",
+                "model_display_label": "EfficientSAM",
+            },
+            "sam2": {
+                "label": "SAM2",
+                "kind": "segmentation_backend",
+                "operator_summary": ("Highest-fidelity segmentation path for runs that need" " stronger scene coverage."),
+                "policy_posture": {
+                    "code": "experimental_segmentation",
+                    "label": "Experimental",
+                    "detail": (
+                        "Use when the run benefits from deeper segmentation"
+                        " coverage and the higher runtime cost is acceptable."
+                    ),
+                },
+                "required_acknowledgments": [],
+                "checkpoint_expectation": {
+                    "required": False,
+                    "field": "sam2_checkpoint_path",
+                    "detail": (
+                        "A local checkpoint path is optional. Supply one only" " when the runtime requires a pinned SAM2 file."
+                    ),
+                },
+                "model_provider_label": "Meta",
+                "model_display_label": "SAM2 Hiera",
+            },
+            "stub": {
+                "label": "Stub",
+                "kind": "segmentation_backend",
+                "operator_summary": ("Deterministic no-model fallback used for contract checks" " and low-risk iteration."),
+                "policy_posture": {
+                    "code": "deterministic_fallback",
+                    "label": "Deterministic fallback",
+                    "detail": ("Keeps segmentation semantics explicit without adding" " a model dependency."),
+                },
+                "required_acknowledgments": [],
+                "checkpoint_expectation": {
+                    "required": False,
+                    "field": None,
+                    "detail": "No checkpoint is used.",
+                },
+                "model_provider_label": "Built-in",
+                "model_display_label": "Portal stub",
+            },
+        },
         "debug_bundle_policy": {
             "acknowledgement_required": True,
             "destination_template": LUX_DEBUG_BUNDLE_DESTINATION_TEMPLATE,
@@ -5148,7 +5268,9 @@ def _argv_from_request(
                         default="v1",
                     )
                     or "v1"
-                ).strip().lower(),
+                )
+                .strip()
+                .lower(),
                 "--run-card-include-proofs",
                 onoff(
                     _pick(

--- a/portal.html
+++ b/portal.html
@@ -243,6 +243,18 @@ Contract notes:
                         <p id="heroWarningCount" class="mt-2 text-sm font-bold text-slate-900 dark:text-white">0</p>
                     </div>
                 </div>
+                <section id="overviewRuntimeClarityShell" class="mt-6">
+                    <div class="flex items-start justify-between gap-3">
+                        <div>
+                            <p class="section-kicker">Runtime Clarity</p>
+                            <p class="mt-2 text-[12px] leading-6 text-slate-500 dark:text-slate-400">
+                                Selected backends, runtime posture, checkpoint expectations, and license acknowledgments stay visible while the draft changes.
+                            </p>
+                        </div>
+                        <span class="micro-status">Backend-owned policy</span>
+                    </div>
+                    <div id="overviewRuntimeBriefing" class="runtime-briefing-grid mt-4" data-ui="runtime-clarity-grid"></div>
+                </section>
                 </div>
             </div>
         </section>
@@ -384,6 +396,18 @@ Contract notes:
                             <input type="password" id="apiKeyInput" class="flex-1 rounded-xl border border-slate-300 dark:border-slate-700 bg-slate-50 dark:bg-slate-800 px-4 py-2.5 text-[13px] font-mono focus:outline-none focus:ring-2 focus:ring-indigo-500 transition-colors" placeholder="Bearer token for /v1/jobs endpoints" autocomplete="off" spellcheck="false" disabled />
                         </div>
                     </div>
+                    <section id="buildRuntimeClarityShell" class="mt-5">
+                        <div class="flex items-start justify-between gap-3">
+                            <div>
+                                <p class="section-kicker">Execution Briefing</p>
+                                <p class="mt-2 text-[12px] leading-6 text-slate-500 dark:text-slate-400">
+                                    The selected depth path, segmentation mode, checkpoint expectation, and license posture stay pinned here while you move through Steps 2-4.
+                                </p>
+                            </div>
+                            <span class="micro-status">Decision support</span>
+                        </div>
+                        <div id="buildRuntimeBriefing" class="runtime-briefing-grid runtime-briefing-grid--compact mt-4" data-ui="build-runtime-clarity"></div>
+                    </section>
                     </div>
                 </div>
 
@@ -1257,6 +1281,13 @@ Contract notes:
                                 Choose a job from the queue or dispatch a new run to inspect progress, artifacts, and live stream state.
                             </p>
                         </div>
+                        <div class="panel-subtle rounded-2xl p-4" data-ui="selected-job-recovery">
+                            <p class="text-[10px] font-bold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">Next Recovery Action</p>
+                            <p id="selectedJobRecoveryTitle" class="mt-2 text-[12px] font-semibold text-slate-800 dark:text-slate-100">Select a run or dispatch one</p>
+                            <p id="selectedJobRecoveryDetail" class="mt-2 text-[12px] leading-6 text-slate-600 dark:text-slate-300">
+                                Use the selected run state, warning context, and freshness above to decide whether to recover or open review.
+                            </p>
+                        </div>
                     </div>
 
                     <div class="mt-5 flex flex-wrap items-center gap-2 border-b border-slate-200 dark:border-slate-800 pb-4">
@@ -1327,6 +1358,7 @@ Contract notes:
                             <p class="surface-empty-kicker">Queue</p>
                             <p id="emptyQueueTitle" class="surface-empty-title">No runs yet</p>
                             <p id="emptyQueueDetail" class="surface-empty-detail">Dispatch a run from Build or restore backend connectivity to recover recent operator activity.</p>
+                            <p id="emptyQueueAction" class="surface-empty-action">Next action: open Build to prepare the next run or restore backend connectivity to recover recent history.</p>
                         </div>
                     </div>
                 </div>
@@ -1392,6 +1424,7 @@ Contract notes:
                             <p class="review-status-kicker">Run Status</p>
                             <p id="reviewStatusTitle" class="review-status-title">Awaiting completed run</p>
                             <p id="reviewStatusDetail" class="review-status-detail">Select a job to review related warnings, completion state, and output readiness.</p>
+                            <p id="reviewStatusAction" class="review-status-action">Next action: use the selected run state, warning context, and freshness above to decide whether to recover or open review.</p>
                         </div>
                         <div id="reviewProvenanceGrid" class="review-provenance-grid hidden" data-ui="review-provenance-grid">
                             <div class="review-provenance-item">
@@ -1446,6 +1479,7 @@ Contract notes:
                             <p class="surface-empty-kicker">Review</p>
                             <p id="emptyArtifactTitle" class="surface-empty-title">No indexed artifacts</p>
                             <p id="emptyArtifactDetail" class="surface-empty-detail">Choose a completed run or wait for outputs to index so review surfaces can populate.</p>
+                            <p id="emptyArtifactAction" class="surface-empty-action">Next action: inspect the selected run in Operate or wait for indexed outputs before reopening review.</p>
                         </div>
                     </div>
                     </div>

--- a/public/portal-assets/portal.css
+++ b/public/portal-assets/portal.css
@@ -738,7 +738,8 @@ progress::-moz-progress-bar { background-color: #4f46e5; transition: width 0.3s 
 }
 
 .console-context-card::before,
-.build-pulse-card::before {
+.build-pulse-card::before,
+.runtime-briefing-card::before {
     content: "";
     position: absolute;
     inset: 0 auto auto 0;
@@ -749,7 +750,8 @@ progress::-moz-progress-bar { background-color: #4f46e5; transition: width 0.3s 
 }
 
 .console-context-card[data-tone="ready"],
-.build-pulse-card[data-tone="ready"] {
+.build-pulse-card[data-tone="ready"],
+.runtime-briefing-card[data-tone="ready"] {
     border-color: rgba(13, 148, 136, 0.18);
     background:
         linear-gradient(180deg, rgba(240, 253, 250, 0.94), rgba(255, 255, 255, 0.7)),
@@ -757,12 +759,14 @@ progress::-moz-progress-bar { background-color: #4f46e5; transition: width 0.3s 
 }
 
 .console-context-card[data-tone="ready"]::before,
-.build-pulse-card[data-tone="ready"]::before {
+.build-pulse-card[data-tone="ready"]::before,
+.runtime-briefing-card[data-tone="ready"]::before {
     background: rgba(13, 148, 136, 0.82);
 }
 
 .console-context-card[data-tone="warning"],
-.build-pulse-card[data-tone="warning"] {
+.build-pulse-card[data-tone="warning"],
+.runtime-briefing-card[data-tone="warning"] {
     border-color: rgba(217, 119, 6, 0.18);
     background:
         linear-gradient(180deg, rgba(255, 251, 235, 0.96), rgba(255, 255, 255, 0.7)),
@@ -770,12 +774,14 @@ progress::-moz-progress-bar { background-color: #4f46e5; transition: width 0.3s 
 }
 
 .console-context-card[data-tone="warning"]::before,
-.build-pulse-card[data-tone="warning"]::before {
+.build-pulse-card[data-tone="warning"]::before,
+.runtime-briefing-card[data-tone="warning"]::before {
     background: rgba(217, 119, 6, 0.82);
 }
 
 .console-context-card[data-tone="blocked"],
-.build-pulse-card[data-tone="blocked"] {
+.build-pulse-card[data-tone="blocked"],
+.runtime-briefing-card[data-tone="blocked"] {
     border-color: rgba(220, 38, 38, 0.18);
     background:
         linear-gradient(180deg, rgba(254, 242, 242, 0.94), rgba(255, 255, 255, 0.7)),
@@ -783,12 +789,14 @@ progress::-moz-progress-bar { background-color: #4f46e5; transition: width 0.3s 
 }
 
 .console-context-card[data-tone="blocked"]::before,
-.build-pulse-card[data-tone="blocked"]::before {
+.build-pulse-card[data-tone="blocked"]::before,
+.runtime-briefing-card[data-tone="blocked"]::before {
     background: rgba(220, 38, 38, 0.82);
 }
 
 .dark .console-context-card[data-tone="ready"],
-.dark .build-pulse-card[data-tone="ready"] {
+.dark .build-pulse-card[data-tone="ready"],
+.dark .runtime-briefing-card[data-tone="ready"] {
     border-color: rgba(45, 212, 191, 0.24);
     background:
         linear-gradient(180deg, rgba(15, 118, 110, 0.18), rgba(15, 23, 42, 0.76)),
@@ -796,7 +804,8 @@ progress::-moz-progress-bar { background-color: #4f46e5; transition: width 0.3s 
 }
 
 .dark .console-context-card[data-tone="warning"],
-.dark .build-pulse-card[data-tone="warning"] {
+.dark .build-pulse-card[data-tone="warning"],
+.dark .runtime-briefing-card[data-tone="warning"] {
     border-color: rgba(251, 191, 36, 0.24);
     background:
         linear-gradient(180deg, rgba(120, 53, 15, 0.24), rgba(15, 23, 42, 0.76)),
@@ -804,7 +813,8 @@ progress::-moz-progress-bar { background-color: #4f46e5; transition: width 0.3s 
 }
 
 .dark .console-context-card[data-tone="blocked"],
-.dark .build-pulse-card[data-tone="blocked"] {
+.dark .build-pulse-card[data-tone="blocked"],
+.dark .runtime-briefing-card[data-tone="blocked"] {
     border-color: rgba(248, 113, 113, 0.24);
     background:
         linear-gradient(180deg, rgba(127, 29, 29, 0.24), rgba(15, 23, 42, 0.76)),
@@ -841,6 +851,16 @@ progress::-moz-progress-bar { background-color: #4f46e5; transition: width 0.3s 
     grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
 }
 
+.runtime-briefing-grid {
+    display: grid;
+    gap: 0.75rem;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.runtime-briefing-grid--compact {
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
 .build-pulse-card {
     position: relative;
     min-height: 100%;
@@ -854,6 +874,25 @@ progress::-moz-progress-bar { background-color: #4f46e5; transition: width 0.3s 
 }
 
 .dark .build-pulse-card {
+    background: rgba(15, 23, 42, 0.64);
+    box-shadow:
+        inset 0 1px 0 rgba(148, 163, 184, 0.04),
+        0 12px 26px rgba(2, 6, 23, 0.18);
+}
+
+.runtime-briefing-card {
+    position: relative;
+    min-height: 100%;
+    border: 1px solid var(--shell-border);
+    border-radius: 8px;
+    background: rgba(255, 255, 255, 0.68);
+    padding: 0.85rem 0.95rem;
+    box-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.22),
+        0 10px 24px rgba(15, 23, 42, 0.04);
+}
+
+.dark .runtime-briefing-card {
     background: rgba(15, 23, 42, 0.64);
     box-shadow:
         inset 0 1px 0 rgba(148, 163, 184, 0.04),
@@ -880,6 +919,37 @@ progress::-moz-progress-bar { background-color: #4f46e5; transition: width 0.3s 
     margin-top: 0.4rem;
     font-size: 11px;
     line-height: 1.55;
+    color: var(--shell-muted);
+}
+
+.runtime-briefing-label {
+    font-size: 10px;
+    font-weight: 800;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--shell-muted);
+}
+
+.runtime-briefing-value {
+    margin-top: 0.45rem;
+    font-size: 13px;
+    font-weight: 800;
+    line-height: 1.4;
+    color: var(--shell-ink);
+    word-break: break-word;
+}
+
+.runtime-briefing-detail {
+    margin-top: 0.45rem;
+    font-size: 11.5px;
+    line-height: 1.55;
+    color: var(--shell-muted);
+}
+
+.runtime-briefing-meta {
+    margin-top: 0.45rem;
+    font-size: 10.5px;
+    line-height: 1.5;
     color: var(--shell-muted);
 }
 
@@ -1470,6 +1540,13 @@ details[open] .disclosure-chevron {
     color: var(--shell-muted);
 }
 
+.review-status-action {
+    font-size: 11.5px;
+    line-height: 1.55;
+    font-weight: 600;
+    color: var(--shell-ink);
+}
+
 .surface-empty-state {
     gap: 0.55rem;
     border: 1px dashed rgba(148, 163, 184, 0.28);
@@ -1546,6 +1623,15 @@ details[open] .disclosure-chevron {
     font-size: 12.5px;
     line-height: 1.65;
     color: var(--shell-muted);
+}
+
+.surface-empty-action {
+    margin: 0;
+    max-width: 26rem;
+    font-size: 12px;
+    line-height: 1.65;
+    font-weight: 600;
+    color: var(--shell-ink);
 }
 
 .review-provenance-grid {
@@ -2354,6 +2440,10 @@ textarea,
     }
 
     .overview-meta-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .runtime-briefing-grid {
         grid-template-columns: 1fr;
     }
 

--- a/public/portal-assets/portal.js
+++ b/public/portal-assets/portal.js
@@ -163,7 +163,8 @@ const state = {
         fields: {},
         estimate_bands: {},
         debug_bundle_policy: {},
-        advanced_sections: []
+        advanced_sections: [],
+        backend_catalog: {},
     },
     preview: {
         pipeline: '',
@@ -250,6 +251,8 @@ const state = {
 
 const els = {
     overviewShell: document.getElementById('overview-shell'),
+    overviewRuntimeClarityShell: document.getElementById('overviewRuntimeClarityShell'),
+    overviewRuntimeBriefing: document.getElementById('overviewRuntimeBriefing'),
     missionShell: document.getElementById('mission-shell'),
     missionShellContent: document.getElementById('missionShellContent'),
     missionShellSkeletonState: document.getElementById('missionShellSkeletonState'),
@@ -477,6 +480,8 @@ const els = {
     profileShell: document.getElementById('profile-shell'),
     profileShellContent: document.getElementById('profileShellContent'),
     profileShellSkeletonState: document.getElementById('profileShellSkeletonState'),
+    buildRuntimeClarityShell: document.getElementById('buildRuntimeClarityShell'),
+    buildRuntimeBriefing: document.getElementById('buildRuntimeBriefing'),
     buildStepperShell: document.getElementById('buildStepperShell'),
     buildStepperShellContent: document.getElementById('buildStepperShellContent'),
     buildStepperSkeletonState: document.getElementById('buildStepperSkeletonState'),
@@ -494,6 +499,7 @@ const els = {
     emptyQueueState: document.getElementById('emptyQueueState'),
     emptyQueueTitle: document.getElementById('emptyQueueTitle'),
     emptyQueueDetail: document.getElementById('emptyQueueDetail'),
+    emptyQueueAction: document.getElementById('emptyQueueAction'),
     queueCount: document.getElementById('queueCount'),
     selectedJobStateBadge: document.getElementById('selectedJobStateBadge'),
     selectedJobIdLabel: document.getElementById('selectedJobIdLabel'),
@@ -505,6 +511,8 @@ const els = {
     selectedJobMetaLine: document.getElementById('selectedJobMetaLine'),
     selectedJobFreshness: document.getElementById('selectedJobFreshness'),
     selectedJobSummary: document.getElementById('selectedJobSummary'),
+    selectedJobRecoveryTitle: document.getElementById('selectedJobRecoveryTitle'),
+    selectedJobRecoveryDetail: document.getElementById('selectedJobRecoveryDetail'),
     selectedJobTransportAlert: document.getElementById('selectedJobTransportAlert'),
     openRunDetailsBtn: document.getElementById('openRunDetailsBtn'),
     inspectorOverviewTab: document.getElementById('inspectorOverviewTab'),
@@ -523,6 +531,7 @@ const els = {
     emptyArtifactState: document.getElementById('emptyArtifactState'),
     emptyArtifactTitle: document.getElementById('emptyArtifactTitle'),
     emptyArtifactDetail: document.getElementById('emptyArtifactDetail'),
+    emptyArtifactAction: document.getElementById('emptyArtifactAction'),
     artifactCompareBtn: document.getElementById('artifactCompareBtn'),
     artifactPreviewStage: document.getElementById('artifactPreviewStage'),
     artifactCompareStage: document.getElementById('artifactCompareStage'),
@@ -538,6 +547,7 @@ const els = {
     reviewStatusBanner: document.getElementById('reviewStatusBanner'),
     reviewStatusTitle: document.getElementById('reviewStatusTitle'),
     reviewStatusDetail: document.getElementById('reviewStatusDetail'),
+    reviewStatusAction: document.getElementById('reviewStatusAction'),
     reviewProvenanceGrid: document.getElementById('reviewProvenanceGrid'),
     reviewProvenanceArtifactRole: document.getElementById('reviewProvenanceArtifactRole'),
     reviewProvenanceRunState: document.getElementById('reviewProvenanceRunState'),
@@ -1291,6 +1301,376 @@ function _previewSurfaceSummary(payload = null) {
         meta: 'Preview-backed validation will summarize the active draft here.',
         tone: 'info'
     };
+}
+
+function _metadataBackendEntry(name) {
+    const catalog = state.metadata?.backend_catalog;
+    const key = String(name || '').trim().toLowerCase();
+    if (!key || !catalog || typeof catalog !== 'object') return null;
+    const entry = catalog[key];
+    return entry && typeof entry === 'object' ? entry : null;
+}
+
+function _runtimeBriefingPolicyTone(entry) {
+    const code = String(entry?.policy_posture?.code || '').trim().toLowerCase();
+    if (code === 'governed_default') return 'ready';
+    if (code === 'managed_optional' || code === 'deterministic_fallback') return 'info';
+    if (code === 'research_only' || code === 'experimental_segmentation') return 'warning';
+    return 'info';
+}
+
+function _runtimeBriefingArgs(payload = null) {
+    const currentPayload = payload || generatePayload();
+    const preview = _currentPreviewForPayload(currentPayload);
+    const normalizedArgs = preview?.normalized_args && typeof preview.normalized_args === 'object'
+        ? preview.normalized_args
+        : null;
+    return {
+        payload: currentPayload,
+        preview,
+        args: normalizedArgs ? { ...(currentPayload.args || {}), ...normalizedArgs } : (currentPayload.args || {})
+    };
+}
+
+function _runtimeAcknowledgmentSnapshot(entry, args = {}) {
+    const required = Array.isArray(entry?.required_acknowledgments) ? entry.required_acknowledgments : [];
+    const pending = [];
+    const completed = [];
+    required.forEach((item) => {
+        const field = String(item?.field || '').trim();
+        if (!field) return;
+        const label = String(item?.label || titleCaseToken(field, field)).trim();
+        if (parseBoolLike(args[field], false)) {
+            completed.push(label);
+            return;
+        }
+        pending.push(label);
+    });
+    return { pending, completed };
+}
+
+function _runtimeBriefingCardSummary(summary = {}) {
+    return {
+        label: String(summary.label || 'Runtime summary'),
+        value: String(summary.value || 'Unavailable'),
+        detail: String(summary.detail || ''),
+        meta: String(summary.meta || ''),
+        tone: String(summary.tone || 'info')
+    };
+}
+
+function _runtimeDepthBackendSummary(args = {}) {
+    const backendName = _resolveDepthBackend(args.depth_backend || state.config.depthBackend || 'da3');
+    const entry = _metadataBackendEntry(backendName);
+    const acknowledgments = _runtimeAcknowledgmentSnapshot(entry, args);
+    const meta = [
+        entry?.model_provider_label,
+        entry?.model_display_label,
+        acknowledgments.pending.length > 0
+            ? `Pending: ${acknowledgments.pending.join(', ')}`
+            : entry?.policy_posture?.label
+    ].filter(Boolean).join(' • ');
+    return _runtimeBriefingCardSummary({
+        label: 'Depth backend',
+        value: entry?.label || titleCaseToken(backendName, 'Unknown'),
+        detail: entry?.operator_summary || 'Backend-owned metadata is unavailable, so keep using readiness and preview as the source of truth.',
+        meta: meta || 'Backend-owned policy',
+        tone: acknowledgments.pending.length > 0 ? 'blocked' : _runtimeBriefingPolicyTone(entry)
+    });
+}
+
+function _runtimeSegmentationBackendSummary(args = {}) {
+    const segmentationEnabled = parseBoolLike(args.enable_segmentation, false);
+    if (!segmentationEnabled) {
+        return _runtimeBriefingCardSummary({
+            label: 'Segmentation backend',
+            value: 'Segmentation off',
+            detail: 'This draft stays on the deterministic path until segmentation is enabled.',
+            meta: 'Enable segmentation to choose EfficientSAM or SAM2.',
+            tone: 'info'
+        });
+    }
+
+    const backendName = _resolveSegmentationBackend(args.segmentation_backend || state.config.segmentation?.backend || 'stub');
+    const entry = _metadataBackendEntry(backendName);
+    const modelSize = backendName === 'sam2'
+        ? _resolveSam2ModelSize(args.sam2_model_size || state.config.segmentation?.sam2ModelSize || 'base')
+        : '';
+    const meta = [
+        entry?.model_provider_label,
+        entry?.model_display_label,
+        modelSize ? `Model ${_titleizeEstimateToken(modelSize)}` : '',
+        parseBoolLike(args.strict_segmentation, false) ? 'Strict masks on' : 'Strict masks off'
+    ].filter(Boolean).join(' • ');
+    return _runtimeBriefingCardSummary({
+        label: 'Segmentation backend',
+        value: entry?.label || titleCaseToken(backendName, 'Unknown'),
+        detail: entry?.operator_summary || 'Segmentation metadata is unavailable, so keep the configured backend visible in the draft.',
+        meta: meta || 'Backend-owned policy',
+        tone: _runtimeBriefingPolicyTone(entry)
+    });
+}
+
+function _runtimeStateSummary(payload = null) {
+    const { preview } = _runtimeBriefingArgs(payload);
+    const readiness = currentPipelineReadiness(payload);
+    const issues = currentPipelineReadinessIssues(payload);
+    const dispatchStatus = titleCaseToken(currentPipelineDispatchStatus(payload) || readiness?.status || 'unknown', 'Unknown');
+
+    if (!state.backendOk) {
+        return _runtimeBriefingCardSummary({
+            label: 'Canary/runtime state',
+            value: 'Backend offline',
+            detail: 'Live readiness, canary posture, and recent-run recovery resume when backend connectivity returns.',
+            meta: 'Preview-backed dispatch remains paused while the orchestrator backend is offline.',
+            tone: 'blocked'
+        });
+    }
+
+    if (preview?.status === 'loading' && !readiness) {
+        return _runtimeBriefingCardSummary({
+            label: 'Canary/runtime state',
+            value: 'Refreshing',
+            detail: 'Preview-backed readiness is recalculating the active draft.',
+            meta: 'Canary posture appears here when backend readiness returns.',
+            tone: 'info'
+        });
+    }
+
+    if (!readiness || typeof readiness !== 'object') {
+        return _runtimeBriefingCardSummary({
+            label: 'Canary/runtime state',
+            value: 'Readiness loading',
+            detail: 'Base readiness and canary posture are still hydrating from the backend.',
+            meta: 'Dispatch state becomes authoritative when readiness finishes.',
+            tone: 'info'
+        });
+    }
+
+    const canaryLabel = `Canary ${titleCaseToken(readiness.canary_status || 'unknown', 'Unknown')}`;
+    const firstIssue = issues[0];
+    if (firstIssue) {
+        return _runtimeBriefingCardSummary({
+            label: 'Canary/runtime state',
+            value: `${dispatchStatus} • ${canaryLabel}`,
+            detail: String(firstIssue.message || 'Pipeline readiness reported an operator-facing prerequisite.'),
+            meta: 'Resolve the current readiness issue before dispatching this draft.',
+            tone: String(firstIssue.severity || '').trim().toLowerCase() === 'blocked' ? 'blocked' : 'warning'
+        });
+    }
+
+    const notes = Array.isArray(readiness.notes)
+        ? readiness.notes.map((item) => String(item || '').trim()).filter(Boolean)
+        : [];
+    return _runtimeBriefingCardSummary({
+        label: 'Canary/runtime state',
+        value: canaryLabel,
+        detail: notes[notes.length - 1] || notes[0] || 'Base readiness and canary posture are aligned with the current draft.',
+        meta: `Dispatch ${dispatchStatus}`,
+        tone: readiness.canary_status === 'ready'
+            ? 'ready'
+            : readiness.canary_status === 'degraded' || readiness.canary_status === 'unavailable'
+                ? 'warning'
+                : 'info'
+    });
+}
+
+function _runtimeCheckpointExpectationSummary(args = {}) {
+    const depthEntry = _metadataBackendEntry(_resolveDepthBackend(args.depth_backend || state.config.depthBackend || 'da3'));
+    const entries = [{ entry: depthEntry }];
+    if (parseBoolLike(args.enable_segmentation, false)) {
+        entries.push({
+            entry: _metadataBackendEntry(
+                _resolveSegmentationBackend(args.segmentation_backend || state.config.segmentation?.backend || 'stub')
+            )
+        });
+    }
+
+    const statements = [];
+    const details = [];
+    let hasRequiredFieldMissing = false;
+    let hasRuntimeManagedRequirement = false;
+    let hasOptionalPath = false;
+    let hasOptionalUnset = false;
+    let hasNoPathRequirement = false;
+
+    entries.forEach(({ entry }) => {
+        if (!entry) return;
+        const expectation = entry.checkpoint_expectation && typeof entry.checkpoint_expectation === 'object'
+            ? entry.checkpoint_expectation
+            : null;
+        if (!expectation) return;
+        const entryLabel = String(entry.label || 'Backend').trim();
+        const field = String(expectation.field || '').trim();
+        const providedValue = field ? String(args[field] || '').trim() : '';
+
+        if (expectation.required && field && !providedValue) {
+            hasRequiredFieldMissing = true;
+            statements.push(`${entryLabel}: required checkpoint path missing.`);
+        } else if (expectation.required && field && providedValue) {
+            statements.push(`${entryLabel}: required checkpoint path supplied.`);
+        } else if (expectation.required) {
+            hasRuntimeManagedRequirement = true;
+            statements.push(`${entryLabel}: runtime-managed checkpoint required.`);
+        } else if (field && providedValue) {
+            hasOptionalPath = true;
+            statements.push(`${entryLabel}: optional checkpoint path supplied.`);
+        } else if (field) {
+            hasOptionalUnset = true;
+            statements.push(`${entryLabel}: optional checkpoint path not set.`);
+        } else {
+            hasNoPathRequirement = true;
+            statements.push(`${entryLabel}: no explicit checkpoint path required.`);
+        }
+
+        const detail = String(expectation.detail || '').trim();
+        if (detail) details.push(detail);
+    });
+
+    let value = 'No explicit path required';
+    let tone = 'ready';
+    if (hasRequiredFieldMissing) {
+        value = 'Checkpoint path missing';
+        tone = 'blocked';
+    } else if (hasRuntimeManagedRequirement) {
+        value = 'Runtime checkpoint required';
+        tone = 'warning';
+    } else if (hasOptionalPath) {
+        value = 'Checkpoint path supplied';
+        tone = 'ready';
+    } else if (hasOptionalUnset) {
+        value = 'Checkpoint path optional';
+        tone = 'info';
+    } else if (hasNoPathRequirement) {
+        value = 'No explicit path required';
+        tone = 'ready';
+    }
+
+    return _runtimeBriefingCardSummary({
+        label: 'Checkpoint expectation',
+        value,
+        detail: statements.join(' ') || 'Checkpoint expectations load from backend metadata.',
+        meta: details.join(' ') || 'Backend-owned runtime expectation',
+        tone
+    });
+}
+
+function _runtimeLicensePostureSummary(args = {}) {
+    const selectedEntries = [
+        _metadataBackendEntry(_resolveDepthBackend(args.depth_backend || state.config.depthBackend || 'da3'))
+    ];
+    if (parseBoolLike(args.enable_segmentation, false)) {
+        selectedEntries.push(
+            _metadataBackendEntry(
+                _resolveSegmentationBackend(args.segmentation_backend || state.config.segmentation?.backend || 'stub')
+            )
+        );
+    }
+
+    const postures = [];
+    const pending = new Set();
+    const completed = new Set();
+    const details = [];
+    let tone = 'ready';
+
+    selectedEntries.filter(Boolean).forEach((entry) => {
+        const acknowledgments = _runtimeAcknowledgmentSnapshot(entry, args);
+        const postureLabel = String(entry?.policy_posture?.label || entry?.label || 'Policy').trim();
+        postures.push(`${String(entry?.label || 'Backend').trim()}: ${postureLabel}`);
+        acknowledgments.pending.forEach((label) => pending.add(label));
+        acknowledgments.completed.forEach((label) => completed.add(label));
+        const detail = String(entry?.policy_posture?.detail || entry?.operator_summary || '').trim();
+        if (detail) details.push(detail);
+        if (acknowledgments.pending.length > 0) {
+            tone = 'blocked';
+        } else if (tone !== 'blocked') {
+            const entryTone = _runtimeBriefingPolicyTone(entry);
+            tone = entryTone === 'ready' ? tone : entryTone;
+        }
+    });
+
+    const meta = [];
+    if (pending.size > 0) {
+        meta.push(`Pending: ${Array.from(pending).join(', ')}`);
+    } else if (completed.size > 0) {
+        meta.push(`Acknowledged: ${Array.from(completed).join(', ')}`);
+    } else {
+        meta.push('No backend acknowledgments are currently required.');
+    }
+    if (parseBoolLike(args.enable_reconstruction, false)) {
+        meta.push('Scene reconstruction governance stays in the primary governance panel.');
+    }
+
+    return _runtimeBriefingCardSummary({
+        label: 'License posture',
+        value: pending.size > 0 ? 'Acknowledgment required' : (postures.join(' • ') || 'Backend-owned policy'),
+        detail: details.join(' ') || 'Backend-owned policy remains the operator source of truth for selected backends.',
+        meta: meta.join(' • '),
+        tone
+    });
+}
+
+function _renderRuntimeBriefingCard(summary = {}) {
+    const card = document.createElement('article');
+    card.className = 'runtime-briefing-card';
+    card.dataset.tone = String(summary.tone || 'info');
+
+    const label = document.createElement('p');
+    label.className = 'runtime-briefing-label';
+    label.textContent = String(summary.label || 'Runtime summary');
+
+    const value = document.createElement('p');
+    value.className = 'runtime-briefing-value';
+    value.textContent = String(summary.value || 'Unavailable');
+
+    const detail = document.createElement('p');
+    detail.className = 'runtime-briefing-detail';
+    detail.textContent = String(summary.detail || '');
+
+    const meta = document.createElement('p');
+    meta.className = 'runtime-briefing-meta';
+    meta.textContent = String(summary.meta || '');
+
+    card.appendChild(label);
+    card.appendChild(value);
+    if (detail.textContent) card.appendChild(detail);
+    if (meta.textContent) card.appendChild(meta);
+    return card;
+}
+
+function renderRuntimeBriefing(payload = null) {
+    const currentPayload = payload || generatePayload();
+    const shells = [els.overviewRuntimeClarityShell, els.buildRuntimeClarityShell].filter(Boolean);
+    const containers = [els.overviewRuntimeBriefing, els.buildRuntimeBriefing].filter(Boolean);
+    const isLuxPipeline = String(currentPayload.pipeline || '').trim() === 'lux-depth-v3';
+
+    shells.forEach((shell) => {
+        shell.classList.toggle('hidden', !isLuxPipeline);
+    });
+    if (!isLuxPipeline) {
+        containers.forEach((container) => {
+            container.innerHTML = '';
+        });
+        return;
+    }
+
+    const { args } = _runtimeBriefingArgs(currentPayload);
+    const summaries = [
+        _runtimeDepthBackendSummary(args),
+        _runtimeSegmentationBackendSummary(args),
+        _runtimeStateSummary(currentPayload),
+        _runtimeCheckpointExpectationSummary(args),
+        _runtimeLicensePostureSummary(args)
+    ];
+
+    containers.forEach((container) => {
+        container.innerHTML = '';
+        const fragment = document.createDocumentFragment();
+        summaries.forEach((summary) => {
+            fragment.appendChild(_renderRuntimeBriefingCard(summary));
+        });
+        container.appendChild(fragment);
+    });
 }
 
 function renderBuildStepPulse(payload = null) {
@@ -2742,6 +3122,7 @@ function renderMissionControl(payload = null) {
     renderGovernanceBanner(currentPayload);
     syncDisclosurePanels(currentPayload);
     renderBuildStepPulse(currentPayload);
+    renderRuntimeBriefing(currentPayload);
     renderConsoleContextRibbon();
     _syncOverviewBuildLoadingState(currentPayload);
 }
@@ -2874,6 +3255,85 @@ function renderSelectedJobTimeline(job) {
     els.selectedJobTimelineList.appendChild(fragment);
 }
 
+function _selectedJobRecoverySnapshot(job) {
+    if (!job) {
+        return {
+            title: 'Select or dispatch a run',
+            detail: 'Use Queue to inspect a recent run or open Build to create the next governed dispatch.'
+        };
+    }
+
+    const artifactCount = Array.isArray(job.artifacts) ? job.artifacts.length : 0;
+    const visibleWarning = _latestVisibleTransportWarning(job);
+
+    if (job.reconnectBlocked) {
+        return {
+            title: 'Restore authentication',
+            detail: 'Authentication must be restored before live transport can reconnect and freshness can recover.'
+        };
+    }
+
+    if (visibleWarning) {
+        return {
+            title: 'Review the latest warning',
+            detail: String(visibleWarning.detail || 'Live transport reported an operator-visible warning.')
+        };
+    }
+
+    if (job.state === 'failed' || job.state === 'canceled') {
+        return artifactCount > 0
+            ? {
+                title: 'Open review for retained outputs',
+                detail: 'Review the indexed outputs before deciding whether this run needs a retry.'
+            }
+            : {
+                title: 'Inspect failure before rerun',
+                detail: 'No reviewable outputs were indexed. Use the run state and warning context above before retrying.'
+            };
+    }
+
+    if (job.state === 'offline') {
+        return artifactCount > 0
+            ? {
+                title: 'Review cached outputs while backend recovers',
+                detail: 'Outputs remain available, but live backend state is stale until connectivity returns.'
+            }
+            : {
+                title: 'Restore backend connectivity',
+                detail: 'Backend connectivity must recover before this run state can be trusted again.'
+            };
+    }
+
+    if (job.state === 'running' || job.state === 'queued') {
+        return artifactCount > 0
+            ? {
+                title: 'Stay with the live run',
+                detail: 'Fresh artifacts are already indexing. Keep Operate open until review context stabilizes.'
+            }
+            : {
+                title: 'Wait for indexed outputs',
+                detail: 'Use the selected run state, warning context, and freshness above to decide whether to recover or open review.'
+            };
+    }
+
+    if (job.state === 'partial') {
+        return {
+            title: 'Open review for partial outputs',
+            detail: 'Review the indexed artifacts and warning context before deciding whether to rerun the failed inputs.'
+        };
+    }
+
+    return artifactCount > 0
+        ? {
+            title: 'Open review',
+            detail: 'Outputs and provenance are ready. Move to Review when you want compare and artifact actions.'
+        }
+        : {
+            title: 'Wait for indexed outputs',
+            detail: 'Use the selected run state, warning context, and freshness above to decide whether to recover or open review.'
+        };
+}
+
 function renderSelectedJobInspector() {
     const jobsLoading = _isJobsHydrationPending();
     _toggleSurfaceSkeleton(els.selectedJobShell, els.selectedJobShellContent, els.selectedJobSkeletonState, jobsLoading);
@@ -2882,6 +3342,10 @@ function renderSelectedJobInspector() {
         if (els.selectedJobFreshness) els.selectedJobFreshness.textContent = 'Hydrating queue';
         if (els.selectedJobMetaLine) {
             els.selectedJobMetaLine.textContent = 'Recovering recent runs, transport state, and previewable outputs.';
+        }
+        if (els.selectedJobRecoveryTitle) els.selectedJobRecoveryTitle.textContent = 'Recovering selected run context';
+        if (els.selectedJobRecoveryDetail) {
+            els.selectedJobRecoveryDetail.textContent = 'The latest warning, artifact freshness, and recovery action will repopulate here when queue hydration finishes.';
         }
         if (els.openRunDetailsBtn) els.openRunDetailsBtn.disabled = true;
         renderConsoleContextRibbon();
@@ -2901,6 +3365,10 @@ function renderSelectedJobInspector() {
         if (els.selectedJobFreshness) els.selectedJobFreshness.textContent = 'No live telemetry';
         if (els.logMetaLabel) els.logMetaLabel.textContent = 'Select a job to stream or inspect its log output.';
         if (els.selectedJobSummary) els.selectedJobSummary.textContent = 'Choose a job from the queue or dispatch a new run to inspect progress, artifacts, and live stream state.';
+        if (els.selectedJobRecoveryTitle) els.selectedJobRecoveryTitle.textContent = 'Select or dispatch a run';
+        if (els.selectedJobRecoveryDetail) {
+            els.selectedJobRecoveryDetail.textContent = 'Use Queue to inspect a recent run or open Build to create the next governed dispatch.';
+        }
         if (els.selectedJobTransportAlert) {
             els.selectedJobTransportAlert.classList.add('hidden');
             els.selectedJobTransportAlert.textContent = '';
@@ -2971,6 +3439,9 @@ function renderSelectedJobInspector() {
                     ? `${outcomeSummary}.`
                     : `Operators can now read ${titleCaseToken(selected.state, 'job')} state at a glance: ${artifactCount} artifact${artifactCount === 1 ? '' : 's'} indexed, ${transportLabel} transport, ${elapsedLabel}.`;
     }
+    const recovery = _selectedJobRecoverySnapshot(selected);
+    if (els.selectedJobRecoveryTitle) els.selectedJobRecoveryTitle.textContent = recovery.title;
+    if (els.selectedJobRecoveryDetail) els.selectedJobRecoveryDetail.textContent = recovery.detail;
     if (els.selectedJobTransportAlert) {
         if (visibleAlert) {
             els.selectedJobTransportAlert.textContent = String(visibleAlert.detail || '');
@@ -3842,7 +4313,8 @@ function _reviewStatusSnapshot(job, artifact) {
             visible: false,
             tone: 'info',
             title: 'Awaiting completed run',
-            detail: 'Select a job to review related warnings, completion state, and output readiness.'
+            detail: 'Select a job to review related warnings, completion state, and output readiness.',
+            action: 'Next action: use the selected run state, warning context, and freshness above to decide whether to recover or open review.'
         };
     }
 
@@ -3862,7 +4334,8 @@ function _reviewStatusSnapshot(job, artifact) {
             title: 'Run partially completed',
             detail: outcomeSummary
                 ? `${outcomeSummary}. Updated ${freshnessLabel}.`
-                : 'Some inputs failed, but outputs remain reviewable.'
+                : 'Some inputs failed, but outputs remain reviewable.',
+            action: 'Next action: open review for the retained outputs before rerunning failed inputs.'
         };
     }
 
@@ -3874,7 +4347,10 @@ function _reviewStatusSnapshot(job, artifact) {
             detail: readableError
                 || (reviewableOutputs
                     ? `${artifactCount} artifact${artifactCount === 1 ? '' : 's'} remain available for review. Updated ${freshnessLabel}.`
-                    : 'No reviewable outputs were indexed before the failure was reported.')
+                    : 'No reviewable outputs were indexed before the failure was reported.'),
+            action: reviewableOutputs
+                ? 'Next action: open review for the retained outputs, then decide whether this run needs a retry.'
+                : 'Next action: inspect the latest warning and failure context in Operate before retrying the run.'
         };
     }
 
@@ -3885,7 +4361,10 @@ function _reviewStatusSnapshot(job, artifact) {
             title: reviewableOutputs ? 'Run canceled after partial output capture' : 'Run canceled before review outputs were ready',
             detail: reviewableOutputs
                 ? `${artifactCount} artifact${artifactCount === 1 ? '' : 's'} remain available for review despite cancellation. Updated ${freshnessLabel}.`
-                : 'Execution was canceled before reviewable outputs were indexed.'
+                : 'Execution was canceled before reviewable outputs were indexed.',
+            action: reviewableOutputs
+                ? 'Next action: review the retained outputs before deciding whether to rerun the canceled work.'
+                : 'Next action: reopen Build or restore the run context before dispatching again.'
         };
     }
 
@@ -3896,7 +4375,10 @@ function _reviewStatusSnapshot(job, artifact) {
             title: reviewableOutputs ? 'Run is offline with reviewable outputs' : 'Run is offline',
             detail: reviewableOutputs
                 ? `${artifactCount} artifact${artifactCount === 1 ? '' : 's'} remain available, but live backend status is stale until connectivity is restored.`
-                : 'Live backend status is stale until connectivity is restored.'
+                : 'Live backend status is stale until connectivity is restored.',
+            action: reviewableOutputs
+                ? 'Next action: review the cached outputs while backend connectivity recovers.'
+                : 'Next action: restore backend connectivity before depending on this run state.'
         };
     }
 
@@ -3905,7 +4387,8 @@ function _reviewStatusSnapshot(job, artifact) {
             visible: true,
             tone: 'warning',
             title: 'Transport warning recorded',
-            detail: 'Authentication must be restored before live event transport can reconnect.'
+            detail: 'Authentication must be restored before live event transport can reconnect.',
+            action: 'Next action: restore authentication so live transport and freshness can recover.'
         };
     }
 
@@ -3914,7 +4397,8 @@ function _reviewStatusSnapshot(job, artifact) {
             visible: true,
             tone: visibleWarning.tone === 'error' ? 'error' : 'warning',
             title: 'Transport warning recorded',
-            detail: String(visibleWarning.detail || 'Live transport reported an operator-visible warning.')
+            detail: String(visibleWarning.detail || 'Live transport reported an operator-visible warning.'),
+            action: 'Next action: inspect the latest transport warning in Operate before continuing into review.'
         };
     }
 
@@ -3925,7 +4409,10 @@ function _reviewStatusSnapshot(job, artifact) {
             title: 'Run still in progress',
             detail: artifactCount > 0
                 ? `${artifactCount} artifact${artifactCount === 1 ? '' : 's'} already indexed. Updated ${freshnessLabel}.`
-                : 'Artifacts and provenance will populate here as outputs arrive.'
+                : 'Artifacts and provenance will populate here as outputs arrive.',
+            action: artifactCount > 0
+                ? 'Next action: keep review open only if you need the early artifacts; Operate remains the primary live surface.'
+                : 'Next action: stay in Operate until indexed outputs or a blocking warning arrives.'
         };
     }
 
@@ -3935,7 +4422,8 @@ function _reviewStatusSnapshot(job, artifact) {
         title: artifact ? 'Outputs ready for review' : 'Run ready for review',
         detail: outcomeSummary
             ? `${outcomeSummary}. Updated ${freshnessLabel}.`
-            : `${artifactCount} artifact${artifactCount === 1 ? '' : 's'} indexed and ready for operator review.`
+            : `${artifactCount} artifact${artifactCount === 1 ? '' : 's'} indexed and ready for operator review.`,
+        action: 'Next action: use the selected run state, warning context, and freshness above to decide whether to recover or open review.'
     };
 }
 
@@ -3947,10 +4435,12 @@ function _renderReviewStatusBanner(job, artifact) {
         els.reviewStatusBanner.classList.add('hidden');
         els.reviewStatusTitle.textContent = snapshot.title;
         els.reviewStatusDetail.textContent = snapshot.detail;
+        if (els.reviewStatusAction) els.reviewStatusAction.textContent = snapshot.action;
         return;
     }
     els.reviewStatusTitle.textContent = snapshot.title;
     els.reviewStatusDetail.textContent = snapshot.detail;
+    if (els.reviewStatusAction) els.reviewStatusAction.textContent = snapshot.action;
     els.reviewStatusBanner.classList.remove('hidden');
 }
 
@@ -4053,12 +4543,14 @@ function renderArtifactPanel() {
 
     if (!selected) {
         _resetArtifactActionButtons();
+        const emptyCopy = _artifactEmptyStateCopy(null);
         _setSurfaceEmptyState(
             els.emptyArtifactState,
             els.emptyArtifactTitle,
             els.emptyArtifactDetail,
-            _artifactEmptyStateCopy(null)
+            emptyCopy
         );
+        if (els.emptyArtifactAction) els.emptyArtifactAction.textContent = emptyCopy.action || '';
         els.artifactMeta.textContent = 'No job selected';
         els.artifactThumbnailRail.innerHTML = '';
         if (els.artifactSelectionTitle) els.artifactSelectionTitle.textContent = 'No artifact selected';
@@ -4100,12 +4592,14 @@ function renderArtifactPanel() {
 
     if (artifacts.length === 0) {
         _resetArtifactActionButtons();
+        const emptyCopy = _artifactEmptyStateCopy(selected);
         _setSurfaceEmptyState(
             els.emptyArtifactState,
             els.emptyArtifactTitle,
             els.emptyArtifactDetail,
-            _artifactEmptyStateCopy(selected)
+            emptyCopy
         );
+        if (els.emptyArtifactAction) els.emptyArtifactAction.textContent = emptyCopy.action || '';
         els.artifactThumbnailRail.innerHTML = '';
         if (els.artifactSelectionTitle) els.artifactSelectionTitle.textContent = 'No artifact selected';
         if (els.artifactSelectionMeta) els.artifactSelectionMeta.textContent = 'Review surfaces will populate here when the selected run indexes outputs.';
@@ -5436,7 +5930,8 @@ async function fetchConfigMetadata(pipelineName = state.pipeline, silent = false
             fields: {},
             estimate_bands: {},
             debug_bundle_policy: {},
-            advanced_sections: []
+            advanced_sections: [],
+            backend_catalog: {},
         };
         renderReviewSurfaces();
         return;
@@ -5458,7 +5953,8 @@ async function fetchConfigMetadata(pipelineName = state.pipeline, silent = false
             fields: data.fields && typeof data.fields === 'object' ? data.fields : {},
             estimate_bands: data.estimate_bands && typeof data.estimate_bands === 'object' ? data.estimate_bands : {},
             debug_bundle_policy: data.debug_bundle_policy && typeof data.debug_bundle_policy === 'object' ? data.debug_bundle_policy : {},
-            advanced_sections: Array.isArray(data.advanced_sections) ? data.advanced_sections.map((item) => String(item || '')) : []
+            advanced_sections: Array.isArray(data.advanced_sections) ? data.advanced_sections.map((item) => String(item || '')) : [],
+            backend_catalog: data.backend_catalog && typeof data.backend_catalog === 'object' ? data.backend_catalog : {},
         };
         applyLuxMetadataToControls();
         renderReviewSurfaces();
@@ -7138,20 +7634,23 @@ function _queueEmptyStateCopy() {
         return {
             tone: 'warning',
             title: 'Queue unavailable',
-            detail: 'Backend connectivity is offline. Restore the managed backend to recover recent runs and live transport state.'
+            detail: 'Backend connectivity is offline. Restore the managed backend to recover recent runs and live transport state.',
+            action: 'Next action: restore backend connectivity so recent runs and live transport can recover.'
         };
     }
     if (state.jobsLoadStatus === 'error') {
         return {
             tone: 'error',
             title: 'Queue recovery needs attention',
-            detail: 'Recent jobs could not be recovered. Refresh the workspace after backend health returns to continue.'
+            detail: 'Recent jobs could not be recovered. Refresh the workspace after backend health returns to continue.',
+            action: 'Next action: confirm backend health, then refresh the workspace to rehydrate recent runs.'
         };
     }
     return {
         tone: 'neutral',
         title: 'No runs yet',
-        detail: 'Dispatch a run from Build or wait for recovery to repopulate recent operator activity.'
+        detail: 'Dispatch a run from Build or wait for recovery to repopulate recent operator activity.',
+        action: 'Next action: open Build to prepare the next run or restore backend connectivity to recover recent history.'
     };
 }
 
@@ -7160,27 +7659,31 @@ function _artifactEmptyStateCopy(job) {
         return {
             tone: 'neutral',
             title: 'Select a completed run',
-            detail: 'Choose a reviewable job to load preview, provenance, and compare context here.'
+            detail: 'Choose a reviewable job to load preview, provenance, and compare context here.',
+            action: 'Next action: inspect the selected run in Operate or wait for indexed outputs before reopening review.'
         };
     }
     if (job.state === 'running' || job.state === 'queued') {
         return {
             tone: 'info',
             title: 'Outputs are still arriving',
-            detail: 'This run has not indexed reviewable artifacts yet. Stay on the inspector for live progress and freshness updates.'
+            detail: 'This run has not indexed reviewable artifacts yet. Stay on the inspector for live progress and freshness updates.',
+            action: 'Next action: keep the run in Operate until indexed outputs appear or a blocking warning arrives.'
         };
     }
     if (job.state === 'failed' || job.state === 'canceled') {
         return {
             tone: 'warning',
             title: 'No reviewable outputs indexed',
-            detail: 'This run ended before artifacts were available. Inspect the run status and transport warnings above for recovery context.'
+            detail: 'This run ended before artifacts were available. Inspect the run status and transport warnings above for recovery context.',
+            action: 'Next action: inspect the selected run in Operate or decide whether the failed run should be retried.'
         };
     }
     return {
         tone: 'neutral',
         title: 'No indexed artifacts yet',
-        detail: 'Artifacts will appear here when the selected run finishes indexing its review outputs.'
+        detail: 'Artifacts will appear here when the selected run finishes indexing its review outputs.',
+        action: 'Next action: inspect the selected run in Operate or wait for indexed outputs before reopening review.'
     };
 }
 
@@ -7212,6 +7715,7 @@ function renderJobQueue(includeReviewSurfaces = true) {
     if (state.jobs.length === 0) {
         const emptyCopy = _queueEmptyStateCopy();
         _setSurfaceEmptyState(els.emptyQueueState, els.emptyQueueTitle, els.emptyQueueDetail, emptyCopy);
+        if (els.emptyQueueAction) els.emptyQueueAction.textContent = emptyCopy.action || '';
         if (els.emptyQueueState) els.emptyQueueState.style.display = 'flex';
         if (els.queueStatusSummary) {
             els.queueStatusSummary.textContent = state.jobsLoadStatus === 'ready'

--- a/tests/test_app_orchestrator_contract_http.py
+++ b/tests/test_app_orchestrator_contract_http.py
@@ -299,6 +299,9 @@ def test_config_metadata_contract_for_lux_depth_pipeline(client: TestClient) -> 
     assert body["data"]["fields"]["reconstruction_tier"]["default"] == "apex_research"
     assert body["data"]["fields"]["reconstruction_iterations"]["recommended"]["balanced"] == 1000
     assert body["data"]["fields"]["raw_wb_mode"]["kind"] == "locked"
+    assert body["data"]["backend_catalog"]["da3"]["policy_posture"]["code"] == "governed_default"
+    assert body["data"]["backend_catalog"]["depth_pro"]["required_acknowledgments"][0]["field"] == "non_commercial_ok"
+    assert body["data"]["backend_catalog"]["sam2"]["checkpoint_expectation"]["field"] == "sam2_checkpoint_path"
     assert body["data"]["debug_bundle_policy"]["acknowledgement_required"] is True
 
 

--- a/tests/test_app_orchestrator_runtime.py
+++ b/tests/test_app_orchestrator_runtime.py
@@ -1549,6 +1549,12 @@ def test_portal_preview_metadata_worker_modes_and_export_contract_are_wired() ->
     assert "renderPreRunDiagnostics(nextPayload);" in preview_body
     assert "_syncBootstrapGuardedControls();" in preview_body
     assert "refreshPreviewDrivenSurfaces(generatePayload());" in preview_body
+    assert "backend_catalog: {}," in content
+    assert (
+        "backend_catalog: data.backend_catalog && typeof data.backend_catalog === 'object' ? data.backend_catalog : {},"
+        in metadata_body
+    )
+    assert "function renderRuntimeBriefing(payload = null) {" in content
     assert "scheduleConfigPreview(true);" in metadata_body
     assert "repo_local_path_repaired" in reconcile_body
     assert "_setBuildSurfacePathFieldValue(fieldName, normalizedValue)" in reconcile_body
@@ -1556,6 +1562,41 @@ def test_portal_preview_metadata_worker_modes_and_export_contract_are_wired() ->
     assert "state.config.gate = state.config.gate || {};" in setter_body
     assert "state.config.segmentation = state.config.segmentation || {};" in setter_body
     assert "state.config.reconstruction = state.config.reconstruction || {};" in setter_body
+
+
+def test_portal_runtime_briefing_and_recovery_surfaces_stay_additive_and_selector_stable() -> None:
+    content = _portal_bundle_content()
+    mission_body = _extract_js_function_body(content, "renderMissionControl")
+    review_status_body = _extract_js_function_body(content, "_reviewStatusSnapshot")
+    queue_empty_body = _extract_js_function_body(content, "_queueEmptyStateCopy")
+    artifact_empty_body = _extract_js_function_body(content, "_artifactEmptyStateCopy")
+    inspector_body = _extract_js_function_body(content, "renderSelectedJobInspector")
+
+    assert 'id="overviewRuntimeBriefing"' in content
+    assert 'data-ui="runtime-clarity-grid"' in content
+    assert 'id="buildRuntimeBriefing"' in content
+    assert 'data-ui="build-runtime-clarity"' in content
+    assert 'id="reviewStatusAction"' in content
+    assert 'id="emptyQueueAction"' in content
+    assert 'id="emptyArtifactAction"' in content
+    assert 'id="selectedJobRecoveryTitle"' in content
+    assert 'id="selectedJobRecoveryDetail"' in content
+    assert "renderRuntimeBriefing(currentPayload);" in mission_body
+    assert (
+        "action: 'Next action: open Build to prepare the next run or restore backend connectivity to recover recent history.'"
+        in queue_empty_body
+    )
+    assert (
+        "action: 'Next action: inspect the selected run in Operate or wait for indexed outputs before reopening review.'"
+        in artifact_empty_body
+    )
+    assert (
+        "action: 'Next action: use the selected run state, warning context, and freshness above to decide whether to recover or open review.'"
+        in review_status_body
+    )
+    assert "els.reviewStatusAction.textContent = snapshot.action;" in content
+    assert "els.selectedJobRecoveryTitle.textContent = recovery.title;" in inspector_body
+    assert "els.selectedJobRecoveryDetail.textContent = recovery.detail;" in inspector_body
 
 
 def test_portal_submit_blocks_preview_unavailable_and_debug_bundle_without_acknowledgement() -> None:


### PR DESCRIPTION
## Summary
- add additive `backend_catalog` metadata for `lux-depth-v3` so the portal can explain selected depth and segmentation backends, checkpoint expectations, acknowledgments, and policy posture before readiness fails
- add runtime briefing modules in overview and build plus consistent recovery copy for selected jobs, review empties, and artifact empties without changing routes, query params, or existing `data-ui` hooks
- keep live readiness and preview status on the existing path while using backend-owned fallback metadata when catalog fields are absent

## Why
- operators were learning runtime posture too late from readiness failures and log-heavy screens
- empty, blocked, and degraded states were inconsistent across overview, operate, and review, which slowed recovery during canary and runtime issues

## Impact
- earlier runtime clarity for DA3, Depth Pro, SAM2, and related checkpoint and license posture
- faster scan order for the build and review flow with explicit next-step guidance
- no browser-side Hugging Face calls, no `HF_TOKEN` exposure, and only additive backend contract changes

## Validation
- `node --check public/portal-assets/portal.js`
- `.venv/bin/python -m py_compile app.py tests/test_app_orchestrator_runtime.py tests/test_app_orchestrator_contract_http.py`
- `.venv/bin/pytest tests/test_app_orchestrator_runtime.py tests/test_app_orchestrator_contract_http.py -k portal`
- `make validate-portal-browser`
- `make pre-commit`
- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/pre-commit run --all-files --show-diff-on-failure` surfaced unrelated repo-wide failures in legacy ML lock freshness and unmarked non-portal tests; the staged commit hook passed on this diff

## Contract Notes
- preserves `/`, `/login`, `/portal`, `/portal/bootstrap`, `/v1/*`, `?view=`, `job=`, `artifact=`, and `compare=1`
- preserves existing `data-ui` hooks; new hooks are additive only
- leaves homepage and login behavior unchanged in this tranche
