### PR TITLE
feat(portal): harden managed entry and operator shell

### DIFF
--- a/portal.html
+++ b/portal.html
@@ -73,7 +73,7 @@ Contract notes:
 
             <div class="portal-topbar__actions flex items-center gap-3" data-ui="portal-topbar-actions">
                 <button id="shortcutsBtn" type="button" class="rounded-full border border-slate-200 dark:border-slate-700 px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 hover:text-slate-900 hover:border-slate-300 dark:text-slate-400 dark:hover:text-white dark:hover:border-slate-600 transition-colors focus:outline-none focus:ring-2 focus:ring-cyan-500">
-                    Shortcuts
+                    Shortcuts <span class="kbd">?</span>
                 </button>
                 <button id="themeBtn" type="button" class="rounded-full px-4 py-2 text-xs font-semibold border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors focus:outline-none focus:ring-2 focus:ring-cyan-500" aria-label="Theme preference: system. Click to switch to dark.">
                     Theme: System
@@ -265,22 +265,37 @@ Contract notes:
                 <p class="workspace-rail-text">
                     Overview, build, live operation, and review in one quiet shell.
                 </p>
+                <p class="workspace-shortcut-hint" data-ui="workspace-shortcut-hint">
+                    Keyboard: <span class="kbd">1</span> overview, <span class="kbd">2</span> build, <span class="kbd">3</span> operate, <span class="kbd">4</span> review, <span class="kbd">?</span> shortcuts.
+                </p>
             </div>
             <div class="workspace-rail-links" role="tablist" aria-label="Console views">
-                <a class="workspace-link is-active" data-view-link="overview" data-ui="view-link" href="?view=overview" role="tab" aria-selected="true">
-                    <span class="workspace-link-label">Overview</span>
+                <a class="workspace-link is-active" data-view-link="overview" data-ui="view-link" href="?view=overview" role="tab" aria-selected="true" aria-keyshortcuts="1">
+                    <span class="workspace-link-heading">
+                        <span class="workspace-link-label">Overview</span>
+                        <span class="workspace-link-shortcut" aria-hidden="true">1</span>
+                    </span>
                     <span class="workspace-link-meta">Status, recent jobs, and next action.</span>
                 </a>
-                <a class="workspace-link" data-view-link="build" data-ui="view-link" href="?view=build" role="tab" aria-selected="false">
-                    <span class="workspace-link-label">Build</span>
+                <a class="workspace-link" data-view-link="build" data-ui="view-link" href="?view=build" role="tab" aria-selected="false" aria-keyshortcuts="2">
+                    <span class="workspace-link-heading">
+                        <span class="workspace-link-label">Build</span>
+                        <span class="workspace-link-shortcut" aria-hidden="true">2</span>
+                    </span>
                     <span class="workspace-link-meta">Preview-backed dispatch flow.</span>
                 </a>
-                <a class="workspace-link" data-view-link="operate" data-ui="view-link" href="?view=operate" role="tab" aria-selected="false">
-                    <span class="workspace-link-label">Operate</span>
+                <a class="workspace-link" data-view-link="operate" data-ui="view-link" href="?view=operate" role="tab" aria-selected="false" aria-keyshortcuts="3">
+                    <span class="workspace-link-heading">
+                        <span class="workspace-link-label">Operate</span>
+                        <span class="workspace-link-shortcut" aria-hidden="true">3</span>
+                    </span>
                     <span class="workspace-link-meta">Queue, inspector, artifacts, and logs.</span>
                 </a>
-                <a class="workspace-link" data-view-link="review" data-ui="view-link" href="?view=review" role="tab" aria-selected="false">
-                    <span class="workspace-link-label">Review</span>
+                <a class="workspace-link" data-view-link="review" data-ui="view-link" href="?view=review" role="tab" aria-selected="false" aria-keyshortcuts="4">
+                    <span class="workspace-link-heading">
+                        <span class="workspace-link-label">Review</span>
+                        <span class="workspace-link-shortcut" aria-hidden="true">4</span>
+                    </span>
                     <span class="workspace-link-meta">Artifact preview, provenance, and actions.</span>
                 </a>
             </div>
@@ -394,6 +409,15 @@ Contract notes:
                         <p id="apiKeyManagedHint" class="text-[12px] leading-relaxed text-slate-500 dark:text-slate-400">Managed mode is active. Backend credentials stay server-side and are never stored in the browser.</p>
                         <div class="flex flex-col sm:flex-row gap-2 sm:items-center">
                             <input type="password" id="apiKeyInput" class="flex-1 rounded-xl border border-slate-300 dark:border-slate-700 bg-slate-50 dark:bg-slate-800 px-4 py-2.5 text-[13px] font-mono focus:outline-none focus:ring-2 focus:ring-indigo-500 transition-colors" placeholder="Bearer token for /v1/jobs endpoints" autocomplete="off" spellcheck="false" disabled />
+                        </div>
+                    </div>
+                    <div id="portalAccessState" class="portal-access-state mt-4" data-ui="portal-access-state" data-tone="info" data-bootstrap-status="pending">
+                        <div class="portal-access-state__head">
+                            <div>
+                                <p class="portal-access-state__kicker">Access posture</p>
+                                <p id="bootstrapRecoveryHint" class="portal-access-state__detail">Bootstrap is still being confirmed. Privileged actions remain disabled until portal authentication is resolved.</p>
+                            </div>
+                            <span id="bootstrapStatusBadge" class="signal-badge portal-access-state__badge" data-tone="info">Confirming access</span>
                         </div>
                     </div>
                     <section id="buildRuntimeClarityShell" class="mt-5">
@@ -1100,6 +1124,9 @@ Contract notes:
                             <p id="governanceBannerBody" class="mt-2 text-sm leading-7 text-slate-600 dark:text-slate-300">
                                 The current configuration is valid for dispatch. Any license acknowledgments or runtime caveats will surface here before execution.
                             </p>
+                            <p id="governancePostureHint" class="step-primary-note mt-3" data-ui="governance-posture-hint">
+                                Step 4 stays aligned to this checklist, so blocked governance items clear here before launch becomes trustworthy.
+                            </p>
                         </div>
                         <div class="signal-badge">Live contract checks</div>
                     </div>
@@ -1136,6 +1163,9 @@ Contract notes:
                             <button id="runJobBtn" type="button" class="mt-4 w-full rounded-2xl px-6 py-4 text-[14px] font-extrabold uppercase tracking-[0.14em] text-white shadow-glow transition-all focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:ring-offset-2 active:scale-[0.98] disabled:opacity-50 disabled:cursor-not-allowed bg-gradient-to-r from-teal-700 via-cyan-600 to-sky-600 hover:from-teal-600 hover:via-cyan-500 hover:to-sky-500 dark:focus:ring-offset-slate-900" disabled data-ui="dispatch-cta" aria-describedby="dispatchReadinessReason">
                                 Execute Job
                             </button>
+                            <p class="dispatch-shortcut-hint mt-3" data-ui="dispatch-shortcut-hint">
+                                Once dispatch unlocks, use <span class="kbd">Ctrl/⌘ + Enter</span> to execute without leaving the keyboard.
+                            </p>
                         </section>
                     </div>
 
@@ -1519,6 +1549,8 @@ Contract notes:
                 </button>
             </div>
             <div class="p-5 text-sm text-slate-700 dark:text-slate-300 space-y-4">
+                <div class="flex justify-between items-center"><span class="text-slate-600 dark:text-slate-400">Open Shortcuts</span> <kbd class="kbd text-[11px]">?</kbd></div>
+                <div class="flex justify-between items-center"><span class="text-slate-600 dark:text-slate-400">Jump to Overview / Build / Operate / Review</span> <kbd class="kbd text-[11px]">1 / 2 / 3 / 4</kbd></div>
                 <div class="flex justify-between items-center"><span class="text-slate-600 dark:text-slate-400">Run Job</span> <kbd class="kbd text-[11px]">Ctrl/⌘ + Enter</kbd></div>
                 <div class="flex justify-between items-center"><span class="text-slate-600 dark:text-slate-400">Copy Command</span> <kbd class="kbd text-[11px]">Ctrl/⌘ + Shift + C</kbd></div>
                 <div class="flex justify-between items-center"><span class="text-slate-600 dark:text-slate-400">Cycle Theme</span> <kbd class="kbd text-[11px]">Ctrl/⌘ + J</kbd></div>

--- a/public/portal-assets/portal.css
+++ b/public/portal-assets/portal.css
@@ -713,6 +713,106 @@ progress::-moz-progress-bar { background-color: #4f46e5; transition: width 0.3s 
     background: rgba(15, 23, 42, 0.48);
 }
 
+.portal-access-state {
+    border: 1px solid var(--shell-border);
+    border-radius: 1rem;
+    background: rgba(255, 255, 255, 0.68);
+    padding: 0.95rem 1rem;
+    box-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.24),
+        0 14px 26px rgba(15, 23, 42, 0.05);
+}
+
+.dark .portal-access-state {
+    background: rgba(15, 23, 42, 0.66);
+}
+
+.portal-access-state__head {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 0.85rem;
+}
+
+.portal-access-state__kicker {
+    margin: 0;
+    font-size: 10px;
+    font-weight: 800;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--shell-muted);
+}
+
+.portal-access-state__detail {
+    margin: 0.45rem 0 0;
+    font-size: 12px;
+    line-height: 1.65;
+    color: var(--shell-muted);
+}
+
+.portal-access-state__badge[data-tone="blocked"],
+.portal-access-state[data-tone="blocked"] .portal-access-state__badge {
+    border-color: rgba(220, 38, 38, 0.18);
+    background: rgba(254, 242, 242, 0.92);
+    color: rgb(153, 27, 27);
+}
+
+.dark .portal-access-state__badge[data-tone="blocked"],
+.dark .portal-access-state[data-tone="blocked"] .portal-access-state__badge {
+    border-color: rgba(248, 113, 113, 0.26);
+    background: rgba(127, 29, 29, 0.28);
+    color: rgb(252, 165, 165);
+}
+
+.portal-access-state__badge[data-tone="warning"],
+.portal-access-state[data-tone="warning"] .portal-access-state__badge {
+    border-color: rgba(217, 119, 6, 0.18);
+    background: rgba(255, 251, 235, 0.92);
+    color: rgb(146, 64, 14);
+}
+
+.dark .portal-access-state__badge[data-tone="warning"],
+.dark .portal-access-state[data-tone="warning"] .portal-access-state__badge {
+    border-color: rgba(251, 191, 36, 0.2);
+    background: rgba(120, 53, 15, 0.28);
+    color: rgb(253, 230, 138);
+}
+
+.portal-access-state__badge[data-tone="ready"],
+.portal-access-state[data-tone="ready"] .portal-access-state__badge {
+    border-color: rgba(13, 148, 136, 0.18);
+    background: rgba(240, 253, 250, 0.92);
+    color: rgb(15, 118, 110);
+}
+
+.dark .portal-access-state__badge[data-tone="ready"],
+.dark .portal-access-state[data-tone="ready"] .portal-access-state__badge {
+    border-color: rgba(45, 212, 191, 0.24);
+    background: rgba(17, 94, 89, 0.28);
+    color: rgb(153, 246, 228);
+}
+
+.portal-access-state__badge[data-tone="info"],
+.portal-access-state[data-tone="info"] .portal-access-state__badge {
+    border-color: rgba(8, 145, 178, 0.18);
+    background: rgba(240, 249, 255, 0.92);
+    color: rgb(14, 116, 144);
+}
+
+.dark .portal-access-state__badge[data-tone="info"],
+.dark .portal-access-state[data-tone="info"] .portal-access-state__badge {
+    border-color: rgba(34, 211, 238, 0.24);
+    background: rgba(14, 116, 144, 0.22);
+    color: rgb(165, 243, 252);
+}
+
+.dispatch-shortcut-hint {
+    margin: 0;
+    font-size: 12px;
+    line-height: 1.55;
+    color: var(--shell-muted);
+}
+
 .console-context-ribbon {
     display: grid;
     gap: 0.75rem;
@@ -1383,6 +1483,13 @@ details[open] .disclosure-chevron {
         box-shadow 0.2s ease;
 }
 
+.workspace-link-heading {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+}
+
 .workspace-link:hover,
 .workspace-link:focus-visible {
     transform: translateY(-1px);
@@ -1428,6 +1535,21 @@ details[open] .disclosure-chevron {
     text-transform: uppercase;
 }
 
+.workspace-link-shortcut {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.5rem;
+    min-height: 1.5rem;
+    border-radius: 0.4rem;
+    border: 1px solid rgba(148, 163, 184, 0.24);
+    background: rgba(255, 255, 255, 0.65);
+    color: var(--shell-muted);
+    font-family: "Portal Mono", monospace;
+    font-size: 11px;
+    font-weight: 700;
+}
+
 .workspace-link-meta {
     font-size: 12px;
     line-height: 1.45;
@@ -1440,6 +1562,19 @@ details[open] .disclosure-chevron {
 
 .dark .workspace-link.is-active .workspace-link-meta {
     color: rgba(226, 232, 240, 0.82);
+}
+
+.dark .workspace-link-shortcut {
+    border-color: rgba(71, 85, 105, 0.7);
+    background: rgba(15, 23, 42, 0.72);
+    color: rgba(203, 213, 225, 0.88);
+}
+
+.workspace-shortcut-hint {
+    margin: 0.45rem 0 0;
+    font-size: 12px;
+    line-height: 1.65;
+    color: var(--shell-muted);
 }
 
 .micro-status {
@@ -2093,6 +2228,10 @@ details[open] .disclosure-chevron {
     line-height: 1.55;
 }
 
+.workspace-link-heading {
+    gap: 0.6rem;
+}
+
 .dark .workspace-link {
     background: rgba(15, 23, 42, 0.76);
     box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.08);
@@ -2485,6 +2624,10 @@ textarea,
         gap: 0.6rem;
     }
 
+    .portal-access-state__head {
+        flex-direction: column;
+    }
+
     #selectedJobShellContent > .mt-5.grid {
         grid-template-columns: 1fr;
     }
@@ -2511,6 +2654,10 @@ textarea,
 @media (max-width: 640px) {
     .console-context-ribbon {
         grid-template-columns: 1fr;
+    }
+
+    .workspace-link-heading {
+        align-items: flex-start;
     }
 
     .review-provenance-grid {

--- a/public/portal-assets/portal.js
+++ b/public/portal-assets/portal.js
@@ -334,6 +334,10 @@ const els = {
     apiKeyInput: document.getElementById('apiKeyInput'),
     authModeBadge: document.getElementById('authModeBadge'),
     apiKeyManagedHint: document.getElementById('apiKeyManagedHint'),
+    portalAccessState: document.getElementById('portalAccessState'),
+    bootstrapStatusBadge: document.getElementById('bootstrapStatusBadge'),
+    bootstrapRecoveryHint: document.getElementById('bootstrapRecoveryHint'),
+    governancePostureHint: document.getElementById('governancePostureHint'),
 
     inputDir: document.getElementById('inputDir'),
     outputDir: document.getElementById('outputDir'),
@@ -942,6 +946,13 @@ const CONSOLE_VIEW_META = {
         meta: 'Completed runs become reviewable products, not just finished jobs.'
     }
 };
+
+const WORKSPACE_VIEW_SHORTCUTS = Object.freeze({
+    '1': 'overview',
+    '2': 'build',
+    '3': 'operate',
+    '4': 'review'
+});
 
 function resolveConsoleView(value) {
     const candidate = String(value || '').trim().toLowerCase();
@@ -2916,6 +2927,7 @@ function renderGovernanceBanner(payload) {
     const items = [];
     let title = 'Run posture is clear.';
     let body = 'The current configuration is valid for dispatch. Any license acknowledgments or runtime caveats will surface here before execution.';
+    let postureHint = 'Step 4 stays aligned to this checklist, so blocked governance items clear here before launch becomes trustworthy.';
 
     if (state.pipeline === 'lux-depth-v3') {
         if (String(args.preset || '').toLowerCase().includes('v3.1')) {
@@ -2991,13 +3003,16 @@ function renderGovernanceBanner(payload) {
     if (hasWarnings) {
         title = 'Execution is blocked.';
         body = 'Before dispatch, satisfy the blocked readiness prerequisites listed below.';
+        postureHint = 'Clear the blocked governance items in this panel before treating the Step 4 launch lane as actionable.';
     } else if (items.some((item) => item.tone === 'info')) {
         title = 'Configuration is valid with readiness caveats.';
         body = 'The run contract is coherent, but at least one prerequisite still needs operator attention before dispatch can be treated as fully ready.';
+        postureHint = 'Use this panel to resolve readiness caveats first; Step 4 will remain cautious until they settle.';
     }
 
     if (els.governanceBannerTitle) els.governanceBannerTitle.textContent = title;
     if (els.governanceBannerBody) els.governanceBannerBody.textContent = body;
+    if (els.governancePostureHint) els.governancePostureHint.textContent = postureHint;
 
     els.governanceChecklist.innerHTML = '';
     items.forEach((item) => {
@@ -3780,6 +3795,42 @@ function _isManagedUnavailableMode() {
     return state.auth && state.auth.mode === 'managed_unavailable';
 }
 
+function _bootstrapSurfaceSummary() {
+    const bootstrapStatus = String(state.bootstrap.status || 'pending').trim().toLowerCase();
+    if (bootstrapStatus === 'ready') {
+        if (_isManagedAuthMode()) {
+            return {
+                tone: 'ready',
+                badge: 'Managed access',
+                detail: 'Managed access is verified. Backend credentials stay server-side and browser-side API key entry remains hidden.',
+                apiHint: 'Managed mode is active. Backend credentials stay server-side and are never stored in the browser.'
+            };
+        }
+        return {
+            tone: 'warning',
+            badge: 'Direct debug',
+            detail: 'Direct debug is active. Browser-side API key entry is available only for local troubleshooting.',
+            apiHint: 'Direct debug is active. Browser-side API key entry is available only for local troubleshooting.'
+        };
+    }
+    if (bootstrapStatus === 'degraded' || bootstrapStatus === 'unavailable') {
+        const failure = _bootstrapFailureDetails(state.bootstrap.lastErrorReason, state.bootstrap.lastHttpStatus);
+        const tone = failure.retryable ? 'warning' : 'blocked';
+        return {
+            tone,
+            badge: failure.retryable ? 'Recovery pending' : 'Recovery required',
+            detail: failure.actionMessage,
+            apiHint: failure.actionMessage
+        };
+    }
+    return {
+        tone: 'info',
+        badge: 'Confirming access',
+        detail: 'Bootstrap is still being confirmed. Privileged actions remain disabled until portal authentication is resolved.',
+        apiHint: 'Bootstrap is still being confirmed. Privileged actions remain disabled until portal authentication is resolved.'
+    };
+}
+
 function _clearStoredApiKeyState(clearPersisted = true) {
     if (clearPersisted) {
         localStorage.removeItem(API_KEY_STORAGE_KEY);
@@ -3792,20 +3843,35 @@ function _syncBootstrapUi() {
     const bootstrapReady = _isBootstrapReady();
     const showApiKeyInput = bootstrapReady && state.auth.features.apiKeyInput;
     const badgeLabel = bootstrapReady ? state.auth.mode : 'unknown';
+    const summary = _bootstrapSurfaceSummary();
     if (els.apiKeySection) {
         els.apiKeySection.classList.toggle('hidden', !showApiKeyInput);
     }
     if (els.authModeBadge) {
         els.authModeBadge.textContent = badgeLabel;
     }
+    if (document.body) {
+        document.body.dataset.bootstrapReason = String(state.bootstrap.lastErrorReason || '');
+        document.body.dataset.authMode = String(state.auth.mode || 'managed_unavailable');
+    }
+    if (els.portalAccessState) {
+        els.portalAccessState.dataset.tone = summary.tone;
+        els.portalAccessState.dataset.bootstrapStatus = String(state.bootstrap.status || 'pending');
+        els.portalAccessState.dataset.bootstrapReason = String(state.bootstrap.lastErrorReason || '');
+    }
+    if (els.bootstrapStatusBadge) {
+        els.bootstrapStatusBadge.dataset.tone = summary.tone;
+        els.bootstrapStatusBadge.textContent = summary.badge;
+    }
+    if (els.bootstrapRecoveryHint) {
+        els.bootstrapRecoveryHint.textContent = summary.detail;
+    }
     if (els.apiKeyManagedHint) {
         if (bootstrapReady && !_isManagedAuthMode()) {
             els.apiKeyManagedHint.classList.add('hidden');
         } else {
             els.apiKeyManagedHint.classList.remove('hidden');
-            els.apiKeyManagedHint.textContent = bootstrapReady
-                ? 'Managed mode is active. Backend credentials stay server-side and are never stored in the browser.'
-                : 'Bootstrap is still being confirmed. Privileged actions remain disabled until portal authentication is resolved.';
+            els.apiKeyManagedHint.textContent = summary.apiHint;
         }
     }
     if (els.apiKeyInput) {
@@ -9130,6 +9196,16 @@ function _trapOverlayFocus(event) {
     return false;
 }
 
+function _isTypingTarget(target) {
+    if (!(target instanceof HTMLElement)) return false;
+    const tagName = String(target.tagName || '').toLowerCase();
+    if (target.isContentEditable || target.closest('[contenteditable="true"]')) return true;
+    if (tagName === 'textarea' || tagName === 'select') return true;
+    if (tagName !== 'input') return false;
+    const inputType = String(target.getAttribute('type') || 'text').trim().toLowerCase();
+    return !['button', 'checkbox', 'color', 'file', 'hidden', 'radio', 'range', 'reset', 'submit'].includes(inputType);
+}
+
 const toggleModal = (show, trigger = document.activeElement) => {
     if (show) {
         _rememberOverlayTrigger(trigger);
@@ -9204,6 +9280,8 @@ document.addEventListener('keydown', (e) => {
     if (_trapOverlayFocus(e)) {
         return;
     }
+    const key = String(e.key || '');
+    const isPlainShortcut = !e.ctrlKey && !e.metaKey && !e.altKey && !_isTypingTarget(e.target);
     if (e.key === "Escape" && els.effectiveConfigDrawer && !els.effectiveConfigDrawer.classList.contains("hidden")) {
         e.preventDefault();
         toggleEffectiveConfigDrawer(false);
@@ -9212,6 +9290,24 @@ document.addEventListener('keydown', (e) => {
     if (e.key === "Escape" && els.shortcutsModal && !els.shortcutsModal.classList.contains("hidden")) {
         e.preventDefault();
         toggleModal(false);
+        return;
+    }
+    if (isPlainShortcut && (key === '?' || (key === '/' && e.shiftKey))) {
+        if (els.shortcutsModal && els.shortcutsModal.classList.contains('hidden')) {
+            e.preventDefault();
+            toggleModal(true);
+        }
+        return;
+    }
+    if (isPlainShortcut && Object.prototype.hasOwnProperty.call(WORKSPACE_VIEW_SHORTCUTS, key)) {
+        const nextView = WORKSPACE_VIEW_SHORTCUTS[key];
+        if (nextView === 'review' && !state.selectedJobId) {
+            e.preventDefault();
+            createToast('Select a run first, then open its review surface.', 'info');
+            return;
+        }
+        e.preventDefault();
+        navigateConsoleView(nextView);
         return;
     }
     if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {

--- a/scripts/validation/validate_frontdoor_browser_smoke.py
+++ b/scripts/validation/validate_frontdoor_browser_smoke.py
@@ -400,9 +400,11 @@ def _frontdoor_state_probe_expression() -> str:
     readyState: document.readyState,
     pathname: window.location.pathname,
     homepageHeroReady: !!document.querySelector('[data-ui="homepage-hero-title"]'),
+    homepageEntryRailReady: !!document.querySelector('[data-ui="homepage-entry-rail"]'),
     homepageLearnLinkReady: !!document.querySelector('[data-ui="homepage-learn-link"]'),
     homepagePrimaryCtaHref: attr('[data-ui="homepage-primary-cta"]', 'href'),
     loginTitleReady: !!document.querySelector('[data-ui="login-title"]'),
+    loginEntryStateReady: !!document.querySelector('[data-ui="login-entry-state"]'),
     loginSequenceReady: !!document.querySelector('[data-ui="login-sequence"]'),
     brandAssetPresent: !!document.querySelector('.brand-asset'),
     hasHeroVideo: !!document.querySelector('.hero-video, .homepage-video'),
@@ -412,7 +414,8 @@ def _frontdoor_state_probe_expression() -> str:
     passwordPresent: !!document.querySelector('input[name="password"]'),
     authModeBadge: text('#authModeBadge'),
     currentView: document.body ? String(document.body.dataset.consoleView || '') : '',
-    apiKeySectionHidden: hidden('apiKeySection')
+    apiKeySectionHidden: hidden('apiKeySection'),
+    portalAccessStateReady: !!document.querySelector('[data-ui="portal-access-state"]')
   };
 })()
 """
@@ -555,6 +558,7 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
                 isinstance(value, dict)
                 and value.get("readyState") == "complete"
                 and bool(value.get("homepageHeroReady"))
+                and bool(value.get("homepageEntryRailReady"))
                 and bool(value.get("homepageLearnLinkReady"))
                 and str(value.get("homepagePrimaryCtaHref", "")) == "/login"
             ),
@@ -573,6 +577,7 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
                 isinstance(value, dict)
                 and str(value.get("pathname", "")) == "/login"
                 and bool(value.get("loginTitleReady"))
+                and bool(value.get("loginEntryStateReady"))
                 and bool(value.get("loginSequenceReady"))
                 and bool(value.get("brandAssetPresent"))
                 and bool(value.get("loginFormPresent"))
@@ -595,6 +600,7 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
                 and str(value.get("pathname", "")) == "/portal"
                 and str(value.get("currentView", "")) == "overview"
                 and bool(value.get("apiKeySectionHidden"))
+                and bool(value.get("portalAccessStateReady"))
                 and str(value.get("authModeBadge", "")).lower() == "managed"
             ),
             timeout_seconds=args.timeout_seconds,

--- a/tests/test_app_orchestrator_runtime.py
+++ b/tests/test_app_orchestrator_runtime.py
@@ -734,14 +734,27 @@ def test_portal_bootstrap_loader_uses_abortable_timeout_and_state_contract() -> 
 def test_portal_managed_mode_clears_api_keys_and_hides_secret_ui() -> None:
     content = _portal_bundle_content()
     clear_body = _extract_js_function_body(content, "_clearStoredApiKeyState")
+    summary_body = _extract_js_function_body(content, "_bootstrapSurfaceSummary")
     sync_body = _extract_js_function_body(content, "_syncBootstrapUi")
 
     assert "localStorage.removeItem(API_KEY_STORAGE_KEY);" in clear_body
     assert "sessionStorage.removeItem(API_KEY_STORAGE_KEY);" in clear_body
     assert "_clearStoredApiKeyState(true);" in content
     assert "_loadApiKeyIntoInputs();" in content
+    assert 'id="portalAccessState"' in content
+    assert 'id="bootstrapStatusBadge"' in content
+    assert 'id="bootstrapRecoveryHint"' in content
+    assert "badge: 'Managed access'" in summary_body
+    assert "badge: 'Direct debug'" in summary_body
+    assert "badge: failure.retryable ? 'Recovery pending' : 'Recovery required'" in summary_body
+    assert "badge: 'Confirming access'" in summary_body
     assert "const showApiKeyInput = bootstrapReady && state.auth.features.apiKeyInput;" in sync_body
     assert "els.apiKeySection.classList.toggle('hidden', !showApiKeyInput);" in sync_body
+    assert "document.body.dataset.bootstrapReason = String(state.bootstrap.lastErrorReason || '');" in sync_body
+    assert "document.body.dataset.authMode = String(state.auth.mode || 'managed_unavailable');" in sync_body
+    assert "els.portalAccessState.dataset.bootstrapStatus = String(state.bootstrap.status || 'pending');" in sync_body
+    assert "els.bootstrapStatusBadge.textContent = summary.badge;" in sync_body
+    assert "els.bootstrapRecoveryHint.textContent = summary.detail;" in sync_body
     assert "els.apiKeyInput.disabled = !showApiKeyInput;" in sync_body
     assert "rememberApiKey" not in content
 
@@ -1124,6 +1137,11 @@ def test_portal_console_views_use_query_param_navigation_without_backend_route_c
     assert 'data-view-link="build"' in content
     assert 'data-view-link="operate"' in content
     assert 'data-view-link="review"' in content
+    assert 'data-ui="workspace-shortcut-hint"' in content
+    assert 'aria-keyshortcuts="1"' in content
+    assert 'aria-keyshortcuts="2"' in content
+    assert 'aria-keyshortcuts="3"' in content
+    assert 'aria-keyshortcuts="4"' in content
     assert "const resolvedView = resolveConsoleView(viewName);" in route_body
     assert "url.searchParams.set('view', resolvedView);" in route_body
     assert "url.searchParams.set('artifact', resolvedArtifactPath);" in route_body
@@ -1235,6 +1253,8 @@ def test_portal_dispatch_review_keeps_cli_parity_in_secondary_disclosure() -> No
 
     assert 'data-ui="dispatch-primary-lane"' in content
     assert 'data-ui="dispatch-launch"' in content
+    assert 'data-ui="dispatch-shortcut-hint"' in content
+    assert 'data-ui="governance-posture-hint"' in content
     assert 'id="dispatchReadinessReason"' in content
     assert 'aria-live="polite"' in content
     assert 'aria-atomic="true"' in content
@@ -1249,6 +1269,23 @@ def test_portal_dispatch_review_keeps_cli_parity_in_secondary_disclosure() -> No
     assert 'id="exportBtn"' in content
     assert 'id="copyCliBtn"' in content
     assert 'id="cliPreview"' in content
+
+
+def test_portal_keyboard_shortcuts_cover_view_navigation_and_help_without_text_fragility() -> None:
+    content = _portal_bundle_content()
+    typing_body = _extract_js_function_body(content, "_isTypingTarget")
+
+    assert "const WORKSPACE_VIEW_SHORTCUTS = Object.freeze({" in content
+    assert "'1': 'overview'" in content
+    assert "'4': 'review'" in content
+    assert "function _isTypingTarget(target) {" in content
+    assert "target.isContentEditable || target.closest('[contenteditable=\"true\"]')" in typing_body
+    assert "tagName === 'textarea' || tagName === 'select'" in typing_body
+    assert "if (isPlainShortcut && (key === '?' || (key === '/' && e.shiftKey)))" in content
+    assert "toggleModal(true);" in content
+    assert "if (isPlainShortcut && Object.prototype.hasOwnProperty.call(WORKSPACE_VIEW_SHORTCUTS, key)) {" in content
+    assert "const nextView = WORKSPACE_VIEW_SHORTCUTS[key];" in content
+    assert "navigateConsoleView(nextView);" in content
 
 
 def test_portal_build_surface_keeps_primary_posture_band_outside_contextual_disclosures() -> None:

--- a/tests/validation/test_portal_smoke_scripts.py
+++ b/tests/validation/test_portal_smoke_scripts.py
@@ -397,13 +397,19 @@ def test_frontdoor_browser_waits_for_managed_portal_bootstrap_before_passing():
     assert 'and str(value.get("readyState", "")) == "complete"' in content
     assert 'and str(value.get("authModeBadge", "")).lower() == "managed"' in content
     assert "homepageHeroReady" in content
+    assert "homepageEntryRailReady" in content
     assert "homepageLearnLinkReady" in content
     assert "homepagePrimaryCtaHref" in content
+    assert "loginEntryStateReady" in content
     assert "loginSequenceReady" in content
+    assert "portalAccessStateReady" in content
     assert '[data-ui="homepage-hero-title"]' in content
+    assert '[data-ui="homepage-entry-rail"]' in content
     assert '[data-ui="homepage-learn-link"]' in content
     assert '[data-ui="login-form"]' in content
+    assert '[data-ui="login-entry-state"]' in content
     assert '[data-ui="login-sequence"]' in content
+    assert '[data-ui="portal-access-state"]' in content
     assert ".hero-video, .homepage-video" in content
     assert "form.requestSubmit" in content
     assert "form.submit();" in content

--- a/web/secure-landing/app/login/route.js
+++ b/web/secure-landing/app/login/route.js
@@ -30,8 +30,37 @@ function resolveLoginMessage(code) {
   return "Invalid username or password.";
 }
 
+function resolveRecoveryGuidance(code) {
+  if (code === "access") return "Re-open the verified access path, then return here after Access identity is restored.";
+  if (code === "csrf") return "Refresh the page to mint a clean session, then retry the operator credential handoff.";
+  if (code === "throttled") return "Wait for the throttle window to clear before attempting the operator credential handoff again.";
+  if (code === "configuration") return "Managed entry is fail-closed until the front door configuration is restored.";
+  return "Re-enter operator credentials after verifying the managed access context above.";
+}
+
+function resolveEntryState({ accessEmail, errorCode }) {
+  const hasVerifiedAccess = Boolean(accessEmail);
+  const hasRecoveryIssue = Boolean(errorCode);
+  return {
+    accessState: hasVerifiedAccess ? "verified" : "required",
+    credentialState: hasRecoveryIssue ? "blocked" : hasVerifiedAccess ? "ready" : "waiting",
+    accessLabel: hasVerifiedAccess ? "Verified access ready" : "Managed access required",
+    accessDetail: hasVerifiedAccess
+      ? `Cloudflare Access is already verified for <strong>${escapeHtml(accessEmail)}</strong>.`
+      : "Managed access verification completes before operator credential handoff opens.",
+    credentialLabel: hasRecoveryIssue ? "Recovery required" : hasVerifiedAccess ? "Credential handoff ready" : "Waiting on verified access",
+    credentialDetail: hasRecoveryIssue
+      ? escapeHtml(resolveRecoveryGuidance(errorCode))
+      : hasVerifiedAccess
+        ? "Continue with operator credentials to rotate into the governed portal session."
+        : "Operator credential handoff stays blocked until the verified access context is present.",
+    recoveryState: hasRecoveryIssue ? String(errorCode || "").trim().toLowerCase() || "invalid" : "clear",
+  };
+}
+
 function renderLoginPage({ csrfToken, accessEmail, errorCode }) {
   const errorMessage = errorCode ? resolveLoginMessage(errorCode) : "";
+  const entryState = resolveEntryState({ accessEmail, errorCode });
   const escapedAccessEmail = accessEmail ? escapeHtml(accessEmail) : "";
   const accessSequenceDetail = accessEmail
     ? `Managed access already verified for <strong>${escapedAccessEmail}</strong>.`
@@ -39,6 +68,17 @@ function renderLoginPage({ csrfToken, accessEmail, errorCode }) {
   const accessText = accessEmail
     ? `Access identity verified for <strong>${escapedAccessEmail}</strong>. Credential entry is now available.`
     : "";
+  const recoveryCard = errorMessage
+    ? {
+      title: "Recovery path",
+      detail: resolveRecoveryGuidance(errorCode)
+    }
+    : accessEmail
+      ? {
+        title: "Verified access context",
+        detail: `Managed access has already been verified for ${escapedAccessEmail}. Successful sign-in rotates this browser into the governed portal session.`
+      }
+      : null;
 
   return `<!DOCTYPE html>
 <html lang="en">
@@ -66,7 +106,15 @@ function renderLoginPage({ csrfToken, accessEmail, errorCode }) {
         <source src="${FRONTDOOR_ASSETS.loopVideo}" type="video/mp4" />
       </video>
       <div class="login-vignette" aria-hidden="true"></div>
-      <section id="main-content" class="content" tabindex="-1" data-ui="login-shell">
+      <section
+        id="main-content"
+        class="content"
+        tabindex="-1"
+        data-ui="login-shell"
+        data-access-state="${escapeHtml(entryState.accessState)}"
+        data-credential-state="${escapeHtml(entryState.credentialState)}"
+        data-recovery-state="${escapeHtml(entryState.recoveryState)}"
+      >
         <div class="login-stage" data-ui="login-stage">
           <a class="brand-lockup brand-lockup--stacked" href="/" aria-label="Dynamic Neural Access home">
             <span class="brand-asset-frame brand-asset-frame--login">
@@ -85,6 +133,18 @@ function renderLoginPage({ csrfToken, accessEmail, errorCode }) {
             <p class="lede" data-ui="login-lede">
               Managed access and operator credentials stay separate on purpose. Confirm the verified access context first, then complete credential handoff into the governed console.
             </p>
+            <div class="login-entry-state" data-ui="login-entry-state">
+              <article class="login-status-card" data-ui="login-access-status" data-state="${escapeHtml(entryState.accessState)}">
+                <p class="login-status-card-kicker">Verified access</p>
+                <p class="login-status-card-title">${entryState.accessLabel}</p>
+                <p class="login-status-card-detail">${entryState.accessDetail}</p>
+              </article>
+              <article class="login-status-card" data-ui="login-credential-status" data-state="${escapeHtml(entryState.credentialState)}">
+                <p class="login-status-card-kicker">Credential handoff</p>
+                <p class="login-status-card-title">${entryState.credentialLabel}</p>
+                <p class="login-status-card-detail">${entryState.credentialDetail}</p>
+              </article>
+            </div>
             <div class="login-sequence" data-ui="login-sequence">
               <article class="login-sequence-step${accessEmail ? " login-sequence-step--ready" : ""}">
                 <p class="login-sequence-step-kicker">Step 1</p>
@@ -103,6 +163,10 @@ function renderLoginPage({ csrfToken, accessEmail, errorCode }) {
                 <p class="banner-detail">${escapeHtml(errorMessage)}</p>
               </div>` : ""}
               ${accessText ? `<p class="card-meta card-meta--verified" data-ui="login-access-context">${accessText}</p>` : ""}
+              ${recoveryCard ? `<div class="login-recovery-card" data-ui="login-recovery-card" data-state="${escapeHtml(entryState.recoveryState)}">
+                <p class="login-recovery-card-title">${escapeHtml(recoveryCard.title)}</p>
+                <p class="login-recovery-card-detail">${escapeHtml(recoveryCard.detail)}</p>
+              </div>` : ""}
             </div>` : ""}
             <form method="post" action="/login" autocomplete="on" data-ui="login-form">
               <input type="hidden" name="csrf_token" value="${escapeHtml(csrfToken)}" />

--- a/web/secure-landing/app/login/route.js
+++ b/web/secure-landing/app/login/route.js
@@ -76,7 +76,7 @@ function renderLoginPage({ csrfToken, accessEmail, errorCode }) {
     : accessEmail
       ? {
         title: "Verified access context",
-        detail: `Managed access has already been verified for ${escapedAccessEmail}. Successful sign-in rotates this browser into the governed portal session.`
+        detail: `Managed access has already been verified for ${accessEmail}. Successful sign-in rotates this browser into the governed portal session.`
       }
       : null;
 

--- a/web/secure-landing/app/portal/route.js
+++ b/web/secure-landing/app/portal/route.js
@@ -1,7 +1,8 @@
 import { NextResponse } from "next/server.js";
 
 import { resolveAuthenticatedAccessSession, revokeSessionOnAccessFailure } from "../../lib/access.js";
-import { applySecurityHeaders } from "../../lib/http.js";
+import { escapeHtml, FRONTDOOR_ASSETS, renderBrandAsset } from "../../lib/brand.js";
+import { applySecurityHeaders, LOGIN_CSP } from "../../lib/http.js";
 import { copyUpstreamResponseHeaders } from "../../lib/proxy.js";
 import { getConfig } from "../../lib/config.js";
 import {
@@ -14,6 +15,114 @@ import {
 import { clearSessionCookie } from "../../lib/sessions.js";
 
 export const runtime = "nodejs";
+
+function resolveManagedRecoveryContent(reason, message) {
+  const detail = String(message || "").trim();
+  if (reason === MANAGED_FAILURE_REASON.ACCESS_OUTAGE) {
+    return {
+      title: "Managed entry is waiting on access recovery.",
+      label: "Retry when Access recovers",
+      detail: detail || "Managed access verification is temporarily unavailable.",
+      nextStep: "Refresh the verified access session, then return to the portal once Access validation responds again."
+    };
+  }
+  if (reason === MANAGED_FAILURE_REASON.CONFIG_FAILURE) {
+    return {
+      title: "Managed entry is blocked by configuration.",
+      label: "Configuration required",
+      detail: detail || "Managed front door configuration is unavailable.",
+      nextStep: "Restore the managed front door configuration before retrying portal entry."
+    };
+  }
+  return {
+    title: "Portal handoff is waiting on backend recovery.",
+    label: "Backend recovery",
+    detail: detail || "The upstream portal service is temporarily unavailable.",
+    nextStep: "Wait for the FastAPI operator shell to recover, then retry portal entry from the managed boundary."
+  };
+}
+
+function renderManagedPortalRecoveryPage({ reason, message }) {
+  const content = resolveManagedRecoveryContent(reason, message);
+  const safeReason = escapeHtml(reason || MANAGED_FAILURE_REASON.UPSTREAM_UNAVAILABLE);
+  const safeLabel = escapeHtml(content.label);
+  const safeTitle = escapeHtml(content.title);
+  const safeDetail = escapeHtml(content.detail);
+  const safeNextStep = escapeHtml(content.nextStep);
+  const recoveryTone = safeReason === MANAGED_FAILURE_REASON.ACCESS_OUTAGE ? "waiting" : "blocked";
+
+  return `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Dynamic Neural Access | Managed Recovery</title>
+    <link rel="stylesheet" href="/login.css" />
+  </head>
+  <body>
+    <a class="skip-link" href="#main-content">Skip to recovery</a>
+    <main class="shell">
+      <video
+        class="hero-video"
+        autoplay
+        muted
+        loop
+        playsinline
+        preload="metadata"
+        disablePictureInPicture
+        disableRemotePlayback
+        poster=""
+        aria-hidden="true"
+      >
+        <source src="${FRONTDOOR_ASSETS.loopVideo}" type="video/mp4" />
+      </video>
+      <div class="login-vignette" aria-hidden="true"></div>
+      <section id="main-content" class="content" tabindex="-1" data-ui="managed-recovery-shell" data-reason="${safeReason}">
+        <div class="login-stage">
+          <a class="brand-lockup brand-lockup--stacked" href="/" aria-label="Dynamic Neural Access home">
+            <span class="brand-asset-frame brand-asset-frame--login">
+              ${renderBrandAsset({
+                kind: "lockup",
+                variant: "dark",
+                alt: "Dynamic Neural Access",
+                className: "brand-asset"
+              })}
+            </span>
+            <span class="brand-subtitle">Managed portal recovery</span>
+          </a>
+          <div class="card card--login" data-ui="managed-recovery-card">
+            <p class="eyebrow">Managed portal entry</p>
+            <h1>${safeTitle}</h1>
+            <p class="lede">${safeDetail}</p>
+            <div class="login-entry-state">
+              <article class="login-status-card" data-state="${recoveryTone}">
+                <p class="login-status-card-kicker">State</p>
+                <p class="login-status-card-title">${safeLabel}</p>
+                <p class="login-status-card-detail">${safeDetail}</p>
+              </article>
+              <article class="login-status-card" data-state="${recoveryTone}">
+                <p class="login-status-card-kicker">Next step</p>
+                <p class="login-status-card-title">Recover, then retry</p>
+                <p class="login-status-card-detail">${safeNextStep}</p>
+              </article>
+            </div>
+            <div class="login-status-stack">
+              <div class="login-recovery-card" data-ui="managed-recovery-guidance" data-state="${safeReason}">
+                <p class="login-recovery-card-title">Managed boundary stays fail-closed</p>
+                <p class="login-recovery-card-detail">Browser-side API key entry remains unavailable in managed mode while portal recovery is pending.</p>
+              </div>
+            </div>
+            <div class="login-actions" data-ui="managed-recovery-actions">
+              <a class="login-secondary-link" href="/login">Return to login</a>
+              <a class="login-secondary-link" href="/">Review public proof surface</a>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>`;
+}
 
 export async function GET(request) {
   const authState = await resolveAuthenticatedAccessSession(request, { touch: true });
@@ -29,11 +138,16 @@ export async function GET(request) {
     if (reason !== MANAGED_FAILURE_REASON.AUTH_FAILURE) {
       const headers = new Headers();
       headers.set("Cache-Control", "no-store");
+      headers.set("Content-Type", "text/html; charset=utf-8");
       return applySecurityHeaders(
-        new Response(getManagedFailureMessage("portal", reason), {
+        new Response(renderManagedPortalRecoveryPage({
+          reason,
+          message: getManagedFailureMessage("portal", reason)
+        }), {
           status: 503,
           headers
-        })
+        }),
+        { csp: LOGIN_CSP }
       );
     }
 
@@ -67,11 +181,16 @@ export async function GET(request) {
     });
     const headers = new Headers();
     headers.set("Cache-Control", "no-store");
+    headers.set("Content-Type", "text/html; charset=utf-8");
     return applySecurityHeaders(
-      new Response(getManagedFailureMessage("portal", MANAGED_FAILURE_REASON.UPSTREAM_UNAVAILABLE), {
+      new Response(renderManagedPortalRecoveryPage({
+        reason: MANAGED_FAILURE_REASON.UPSTREAM_UNAVAILABLE,
+        message: getManagedFailureMessage("portal", MANAGED_FAILURE_REASON.UPSTREAM_UNAVAILABLE)
+      }), {
         status: 503,
         headers
-      })
+      }),
+      { csp: LOGIN_CSP }
     );
   }
 
@@ -87,11 +206,16 @@ export async function GET(request) {
       });
       const headers = new Headers();
       headers.set("Cache-Control", "no-store");
+      headers.set("Content-Type", "text/html; charset=utf-8");
       return applySecurityHeaders(
-        new Response(getManagedFailureMessage("portal", reason), {
+        new Response(renderManagedPortalRecoveryPage({
+          reason,
+          message: getManagedFailureMessage("portal", reason)
+        }), {
           status: 503,
           headers
-        })
+        }),
+        { csp: LOGIN_CSP }
       );
     }
   }

--- a/web/secure-landing/app/portal/route.js
+++ b/web/secure-landing/app/portal/route.js
@@ -43,13 +43,14 @@ function resolveManagedRecoveryContent(reason, message) {
 }
 
 function renderManagedPortalRecoveryPage({ reason, message }) {
-  const content = resolveManagedRecoveryContent(reason, message);
-  const safeReason = escapeHtml(reason || MANAGED_FAILURE_REASON.UPSTREAM_UNAVAILABLE);
+  const resolvedReason = reason || MANAGED_FAILURE_REASON.UPSTREAM_UNAVAILABLE;
+  const content = resolveManagedRecoveryContent(resolvedReason, message);
+  const safeReason = escapeHtml(resolvedReason);
   const safeLabel = escapeHtml(content.label);
   const safeTitle = escapeHtml(content.title);
   const safeDetail = escapeHtml(content.detail);
   const safeNextStep = escapeHtml(content.nextStep);
-  const recoveryTone = safeReason === MANAGED_FAILURE_REASON.ACCESS_OUTAGE ? "waiting" : "blocked";
+  const recoveryTone = resolvedReason === MANAGED_FAILURE_REASON.ACCESS_OUTAGE ? "waiting" : "blocked";
 
   return `<!DOCTYPE html>
 <html lang="en">

--- a/web/secure-landing/lib/homepage.js
+++ b/web/secure-landing/lib/homepage.js
@@ -505,6 +505,23 @@ export function renderHomepage() {
           <p class="hero-access-note" data-ui="homepage-hero-note">
             Review the public proof surface first. Operator build, operate, and review work remains gated behind managed access.
           </p>
+          <div class="entry-rail" data-ui="homepage-entry-rail">
+            <article class="entry-card" data-state="public-proof">
+              <p class="entry-card__kicker">Public proof</p>
+              <p class="entry-card__title">Start with orientation.</p>
+              <p class="entry-card__detail">Open the public proof surface to inspect release posture, verification context, and workflow scope before any operator session begins.</p>
+            </article>
+            <article class="entry-card" data-state="verified-access">
+              <p class="entry-card__kicker">Verified access</p>
+              <p class="entry-card__title">Confirm identity before credential handoff.</p>
+              <p class="entry-card__detail">Managed entry keeps Cloudflare Access verification separate from operator credentials so the browser never becomes the system of record.</p>
+            </article>
+            <article class="entry-card" data-state="governed-console">
+              <p class="entry-card__kicker">Governed console</p>
+              <p class="entry-card__title">Run build, operate, and review work inside the portal.</p>
+              <p class="entry-card__detail">Managed entry hands work into the operator console only after verification is complete and the governed shell is ready.</p>
+            </article>
+          </div>
           <div class="hero-route-grid" data-ui="homepage-route-grid">
             ${renderList(HERO_PATHS, renderHeroRouteCard)}
           </div>

--- a/web/secure-landing/public/frontdoor-homepage.css
+++ b/web/secure-landing/public/frontdoor-homepage.css
@@ -496,6 +496,62 @@ body.frontdoor-homepage .hero-access-note strong {
   color: var(--fd-text-strong);
 }
 
+body.frontdoor-homepage .entry-rail {
+  display: grid;
+  gap: 0.9rem;
+  margin-top: 1.4rem;
+}
+
+body.frontdoor-homepage .entry-card {
+  display: grid;
+  gap: 0.4rem;
+  padding: 1rem 1.05rem;
+  border-radius: 1.2rem;
+  border: 1px solid var(--fd-border);
+  background: rgba(15, 23, 42, 0.64);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+body.frontdoor-homepage .entry-card[data-state="verified-access"] {
+  border-color: rgba(103, 232, 249, 0.26);
+  background:
+    linear-gradient(180deg, rgba(8, 145, 178, 0.12), rgba(15, 23, 42, 0.7)),
+    rgba(15, 23, 42, 0.74);
+}
+
+body.frontdoor-homepage .entry-card[data-state="governed-console"] {
+  border-color: rgba(45, 212, 191, 0.24);
+}
+
+body.frontdoor-homepage .entry-card__kicker {
+  margin: 0;
+  color: var(--fd-accent);
+  font-family:
+    "SFMono-Regular",
+    "SF Mono",
+    "Menlo",
+    "Consolas",
+    monospace;
+  font-size: 0.72rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+body.frontdoor-homepage .entry-card__title {
+  margin: 0;
+  color: var(--fd-text-strong);
+  font-size: 0.98rem;
+  font-weight: 700;
+  line-height: 1.45;
+}
+
+body.frontdoor-homepage .entry-card__detail {
+  margin: 0;
+  color: var(--fd-text-soft);
+  font-size: 0.9rem;
+  line-height: 1.65;
+}
+
 body.frontdoor-homepage .site-link {
   display: inline-flex;
   align-items: center;
@@ -1003,6 +1059,10 @@ body.frontdoor-homepage .site-footer__copy {
   body.frontdoor-homepage .hero-section {
     grid-template-columns: minmax(0, 1.05fr) minmax(21rem, 35rem);
     align-items: start;
+  }
+
+  body.frontdoor-homepage .entry-rail {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 
   body.frontdoor-homepage .proof-layout {

--- a/web/secure-landing/public/login.css
+++ b/web/secure-landing/public/login.css
@@ -251,6 +251,64 @@ h1 {
   line-height: 1.7;
 }
 
+.login-entry-state {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.8rem;
+  margin-bottom: 1.2rem;
+}
+
+.login-status-card {
+  display: grid;
+  gap: 0.35rem;
+  min-height: 100%;
+  border-radius: 1.1rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(7, 13, 26, 0.48);
+  padding: 0.95rem 1rem;
+}
+
+.login-status-card[data-state="verified"],
+.login-status-card[data-state="ready"] {
+  border-color: rgba(45, 212, 191, 0.28);
+  background:
+    linear-gradient(180deg, rgba(15, 118, 110, 0.12), rgba(7, 13, 26, 0.6)),
+    rgba(7, 13, 26, 0.56);
+}
+
+.login-status-card[data-state="blocked"] {
+  border-color: rgba(248, 113, 113, 0.34);
+  background:
+    linear-gradient(180deg, rgba(127, 29, 29, 0.18), rgba(7, 13, 26, 0.6)),
+    rgba(7, 13, 26, 0.58);
+}
+
+.login-status-card-kicker,
+.login-recovery-card-title {
+  margin: 0;
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: rgba(148, 220, 255, 0.88);
+}
+
+.login-status-card-title {
+  margin: 0;
+  font-size: 0.98rem;
+  font-weight: 800;
+  line-height: 1.35;
+  color: var(--frontdoor-ink);
+}
+
+.login-status-card-detail,
+.login-recovery-card-detail {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.6;
+  color: var(--frontdoor-muted-soft);
+}
+
 .login-status-stack {
   display: grid;
   gap: 0.85rem;
@@ -351,6 +409,30 @@ h1 {
   color: #d1fae5;
   padding: 0.8rem 0.95rem;
   text-align: left;
+}
+
+.login-recovery-card {
+  display: grid;
+  gap: 0.35rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  background: rgba(7, 13, 26, 0.54);
+  padding: 0.85rem 0.95rem;
+}
+
+.login-recovery-card[data-state="clear"] {
+  border-color: rgba(45, 212, 191, 0.24);
+}
+
+.login-recovery-card[data-state="access"],
+.login-recovery-card[data-state="access_outage"],
+.login-recovery-card[data-state="configuration"],
+.login-recovery-card[data-state="config_failure"],
+.login-recovery-card[data-state="csrf"],
+.login-recovery-card[data-state="throttled"],
+.login-recovery-card[data-state="invalid"],
+.login-recovery-card[data-state="upstream_unavailable"] {
+  border-color: rgba(248, 113, 113, 0.28);
 }
 
 form {
@@ -676,6 +758,7 @@ code {
     width: min(100%, 32rem);
   }
 
+  .login-entry-state,
   .login-sequence {
     grid-template-columns: 1fr;
   }

--- a/web/secure-landing/tests/routes.test.mjs
+++ b/web/secure-landing/tests/routes.test.mjs
@@ -404,6 +404,38 @@ test("login GET serves a minimal branded sign-in shell and boots an anonymous se
   }
 });
 
+test("login GET escapes verified access context exactly once in the recovery card", async () => {
+  const env = withTempEnvironment();
+
+  try {
+    const { GET } = await importFresh("../app/login/route.js");
+    const restoreFetch = withMockedAccessCerts();
+
+    try {
+      const accessEmail = "admin+ops&support@example.com";
+      const request = buildRequest("https://portal.example.com/login", {
+        headers: new Headers({
+          "Cf-Access-Jwt-Assertion": createAccessJwt({ email: accessEmail }),
+          "cf-access-authenticated-user-email": accessEmail
+        })
+      });
+
+      const response = await GET(request);
+      const html = await response.text();
+
+      assert.equal(response.status, 200);
+      assert.match(html, /data-access-state="verified"/);
+      assert.match(html, /data-ui="login-recovery-card"/);
+      assert.match(html, /Managed access has already been verified for admin\+ops&amp;support@example\.com\./);
+      assert.doesNotMatch(html, /admin\+ops&amp;amp;support@example\.com/);
+    } finally {
+      restoreFetch();
+    }
+  } finally {
+    env.cleanup();
+  }
+});
+
 test("homepage GET serves the public DNA landing page instead of redirecting", async () => {
   const env = withTempEnvironment();
 
@@ -1150,6 +1182,56 @@ test("portal returns 503 with no-store when the FastAPI UI origin is unavailable
       assert.match(html, /Return to login/);
     } finally {
       restoreFetch();
+    }
+  } finally {
+    env.cleanup();
+  }
+});
+
+test("portal renders waiting recovery posture for Access outages", async () => {
+  const outageTeamDomain = "https://tp-frontdoor-outage.cloudflareaccess.com";
+  const env = withTempEnvironment({
+    TP_CF_ACCESS_TEAM_DOMAIN: outageTeamDomain
+  });
+
+  try {
+    const sessions = await importFresh("../lib/sessions.js");
+    const { GET } = await importFresh("../app/portal/route.js");
+    const originalFetch = global.fetch;
+    global.fetch = async (url, init) => {
+      assert.equal(String(url), `${outageTeamDomain}/cdn-cgi/access/certs`);
+      assert.ok(init.signal);
+      throw Object.assign(new Error("timed out"), { name: "AbortError" });
+    };
+
+    try {
+      const authenticatedSession = sessions.rotateAuthenticatedSession(
+        sessions.createAnonymousSession(),
+        {
+          username: "admin",
+          accessEmail: "admin@example.com",
+          role: "admin"
+        }
+      );
+
+      const request = buildRequest("https://portal.example.com/portal", {
+        method: "GET",
+        headers: new Headers({
+          cookie: `__Host-tp_session=${authenticatedSession.id}`,
+          "Cf-Access-Jwt-Assertion": createAccessJwt({ iss: outageTeamDomain })
+        })
+      });
+
+      const response = await GET(request);
+      const html = await response.text();
+
+      assert.equal(response.status, 503);
+      assert.match(html, /data-ui="managed-recovery-shell"/);
+      assert.match(html, /data-reason="access_outage"/);
+      assert.match(html, /class="login-status-card" data-state="waiting"/);
+      assert.match(html, /Retry when Access recovers/);
+    } finally {
+      global.fetch = originalFetch;
     }
   } finally {
     env.cleanup();

--- a/web/secure-landing/tests/routes.test.mjs
+++ b/web/secure-landing/tests/routes.test.mjs
@@ -381,6 +381,9 @@ test("login GET serves a minimal branded sign-in shell and boots an anonymous se
     assert.match(html, /id="main-content"/);
     assert.match(html, /Transformation Portal operator console/);
     assert.match(html, /data-ui="login-title"/);
+    assert.match(html, /data-ui="login-entry-state"/);
+    assert.match(html, /data-ui="login-access-status"/);
+    assert.match(html, /data-ui="login-credential-status"/);
     assert.match(html, /data-ui="login-sequence"/);
     assert.match(html, /data-ui="login-form"/);
     assert.match(html, /form method="post" action="\/login"/);
@@ -429,6 +432,7 @@ test("homepage GET serves the public DNA landing page instead of redirecting", a
     assert.match(html, /\/brand\/dna-lockup-dark\.svg/);
     assert.match(html, /data-ui="homepage-hero-lockup"/);
     assert.match(html, /data-ui="homepage-hero-title"/);
+    assert.match(html, /data-ui="homepage-entry-rail"/);
     assert.match(html, /(?:data-ui="homepage-learn-link"[^>]*href="#workflow"|href="#workflow"[^>]*data-ui="homepage-learn-link")/);
     assert.match(html, /(?:data-ui="homepage-primary-cta"[^>]*href="\/login"|href="\/login"[^>]*data-ui="homepage-primary-cta")/);
     assert.match(html, /(?:data-ui="homepage-secondary-cta"[^>]*href="#proof-report"|href="#proof-report"[^>]*data-ui="homepage-secondary-cta")/);
@@ -1138,7 +1142,12 @@ test("portal returns 503 with no-store when the FastAPI UI origin is unavailable
 
       assert.equal(response.status, 503);
       assert.equal(response.headers.get("cache-control"), "no-store");
-      assert.equal(await response.text(), "Portal upstream unavailable");
+      assert.match(response.headers.get("content-security-policy") || "", /default-src 'self'/);
+      const html = await response.text();
+      assert.match(html, /data-ui="managed-recovery-shell"/);
+      assert.match(html, /data-reason="upstream_unavailable"/);
+      assert.match(html, /Portal upstream unavailable/);
+      assert.match(html, /Return to login/);
     } finally {
       restoreFetch();
     }
@@ -1176,7 +1185,12 @@ test("portal returns configuration guidance when managed access config is incomp
 
       assert.equal(response.status, 503);
       assert.equal(response.headers.get("cache-control"), "no-store");
-      assert.equal(await response.text(), "Managed front door configuration unavailable");
+      assert.match(response.headers.get("content-security-policy") || "", /default-src 'self'/);
+      const html = await response.text();
+      assert.match(html, /data-ui="managed-recovery-shell"/);
+      assert.match(html, /data-reason="config_failure"/);
+      assert.match(html, /Managed front door configuration unavailable/);
+      assert.match(html, /Managed boundary stays fail-closed/);
       assert.equal(events.length, 1);
       assert.equal(events[0].surface, "portal");
       assert.equal(events[0].reason, "config_failure");


### PR DESCRIPTION
## Summary
- refine the managed frontdoor homepage and login surfaces so public proof, verified-access context, and credential handoff are clearer without changing auth mechanics or route contracts
- harden managed `/portal` degraded behavior with a branded fail-closed recovery shell and additive state markers instead of copy-dependent error handling
- tighten the FastAPI operator console shell with visible access posture, stronger shortcut discoverability, clearer selected context, and sharper Step 3 / Step 4 recovery cues
- update route tests, portal runtime/contract tests, and browser smoke probes to anchor on durable selectors rather than copy
- add the Figma source-of-truth for the tranche states: https://www.figma.com/design/fh6NpxKtETqkAgspTa7izC

## Scope
- preserve `/`, `/login`, `/portal`, `/portal/assets/*`, `/portal/bootstrap`, `/healthz`, `/ready`, and `/v1/*`
- preserve `?view=overview|build|operate|review`, additive `job=`, `artifact=`, and `compare=1`
- keep managed/direct-debug split explicit and fail-closed
- keep backend envelope shapes intact; all new observability is additive `data-ui` / `data-state`

## Validation
- `make test-orchestrator-contract`
- `PATH=/Users/richardcheetham/.nvm/versions/node/v22.22.2/bin:$PATH make test-frontdoor-contract`
- `make validate-portal-browser`
- `PATH=/Users/richardcheetham/.nvm/versions/node/v22.22.2/bin:$PATH make validate-frontdoor-browser`

## Pre-commit
- Ran `PRE_COMMIT_HOME=/tmp/pre-commit PATH=/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin:$PATH make pre-commit`
- Remaining failures are unrelated repo-baseline issues outside this tranche:
  - `validate-dependency-constraints` reports stale ML lockfile warnings in existing requirement lanes
  - `check-test-markers` reports missing ADR-044 markers in unrelated existing tests under `tests/lux_depth_v3`, `tests/crypto`, and `tests/validation`
- The tranche files themselves were left staged cleanly and committed without pulling in unrelated worktree state

## Notes
- left the pre-existing `web/secure-landing/package-lock.json` worktree diff out of this branch on purpose
- no Cloudflare or Vercel rollout changes are included in this PR