### PR TITLE
feat(portal): add contextual action rail

### DIFF
--- a/portal.html
+++ b/portal.html
@@ -332,6 +332,21 @@ Contract notes:
                     <p id="contextRibbonCompareMeta" class="console-context-meta">No paired comparison is available for the current artifact.</p>
                 </div>
             </div>
+            <section id="consoleActionRail" class="console-action-rail mt-4 hidden" data-ui="console-action-rail" data-tone="info" aria-live="polite">
+                <div class="console-action-rail-copy">
+                    <p class="console-action-rail-kicker">Action Rail</p>
+                    <p id="consoleActionRailTitle" class="console-action-rail-title">Keep the next operator move pinned</p>
+                    <p id="consoleActionRailDetail" class="console-action-rail-detail">Contextual review, artifact, compare, and recovery actions will update here from the current run state.</p>
+                    <p id="consoleActionRailHint" class="console-action-rail-hint" data-ui="console-action-shortcuts">
+                        Keyboard: <span class="kbd">1</span> overview, <span class="kbd">2</span> build, <span class="kbd">3</span> operate, <span class="kbd">4</span> review, <span class="kbd">?</span> shortcuts.
+                    </p>
+                </div>
+                <div id="consoleActionRailActions" class="console-action-rail-actions">
+                    <button id="consoleActionPrimaryBtn" type="button" class="operator-action-btn operator-action-btn-primary hidden" data-ui="console-action-primary"></button>
+                    <button id="consoleActionSecondaryBtn1" type="button" class="operator-action-btn operator-action-btn-secondary hidden" data-ui="console-action-secondary-1"></button>
+                    <button id="consoleActionSecondaryBtn2" type="button" class="operator-action-btn operator-action-btn-secondary hidden" data-ui="console-action-secondary-2"></button>
+                </div>
+            </section>
         </section>
 
         <!-- ============================================ -->
@@ -1317,6 +1332,10 @@ Contract notes:
                             <p id="selectedJobRecoveryDetail" class="mt-2 text-[12px] leading-6 text-slate-600 dark:text-slate-300">
                                 Use the selected run state, warning context, and freshness above to decide whether to recover or open review.
                             </p>
+                            <div id="selectedJobRecoveryActions" class="contextual-action-row mt-3 hidden" data-ui="selected-job-recovery-actions">
+                                <button id="selectedJobRecoveryPrimaryBtn" type="button" class="operator-action-btn operator-action-btn-primary hidden" data-ui="selected-job-recovery-primary"></button>
+                                <button id="selectedJobRecoverySecondaryBtn" type="button" class="operator-action-btn operator-action-btn-secondary hidden" data-ui="selected-job-recovery-secondary"></button>
+                            </div>
                         </div>
                     </div>
 
@@ -1455,6 +1474,10 @@ Contract notes:
                             <p id="reviewStatusTitle" class="review-status-title">Awaiting completed run</p>
                             <p id="reviewStatusDetail" class="review-status-detail">Select a job to review related warnings, completion state, and output readiness.</p>
                             <p id="reviewStatusAction" class="review-status-action">Next action: use the selected run state, warning context, and freshness above to decide whether to recover or open review.</p>
+                            <div id="reviewStatusActions" class="review-status-actions hidden" data-ui="review-status-actions">
+                                <button id="reviewStatusPrimaryBtn" type="button" class="operator-action-btn operator-action-btn-primary hidden" data-ui="review-status-primary"></button>
+                                <button id="reviewStatusSecondaryBtn" type="button" class="operator-action-btn operator-action-btn-secondary hidden" data-ui="review-status-secondary"></button>
+                            </div>
                         </div>
                         <div id="reviewProvenanceGrid" class="review-provenance-grid hidden" data-ui="review-provenance-grid">
                             <div class="review-provenance-item">

--- a/public/portal-assets/portal.css
+++ b/public/portal-assets/portal.css
@@ -944,6 +944,157 @@ progress::-moz-progress-bar { background-color: #4f46e5; transition: width 0.3s 
     color: var(--shell-muted);
 }
 
+.console-action-rail {
+    display: grid;
+    gap: 1rem;
+    border: 1px solid var(--shell-border);
+    border-radius: 8px;
+    background:
+        linear-gradient(135deg, rgba(248, 250, 252, 0.94), rgba(255, 255, 255, 0.82)),
+        rgba(255, 255, 255, 0.76);
+    padding: 1rem 1.05rem;
+    box-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.32),
+        0 14px 28px rgba(15, 23, 42, 0.05);
+}
+
+.dark .console-action-rail {
+    background:
+        linear-gradient(135deg, rgba(15, 23, 42, 0.88), rgba(15, 23, 42, 0.74)),
+        rgba(15, 23, 42, 0.78);
+    box-shadow:
+        inset 0 1px 0 rgba(148, 163, 184, 0.05),
+        0 16px 30px rgba(2, 6, 23, 0.22);
+}
+
+.console-action-rail[data-tone="ready"] {
+    border-color: rgba(13, 148, 136, 0.18);
+}
+
+.console-action-rail[data-tone="warning"] {
+    border-color: rgba(217, 119, 6, 0.2);
+}
+
+.console-action-rail[data-tone="blocked"] {
+    border-color: rgba(220, 38, 38, 0.2);
+}
+
+.console-action-rail-copy {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    min-width: 0;
+}
+
+.console-action-rail-kicker {
+    margin: 0;
+    font-size: 10px;
+    font-weight: 800;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--shell-muted);
+}
+
+.console-action-rail-title {
+    margin: 0;
+    font-size: 14px;
+    font-weight: 700;
+    line-height: 1.45;
+    color: var(--shell-ink);
+}
+
+.console-action-rail-detail {
+    margin: 0;
+    font-size: 12.5px;
+    line-height: 1.65;
+    color: var(--shell-muted);
+}
+
+.console-action-rail-hint {
+    margin: 0;
+    font-size: 11px;
+    line-height: 1.6;
+    color: var(--shell-muted);
+}
+
+.console-action-rail-actions,
+.contextual-action-row,
+.review-status-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.65rem;
+    align-items: center;
+}
+
+.operator-action-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 2.4rem;
+    min-width: 0;
+    border-radius: 8px;
+    border: 1px solid var(--shell-border);
+    padding: 0.72rem 0.95rem;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    transition: background 180ms ease, border-color 180ms ease, color 180ms ease, transform 180ms ease;
+}
+
+.operator-action-btn:hover:not(:disabled) {
+    transform: translateY(-1px);
+}
+
+.operator-action-btn:disabled {
+    cursor: not-allowed;
+    opacity: 0.55;
+}
+
+.operator-action-btn-primary {
+    border-color: rgba(8, 145, 178, 0.18);
+    background: linear-gradient(135deg, rgba(8, 145, 178, 0.92), rgba(14, 165, 233, 0.84));
+    color: #fff;
+    box-shadow: 0 12px 24px rgba(14, 116, 144, 0.16);
+}
+
+.operator-action-btn-primary:hover:not(:disabled) {
+    background: linear-gradient(135deg, rgba(8, 145, 178, 0.98), rgba(2, 132, 199, 0.9));
+}
+
+.operator-action-btn-secondary {
+    background: rgba(255, 255, 255, 0.78);
+    color: var(--shell-ink);
+}
+
+.dark .operator-action-btn-secondary {
+    background: rgba(15, 23, 42, 0.76);
+    color: var(--shell-ink);
+}
+
+.operator-action-btn[data-tone="warning"].operator-action-btn-secondary {
+    border-color: rgba(217, 119, 6, 0.22);
+}
+
+.operator-action-btn[data-tone="blocked"].operator-action-btn-secondary {
+    border-color: rgba(220, 38, 38, 0.24);
+}
+
+.operator-action-btn[data-tone="ready"].operator-action-btn-secondary {
+    border-color: rgba(13, 148, 136, 0.2);
+}
+
+@media (min-width: 1024px) {
+    .console-action-rail {
+        grid-template-columns: minmax(0, 1fr) auto;
+        align-items: end;
+    }
+
+    .console-action-rail-actions {
+        justify-content: flex-end;
+    }
+}
+
 .build-pulse-grid {
     display: grid;
     gap: 0.75rem;
@@ -1679,6 +1830,10 @@ details[open] .disclosure-chevron {
     line-height: 1.55;
     font-weight: 600;
     color: var(--shell-ink);
+}
+
+.review-status-actions {
+    margin-top: 0.9rem;
 }
 
 .surface-empty-state {

--- a/public/portal-assets/portal.js
+++ b/public/portal-assets/portal.js
@@ -537,6 +537,14 @@ const els = {
     consoleViewSummary: _domId('consoleViewSummary'),
     consoleViewMeta: _domId('consoleViewMeta'),
     consoleContextRibbon: _domId('consoleContextRibbon'),
+    consoleActionRail: _domId('consoleActionRail'),
+    consoleActionRailTitle: _domId('consoleActionRailTitle'),
+    consoleActionRailDetail: _domId('consoleActionRailDetail'),
+    consoleActionRailHint: _domId('consoleActionRailHint'),
+    consoleActionRailActions: _domId('consoleActionRailActions'),
+    consoleActionPrimaryBtn: _domId('consoleActionPrimaryBtn'),
+    consoleActionSecondaryBtn1: _domId('consoleActionSecondaryBtn1'),
+    consoleActionSecondaryBtn2: _domId('consoleActionSecondaryBtn2'),
     contextRibbonCard1: _domId('contextRibbonCard1'),
     contextRibbonCard1Label: _domId('contextRibbonCard1Label'),
     contextRibbonJob: _domId('contextRibbonJob'),
@@ -789,6 +797,9 @@ const els = {
     selectedJobSummary: _domId('selectedJobSummary'),
     selectedJobRecoveryTitle: _domId('selectedJobRecoveryTitle'),
     selectedJobRecoveryDetail: _domId('selectedJobRecoveryDetail'),
+    selectedJobRecoveryActions: _domId('selectedJobRecoveryActions'),
+    selectedJobRecoveryPrimaryBtn: _domId('selectedJobRecoveryPrimaryBtn'),
+    selectedJobRecoverySecondaryBtn: _domId('selectedJobRecoverySecondaryBtn'),
     selectedJobTransportAlert: _domId('selectedJobTransportAlert'),
     openRunDetailsBtn: _domId('openRunDetailsBtn'),
     inspectorOverviewTab: _domId('inspectorOverviewTab'),
@@ -824,6 +835,9 @@ const els = {
     reviewStatusTitle: _domId('reviewStatusTitle'),
     reviewStatusDetail: _domId('reviewStatusDetail'),
     reviewStatusAction: _domId('reviewStatusAction'),
+    reviewStatusActions: _domId('reviewStatusActions'),
+    reviewStatusPrimaryBtn: _domId('reviewStatusPrimaryBtn'),
+    reviewStatusSecondaryBtn: _domId('reviewStatusSecondaryBtn'),
     reviewProvenanceGrid: _domId('reviewProvenanceGrid'),
     reviewProvenanceArtifactRole: _domId('reviewProvenanceArtifactRole'),
     reviewProvenanceRunState: _domId('reviewProvenanceRunState'),
@@ -1381,6 +1395,528 @@ function _compareSurfaceCopy(selectedArtifact, compareArtifact, compareEnabled) 
         summaryTitle: 'Paired comparison available',
         summaryDetail: `${compareLabel} is available as a side-by-side comparison for ${primaryLabel}.`,
     };
+}
+
+function _findJobById(jobId) {
+    const normalizedJobId = _normalizeSelectedJobId(jobId);
+    if (!normalizedJobId) return null;
+    return state.jobs.find((job) => _normalizeSelectedJobId(job?.id) === normalizedJobId) || null;
+}
+
+function _jobHasReviewableOutputs(job) {
+    if (!job) return false;
+    const summary = normalizeRunSummary(job.run_summary);
+    const artifactCount = Array.isArray(job.artifacts) ? job.artifacts.length : 0;
+    return artifactCount > 0 || Boolean(summary?.reviewable_outputs);
+}
+
+function _operatorAction(key, label, options = {}) {
+    const normalizedKey = String(key || '').trim();
+    const normalizedLabel = String(label || '').trim();
+    if (!normalizedKey || !normalizedLabel) return null;
+    return {
+        key: normalizedKey,
+        label: normalizedLabel,
+        tone: String(options.tone || 'info'),
+        jobId: _normalizeSelectedJobId(options.jobId || ''),
+        artifactPath: _normalizeArtifactRoutePath(options.artifactPath || ''),
+        detail: String(options.detail || '').trim(),
+        disabled: Boolean(options.disabled)
+    };
+}
+
+function _compactOperatorActions(actions, maxCount = 2) {
+    const seen = new Set();
+    const compact = [];
+    (Array.isArray(actions) ? actions : []).forEach((action) => {
+        if (!action || !action.key || seen.has(action.key)) return;
+        seen.add(action.key);
+        compact.push(action);
+    });
+    return compact.slice(0, maxCount);
+}
+
+function _operatorActionContext(job) {
+    const normalizedJobId = _normalizeSelectedJobId(job?.id);
+    const artifacts = Array.isArray(job?.artifacts) ? rankArtifactsForDisplay(job.artifacts) : [];
+    const selectedArtifact = job ? _selectedArtifactForJob(job) : null;
+    const heroArtifact = artifacts[0] || selectedArtifact || null;
+    const activeArtifact = selectedArtifact || heroArtifact;
+    const compareCandidate = job ? findCompareArtifact(activeArtifact, artifacts) : null;
+    const compareEnabled = Boolean(
+        normalizedJobId
+        && compareCandidate
+        && state.artifactUi.compareByJob[normalizedJobId]
+    );
+    return {
+        job,
+        jobId: normalizedJobId,
+        artifacts,
+        artifactCount: artifacts.length,
+        selectedArtifact: activeArtifact,
+        heroArtifact,
+        compareCandidate,
+        compareEnabled,
+        reviewableOutputs: _jobHasReviewableOutputs(job)
+    };
+}
+
+function _preferredOperatorActionJob() {
+    const preferredJobId = _preferredSelectedJobId();
+    return _findJobById(preferredJobId) || _latestActiveJob() || _latestReviewableJob() || null;
+}
+
+function _operatorActionHintHtml() {
+    const base = [
+        '<span class="kbd">1</span> overview',
+        '<span class="kbd">2</span> build',
+        '<span class="kbd">3</span> operate',
+        '<span class="kbd">4</span> review',
+        '<span class="kbd">?</span> shortcuts'
+    ];
+    if (state.currentView === 'build') {
+        base.push('<span class="kbd">Ctrl/⌘ + Enter</span> dispatch');
+        base.push('<span class="kbd">Ctrl/⌘ + Shift + C</span> copy CLI');
+    }
+    return `Keyboard: ${base.join(', ')}.`;
+}
+
+function _operatorRecoveryActionSnapshot(context) {
+    const job = context.job;
+    const bootstrapStatus = String(state.bootstrap?.status || 'pending').trim().toLowerCase();
+    const reconnectBlocked = Boolean(job?.reconnectBlocked);
+    const hasBootstrapFailure = bootstrapStatus === 'degraded' || bootstrapStatus === 'unavailable';
+    if (!reconnectBlocked && !hasBootstrapFailure) return null;
+
+    const failure = reconnectBlocked
+        ? _bootstrapFailureDetails('auth_failure', 401)
+        : _bootstrapFailureDetails(state.bootstrap.lastErrorReason, state.bootstrap.lastHttpStatus);
+    const tone = failure.retryable ? 'warning' : 'blocked';
+
+    if (failure.reason === 'auth_failure' || reconnectBlocked) {
+        return {
+            title: 'Restore access before live actions continue',
+            detail: failure.actionMessage,
+            tone,
+            primary: _operatorAction('restore_access', 'Restore Access', {
+                jobId: context.jobId,
+                tone,
+                detail: failure.actionMessage
+            }),
+            secondary: _compactOperatorActions([
+                _operatorAction('retry_status_check', 'Retry Status Check', {
+                    jobId: context.jobId,
+                    tone: 'info',
+                    detail: 'Retry bootstrap and backend status checks without expanding the route contract.'
+                })
+            ])
+        };
+    }
+
+    return {
+        title: failure.reason === 'access_outage' ? 'Managed access is degraded' : 'Portal recovery is required',
+        detail: failure.actionMessage,
+        tone,
+        primary: _operatorAction('retry_status_check', 'Retry Status Check', {
+            jobId: context.jobId,
+            tone,
+            detail: failure.actionMessage
+        }),
+        secondary: _compactOperatorActions([
+            context.reviewableOutputs
+                ? _operatorAction('review_retained_outputs', 'Review Retained Outputs', {
+                    jobId: context.jobId,
+                    tone: 'warning',
+                    detail: 'Open retained outputs while live status is recovering.'
+                })
+                : _operatorAction('return_to_build', 'Return to Build', {
+                    tone: 'info',
+                    detail: 'Return to the build surface while access recovery completes.'
+                })
+        ])
+    };
+}
+
+function _operatorActionRailSnapshot(jobOverride = undefined) {
+    const job = arguments.length > 0 ? jobOverride : _preferredOperatorActionJob();
+    const context = _operatorActionContext(job);
+    const recoverySnapshot = _operatorRecoveryActionSnapshot(context);
+    if (recoverySnapshot) return recoverySnapshot;
+
+    if (!job) {
+        return {
+            title: state.backendOk ? 'Prepare the next governed dispatch' : 'Restore backend connectivity',
+            detail: state.backendOk
+                ? 'Open Build to continue the active draft. The last selected run will stay actionable when one exists.'
+                : 'Connectivity must recover before preview-backed dispatch and live review can continue.',
+            tone: state.backendOk ? 'info' : 'warning',
+            primary: _operatorAction('open_build', 'Open Build', {
+                tone: 'info',
+                detail: 'Open Build without changing any route or API contract.'
+            }),
+            secondary: _compactOperatorActions([
+                _operatorAction('resume_draft', 'Resume Draft', {
+                    tone: 'info',
+                    detail: 'Resume the current draft and keep the active step focused.'
+                }),
+                !state.backendOk
+                    ? _operatorAction('retry_status_check', 'Retry Status Check', {
+                        tone: 'warning',
+                        detail: 'Retry bootstrap and backend checks while the portal is offline.'
+                    })
+                    : null
+            ])
+        };
+    }
+
+    if (job.state === 'running' || job.state === 'queued') {
+        return {
+            title: context.artifactCount > 0 ? 'Live run already has early outputs' : 'Stay with the live run',
+            detail: context.artifactCount > 0
+                ? 'Operate stays primary while early artifacts index. Review remains one click away when you need the retained outputs.'
+                : 'Use Operate to watch progress, warnings, and transport freshness until the first artifacts arrive.',
+            tone: _jobSurfaceTone(job),
+            primary: _operatorAction('stay_in_operate', 'Stay in Operate', {
+                jobId: context.jobId,
+                tone: _jobSurfaceTone(job),
+                detail: 'Keep the selected run pinned in Operate.'
+            }),
+            secondary: _compactOperatorActions([
+                context.reviewableOutputs
+                    ? _operatorAction('open_early_artifacts', 'Open Early Artifacts', {
+                        jobId: context.jobId,
+                        tone: 'warning',
+                        detail: 'Open Review using the current selected run and artifact route state.'
+                    })
+                    : null,
+                context.heroArtifact
+                    ? _operatorAction('open_latest_artifact', 'Open Latest Artifact', {
+                        jobId: context.jobId,
+                        artifactPath: _artifactRouteKey(context.heroArtifact),
+                        tone: 'info',
+                        detail: 'Open the highest-ranked indexed artifact for the selected run.'
+                    })
+                    : null
+            ])
+        };
+    }
+
+    if (job.state === 'partial' || job.state === 'failed' || job.state === 'canceled') {
+        return {
+            title: context.reviewableOutputs ? 'Retained outputs are ready for triage' : 'Return to Build after triage',
+            detail: context.reviewableOutputs
+                ? 'Open the retained outputs before rerunning failed inputs or rebuilding the next dispatch.'
+                : 'No reviewable outputs were retained. Return to Build after confirming the latest run context.',
+            tone: context.reviewableOutputs ? 'warning' : 'blocked',
+            primary: context.reviewableOutputs
+                ? _operatorAction('review_retained_outputs', 'Review Retained Outputs', {
+                    jobId: context.jobId,
+                    tone: 'warning',
+                    detail: 'Open Review for the retained outputs of the selected run.'
+                })
+                : _operatorAction('return_to_build', 'Return to Build', {
+                    tone: 'info',
+                    detail: 'Return to the build surface to prepare the next dispatch.'
+                }),
+            secondary: _compactOperatorActions([
+                _operatorAction('return_to_build', 'Return to Build', {
+                    tone: 'info',
+                    detail: 'Return to the build surface to prepare the next dispatch.'
+                }),
+                context.reviewableOutputs && context.heroArtifact
+                    ? _operatorAction('open_latest_artifact', 'Open Latest Artifact', {
+                        jobId: context.jobId,
+                        artifactPath: _artifactRouteKey(context.heroArtifact),
+                        tone: 'warning',
+                        detail: 'Open the highest-ranked retained artifact without changing the current route.'
+                    })
+                    : null
+            ])
+        };
+    }
+
+    if (job.state === 'offline') {
+        return {
+            title: context.reviewableOutputs ? 'Cached outputs remain reviewable' : 'Restore backend connectivity',
+            detail: context.reviewableOutputs
+                ? 'Live status is stale until connectivity returns, but retained artifacts stay available for operator review.'
+                : 'Live status is stale until connectivity returns. Retry the portal status check before trusting this run state.',
+            tone: 'warning',
+            primary: context.reviewableOutputs
+                ? _operatorAction('review_retained_outputs', 'Review Retained Outputs', {
+                    jobId: context.jobId,
+                    tone: 'warning',
+                    detail: 'Review retained outputs while backend connectivity recovers.'
+                })
+                : _operatorAction('retry_status_check', 'Retry Status Check', {
+                    jobId: context.jobId,
+                    tone: 'warning',
+                    detail: 'Retry bootstrap and backend status checks for the selected run.'
+                }),
+            secondary: _compactOperatorActions([
+                _operatorAction('retry_status_check', 'Retry Status Check', {
+                    jobId: context.jobId,
+                    tone: 'warning',
+                    detail: 'Retry bootstrap and backend status checks for the selected run.'
+                }),
+                _operatorAction('return_to_build', 'Return to Build', {
+                    tone: 'info',
+                    detail: 'Return to the build surface while connectivity recovers.'
+                })
+            ])
+        };
+    }
+
+    return {
+        title: context.reviewableOutputs ? 'Review context is ready' : 'Awaiting indexed outputs',
+        detail: context.reviewableOutputs
+            ? 'Open Review, pop the latest indexed artifact, or toggle compare without expanding the current route contract.'
+            : 'This run is selected, but no indexed outputs are available yet. Stay with the selected job context until they arrive.',
+        tone: context.reviewableOutputs ? 'ready' : 'info',
+        primary: context.reviewableOutputs
+            ? _operatorAction('open_review', 'Open Review', {
+                jobId: context.jobId,
+                tone: 'ready',
+                detail: 'Open Review using the selected run and current route-backed compare preference.'
+            })
+            : _operatorAction('stay_in_operate', 'Stay in Operate', {
+                jobId: context.jobId,
+                tone: 'info',
+                detail: 'Keep the selected run pinned in Operate until outputs arrive.'
+            }),
+        secondary: _compactOperatorActions([
+            context.heroArtifact
+                ? _operatorAction('open_latest_artifact', 'Open Latest Artifact', {
+                    jobId: context.jobId,
+                    artifactPath: _artifactRouteKey(context.heroArtifact),
+                    tone: 'ready',
+                    detail: 'Open the highest-ranked indexed artifact for the selected run.'
+                })
+                : null,
+            context.compareCandidate
+                ? _operatorAction('toggle_compare', 'Toggle Compare', {
+                    jobId: context.jobId,
+                    tone: context.compareEnabled ? 'ready' : 'info',
+                    detail: 'Toggle compare using the current artifact route and compare=1 contract.'
+                })
+                : null
+        ])
+    };
+}
+
+function _renderOperatorActionButton(button, action) {
+    if (!button) return;
+    if (!action) {
+        button.classList.add('hidden');
+        button.disabled = true;
+        button.textContent = '';
+        delete button.dataset.actionKey;
+        delete button.dataset.jobId;
+        delete button.dataset.artifactPath;
+        delete button.dataset.tone;
+        delete button.dataset.actionLabel;
+        button.removeAttribute('title');
+        return;
+    }
+    button.textContent = action.label;
+    button.disabled = Boolean(action.disabled);
+    button.dataset.actionKey = action.key;
+    button.dataset.jobId = action.jobId || '';
+    button.dataset.artifactPath = action.artifactPath || '';
+    button.dataset.tone = action.tone || 'info';
+    button.dataset.actionLabel = action.label;
+    if (action.detail) {
+        button.title = action.detail;
+    } else {
+        button.removeAttribute('title');
+    }
+    button.classList.remove('hidden');
+}
+
+function _renderContextualActionRow(container, primaryButton, secondaryButton, primaryAction, secondaryAction = null) {
+    if (!container) return;
+    const hasActions = Boolean(primaryAction || secondaryAction);
+    container.classList.toggle('hidden', !hasActions);
+    _renderOperatorActionButton(primaryButton, primaryAction);
+    _renderOperatorActionButton(secondaryButton, secondaryAction);
+}
+
+function renderOperatorActionRail() {
+    if (!els.consoleActionRail) return;
+    const visible = ['overview', 'build', 'operate', 'review'].includes(state.currentView);
+    els.consoleActionRail.classList.toggle('hidden', !visible);
+    if (!visible) return;
+
+    const snapshot = _operatorActionRailSnapshot();
+    els.consoleActionRail.dataset.tone = snapshot.tone || 'info';
+    if (els.consoleActionRailTitle) els.consoleActionRailTitle.textContent = snapshot.title;
+    if (els.consoleActionRailDetail) els.consoleActionRailDetail.textContent = snapshot.detail;
+    if (els.consoleActionRailHint) {
+        els.consoleActionRailHint.innerHTML = _operatorActionHintHtml();
+    }
+    if (els.consoleActionRailActions) {
+        const hasActions = Boolean(snapshot.primary || (Array.isArray(snapshot.secondary) && snapshot.secondary.length > 0));
+        els.consoleActionRailActions.classList.toggle('hidden', !hasActions);
+    }
+    _renderOperatorActionButton(els.consoleActionPrimaryBtn, snapshot.primary);
+    _renderOperatorActionButton(els.consoleActionSecondaryBtn1, snapshot.secondary?.[0] || null);
+    _renderOperatorActionButton(els.consoleActionSecondaryBtn2, snapshot.secondary?.[1] || null);
+}
+
+function renderSelectedJobRecoveryActions(job) {
+    const snapshot = _operatorActionRailSnapshot(job);
+    _renderContextualActionRow(
+        els.selectedJobRecoveryActions,
+        els.selectedJobRecoveryPrimaryBtn,
+        els.selectedJobRecoverySecondaryBtn,
+        snapshot.primary || null,
+        snapshot.secondary?.[0] || null
+    );
+}
+
+function renderReviewStatusActions(job, artifact) {
+    const snapshot = _operatorActionRailSnapshot(job);
+    _renderContextualActionRow(
+        els.reviewStatusActions,
+        els.reviewStatusPrimaryBtn,
+        els.reviewStatusSecondaryBtn,
+        snapshot.primary || null,
+        snapshot.secondary?.[0] || null
+    );
+}
+
+function _openReviewSurfaceForJob(job, surface = 'job_inspector') {
+    const normalizedJobId = _normalizeSelectedJobId(job?.id);
+    if (!normalizedJobId || !job) {
+        createToast('Select a run first, then open its review surface.', 'info');
+        return false;
+    }
+    void emitPortalEvent('run_details_opened', {
+        surface,
+        metadata: {
+            job_id: normalizedJobId,
+            pipeline: String(job.pipeline || '')
+        }
+    });
+    navigateConsoleView('review', { jobId: normalizedJobId });
+    return true;
+}
+
+function _openArtifactForSelection(job, artifact, surface = 'artifact_review') {
+    if (!job || !artifact) {
+        createToast('No artifact is available for this selection.', 'info');
+        return false;
+    }
+    const url = sanitizeManagedAssetUrl(buildArtifactUrl(job, artifact));
+    if (!url) {
+        createToast('No artifact URL is available for this selection.', 'error');
+        return false;
+    }
+    void emitPortalEvent('artifact_opened', {
+        surface,
+        metadata: {
+            job_id: String(job.id || ''),
+            media_kind: String(artifact.media_kind || 'file'),
+            pipeline: String(job.pipeline || '')
+        }
+    });
+    window.open(url, '_blank', 'noopener,noreferrer');
+    return true;
+}
+
+function _toggleCompareSurface(job, surface = 'artifact_review') {
+    if (!job) return false;
+    const key = _normalizeSelectedJobId(job.id);
+    const selectedArtifact = _selectedArtifactForJob(job);
+    const compareCandidate = findCompareArtifact(
+        selectedArtifact,
+        rankArtifactsForDisplay(Array.isArray(job.artifacts) ? job.artifacts : [])
+    );
+    if (!key || !compareCandidate) {
+        createToast('No paired comparison is available for this artifact.', 'info');
+        return false;
+    }
+    _rememberComparePreference(key, !Boolean(state.artifactUi.compareByJob[key]));
+    void emitPortalEvent('artifact_compared', {
+        surface,
+        metadata: {
+            enabled: Boolean(state.artifactUi.compareByJob[key]),
+            job_id: key,
+            pipeline: String(job.pipeline || '')
+        }
+    });
+    renderReviewSurfaces();
+    return true;
+}
+
+function _retryPortalStatus(job = null) {
+    void loadPortalBootstrap();
+    void checkBackend(true);
+    if (job) {
+        void refreshJobStatus(job);
+    }
+    return true;
+}
+
+function handleOperatorActionClick(event) {
+    const button = event.target.closest('button[data-action-key]');
+    if (!button || button.disabled) return;
+    const actionKey = String(button.dataset.actionKey || '').trim();
+    if (!actionKey) return;
+    const job = _findJobById(button.dataset.jobId || state.selectedJobId || _preferredSelectedJobId());
+    const context = _operatorActionContext(job);
+    switch (actionKey) {
+        case 'open_build':
+            navigateConsoleView('build');
+            setBuildStep(1, { silent: true });
+            if (els.pipelineSelect) els.pipelineSelect.focus();
+            break;
+        case 'resume_draft':
+            navigateConsoleView('build');
+            syncBuildStepUi();
+            {
+                const activeStep = document.querySelector('.build-step-tab.is-active');
+                if (activeStep && typeof activeStep.focus === 'function') activeStep.focus();
+            }
+            break;
+        case 'return_to_build':
+            navigateConsoleView('build');
+            break;
+        case 'stay_in_operate':
+            if (!job) {
+                createToast('No active run is available right now.', 'info');
+                return;
+            }
+            navigateConsoleView('operate', { jobId: context.jobId });
+            break;
+        case 'open_review':
+        case 'review_retained_outputs':
+        case 'open_early_artifacts':
+            if (state.currentView === 'review' && context.jobId) {
+                navigateConsoleView('review', {
+                    jobId: context.jobId,
+                    artifactPath: _artifactRouteKey(context.selectedArtifact),
+                    compareEnabled: context.compareEnabled
+                });
+            } else {
+                _openReviewSurfaceForJob(job, 'action_rail');
+            }
+            break;
+        case 'open_latest_artifact':
+            _openArtifactForSelection(job, context.heroArtifact || context.selectedArtifact, 'action_rail');
+            break;
+        case 'toggle_compare':
+            _toggleCompareSurface(job, 'action_rail');
+            break;
+        case 'retry_status_check':
+            _retryPortalStatus(job);
+            break;
+        case 'restore_access':
+            window.location.assign('/login');
+            break;
+        default:
+            break;
+    }
 }
 
 function _dispatchReadinessSnapshot(payload = null) {
@@ -1987,10 +2523,16 @@ function renderBuildStepPulse(payload = null) {
 }
 
 function renderConsoleContextRibbon() {
-    if (!els.consoleContextRibbon) return;
+    if (!els.consoleContextRibbon) {
+        renderOperatorActionRail();
+        return;
+    }
     const ribbonVisible = ['overview', 'build', 'operate', 'review'].includes(state.currentView);
     els.consoleContextRibbon.classList.toggle('hidden', !ribbonVisible);
-    if (!ribbonVisible) return;
+    if (!ribbonVisible) {
+        renderOperatorActionRail();
+        return;
+    }
 
     if (state.currentView === 'operate' || state.currentView === 'review') {
         const selected = state.jobs.find((job) => job.id === state.selectedJobId) || null;
@@ -2029,6 +2571,7 @@ function renderConsoleContextRibbon() {
             meta: selected ? compareCopy.ribbonMeta : 'Deep-linkable review context stays aligned with the URL.',
             tone: selected && compareEnabled ? 'ready' : 'info'
         });
+        renderOperatorActionRail();
         return;
     }
 
@@ -2085,6 +2628,7 @@ function renderConsoleContextRibbon() {
             : `${String(state.pipeline || 'lux-depth-v3')} • ${state.backendOk ? 'live backend connected' : 'dispatch paused until the backend recovers'}.`,
         tone: 'info'
     });
+    renderOperatorActionRail();
 }
 
 function applyConsoleViewLayout() {
@@ -2131,6 +2675,8 @@ function navigateConsoleView(viewName, options = {}) {
         _rememberSelectedJob(explicitJobId);
         if (hasArtifactOption) {
             _rememberArtifactSelection(explicitJobId, options.artifactPath);
+        } else if (state.currentView === 'review') {
+            _rememberArtifactSelection(explicitJobId, '');
         }
         if (hasCompareOption) {
             _rememberComparePreference(explicitJobId, options.compareEnabled);
@@ -2140,6 +2686,9 @@ function navigateConsoleView(viewName, options = {}) {
         if (preferredJobId) {
             state.selectedJobId = preferredJobId;
             _rememberSelectedJob(preferredJobId);
+            if (state.currentView === 'review' && !hasArtifactOption) {
+                _rememberArtifactSelection(preferredJobId, '');
+            }
         }
     } else if (state.selectedJobId) {
         _rememberSelectedJob(state.selectedJobId);
@@ -3637,6 +4186,7 @@ function renderSelectedJobInspector() {
         if (els.selectedJobRecoveryDetail) {
             els.selectedJobRecoveryDetail.textContent = 'The latest warning, artifact freshness, and recovery action will repopulate here when queue hydration finishes.';
         }
+        renderSelectedJobRecoveryActions(null);
         if (els.openRunDetailsBtn) els.openRunDetailsBtn.disabled = true;
         renderConsoleContextRibbon();
         return;
@@ -3659,6 +4209,7 @@ function renderSelectedJobInspector() {
         if (els.selectedJobRecoveryDetail) {
             els.selectedJobRecoveryDetail.textContent = 'Use Queue to inspect a recent run or open Build to create the next governed dispatch.';
         }
+        renderSelectedJobRecoveryActions(null);
         if (els.selectedJobTransportAlert) {
             els.selectedJobTransportAlert.classList.add('hidden');
             els.selectedJobTransportAlert.textContent = '';
@@ -3732,6 +4283,7 @@ function renderSelectedJobInspector() {
     const recovery = _selectedJobRecoverySnapshot(selected);
     if (els.selectedJobRecoveryTitle) els.selectedJobRecoveryTitle.textContent = recovery.title;
     if (els.selectedJobRecoveryDetail) els.selectedJobRecoveryDetail.textContent = recovery.detail;
+    renderSelectedJobRecoveryActions(selected);
     if (els.selectedJobTransportAlert) {
         if (visibleAlert) {
             els.selectedJobTransportAlert.textContent = String(visibleAlert.detail || '');
@@ -4154,6 +4706,10 @@ function _syncBootstrapUi() {
     }
     _syncBootstrapGuardedControls();
     _syncOverviewBuildLoadingState();
+    renderOperatorActionRail();
+    const selectedJob = _findJobById(state.selectedJobId);
+    renderSelectedJobRecoveryActions(selectedJob);
+    renderReviewStatusActions(selectedJob);
 }
 
 function _applyPortalBootstrap(rawBootstrap, options = {}) {
@@ -4777,12 +5333,14 @@ function _renderReviewStatusBanner(job, artifact) {
         els.reviewStatusTitle.textContent = snapshot.title;
         els.reviewStatusDetail.textContent = snapshot.detail;
         if (els.reviewStatusAction) els.reviewStatusAction.textContent = snapshot.action;
+        renderReviewStatusActions(job, artifact);
         return;
     }
     els.reviewStatusTitle.textContent = snapshot.title;
     els.reviewStatusDetail.textContent = snapshot.detail;
     if (els.reviewStatusAction) els.reviewStatusAction.textContent = snapshot.action;
     els.reviewStatusBanner.classList.remove('hidden');
+    renderReviewStatusActions(job, artifact);
 }
 
 function _renderArtifactProvenance(job, artifact) {
@@ -6207,7 +6765,7 @@ function _latestReviewableJob() {
         const summary = normalizeRunSummary(job.run_summary);
         const artifactCount = Array.isArray(job.artifacts) ? job.artifacts.length : 0;
         return artifactCount > 0
-            || Boolean(summary.reviewable_outputs)
+            || Boolean(summary?.reviewable_outputs)
             || job.state === 'succeeded'
             || job.state === 'partial';
     });
@@ -9188,19 +9746,8 @@ if (els.inspectorTimelineTab) els.inspectorTimelineTab.addEventListener('click',
 if (els.inspectorLogsTab) els.inspectorLogsTab.addEventListener('click', () => setInspectorTab('logs'));
 if (els.openRunDetailsBtn) {
     els.openRunDetailsBtn.addEventListener('click', () => {
-        if (!state.selectedJobId) {
-            createToast('Select a run first, then open its review surface.', 'info');
-            return;
-        }
         const selectedJob = state.jobs.find((item) => item.id === state.selectedJobId);
-        void emitPortalEvent('run_details_opened', {
-            surface: 'job_inspector',
-            metadata: {
-                job_id: String(state.selectedJobId || ''),
-                pipeline: String(selectedJob?.pipeline || '')
-            }
-        });
-        navigateConsoleView('review', { jobId: state.selectedJobId });
+        _openReviewSurfaceForJob(selectedJob, 'job_inspector');
     });
 }
 
@@ -9227,38 +9774,14 @@ if (els.artifactThumbnailRail) {
 if (els.artifactCompareBtn) {
     els.artifactCompareBtn.addEventListener('click', () => {
         const selectedJob = state.jobs.find((item) => item.id === state.selectedJobId);
-        if (!selectedJob) return;
-        const key = String(selectedJob.id || '');
-        _rememberComparePreference(key, !Boolean(state.artifactUi.compareByJob[key]));
-        void emitPortalEvent('artifact_compared', {
-            surface: 'artifact_review',
-            metadata: {
-                enabled: Boolean(state.artifactUi.compareByJob[key]),
-                job_id: key,
-                pipeline: String(selectedJob.pipeline || '')
-            }
-        });
-        renderReviewSurfaces();
+        _toggleCompareSurface(selectedJob, 'artifact_review');
     });
 }
 
 if (els.openArtifactBtn) {
     els.openArtifactBtn.addEventListener('click', () => {
-        const url = sanitizeManagedAssetUrl(els.openArtifactBtn.dataset.url);
-        if (!url) {
-            createToast('No artifact URL is available for this selection.', 'error');
-            return;
-        }
         const selectedJob = state.jobs.find((item) => item.id === state.selectedJobId);
-        void emitPortalEvent('artifact_opened', {
-            surface: 'artifact_review',
-            metadata: {
-                job_id: String(selectedJob?.id || ''),
-                media_kind: String(_selectedArtifactForJob(selectedJob)?.media_kind || 'file'),
-                pipeline: String(selectedJob?.pipeline || '')
-            }
-        });
-        window.open(url, '_blank', 'noopener,noreferrer');
+        _openArtifactForSelection(selectedJob, _selectedArtifactForJob(selectedJob), 'artifact_review');
     });
 }
 
@@ -9333,6 +9856,15 @@ if (els.refreshHealthBtn) {
         }
         navigateConsoleView('review', { jobId });
     });
+}
+if (els.consoleActionRailActions) {
+    els.consoleActionRailActions.addEventListener('click', handleOperatorActionClick);
+}
+if (els.selectedJobRecoveryActions) {
+    els.selectedJobRecoveryActions.addEventListener('click', handleOperatorActionClick);
+}
+if (els.reviewStatusActions) {
+    els.reviewStatusActions.addEventListener('click', handleOperatorActionClick);
 }
 if (els.jobList) els.jobList.addEventListener('click', handleJobListClick);
 if (els.jobList) els.jobList.addEventListener('keydown', handleJobListKeydown);

--- a/public/portal-assets/portal.js
+++ b/public/portal-assets/portal.js
@@ -3059,6 +3059,7 @@ function artifactLabel(artifact) {
 }
 
 function _artifactRouteKey(artifact) {
+    if (!artifact || typeof artifact !== 'object') return '';
     return _normalizeArtifactRoutePath(artifactLabel(artifact));
 }
 

--- a/scripts/validation/validate_portal_browser_smoke.py
+++ b/scripts/validation/validate_portal_browser_smoke.py
@@ -658,6 +658,25 @@ def _state_probe_expression() -> str:
     const el = document.getElementById(id);
     return el ? String(el.value || '') : '';
   };
+  const buttonMeta = (id) => {
+    const el = document.getElementById(id);
+    if (!el) {
+      return { visible: false, label: '', key: '', tone: '' };
+    }
+    return {
+      visible: !el.classList.contains('hidden') && !el.disabled,
+      label: (el.textContent || '').trim(),
+      key: String(el.dataset.actionKey || ''),
+      tone: String(el.dataset.tone || '')
+    };
+  };
+  const consoleActionPrimary = buttonMeta('consoleActionPrimaryBtn');
+  const consoleActionSecondary1 = buttonMeta('consoleActionSecondaryBtn1');
+  const consoleActionSecondary2 = buttonMeta('consoleActionSecondaryBtn2');
+  const selectedRecoveryPrimary = buttonMeta('selectedJobRecoveryPrimaryBtn');
+  const selectedRecoverySecondary = buttonMeta('selectedJobRecoverySecondaryBtn');
+  const reviewStatusPrimary = buttonMeta('reviewStatusPrimaryBtn');
+  const reviewStatusSecondary = buttonMeta('reviewStatusSecondaryBtn');
   return {
     title: document.title,
     readyState: document.readyState,
@@ -686,6 +705,24 @@ def _state_probe_expression() -> str:
     contextRibbonFreshness: text('contextRibbonFreshness'),
     contextRibbonArtifact: text('contextRibbonArtifact'),
     contextRibbonCompare: text('contextRibbonCompare'),
+    actionRailVisible: (() => {
+      const el = document.getElementById('consoleActionRail');
+      return !!(el && !el.classList.contains('hidden'));
+    })(),
+    actionRailTitle: text('consoleActionRailTitle'),
+    actionRailDetail: text('consoleActionRailDetail'),
+    actionPrimaryVisible: consoleActionPrimary.visible,
+    actionPrimaryLabel: consoleActionPrimary.label,
+    actionPrimaryKey: consoleActionPrimary.key,
+    actionPrimaryTone: consoleActionPrimary.tone,
+    actionSecondary1Visible: consoleActionSecondary1.visible,
+    actionSecondary1Label: consoleActionSecondary1.label,
+    actionSecondary1Key: consoleActionSecondary1.key,
+    actionSecondary1Tone: consoleActionSecondary1.tone,
+    actionSecondary2Visible: consoleActionSecondary2.visible,
+    actionSecondary2Label: consoleActionSecondary2.label,
+    actionSecondary2Key: consoleActionSecondary2.key,
+    actionSecondary2Tone: consoleActionSecondary2.tone,
     reviewStatusTitle: text('reviewStatusTitle'),
     reviewStatusDetail: text('reviewStatusDetail'),
     reviewStatusTone: (() => {
@@ -696,6 +733,18 @@ def _state_probe_expression() -> str:
       const el = document.getElementById('reviewStatusBanner');
       return !!(el && !el.classList.contains('hidden'));
     })(),
+    reviewStatusPrimaryVisible: reviewStatusPrimary.visible,
+    reviewStatusPrimaryLabel: reviewStatusPrimary.label,
+    reviewStatusPrimaryKey: reviewStatusPrimary.key,
+    reviewStatusSecondaryVisible: reviewStatusSecondary.visible,
+    reviewStatusSecondaryLabel: reviewStatusSecondary.label,
+    reviewStatusSecondaryKey: reviewStatusSecondary.key,
+    selectedRecoveryPrimaryVisible: selectedRecoveryPrimary.visible,
+    selectedRecoveryPrimaryLabel: selectedRecoveryPrimary.label,
+    selectedRecoveryPrimaryKey: selectedRecoveryPrimary.key,
+    selectedRecoverySecondaryVisible: selectedRecoverySecondary.visible,
+    selectedRecoverySecondaryLabel: selectedRecoverySecondary.label,
+    selectedRecoverySecondaryKey: selectedRecoverySecondary.key,
     reviewProvenanceArtifactRole: text('reviewProvenanceArtifactRole'),
     reviewProvenanceRunState: text('reviewProvenanceRunState'),
     reviewProvenancePath: text('reviewProvenancePath'),
@@ -1128,6 +1177,71 @@ def _click_expression(selector: str) -> str:
   if (!el) throw new Error('missing element for selector ' + {encoded});
   el.click();
   return true;
+}})()
+"""
+
+
+def _simulate_bootstrap_degraded_expression(*, reason: str, http_status: int) -> str:
+    payload = json.dumps({"reason": reason, "http_status": http_status})
+    return f"""
+(() => {{
+  const cfg = {payload};
+  _applyPortalBootstrap(portalInternals.defaultPortalBootstrapPayload(), {{
+    status: 'degraded',
+    reason: cfg.reason,
+    httpStatus: cfg.http_status
+  }});
+  renderSelectedJobInspector();
+  renderArtifactPanel();
+  renderConsoleContextRibbon();
+  return ({_state_probe_expression()});
+}})()
+"""
+
+
+def _inject_compare_ready_review_expression(job_id: str) -> str:
+    payload = json.dumps({"job_id": job_id})
+    return f"""
+(() => {{
+  const cfg = {payload};
+  const job = (typeof state !== 'undefined' && Array.isArray(state.jobs))
+    ? state.jobs.find((item) => String(item && item.id || '') === String(cfg.job_id || ''))
+    : null;
+  if (!job) {{
+    throw new Error(`missing job ${{cfg.job_id}}`);
+  }}
+  upsertArtifact(job, {{
+    path: 'synthetic/review-primary.png',
+    relative_path: 'synthetic/review-primary.png',
+    artifact_type: 'image',
+    media_kind: 'image',
+    previewable: true,
+    content_type: 'image/png',
+    size_bytes: 2048,
+    display_hint: {{
+      label: 'Synthetic Primary',
+      priority: 1000,
+      compare_group: 'portal-smoke-compare'
+    }}
+  }});
+  upsertArtifact(job, {{
+    path: 'synthetic/review-compare.png',
+    relative_path: 'synthetic/review-compare.png',
+    artifact_type: 'image',
+    media_kind: 'image',
+    previewable: true,
+    content_type: 'image/png',
+    size_bytes: 1984,
+    display_hint: {{
+      label: 'Synthetic Compare',
+      priority: 990,
+      compare_group: 'portal-smoke-compare'
+    }}
+  }});
+  state.artifactUi.selectedByJob[String(cfg.job_id)] = 'synthetic/review-primary.png';
+  state.artifactUi.compareByJob[String(cfg.job_id)] = false;
+  renderReviewSurfaces();
+  return ({_state_probe_expression()});
 }})()
 """
 
@@ -1819,9 +1933,21 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
             and str(terminal_state.get("contextRibbonJob", "")).strip() == submitted_job_id,
             f"Operate view should expose the compact context ribbon for the selected job: {terminal_state}",
         )
+        _expect(
+            bool(terminal_state.get("actionRailVisible")),
+            f"Operate view should surface the contextual action rail: {terminal_state}",
+        )
+        _expect(
+            str(terminal_state.get("actionPrimaryKey", "")).strip() == "open_review",
+            f"Completed runs should promote review entry as the primary action: {terminal_state}",
+        )
+        _expect(
+            str(terminal_state.get("selectedRecoveryPrimaryKey", "")).strip() == "open_review",
+            f"Selected-job recovery controls should reuse the review-entry action: {terminal_state}",
+        )
 
-        print("portal-browser-smoke: opening review view", flush=True)
-        connection.evaluate(_navigate_to_console_view_expression("review", submitted_job_id))
+        print("portal-browser-smoke: opening review from the contextual action rail", flush=True)
+        connection.evaluate(_click_expression("#consoleActionPrimaryBtn"))
         run_state = _poll(
             connection,
             _state_probe_expression(),
@@ -1833,6 +1959,7 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
                 and bool(value.get("reviewSurfaceVisible"))
                 and bool(value.get("reviewStatusVisible"))
                 and str(value.get("reviewProvenancePath", "")).strip() != ""
+                and "artifact=" in str(value.get("locationSearch", ""))
             ),
             timeout_seconds=args.timeout_seconds,
             description="review view to become active",
@@ -1869,8 +1996,62 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
             f"Review ribbon should stay aligned with the selected artifact context: {run_state}",
         )
 
-        selected_artifact_path = str(run_state.get("reviewProvenancePath", "")).strip()
-        _expect(selected_artifact_path, f"Review deep-link validation requires a selected artifact path: {run_state}")
+        print("portal-browser-smoke: synthesizing compare-ready review state", flush=True)
+        compare_ready_state = connection.evaluate(_inject_compare_ready_review_expression(submitted_job_id))
+        _expect(isinstance(compare_ready_state, dict), f"Unexpected compare-ready portal state: {compare_ready_state!r}")
+        compare_ready_state = _poll(
+            connection,
+            _state_probe_expression(),
+            predicate=lambda value: (
+                isinstance(value, dict)
+                and str(value.get("currentView", "")) == "review"
+                and str(value.get("selectedJobId", "")).strip() == submitted_job_id
+                and str(value.get("reviewProvenancePath", "")).strip() == "synthetic/review-primary.png"
+                and (
+                    str(value.get("actionSecondary2Key", "")).strip() == "toggle_compare"
+                    or str(value.get("actionSecondary1Key", "")).strip() == "toggle_compare"
+                    or str(value.get("reviewStatusSecondaryKey", "")).strip() == "toggle_compare"
+                )
+            ),
+            timeout_seconds=args.timeout_seconds,
+            description="synthetic compare-capable review state",
+        )
+        selected_artifact_path = str(compare_ready_state.get("reviewProvenancePath", "")).strip()
+        _expect(
+            selected_artifact_path == "synthetic/review-primary.png",
+            f"Compare-ready review state should promote the injected primary artifact: {compare_ready_state}",
+        )
+
+        compare_toggle_selector = ""
+        if str(compare_ready_state.get("actionSecondary2Key", "")).strip() == "toggle_compare":
+            compare_toggle_selector = "#consoleActionSecondaryBtn2"
+        elif str(compare_ready_state.get("actionSecondary1Key", "")).strip() == "toggle_compare":
+            compare_toggle_selector = "#consoleActionSecondaryBtn1"
+        elif str(compare_ready_state.get("reviewStatusSecondaryKey", "")).strip() == "toggle_compare":
+            compare_toggle_selector = "#reviewStatusSecondaryBtn"
+        _expect(
+            bool(compare_toggle_selector),
+            f"Ready review state should surface a compare toggle in the new action controls: {compare_ready_state}",
+        )
+        print("portal-browser-smoke: toggling compare from the new action controls", flush=True)
+        connection.evaluate(_click_expression(compare_toggle_selector))
+        compare_state = _poll(
+            connection,
+            _state_probe_expression(),
+            predicate=lambda value: (
+                isinstance(value, dict)
+                and str(value.get("currentView", "")) == "review"
+                and str(value.get("selectedJobId", "")).strip() == submitted_job_id
+                and bool(value.get("reviewCompareEnabled"))
+                and "compare=1" in str(value.get("locationSearch", ""))
+            ),
+            timeout_seconds=args.timeout_seconds,
+            description="compare toggle action to enable compare mode",
+        )
+        _expect(
+            str(compare_state.get("contextRibbonCompare", "")).strip().lower() == "compare on",
+            f"Action-rail compare toggles should preserve the compare route contract: {compare_state}",
+        )
 
         print("portal-browser-smoke: restoring review from an artifact deep link", flush=True)
         connection.evaluate(_navigate_to_console_view_expression("build"))
@@ -1958,6 +2139,42 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
         _expect(
             str(normalized_review_state.get("contextRibbonCompare", "")).strip().lower() != "compare on",
             f"Invalid compare deep links should fall back to a valid single-view review state: {normalized_review_state}",
+        )
+
+        print("portal-browser-smoke: simulating degraded auth recovery controls", flush=True)
+        degraded_state = connection.evaluate(
+            _simulate_bootstrap_degraded_expression(reason="auth_failure", http_status=401)
+        )
+        _expect(isinstance(degraded_state, dict), f"Unexpected degraded portal state: {degraded_state!r}")
+        _expect(
+            str(degraded_state.get("actionPrimaryKey", "")).strip() == "restore_access",
+            f"Degraded auth state should promote Restore Access in the action rail: {degraded_state}",
+        )
+        _expect(
+            str(degraded_state.get("actionSecondary1Key", "")).strip() == "retry_status_check",
+            f"Degraded auth state should surface Retry Status Check in the action rail: {degraded_state}",
+        )
+        _expect(
+            str(degraded_state.get("selectedRecoveryPrimaryKey", "")).strip() == "restore_access"
+            and str(degraded_state.get("reviewStatusPrimaryKey", "")).strip() == "restore_access",
+            f"Inspector and review recovery controls should stay aligned with degraded auth recovery: {degraded_state}",
+        )
+        connection.evaluate(_click_expression("#consoleActionSecondaryBtn1"))
+        recovered_state = _poll(
+            connection,
+            _state_probe_expression(),
+            predicate=lambda value: (
+                isinstance(value, dict)
+                and str(value.get("bootstrapStatus", "")).strip().lower() == "ready"
+                and str(value.get("currentView", "")).strip() == "review"
+                and str(value.get("selectedJobId", "")).strip() == submitted_job_id
+            ),
+            timeout_seconds=args.timeout_seconds,
+            description="retry status check to recover degraded bootstrap state",
+        )
+        _expect(
+            str(recovered_state.get("actionPrimaryKey", "")).strip() != "restore_access",
+            f"Retry Status Check should restore the contextual action rail once bootstrap recovers: {recovered_state}",
         )
 
         print("portal-browser-smoke: round-tripping through build and back to operate", flush=True)

--- a/tests/test_app_orchestrator_runtime.py
+++ b/tests/test_app_orchestrator_runtime.py
@@ -873,6 +873,7 @@ def test_portal_artifact_gallery_renders_visual_review_controls() -> None:
     rank_body = _extract_js_function_body(content, "rankArtifactsForDisplay")
     compare_body = _extract_js_function_body(content, "findCompareArtifact")
     normalize_body = _extract_js_function_body(content, "normalizeArtifactItems")
+    route_key_body = _extract_js_function_body(content, "_artifactRouteKey")
 
     assert 'id="artifactPreviewStage"' in content
     assert 'id="artifactThumbnailRail"' in content
@@ -894,6 +895,7 @@ def test_portal_artifact_gallery_renders_visual_review_controls() -> None:
     assert "artifactDisplayPriority(right)" in rank_body
     assert "artifactCompareGroup(candidate) === primaryGroup" in compare_body
     assert "display_hint: _normalizeArtifactDisplayHint(item.display_hint)" in normalize_body
+    assert "if (!artifact || typeof artifact !== 'object') return '';" in route_key_body
     assert "_resetArtifactActionButtons();" in body
     assert "renderConsoleContextRibbon();" in body
     assert "_syncConsoleRoute(true);" in body

--- a/tests/test_app_orchestrator_runtime.py
+++ b/tests/test_app_orchestrator_runtime.py
@@ -869,6 +869,7 @@ def test_portal_artifact_gallery_renders_visual_review_controls() -> None:
     body = _extract_js_function_body(content, "renderArtifactPanel")
     reset_body = _extract_js_function_body(content, "_resetArtifactActionButtons")
     sanitize_body = _extract_js_function_body(content, "sanitizeManagedAssetUrl")
+    open_artifact_body = _extract_js_function_body(content, "_openArtifactForSelection")
     rank_body = _extract_js_function_body(content, "rankArtifactsForDisplay")
     compare_body = _extract_js_function_body(content, "findCompareArtifact")
     normalize_body = _extract_js_function_body(content, "normalizeArtifactItems")
@@ -901,7 +902,7 @@ def test_portal_artifact_gallery_renders_visual_review_controls() -> None:
     assert "delete els.copyArtifactPathBtn.dataset.path;" in reset_body
     assert "parsed.origin !== window.location.origin" in sanitize_body
     assert "parsed.pathname.startsWith('/v1/jobs/')" in sanitize_body
-    assert "sanitizeManagedAssetUrl(els.openArtifactBtn.dataset.url)" in content
+    assert "sanitizeManagedAssetUrl(buildArtifactUrl(job, artifact))" in open_artifact_body
     assert "sanitizeManagedAssetUrl(els.downloadArtifactBtn.dataset.url)" in content
 
 
@@ -1655,6 +1656,50 @@ def test_portal_runtime_briefing_and_recovery_surfaces_stay_additive_and_selecto
     assert "els.reviewStatusAction.textContent = snapshot.action;" in content
     assert "els.selectedJobRecoveryTitle.textContent = recovery.title;" in inspector_body
     assert "els.selectedJobRecoveryDetail.textContent = recovery.detail;" in inspector_body
+
+
+def test_portal_contextual_action_rail_reuses_existing_route_and_recovery_contracts() -> None:
+    content = _portal_bundle_content()
+    rail_snapshot_body = _extract_js_function_body(content, "_operatorActionRailSnapshot")
+    recovery_snapshot_body = _extract_js_function_body(content, "_operatorRecoveryActionSnapshot")
+    rail_render_body = _extract_js_function_body(content, "renderOperatorActionRail")
+    inspector_actions_body = _extract_js_function_body(content, "renderSelectedJobRecoveryActions")
+    review_actions_body = _extract_js_function_body(content, "renderReviewStatusActions")
+    handler_body = _extract_js_function_body(content, "handleOperatorActionClick")
+
+    assert 'data-ui="console-action-rail"' in content
+    assert 'data-ui="console-action-shortcuts"' in content
+    assert 'data-ui="console-action-primary"' in content
+    assert 'data-ui="console-action-secondary-1"' in content
+    assert 'data-ui="console-action-secondary-2"' in content
+    assert 'data-ui="selected-job-recovery-actions"' in content
+    assert 'data-ui="selected-job-recovery-primary"' in content
+    assert 'data-ui="selected-job-recovery-secondary"' in content
+    assert 'data-ui="review-status-actions"' in content
+    assert 'data-ui="review-status-primary"' in content
+    assert 'data-ui="review-status-secondary"' in content
+    assert "Open Review" in rail_snapshot_body
+    assert "Open Latest Artifact" in rail_snapshot_body
+    assert "Toggle Compare" in rail_snapshot_body
+    assert "Stay in Operate" in rail_snapshot_body
+    assert "Open Early Artifacts" in rail_snapshot_body
+    assert "Review Retained Outputs" in rail_snapshot_body
+    assert "Return to Build" in rail_snapshot_body
+    assert "Restore Access" in recovery_snapshot_body
+    assert "Retry Status Check" in recovery_snapshot_body
+    assert "els.consoleActionRailHint.innerHTML = _operatorActionHintHtml();" in rail_render_body
+    assert "const snapshot = _operatorActionRailSnapshot(job);" in inspector_actions_body
+    assert "const snapshot = _operatorActionRailSnapshot(job);" in review_actions_body
+    assert "_openReviewSurfaceForJob(job, 'action_rail');" in handler_body
+    assert "_openArtifactForSelection(job, context.heroArtifact || context.selectedArtifact, 'action_rail');" in handler_body
+    assert "_toggleCompareSurface(job, 'action_rail');" in handler_body
+    assert "_retryPortalStatus(job);" in handler_body
+    assert "window.location.assign('/login');" in handler_body
+    assert "_rememberArtifactSelection(explicitJobId, '');" in content
+    assert "_rememberArtifactSelection(preferredJobId, '');" in content
+    assert "url.searchParams.set('action'" not in content
+    assert "url.searchParams.set('mode'" not in content
+    assert "url.searchParams.set('shortcut'" not in content
 
 
 def test_portal_submit_blocks_preview_unavailable_and_debug_bundle_without_acknowledgement() -> None:

--- a/tests/validation/test_portal_smoke_scripts.py
+++ b/tests/validation/test_portal_smoke_scripts.py
@@ -144,6 +144,49 @@ def test_portal_browser_help_text_describes_api_key_default(capsys: pytest.Captu
     assert "default: unset; uses TP_API_KEY when set" in help_output
 
 
+def test_portal_browser_state_probe_tracks_contextual_action_controls():
+    module = _load_module(PORTAL_BROWSER_SCRIPT_PATH, "tests_validate_portal_browser_smoke_action_probe")
+
+    expression = module._state_probe_expression()
+
+    assert "consoleActionPrimaryBtn" in expression
+    assert "consoleActionSecondaryBtn1" in expression
+    assert "consoleActionSecondaryBtn2" in expression
+    assert "selectedJobRecoveryPrimaryBtn" in expression
+    assert "selectedJobRecoverySecondaryBtn" in expression
+    assert "reviewStatusPrimaryBtn" in expression
+    assert "reviewStatusSecondaryBtn" in expression
+    assert "actionPrimaryKey" in expression
+    assert "actionSecondary2Key" in expression
+    assert "selectedRecoveryPrimaryKey" in expression
+    assert "reviewStatusPrimaryKey" in expression
+
+
+def test_portal_browser_can_simulate_bootstrap_degraded_recovery_actions():
+    module = _load_module(PORTAL_BROWSER_SCRIPT_PATH, "tests_validate_portal_browser_smoke_degraded_expr")
+
+    expression = module._simulate_bootstrap_degraded_expression(reason="auth_failure", http_status=401)
+
+    assert "_applyPortalBootstrap" in expression
+    assert "status: 'degraded'" in expression
+    assert '"reason": "auth_failure"' in expression
+    assert '"http_status": 401' in expression
+    assert "renderSelectedJobInspector();" in expression
+    assert "renderArtifactPanel();" in expression
+    assert "renderConsoleContextRibbon();" in expression
+
+
+def test_portal_browser_can_inject_compare_ready_review_state():
+    module = _load_module(PORTAL_BROWSER_SCRIPT_PATH, "tests_validate_portal_browser_smoke_compare_expr")
+
+    expression = module._inject_compare_ready_review_expression("job_demo")
+
+    assert "synthetic/review-primary.png" in expression
+    assert "synthetic/review-compare.png" in expression
+    assert "portal-smoke-compare" in expression
+    assert "renderReviewSurfaces();" in expression
+
+
 def test_portal_browser_preview_preflight_classifies_auth_failures(monkeypatch: pytest.MonkeyPatch):
     module = _load_module(PORTAL_BROWSER_SCRIPT_PATH, "tests_validate_portal_browser_smoke_preflight_auth")
 

--- a/web/secure-landing/portal-src/portal.template.js
+++ b/web/secure-landing/portal-src/portal.template.js
@@ -2663,6 +2663,7 @@ function artifactLabel(artifact) {
 }
 
 function _artifactRouteKey(artifact) {
+    if (!artifact || typeof artifact !== 'object') return '';
     return _normalizeArtifactRoutePath(artifactLabel(artifact));
 }
 

--- a/web/secure-landing/portal-src/portal.template.js
+++ b/web/secure-landing/portal-src/portal.template.js
@@ -141,6 +141,14 @@ const els = {
     consoleViewSummary: _domId('consoleViewSummary'),
     consoleViewMeta: _domId('consoleViewMeta'),
     consoleContextRibbon: _domId('consoleContextRibbon'),
+    consoleActionRail: _domId('consoleActionRail'),
+    consoleActionRailTitle: _domId('consoleActionRailTitle'),
+    consoleActionRailDetail: _domId('consoleActionRailDetail'),
+    consoleActionRailHint: _domId('consoleActionRailHint'),
+    consoleActionRailActions: _domId('consoleActionRailActions'),
+    consoleActionPrimaryBtn: _domId('consoleActionPrimaryBtn'),
+    consoleActionSecondaryBtn1: _domId('consoleActionSecondaryBtn1'),
+    consoleActionSecondaryBtn2: _domId('consoleActionSecondaryBtn2'),
     contextRibbonCard1: _domId('contextRibbonCard1'),
     contextRibbonCard1Label: _domId('contextRibbonCard1Label'),
     contextRibbonJob: _domId('contextRibbonJob'),
@@ -393,6 +401,9 @@ const els = {
     selectedJobSummary: _domId('selectedJobSummary'),
     selectedJobRecoveryTitle: _domId('selectedJobRecoveryTitle'),
     selectedJobRecoveryDetail: _domId('selectedJobRecoveryDetail'),
+    selectedJobRecoveryActions: _domId('selectedJobRecoveryActions'),
+    selectedJobRecoveryPrimaryBtn: _domId('selectedJobRecoveryPrimaryBtn'),
+    selectedJobRecoverySecondaryBtn: _domId('selectedJobRecoverySecondaryBtn'),
     selectedJobTransportAlert: _domId('selectedJobTransportAlert'),
     openRunDetailsBtn: _domId('openRunDetailsBtn'),
     inspectorOverviewTab: _domId('inspectorOverviewTab'),
@@ -428,6 +439,9 @@ const els = {
     reviewStatusTitle: _domId('reviewStatusTitle'),
     reviewStatusDetail: _domId('reviewStatusDetail'),
     reviewStatusAction: _domId('reviewStatusAction'),
+    reviewStatusActions: _domId('reviewStatusActions'),
+    reviewStatusPrimaryBtn: _domId('reviewStatusPrimaryBtn'),
+    reviewStatusSecondaryBtn: _domId('reviewStatusSecondaryBtn'),
     reviewProvenanceGrid: _domId('reviewProvenanceGrid'),
     reviewProvenanceArtifactRole: _domId('reviewProvenanceArtifactRole'),
     reviewProvenanceRunState: _domId('reviewProvenanceRunState'),
@@ -985,6 +999,528 @@ function _compareSurfaceCopy(selectedArtifact, compareArtifact, compareEnabled) 
         summaryTitle: 'Paired comparison available',
         summaryDetail: `${compareLabel} is available as a side-by-side comparison for ${primaryLabel}.`,
     };
+}
+
+function _findJobById(jobId) {
+    const normalizedJobId = _normalizeSelectedJobId(jobId);
+    if (!normalizedJobId) return null;
+    return state.jobs.find((job) => _normalizeSelectedJobId(job?.id) === normalizedJobId) || null;
+}
+
+function _jobHasReviewableOutputs(job) {
+    if (!job) return false;
+    const summary = normalizeRunSummary(job.run_summary);
+    const artifactCount = Array.isArray(job.artifacts) ? job.artifacts.length : 0;
+    return artifactCount > 0 || Boolean(summary?.reviewable_outputs);
+}
+
+function _operatorAction(key, label, options = {}) {
+    const normalizedKey = String(key || '').trim();
+    const normalizedLabel = String(label || '').trim();
+    if (!normalizedKey || !normalizedLabel) return null;
+    return {
+        key: normalizedKey,
+        label: normalizedLabel,
+        tone: String(options.tone || 'info'),
+        jobId: _normalizeSelectedJobId(options.jobId || ''),
+        artifactPath: _normalizeArtifactRoutePath(options.artifactPath || ''),
+        detail: String(options.detail || '').trim(),
+        disabled: Boolean(options.disabled)
+    };
+}
+
+function _compactOperatorActions(actions, maxCount = 2) {
+    const seen = new Set();
+    const compact = [];
+    (Array.isArray(actions) ? actions : []).forEach((action) => {
+        if (!action || !action.key || seen.has(action.key)) return;
+        seen.add(action.key);
+        compact.push(action);
+    });
+    return compact.slice(0, maxCount);
+}
+
+function _operatorActionContext(job) {
+    const normalizedJobId = _normalizeSelectedJobId(job?.id);
+    const artifacts = Array.isArray(job?.artifacts) ? rankArtifactsForDisplay(job.artifacts) : [];
+    const selectedArtifact = job ? _selectedArtifactForJob(job) : null;
+    const heroArtifact = artifacts[0] || selectedArtifact || null;
+    const activeArtifact = selectedArtifact || heroArtifact;
+    const compareCandidate = job ? findCompareArtifact(activeArtifact, artifacts) : null;
+    const compareEnabled = Boolean(
+        normalizedJobId
+        && compareCandidate
+        && state.artifactUi.compareByJob[normalizedJobId]
+    );
+    return {
+        job,
+        jobId: normalizedJobId,
+        artifacts,
+        artifactCount: artifacts.length,
+        selectedArtifact: activeArtifact,
+        heroArtifact,
+        compareCandidate,
+        compareEnabled,
+        reviewableOutputs: _jobHasReviewableOutputs(job)
+    };
+}
+
+function _preferredOperatorActionJob() {
+    const preferredJobId = _preferredSelectedJobId();
+    return _findJobById(preferredJobId) || _latestActiveJob() || _latestReviewableJob() || null;
+}
+
+function _operatorActionHintHtml() {
+    const base = [
+        '<span class="kbd">1</span> overview',
+        '<span class="kbd">2</span> build',
+        '<span class="kbd">3</span> operate',
+        '<span class="kbd">4</span> review',
+        '<span class="kbd">?</span> shortcuts'
+    ];
+    if (state.currentView === 'build') {
+        base.push('<span class="kbd">Ctrl/⌘ + Enter</span> dispatch');
+        base.push('<span class="kbd">Ctrl/⌘ + Shift + C</span> copy CLI');
+    }
+    return `Keyboard: ${base.join(', ')}.`;
+}
+
+function _operatorRecoveryActionSnapshot(context) {
+    const job = context.job;
+    const bootstrapStatus = String(state.bootstrap?.status || 'pending').trim().toLowerCase();
+    const reconnectBlocked = Boolean(job?.reconnectBlocked);
+    const hasBootstrapFailure = bootstrapStatus === 'degraded' || bootstrapStatus === 'unavailable';
+    if (!reconnectBlocked && !hasBootstrapFailure) return null;
+
+    const failure = reconnectBlocked
+        ? _bootstrapFailureDetails('auth_failure', 401)
+        : _bootstrapFailureDetails(state.bootstrap.lastErrorReason, state.bootstrap.lastHttpStatus);
+    const tone = failure.retryable ? 'warning' : 'blocked';
+
+    if (failure.reason === 'auth_failure' || reconnectBlocked) {
+        return {
+            title: 'Restore access before live actions continue',
+            detail: failure.actionMessage,
+            tone,
+            primary: _operatorAction('restore_access', 'Restore Access', {
+                jobId: context.jobId,
+                tone,
+                detail: failure.actionMessage
+            }),
+            secondary: _compactOperatorActions([
+                _operatorAction('retry_status_check', 'Retry Status Check', {
+                    jobId: context.jobId,
+                    tone: 'info',
+                    detail: 'Retry bootstrap and backend status checks without expanding the route contract.'
+                })
+            ])
+        };
+    }
+
+    return {
+        title: failure.reason === 'access_outage' ? 'Managed access is degraded' : 'Portal recovery is required',
+        detail: failure.actionMessage,
+        tone,
+        primary: _operatorAction('retry_status_check', 'Retry Status Check', {
+            jobId: context.jobId,
+            tone,
+            detail: failure.actionMessage
+        }),
+        secondary: _compactOperatorActions([
+            context.reviewableOutputs
+                ? _operatorAction('review_retained_outputs', 'Review Retained Outputs', {
+                    jobId: context.jobId,
+                    tone: 'warning',
+                    detail: 'Open retained outputs while live status is recovering.'
+                })
+                : _operatorAction('return_to_build', 'Return to Build', {
+                    tone: 'info',
+                    detail: 'Return to the build surface while access recovery completes.'
+                })
+        ])
+    };
+}
+
+function _operatorActionRailSnapshot(jobOverride = undefined) {
+    const job = arguments.length > 0 ? jobOverride : _preferredOperatorActionJob();
+    const context = _operatorActionContext(job);
+    const recoverySnapshot = _operatorRecoveryActionSnapshot(context);
+    if (recoverySnapshot) return recoverySnapshot;
+
+    if (!job) {
+        return {
+            title: state.backendOk ? 'Prepare the next governed dispatch' : 'Restore backend connectivity',
+            detail: state.backendOk
+                ? 'Open Build to continue the active draft. The last selected run will stay actionable when one exists.'
+                : 'Connectivity must recover before preview-backed dispatch and live review can continue.',
+            tone: state.backendOk ? 'info' : 'warning',
+            primary: _operatorAction('open_build', 'Open Build', {
+                tone: 'info',
+                detail: 'Open Build without changing any route or API contract.'
+            }),
+            secondary: _compactOperatorActions([
+                _operatorAction('resume_draft', 'Resume Draft', {
+                    tone: 'info',
+                    detail: 'Resume the current draft and keep the active step focused.'
+                }),
+                !state.backendOk
+                    ? _operatorAction('retry_status_check', 'Retry Status Check', {
+                        tone: 'warning',
+                        detail: 'Retry bootstrap and backend checks while the portal is offline.'
+                    })
+                    : null
+            ])
+        };
+    }
+
+    if (job.state === 'running' || job.state === 'queued') {
+        return {
+            title: context.artifactCount > 0 ? 'Live run already has early outputs' : 'Stay with the live run',
+            detail: context.artifactCount > 0
+                ? 'Operate stays primary while early artifacts index. Review remains one click away when you need the retained outputs.'
+                : 'Use Operate to watch progress, warnings, and transport freshness until the first artifacts arrive.',
+            tone: _jobSurfaceTone(job),
+            primary: _operatorAction('stay_in_operate', 'Stay in Operate', {
+                jobId: context.jobId,
+                tone: _jobSurfaceTone(job),
+                detail: 'Keep the selected run pinned in Operate.'
+            }),
+            secondary: _compactOperatorActions([
+                context.reviewableOutputs
+                    ? _operatorAction('open_early_artifacts', 'Open Early Artifacts', {
+                        jobId: context.jobId,
+                        tone: 'warning',
+                        detail: 'Open Review using the current selected run and artifact route state.'
+                    })
+                    : null,
+                context.heroArtifact
+                    ? _operatorAction('open_latest_artifact', 'Open Latest Artifact', {
+                        jobId: context.jobId,
+                        artifactPath: _artifactRouteKey(context.heroArtifact),
+                        tone: 'info',
+                        detail: 'Open the highest-ranked indexed artifact for the selected run.'
+                    })
+                    : null
+            ])
+        };
+    }
+
+    if (job.state === 'partial' || job.state === 'failed' || job.state === 'canceled') {
+        return {
+            title: context.reviewableOutputs ? 'Retained outputs are ready for triage' : 'Return to Build after triage',
+            detail: context.reviewableOutputs
+                ? 'Open the retained outputs before rerunning failed inputs or rebuilding the next dispatch.'
+                : 'No reviewable outputs were retained. Return to Build after confirming the latest run context.',
+            tone: context.reviewableOutputs ? 'warning' : 'blocked',
+            primary: context.reviewableOutputs
+                ? _operatorAction('review_retained_outputs', 'Review Retained Outputs', {
+                    jobId: context.jobId,
+                    tone: 'warning',
+                    detail: 'Open Review for the retained outputs of the selected run.'
+                })
+                : _operatorAction('return_to_build', 'Return to Build', {
+                    tone: 'info',
+                    detail: 'Return to the build surface to prepare the next dispatch.'
+                }),
+            secondary: _compactOperatorActions([
+                _operatorAction('return_to_build', 'Return to Build', {
+                    tone: 'info',
+                    detail: 'Return to the build surface to prepare the next dispatch.'
+                }),
+                context.reviewableOutputs && context.heroArtifact
+                    ? _operatorAction('open_latest_artifact', 'Open Latest Artifact', {
+                        jobId: context.jobId,
+                        artifactPath: _artifactRouteKey(context.heroArtifact),
+                        tone: 'warning',
+                        detail: 'Open the highest-ranked retained artifact without changing the current route.'
+                    })
+                    : null
+            ])
+        };
+    }
+
+    if (job.state === 'offline') {
+        return {
+            title: context.reviewableOutputs ? 'Cached outputs remain reviewable' : 'Restore backend connectivity',
+            detail: context.reviewableOutputs
+                ? 'Live status is stale until connectivity returns, but retained artifacts stay available for operator review.'
+                : 'Live status is stale until connectivity returns. Retry the portal status check before trusting this run state.',
+            tone: 'warning',
+            primary: context.reviewableOutputs
+                ? _operatorAction('review_retained_outputs', 'Review Retained Outputs', {
+                    jobId: context.jobId,
+                    tone: 'warning',
+                    detail: 'Review retained outputs while backend connectivity recovers.'
+                })
+                : _operatorAction('retry_status_check', 'Retry Status Check', {
+                    jobId: context.jobId,
+                    tone: 'warning',
+                    detail: 'Retry bootstrap and backend status checks for the selected run.'
+                }),
+            secondary: _compactOperatorActions([
+                _operatorAction('retry_status_check', 'Retry Status Check', {
+                    jobId: context.jobId,
+                    tone: 'warning',
+                    detail: 'Retry bootstrap and backend status checks for the selected run.'
+                }),
+                _operatorAction('return_to_build', 'Return to Build', {
+                    tone: 'info',
+                    detail: 'Return to the build surface while connectivity recovers.'
+                })
+            ])
+        };
+    }
+
+    return {
+        title: context.reviewableOutputs ? 'Review context is ready' : 'Awaiting indexed outputs',
+        detail: context.reviewableOutputs
+            ? 'Open Review, pop the latest indexed artifact, or toggle compare without expanding the current route contract.'
+            : 'This run is selected, but no indexed outputs are available yet. Stay with the selected job context until they arrive.',
+        tone: context.reviewableOutputs ? 'ready' : 'info',
+        primary: context.reviewableOutputs
+            ? _operatorAction('open_review', 'Open Review', {
+                jobId: context.jobId,
+                tone: 'ready',
+                detail: 'Open Review using the selected run and current route-backed compare preference.'
+            })
+            : _operatorAction('stay_in_operate', 'Stay in Operate', {
+                jobId: context.jobId,
+                tone: 'info',
+                detail: 'Keep the selected run pinned in Operate until outputs arrive.'
+            }),
+        secondary: _compactOperatorActions([
+            context.heroArtifact
+                ? _operatorAction('open_latest_artifact', 'Open Latest Artifact', {
+                    jobId: context.jobId,
+                    artifactPath: _artifactRouteKey(context.heroArtifact),
+                    tone: 'ready',
+                    detail: 'Open the highest-ranked indexed artifact for the selected run.'
+                })
+                : null,
+            context.compareCandidate
+                ? _operatorAction('toggle_compare', 'Toggle Compare', {
+                    jobId: context.jobId,
+                    tone: context.compareEnabled ? 'ready' : 'info',
+                    detail: 'Toggle compare using the current artifact route and compare=1 contract.'
+                })
+                : null
+        ])
+    };
+}
+
+function _renderOperatorActionButton(button, action) {
+    if (!button) return;
+    if (!action) {
+        button.classList.add('hidden');
+        button.disabled = true;
+        button.textContent = '';
+        delete button.dataset.actionKey;
+        delete button.dataset.jobId;
+        delete button.dataset.artifactPath;
+        delete button.dataset.tone;
+        delete button.dataset.actionLabel;
+        button.removeAttribute('title');
+        return;
+    }
+    button.textContent = action.label;
+    button.disabled = Boolean(action.disabled);
+    button.dataset.actionKey = action.key;
+    button.dataset.jobId = action.jobId || '';
+    button.dataset.artifactPath = action.artifactPath || '';
+    button.dataset.tone = action.tone || 'info';
+    button.dataset.actionLabel = action.label;
+    if (action.detail) {
+        button.title = action.detail;
+    } else {
+        button.removeAttribute('title');
+    }
+    button.classList.remove('hidden');
+}
+
+function _renderContextualActionRow(container, primaryButton, secondaryButton, primaryAction, secondaryAction = null) {
+    if (!container) return;
+    const hasActions = Boolean(primaryAction || secondaryAction);
+    container.classList.toggle('hidden', !hasActions);
+    _renderOperatorActionButton(primaryButton, primaryAction);
+    _renderOperatorActionButton(secondaryButton, secondaryAction);
+}
+
+function renderOperatorActionRail() {
+    if (!els.consoleActionRail) return;
+    const visible = ['overview', 'build', 'operate', 'review'].includes(state.currentView);
+    els.consoleActionRail.classList.toggle('hidden', !visible);
+    if (!visible) return;
+
+    const snapshot = _operatorActionRailSnapshot();
+    els.consoleActionRail.dataset.tone = snapshot.tone || 'info';
+    if (els.consoleActionRailTitle) els.consoleActionRailTitle.textContent = snapshot.title;
+    if (els.consoleActionRailDetail) els.consoleActionRailDetail.textContent = snapshot.detail;
+    if (els.consoleActionRailHint) {
+        els.consoleActionRailHint.innerHTML = _operatorActionHintHtml();
+    }
+    if (els.consoleActionRailActions) {
+        const hasActions = Boolean(snapshot.primary || (Array.isArray(snapshot.secondary) && snapshot.secondary.length > 0));
+        els.consoleActionRailActions.classList.toggle('hidden', !hasActions);
+    }
+    _renderOperatorActionButton(els.consoleActionPrimaryBtn, snapshot.primary);
+    _renderOperatorActionButton(els.consoleActionSecondaryBtn1, snapshot.secondary?.[0] || null);
+    _renderOperatorActionButton(els.consoleActionSecondaryBtn2, snapshot.secondary?.[1] || null);
+}
+
+function renderSelectedJobRecoveryActions(job) {
+    const snapshot = _operatorActionRailSnapshot(job);
+    _renderContextualActionRow(
+        els.selectedJobRecoveryActions,
+        els.selectedJobRecoveryPrimaryBtn,
+        els.selectedJobRecoverySecondaryBtn,
+        snapshot.primary || null,
+        snapshot.secondary?.[0] || null
+    );
+}
+
+function renderReviewStatusActions(job, artifact) {
+    const snapshot = _operatorActionRailSnapshot(job);
+    _renderContextualActionRow(
+        els.reviewStatusActions,
+        els.reviewStatusPrimaryBtn,
+        els.reviewStatusSecondaryBtn,
+        snapshot.primary || null,
+        snapshot.secondary?.[0] || null
+    );
+}
+
+function _openReviewSurfaceForJob(job, surface = 'job_inspector') {
+    const normalizedJobId = _normalizeSelectedJobId(job?.id);
+    if (!normalizedJobId || !job) {
+        createToast('Select a run first, then open its review surface.', 'info');
+        return false;
+    }
+    void emitPortalEvent('run_details_opened', {
+        surface,
+        metadata: {
+            job_id: normalizedJobId,
+            pipeline: String(job.pipeline || '')
+        }
+    });
+    navigateConsoleView('review', { jobId: normalizedJobId });
+    return true;
+}
+
+function _openArtifactForSelection(job, artifact, surface = 'artifact_review') {
+    if (!job || !artifact) {
+        createToast('No artifact is available for this selection.', 'info');
+        return false;
+    }
+    const url = sanitizeManagedAssetUrl(buildArtifactUrl(job, artifact));
+    if (!url) {
+        createToast('No artifact URL is available for this selection.', 'error');
+        return false;
+    }
+    void emitPortalEvent('artifact_opened', {
+        surface,
+        metadata: {
+            job_id: String(job.id || ''),
+            media_kind: String(artifact.media_kind || 'file'),
+            pipeline: String(job.pipeline || '')
+        }
+    });
+    window.open(url, '_blank', 'noopener,noreferrer');
+    return true;
+}
+
+function _toggleCompareSurface(job, surface = 'artifact_review') {
+    if (!job) return false;
+    const key = _normalizeSelectedJobId(job.id);
+    const selectedArtifact = _selectedArtifactForJob(job);
+    const compareCandidate = findCompareArtifact(
+        selectedArtifact,
+        rankArtifactsForDisplay(Array.isArray(job.artifacts) ? job.artifacts : [])
+    );
+    if (!key || !compareCandidate) {
+        createToast('No paired comparison is available for this artifact.', 'info');
+        return false;
+    }
+    _rememberComparePreference(key, !Boolean(state.artifactUi.compareByJob[key]));
+    void emitPortalEvent('artifact_compared', {
+        surface,
+        metadata: {
+            enabled: Boolean(state.artifactUi.compareByJob[key]),
+            job_id: key,
+            pipeline: String(job.pipeline || '')
+        }
+    });
+    renderReviewSurfaces();
+    return true;
+}
+
+function _retryPortalStatus(job = null) {
+    void loadPortalBootstrap();
+    void checkBackend(true);
+    if (job) {
+        void refreshJobStatus(job);
+    }
+    return true;
+}
+
+function handleOperatorActionClick(event) {
+    const button = event.target.closest('button[data-action-key]');
+    if (!button || button.disabled) return;
+    const actionKey = String(button.dataset.actionKey || '').trim();
+    if (!actionKey) return;
+    const job = _findJobById(button.dataset.jobId || state.selectedJobId || _preferredSelectedJobId());
+    const context = _operatorActionContext(job);
+    switch (actionKey) {
+        case 'open_build':
+            navigateConsoleView('build');
+            setBuildStep(1, { silent: true });
+            if (els.pipelineSelect) els.pipelineSelect.focus();
+            break;
+        case 'resume_draft':
+            navigateConsoleView('build');
+            syncBuildStepUi();
+            {
+                const activeStep = document.querySelector('.build-step-tab.is-active');
+                if (activeStep && typeof activeStep.focus === 'function') activeStep.focus();
+            }
+            break;
+        case 'return_to_build':
+            navigateConsoleView('build');
+            break;
+        case 'stay_in_operate':
+            if (!job) {
+                createToast('No active run is available right now.', 'info');
+                return;
+            }
+            navigateConsoleView('operate', { jobId: context.jobId });
+            break;
+        case 'open_review':
+        case 'review_retained_outputs':
+        case 'open_early_artifacts':
+            if (state.currentView === 'review' && context.jobId) {
+                navigateConsoleView('review', {
+                    jobId: context.jobId,
+                    artifactPath: _artifactRouteKey(context.selectedArtifact),
+                    compareEnabled: context.compareEnabled
+                });
+            } else {
+                _openReviewSurfaceForJob(job, 'action_rail');
+            }
+            break;
+        case 'open_latest_artifact':
+            _openArtifactForSelection(job, context.heroArtifact || context.selectedArtifact, 'action_rail');
+            break;
+        case 'toggle_compare':
+            _toggleCompareSurface(job, 'action_rail');
+            break;
+        case 'retry_status_check':
+            _retryPortalStatus(job);
+            break;
+        case 'restore_access':
+            window.location.assign('/login');
+            break;
+        default:
+            break;
+    }
 }
 
 function _dispatchReadinessSnapshot(payload = null) {
@@ -1591,10 +2127,16 @@ function renderBuildStepPulse(payload = null) {
 }
 
 function renderConsoleContextRibbon() {
-    if (!els.consoleContextRibbon) return;
+    if (!els.consoleContextRibbon) {
+        renderOperatorActionRail();
+        return;
+    }
     const ribbonVisible = ['overview', 'build', 'operate', 'review'].includes(state.currentView);
     els.consoleContextRibbon.classList.toggle('hidden', !ribbonVisible);
-    if (!ribbonVisible) return;
+    if (!ribbonVisible) {
+        renderOperatorActionRail();
+        return;
+    }
 
     if (state.currentView === 'operate' || state.currentView === 'review') {
         const selected = state.jobs.find((job) => job.id === state.selectedJobId) || null;
@@ -1633,6 +2175,7 @@ function renderConsoleContextRibbon() {
             meta: selected ? compareCopy.ribbonMeta : 'Deep-linkable review context stays aligned with the URL.',
             tone: selected && compareEnabled ? 'ready' : 'info'
         });
+        renderOperatorActionRail();
         return;
     }
 
@@ -1689,6 +2232,7 @@ function renderConsoleContextRibbon() {
             : `${String(state.pipeline || 'lux-depth-v3')} • ${state.backendOk ? 'live backend connected' : 'dispatch paused until the backend recovers'}.`,
         tone: 'info'
     });
+    renderOperatorActionRail();
 }
 
 function applyConsoleViewLayout() {
@@ -1735,6 +2279,8 @@ function navigateConsoleView(viewName, options = {}) {
         _rememberSelectedJob(explicitJobId);
         if (hasArtifactOption) {
             _rememberArtifactSelection(explicitJobId, options.artifactPath);
+        } else if (state.currentView === 'review') {
+            _rememberArtifactSelection(explicitJobId, '');
         }
         if (hasCompareOption) {
             _rememberComparePreference(explicitJobId, options.compareEnabled);
@@ -1744,6 +2290,9 @@ function navigateConsoleView(viewName, options = {}) {
         if (preferredJobId) {
             state.selectedJobId = preferredJobId;
             _rememberSelectedJob(preferredJobId);
+            if (state.currentView === 'review' && !hasArtifactOption) {
+                _rememberArtifactSelection(preferredJobId, '');
+            }
         }
     } else if (state.selectedJobId) {
         _rememberSelectedJob(state.selectedJobId);
@@ -3241,6 +3790,7 @@ function renderSelectedJobInspector() {
         if (els.selectedJobRecoveryDetail) {
             els.selectedJobRecoveryDetail.textContent = 'The latest warning, artifact freshness, and recovery action will repopulate here when queue hydration finishes.';
         }
+        renderSelectedJobRecoveryActions(null);
         if (els.openRunDetailsBtn) els.openRunDetailsBtn.disabled = true;
         renderConsoleContextRibbon();
         return;
@@ -3263,6 +3813,7 @@ function renderSelectedJobInspector() {
         if (els.selectedJobRecoveryDetail) {
             els.selectedJobRecoveryDetail.textContent = 'Use Queue to inspect a recent run or open Build to create the next governed dispatch.';
         }
+        renderSelectedJobRecoveryActions(null);
         if (els.selectedJobTransportAlert) {
             els.selectedJobTransportAlert.classList.add('hidden');
             els.selectedJobTransportAlert.textContent = '';
@@ -3336,6 +3887,7 @@ function renderSelectedJobInspector() {
     const recovery = _selectedJobRecoverySnapshot(selected);
     if (els.selectedJobRecoveryTitle) els.selectedJobRecoveryTitle.textContent = recovery.title;
     if (els.selectedJobRecoveryDetail) els.selectedJobRecoveryDetail.textContent = recovery.detail;
+    renderSelectedJobRecoveryActions(selected);
     if (els.selectedJobTransportAlert) {
         if (visibleAlert) {
             els.selectedJobTransportAlert.textContent = String(visibleAlert.detail || '');
@@ -3758,6 +4310,10 @@ function _syncBootstrapUi() {
     }
     _syncBootstrapGuardedControls();
     _syncOverviewBuildLoadingState();
+    renderOperatorActionRail();
+    const selectedJob = _findJobById(state.selectedJobId);
+    renderSelectedJobRecoveryActions(selectedJob);
+    renderReviewStatusActions(selectedJob);
 }
 
 function _applyPortalBootstrap(rawBootstrap, options = {}) {
@@ -4381,12 +4937,14 @@ function _renderReviewStatusBanner(job, artifact) {
         els.reviewStatusTitle.textContent = snapshot.title;
         els.reviewStatusDetail.textContent = snapshot.detail;
         if (els.reviewStatusAction) els.reviewStatusAction.textContent = snapshot.action;
+        renderReviewStatusActions(job, artifact);
         return;
     }
     els.reviewStatusTitle.textContent = snapshot.title;
     els.reviewStatusDetail.textContent = snapshot.detail;
     if (els.reviewStatusAction) els.reviewStatusAction.textContent = snapshot.action;
     els.reviewStatusBanner.classList.remove('hidden');
+    renderReviewStatusActions(job, artifact);
 }
 
 function _renderArtifactProvenance(job, artifact) {
@@ -5811,7 +6369,7 @@ function _latestReviewableJob() {
         const summary = normalizeRunSummary(job.run_summary);
         const artifactCount = Array.isArray(job.artifacts) ? job.artifacts.length : 0;
         return artifactCount > 0
-            || Boolean(summary.reviewable_outputs)
+            || Boolean(summary?.reviewable_outputs)
             || job.state === 'succeeded'
             || job.state === 'partial';
     });
@@ -8792,19 +9350,8 @@ if (els.inspectorTimelineTab) els.inspectorTimelineTab.addEventListener('click',
 if (els.inspectorLogsTab) els.inspectorLogsTab.addEventListener('click', () => setInspectorTab('logs'));
 if (els.openRunDetailsBtn) {
     els.openRunDetailsBtn.addEventListener('click', () => {
-        if (!state.selectedJobId) {
-            createToast('Select a run first, then open its review surface.', 'info');
-            return;
-        }
         const selectedJob = state.jobs.find((item) => item.id === state.selectedJobId);
-        void emitPortalEvent('run_details_opened', {
-            surface: 'job_inspector',
-            metadata: {
-                job_id: String(state.selectedJobId || ''),
-                pipeline: String(selectedJob?.pipeline || '')
-            }
-        });
-        navigateConsoleView('review', { jobId: state.selectedJobId });
+        _openReviewSurfaceForJob(selectedJob, 'job_inspector');
     });
 }
 
@@ -8831,38 +9378,14 @@ if (els.artifactThumbnailRail) {
 if (els.artifactCompareBtn) {
     els.artifactCompareBtn.addEventListener('click', () => {
         const selectedJob = state.jobs.find((item) => item.id === state.selectedJobId);
-        if (!selectedJob) return;
-        const key = String(selectedJob.id || '');
-        _rememberComparePreference(key, !Boolean(state.artifactUi.compareByJob[key]));
-        void emitPortalEvent('artifact_compared', {
-            surface: 'artifact_review',
-            metadata: {
-                enabled: Boolean(state.artifactUi.compareByJob[key]),
-                job_id: key,
-                pipeline: String(selectedJob.pipeline || '')
-            }
-        });
-        renderReviewSurfaces();
+        _toggleCompareSurface(selectedJob, 'artifact_review');
     });
 }
 
 if (els.openArtifactBtn) {
     els.openArtifactBtn.addEventListener('click', () => {
-        const url = sanitizeManagedAssetUrl(els.openArtifactBtn.dataset.url);
-        if (!url) {
-            createToast('No artifact URL is available for this selection.', 'error');
-            return;
-        }
         const selectedJob = state.jobs.find((item) => item.id === state.selectedJobId);
-        void emitPortalEvent('artifact_opened', {
-            surface: 'artifact_review',
-            metadata: {
-                job_id: String(selectedJob?.id || ''),
-                media_kind: String(_selectedArtifactForJob(selectedJob)?.media_kind || 'file'),
-                pipeline: String(selectedJob?.pipeline || '')
-            }
-        });
-        window.open(url, '_blank', 'noopener,noreferrer');
+        _openArtifactForSelection(selectedJob, _selectedArtifactForJob(selectedJob), 'artifact_review');
     });
 }
 
@@ -8937,6 +9460,15 @@ if (els.refreshHealthBtn) {
         }
         navigateConsoleView('review', { jobId });
     });
+}
+if (els.consoleActionRailActions) {
+    els.consoleActionRailActions.addEventListener('click', handleOperatorActionClick);
+}
+if (els.selectedJobRecoveryActions) {
+    els.selectedJobRecoveryActions.addEventListener('click', handleOperatorActionClick);
+}
+if (els.reviewStatusActions) {
+    els.reviewStatusActions.addEventListener('click', handleOperatorActionClick);
 }
 if (els.jobList) els.jobList.addEventListener('click', handleJobListClick);
 if (els.jobList) els.jobList.addEventListener('keydown', handleJobListKeydown);


### PR DESCRIPTION
## Summary
- add a state-driven operator action rail to `/portal` with one primary action and up to two secondary actions derived from selected-job, artifact, compare, and degraded bootstrap state
- keep selected-job continuity across overview/build/operate/review, auto-select the highest-ranked artifact on review entry when outputs exist, and promote degraded recovery guidance into actual actions without expanding route or query contracts
- extend portal runtime and browser smoke coverage for action-rail hooks, review entry, artifact auto-selection, compare toggling, and degraded recovery controls

## Validation
- `make test-portal-contract`
- `make validate-portal-browser`

## Notes
- `make pre-commit` reformatted the touched portal files, then failed on unrelated repo-baseline issues outside this tranche: stale ML lockfile warnings from ADR-032 and missing ADR-044 markers in pre-existing tests under `tests/lux_depth_v3/`, `tests/crypto/`, and `tests/validation/`
- managed frontdoor contract/browser validations were not rerun because this change stays inside `/portal` presentation and does not alter frontdoor or auth semantics
- aligned the Figma source-of-truth file `fh6NpxKtETqkAgspTa7izC` with ready, partial, offline, and auth-expired operator-speed rail states