### PR TITLE
feat(ui): adopt quiet editorial declutter across frontdoor and portal

### DIFF
--- a/portal.html
+++ b/portal.html
@@ -243,18 +243,21 @@ Contract notes:
                         <p id="heroWarningCount" class="mt-2 text-sm font-bold text-slate-900 dark:text-white">0</p>
                     </div>
                 </div>
-                <section id="overviewRuntimeClarityShell" class="mt-6">
-                    <div class="flex items-start justify-between gap-3">
+                <details id="overviewRuntimeClarityShell" class="quiet-disclosure mt-6">
+                    <summary class="quiet-disclosure__summary">
                         <div>
-                            <p class="section-kicker">Runtime Clarity</p>
-                            <p class="mt-2 text-[12px] leading-6 text-slate-500 dark:text-slate-400">
-                                Selected backends, runtime posture, checkpoint expectations, and license acknowledgments stay visible while the draft changes.
-                            </p>
+                            <p class="section-kicker">Runtime summary</p>
+                            <p class="quiet-disclosure__title">Open runtime posture and checkpoint detail</p>
                         </div>
                         <span class="micro-status">Backend-owned policy</span>
+                    </summary>
+                    <div class="quiet-disclosure__body">
+                        <p class="text-[12px] leading-6 text-slate-500 dark:text-slate-400">
+                            Selected backends, runtime posture, checkpoint expectations, and license acknowledgments stay available while the draft changes.
+                        </p>
+                        <div id="overviewRuntimeBriefing" class="runtime-briefing-grid mt-4" data-ui="runtime-clarity-grid"></div>
                     </div>
-                    <div id="overviewRuntimeBriefing" class="runtime-briefing-grid mt-4" data-ui="runtime-clarity-grid"></div>
-                </section>
+                </details>
                 </div>
             </div>
         </section>
@@ -310,43 +313,45 @@ Contract notes:
                 </div>
                 <p id="consoleViewMeta" class="portal-context-meta text-[11px] font-mono text-slate-500 dark:text-slate-400">View routing stays client-side to preserve the live orchestrator contract.</p>
             </div>
-            <div id="consoleContextRibbon" class="console-context-ribbon portal-context-ribbon mt-4 hidden" data-ui="console-context-ribbon" aria-live="polite">
-                <div id="contextRibbonCard1" class="console-context-card" data-tone="info">
-                    <p id="contextRibbonCard1Label" class="console-context-label">Job</p>
-                    <p id="contextRibbonJob" class="console-context-value">No job selected</p>
-                    <p id="contextRibbonJobMeta" class="console-context-meta">Choose a run in operate or review to pin context here.</p>
+            <div class="console-context-strip mt-4" data-ui="console-context-strip">
+                <div id="consoleContextRibbon" class="console-context-ribbon portal-context-ribbon hidden" data-ui="console-context-ribbon" aria-live="polite">
+                    <div id="contextRibbonCard1" class="console-context-card" data-tone="info">
+                        <p id="contextRibbonCard1Label" class="console-context-label">Job</p>
+                        <p id="contextRibbonJob" class="console-context-value">No job selected</p>
+                        <p id="contextRibbonJobMeta" class="console-context-meta">Choose a run in operate or review to pin context here.</p>
+                    </div>
+                    <div id="contextRibbonCard2" class="console-context-card" data-tone="info">
+                        <p id="contextRibbonCard2Label" class="console-context-label">State</p>
+                        <p id="contextRibbonState" class="console-context-value">Idle</p>
+                        <p id="contextRibbonFreshness" class="console-context-meta">No live telemetry</p>
+                    </div>
+                    <div id="contextRibbonCard3" class="console-context-card" data-tone="info">
+                        <p id="contextRibbonCard3Label" class="console-context-label">Artifact</p>
+                        <p id="contextRibbonArtifact" class="console-context-value">Awaiting selection</p>
+                        <p id="contextRibbonArtifactMeta" class="console-context-meta">Review context will show the active artifact path here.</p>
+                    </div>
+                    <div id="contextRibbonCard4" class="console-context-card" data-tone="info">
+                        <p id="contextRibbonCard4Label" class="console-context-label">Compare</p>
+                        <p id="contextRibbonCompare" class="console-context-value">No compare pair</p>
+                        <p id="contextRibbonCompareMeta" class="console-context-meta">No paired comparison is available for the current artifact.</p>
+                    </div>
                 </div>
-                <div id="contextRibbonCard2" class="console-context-card" data-tone="info">
-                    <p id="contextRibbonCard2Label" class="console-context-label">State</p>
-                    <p id="contextRibbonState" class="console-context-value">Idle</p>
-                    <p id="contextRibbonFreshness" class="console-context-meta">No live telemetry</p>
-                </div>
-                <div id="contextRibbonCard3" class="console-context-card" data-tone="info">
-                    <p id="contextRibbonCard3Label" class="console-context-label">Artifact</p>
-                    <p id="contextRibbonArtifact" class="console-context-value">Awaiting selection</p>
-                    <p id="contextRibbonArtifactMeta" class="console-context-meta">Review context will show the active artifact path here.</p>
-                </div>
-                <div id="contextRibbonCard4" class="console-context-card" data-tone="info">
-                    <p id="contextRibbonCard4Label" class="console-context-label">Compare</p>
-                    <p id="contextRibbonCompare" class="console-context-value">No compare pair</p>
-                    <p id="contextRibbonCompareMeta" class="console-context-meta">No paired comparison is available for the current artifact.</p>
-                </div>
+                <section id="consoleActionRail" class="console-action-rail hidden" data-ui="console-action-rail" data-tone="info" aria-live="polite">
+                    <div class="console-action-rail-copy">
+                        <p class="console-action-rail-kicker">Action rail</p>
+                        <p id="consoleActionRailTitle" class="console-action-rail-title">Keep the next operator move pinned</p>
+                        <p id="consoleActionRailDetail" class="console-action-rail-detail">Contextual review, artifact, compare, and recovery actions update here from the current run state.</p>
+                        <p id="consoleActionRailHint" class="console-action-rail-hint" data-ui="console-action-shortcuts">
+                            Keyboard: <span class="kbd">1</span> overview, <span class="kbd">2</span> build, <span class="kbd">3</span> operate, <span class="kbd">4</span> review, <span class="kbd">?</span> shortcuts.
+                        </p>
+                    </div>
+                    <div id="consoleActionRailActions" class="console-action-rail-actions">
+                        <button id="consoleActionPrimaryBtn" type="button" class="operator-action-btn operator-action-btn-primary hidden" data-ui="console-action-primary"></button>
+                        <button id="consoleActionSecondaryBtn1" type="button" class="operator-action-btn operator-action-btn-secondary hidden" data-ui="console-action-secondary-1"></button>
+                        <button id="consoleActionSecondaryBtn2" type="button" class="operator-action-btn operator-action-btn-secondary hidden" data-ui="console-action-secondary-2"></button>
+                    </div>
+                </section>
             </div>
-            <section id="consoleActionRail" class="console-action-rail mt-4 hidden" data-ui="console-action-rail" data-tone="info" aria-live="polite">
-                <div class="console-action-rail-copy">
-                    <p class="console-action-rail-kicker">Action Rail</p>
-                    <p id="consoleActionRailTitle" class="console-action-rail-title">Keep the next operator move pinned</p>
-                    <p id="consoleActionRailDetail" class="console-action-rail-detail">Contextual review, artifact, compare, and recovery actions will update here from the current run state.</p>
-                    <p id="consoleActionRailHint" class="console-action-rail-hint" data-ui="console-action-shortcuts">
-                        Keyboard: <span class="kbd">1</span> overview, <span class="kbd">2</span> build, <span class="kbd">3</span> operate, <span class="kbd">4</span> review, <span class="kbd">?</span> shortcuts.
-                    </p>
-                </div>
-                <div id="consoleActionRailActions" class="console-action-rail-actions">
-                    <button id="consoleActionPrimaryBtn" type="button" class="operator-action-btn operator-action-btn-primary hidden" data-ui="console-action-primary"></button>
-                    <button id="consoleActionSecondaryBtn1" type="button" class="operator-action-btn operator-action-btn-secondary hidden" data-ui="console-action-secondary-1"></button>
-                    <button id="consoleActionSecondaryBtn2" type="button" class="operator-action-btn operator-action-btn-secondary hidden" data-ui="console-action-secondary-2"></button>
-                </div>
-            </section>
         </section>
 
         <!-- ============================================ -->
@@ -435,18 +440,21 @@ Contract notes:
                             <span id="bootstrapStatusBadge" class="signal-badge portal-access-state__badge" data-tone="info">Confirming access</span>
                         </div>
                     </div>
-                    <section id="buildRuntimeClarityShell" class="mt-5">
-                        <div class="flex items-start justify-between gap-3">
+                    <details id="buildRuntimeClarityShell" class="quiet-disclosure mt-5">
+                        <summary class="quiet-disclosure__summary">
                             <div>
-                                <p class="section-kicker">Execution Briefing</p>
-                                <p class="mt-2 text-[12px] leading-6 text-slate-500 dark:text-slate-400">
-                                    The selected depth path, segmentation mode, checkpoint expectation, and license posture stay pinned here while you move through Steps 2-4.
-                                </p>
+                                <p class="section-kicker">Execution briefing</p>
+                                <p class="quiet-disclosure__title">Open runtime and license posture detail</p>
                             </div>
                             <span class="micro-status">Decision support</span>
+                        </summary>
+                        <div class="quiet-disclosure__body">
+                            <p class="text-[12px] leading-6 text-slate-500 dark:text-slate-400">
+                                The selected depth path, segmentation mode, checkpoint expectation, and license posture stay pinned here while you move through Steps 2-4.
+                            </p>
+                            <div id="buildRuntimeBriefing" class="runtime-briefing-grid runtime-briefing-grid--compact mt-4" data-ui="build-runtime-clarity"></div>
                         </div>
-                        <div id="buildRuntimeBriefing" class="runtime-briefing-grid runtime-briefing-grid--compact mt-4" data-ui="build-runtime-clarity"></div>
-                    </section>
+                    </details>
                     </div>
                 </div>
 

--- a/public/portal-assets/portal.css
+++ b/public/portal-assets/portal.css
@@ -4018,3 +4018,288 @@ textarea,
 }
 .disabled\:opacity-50:disabled { opacity: 0.5; }
 .disabled\:cursor-not-allowed:disabled { cursor: not-allowed; }
+
+html {
+  scroll-padding-top: 12rem;
+}
+
+.shell-bg {
+  background:
+    radial-gradient(circle at 18% 16%, rgba(15, 118, 110, 0.06), transparent 24%),
+    linear-gradient(180deg, rgba(248, 250, 252, 0.98) 0%, rgba(241, 245, 249, 1) 100%);
+}
+
+.dark .shell-bg {
+  background:
+    radial-gradient(circle at 18% 16%, rgba(34, 211, 238, 0.08), transparent 24%),
+    linear-gradient(180deg, rgba(2, 6, 23, 0.98) 0%, rgba(15, 23, 42, 0.96) 52%, rgba(2, 6, 23, 1) 100%);
+}
+
+.shell-noise {
+  display: none;
+}
+
+.portal-topbar,
+.workspace-rail,
+.portal-context-shell,
+.workspace-shell,
+.shell-panel,
+.shell-panel-strong,
+.panel-subtle,
+.stat-tile,
+.console-context-card,
+.console-action-rail,
+.build-pulse-card,
+.runtime-briefing-card,
+.review-status-banner,
+.review-provenance-item,
+.review-compare-summary,
+#artifactPreviewStage,
+#artifactMetadataBar,
+#artifactMetadataCard,
+#reconstructionRuntimeSummary,
+.build-step-tab {
+  border-radius: var(--ux-radius-lg);
+}
+
+.portal-topbar,
+.workspace-rail,
+.portal-context-shell,
+.workspace-shell,
+.shell-panel,
+.shell-panel-strong {
+  box-shadow: var(--ux-shadow-surface);
+}
+
+.workspace-shell,
+.shell-panel,
+.shell-panel-strong,
+.panel-subtle,
+.stat-tile,
+.console-context-card,
+.console-action-rail,
+.build-pulse-card,
+.runtime-briefing-card,
+.review-status-banner,
+.review-provenance-item,
+.review-compare-summary,
+#artifactPreviewStage,
+#artifactMetadataBar,
+#artifactMetadataCard,
+#reconstructionRuntimeSummary,
+.build-step-tab {
+  border-color: var(--ux-border-subtle);
+  background: var(--ux-surface-elevated);
+}
+
+.dark .workspace-shell,
+.dark .shell-panel,
+.dark .shell-panel-strong,
+.dark .panel-subtle,
+.dark .stat-tile,
+.dark .console-context-card,
+.dark .console-action-rail,
+.dark .build-pulse-card,
+.dark .runtime-briefing-card,
+.dark .review-status-banner,
+.dark .review-provenance-item,
+.dark .review-compare-summary,
+.dark #artifactPreviewStage,
+.dark #artifactMetadataBar,
+.dark #artifactMetadataCard,
+.dark #reconstructionRuntimeSummary,
+.dark .build-step-tab {
+  background: var(--ux-surface-muted);
+}
+
+.section-kicker,
+.stat-label,
+.console-context-label,
+.console-action-rail-kicker,
+.build-pulse-label,
+.review-status-kicker,
+.review-provenance-label,
+.micro-status,
+.workspace-link-label {
+  letter-spacing: var(--ux-meta-tracking);
+}
+
+.portal-context-shell {
+  position: relative;
+  backdrop-filter: blur(12px);
+}
+
+.console-context-strip {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.console-context-ribbon {
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.console-context-card,
+.build-pulse-card,
+.runtime-briefing-card,
+.review-provenance-item {
+  box-shadow: var(--ux-shadow-surface);
+}
+
+.console-action-rail {
+  padding: 1rem;
+  border: 1px solid var(--ux-border-subtle);
+  background: var(--ux-surface-overlay);
+}
+
+.dark .console-action-rail {
+  background: var(--ux-surface-overlay);
+}
+
+.console-action-rail[data-tone="ready"],
+.console-action-rail[data-tone="warning"],
+.console-action-rail[data-tone="blocked"],
+.review-status-banner[data-tone="ready"],
+.review-status-banner[data-tone="warning"],
+.review-status-banner[data-tone="error"],
+.review-status-banner[data-tone="info"] {
+  background: var(--ux-surface-overlay);
+}
+
+.console-action-rail[data-tone="ready"],
+.review-status-banner[data-tone="ready"] {
+  border-color: rgba(15, 118, 110, 0.24);
+}
+
+.console-action-rail[data-tone="warning"],
+.review-status-banner[data-tone="warning"] {
+  border-color: rgba(180, 83, 9, 0.26);
+}
+
+.console-action-rail[data-tone="blocked"],
+.review-status-banner[data-tone="error"] {
+  border-color: rgba(185, 28, 28, 0.26);
+}
+
+.review-status-banner[data-tone="info"] {
+  border-color: rgba(8, 145, 178, 0.24);
+}
+
+.workspace-link,
+.operator-action-btn,
+.hero-action,
+.stepper-nav-btn,
+.dispatch-tool-btn,
+#openRunDetailsBtn,
+#artifactCompareBtn,
+#themeBtn,
+#shortcutsBtn {
+  min-height: var(--ux-target-min-size);
+  border-radius: var(--ux-radius-md);
+}
+
+.workspace-link {
+  padding: 0.85rem 0.95rem;
+  background: var(--ux-surface-elevated);
+  box-shadow: none;
+}
+
+.dark .workspace-link {
+  background: var(--ux-surface-muted);
+}
+
+.workspace-link-heading {
+  align-items: center;
+}
+
+.workspace-link-shortcut {
+  min-width: 1.8rem;
+  min-height: 1.8rem;
+  border-radius: var(--ux-radius-md);
+}
+
+.hero-action,
+.operator-action-btn,
+.stepper-nav-btn,
+.dispatch-tool-btn {
+  box-shadow: none;
+}
+
+.hero-action-primary,
+.operator-action-btn-primary {
+  background: linear-gradient(135deg, rgba(15, 118, 110, 0.96), rgba(8, 145, 178, 0.88));
+  border-color: rgba(8, 145, 178, 0.2);
+}
+
+.hero-action-secondary,
+.operator-action-btn-secondary,
+.stepper-nav-btn,
+.dispatch-tool-btn,
+#openRunDetailsBtn,
+#artifactCompareBtn,
+#themeBtn,
+#shortcutsBtn {
+  border-color: var(--ux-border-subtle);
+  background: var(--ux-surface-elevated);
+}
+
+.dark .hero-action-secondary,
+.dark .operator-action-btn-secondary,
+.dark .stepper-nav-btn,
+.dark .dispatch-tool-btn,
+.dark #openRunDetailsBtn,
+.dark #artifactCompareBtn,
+.dark #themeBtn,
+.dark #shortcutsBtn {
+  background: var(--ux-surface-muted);
+}
+
+.quiet-disclosure {
+  border: 1px solid var(--ux-border-subtle);
+  border-radius: var(--ux-radius-lg);
+  background: var(--ux-surface-elevated);
+  box-shadow: var(--ux-shadow-surface);
+}
+
+.dark .quiet-disclosure {
+  background: var(--ux-surface-muted);
+}
+
+.quiet-disclosure__summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  min-height: var(--ux-target-min-size);
+  padding: 0.95rem 1rem;
+  cursor: pointer;
+  list-style: none;
+}
+
+.quiet-disclosure__summary::-webkit-details-marker {
+  display: none;
+}
+
+.quiet-disclosure__title {
+  margin: 0.2rem 0 0;
+  color: var(--shell-ink);
+  font-size: 13px;
+  line-height: 1.55;
+  font-weight: 700;
+}
+
+.quiet-disclosure__body {
+  padding: 0 1rem 1rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .workspace-shell,
+  .workspace-shell[data-ambient-active="true"],
+  .build-pulse-card,
+  .runtime-briefing-card,
+  .console-context-card,
+  .portal-context-shell {
+    transform: none !important;
+    animation: none !important;
+  }
+}

--- a/public/portal-assets/shared-ui-tokens.css
+++ b/public/portal-assets/shared-ui-tokens.css
@@ -1,4 +1,5 @@
-/* Shared UI primitives used by both the managed frontdoor and portal console. */
+/* Canonical shared UI token source used by both the managed frontdoor and portal console. */
+/* build-portal-bundle.mjs copies this file into the shipped frontdoor and portal asset targets. */
 :root {
   color-scheme: light dark;
 

--- a/public/portal-assets/shared-ui-tokens.css
+++ b/public/portal-assets/shared-ui-tokens.css
@@ -1,6 +1,86 @@
 /* Shared UI primitives used by both the managed frontdoor and portal console. */
 :root {
+  color-scheme: light dark;
+
   --ux-target-min-size: 44px;
-  --ux-label-size: 0.8125rem;
   --ux-body-size: 1rem;
+  --ux-label-size: 0.75rem;
+  --ux-meta-size: 0.8125rem;
+
+  --ux-space-1: 0.25rem;
+  --ux-space-2: 0.5rem;
+  --ux-space-3: 0.75rem;
+  --ux-space-4: 1rem;
+  --ux-space-5: 1.25rem;
+  --ux-space-6: 1.5rem;
+  --ux-space-8: 2rem;
+
+  --ux-radius-sm: 6px;
+  --ux-radius-md: 8px;
+  --ux-radius-lg: 8px;
+  --ux-radius-pill: 999px;
+
+  --ux-focus-ring: rgba(8, 145, 178, 0.92);
+  --ux-focus-shadow: rgba(8, 145, 178, 0.18);
+
+  --ux-shadow-surface: 0 10px 24px rgba(15, 23, 42, 0.06);
+  --ux-shadow-overlay: 0 20px 44px rgba(15, 23, 42, 0.16);
+
+  --ux-border-subtle: rgba(100, 116, 139, 0.18);
+  --ux-border-strong: rgba(8, 145, 178, 0.24);
+
+  --ux-text-strong: #0f172a;
+  --ux-text-primary: #1e293b;
+  --ux-text-muted: #475569;
+  --ux-text-soft: #64748b;
+
+  --ux-surface-canvas: #f4f7fb;
+  --ux-surface-elevated: rgba(255, 255, 255, 0.92);
+  --ux-surface-muted: rgba(248, 250, 252, 0.9);
+  --ux-surface-overlay: rgba(255, 255, 255, 0.97);
+
+  --ux-accent-primary: #0f766e;
+  --ux-accent-secondary: #0f766e;
+  --ux-status-ready: #0f766e;
+  --ux-status-warning: #b45309;
+  --ux-status-blocked: #b91c1c;
+
+  --ux-meta-tracking: 0.12em;
+  --ux-motion-fast: 160ms;
+  --ux-motion-normal: 220ms;
+}
+
+:root.dark,
+.dark:root {
+  --ux-focus-ring: rgba(103, 232, 249, 0.96);
+  --ux-focus-shadow: rgba(34, 211, 238, 0.18);
+
+  --ux-shadow-surface: 0 12px 28px rgba(2, 6, 23, 0.22);
+  --ux-shadow-overlay: 0 22px 48px rgba(2, 6, 23, 0.38);
+
+  --ux-border-subtle: rgba(100, 116, 139, 0.34);
+  --ux-border-strong: rgba(103, 232, 249, 0.22);
+
+  --ux-text-strong: #f8fafc;
+  --ux-text-primary: #e2e8f0;
+  --ux-text-muted: #b8c4d4;
+  --ux-text-soft: #94a3b8;
+
+  --ux-surface-canvas: #020617;
+  --ux-surface-elevated: rgba(12, 18, 34, 0.9);
+  --ux-surface-muted: rgba(15, 23, 42, 0.86);
+  --ux-surface-overlay: rgba(8, 15, 29, 0.96);
+
+  --ux-accent-primary: #67e8f9;
+  --ux-accent-secondary: #99f6e4;
+  --ux-status-ready: #5eead4;
+  --ux-status-warning: #fbbf24;
+  --ux-status-blocked: #fca5a5;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --ux-motion-fast: 0ms;
+    --ux-motion-normal: 0ms;
+  }
 }

--- a/scripts/validation/validate_frontdoor_browser_smoke.py
+++ b/scripts/validation/validate_frontdoor_browser_smoke.py
@@ -421,6 +421,66 @@ def _frontdoor_state_probe_expression() -> str:
 """
 
 
+def _frontdoor_accessibility_probe_expression() -> str:
+    return r"""
+(() => {
+  const visible = (el) => {
+    if (!el) return false;
+    const style = window.getComputedStyle(el);
+    const rect = el.getBoundingClientRect();
+    return style.display !== 'none' && style.visibility !== 'hidden' && rect.width > 0 && rect.height > 0;
+  };
+  const minTarget = (selector) => {
+    const el = document.querySelector(selector);
+    if (!visible(el)) return false;
+    const rect = el.getBoundingClientRect();
+    return rect.width >= 44 && rect.height >= 44;
+  };
+  const maxDisclosureDepth = (() => {
+    const detailsNodes = Array.from(document.querySelectorAll('details'));
+    if (!detailsNodes.length) return 0;
+    const depthFor = (node) => {
+      let depth = 1;
+      let current = node.parentElement;
+      while (current) {
+        if (current.tagName === 'DETAILS') depth += 1;
+        current = current.parentElement;
+      }
+      return depth;
+    };
+    return Math.max(...detailsNodes.map(depthFor));
+  })();
+  const focusVisibleWithStickyHeader = (() => {
+    const header = document.querySelector('.site-header');
+    const target = document.querySelector('[data-ui="homepage-primary-cta"]');
+    if (!header || !visible(target)) return false;
+    target.scrollIntoView({ block: 'center' });
+    target.focus();
+    const headerRect = header.getBoundingClientRect();
+    const targetRect = target.getBoundingClientRect();
+    return targetRect.top >= headerRect.bottom - 2 && targetRect.bottom <= window.innerHeight + 2;
+  })();
+  return {
+    pathname: window.location.pathname,
+    homepagePrimaryMinTarget: minTarget('[data-ui="homepage-primary-cta"]'),
+    homepageSecondaryMinTarget: minTarget('[data-ui="homepage-secondary-cta"]'),
+    homepageLearnMinTarget: minTarget('[data-ui="homepage-learn-link"]'),
+    loginSubmitMinTarget: minTarget('[data-ui="login-submit"]'),
+    loginSecondaryMinTarget: minTarget('[data-ui="login-secondary-link"]'),
+    focusVisibleWithStickyHeader,
+    maxDisclosureDepth,
+    reducedMotion: window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+    decorativeMotionStatic: (() => {
+      const video = document.querySelector('.hero-video, .homepage-video');
+      if (!video) return true;
+      const style = window.getComputedStyle(video);
+      return style.display === 'none' || style.animationName === 'none' || style.animationDuration === '0s';
+    })()
+  };
+})()
+"""
+
+
 def _navigate_expression(pathname: str) -> str:
     encoded = json.dumps(pathname)
     return f"""
@@ -567,6 +627,21 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
         )
         _expect(str(homepage_state.get("pathname", "")) == "/", f"Front-door homepage did not load at root: {homepage_state}")
         _expect(bool(homepage_state.get("hasHeroVideo")), f"Homepage video canvas was not rendered: {homepage_state}")
+        homepage_accessibility = connection.evaluate(_frontdoor_accessibility_probe_expression())
+        _expect(
+            bool(homepage_accessibility.get("homepagePrimaryMinTarget"))
+            and bool(homepage_accessibility.get("homepageSecondaryMinTarget"))
+            and bool(homepage_accessibility.get("homepageLearnMinTarget")),
+            f"Homepage interactive targets fell below the 44px contract: {homepage_accessibility}",
+        )
+        _expect(
+            bool(homepage_accessibility.get("focusVisibleWithStickyHeader")),
+            f"Homepage sticky header obscured focused actions: {homepage_accessibility}",
+        )
+        _expect(
+            int(homepage_accessibility.get("maxDisclosureDepth", 0)) <= 1,
+            f"Homepage disclosure depth exceeded the single-level contract: {homepage_accessibility}",
+        )
 
         print("frontdoor-browser-smoke: opening login", flush=True)
         connection.evaluate(_navigate_expression("/login"))
@@ -588,6 +663,42 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
             description="front-door login to render",
         )
         _expect(bool(login_state.get("hasHeroVideo")), f"Login page lost hero video shell: {login_state}")
+        login_accessibility = connection.evaluate(_frontdoor_accessibility_probe_expression())
+        _expect(
+            bool(login_accessibility.get("loginSubmitMinTarget")) and bool(login_accessibility.get("loginSecondaryMinTarget")),
+            f"Login interactive targets fell below the 44px contract: {login_accessibility}",
+        )
+        _expect(
+            int(login_accessibility.get("maxDisclosureDepth", 0)) <= 1,
+            f"Login disclosure depth exceeded the single-level contract: {login_accessibility}",
+        )
+
+        print("frontdoor-browser-smoke: checking reduced motion", flush=True)
+        connection.call(
+            "Emulation.setEmulatedMedia",
+            {"features": [{"name": "prefers-reduced-motion", "value": "reduce"}]},
+        )
+        reduced_motion_state = _poll(
+            connection,
+            _frontdoor_accessibility_probe_expression(),
+            predicate=lambda value: (
+                isinstance(value, dict)
+                and str(value.get("pathname", "")) == "/login"
+                and bool(value.get("reducedMotion"))
+                and bool(value.get("decorativeMotionStatic"))
+                and bool(value.get("loginSubmitMinTarget"))
+            ),
+            timeout_seconds=args.timeout_seconds,
+            description="front-door reduced-motion login shell",
+        )
+        _expect(
+            bool(reduced_motion_state.get("decorativeMotionStatic")),
+            f"Reduced-motion mode left decorative front-door motion active: {reduced_motion_state}",
+        )
+        connection.call(
+            "Emulation.setEmulatedMedia",
+            {"features": [{"name": "prefers-reduced-motion", "value": "no-preference"}]},
+        )
 
         print("frontdoor-browser-smoke: submitting operator login", flush=True)
         connection.evaluate(_submit_login_expression(username, password))

--- a/scripts/validation/validate_frontdoor_browser_smoke.py
+++ b/scripts/validation/validate_frontdoor_browser_smoke.py
@@ -474,7 +474,16 @@ def _frontdoor_accessibility_probe_expression() -> str:
       const video = document.querySelector('.hero-video, .homepage-video');
       if (!video) return true;
       const style = window.getComputedStyle(video);
-      return style.display === 'none' || style.animationName === 'none' || style.animationDuration === '0s';
+      if (style.display === 'none') return true;
+      const hasSource = Array.from(video.querySelectorAll('source'))
+        .some((source) => Boolean(source.getAttribute('src')));
+      const hasPlayableMedia = Boolean(video.currentSrc) || hasSource;
+      return (
+        video.paused
+        || video.ended
+        || !hasPlayableMedia
+        || video.readyState < HTMLMediaElement.HAVE_CURRENT_DATA
+      );
     })()
   };
 })()

--- a/scripts/validation/validate_portal_browser_smoke.py
+++ b/scripts/validation/validate_portal_browser_smoke.py
@@ -990,31 +990,47 @@ def _accessibility_probe_expression() -> str:
     };
     return Math.max(...detailsNodes.map(depthFor));
   })();
-  const focusVisibleWithStickyShells = (() => {
-    const target =
-      document.getElementById('pipelineSelect')
-      || document.getElementById('presetSelect')
-      || document.getElementById('buildStepTab1')
-      || document.querySelector('[data-ui="view-link"]')
-      || document.getElementById('themeBtn');
-    if (!visible(target)) return false;
-    const absoluteTop = target.getBoundingClientRect().top + window.scrollY;
-    const root = document.documentElement;
-    const previousScrollBehavior = root.style.scrollBehavior;
-    root.style.scrollBehavior = 'auto';
-    window.scrollTo(0, Math.max(0, absoluteTop - 220));
-    root.style.scrollBehavior = previousScrollBehavior;
-    target.focus();
-    const blockers = Array.from(document.querySelectorAll('.portal-topbar, [data-ui="console-context-shell"]'))
+  const focusTarget = () =>
+    document.getElementById('pipelineSelect')
+    || document.getElementById('presetSelect')
+    || document.getElementById('buildStepTab1')
+    || document.querySelector('[data-ui="view-link"]')
+    || document.getElementById('themeBtn');
+  const stickyBlockers = () =>
+    Array.from(document.querySelectorAll('.portal-topbar, [data-ui="console-context-shell"]'))
       .filter((el) => {
         if (!visible(el)) return false;
         const position = window.getComputedStyle(el).position;
         return position === 'sticky' || position === 'fixed';
       });
-    const blockerBottom = blockers.reduce((max, el) => Math.max(max, el.getBoundingClientRect().bottom), 0);
-    const targetRect = target.getBoundingClientRect();
-    return targetRect.top >= blockerBottom - 2 && targetRect.bottom <= window.innerHeight + 2;
+  const measureStickyBlockerBottom = () =>
+    stickyBlockers().reduce((max, el) => Math.max(max, el.getBoundingClientRect().bottom), 0);
+  const focusVisibleWithStickyShells = (() => {
+    const target = focusTarget();
+    if (!visible(target)) return false;
+    const absoluteTop = target.getBoundingClientRect().top + window.scrollY;
+    const root = document.documentElement;
+    const previousScrollBehavior = root.style.scrollBehavior;
+    const previousScrollX = window.scrollX;
+    const previousScrollY = window.scrollY;
+    const clearance = Math.ceil(measureStickyBlockerBottom() + 16);
+    root.style.scrollBehavior = 'auto';
+    try {
+      window.scrollTo(previousScrollX, Math.max(0, absoluteTop - clearance));
+      try {
+        target.focus({ preventScroll: true });
+      } catch {
+        target.focus();
+      }
+      const blockerBottom = measureStickyBlockerBottom();
+      const targetRect = target.getBoundingClientRect();
+      return targetRect.top >= blockerBottom - 2 && targetRect.bottom <= window.innerHeight + 2;
+    } finally {
+      window.scrollTo(previousScrollX, previousScrollY);
+      root.style.scrollBehavior = previousScrollBehavior;
+    }
   })();
+  const focusTargetNode = focusTarget();
   const discoverableDisclosures = Array.from(document.querySelectorAll('details > summary'))
     .filter((summary) => visible(summary) && String(summary.textContent || '').trim().length > 0)
     .length;
@@ -1027,40 +1043,10 @@ def _accessibility_probe_expression() -> str:
     shortcutsTargetMin: minTarget('#shortcutsBtn'),
     workspaceLinkTargetMin: minTarget('[data-ui="view-link"]'),
     buildStepTargetMin: minTarget('#buildStepTab1'),
-    focusTargetId: (() => {
-      const target =
-        document.getElementById('pipelineSelect')
-        || document.getElementById('presetSelect')
-        || document.getElementById('buildStepTab1')
-        || document.querySelector('[data-ui="view-link"]')
-        || document.getElementById('themeBtn');
-      return target ? String(target.id || target.getAttribute('data-ui') || target.tagName || '') : '';
-    })(),
-    focusTargetTop: (() => {
-      const target =
-        document.getElementById('pipelineSelect')
-        || document.getElementById('presetSelect')
-        || document.getElementById('buildStepTab1')
-        || document.querySelector('[data-ui="view-link"]')
-        || document.getElementById('themeBtn');
-      return target ? Number(target.getBoundingClientRect().top || 0) : 0;
-    })(),
-    focusTargetBottom: (() => {
-      const target =
-        document.getElementById('pipelineSelect')
-        || document.getElementById('presetSelect')
-        || document.getElementById('buildStepTab1')
-        || document.querySelector('[data-ui="view-link"]')
-        || document.getElementById('themeBtn');
-      return target ? Number(target.getBoundingClientRect().bottom || 0) : 0;
-    })(),
-    stickyBlockerBottom: Array.from(document.querySelectorAll('.portal-topbar, [data-ui="console-context-shell"]'))
-      .filter((el) => {
-        if (!visible(el)) return false;
-        const position = window.getComputedStyle(el).position;
-        return position === 'sticky' || position === 'fixed';
-      })
-      .reduce((max, el) => Math.max(max, el.getBoundingClientRect().bottom), 0),
+    focusTargetId: focusTargetNode ? String(focusTargetNode.id || focusTargetNode.getAttribute('data-ui') || focusTargetNode.tagName || '') : '',
+    focusTargetTop: focusTargetNode ? Number(focusTargetNode.getBoundingClientRect().top || 0) : 0,
+    focusTargetBottom: focusTargetNode ? Number(focusTargetNode.getBoundingClientRect().bottom || 0) : 0,
+    stickyBlockerBottom: measureStickyBlockerBottom(),
     focusVisibleWithStickyShells,
     maxDisclosureDepth,
     discoverableDisclosures,

--- a/scripts/validation/validate_portal_browser_smoke.py
+++ b/scripts/validation/validate_portal_browser_smoke.py
@@ -961,6 +961,118 @@ def _state_probe_expression() -> str:
 """
 
 
+def _accessibility_probe_expression() -> str:
+    return r"""
+(() => {
+  const visible = (el) => {
+    if (!el) return false;
+    const style = window.getComputedStyle(el);
+    const rect = el.getBoundingClientRect();
+    return style.display !== 'none' && style.visibility !== 'hidden' && rect.width > 0 && rect.height > 0;
+  };
+  const minTarget = (selector) => {
+    const el = document.querySelector(selector);
+    if (!visible(el)) return false;
+    const rect = el.getBoundingClientRect();
+    return rect.width >= 44 && rect.height >= 44;
+  };
+  const maxDisclosureDepth = (() => {
+    const detailsNodes = Array.from(document.querySelectorAll('details'));
+    if (!detailsNodes.length) return 0;
+    const depthFor = (node) => {
+      let depth = 1;
+      let current = node.parentElement;
+      while (current) {
+        if (current.tagName === 'DETAILS') depth += 1;
+        current = current.parentElement;
+      }
+      return depth;
+    };
+    return Math.max(...detailsNodes.map(depthFor));
+  })();
+  const focusVisibleWithStickyShells = (() => {
+    const target =
+      document.getElementById('pipelineSelect')
+      || document.getElementById('presetSelect')
+      || document.getElementById('buildStepTab1')
+      || document.querySelector('[data-ui="view-link"]')
+      || document.getElementById('themeBtn');
+    if (!visible(target)) return false;
+    const absoluteTop = target.getBoundingClientRect().top + window.scrollY;
+    const root = document.documentElement;
+    const previousScrollBehavior = root.style.scrollBehavior;
+    root.style.scrollBehavior = 'auto';
+    window.scrollTo(0, Math.max(0, absoluteTop - 220));
+    root.style.scrollBehavior = previousScrollBehavior;
+    target.focus();
+    const blockers = Array.from(document.querySelectorAll('.portal-topbar, [data-ui="console-context-shell"]'))
+      .filter((el) => {
+        if (!visible(el)) return false;
+        const position = window.getComputedStyle(el).position;
+        return position === 'sticky' || position === 'fixed';
+      });
+    const blockerBottom = blockers.reduce((max, el) => Math.max(max, el.getBoundingClientRect().bottom), 0);
+    const targetRect = target.getBoundingClientRect();
+    return targetRect.top >= blockerBottom - 2 && targetRect.bottom <= window.innerHeight + 2;
+  })();
+  const discoverableDisclosures = Array.from(document.querySelectorAll('details > summary'))
+    .filter((summary) => visible(summary) && String(summary.textContent || '').trim().length > 0)
+    .length;
+  const shellNoise = document.querySelector('.shell-noise');
+  const visiblePulseAnimation = Array.from(document.querySelectorAll('.animate-pulse'))
+    .some((el) => visible(el) && window.getComputedStyle(el).animationName !== 'none' && window.getComputedStyle(el).animationDuration !== '0s');
+  return {
+    currentView: document.body ? String(document.body.dataset.consoleView || '') : '',
+    themeTargetMin: minTarget('#themeBtn'),
+    shortcutsTargetMin: minTarget('#shortcutsBtn'),
+    workspaceLinkTargetMin: minTarget('[data-ui="view-link"]'),
+    buildStepTargetMin: minTarget('#buildStepTab1'),
+    focusTargetId: (() => {
+      const target =
+        document.getElementById('pipelineSelect')
+        || document.getElementById('presetSelect')
+        || document.getElementById('buildStepTab1')
+        || document.querySelector('[data-ui="view-link"]')
+        || document.getElementById('themeBtn');
+      return target ? String(target.id || target.getAttribute('data-ui') || target.tagName || '') : '';
+    })(),
+    focusTargetTop: (() => {
+      const target =
+        document.getElementById('pipelineSelect')
+        || document.getElementById('presetSelect')
+        || document.getElementById('buildStepTab1')
+        || document.querySelector('[data-ui="view-link"]')
+        || document.getElementById('themeBtn');
+      return target ? Number(target.getBoundingClientRect().top || 0) : 0;
+    })(),
+    focusTargetBottom: (() => {
+      const target =
+        document.getElementById('pipelineSelect')
+        || document.getElementById('presetSelect')
+        || document.getElementById('buildStepTab1')
+        || document.querySelector('[data-ui="view-link"]')
+        || document.getElementById('themeBtn');
+      return target ? Number(target.getBoundingClientRect().bottom || 0) : 0;
+    })(),
+    stickyBlockerBottom: Array.from(document.querySelectorAll('.portal-topbar, [data-ui="console-context-shell"]'))
+      .filter((el) => {
+        if (!visible(el)) return false;
+        const position = window.getComputedStyle(el).position;
+        return position === 'sticky' || position === 'fixed';
+      })
+      .reduce((max, el) => Math.max(max, el.getBoundingClientRect().bottom), 0),
+    focusVisibleWithStickyShells,
+    maxDisclosureDepth,
+    discoverableDisclosures,
+    reducedMotion: window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+    decorativeMotionStatic:
+      (!shellNoise || window.getComputedStyle(shellNoise).display === 'none')
+      && !visiblePulseAnimation
+  };
+})()
+"""
+
+
 def _navigate_to_console_view_expression(
     view: str,
     job_id: str = "",
@@ -1419,6 +1531,21 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
             f"Portal did not default to lux-depth-v3: {online_state}",
         )
         _expect(bool(online_state.get("overviewViewVisible")), f"Overview shell did not remain visible: {online_state}")
+        overview_accessibility = connection.evaluate(_accessibility_probe_expression())
+        _expect(
+            bool(overview_accessibility.get("themeTargetMin"))
+            and bool(overview_accessibility.get("shortcutsTargetMin"))
+            and bool(overview_accessibility.get("workspaceLinkTargetMin")),
+            f"Portal overview controls fell below the 44px contract: {overview_accessibility}",
+        )
+        _expect(
+            int(overview_accessibility.get("maxDisclosureDepth", 0)) <= 1,
+            f"Portal disclosure depth exceeded the single-level contract: {overview_accessibility}",
+        )
+        _expect(
+            int(overview_accessibility.get("discoverableDisclosures", 0)) >= 1,
+            f"Portal disclosures were no longer discoverable: {overview_accessibility}",
+        )
 
         print("portal-browser-smoke: opening build view", flush=True)
         connection.evaluate(_navigate_to_console_view_expression("build"))
@@ -1436,6 +1563,41 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
         _expect(
             not bool(build_state.get("operateViewVisible")),
             f"Build view should suppress operate shell: {build_state}",
+        )
+        build_accessibility = connection.evaluate(_accessibility_probe_expression())
+        _expect(
+            bool(build_accessibility.get("buildStepTargetMin")),
+            f"Build step tabs fell below the 44px contract: {build_accessibility}",
+        )
+        _expect(
+            bool(build_accessibility.get("focusVisibleWithStickyShells")),
+            f"Sticky portal chrome obscured focused controls: {build_accessibility}",
+        )
+
+        print("portal-browser-smoke: checking reduced motion", flush=True)
+        connection.call(
+            "Emulation.setEmulatedMedia",
+            {"features": [{"name": "prefers-reduced-motion", "value": "reduce"}]},
+        )
+        reduced_motion_state = _poll(
+            connection,
+            _accessibility_probe_expression(),
+            predicate=lambda value: (
+                isinstance(value, dict)
+                and bool(value.get("reducedMotion"))
+                and bool(value.get("decorativeMotionStatic"))
+                and bool(value.get("buildStepTargetMin"))
+            ),
+            timeout_seconds=args.timeout_seconds,
+            description="portal reduced-motion shell",
+        )
+        _expect(
+            bool(reduced_motion_state.get("decorativeMotionStatic")),
+            f"Reduced-motion mode left decorative portal motion active: {reduced_motion_state}",
+        )
+        connection.call(
+            "Emulation.setEmulatedMedia",
+            {"features": [{"name": "prefers-reduced-motion", "value": "no-preference"}]},
         )
 
         print("portal-browser-smoke: confirming lux-depth-v3 build defaults", flush=True)
@@ -2142,9 +2304,7 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
         )
 
         print("portal-browser-smoke: simulating degraded auth recovery controls", flush=True)
-        degraded_state = connection.evaluate(
-            _simulate_bootstrap_degraded_expression(reason="auth_failure", http_status=401)
-        )
+        degraded_state = connection.evaluate(_simulate_bootstrap_degraded_expression(reason="auth_failure", http_status=401))
         _expect(isinstance(degraded_state, dict), f"Unexpected degraded portal state: {degraded_state!r}")
         _expect(
             str(degraded_state.get("actionPrimaryKey", "")).strip() == "restore_access",

--- a/tests/validation/test_portal_smoke_scripts.py
+++ b/tests/validation/test_portal_smoke_scripts.py
@@ -162,6 +162,22 @@ def test_portal_browser_state_probe_tracks_contextual_action_controls():
     assert "reviewStatusPrimaryKey" in expression
 
 
+def test_portal_browser_accessibility_probe_tracks_target_size_and_disclosure_contracts():
+    module = _load_module(PORTAL_BROWSER_SCRIPT_PATH, "tests_validate_portal_browser_smoke_accessibility_probe")
+
+    expression = module._accessibility_probe_expression()
+
+    assert "#themeBtn" in expression
+    assert "#shortcutsBtn" in expression
+    assert '[data-ui="view-link"]' in expression
+    assert "#buildStepTab1" in expression
+    assert "focusVisibleWithStickyShells" in expression
+    assert "maxDisclosureDepth" in expression
+    assert "discoverableDisclosures" in expression
+    assert "prefers-reduced-motion" in expression
+    assert "decorativeMotionStatic" in expression
+
+
 def test_portal_browser_can_simulate_bootstrap_degraded_recovery_actions():
     module = _load_module(PORTAL_BROWSER_SCRIPT_PATH, "tests_validate_portal_browser_smoke_degraded_expr")
 
@@ -459,6 +475,22 @@ def test_frontdoor_browser_waits_for_managed_portal_bootstrap_before_passing():
     assert "/healthz" in content
     assert "--spawn-local-frontdoor" in content
     assert "--spawn-local-backend" in content
+
+
+def test_frontdoor_browser_accessibility_probe_tracks_target_size_and_reduced_motion():
+    module = _load_module(FRONTDOOR_BROWSER_SCRIPT_PATH, "tests_validate_frontdoor_browser_smoke_accessibility_probe")
+
+    expression = module._frontdoor_accessibility_probe_expression()
+
+    assert '[data-ui="homepage-primary-cta"]' in expression
+    assert '[data-ui="homepage-secondary-cta"]' in expression
+    assert '[data-ui="homepage-learn-link"]' in expression
+    assert '[data-ui="login-submit"]' in expression
+    assert '[data-ui="login-secondary-link"]' in expression
+    assert "maxDisclosureDepth" in expression
+    assert "focusVisibleWithStickyHeader" in expression
+    assert "prefers-reduced-motion" in expression
+    assert "decorativeMotionStatic" in expression
 
 
 def test_portal_browser_smoke_tracks_archive_readiness_fields_and_canonical_commands():

--- a/web/secure-landing/app/global-error.js
+++ b/web/secure-landing/app/global-error.js
@@ -1,62 +1,35 @@
 "use client";
 
+import { FrontdoorErrorShell } from "../components/frontdoor-error-shell.js";
+
 export const dynamic = "force-dynamic";
 
 export default function GlobalError({ error, reset }) {
   return (
     <html lang="en">
-      <body
-        style={{
-          margin: 0,
-          minHeight: "100vh",
-          display: "grid",
-          placeItems: "center",
-          padding: "2rem",
-          background: "#08111a",
-          color: "#f5f7fb",
-          fontFamily: "system-ui, sans-serif"
-        }}
-      >
-        <main style={{ maxWidth: "40rem" }}>
-          <p
-            style={{
-              margin: 0,
-              fontSize: "0.8rem",
-              letterSpacing: "0.12em",
-              textTransform: "uppercase",
-              color: "#8bc5ff"
-            }}
-          >
-            Dynamic Neural Access
-          </p>
-          <h1 style={{ margin: "0.75rem 0 0", fontSize: "2rem", lineHeight: 1.1 }}>
-            The managed front door hit an unexpected failure.
-          </h1>
-          <p style={{ margin: "1rem 0 0", color: "#c5d1de", lineHeight: 1.6 }}>
-            Retry the request. If the problem persists, inspect the runtime logs for the active
-            front door instance.
-          </p>
-          <button
-            type="button"
-            onClick={() => reset()}
-            style={{
-              marginTop: "1.5rem",
-              border: "1px solid #8bc5ff",
-              borderRadius: "999px",
-              padding: "0.8rem 1.25rem",
-              background: "transparent",
-              color: "inherit",
-              cursor: "pointer"
-            }}
-          >
-            Retry
-          </button>
-          {error?.digest ? (
-            <p style={{ margin: "1rem 0 0", color: "#9aa8b7", fontSize: "0.9rem" }}>
-              Reference: {error.digest}
-            </p>
-          ) : null}
-        </main>
+      <body>
+        <FrontdoorErrorShell
+          title="The managed front door hit an unexpected failure."
+          message="Retry the request. If the problem persists, inspect the runtime logs for the active front door instance."
+          primaryAction={
+            <button
+              type="button"
+              onClick={() => reset()}
+              style={{
+                minHeight: "44px",
+                border: "1px solid #7dd3fc",
+                borderRadius: "8px",
+                padding: "0.8rem 1rem",
+                background: "transparent",
+                color: "#f8fafc",
+                cursor: "pointer"
+              }}
+            >
+              Retry
+            </button>
+          }
+          reference={error?.digest ? String(error.digest) : ""}
+        />
       </body>
     </html>
   );

--- a/web/secure-landing/app/login/route.js
+++ b/web/secure-landing/app/login/route.js
@@ -46,14 +46,14 @@ function resolveEntryState({ accessEmail, errorCode }) {
     credentialState: hasRecoveryIssue ? "blocked" : hasVerifiedAccess ? "ready" : "waiting",
     accessLabel: hasVerifiedAccess ? "Verified access ready" : "Managed access required",
     accessDetail: hasVerifiedAccess
-      ? `Cloudflare Access is already verified for <strong>${escapeHtml(accessEmail)}</strong>.`
-      : "Managed access verification completes before operator credential handoff opens.",
+      ? `Verified for <strong>${escapeHtml(accessEmail)}</strong>.`
+      : "Managed access verification opens the next step.",
     credentialLabel: hasRecoveryIssue ? "Recovery required" : hasVerifiedAccess ? "Credential handoff ready" : "Waiting on verified access",
     credentialDetail: hasRecoveryIssue
       ? escapeHtml(resolveRecoveryGuidance(errorCode))
       : hasVerifiedAccess
-        ? "Continue with operator credentials to rotate into the governed portal session."
-        : "Operator credential handoff stays blocked until the verified access context is present.",
+        ? "Continue with operator credentials."
+        : "Credential handoff stays closed until access is verified.",
     recoveryState: hasRecoveryIssue ? String(errorCode || "").trim().toLowerCase() || "invalid" : "clear",
   };
 }
@@ -79,6 +79,16 @@ function renderLoginPage({ csrfToken, accessEmail, errorCode }) {
         detail: `Managed access has already been verified for ${accessEmail}. Successful sign-in rotates this browser into the governed portal session.`
       }
       : null;
+  const nextStepTitle = errorMessage
+    ? "Recovery is required before sign-in can continue."
+    : accessEmail
+      ? "Credential handoff is ready."
+      : "Managed access must complete first.";
+  const nextStepDetail = errorMessage
+    ? resolveRecoveryGuidance(errorCode)
+    : accessEmail
+      ? "Use your operator username and password to continue into the governed console."
+      : "Return after managed access verification opens operator credential entry.";
 
   return `<!DOCTYPE html>
 <html lang="en">
@@ -131,7 +141,7 @@ function renderLoginPage({ csrfToken, accessEmail, errorCode }) {
             <p class="eyebrow" data-ui="login-eyebrow">Managed operator access</p>
             <h1 data-ui="login-title">Continue to the operator console.</h1>
             <p class="lede" data-ui="login-lede">
-              Managed access and operator credentials stay separate on purpose. Confirm the verified access context first, then complete credential handoff into the governed console.
+              Confirm the managed access state, then complete operator credential handoff into the governed console.
             </p>
             <div class="login-entry-state" data-ui="login-entry-state">
               <article class="login-status-card" data-ui="login-access-status" data-state="${escapeHtml(entryState.accessState)}">
@@ -145,29 +155,42 @@ function renderLoginPage({ csrfToken, accessEmail, errorCode }) {
                 <p class="login-status-card-detail">${entryState.credentialDetail}</p>
               </article>
             </div>
-            <div class="login-sequence" data-ui="login-sequence">
-              <article class="login-sequence-step${accessEmail ? " login-sequence-step--ready" : ""}">
-                <p class="login-sequence-step-kicker">Step 1</p>
-                <p class="login-sequence-step-title">Verified access</p>
-                <p class="login-sequence-step-detail">${accessSequenceDetail}</p>
-              </article>
-              <article class="login-sequence-step login-sequence-step--active">
-                <p class="login-sequence-step-kicker">Step 2</p>
-                <p class="login-sequence-step-title">Operator credentials</p>
-                <p class="login-sequence-step-detail">Use your portal username and password to rotate into the governed build, operate, and review session.</p>
-              </article>
+            <div class="login-next-step" data-state="${escapeHtml(entryState.credentialState)}">
+              <p class="login-next-step-kicker">Next step</p>
+              <p class="login-next-step-title">${escapeHtml(nextStepTitle)}</p>
+              <p class="login-next-step-detail">${escapeHtml(nextStepDetail)}</p>
             </div>
-            ${errorMessage || accessText ? `<div class="login-status-stack" data-ui="login-status-stack">
+            ${errorMessage ? `<div class="login-status-stack" data-ui="login-status-stack">
               ${errorMessage ? `<div class="banner" data-ui="login-error-banner" role="alert">
                 <p class="banner-title">Sign-in needs attention</p>
                 <p class="banner-detail">${escapeHtml(errorMessage)}</p>
               </div>` : ""}
-              ${accessText ? `<p class="card-meta card-meta--verified" data-ui="login-access-context">${accessText}</p>` : ""}
-              ${recoveryCard ? `<div class="login-recovery-card" data-ui="login-recovery-card" data-state="${escapeHtml(entryState.recoveryState)}">
-                <p class="login-recovery-card-title">${escapeHtml(recoveryCard.title)}</p>
-                <p class="login-recovery-card-detail">${escapeHtml(recoveryCard.detail)}</p>
-              </div>` : ""}
             </div>` : ""}
+            <details class="login-secondary-details" data-ui="login-sequence">
+              <summary>
+                <span>Access details</span>
+                <span class="login-secondary-details__meta">${accessEmail ? "Verified context" : "Managed entry flow"}</span>
+              </summary>
+              <div class="login-secondary-details__content">
+                <div class="login-sequence">
+                  <article class="login-sequence-step${accessEmail ? " login-sequence-step--ready" : ""}">
+                    <p class="login-sequence-step-kicker">Step 1</p>
+                    <p class="login-sequence-step-title">Verified access</p>
+                    <p class="login-sequence-step-detail">${accessSequenceDetail}</p>
+                  </article>
+                  <article class="login-sequence-step login-sequence-step--active">
+                    <p class="login-sequence-step-kicker">Step 2</p>
+                    <p class="login-sequence-step-title">Operator credentials</p>
+                    <p class="login-sequence-step-detail">Use your portal username and password to rotate into the governed build, operate, and review session.</p>
+                  </article>
+                </div>
+                ${accessText ? `<p class="card-meta card-meta--verified" data-ui="login-access-context">${accessText}</p>` : ""}
+                ${recoveryCard ? `<div class="login-recovery-card" data-ui="login-recovery-card" data-state="${escapeHtml(entryState.recoveryState)}">
+                  <p class="login-recovery-card-title">${escapeHtml(recoveryCard.title)}</p>
+                  <p class="login-recovery-card-detail">${escapeHtml(recoveryCard.detail)}</p>
+                </div>` : ""}
+              </div>
+            </details>
             <form method="post" action="/login" autocomplete="on" data-ui="login-form">
               <input type="hidden" name="csrf_token" value="${escapeHtml(csrfToken)}" />
               <label data-ui="login-username-field">
@@ -179,7 +202,7 @@ function renderLoginPage({ csrfToken, accessEmail, errorCode }) {
                 <input type="password" name="password" autocomplete="current-password" required />
               </label>
               <p class="login-helper" data-ui="login-helper">
-                Use your operator credentials. Successful sign-in rotates the session before handoff to the governed portal.
+                Use your operator credentials. Successful sign-in rotates the session before portal handoff.
               </p>
               <div class="login-actions" data-ui="login-actions">
                 <button type="submit" data-ui="login-submit">Sign in</button>

--- a/web/secure-landing/app/not-found.js
+++ b/web/secure-landing/app/not-found.js
@@ -1,37 +1,12 @@
+import { FrontdoorErrorShell } from "../components/frontdoor-error-shell.js";
+
 export const dynamic = "force-dynamic";
 
 export default function NotFound() {
   return (
-    <main
-      style={{
-        minHeight: "100vh",
-        display: "grid",
-        placeItems: "center",
-        padding: "2rem",
-        background: "#08111a",
-        color: "#f5f7fb",
-        fontFamily: "system-ui, sans-serif"
-      }}
-    >
-      <div style={{ maxWidth: "36rem" }}>
-        <p
-          style={{
-            margin: 0,
-            fontSize: "0.8rem",
-            letterSpacing: "0.12em",
-            textTransform: "uppercase",
-            color: "#8bc5ff"
-          }}
-        >
-          Dynamic Neural Access
-        </p>
-        <h1 style={{ margin: "0.75rem 0 0", fontSize: "2rem", lineHeight: 1.1 }}>
-          The requested front door route was not found.
-        </h1>
-        <p style={{ margin: "1rem 0 0", color: "#c5d1de", lineHeight: 1.6 }}>
-          Check the managed entry path and retry from the secure landing surface.
-        </p>
-      </div>
-    </main>
+    <FrontdoorErrorShell
+      title="The requested front door route was not found."
+      message="Check the managed entry path and retry from the secure landing surface."
+    />
   );
 }

--- a/web/secure-landing/app/portal/route.js
+++ b/web/secure-landing/app/portal/route.js
@@ -94,18 +94,18 @@ function renderManagedPortalRecoveryPage({ reason, message }) {
           <div class="card card--login" data-ui="managed-recovery-card">
             <p class="eyebrow">Managed portal entry</p>
             <h1>${safeTitle}</h1>
-            <p class="lede">${safeDetail}</p>
+            <p class="lede">The managed boundary stays closed until the blocking condition is resolved.</p>
             <div class="login-entry-state">
-              <article class="login-status-card" data-state="${recoveryTone}">
-                <p class="login-status-card-kicker">State</p>
+              <article class="login-status-card login-status-card--full" data-state="${recoveryTone}">
+                <p class="login-status-card-kicker">Current state</p>
                 <p class="login-status-card-title">${safeLabel}</p>
                 <p class="login-status-card-detail">${safeDetail}</p>
               </article>
-              <article class="login-status-card" data-state="${recoveryTone}">
-                <p class="login-status-card-kicker">Next step</p>
-                <p class="login-status-card-title">Recover, then retry</p>
-                <p class="login-status-card-detail">${safeNextStep}</p>
-              </article>
+            </div>
+            <div class="login-next-step" data-state="${recoveryTone}">
+              <p class="login-next-step-kicker">Next step</p>
+              <p class="login-next-step-title">Recover, then retry</p>
+              <p class="login-next-step-detail">${safeNextStep}</p>
             </div>
             <div class="login-status-stack">
               <div class="login-recovery-card" data-ui="managed-recovery-guidance" data-state="${safeReason}">

--- a/web/secure-landing/components/frontdoor-error-shell.js
+++ b/web/secure-landing/components/frontdoor-error-shell.js
@@ -1,0 +1,88 @@
+const SHELL_STYLE = {
+  position: "fixed",
+  inset: 0,
+  overflow: "auto",
+  display: "grid",
+  placeItems: "center",
+  padding: "2rem",
+  background: "linear-gradient(180deg, #06111d 0%, #081523 48%, #06111d 100%)",
+  color: "#f8fafc",
+  fontFamily: "system-ui, sans-serif",
+  boxSizing: "border-box",
+};
+
+const PANEL_STYLE = {
+  width: "min(100%, 32rem)",
+  border: "1px solid rgba(148, 163, 184, 0.24)",
+  borderRadius: "8px",
+  background: "rgba(8, 15, 29, 0.94)",
+  boxShadow: "0 20px 44px rgba(2, 6, 23, 0.38)",
+  padding: "1.5rem",
+};
+
+const META_STYLE = {
+  margin: 0,
+  fontSize: "0.75rem",
+  letterSpacing: "0.12em",
+  textTransform: "uppercase",
+  color: "#93c5fd",
+};
+
+const TITLE_STYLE = {
+  margin: "0.75rem 0 0",
+  fontSize: "2rem",
+  lineHeight: 1.1,
+};
+
+const COPY_STYLE = {
+  margin: "0.9rem 0 0",
+  color: "#cbd5e1",
+  lineHeight: 1.6,
+};
+
+const ACTION_ROW_STYLE = {
+  display: "flex",
+  flexWrap: "wrap",
+  gap: "0.75rem",
+  marginTop: "1.5rem",
+};
+
+const SECONDARY_ACTION_STYLE = {
+  minHeight: "44px",
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  border: "1px solid rgba(148, 163, 184, 0.24)",
+  borderRadius: "8px",
+  padding: "0.8rem 1rem",
+  color: "#cbd5e1",
+  textDecoration: "none",
+};
+
+export function FrontdoorErrorShell({
+  title,
+  message,
+  primaryAction = null,
+  reference = "",
+}) {
+  return (
+    <main style={SHELL_STYLE}>
+      <section style={PANEL_STYLE}>
+        <p style={META_STYLE}>Dynamic Neural Access</p>
+        <h1 style={TITLE_STYLE}>{title}</h1>
+        <p style={COPY_STYLE}>{message}</p>
+        <div style={ACTION_ROW_STYLE}>
+          {primaryAction}
+          <a href="/" style={SECONDARY_ACTION_STYLE}>
+            Return home
+          </a>
+        </div>
+        {reference ? (
+          <p style={{ ...COPY_STYLE, fontSize: "0.9rem", color: "#94a3b8" }}>
+            Reference: {reference}
+          </p>
+        ) : null}
+      </section>
+    </main>
+  );
+}

--- a/web/secure-landing/lib/homepage.js
+++ b/web/secure-landing/lib/homepage.js
@@ -514,9 +514,18 @@ export function renderHomepage() {
                 <p class="entry-card__detail">Verification report, provenance artifacts, rights posture, and operator review stay in one reviewable handoff.</p>
               </div>
               <div class="entry-card__meta">
-                <p><strong>Public proof</strong> Inspect the report before access is requested.</p>
-                <p><strong>Managed entry</strong> Access verification stays separate from operator credentials.</p>
-                <p><strong>Operator console</strong> Build, operate, and review continue inside the governed shell.</p>
+                <div class="entry-card__meta-item">
+                  <p class="entry-card__meta-label">Public proof</p>
+                  <p class="entry-card__meta-value">Inspect the report before access is requested.</p>
+                </div>
+                <div class="entry-card__meta-item">
+                  <p class="entry-card__meta-label">Managed entry</p>
+                  <p class="entry-card__meta-value">Access verification stays separate from operator credentials.</p>
+                </div>
+                <div class="entry-card__meta-item">
+                  <p class="entry-card__meta-label">Operator console</p>
+                  <p class="entry-card__meta-value">Build, operate, and review continue inside the governed shell.</p>
+                </div>
               </div>
             </article>
           </div>

--- a/web/secure-landing/lib/homepage.js
+++ b/web/secure-landing/lib/homepage.js
@@ -496,43 +496,35 @@ export function renderHomepage() {
           <p class="section-kicker">Dynamic Neural Access</p>
           <h1 id="hero-title" data-ui="homepage-hero-title">Make premium media verifiable before it ships.</h1>
           <p class="hero-lede" data-ui="homepage-hero-lede">
-            Dynamic Neural Access is the certification layer for high-value media workflows. Turn raw or AI-assisted assets into partner-safe releases with reviewable provenance, rights posture, operator history, and distribution-ready proof.
+            Verifier-backed release proof for premium media. Keep provenance, rights posture, and operator history attached before anything leaves the workflow.
           </p>
           <div class="hero-actions" data-ui="homepage-hero-actions">
             <a class="site-cta" href="/login" data-ui="homepage-primary-cta">Operator Access</a>
             <a class="site-cta site-cta--secondary" href="#proof-report" data-ui="homepage-secondary-cta">Inspect Verification Report</a>
+            <a class="hero-inline-link" href="#workflow" data-ui="homepage-learn-link">Explore workflow</a>
           </div>
           <p class="hero-access-note" data-ui="homepage-hero-note">
-            Review the public proof surface first. Operator build, operate, and review work remains gated behind managed access.
+            Public proof stays visible. Managed entry opens only when operator work needs to continue.
           </p>
           <div class="entry-rail" data-ui="homepage-entry-rail">
-            <article class="entry-card" data-state="public-proof">
-              <p class="entry-card__kicker">Public proof</p>
-              <p class="entry-card__title">Start with orientation.</p>
-              <p class="entry-card__detail">Open the public proof surface to inspect release posture, verification context, and workflow scope before any operator session begins.</p>
+            <article class="entry-card entry-card--proofband" data-state="public-proof">
+              <div class="entry-card__summary">
+                <p class="entry-card__kicker">Proof snapshot</p>
+                <p class="entry-card__title">One release bundle, one decision path.</p>
+                <p class="entry-card__detail">Verification report, provenance artifacts, rights posture, and operator review stay in one reviewable handoff.</p>
+              </div>
+              <div class="entry-card__meta">
+                <p><strong>Public proof</strong> Inspect the report before access is requested.</p>
+                <p><strong>Managed entry</strong> Access verification stays separate from operator credentials.</p>
+                <p><strong>Operator console</strong> Build, operate, and review continue inside the governed shell.</p>
+              </div>
             </article>
-            <article class="entry-card" data-state="verified-access">
-              <p class="entry-card__kicker">Verified access</p>
-              <p class="entry-card__title">Confirm identity before credential handoff.</p>
-              <p class="entry-card__detail">Managed entry keeps Cloudflare Access verification separate from operator credentials so the browser never becomes the system of record.</p>
-            </article>
-            <article class="entry-card" data-state="governed-console">
-              <p class="entry-card__kicker">Governed console</p>
-              <p class="entry-card__title">Run build, operate, and review work inside the portal.</p>
-              <p class="entry-card__detail">Managed entry hands work into the operator console only after verification is complete and the governed shell is ready.</p>
-            </article>
-          </div>
-          <div class="hero-route-grid" data-ui="homepage-route-grid">
-            ${renderList(HERO_PATHS, renderHeroRouteCard)}
           </div>
           <div class="signal-strip" aria-label="Proof signals">
             ${renderList(HERO_SIGNALS, (item) => `<span class="signal-pill">${escapeHtml(item)}</span>`)}
           </div>
           <div class="guardrail-callout">
             <strong>Not a truth engine.</strong> A release-readiness system for provenance context, rights clarity, and reviewable evidence.
-          </div>
-          <div class="highlight-grid">
-            ${renderList(HERO_HIGHLIGHTS, renderHighlightCard)}
           </div>
         </div>
         ${renderReleaseBundlePreview()}

--- a/web/secure-landing/public/frontdoor-homepage.css
+++ b/web/secure-landing/public/frontdoor-homepage.css
@@ -1133,6 +1133,208 @@ body.frontdoor-homepage .site-footer__copy {
   }
 }
 
+body.frontdoor-homepage {
+  --fd-border: var(--ux-border-subtle);
+  --fd-border-strong: var(--ux-border-strong);
+  --fd-text: var(--ux-text-primary);
+  --fd-text-strong: var(--ux-text-strong);
+  --fd-text-soft: var(--ux-text-muted);
+  --fd-accent: var(--ux-accent-primary);
+  --fd-accent-strong: var(--ux-accent-secondary);
+  background:
+    radial-gradient(circle at top, rgba(6, 182, 212, 0.08), transparent 32%),
+    linear-gradient(180deg, rgba(2, 6, 23, 0.98), rgba(2, 6, 23, 1));
+}
+
+body.frontdoor-homepage .homepage-video {
+  opacity: 0.08;
+  filter: saturate(0.78) brightness(0.76);
+}
+
+body.frontdoor-homepage .homepage-backdrop__grid,
+body.frontdoor-homepage .homepage-backdrop__glow {
+  display: none;
+}
+
+body.frontdoor-homepage .homepage-backdrop__overlay {
+  background: linear-gradient(180deg, rgba(2, 6, 23, 0.78), rgba(2, 6, 23, 0.96));
+}
+
+body.frontdoor-homepage .site-header {
+  backdrop-filter: blur(12px);
+  background: rgba(2, 6, 23, 0.88);
+  box-shadow: var(--ux-shadow-surface);
+}
+
+body.frontdoor-homepage .brand-lockup__mark,
+body.frontdoor-homepage .entry-card,
+body.frontdoor-homepage .highlight-card,
+body.frontdoor-homepage .feature-card,
+body.frontdoor-homepage .evidence-card,
+body.frontdoor-homepage .audience-card,
+body.frontdoor-homepage .principle-card,
+body.frontdoor-homepage .faq-item,
+body.frontdoor-homepage .workflow-card,
+body.frontdoor-homepage .proof-panel,
+body.frontdoor-homepage .cta-panel,
+body.frontdoor-homepage .guardrail-callout,
+body.frontdoor-homepage .report-panel pre,
+body.frontdoor-homepage .status-card,
+body.frontdoor-homepage .checkpoint-row,
+body.frontdoor-homepage .artifact-row {
+  border-radius: var(--ux-radius-lg);
+}
+
+body.frontdoor-homepage .brand-lockup__mark {
+  border-color: var(--fd-border);
+  background: rgba(8, 15, 29, 0.88);
+  box-shadow: none;
+}
+
+body.frontdoor-homepage .brand-lockup__kicker,
+body.frontdoor-homepage .section-kicker,
+body.frontdoor-homepage .subsection-kicker,
+body.frontdoor-homepage .status-label,
+body.frontdoor-homepage .artifact-status,
+body.frontdoor-homepage .workflow-step,
+body.frontdoor-homepage .workflow-output-label,
+body.frontdoor-homepage .card-kicker,
+body.frontdoor-homepage .entry-card__kicker {
+  letter-spacing: var(--ux-meta-tracking);
+}
+
+body.frontdoor-homepage .hero-copy h1 {
+  max-width: 13ch;
+  line-height: 1.05;
+}
+
+body.frontdoor-homepage .hero-lede {
+  max-width: 38rem;
+  margin-top: 1.2rem;
+  color: var(--fd-text);
+}
+
+body.frontdoor-homepage .hero-actions {
+  gap: 0.75rem;
+  align-items: stretch;
+}
+
+body.frontdoor-homepage .site-cta,
+body.frontdoor-homepage .site-link,
+body.frontdoor-homepage .homepage-nav-link,
+body.frontdoor-homepage .homepage-mobile-link,
+body.frontdoor-homepage .site-mobile-menu,
+body.frontdoor-homepage .hero-inline-link {
+  min-height: var(--ux-target-min-size);
+  border-radius: var(--ux-radius-md);
+}
+
+body.frontdoor-homepage .site-cta {
+  padding: 0.85rem 1.15rem;
+  border-color: rgba(255, 255, 255, 0.06);
+  background: linear-gradient(135deg, rgba(15, 118, 110, 0.96), rgba(8, 145, 178, 0.9));
+  box-shadow: var(--ux-shadow-surface);
+}
+
+body.frontdoor-homepage .site-cta--secondary,
+body.frontdoor-homepage .site-cta--ghost,
+body.frontdoor-homepage .site-link,
+body.frontdoor-homepage .hero-inline-link {
+  border: 1px solid var(--fd-border);
+  background: rgba(15, 23, 42, 0.76);
+  box-shadow: none;
+}
+
+body.frontdoor-homepage .hero-inline-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1rem;
+  color: var(--fd-text);
+  font-weight: 600;
+}
+
+body.frontdoor-homepage .entry-rail {
+  gap: 0.75rem;
+}
+
+body.frontdoor-homepage .entry-card {
+  padding: 1rem;
+  border-color: var(--fd-border);
+  background: rgba(8, 15, 29, 0.82);
+  box-shadow: var(--ux-shadow-surface);
+}
+
+body.frontdoor-homepage .entry-card--proofband {
+  gap: 0.75rem;
+}
+
+body.frontdoor-homepage .entry-card__summary {
+  margin: 0;
+  color: var(--fd-text);
+  line-height: 1.6;
+}
+
+body.frontdoor-homepage .entry-card__meta {
+  display: grid;
+  gap: 0.55rem;
+  grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+}
+
+body.frontdoor-homepage .entry-card__meta-item {
+  display: grid;
+  gap: 0.2rem;
+}
+
+body.frontdoor-homepage .entry-card__meta-label {
+  margin: 0;
+  color: var(--fd-accent);
+  font-size: var(--ux-label-size);
+  font-family:
+    "SFMono-Regular",
+    "SF Mono",
+    "Menlo",
+    "Consolas",
+    monospace;
+  letter-spacing: var(--ux-meta-tracking);
+  text-transform: uppercase;
+}
+
+body.frontdoor-homepage .entry-card__meta-value {
+  margin: 0;
+  color: var(--fd-text-strong);
+  font-size: 0.92rem;
+  line-height: 1.55;
+}
+
+body.frontdoor-homepage .signal-pill,
+body.frontdoor-homepage .guardrail-callout,
+body.frontdoor-homepage .highlight-card,
+body.frontdoor-homepage .feature-card,
+body.frontdoor-homepage .evidence-card,
+body.frontdoor-homepage .audience-card,
+body.frontdoor-homepage .principle-card,
+body.frontdoor-homepage .faq-item,
+body.frontdoor-homepage .workflow-card,
+body.frontdoor-homepage .proof-panel,
+body.frontdoor-homepage .status-card,
+body.frontdoor-homepage .checkpoint-row,
+body.frontdoor-homepage .artifact-row,
+body.frontdoor-homepage .report-panel pre,
+body.frontdoor-homepage .cta-panel {
+  border-color: var(--fd-border);
+  background: rgba(8, 15, 29, 0.82);
+  box-shadow: var(--ux-shadow-surface);
+}
+
+body.frontdoor-homepage .cta-panel {
+  background: rgba(8, 15, 29, 0.88);
+}
+
+body.frontdoor-homepage .signal-pill {
+  padding: 0.72rem 0.9rem;
+}
+
 @media (prefers-reduced-motion: reduce) {
   body.frontdoor-homepage *,
   body.frontdoor-homepage *::before,
@@ -1148,5 +1350,9 @@ body.frontdoor-homepage .site-footer__copy {
   body.frontdoor-homepage .homepage-nav-link:hover,
   body.frontdoor-homepage .homepage-mobile-link:hover {
     transform: none !important;
+  }
+
+  body.frontdoor-homepage .homepage-video {
+    display: none;
   }
 }

--- a/web/secure-landing/public/login.css
+++ b/web/secure-landing/public/login.css
@@ -464,6 +464,9 @@ input::placeholder {
 
 button {
   border: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   border-radius: 999px;
   min-height: var(--ux-target-min-size);
   padding: 0.95rem 1.15rem;
@@ -761,6 +764,194 @@ code {
   .login-sequence {
     grid-template-columns: 1fr;
   }
+}
+
+body {
+  background:
+    radial-gradient(circle at top right, rgba(56, 189, 248, 0.08), transparent 24%),
+    linear-gradient(180deg, #020617 0%, #081122 48%, #020617 100%);
+}
+
+.hero-video {
+  opacity: 0.12;
+  filter: saturate(0.84) brightness(0.7) contrast(1);
+}
+
+.shell::after {
+  background: linear-gradient(180deg, rgba(2, 6, 23, 0.28), rgba(2, 6, 23, 0.88));
+}
+
+.brand-kicker,
+.brand-subtitle,
+.eyebrow,
+.login-status-card-kicker,
+.login-recovery-card-title,
+.login-sequence-step-kicker,
+.login-next-step-kicker {
+  letter-spacing: var(--ux-meta-tracking);
+}
+
+.card,
+.card--login,
+.login-status-card,
+.login-sequence-step,
+.login-recovery-card,
+.banner,
+.card-meta--verified,
+input,
+button,
+.login-secondary-link,
+.login-next-step,
+.login-secondary-details,
+.login-secondary-details summary {
+  border-radius: var(--ux-radius-lg);
+}
+
+.card {
+  width: min(100%, 29rem);
+  border-color: var(--ux-border-subtle);
+  background: rgba(8, 15, 29, 0.92);
+  backdrop-filter: blur(12px);
+  box-shadow: var(--ux-shadow-overlay);
+}
+
+.card--login {
+  background: rgba(8, 15, 29, 0.94);
+}
+
+.lede {
+  margin-bottom: 1.15rem;
+  color: var(--ux-text-muted);
+}
+
+.login-entry-state {
+  grid-template-columns: 1fr;
+  margin-bottom: 1rem;
+}
+
+.login-status-card,
+.login-sequence-step,
+.login-recovery-card,
+.card-meta--verified,
+.login-next-step {
+  border-color: var(--ux-border-subtle);
+  background: rgba(15, 23, 42, 0.74);
+  box-shadow: var(--ux-shadow-surface);
+}
+
+.login-status-card[data-state="verified"],
+.login-status-card[data-state="ready"],
+.login-sequence-step--ready,
+.card-meta--verified {
+  border-color: rgba(94, 234, 212, 0.24);
+  background:
+    linear-gradient(180deg, rgba(15, 118, 110, 0.1), rgba(15, 23, 42, 0.78)),
+    rgba(15, 23, 42, 0.76);
+}
+
+.login-status-card[data-state="blocked"],
+.login-recovery-card[data-state="access"],
+.login-recovery-card[data-state="access_outage"],
+.login-recovery-card[data-state="configuration"],
+.login-recovery-card[data-state="config_failure"],
+.login-recovery-card[data-state="csrf"],
+.login-recovery-card[data-state="throttled"],
+.login-recovery-card[data-state="invalid"],
+.login-recovery-card[data-state="upstream_unavailable"] {
+  border-color: rgba(248, 113, 113, 0.24);
+  background:
+    linear-gradient(180deg, rgba(127, 29, 29, 0.12), rgba(15, 23, 42, 0.78)),
+    rgba(15, 23, 42, 0.76);
+}
+
+.login-next-step {
+  display: grid;
+  gap: 0.35rem;
+  margin-bottom: 1rem;
+  padding: 0.95rem 1rem;
+}
+
+.login-next-step-kicker,
+.login-next-step-title,
+.login-next-step-detail {
+  margin: 0;
+}
+
+.login-next-step-title {
+  font-size: 0.98rem;
+  font-weight: 800;
+  line-height: 1.35;
+  color: var(--frontdoor-ink);
+}
+
+.login-next-step-detail {
+  font-size: 0.9rem;
+  line-height: 1.6;
+  color: var(--frontdoor-muted-soft);
+}
+
+.login-secondary-details {
+  margin-bottom: 1rem;
+  border: 1px solid var(--ux-border-subtle);
+  background: rgba(8, 15, 29, 0.88);
+  box-shadow: var(--ux-shadow-surface);
+}
+
+.login-secondary-details summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  min-height: var(--ux-target-min-size);
+  padding: 0.85rem 1rem;
+  cursor: pointer;
+  list-style: none;
+  color: var(--frontdoor-ink);
+  font-weight: 700;
+}
+
+.login-secondary-details summary::-webkit-details-marker {
+  display: none;
+}
+
+.login-secondary-details__meta {
+  color: var(--frontdoor-muted-soft);
+  font-size: var(--ux-label-size);
+  letter-spacing: var(--ux-meta-tracking);
+  text-transform: uppercase;
+}
+
+.login-secondary-details__content {
+  display: grid;
+  gap: 0.9rem;
+  padding: 0 1rem 1rem;
+}
+
+input,
+button,
+.login-secondary-link {
+  min-height: var(--ux-target-min-size);
+}
+
+input {
+  border-color: var(--ux-border-subtle);
+  background: rgba(15, 23, 42, 0.78);
+}
+
+button {
+  border: 1px solid rgba(125, 211, 252, 0.18);
+  background: linear-gradient(135deg, rgba(15, 118, 110, 0.96), rgba(8, 145, 178, 0.9));
+  box-shadow: var(--ux-shadow-surface);
+}
+
+.login-secondary-link {
+  border-color: var(--ux-border-subtle);
+  background: rgba(15, 23, 42, 0.74);
+}
+
+button,
+.login-secondary-link {
+  width: 100%;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/web/secure-landing/public/shared-ui-tokens.css
+++ b/web/secure-landing/public/shared-ui-tokens.css
@@ -1,4 +1,5 @@
-/* Shared UI primitives used by both the managed frontdoor and portal console. */
+/* Canonical shared UI token source used by both the managed frontdoor and portal console. */
+/* build-portal-bundle.mjs copies this file into the shipped frontdoor and portal asset targets. */
 :root {
   color-scheme: light dark;
 

--- a/web/secure-landing/public/shared-ui-tokens.css
+++ b/web/secure-landing/public/shared-ui-tokens.css
@@ -1,6 +1,86 @@
 /* Shared UI primitives used by both the managed frontdoor and portal console. */
 :root {
+  color-scheme: light dark;
+
   --ux-target-min-size: 44px;
-  --ux-label-size: 0.8125rem;
   --ux-body-size: 1rem;
+  --ux-label-size: 0.75rem;
+  --ux-meta-size: 0.8125rem;
+
+  --ux-space-1: 0.25rem;
+  --ux-space-2: 0.5rem;
+  --ux-space-3: 0.75rem;
+  --ux-space-4: 1rem;
+  --ux-space-5: 1.25rem;
+  --ux-space-6: 1.5rem;
+  --ux-space-8: 2rem;
+
+  --ux-radius-sm: 6px;
+  --ux-radius-md: 8px;
+  --ux-radius-lg: 8px;
+  --ux-radius-pill: 999px;
+
+  --ux-focus-ring: rgba(8, 145, 178, 0.92);
+  --ux-focus-shadow: rgba(8, 145, 178, 0.18);
+
+  --ux-shadow-surface: 0 10px 24px rgba(15, 23, 42, 0.06);
+  --ux-shadow-overlay: 0 20px 44px rgba(15, 23, 42, 0.16);
+
+  --ux-border-subtle: rgba(100, 116, 139, 0.18);
+  --ux-border-strong: rgba(8, 145, 178, 0.24);
+
+  --ux-text-strong: #0f172a;
+  --ux-text-primary: #1e293b;
+  --ux-text-muted: #475569;
+  --ux-text-soft: #64748b;
+
+  --ux-surface-canvas: #f4f7fb;
+  --ux-surface-elevated: rgba(255, 255, 255, 0.92);
+  --ux-surface-muted: rgba(248, 250, 252, 0.9);
+  --ux-surface-overlay: rgba(255, 255, 255, 0.97);
+
+  --ux-accent-primary: #0f766e;
+  --ux-accent-secondary: #0f766e;
+  --ux-status-ready: #0f766e;
+  --ux-status-warning: #b45309;
+  --ux-status-blocked: #b91c1c;
+
+  --ux-meta-tracking: 0.12em;
+  --ux-motion-fast: 160ms;
+  --ux-motion-normal: 220ms;
+}
+
+:root.dark,
+.dark:root {
+  --ux-focus-ring: rgba(103, 232, 249, 0.96);
+  --ux-focus-shadow: rgba(34, 211, 238, 0.18);
+
+  --ux-shadow-surface: 0 12px 28px rgba(2, 6, 23, 0.22);
+  --ux-shadow-overlay: 0 22px 48px rgba(2, 6, 23, 0.38);
+
+  --ux-border-subtle: rgba(100, 116, 139, 0.34);
+  --ux-border-strong: rgba(103, 232, 249, 0.22);
+
+  --ux-text-strong: #f8fafc;
+  --ux-text-primary: #e2e8f0;
+  --ux-text-muted: #b8c4d4;
+  --ux-text-soft: #94a3b8;
+
+  --ux-surface-canvas: #020617;
+  --ux-surface-elevated: rgba(12, 18, 34, 0.9);
+  --ux-surface-muted: rgba(15, 23, 42, 0.86);
+  --ux-surface-overlay: rgba(8, 15, 29, 0.96);
+
+  --ux-accent-primary: #67e8f9;
+  --ux-accent-secondary: #99f6e4;
+  --ux-status-ready: #5eead4;
+  --ux-status-warning: #fbbf24;
+  --ux-status-blocked: #fca5a5;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --ux-motion-fast: 0ms;
+    --ux-motion-normal: 0ms;
+  }
 }

--- a/web/secure-landing/tests/routes.test.mjs
+++ b/web/secure-landing/tests/routes.test.mjs
@@ -1228,7 +1228,7 @@ test("portal renders waiting recovery posture for Access outages", async () => {
       assert.equal(response.status, 503);
       assert.match(html, /data-ui="managed-recovery-shell"/);
       assert.match(html, /data-reason="access_outage"/);
-      assert.match(html, /class="login-status-card" data-state="waiting"/);
+      assert.match(html, /class="login-status-card(?: [^"]*)?" data-state="waiting"/);
       assert.match(html, /Retry when Access recovers/);
     } finally {
       global.fetch = originalFetch;

--- a/web/secure-landing/tests/routes.test.mjs
+++ b/web/secure-landing/tests/routes.test.mjs
@@ -1228,7 +1228,8 @@ test("portal renders waiting recovery posture for Access outages", async () => {
       assert.equal(response.status, 503);
       assert.match(html, /data-ui="managed-recovery-shell"/);
       assert.match(html, /data-reason="access_outage"/);
-      assert.match(html, /class="login-status-card(?: [^"]*)?" data-state="waiting"/);
+      assert.match(html, /class="[^"]*\blogin-status-card\b[^"]*"/);
+      assert.match(html, /data-state="waiting"/);
       assert.match(html, /Retry when Access recovers/);
     } finally {
       global.fetch = originalFetch;
@@ -1710,6 +1711,22 @@ test("shared portal asset manifest pins the managed asset proxy allowlist", asyn
     "brand/dna-symbol-dark.svg",
     "brand/dna-symbol-light.svg"
   ]);
+});
+
+test("shared UI tokens stay synced to the canonical source", () => {
+  const repoRoot = path.resolve(process.cwd(), "..", "..");
+  const canonicalTokenPath = path.join(repoRoot, "web", "shared", "shared-ui-tokens.css");
+  const frontdoorTokenPath = path.join(process.cwd(), "public", "shared-ui-tokens.css");
+  const portalTokenPath = path.join(repoRoot, "public", "portal-assets", "shared-ui-tokens.css");
+  const buildScriptPath = path.join(process.cwd(), "scripts", "build-portal-bundle.mjs");
+  const canonicalTokens = readFileSync(canonicalTokenPath, "utf-8");
+  const buildScript = readFileSync(buildScriptPath, "utf-8");
+
+  assert.equal(readFileSync(frontdoorTokenPath, "utf-8"), canonicalTokens);
+  assert.equal(readFileSync(portalTokenPath, "utf-8"), canonicalTokens);
+  assert.match(buildScript, /const SHARED_TOKEN_SOURCE_PATH = path\.resolve\(REPO_ROOT, "web", "shared", "shared-ui-tokens\.css"\);/);
+  assert.match(buildScript, /copyIfChanged\(SHARED_TOKEN_SOURCE_PATH,\s*PORTAL_SHARED_TOKEN_TARGET\)/);
+  assert.match(buildScript, /copyIfChanged\(SHARED_TOKEN_SOURCE_PATH,\s*FRONTDOOR_SHARED_TOKEN_TARGET\)/);
 });
 
 test("v1 POST rejects requests missing valid same-origin CSRF protections", async () => {

--- a/web/shared/shared-ui-tokens.css
+++ b/web/shared/shared-ui-tokens.css
@@ -1,4 +1,5 @@
-/* Shared UI primitives used by both the managed frontdoor and portal console. */
+/* Canonical shared UI token source used by both the managed frontdoor and portal console. */
+/* build-portal-bundle.mjs copies this file into the shipped frontdoor and portal asset targets. */
 :root {
   color-scheme: light dark;
 

--- a/web/shared/shared-ui-tokens.css
+++ b/web/shared/shared-ui-tokens.css
@@ -1,6 +1,86 @@
 /* Shared UI primitives used by both the managed frontdoor and portal console. */
 :root {
+  color-scheme: light dark;
+
   --ux-target-min-size: 44px;
-  --ux-label-size: 0.8125rem;
   --ux-body-size: 1rem;
+  --ux-label-size: 0.75rem;
+  --ux-meta-size: 0.8125rem;
+
+  --ux-space-1: 0.25rem;
+  --ux-space-2: 0.5rem;
+  --ux-space-3: 0.75rem;
+  --ux-space-4: 1rem;
+  --ux-space-5: 1.25rem;
+  --ux-space-6: 1.5rem;
+  --ux-space-8: 2rem;
+
+  --ux-radius-sm: 6px;
+  --ux-radius-md: 8px;
+  --ux-radius-lg: 8px;
+  --ux-radius-pill: 999px;
+
+  --ux-focus-ring: rgba(8, 145, 178, 0.92);
+  --ux-focus-shadow: rgba(8, 145, 178, 0.18);
+
+  --ux-shadow-surface: 0 10px 24px rgba(15, 23, 42, 0.06);
+  --ux-shadow-overlay: 0 20px 44px rgba(15, 23, 42, 0.16);
+
+  --ux-border-subtle: rgba(100, 116, 139, 0.18);
+  --ux-border-strong: rgba(8, 145, 178, 0.24);
+
+  --ux-text-strong: #0f172a;
+  --ux-text-primary: #1e293b;
+  --ux-text-muted: #475569;
+  --ux-text-soft: #64748b;
+
+  --ux-surface-canvas: #f4f7fb;
+  --ux-surface-elevated: rgba(255, 255, 255, 0.92);
+  --ux-surface-muted: rgba(248, 250, 252, 0.9);
+  --ux-surface-overlay: rgba(255, 255, 255, 0.97);
+
+  --ux-accent-primary: #0f766e;
+  --ux-accent-secondary: #0f766e;
+  --ux-status-ready: #0f766e;
+  --ux-status-warning: #b45309;
+  --ux-status-blocked: #b91c1c;
+
+  --ux-meta-tracking: 0.12em;
+  --ux-motion-fast: 160ms;
+  --ux-motion-normal: 220ms;
+}
+
+:root.dark,
+.dark:root {
+  --ux-focus-ring: rgba(103, 232, 249, 0.96);
+  --ux-focus-shadow: rgba(34, 211, 238, 0.18);
+
+  --ux-shadow-surface: 0 12px 28px rgba(2, 6, 23, 0.22);
+  --ux-shadow-overlay: 0 22px 48px rgba(2, 6, 23, 0.38);
+
+  --ux-border-subtle: rgba(100, 116, 139, 0.34);
+  --ux-border-strong: rgba(103, 232, 249, 0.22);
+
+  --ux-text-strong: #f8fafc;
+  --ux-text-primary: #e2e8f0;
+  --ux-text-muted: #b8c4d4;
+  --ux-text-soft: #94a3b8;
+
+  --ux-surface-canvas: #020617;
+  --ux-surface-elevated: rgba(12, 18, 34, 0.9);
+  --ux-surface-muted: rgba(15, 23, 42, 0.86);
+  --ux-surface-overlay: rgba(8, 15, 29, 0.96);
+
+  --ux-accent-primary: #67e8f9;
+  --ux-accent-secondary: #99f6e4;
+  --ux-status-ready: #5eead4;
+  --ux-status-warning: #fbbf24;
+  --ux-status-blocked: #fca5a5;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --ux-motion-fast: 0ms;
+    --ux-motion-normal: 0ms;
+  }
 }


### PR DESCRIPTION
## Summary
- adopt a shared quiet editorial token baseline across the frontdoor and portal shells without changing routes, query params, auth posture, or managed access contracts
- simplify the homepage, login, managed recovery, and error shells while preserving the existing `data-ui` hooks and compatibility surfaces used by runtime bindings and browser smokes
- consolidate the portal context and runtime presentation into quieter panels and disclosures, and extend the browser smokes to cover target size, reduced motion, disclosure depth, and focus visibility

## Why
The frontdoor and portal had accumulated multiple overlapping presentation patterns, decorative treatments, and repeated status bands. This change reduces visual noise and normalizes component behavior while keeping the contract surface stable for operators, runtime bindings, and smoke validation.

## Validation
- `make test-frontdoor-contract`
- `make test-portal-contract`
- `make validate-frontdoor-browser`
- `make validate-portal-browser`
- `make check-worktree`
