### PR TITLE
[codex] Align validation smoke contracts

### DIFF
--- a/scripts/validation/validate_frontdoor_browser_smoke.py
+++ b/scripts/validation/validate_frontdoor_browser_smoke.py
@@ -462,6 +462,7 @@ def _frontdoor_accessibility_probe_expression() -> str:
   })();
   return {
     pathname: window.location.pathname,
+    readyState: document.readyState,
     homepagePrimaryMinTarget: minTarget('[data-ui="homepage-primary-cta"]'),
     homepageSecondaryMinTarget: minTarget('[data-ui="homepage-secondary-cta"]'),
     homepageLearnMinTarget: minTarget('[data-ui="homepage-learn-link"]'),
@@ -488,6 +489,34 @@ def _frontdoor_accessibility_probe_expression() -> str:
   };
 })()
 """
+
+
+def _frontdoor_accessibility_snapshot(result: object, *, page: str) -> dict[str, object]:
+    payload = result if isinstance(result, dict) else {}
+    scoped_keys = {
+        "homepage": (
+            "pathname",
+            "readyState",
+            "homepagePrimaryMinTarget",
+            "homepageSecondaryMinTarget",
+            "homepageLearnMinTarget",
+            "focusVisibleWithStickyHeader",
+            "maxDisclosureDepth",
+        ),
+        "login": (
+            "pathname",
+            "readyState",
+            "loginSubmitMinTarget",
+            "loginSecondaryMinTarget",
+            "maxDisclosureDepth",
+            "reducedMotion",
+            "decorativeMotionStatic",
+        ),
+    }
+    keys = scoped_keys.get(page)
+    if keys is None:
+        raise ValueError(f"Unsupported frontdoor accessibility page scope: {page}")
+    return {key: payload.get(key) for key in keys}
 
 
 def _navigate_expression(pathname: str) -> str:
@@ -636,7 +665,10 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
         )
         _expect(str(homepage_state.get("pathname", "")) == "/", f"Front-door homepage did not load at root: {homepage_state}")
         _expect(bool(homepage_state.get("hasHeroVideo")), f"Homepage video canvas was not rendered: {homepage_state}")
-        homepage_accessibility = connection.evaluate(_frontdoor_accessibility_probe_expression())
+        homepage_accessibility = _frontdoor_accessibility_snapshot(
+            connection.evaluate(_frontdoor_accessibility_probe_expression()),
+            page="homepage",
+        )
         _expect(
             bool(homepage_accessibility.get("homepagePrimaryMinTarget"))
             and bool(homepage_accessibility.get("homepageSecondaryMinTarget"))
@@ -659,6 +691,7 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
             _frontdoor_state_probe_expression(),
             predicate=lambda value: (
                 isinstance(value, dict)
+                and str(value.get("readyState", "")) == "complete"
                 and str(value.get("pathname", "")) == "/login"
                 and bool(value.get("loginTitleReady"))
                 and bool(value.get("loginEntryStateReady"))
@@ -672,7 +705,10 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
             description="front-door login to render",
         )
         _expect(bool(login_state.get("hasHeroVideo")), f"Login page lost hero video shell: {login_state}")
-        login_accessibility = connection.evaluate(_frontdoor_accessibility_probe_expression())
+        login_accessibility = _frontdoor_accessibility_snapshot(
+            connection.evaluate(_frontdoor_accessibility_probe_expression()),
+            page="login",
+        )
         _expect(
             bool(login_accessibility.get("loginSubmitMinTarget")) and bool(login_accessibility.get("loginSecondaryMinTarget")),
             f"Login interactive targets fell below the 44px contract: {login_accessibility}",
@@ -692,6 +728,7 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
             _frontdoor_accessibility_probe_expression(),
             predicate=lambda value: (
                 isinstance(value, dict)
+                and str(value.get("readyState", "")) == "complete"
                 and str(value.get("pathname", "")) == "/login"
                 and bool(value.get("reducedMotion"))
                 and bool(value.get("decorativeMotionStatic"))
@@ -700,6 +737,7 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
             timeout_seconds=args.timeout_seconds,
             description="front-door reduced-motion login shell",
         )
+        reduced_motion_state = _frontdoor_accessibility_snapshot(reduced_motion_state, page="login")
         _expect(
             bool(reduced_motion_state.get("decorativeMotionStatic")),
             f"Reduced-motion mode left decorative front-door motion active: {reduced_motion_state}",

--- a/scripts/validation/validate_orchestrator_http_smoke.py
+++ b/scripts/validation/validate_orchestrator_http_smoke.py
@@ -418,8 +418,16 @@ def main(argv: list[str] | None = None) -> int:
         )
         _expect_status(blocked_status, 400, "POST /v1/jobs blocked archive-gate-b", blocked_body)
         _expect(
-            ((blocked_body.get("error") or {}).get("details") or {}).get("reason") == "rights_manifest_required",
-            f"archive-gate-b did not fail closed with rights_manifest_required: {blocked_body}",
+            ((blocked_body.get("error") or {}).get("code") == "INVALID_ARGUMENT"),
+            f"archive-gate-b did not return INVALID_ARGUMENT: {blocked_body}",
+        )
+        _expect(
+            ((blocked_body.get("error") or {}).get("details") or {}).get("field") == "manifest_jsonl",
+            f"archive-gate-b did not fail closed on manifest_jsonl: {blocked_body}",
+        )
+        _expect(
+            ((blocked_body.get("error") or {}).get("details") or {}).get("reason") == "required",
+            f"archive-gate-b did not fail closed with required manifest_jsonl validation: {blocked_body}",
         )
 
         gate_a_payload = {

--- a/tests/validation/test_portal_smoke_scripts.py
+++ b/tests/validation/test_portal_smoke_scripts.py
@@ -319,7 +319,8 @@ def test_orchestrator_http_smoke_covers_readiness_and_fail_closed_archive_prereq
     assert "GET /v1/readiness" in content
     assert '"archive-gate-b"' in content
     assert '"archive-gate-c"' in content
-    assert "rights_manifest_required" in content
+    assert '"details") or {}).get("field") == "manifest_jsonl"' in content
+    assert '"details") or {}).get("reason") == "required"' in content
     assert "manifest-build" in content
     assert "rights-apply" in content
     assert "bag-build" in content
@@ -454,6 +455,7 @@ def test_frontdoor_browser_waits_for_managed_portal_bootstrap_before_passing():
     content = FRONTDOOR_BROWSER_SCRIPT_PATH.read_text(encoding="utf-8")
 
     assert 'and str(value.get("readyState", "")) == "complete"' in content
+    assert content.count('and str(value.get("readyState", "")) == "complete"') >= 3
     assert 'and str(value.get("authModeBadge", "")).lower() == "managed"' in content
     assert "homepageHeroReady" in content
     assert "homepageEntryRailReady" in content
@@ -482,6 +484,7 @@ def test_frontdoor_browser_accessibility_probe_tracks_target_size_and_reduced_mo
 
     expression = module._frontdoor_accessibility_probe_expression()
 
+    assert "readyState: document.readyState" in expression
     assert '[data-ui="homepage-primary-cta"]' in expression
     assert '[data-ui="homepage-secondary-cta"]' in expression
     assert '[data-ui="homepage-learn-link"]' in expression
@@ -491,6 +494,38 @@ def test_frontdoor_browser_accessibility_probe_tracks_target_size_and_reduced_mo
     assert "focusVisibleWithStickyHeader" in expression
     assert "prefers-reduced-motion" in expression
     assert "decorativeMotionStatic" in expression
+
+
+def test_frontdoor_browser_accessibility_snapshot_is_page_scoped():
+    module = _load_module(FRONTDOOR_BROWSER_SCRIPT_PATH, "tests_validate_frontdoor_browser_smoke_accessibility_scope")
+
+    snapshot = {
+        "pathname": "/login",
+        "readyState": "complete",
+        "homepagePrimaryMinTarget": True,
+        "homepageSecondaryMinTarget": True,
+        "homepageLearnMinTarget": True,
+        "focusVisibleWithStickyHeader": True,
+        "loginSubmitMinTarget": False,
+        "loginSecondaryMinTarget": True,
+        "maxDisclosureDepth": 1,
+        "reducedMotion": False,
+        "decorativeMotionStatic": True,
+    }
+
+    homepage_snapshot = module._frontdoor_accessibility_snapshot(snapshot, page="homepage")
+    login_snapshot = module._frontdoor_accessibility_snapshot(snapshot, page="login")
+
+    assert homepage_snapshot["pathname"] == "/login"
+    assert homepage_snapshot["readyState"] == "complete"
+    assert homepage_snapshot["homepagePrimaryMinTarget"] is True
+    assert "loginSubmitMinTarget" not in homepage_snapshot
+
+    assert login_snapshot["pathname"] == "/login"
+    assert login_snapshot["readyState"] == "complete"
+    assert login_snapshot["loginSubmitMinTarget"] is False
+    assert login_snapshot["decorativeMotionStatic"] is True
+    assert "homepagePrimaryMinTarget" not in login_snapshot
 
 
 def test_portal_browser_smoke_tracks_archive_readiness_fields_and_canonical_commands():


### PR DESCRIPTION
## Summary
This change aligns the live validation smokes with the current production contracts and removes a cold-start flake from the managed frontdoor browser smoke.

## What Changed
- updated the live orchestrator HTTP smoke to assert the existing `POST /v1/jobs` archive-gate-b failure envelope (`INVALID_ARGUMENT`, `field=manifest_jsonl`, `reason=required`)
- kept the readiness contract unchanged while documenting the distinction between readiness reasons and create-job validation errors
- tightened the frontdoor browser smoke so `/login` must reach `readyState == "complete"` before target-size and reduced-motion accessibility checks run
- scoped login accessibility failure payloads to login-relevant fields so homepage-only signals do not produce misleading error output
- refreshed the smoke-script regression tests to cover the new assertions and page-scoped accessibility snapshots

## Root Cause
- the orchestrator live smoke had drifted behind the backend contract by asserting the readiness-only `rights_manifest_required` token against the create-job API
- the frontdoor browser smoke could sample the login page before CSS had fully applied on a cold isolated Next dev launch, which produced false 44px target-size failures

## Impact
- canonical live validation now matches the current backend API behavior without changing any public product contract
- the managed frontdoor cold-start browser gate is deterministic again on isolated launches
- reviewers get clearer failure output when a login accessibility check fails

## Validation
- `PRE_COMMIT_HOME=/tmp/pre-commit PATH=/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin:$PATH TP_LINT_PYTHON=/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin/python .venv/bin/pre-commit run --files scripts/validation/validate_frontdoor_browser_smoke.py scripts/validation/validate_orchestrator_http_smoke.py tests/validation/test_portal_smoke_scripts.py`
- `.venv/bin/pytest tests/validation/test_portal_smoke_scripts.py`
- `.venv/bin/pytest tests/test_app_orchestrator_contract_http.py -k archive_gate_b_submission_fails_closed_without_rights_manifest`
- `TP_API_KEY=contract-secret make validate-orchestrator-http`
- `make validate-frontdoor-browser`