### PR TITLE
[codex] Close out PR #1435 follow-ups

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,7 @@ Quick reference for common workflows and commands in this repo.
 - `./scripts/pipelines/run_sealed_eval_72h.sh --archive-index <path> --archive-root <path>` run sealed pre/post fixity verification around an optional eval command and emit an audit package.
 - `./scripts/pipelines/hdr_production_pipeline.sh` interactive HDR video mastering workflow that pairs source footage with a 3D LUT and writes web deliverables.
 - `./scripts/setup/install_da3_runtime.sh` install the repo-local DA3 subprocess runtime (validated `.runtime/Depth-Anything-3` ref + auto-discovered `./.venv-da3/bin/python` contract + `.runtime/da3-pip-freeze.txt` snapshot).
+- `./scripts/setup/install_depth_pro_runtime.sh` install the repo-local Depth Pro subprocess runtime (pinned `torch==2.7.1` / `torchvision==0.22.1` / `numpy==1.26.4` + pinned Apple `ml-depth-pro` ref + auto-discovered `./.venv-depth-pro/bin/python` contract + `.runtime/depth-pro-pip-freeze.txt` snapshot).
 - `./scripts/setup/install_raw_runtime.sh` install the repo-local RAW subprocess runtime (auto-discovered `./.venv-raw/bin/python` contract + `.runtime/raw-pip-freeze.txt` snapshot).
 - `./scripts/setup/run_frontdoor_local.sh` start the local managed frontdoor only when the backend is ready, auth env is set, and `localhost:3000` is free.
 - `./scripts/test_v2_integration.sh` validate end-to-end lux-depth-v3 + V2 stage integration (`--verbose`, `--clean` available).

--- a/README.md
+++ b/README.md
@@ -250,15 +250,16 @@ See [SETUP_GUIDE.md](docs/guides/SETUP_GUIDE.md) for environment details.
 Use `depth_pro` when you need metric depth and are operating in an explicit research-only workflow.
 
 ```bash
-# Use any Python 3.11+ interpreter (e.g., python3.11, python3.12, python3.13)
-# The resolver picks a compatible one automatically:
-"$(./scripts/setup/resolve_python_311.sh)" -m venv .venv-depth-pro
-./.venv-depth-pro/bin/python -m pip install --upgrade pip depth-pro
 mkdir -p checkpoints
 curl -L https://ml-site.cdn-apple.com/models/depth-pro/depth_pro.pt -o checkpoints/depth_pro.pt
+./scripts/setup/install_depth_pro_runtime.sh
 ```
 
-Keep `depth-pro` in its own environment. Its dependency constraints conflict with the main repository stack.
+Keep `depth-pro` in its own environment. Its dependency constraints conflict with
+the main repository stack, and the repo-owned setup script pins the known-good
+Depth Pro runtime surface (`torch==2.7.1`, `torchvision==0.22.1`,
+`numpy==1.26.4`) that restores MPS readiness on current macOS 26.x pip-wheel
+hosts.
 
 Required CLI wiring:
 ```bash

--- a/docs/depth_pipeline/DEPTH_PRO_QUICKSTART.md
+++ b/docs/depth_pipeline/DEPTH_PRO_QUICKSTART.md
@@ -7,16 +7,17 @@ This guide helps you get started with Apple's Depth Pro for metric depth estimat
 ### 1. Create a Dedicated Depth Pro Environment
 
 ```bash
-# Use any Python 3.11+ interpreter (e.g., python3.11, python3.12, python3.13).
-# The resolver picks a compatible one automatically:
-"$(./scripts/setup/resolve_python_311.sh)" -m venv .venv-depth-pro
-./.venv-depth-pro/bin/python -m pip install --upgrade pip
-./.venv-depth-pro/bin/python -m pip install depth-pro
+./scripts/setup/install_depth_pro_runtime.sh --skip-verify
 ```
 
 Keep `depth-pro` out of the main Transformation Portal environment. Depth Pro
 currently requires `numpy<2`, while the primary repository environment is pinned
-around NumPy 2.x for OpenCV, imagecodecs, and related tooling.
+around NumPy 2.x for OpenCV, imagecodecs, and related tooling. The repo-owned
+setup script pins the validated Depth Pro runtime surface:
+- `torch==2.7.1`
+- `torchvision==0.22.1`
+- `numpy==1.26.4`
+- `depth_pro` from Apple `ml-depth-pro` git ref `9efe5c1def37a26c5367a71df664b18e1306c708`
 
 ### 2. Download Checkpoint (1.9 GB)
 
@@ -33,13 +34,15 @@ curl -L https://ml-site.cdn-apple.com/models/depth-pro/depth_pro.pt \
 
 ### 3. Validate Checkpoint (Recommended)
 
-Run the validation script to ensure your checkpoint is correct:
+Run the pinned runtime verification, then the slower end-to-end inference smoke:
 
 ```bash
+./scripts/setup/install_depth_pro_runtime.sh
 ./.venv-depth-pro/bin/python scripts/validate_depth_pro_checkpoint.py
 ```
 
-This will:
+The setup script verifies the pinned runtime and requested device (`mps` on
+Apple Silicon, `cpu` elsewhere). The checkpoint validator then confirms:
 - ✓ Verify file exists and has correct size (~1.9 GB)
 - ✓ Verify SHA-256 hash matches expected value
 - ✓ Check depth-pro package is installed
@@ -281,7 +284,7 @@ ImportError: depth_pro package not installed.
 
 **Solution:**
 ```bash
-./.venv-depth-pro/bin/python -m pip install depth-pro
+./scripts/setup/install_depth_pro_runtime.sh --skip-verify
 ```
 
 Then point the main pipeline at that environment:

--- a/docs/guides/LUX_DEPTH_V3_TROUBLESHOOTING.md
+++ b/docs/guides/LUX_DEPTH_V3_TROUBLESHOOTING.md
@@ -364,8 +364,9 @@ The pipeline has been updated to defer torch imports during backend initializati
 which prevents this collision in most cases. However, if you still encounter this error:
 
 1. **Ensure consistent libomp across environments:**
-   - Rebuild `.venv-depth-pro` using the same PyTorch version/build as your main environment
-   - Or use the subprocess isolation mode (configured via `--depth-pro-python`)
+   - Rebuild `.venv-depth-pro` with `./scripts/setup/install_depth_pro_runtime.sh`
+   - Keep the Depth Pro subprocess on the repo-owned pin (`torch==2.7.1`, `torchvision==0.22.1`, `numpy==1.26.4`) instead of mirroring the main repo runtime
+   - Use the subprocess isolation mode (configured via `--depth-pro-python`)
 
 2. **Temporary diagnostic workaround (not recommended for production):**
    ```bash

--- a/scripts/setup/README.md
+++ b/scripts/setup/README.md
@@ -52,6 +52,36 @@ lux-depth-v3 --input-dir ./input --output-dir ./output --da3-python ~/venvs/da3/
 - Git repository
 - Bash shell (Linux, macOS, or Windows with WSL/Git Bash)
 
+### `install_depth_pro_runtime.sh`
+
+Bootstraps the repo-local Depth Pro subprocess runtime used by the
+auto-discovered `./.venv-depth-pro/bin/python` contract and by explicit
+`--depth-pro-python` overrides.
+
+**Usage:**
+```bash
+./scripts/setup/install_depth_pro_runtime.sh --skip-verify
+mkdir -p checkpoints
+curl -L https://ml-site.cdn-apple.com/models/depth-pro/depth_pro.pt -o checkpoints/depth_pro.pt
+./scripts/setup/install_depth_pro_runtime.sh
+```
+
+**What it does:**
+- Resolves a Python 3.11+ bootstrap interpreter (preferring the repo `.venv` when available)
+- Creates the isolated Depth Pro venv at `./.venv-depth-pro`
+- Installs the repo-owned pinned Depth Pro surface (`torch==2.7.1`, `torchvision==0.22.1`, `numpy==1.26.4`) plus the Apple `ml-depth-pro` package from a pinned git ref
+- Captures a runtime package snapshot at `.runtime/depth-pro-pip-freeze.txt`
+- Runs `pip check`
+- Runs the Depth Pro worker readiness check used by the subprocess adapter
+
+**Stable contract:**
+```bash
+lux-depth-v3 --input-dir ./input --output-dir ./output --depth-pro-python ./.venv-depth-pro/bin/python
+```
+
+Use `--verify-device cpu` when you only need a CPU-safe contract. The default
+`--verify-device auto` validates `mps` on Apple Silicon and `cpu` elsewhere.
+
 ### `install_raw_runtime.sh`
 
 Bootstraps the repo-local RAW subprocess runtime used by the

--- a/scripts/setup/install_depth_pro_runtime.sh
+++ b/scripts/setup/install_depth_pro_runtime.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+#
+# install_depth_pro_runtime.sh
+# Bootstrap a repo-local Depth Pro runtime for the subprocess-backed adapter.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+PYTHON_RESOLVER="${REPO_ROOT}/scripts/setup/resolve_python_311.sh"
+
+VENV_DIR="${REPO_ROOT}/.venv-depth-pro"
+RUNTIME_METADATA_DIR="${REPO_ROOT}/.runtime"
+RUNTIME_FREEZE_FILE="${RUNTIME_METADATA_DIR}/depth-pro-pip-freeze.txt"
+CHECKPOINT_PATH="${REPO_ROOT}/checkpoints/depth_pro.pt"
+DEPTH_PRO_REPO_URL="https://github.com/apple/ml-depth-pro.git"
+DEFAULT_REF="9efe5c1def37a26c5367a71df664b18e1306c708"
+REF="${DEPTH_PRO_RUNTIME_REF:-${DEFAULT_REF}}"
+VERIFY_DEVICE="auto"
+DRY_RUN=false
+SKIP_VERIFY=false
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Install a pinned repo-local Depth Pro runtime for:
+  --depth-pro-python ./.venv-depth-pro/bin/python
+
+Default paths:
+  venv:       ${VENV_DIR}
+  checkpoint: ${CHECKPOINT_PATH}
+
+OPTIONS:
+  --venv-dir PATH         Override the isolated Depth Pro venv path
+  --checkpoint PATH       Override the checkpoint path used for readiness checks
+  --ref REF               Apple ml-depth-pro git ref to install (default: ${DEFAULT_REF})
+  --verify-device DEVICE  Device to validate after install: auto|cpu|mps|cuda
+  --dry-run               Print commands without executing them
+  --skip-verify           Skip the Depth Pro worker readiness check
+  --help                  Show this help text
+EOF
+}
+
+log() {
+    printf '[INFO] %s\n' "$*"
+}
+
+run() {
+    if [[ "${DRY_RUN}" == "true" ]]; then
+        printf '+'
+        for arg in "$@"; do
+            printf ' %q' "${arg}"
+        done
+        printf '\n'
+        return 0
+    fi
+    "$@"
+}
+
+resolve_verify_device() {
+    if [[ "${VERIFY_DEVICE}" != "auto" ]]; then
+        printf '%s\n' "${VERIFY_DEVICE}"
+        return 0
+    fi
+
+    case "$(uname -s)-$(uname -m)" in
+        Darwin-arm64)
+            printf 'mps\n'
+            ;;
+        *)
+            printf 'cpu\n'
+            ;;
+    esac
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --venv-dir)
+            VENV_DIR="$2"
+            shift 2
+            ;;
+        --checkpoint)
+            CHECKPOINT_PATH="$2"
+            shift 2
+            ;;
+        --ref)
+            REF="$2"
+            shift 2
+            ;;
+        --verify-device)
+            VERIFY_DEVICE="$2"
+            shift 2
+            ;;
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        --skip-verify)
+            SKIP_VERIFY=true
+            shift
+            ;;
+        --help)
+            usage
+            exit 0
+            ;;
+        *)
+            printf '[ERROR] Unknown argument: %s\n' "$1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+if ! command -v git >/dev/null 2>&1; then
+    printf '[ERROR] git is required but not available on PATH.\n' >&2
+    exit 1
+fi
+
+if [[ ! -x "${PYTHON_RESOLVER}" ]]; then
+    printf '[ERROR] Python resolver missing: %s\n' "${PYTHON_RESOLVER}" >&2
+    exit 1
+fi
+
+case "${VERIFY_DEVICE}" in
+    auto|cpu|mps|cuda)
+        ;;
+    *)
+        printf '[ERROR] Unsupported --verify-device value: %s\n' "${VERIFY_DEVICE}" >&2
+        exit 1
+        ;;
+esac
+
+BOOTSTRAP_PYTHON="$("${PYTHON_RESOLVER}")"
+
+if [[ -d "${VENV_DIR}" ]]; then
+    log "Refreshing isolated Depth Pro venv at ${VENV_DIR}"
+else
+    log "Creating isolated Depth Pro venv at ${VENV_DIR}"
+fi
+log "Using bootstrap interpreter: ${BOOTSTRAP_PYTHON}"
+run "${BOOTSTRAP_PYTHON}" -m venv --clear "${VENV_DIR}"
+
+PYTHON_BIN="${VENV_DIR}/bin/python"
+
+log "Upgrading pip in ${VENV_DIR}"
+run "${PYTHON_BIN}" -m pip install --upgrade pip
+
+log "Installing pinned Depth Pro dependencies"
+run "${PYTHON_BIN}" -m pip install \
+    "numpy==1.26.4" \
+    "torch==2.7.1" \
+    "torchvision==0.22.1" \
+    "matplotlib==3.10.8" \
+    "pillow==12.2.0" \
+    "pillow_heif==1.3.0" \
+    "timm==1.0.26"
+
+log "Installing Depth Pro from pinned git ref ${REF}"
+run "${PYTHON_BIN}" -m pip install --force-reinstall --no-deps \
+    "depth_pro @ git+${DEPTH_PRO_REPO_URL}@${REF}"
+
+run mkdir -p "${RUNTIME_METADATA_DIR}"
+if [[ "${DRY_RUN}" == "true" ]]; then
+    log "Would capture Depth Pro runtime package snapshot at ${RUNTIME_FREEZE_FILE}"
+else
+    log "Capturing Depth Pro runtime package snapshot at ${RUNTIME_FREEZE_FILE}"
+    "${PYTHON_BIN}" -m pip freeze > "${RUNTIME_FREEZE_FILE}"
+fi
+
+log "Running pip check in ${VENV_DIR}"
+run "${PYTHON_BIN}" -m pip check
+
+if [[ "${SKIP_VERIFY}" != "true" ]]; then
+    if [[ ! -f "${CHECKPOINT_PATH}" ]]; then
+        printf '[ERROR] Depth Pro checkpoint not found for readiness check: %s\n' "${CHECKPOINT_PATH}" >&2
+        printf '[ERROR] Download it first or rerun with --skip-verify.\n' >&2
+        exit 1
+    fi
+    RESOLVED_VERIFY_DEVICE="$(resolve_verify_device)"
+    log "Running Depth Pro worker readiness check on device=${RESOLVED_VERIFY_DEVICE}"
+    run env \
+        PYTHONPATH="${REPO_ROOT}/src${PYTHONPATH:+:${PYTHONPATH}}" \
+        "${PYTHON_BIN}" \
+        -m transformation_portal.depth.backends.depth_pro_worker \
+        --check \
+        --checkpoint "${CHECKPOINT_PATH}" \
+        --device "${RESOLVED_VERIFY_DEVICE}"
+fi
+
+cat <<EOF
+[INFO] Depth Pro runtime ready.
+[INFO] Stable executable: ./.venv-depth-pro/bin/python
+[INFO] Pinned refs: torch==2.7.1 torchvision==0.22.1 numpy==1.26.4 depth_pro@${REF}
+[INFO] Example:
+lux-depth-v3 --input-dir ./input --output-dir ./output --depth-pro-python ./.venv-depth-pro/bin/python
+EOF

--- a/scripts/validate_depth_pro_checkpoint.py
+++ b/scripts/validate_depth_pro_checkpoint.py
@@ -17,6 +17,11 @@ import sys
 import time
 from pathlib import Path
 
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO_ROOT / "src"
+if SRC_ROOT.exists():
+    sys.path.insert(0, str(SRC_ROOT))
+
 # Expected values
 EXPECTED_SHA256 = "3eb35ca68168ad3d14cb150f8947a4edf85589941661fdb2686259c80685c0ce"
 EXPECTED_SIZE_GB_MIN = 1.5
@@ -129,7 +134,7 @@ def check_depth_pro_package():
     except ImportError:
         print_error("depth-pro package not installed")
         print("\n  Install with:")
-        print("    pip install depth-pro")
+        print("    ./scripts/setup/install_depth_pro_runtime.sh --skip-verify")
         return False
 
 

--- a/src/transformation_portal/depth/backends/depth_pro.py
+++ b/src/transformation_portal/depth/backends/depth_pro.py
@@ -69,7 +69,7 @@ class DepthProBackend:
         self._checkpoint_path = self._resolve_checkpoint_path(config)
         self._checkpoint_hash_cached: Optional[str] = None
         self._python_executable = self._resolve_python_executable(config)
-        self._subprocess_available_checked = False
+        self._subprocess_available_devices: set[str] = set()
 
     def _find_repo_root(self) -> Optional[Path]:
         """Find repository root by walking parent directories when in a checkout."""
@@ -212,23 +212,26 @@ class DepthProBackend:
             raise ImportError(
                 "depth_pro package not installed in the active environment.\n\n"
                 "Preferred setup:\n"
-                "  1. Create a dedicated Depth Pro environment\n"
-                "  2. Install depth-pro there\n"
-                "  3. Set depth_pro_python_executable or TRANSFORMATION_PORTAL_DEPTH_PRO_PYTHON\n\n"
+                "  1. Bootstrap the repo-local Depth Pro runtime with\n"
+                "     ./scripts/setup/install_depth_pro_runtime.sh\n"
+                "  2. Set depth_pro_python_executable or TRANSFORMATION_PORTAL_DEPTH_PRO_PYTHON\n\n"
                 "Legacy in-process install:\n"
                 "  pip install depth-pro\n\n"
                 "See: https://github.com/apple/ml-depth-pro"
             ) from exc
 
-    def _ensure_subprocess_available(self) -> None:
+    def _ensure_subprocess_available(self, device: Optional[str] = None) -> None:
         """Ensure the dedicated Depth Pro subprocess environment is usable."""
-        if self._subprocess_available_checked:
+        use_device = str(device or self._device).strip().lower() or "cpu"
+        if use_device in self._subprocess_available_devices:
             return
 
         command = self._build_worker_command(
             "--check",
             "--checkpoint",
             str(self._checkpoint_path.resolve()),
+            "--device",
+            use_device,
         )
         result = subprocess.run(
             command,
@@ -246,7 +249,7 @@ class DepthProBackend:
                 f"Command: {' '.join(command)}\n"
                 f"Output:\n{output}"
             )
-        self._subprocess_available_checked = True
+        self._subprocess_available_devices.add(use_device)
 
     @staticmethod
     def _format_subprocess_output(stdout: str, stderr: str) -> str:
@@ -261,11 +264,11 @@ class DepthProBackend:
             return stdout_clean
         return "(no output)"
 
-    def ensure_available(self) -> None:
+    def ensure_available(self, device: Optional[str] = None) -> None:
         """Ensure Depth Pro dependencies and checkpoint are available."""
         self._ensure_checkpoint_exists()
         if self._uses_subprocess():
-            self._ensure_subprocess_available()
+            self._ensure_subprocess_available(device=device)
             return
         self._ensure_local_package_available()
 
@@ -281,11 +284,12 @@ class DepthProBackend:
     ) -> DepthResult:
         """Estimate metric depth from image."""
         self._validate_license_runtime()
-        self.ensure_available()
+        use_device = device or self._device
+        self.ensure_available(device=use_device)
 
         if self._uses_subprocess():
-            return self._compute_subprocess(image, device)
-        return self._compute_local(image, device)
+            return self._compute_subprocess(image, use_device)
+        return self._compute_local(image, use_device)
 
     def _prepare_image(
         self,

--- a/src/transformation_portal/depth/backends/depth_pro.py
+++ b/src/transformation_portal/depth/backends/depth_pro.py
@@ -264,13 +264,17 @@ class DepthProBackend:
             return stdout_clean
         return "(no output)"
 
-    def ensure_available(self, device: Optional[str] = None) -> None:
-        """Ensure Depth Pro dependencies and checkpoint are available."""
+    def _ensure_runtime_available(self, device: Optional[str] = None) -> None:
+        """Ensure Depth Pro dependencies and checkpoint are available for a device."""
         self._ensure_checkpoint_exists()
         if self._uses_subprocess():
             self._ensure_subprocess_available(device=device)
             return
         self._ensure_local_package_available()
+
+    def ensure_available(self) -> None:
+        """Ensure Depth Pro dependencies and checkpoint are available."""
+        self._ensure_runtime_available(device=self._device)
 
     @classmethod
     def required_packages(cls) -> list[str]:
@@ -285,7 +289,7 @@ class DepthProBackend:
         """Estimate metric depth from image."""
         self._validate_license_runtime()
         use_device = device or self._device
-        self.ensure_available(device=use_device)
+        self._ensure_runtime_available(device=use_device)
 
         if self._uses_subprocess():
             return self._compute_subprocess(image, use_device)

--- a/src/transformation_portal/depth/backends/depth_pro.py
+++ b/src/transformation_portal/depth/backends/depth_pro.py
@@ -105,9 +105,14 @@ class DepthProBackend:
         if config is not None:
             device = getattr(config, "depth_device", None)
             if device:
-                return device
+                return self._normalize_device(device)
 
         return "cpu"
+
+    @staticmethod
+    def _normalize_device(device: Any) -> str:
+        """Normalize explicit or override device strings to worker-safe tokens."""
+        return str(device or "").strip().lower() or "cpu"
 
     def _resolve_checkpoint_path(
         self,
@@ -222,7 +227,7 @@ class DepthProBackend:
 
     def _ensure_subprocess_available(self, device: Optional[str] = None) -> None:
         """Ensure the dedicated Depth Pro subprocess environment is usable."""
-        use_device = str(device or self._device).strip().lower() or "cpu"
+        use_device = self._normalize_device(device or self._device)
         if use_device in self._subprocess_available_devices:
             return
 
@@ -288,7 +293,7 @@ class DepthProBackend:
     ) -> DepthResult:
         """Estimate metric depth from image."""
         self._validate_license_runtime()
-        use_device = device or self._device
+        use_device = self._normalize_device(device or self._device)
         self._ensure_runtime_available(device=use_device)
 
         if self._uses_subprocess():
@@ -326,7 +331,7 @@ class DepthProBackend:
 
         from ...stage_graph.stage import StageContext, StageStatus
 
-        use_device = device or self._device
+        use_device = self._normalize_device(device or self._device)
         context = StageContext(
             artifacts={"image": image_pil},
             device=use_device,
@@ -367,7 +372,7 @@ class DepthProBackend:
     ) -> DepthResult:
         """Run Depth Pro inference in a dedicated Python subprocess."""
         image_pil, image_array = self._prepare_image(image)
-        use_device = device or self._device
+        use_device = self._normalize_device(device or self._device)
 
         with tempfile.TemporaryDirectory(prefix="tp_depth_pro_") as tmpdir:
             tmp_root = Path(tmpdir)

--- a/src/transformation_portal/depth/backends/depth_pro_worker.py
+++ b/src/transformation_portal/depth/backends/depth_pro_worker.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-import json
 import platform
 import sys
 from pathlib import Path
@@ -12,7 +11,7 @@ from typing import Any
 import numpy as np
 from PIL import Image
 
-from ...ingest.canonical_json import dump_json
+from ...ingest.canonical_json import dump_json, dumps_json
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -85,7 +84,7 @@ def _emit_check_failure(reason: str, diagnostics: dict[str, Any]) -> int:
         "reason": reason,
         **diagnostics,
     }
-    print(json.dumps(payload, sort_keys=True), file=sys.stderr)
+    print(dumps_json(payload, sort_keys=True), file=sys.stderr)
     return 1
 
 

--- a/src/transformation_portal/depth/backends/depth_pro_worker.py
+++ b/src/transformation_portal/depth/backends/depth_pro_worker.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import argparse
+import json
+import platform
 import sys
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 from PIL import Image
@@ -51,8 +54,69 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _check_availability(checkpoint: Path) -> int:
-    """Validate imports and checkpoint presence for subprocess mode."""
+def _torch_diagnostics(device: str) -> dict[str, Any]:
+    """Collect structured device diagnostics for readiness checks."""
+    diagnostics: dict[str, Any] = {
+        "device": device,
+        "machine": platform.machine(),
+        "platform": platform.platform(),
+    }
+    macos_version = platform.mac_ver()[0]
+    if macos_version:
+        diagnostics["macos_version"] = macos_version
+
+    try:
+        import torch
+    except ImportError as exc:
+        diagnostics["torch_import_error"] = str(exc)
+        return diagnostics
+
+    diagnostics["torch_version"] = getattr(torch, "__version__", "unknown")
+    diagnostics["mps_built"] = bool(torch.backends.mps.is_built())
+    diagnostics["mps_available"] = bool(torch.backends.mps.is_available())
+    diagnostics["cuda_available"] = bool(torch.cuda.is_available())
+    return diagnostics
+
+
+def _emit_check_failure(reason: str, diagnostics: dict[str, Any]) -> int:
+    """Emit a structured readiness failure for subprocess availability checks."""
+    payload = {
+        "status": "unavailable",
+        "reason": reason,
+        **diagnostics,
+    }
+    print(json.dumps(payload, sort_keys=True), file=sys.stderr)
+    return 1
+
+
+def _check_device_availability(device: str) -> int:
+    """Validate that the requested device is actually usable."""
+    normalized_device = str(device or "cpu").strip().lower() or "cpu"
+    diagnostics = _torch_diagnostics(normalized_device)
+
+    if normalized_device == "cpu":
+        return 0
+
+    if "torch_import_error" in diagnostics:
+        return _emit_check_failure("PyTorch import failed for device readiness check.", diagnostics)
+
+    if normalized_device == "mps":
+        if not diagnostics.get("mps_built"):
+            return _emit_check_failure("PyTorch was not built with MPS support.", diagnostics)
+        if not diagnostics.get("mps_available"):
+            return _emit_check_failure("PyTorch MPS backend is not available in this runtime.", diagnostics)
+        return 0
+
+    if normalized_device == "cuda":
+        if not diagnostics.get("cuda_available"):
+            return _emit_check_failure("PyTorch CUDA backend is not available in this runtime.", diagnostics)
+        return 0
+
+    return _emit_check_failure(f"Unsupported depth device: {normalized_device}", diagnostics)
+
+
+def _check_availability(checkpoint: Path, device: str) -> int:
+    """Validate imports, checkpoint presence, and requested device readiness."""
     import depth_pro  # noqa: F401
 
     from ...stage_graph.stages.depth_pro import DepthProStage
@@ -62,7 +126,7 @@ def _check_availability(checkpoint: Path) -> int:
         return 1
 
     _ = DepthProStage
-    return 0
+    return _check_device_availability(device)
 
 
 def _run_inference(
@@ -138,7 +202,7 @@ def main(argv: list[str] | None = None) -> int:
 
     checkpoint = args.checkpoint.expanduser()
     if args.check:
-        return _check_availability(checkpoint)
+        return _check_availability(checkpoint, str(args.device))
 
     if args.input_image is None or args.output_depth is None or args.output_json is None:
         parser.error("--input-image, --output-depth, and --output-json are required unless --check is used.")

--- a/src/transformation_portal/depth/backends/depth_pro_worker.py
+++ b/src/transformation_portal/depth/backends/depth_pro_worker.py
@@ -125,13 +125,13 @@ def _check_device_availability(device: str) -> int:
 
 def _check_availability(checkpoint: Path, device: str) -> int:
     """Validate imports, checkpoint presence, and requested device readiness."""
-    import depth_pro  # noqa: F401
-
-    from ...stage_graph.stages.depth_pro import DepthProStage
-
     if not checkpoint.exists():
         print(f"Checkpoint not found: {checkpoint}", file=sys.stderr)
         return 1
+
+    import depth_pro  # noqa: F401
+
+    from ...stage_graph.stages.depth_pro import DepthProStage
 
     _ = DepthProStage
     return _check_device_availability(device)

--- a/src/transformation_portal/depth/backends/depth_pro_worker.py
+++ b/src/transformation_portal/depth/backends/depth_pro_worker.py
@@ -8,9 +8,6 @@ import sys
 from pathlib import Path
 from typing import Any
 
-import numpy as np
-from PIL import Image
-
 from ...ingest.canonical_json import dump_json, dumps_json
 
 
@@ -70,10 +67,22 @@ def _torch_diagnostics(device: str) -> dict[str, Any]:
         diagnostics["torch_import_error"] = str(exc)
         return diagnostics
 
+    def _safe_bool_call(callback: Any) -> bool:
+        if not callable(callback):
+            return False
+        try:
+            return bool(callback())
+        except Exception:
+            return False
+
+    torch_backends = getattr(torch, "backends", None)
+    mps_backend = getattr(torch_backends, "mps", None)
+    torch_cuda = getattr(torch, "cuda", None)
+
     diagnostics["torch_version"] = getattr(torch, "__version__", "unknown")
-    diagnostics["mps_built"] = bool(torch.backends.mps.is_built())
-    diagnostics["mps_available"] = bool(torch.backends.mps.is_available())
-    diagnostics["cuda_available"] = bool(torch.cuda.is_available())
+    diagnostics["mps_built"] = _safe_bool_call(getattr(mps_backend, "is_built", None))
+    diagnostics["mps_available"] = _safe_bool_call(getattr(mps_backend, "is_available", None))
+    diagnostics["cuda_available"] = _safe_bool_call(getattr(torch_cuda, "is_available", None))
     return diagnostics
 
 
@@ -136,6 +145,9 @@ def _run_inference(
     device: str,
 ) -> int:
     """Run Depth Pro inference and persist structured outputs."""
+    import numpy as np
+    from PIL import Image
+
     from ...stage_graph.stage import StageContext, StageStatus
     from ...stage_graph.stages.depth_pro import DepthProStage
 

--- a/src/transformation_portal/lux_depth_v3/README.md
+++ b/src/transformation_portal/lux_depth_v3/README.md
@@ -327,7 +327,8 @@ Output Deliverables
 ```
 
 The CLI **enforces license compliance** at startup to prevent accidental violations.
-For safe installation, keep `depth-pro` in a dedicated NumPy 1.x environment
+For safe installation, bootstrap `depth-pro` with
+`./scripts/setup/install_depth_pro_runtime.sh` and keep it in a dedicated NumPy 1.x environment
 and point the main pipeline at it with `--depth-pro-python` or
 `TRANSFORMATION_PORTAL_DEPTH_PRO_PYTHON`.
 When explicit `depth_pro` runs are launched from a repo checkout, the pipeline

--- a/src/transformation_portal/lux_depth_v3/__main__.py
+++ b/src/transformation_portal/lux_depth_v3/__main__.py
@@ -326,7 +326,9 @@ def main(
         "--depth-pro-python",
         help=(
             "Optional Python executable for an isolated Depth Pro environment. "
-            "Use this to keep depth_pro out of the main Transformation Portal venv."
+            "Use this to keep depth_pro out of the main Transformation Portal venv or to override "
+            "the auto-discovered repo-local runtime at ./.venv-depth-pro/bin/python "
+            "(bootstrap with ./scripts/setup/install_depth_pro_runtime.sh)."
         ),
     ),
     da3_python: Optional[str] = typer.Option(

--- a/src/transformation_portal/lux_depth_v3/artifact_manager.py
+++ b/src/transformation_portal/lux_depth_v3/artifact_manager.py
@@ -40,6 +40,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from .manifest import compute_file_sha256
+from .path_aliasing import normalize_lexical_path, relative_to_path_alias
 from .security import sanitize_path_component_nonlossy
 
 logger = logging.getLogger(__name__)
@@ -293,18 +294,18 @@ def make_output_key(
     Returns:
         Path representing the output key with preserved directory structure
     """
-    input_resolved = input_path.resolve()
-    root_resolved = input_root.resolve()
+    input_normalized = normalize_lexical_path(input_path)
+    root_normalized = normalize_lexical_path(input_root)
 
     try:
-        relpath = input_resolved.relative_to(root_resolved)
+        relpath = relative_to_path_alias(input_normalized, root_normalized)
     except ValueError:
         logger.warning(
             "%s is not relative to %s, using flat naming",
-            input_path,
-            input_root,
+            input_normalized,
+            root_normalized,
         )
-        relpath = Path(input_resolved.name)
+        relpath = Path(input_normalized.name)
 
     rel_dir = relpath.parent
     name = relpath.stem

--- a/src/transformation_portal/lux_depth_v3/input_discovery.py
+++ b/src/transformation_portal/lux_depth_v3/input_discovery.py
@@ -23,6 +23,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import List, Optional
 
+from .path_aliasing import normalize_lexical_path, resolve_real_path
 from .raw_loader import RAW_EXTENSIONS
 
 logger = logging.getLogger(__name__)
@@ -128,19 +129,21 @@ def discover_images(
     # Exclude only true descendants of output_dir
     # (avoid prefix false positives such as out vs out2)
     output_dir_resolved: Optional[Path] = None
+    output_dir_display: Optional[Path] = None
     if output_dir:
         try:
-            resolved_candidate = output_dir.expanduser().resolve()
+            output_dir_display = normalize_lexical_path(output_dir)
+            resolved_candidate = resolve_real_path(output_dir)
             if not resolved_candidate.is_dir():
                 logger.warning(
                     "Output directory exclusion " + "skipped: %s is not a directory",
-                    resolved_candidate,
+                    output_dir_display,
                 )
             else:
                 output_dir_resolved = resolved_candidate
                 logger.debug(
                     "Output directory to exclude: %s",
-                    output_dir_resolved,
+                    output_dir_display,
                 )
         except Exception as e:
             logger.warning(f"Failed to normalize output_dir: {e}")
@@ -159,7 +162,7 @@ def discover_images(
         # Check if file is in output directory before other checks
         if output_dir_resolved:
             try:
-                candidate_resolved = candidate.resolve()
+                candidate_resolved = resolve_real_path(candidate)
                 if candidate_resolved.is_relative_to(output_dir_resolved):
                     reason = "in output directory"
                     excluded_artifacts.append((candidate, reason))

--- a/src/transformation_portal/lux_depth_v3/orchestrator.py
+++ b/src/transformation_portal/lux_depth_v3/orchestrator.py
@@ -6053,6 +6053,10 @@ class EnhanceOrchestrator:
             backend_selection["logical_backend"] = self._backend_metadata.resolved_backend
             backend_selection["resolved_engine"] = backend_selection_resolved
 
+        artifact_summary_payload: dict[str, Any] = (
+            {"artifact_tree": artifact_tree} if run_card_version == "v2" else {"artifact_merkle_root": artifact_merkle_root}
+        )
+
         run_card = {
             "run_card_version": run_card_version,
             "batch_id": batch_id,
@@ -6078,11 +6082,7 @@ class EnhanceOrchestrator:
             "success_count": sum(1 for r in results if r.get("status") == "ok"),
             "error_count": sum(1 for r in results if r.get("status") == "error"),
             "artifact_index": artifact_index,
-            **(
-                {"artifact_tree": artifact_tree}
-                if run_card_version == "v2"
-                else {"artifact_merkle_root": artifact_merkle_root}
-            ),
+            **artifact_summary_payload,
         }
 
         def _json_default(obj: Any) -> Any:

--- a/src/transformation_portal/lux_depth_v3/orchestrator.py
+++ b/src/transformation_portal/lux_depth_v3/orchestrator.py
@@ -112,6 +112,7 @@ from .reconstruction_runner import (
     run_scene_reconstruction,
     write_scene_debug_bundle,
 )
+from .run_card_contract import render_run_card_output_relative_path
 from .scene_context import SceneContext
 from .scene_groups import SceneGroup, build_scene_groups
 from .scene_integrity import (
@@ -5912,18 +5913,7 @@ class EnhanceOrchestrator:
 
     def _run_card_output_relative_path(self, path_value: Any) -> Optional[str]:
         """Render an output-root-relative path suitable for run-card summaries."""
-        if not isinstance(path_value, str) or not path_value.strip():
-            return None
-        candidate = Path(path_value)
-        output_root_resolved = self.output_root.resolve(strict=False)
-        try:
-            relative_path = candidate.resolve(strict=False).relative_to(output_root_resolved)
-        except ValueError:
-            try:
-                relative_path = candidate.relative_to(self.output_root)
-            except ValueError:
-                relative_path = Path(candidate.name)
-        return str(relative_path).replace(os.sep, "/")
+        return render_run_card_output_relative_path(path_value, self.output_root)
 
     @staticmethod
     def _extract_run_card_segmentation_metadata(materials_v3_result: Any) -> Optional[Dict[str, Any]]:

--- a/src/transformation_portal/lux_depth_v3/path_aliasing.py
+++ b/src/transformation_portal/lux_depth_v3/path_aliasing.py
@@ -1,0 +1,40 @@
+"""Helpers for comparing filesystem paths without losing user-facing aliases.
+
+macOS commonly exposes the same temporary directory through both ``/tmp`` and
+``/private/tmp``. Replay artifacts should preserve the spelling the operator
+supplied, while safety checks still need a canonical real path.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+
+def normalize_lexical_path(path_value: Any) -> Path:
+    """Return an absolute path without resolving symlinks."""
+    path = Path(path_value).expanduser()
+    return Path(os.path.abspath(os.fspath(path)))
+
+
+def resolve_real_path(path_value: Any) -> Path:
+    """Return the canonical real path for safety checks."""
+    return normalize_lexical_path(path_value).resolve(strict=False)
+
+
+def relative_to_path_alias(candidate: Any, root: Any) -> Path:
+    """Return ``candidate`` relative to ``root`` with alias-aware fallback."""
+    candidate_path = normalize_lexical_path(candidate)
+    root_path = normalize_lexical_path(root)
+    try:
+        return candidate_path.relative_to(root_path)
+    except ValueError:
+        return resolve_real_path(candidate_path).relative_to(resolve_real_path(root_path))
+
+
+__all__ = [
+    "normalize_lexical_path",
+    "relative_to_path_alias",
+    "resolve_real_path",
+]

--- a/src/transformation_portal/lux_depth_v3/preprocessing.py
+++ b/src/transformation_portal/lux_depth_v3/preprocessing.py
@@ -615,11 +615,10 @@ def normalize_exif_orientation(input_path: Path, output_path: Path) -> None:
             pass
 
         # Save with preserved EXIF (orientation normalized)
-        save_kwargs = {}
         if exif_data:
-            save_kwargs["exif"] = exif_data
-
-        corrected.save(output_path, **save_kwargs)
+            corrected.save(output_path, exif=exif_data)
+        else:
+            corrected.save(output_path)
         logger.debug("Normalized EXIF orientation: %s -> %s", input_path, output_path)
 
     except (OSError, ValueError) as exc:

--- a/src/transformation_portal/lux_depth_v3/run_card_contract.py
+++ b/src/transformation_portal/lux_depth_v3/run_card_contract.py
@@ -64,10 +64,9 @@ def render_run_card_output_relative_path(path_value: Any, output_root: Any) -> O
     if not isinstance(path_value, str) or not path_value.strip():
         return None
     try:
-        relative_path = relative_to_path_alias(path_value, output_root)
+        return PurePosixPath(relative_to_path_alias(path_value, output_root)).as_posix()
     except ValueError:
-        relative_path = PurePosixPath(normalize_lexical_path(path_value).name)
-    return relative_path.as_posix()
+        return PurePosixPath(normalize_lexical_path(path_value).name).as_posix()
 
 
 __all__ = [

--- a/src/transformation_portal/lux_depth_v3/run_card_contract.py
+++ b/src/transformation_portal/lux_depth_v3/run_card_contract.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from pathlib import PurePosixPath
-from typing import Any
+from typing import Any, Optional
 
 from transformation_portal.schemas.run_card import (
     RUN_CARD_SCHEMA_URIS,
@@ -12,6 +12,8 @@ from transformation_portal.schemas.run_card import (
     get_run_card_schema_uri,
     normalize_run_card_version,
 )
+
+from .path_aliasing import normalize_lexical_path, relative_to_path_alias
 
 
 class RunCardPathValidationError(ValueError):
@@ -57,6 +59,17 @@ def normalize_run_card_relative_path(relative_path: Any) -> str:
     return normalized
 
 
+def render_run_card_output_relative_path(path_value: Any, output_root: Any) -> Optional[str]:
+    """Render an output-root-relative path while tolerating alias-equivalent roots."""
+    if not isinstance(path_value, str) or not path_value.strip():
+        return None
+    try:
+        relative_path = relative_to_path_alias(path_value, output_root)
+    except ValueError:
+        relative_path = PurePosixPath(normalize_lexical_path(path_value).name)
+    return relative_path.as_posix()
+
+
 __all__ = [
     "RUN_CARD_SCHEMA_URIS",
     "SUPPORTED_RUN_CARD_VERSIONS",
@@ -66,5 +79,6 @@ __all__ = [
     "infer_run_card_version",
     "normalize_run_card_relative_path",
     "normalize_run_card_version",
+    "render_run_card_output_relative_path",
     "with_inferred_run_card_version",
 ]

--- a/src/transformation_portal/lux_depth_v3/segmentation_backend.py
+++ b/src/transformation_portal/lux_depth_v3/segmentation_backend.py
@@ -436,7 +436,7 @@ class EfficientSAMBackend:
             logger.error(f"Failed to load EfficientSAM backend: {e}")
             raise RuntimeError(f"EfficientSAM backend loading failed: {e}") from e
 
-    def segment(self, image: np.ndarray) -> Dict[str, np.ndarray]:
+    def segment(self, image: np.ndarray) -> Dict[str, Tuple[np.ndarray, float]]:
         """Run material segmentation on an image.
 
         Args:
@@ -763,7 +763,7 @@ class EfficientSAMBackend:
 
                 # Initialize material masks with tracking for confidence scores
                 h, w = image.shape[:2]
-                material_data = {
+                material_data: Dict[str, Dict[str, Any]] = {
                     name: {"mask": np.zeros((h, w), dtype=np.float32), "scores": [], "areas": []} for name in material_prompts
                 }
 
@@ -817,7 +817,7 @@ class EfficientSAMBackend:
                         )
 
                 # Compute aggregate confidence per material (area-weighted average)
-                material_masks = {}
+                material_masks: Dict[str, Tuple[np.ndarray, float]] = {}
                 for name, data in material_data.items():
                     mask = data["mask"]
                     scores = data["scores"]

--- a/src/transformation_portal/lux_depth_v3/segmentation_backend.py
+++ b/src/transformation_portal/lux_depth_v3/segmentation_backend.py
@@ -443,7 +443,9 @@ class EfficientSAMBackend:
             image: Input RGB image (H, W, 3), uint8 [0-255]
 
         Returns:
-            Dict mapping material names to binary masks (H, W), float32 [0.0-1.0]
+            Dict mapping material names to ``(mask, confidence)`` tuples:
+            - mask: Binary mask (H, W), float32 [0.0-1.0]
+            - confidence: Material confidence score [0.0-1.0]
             V2: Real EfficientSAM + CLIP classification (if dependencies available)
             V1: Heuristic-based segmentation (fallback)
 

--- a/src/transformation_portal/lux_depth_v3/v2_enhance.py
+++ b/src/transformation_portal/lux_depth_v3/v2_enhance.py
@@ -343,16 +343,16 @@ def load_image_preserve_bit_depth(input_path: Path, allow_8bit_output: bool = Fa
             # Fall through to PIL loading
 
     # Standard PIL loading for 8-bit or fallback
-    with Image.open(input_path) as pil_image:
+    with Image.open(input_path) as opened_image:
         # Handle EXIF orientation
-        pil_image = ImageOps.exif_transpose(pil_image)
+        oriented_image: Image.Image = ImageOps.exif_transpose(opened_image)
 
         # After applying exif_transpose, normalize EXIF to avoid double-rotation:
         # - pixels have been rotated already
         # - EXIF Orientation must not request additional rotation in viewers
         exif_data: Optional[bytes] = None
         try:
-            exif_obj = pil_image.getexif()
+            exif_obj = oriented_image.getexif()
             if exif_obj:
                 # Pillow typically normalizes orientation to 1 after transpose
                 exif_data = exif_obj.tobytes()
@@ -363,14 +363,14 @@ def load_image_preserve_bit_depth(input_path: Path, allow_8bit_output: bool = Fa
         metadata["exif"] = exif_data
 
         # Handle palette mode
-        if pil_image.mode == "P":
-            pil_image = pil_image.convert("RGB")
+        if oriented_image.mode == "P":
+            oriented_image = oriented_image.convert("RGB")
 
         # Handle LA mode
-        if pil_image.mode == "LA":
-            pil_image = pil_image.convert("RGBA")
+        if oriented_image.mode == "LA":
+            oriented_image = oriented_image.convert("RGBA")
 
-        image_array = np.array(pil_image)
+        image_array = np.array(oriented_image)
 
     # Track actual loaded bits
     actual_bits = detected_input_bits
@@ -401,26 +401,27 @@ def load_depth_map(depth_path: Path) -> np.ndarray:
         V2EnhancementError: If depth map cannot be loaded
     """
     try:
-        depth_image = Image.open(depth_path)
+        with Image.open(depth_path) as opened_depth_image:
+            depth_image: Image.Image = opened_depth_image
 
-        # Handle 16-bit depth maps explicitly to preserve precision
-        if depth_image.mode in ("I;16", "I;16B", "I;16L", "I;16N"):
-            # Convert to uint16 array and normalize via fixed scale
-            depth_map = np.array(depth_image, dtype=np.uint16).astype(np.float32) / 65535.0
-        else:
-            # Convert to grayscale if needed
-            if depth_image.mode != "L" and depth_image.mode != "I" and depth_image.mode != "F":
-                depth_image = depth_image.convert("L")
+            # Handle 16-bit depth maps explicitly to preserve precision
+            if depth_image.mode in ("I;16", "I;16B", "I;16L", "I;16N"):
+                # Convert to uint16 array and normalize via fixed scale
+                depth_map = np.array(depth_image, dtype=np.uint16).astype(np.float32) / 65535.0
+            else:
+                # Convert to grayscale if needed
+                if depth_image.mode not in ("L", "I", "F"):
+                    depth_image = depth_image.convert("L")
 
-            depth_map = np.array(depth_image, dtype=np.float32)
+                depth_map = np.array(depth_image, dtype=np.float32)
 
-            # Normalize to [0, 1] - handle all-zeros case
-            depth_max = depth_map.max()
-            if depth_max > 1.0:
-                depth_map = depth_map / depth_max
-            elif depth_max == 0.0:
-                # All-zeros depth map: return as-is (will be handled gracefully by enhancement)
-                logger.warning(f"Depth map {depth_path} is all zeros - depth effects will be skipped")
+                # Normalize to [0, 1] - handle all-zeros case
+                depth_max = depth_map.max()
+                if depth_max > 1.0:
+                    depth_map = depth_map / depth_max
+                elif depth_max == 0.0:
+                    # All-zeros depth map: return as-is (will be handled gracefully by enhancement)
+                    logger.warning(f"Depth map {depth_path} is all zeros - depth effects will be skipped")
 
         return depth_map
 
@@ -531,11 +532,11 @@ def enhance_image(
         # 16-bit input MUST produce 16-bit output unless explicitly allowed
         # Decide target dtype up front to ensure consistency throughout pipeline
         if input_bits == 16 and allow_8bit_output:
-            target_dtype = np.uint8
+            target_dtype: np.dtype[Any] = np.dtype(np.uint8)
             target_bits = 8
             logger.warning("Quality Firewall BYPASSED: 16-bit → 8-bit downgrade allowed " "by --allow-8bit flag")
         else:
-            target_dtype = image.dtype
+            target_dtype = np.dtype(image.dtype)
             target_bits = input_bits
             if input_bits == 16:
                 logger.info("Quality Firewall ACTIVE: 16-bit input detected - " "will preserve 16-bit output")
@@ -602,10 +603,10 @@ def enhance_image(
         # Ensure output dtype matches target (handle potential mismatches)
         if enhanced_image.dtype != target_dtype:
             logger.debug(f"Converting enhanced image from {enhanced_image.dtype} to {target_dtype}")
-            if target_dtype == np.uint8 and enhanced_image.dtype == np.uint16:
+            if target_dtype == np.dtype(np.uint8) and enhanced_image.dtype == np.uint16:
                 # 16-bit → 8-bit conversion with proper normalization
                 enhanced_image = (enhanced_image.astype(np.float32) / 65535.0 * 255.0).astype(np.uint8)
-            elif target_dtype == np.uint16 and enhanced_image.dtype == np.uint8:
+            elif target_dtype == np.dtype(np.uint16) and enhanced_image.dtype == np.uint8:
                 # 8-bit → 16-bit conversion (unusual but handle it)
                 enhanced_image = (enhanced_image.astype(np.float32) / 255.0 * 65535.0).astype(np.uint16)
             else:

--- a/src/transformation_portal/lux_depth_v3/v2_runner.py
+++ b/src/transformation_portal/lux_depth_v3/v2_runner.py
@@ -24,6 +24,8 @@ from typing import Any, Dict, Optional
 from transformation_portal.core.security.path import safe_resolve_path
 from transformation_portal.core.security.validation import ValidationError
 
+from .path_aliasing import normalize_lexical_path
+
 logger = logging.getLogger(__name__)
 
 
@@ -145,7 +147,7 @@ class V2Runner:
         except ValidationError:
             # Input paths may legitimately be outside repo (user data directories)
             # Fall back to resolving and logging
-            validated_input = Path(input_path).resolve()
+            validated_input = normalize_lexical_path(input_path)
             logger.debug(f"Input path outside repo root (allowed): {validated_input}")
 
         # Output directory validation - must be within repo or explicitly allowed
@@ -153,7 +155,7 @@ class V2Runner:
             validated_output = safe_resolve_path(output_dir, allowed_root=self.repo_root)
         except ValidationError:
             # Output paths may also be outside repo - resolve but warn
-            validated_output = Path(output_dir).resolve()
+            validated_output = normalize_lexical_path(output_dir)
             logger.warning(
                 f"Output directory outside repo root: {validated_output}. "
                 "Consider using paths within the repository for better isolation."
@@ -165,7 +167,7 @@ class V2Runner:
             try:
                 validated_depth_dir = safe_resolve_path(depth_dir, allowed_root=self.repo_root)
             except ValidationError:
-                validated_depth_dir = Path(depth_dir).resolve()
+                validated_depth_dir = normalize_lexical_path(depth_dir)
                 logger.debug(f"Depth directory outside repo root (allowed): {validated_depth_dir}")
 
         # Validate masks_file if provided
@@ -174,7 +176,7 @@ class V2Runner:
             try:
                 validated_masks_file = safe_resolve_path(masks_file, allowed_root=self.repo_root)
             except ValidationError:
-                validated_masks_file = Path(masks_file).resolve()
+                validated_masks_file = normalize_lexical_path(masks_file)
                 logger.debug(f"Masks file outside repo root (allowed): {validated_masks_file}")
 
         # Validate log_file if provided
@@ -183,7 +185,7 @@ class V2Runner:
             try:
                 validated_log_file = safe_resolve_path(log_file, allowed_root=self.repo_root)
             except ValidationError:
-                validated_log_file = Path(log_file).resolve()
+                validated_log_file = normalize_lexical_path(log_file)
                 logger.debug(f"Log file outside repo root (allowed): {validated_log_file}")
 
         # Ensure output directory exists

--- a/tests/lux_depth_v3/test_artifact_manager.py
+++ b/tests/lux_depth_v3/test_artifact_manager.py
@@ -13,6 +13,7 @@ These tests verify:
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import pytest
@@ -191,6 +192,25 @@ class TestMakeOutputKey:
         key2 = make_output_key(input_path, input_root)
 
         assert key1 == key2
+
+    def test_symlinked_input_root_preserves_relative_structure(self, tmp_path, caplog):
+        """Symlinked input roots should not collapse to flat naming."""
+        from transformation_portal.lux_depth_v3.artifact_manager import make_output_key
+
+        actual_root = tmp_path / "actual_inputs"
+        image_path = actual_root / "scene1" / "image.jpg"
+        image_path.parent.mkdir(parents=True)
+        image_path.touch()
+
+        alias_root = tmp_path / "alias_inputs"
+        alias_root.symlink_to(actual_root, target_is_directory=True)
+        alias_image = alias_root / "scene1" / "image.jpg"
+
+        with caplog.at_level(logging.WARNING):
+            key = make_output_key(alias_image, alias_root)
+
+        assert str(key).startswith("scene1/")
+        assert "using flat naming" not in caplog.text
 
 
 class TestBuildArtifactIndex:

--- a/tests/test_input_discovery.py
+++ b/tests/test_input_discovery.py
@@ -69,6 +69,25 @@ class TestInputDiscovery:
         assert len(images) == 1
         assert images[0].name == "source.jpg"
 
+    def test_exclude_output_dir_with_symlink_alias(self, tmp_path):
+        """Alias-equivalent output roots should still be excluded cleanly."""
+        actual_root = tmp_path / "actual_input"
+        actual_root.mkdir()
+        (actual_root / "source.jpg").touch()
+
+        actual_output = actual_root / "output"
+        actual_output.mkdir()
+        (actual_output / "result.jpg").touch()
+
+        alias_root = tmp_path / "alias_input"
+        alias_root.symlink_to(actual_root, target_is_directory=True)
+
+        config = DiscoveryConfig(strict_mode=False)
+        images = discover_images(alias_root, config, output_dir=alias_root / "output")
+
+        assert len(images) == 1
+        assert images[0].name == "source.jpg"
+
     def test_exclude_hidden_files(self, tmp_path):
         """Verify .DS_Store and .cache/ are excluded."""
         # Create test files

--- a/tests/test_orchestrator_backend_integration.py
+++ b/tests/test_orchestrator_backend_integration.py
@@ -521,6 +521,61 @@ def test_startup_selection_fallback_is_persisted_in_attempt_history(tmp_path):
     assert backend_selection["attempts"][0]["status"] == "failed"
 
 
+def test_startup_selection_fallback_preserves_depth_pro_mps_unavailable_diagnostic(tmp_path):
+    """Selection-time Depth Pro device failures should remain visible in fallback metadata."""
+    import json
+
+    from PIL import Image
+
+    from transformation_portal.lux_depth_v3.input_manager import ImageInput
+
+    test_image = tmp_path / "startup_mps_fallback.png"
+    Image.new("RGB", (64, 64), color="white").save(test_image)
+
+    config = EnhanceConfig(
+        depth_backend="depth_pro",
+        depth_device="mps",
+        enable_v2=False,
+        non_commercial_ok=True,
+        accept_apple_depth_pro_research_license=True,
+    )
+
+    depth_pro_backend = Mock()
+    depth_pro_backend.name = "depth_pro"
+    depth_pro_backend.license_type = Mock(value="research_only")
+    depth_pro_backend.ensure_available.side_effect = ImportError(
+        '{"device":"mps","mps_available":false,"reason":"PyTorch MPS backend is not available in this runtime."}'
+    )
+
+    da3_backend = Mock()
+    da3_backend.name = "da3"
+    da3_backend.license_type = Mock(value="commercial")
+    da3_backend.ensure_available.return_value = None
+    da3_backend.compute.return_value = _make_depth_result()
+
+    registry = Mock()
+    registry.get_backend.side_effect = lambda backend_id, _config: {
+        "depth_pro": depth_pro_backend,
+        "da3": da3_backend,
+    }[backend_id]
+
+    with patch("transformation_portal.lux_depth_v3.orchestrator.DepthBackendRegistry", return_value=registry):
+        orchestrator = EnhanceOrchestrator(config, tmp_path)
+        orchestrator.postprocessor = Mock(process=lambda result: result)
+        result = orchestrator.enhance_image(ImageInput(path=test_image))
+
+    assert result["status"] == "ok"
+    assert result["backend"] == "da3"
+    assert [attempt["backend"] for attempt in result["attempts"]] == ["depth_pro", "da3"]
+    assert '"mps_available":false' in result["attempts"][0]["error_message"]
+
+    manifest = json.loads(Path(result["manifest"]).read_text())
+    backend_selection = manifest["backend_selection"]
+    assert backend_selection["resolved_backend"] == "da3"
+    assert backend_selection["resolution_status"] == "fallback"
+    assert '"mps_available":false' in backend_selection["resolution_reason"]
+
+
 def test_depth_metadata_uses_resolved_backend_not_config_default(tmp_path, mock_da3_available):
     """REGRESSION TEST for ADR-023: depth.model must use resolved backend, not config default.
 

--- a/tests/test_run_card_schema.py
+++ b/tests/test_run_card_schema.py
@@ -28,6 +28,7 @@ from transformation_portal.lux_depth_v3.orchestrator import (
     _validate_run_card_backend_semantics,
     _validate_run_card_payload,
 )
+from transformation_portal.lux_depth_v3.run_card_contract import render_run_card_output_relative_path
 from transformation_portal.lux_depth_v3.security import HashMode
 from transformation_portal.schemas.run_card import load_run_card_schema
 
@@ -209,6 +210,20 @@ def test_run_card_schema_rejects_empty_artifact_index():
 
     with pytest.raises(RuntimeError, match="artifact_index"):
         _validate_run_card_payload(payload, _run_card_schema_path())
+
+
+def test_run_card_output_relative_path_handles_alias_equivalent_roots(tmp_path: Path):
+    actual_root = tmp_path / "actual_output"
+    actual_manifest = actual_root / "manifests" / "alpha.json"
+    actual_manifest.parent.mkdir(parents=True)
+    actual_manifest.write_text("{}")
+
+    alias_root = tmp_path / "alias_output"
+    alias_root.symlink_to(actual_root, target_is_directory=True)
+
+    relative_path = render_run_card_output_relative_path(str(actual_manifest), alias_root)
+
+    assert relative_path == "manifests/alpha.json"
 
 
 def test_build_artifact_index_is_deterministic(tmp_path: Path):

--- a/tests/test_v2_runner.py
+++ b/tests/test_v2_runner.py
@@ -588,6 +588,31 @@ class TestPathValidation:
         assert result["status"] == "success"
 
     @patch("transformation_portal.lux_depth_v3.v2_runner.subprocess.run")
+    def test_output_dir_symlink_alias_preserved_in_command(self, mock_subprocess, tmp_path):
+        """Symlink aliases such as /tmp should be preserved in subprocess args."""
+        mock_subprocess.return_value = Mock(returncode=0, stdout="", stderr="")
+
+        runner = V2Runner()
+        runner.script_path = Path("/fake/enhance_image.py")
+
+        actual_output = tmp_path / "actual_output"
+        actual_output.mkdir()
+        alias_output = tmp_path / "alias_output"
+        alias_output.symlink_to(actual_output, target_is_directory=True)
+
+        with patch.object(Path, "exists", return_value=True):
+            result = runner.run(
+                input_path=tmp_path / "input.jpg",
+                depth_dir=None,
+                output_dir=alias_output,
+            )
+
+        cmd = mock_subprocess.call_args[0][0]
+        output_index = cmd.index("--output-dir")
+        assert cmd[output_index + 1] == str(alias_output)
+        assert result["status"] == "success"
+
+    @patch("transformation_portal.lux_depth_v3.v2_runner.subprocess.run")
     def test_masks_file_validated(self, mock_subprocess, tmp_path):
         """Test that masks_file path is validated and included in command."""
         mock_subprocess.return_value = Mock(returncode=0, stdout="", stderr="")

--- a/tests/unit/depth/backends/test_depth_pro_backend.py
+++ b/tests/unit/depth/backends/test_depth_pro_backend.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import builtins
 import json
 import subprocess
 import sys
@@ -14,6 +15,7 @@ import pytest
 
 from transformation_portal.depth.backends.depth_pro import DepthProBackend
 from transformation_portal.depth.backends.depth_pro_worker import (
+    _check_availability,
     _check_device_availability,
     _torch_diagnostics,
 )
@@ -127,6 +129,27 @@ def test_torch_diagnostics_handles_missing_optional_accelerator_backends(
     assert diagnostics["mps_built"] is False
     assert diagnostics["mps_available"] is False
     assert diagnostics["cuda_available"] is False
+
+
+def test_check_availability_reports_missing_checkpoint_before_imports(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    missing_checkpoint = tmp_path / "missing-depth-pro.pt"
+    real_import = builtins.__import__
+
+    def _guarded_import(name: str, *args: object, **kwargs: object) -> object:
+        if name == "depth_pro":
+            raise AssertionError("depth_pro import should not run when checkpoint is missing")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _guarded_import)
+
+    returncode = _check_availability(missing_checkpoint, "cpu")
+
+    assert returncode == 1
+    assert f"Checkpoint not found: {missing_checkpoint}" in capsys.readouterr().err
 
 
 def test_compute_normalizes_device_override_for_readiness_and_subprocess(tmp_path: Path) -> None:

--- a/tests/unit/depth/backends/test_depth_pro_backend.py
+++ b/tests/unit/depth/backends/test_depth_pro_backend.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import numpy as np
 import pytest
 
 from transformation_portal.depth.backends.depth_pro import DepthProBackend
@@ -16,6 +17,7 @@ from transformation_portal.depth.backends.depth_pro_worker import (
     _check_device_availability,
     _torch_diagnostics,
 )
+from transformation_portal.depth.backends.protocol import DepthResult
 from transformation_portal.lux_depth_v3.config import EnhanceConfig
 
 pytestmark = [
@@ -125,3 +127,35 @@ def test_torch_diagnostics_handles_missing_optional_accelerator_backends(
     assert diagnostics["mps_built"] is False
     assert diagnostics["mps_available"] is False
     assert diagnostics["cuda_available"] is False
+
+
+def test_compute_normalizes_device_override_for_readiness_and_subprocess(tmp_path: Path) -> None:
+    checkpoint = tmp_path / "depth_pro.pt"
+    checkpoint.write_bytes(b"checkpoint")
+    backend = DepthProBackend(_depth_pro_config(checkpoint, device="cpu"))
+
+    with (
+        patch.object(backend, "_ensure_runtime_available") as mock_ready,
+        patch.object(
+            backend,
+            "_compute_subprocess",
+            return_value=DepthResult(
+                depth_map=np.zeros((1, 1), dtype=np.float32),
+                original_image=np.zeros((1, 1, 3), dtype=np.uint8),
+                metadata={},
+                depth_units="meters",
+                focal_length_px=None,
+                field_of_view_deg=None,
+                backend_id=backend.name,
+                device="mps",
+                dtype="float32",
+                input_size=(1, 1),
+            ),
+        ) as mock_subprocess,
+    ):
+        image = np.zeros((1, 1, 3), dtype=np.uint8)
+        backend.compute(image, device="  MPS  ")
+
+    mock_ready.assert_called_once_with(device="mps")
+    mock_subprocess.assert_called_once()
+    assert mock_subprocess.call_args.args[1] == "mps"

--- a/tests/unit/depth/backends/test_depth_pro_backend.py
+++ b/tests/unit/depth/backends/test_depth_pro_backend.py
@@ -1,0 +1,105 @@
+"""Focused unit tests for DepthProBackend subprocess readiness."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from transformation_portal.depth.backends.depth_pro import DepthProBackend
+from transformation_portal.depth.backends.depth_pro_worker import _check_device_availability
+from transformation_portal.lux_depth_v3.config import EnhanceConfig
+
+pytestmark = [
+    pytest.mark.unit,
+]
+
+
+def _depth_pro_config(checkpoint: Path, *, device: str = "mps") -> EnhanceConfig:
+    return EnhanceConfig(
+        depth_backend="depth_pro",
+        depth_device=device,
+        depth_pro_checkpoint_path=str(checkpoint),
+        depth_pro_python_executable=sys.executable,
+        non_commercial_ok=True,
+        accept_apple_depth_pro_research_license=True,
+        enable_v2=False,
+    )
+
+
+def test_subprocess_availability_check_passes_requested_device(tmp_path: Path) -> None:
+    checkpoint = tmp_path / "depth_pro.pt"
+    checkpoint.write_bytes(b"checkpoint")
+    backend = DepthProBackend(_depth_pro_config(checkpoint, device="mps"))
+
+    with patch("transformation_portal.depth.backends.depth_pro.subprocess.run") as mock_run:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=["python"],
+            returncode=0,
+            stdout="",
+            stderr="",
+        )
+
+        backend.ensure_available()
+
+    command = mock_run.call_args.args[0]
+    assert "--check" in command
+    assert "--device" in command
+    assert command[command.index("--device") + 1] == "mps"
+
+
+def test_subprocess_availability_failure_includes_worker_diagnostics(tmp_path: Path) -> None:
+    checkpoint = tmp_path / "depth_pro.pt"
+    checkpoint.write_bytes(b"checkpoint")
+    backend = DepthProBackend(_depth_pro_config(checkpoint, device="mps"))
+
+    diagnostic = json.dumps(
+        {
+            "status": "unavailable",
+            "reason": "PyTorch MPS backend is not available in this runtime.",
+            "device": "mps",
+            "mps_built": True,
+            "mps_available": False,
+            "torch_version": "2.11.0",
+        },
+        sort_keys=True,
+    )
+    with patch("transformation_portal.depth.backends.depth_pro.subprocess.run") as mock_run:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=["python"],
+            returncode=1,
+            stdout="",
+            stderr=diagnostic,
+        )
+
+        with pytest.raises(ImportError) as exc_info:
+            backend.ensure_available()
+
+    message = str(exc_info.value)
+    assert "--device mps" in message
+    assert '"mps_available": false' in message
+    assert "Depth Pro subprocess environment is not ready." in message
+
+
+def test_worker_reports_structured_mps_diagnostics(capsys: pytest.CaptureFixture[str]) -> None:
+    diagnostics = {
+        "device": "mps",
+        "mps_built": True,
+        "mps_available": False,
+        "torch_version": "2.11.0",
+    }
+    with patch(
+        "transformation_portal.depth.backends.depth_pro_worker._torch_diagnostics",
+        return_value=diagnostics,
+    ):
+        returncode = _check_device_availability("mps")
+
+    assert returncode == 1
+    payload = json.loads(capsys.readouterr().err)
+    assert payload["status"] == "unavailable"
+    assert payload["device"] == "mps"
+    assert payload["mps_available"] is False

--- a/tests/unit/depth/backends/test_depth_pro_backend.py
+++ b/tests/unit/depth/backends/test_depth_pro_backend.py
@@ -6,12 +6,16 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
 
 from transformation_portal.depth.backends.depth_pro import DepthProBackend
-from transformation_portal.depth.backends.depth_pro_worker import _check_device_availability
+from transformation_portal.depth.backends.depth_pro_worker import (
+    _check_device_availability,
+    _torch_diagnostics,
+)
 from transformation_portal.lux_depth_v3.config import EnhanceConfig
 
 pytestmark = [
@@ -103,3 +107,21 @@ def test_worker_reports_structured_mps_diagnostics(capsys: pytest.CaptureFixture
     assert payload["status"] == "unavailable"
     assert payload["device"] == "mps"
     assert payload["mps_available"] is False
+
+
+def test_torch_diagnostics_handles_missing_optional_accelerator_backends(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_torch = SimpleNamespace(
+        __version__="test",
+        backends=SimpleNamespace(),
+        cuda=None,
+    )
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+
+    diagnostics = _torch_diagnostics("mps")
+
+    assert diagnostics["torch_version"] == "test"
+    assert diagnostics["mps_built"] is False
+    assert diagnostics["mps_available"] is False
+    assert diagnostics["cuda_available"] is False


### PR DESCRIPTION
## Summary
- close out the remaining PR #1435 follow-up items around Depth Pro fallback selection, APEX replay regressions, and `/tmp` path alias handling
- add a repo-owned Depth Pro runtime bootstrap so the external `.venv-depth-pro` contract stops drifting and can be repaired deterministically
- refresh the local Depth Pro runtime to a pinned, host-working MPS configuration and document the supported install path

## What changed
- made Depth Pro subprocess readiness device-aware so `--check` validates the requested accelerator instead of only import/checkpoint presence
- surfaced structured worker diagnostics for `torch`, `mps_built`, `mps_available`, and `cuda_available`, and preserved that diagnostic context through startup fallback metadata
- normalized alias-equivalent output roots (`/tmp` vs `/private/tmp`) in the V2 and run-card path surfaces without weakening path isolation checks
- added `scripts/setup/install_depth_pro_runtime.sh` to rebuild `./.venv-depth-pro` from a clean pinned baseline:
  - `torch==2.7.1`
  - `torchvision==0.22.1`
  - `numpy==1.26.4`
  - `depth_pro @ git+https://github.com/apple/ml-depth-pro.git@9efe5c1def37a26c5367a71df664b18e1306c708`
- updated Depth Pro setup and troubleshooting docs to point at the repo-owned runtime contract instead of a floating `pip install depth-pro`
- updated `scripts/validate_depth_pro_checkpoint.py` so it can import repo code from `src/` without dragging the full main runtime graph into `.venv-depth-pro`

## Why
The repo-side startup logic was previously willing to select `depth_pro` on `mps` after a false-positive subprocess readiness check, then fail later and fall back. At the same time, the repo-local external Depth Pro runtime had drifted into an incompatible mixed environment and no longer provided a deterministic install surface.

On this macOS 26.4 Apple Silicon host, the old `.venv-depth-pro` runtime using `torch==2.11.0` no longer provided a usable MPS lane. Rebuilding the runtime from a clean pinned baseline on `torch==2.7.1` restored the real host MPS path and eliminated the false `APEX_DEPTH_PLATEAU` regressions that were actually runtime-induced.

## Validation
Passed:
- `./.venv/bin/pytest -p no:rerunfailures tests/unit/depth/backends/test_depth_pro_backend.py tests/test_orchestrator_backend_integration.py tests/lux_depth_v3/test_artifact_manager.py tests/test_input_discovery.py tests/test_v2_runner.py tests/test_run_card_schema.py -q`
- `./scripts/setup/install_depth_pro_runtime.sh`
- `./.venv-depth-pro/bin/python scripts/validate_depth_pro_checkpoint.py`
- direct host MPS smoke via `DepthProStage(..., device="mps")`
- depth-only APEX replay for `DJI_0046.DNG` on repaired `depth_pro`/`mps`
- depth-only APEX replay for `IMG_9110.CR2` on repaired `depth_pro`/`mps`

Replay outcomes after the runtime repair:
- `DJI_0046.DNG`: succeeds on `depth_pro`/`mps` and returns to the April 12 metric-depth success profile
- `IMG_9110.CR2`: succeeds on `depth_pro`/`mps`; the previous plateau failure no longer reproduces
- alias-only `/tmp` vs `/private/tmp` warnings are gone from the repaired replay outputs

## Pre-commit
- commit-time pre-commit hooks over the staged files passed cleanly
- a manual `pre-commit run --all-files --show-diff-on-failure` still reports the existing repo-wide `validate-dependency-constraints` warnings on stale target-owned ML lockfiles (`ml-core-darwin-arm64`, `ml-core-darwin-x86_64`, `ml-core-linux`); this was already failing independently of this diff and is not expanded here

## Follow-up status
This closes out the highest-signal follow-up items called out after PR #1435:
1. Depth Pro MPS worker lane fixed and runtime repaired
2. `DJI_0046.DNG` and `IMG_9110.CR2` replay regressions resolved as runtime fallout rather than surviving APEX gate regressions
3. `/tmp` vs `/private/tmp` replay provenance noise removed
4. ingest workflow long-term pinning remains unchanged and still conditional on that lane growing beyond the current minimal dependency set
