### PR TITLE
docs(portal): correct quickstart validation guidance

### DIFF
--- a/docs/guides/PORTAL_ORCHESTRATOR_QUICKSTART.md
+++ b/docs/guides/PORTAL_ORCHESTRATOR_QUICKSTART.md
@@ -64,7 +64,8 @@ export TP_READY_VERBOSE=1
 ## Endpoints
 
 - `GET /ready` returns a shallow backend liveness signal.
-- `GET /healthz` returns the managed front-door liveness signal.
+- `GET /healthz` returns the backend's minimal liveness signal; the secure front
+  door exposes its own `/healthz` route with the managed readiness checks.
 - `GET /v1/readiness` returns the operator-truth execution readiness matrix for `lux-depth-v3`, `archive-gate-a`, `archive-gate-b`, and `archive-gate-c`.
 - `GET /portal/bootstrap` returns the standalone portal bootstrap contract for `direct_debug` mode.
 - `GET /v1/presets?pipeline=lux-depth-v3` dynamic UI preset catalog.

--- a/docs/guides/PORTAL_SECURE_FRONTDOOR_QUICKSTART.md
+++ b/docs/guides/PORTAL_SECURE_FRONTDOOR_QUICKSTART.md
@@ -235,13 +235,35 @@ checks manually:
 
 ```bash
 cd web/secure-landing
+nvm use 22
 npm test
 TP_NEXT_DIST_DIR=.next-build-verify npm run build
-TP_NEXT_DIST_DIR=.next-build-verify npm run start
+```
 
-python scripts/validation/validate_frontdoor_browser_smoke.py \
-  --spawn-local-backend \
-  --spawn-local-frontdoor
+If you want to launch the standalone build, do that in a separate shell after
+the backend is ready and the local credential fixture exists:
+
+```bash
+make seed-frontdoor-user
+cd web/secure-landing
+TP_FASTAPI_ORIGIN=http://127.0.0.1:8000 \
+TP_BACKEND_API_KEY="${TP_BACKEND_API_KEY:-$TP_API_KEY}" \
+TP_FRONTDOOR_USERS_FILE=/tmp/tp-frontdoor-users.json \
+TP_FRONTDOOR_SESSION_DB=/tmp/transformation-portal-frontdoor-sessions-standalone.db \
+TP_FRONTDOOR_SESSION_SCALING_MODE=single_instance \
+TP_NEXT_DIST_DIR=.next-build-verify \
+npm run start
+```
+
+If you want browser smoke against an already running managed front door, run it
+from the repo root and point it at that instance instead of
+`--spawn-local-frontdoor`:
+
+```bash
+TP_FRONTDOOR_BASE_URL="https://portal.example.com" \
+TP_FRONTDOOR_USERNAME="replace-with-operator-username" \
+TP_FRONTDOOR_PASSWORD="replace-with-operator-password" \
+python scripts/validation/validate_frontdoor_browser_smoke.py
 ```
 
 If you point the browser smoke at an already running or non-local managed

--- a/docs/guides/PORTAL_SECURE_FRONTDOOR_QUICKSTART.md
+++ b/docs/guides/PORTAL_SECURE_FRONTDOOR_QUICKSTART.md
@@ -240,12 +240,15 @@ npm test
 TP_NEXT_DIST_DIR=.next-build-verify npm run build
 ```
 
-If you want to launch the standalone build, do that in a separate shell after
-the backend is ready and the local credential fixture exists:
+If you want to launch the standalone build locally without Cloudflare Access,
+do that in a separate shell after the backend is ready and the local credential
+fixture exists:
 
 ```bash
 make seed-frontdoor-user
 cd web/secure-landing
+NODE_ENV=development \
+TP_ALLOW_LOCAL_ACCESS_BYPASS=1 \
 TP_FASTAPI_ORIGIN=http://127.0.0.1:8000 \
 TP_BACKEND_API_KEY="${TP_BACKEND_API_KEY:-$TP_API_KEY}" \
 TP_FRONTDOOR_USERS_FILE=/tmp/tp-frontdoor-users.json \
@@ -254,6 +257,16 @@ TP_FRONTDOOR_SESSION_SCALING_MODE=single_instance \
 TP_NEXT_DIST_DIR=.next-build-verify \
 npm run start
 ```
+
+For local standalone runs, keep `NODE_ENV=development` and
+`TP_ALLOW_LOCAL_ACCESS_BYPASS=1`; otherwise the front door treats Cloudflare
+Access as required and `/healthz` fails closed until `TP_CF_ACCESS_TEAM_DOMAIN`
+and `TP_CF_ACCESS_AUD` are configured.
+
+If you want standalone validation with the production auth posture instead of
+the local bypass, keep `NODE_ENV=production`, supply
+`TP_CF_ACCESS_TEAM_DOMAIN` + `TP_CF_ACCESS_AUD`, and run it behind HTTPS (or an
+equivalent trusted edge) so the secure-cookie flow remains valid.
 
 If you want browser smoke against an already running managed front door, run it
 from the repo root and point it at that instance instead of


### PR DESCRIPTION
## Summary
- Correct two stale portal quickstart instructions that no longer match the current runtime contracts.
- Keep the fix scoped to documentation so operators get runnable validation steps and accurate endpoint ownership guidance.

## Changes
- Rewrite the secure frontdoor quickstart manual validation section so contract checks, standalone launch, and browser smoke are described as separate runnable flows.
- Remove the stale pairing of an already running standalone frontdoor with `--spawn-local-frontdoor`, and point manual browser smoke back to the repo-root script path.
- Clarify in the orchestrator quickstart that backend `/healthz` is only the minimal FastAPI liveness probe, while the managed readiness `/healthz` contract belongs to the secure front door.

## Validation
Proven green:
- `git diff --check`
- `make check-stale-docs`

Still failing:
- `make pre-commit`
  - tooling failure: the target expects `pre-commit` on `PATH`; this shell only had the repo-local executable at `.venv/bin/pre-commit`.
- `PATH="/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin:$PATH" ./.venv/bin/pre-commit run --all-files --show-diff-on-failure`
  - repo-baseline dependency warning failure: `validate-dependency-constraints` exits non-zero because `requirements/ml-core-darwin-arm64.txt`, `requirements/ml-core-darwin-x86_64.txt`, and `requirements/ml-core-linux.txt` are older than their corresponding `.in` files.
  - This is not caused by the doc-only change.

## Risk
- Low risk: docs-only update, no runtime, selector, route, auth, or contract behavior changes.
- Revert-safe: the diff only changes operator guidance for existing commands and endpoint ownership language.