### PR TITLE
fix(requirements): make target-owned ML freshness checks lane-aware

### DIFF
--- a/.github/workflows/ci-quality-firewall.yml
+++ b/.github/workflows/ci-quality-firewall.yml
@@ -309,6 +309,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install packaging
+          python -m pip install "pip-tools==7.5.2"
 
       - name: Validate dependency constraints
         run: |

--- a/scripts/validate_dependency_constraints.sh
+++ b/scripts/validate_dependency_constraints.sh
@@ -172,24 +172,77 @@ is_target_owned_ml_input() {
     return 1
 }
 
-target_owned_ml_stale_fix() {
+normalize_host_arch() {
+    local arch="$1"
+    case "$arch" in
+        "aarch64")
+            echo "arm64"
+            ;;
+        "amd64")
+            echo "x86_64"
+            ;;
+        *)
+            echo "$arch"
+            ;;
+    esac
+}
+
+current_host_system() {
+    uname -s 2>/dev/null || echo ""
+}
+
+current_host_arch() {
+    local arch
+    arch="$(uname -m 2>/dev/null || echo "")"
+    normalize_host_arch "$arch"
+}
+
+validate_target_owned_ml_freshness() {
     local basename="$1"
+    local txt_file="$2"
+    local host_os=""
+    local host_arch=""
+    local check_target=""
+    local compile_fix=""
+
     case "$basename" in
-        "ml-core-darwin-arm64.in")
-            echo "Run 'cd requirements && make compile-ml-darwin-arm64' on native Darwin arm64."
+        "ml-core-darwin-x86_64.in")
+            if [[ $VERBOSE -eq 1 ]]; then
+                echo "INFO: $basename is frozen and excluded from freshness regeneration checks."
+            fi
             return 0
+            ;;
+        "ml-core-darwin-arm64.in")
+            host_os="$(current_host_system)"
+            host_arch="$(current_host_arch)"
+            if [[ "$host_os" != "Darwin" || "$host_arch" != "arm64" ]]; then
+                return 0
+            fi
+            check_target="check-ml-darwin-arm64"
+            compile_fix="Run 'cd requirements && make compile-ml-darwin-arm64' on native Darwin arm64."
             ;;
         "ml-core-linux.in")
-            echo "Run 'cd requirements && make compile-ml-linux-x86_64' on native Linux x86_64."
-            return 0
+            host_os="$(current_host_system)"
+            host_arch="$(current_host_arch)"
+            if [[ "$host_os" != "Linux" || "$host_arch" != "x86_64" ]]; then
+                return 0
+            fi
+            check_target="check-ml-linux-x86_64"
+            compile_fix="Run 'cd requirements && make compile-ml-linux-x86_64' on native Linux x86_64."
             ;;
-        "ml-core-darwin-x86_64.in")
-            echo "Darwin x86_64 is frozen; do not regenerate until an authoritative lane is defined."
+        *)
             return 0
             ;;
     esac
-    echo "Run the authoritative lane-specific compile command for this target-owned ML lock."
-    return 0
+
+    if make -C requirements "$check_target" LOCK_PYTHON_VERSION=3.11 >/dev/null 2>&1; then
+        return 0
+    fi
+
+    echo -e "${YELLOW}⚠️  $basename: Target-owned ML lock freshness check failed${NC}"
+    echo -e "   ${BOLD}WARNING:${NC} $(basename "$txt_file") could not be validated by $check_target on this authoritative lane"
+    echo -e "   ${BOLD}Fix:${NC} $compile_fix\n"
+    return 1
 }
 
 # Function: Extract version from constraint
@@ -342,12 +395,9 @@ validate_in_file() {
     if [[ -f "$txt_file" ]]; then
         if [[ "$txt_file" -ot "$in_file" ]]; then
             if is_target_owned_ml_input "$basename"; then
-                local stale_fix
-                stale_fix=$(target_owned_ml_stale_fix "$basename")
-                echo -e "${YELLOW}⚠️  $basename: Compiled .txt file is stale${NC}"
-                echo -e "   ${BOLD}WARNING:${NC} $(basename "$txt_file") is older than $basename"
-                echo -e "   ${BOLD}Fix:${NC} $stale_fix\n"
-                file_warnings=$((file_warnings + 1))
+                if ! validate_target_owned_ml_freshness "$basename" "$txt_file"; then
+                    file_warnings=$((file_warnings + 1))
+                fi
             else
                 echo -e "${YELLOW}⚠️  $basename: Compiled .txt file is stale${NC}"
                 echo -e "   ${BOLD}WARNING:${NC} $(basename "$txt_file") is older than $basename"

--- a/scripts/validate_dependency_constraints.sh
+++ b/scripts/validate_dependency_constraints.sh
@@ -204,6 +204,7 @@ validate_target_owned_ml_freshness() {
     local host_arch=""
     local check_target=""
     local compile_fix=""
+    local check_output=""
 
     case "$basename" in
         "ml-core-darwin-x86_64.in")
@@ -235,12 +236,24 @@ validate_target_owned_ml_freshness() {
             ;;
     esac
 
-    if make -C requirements "$check_target" LOCK_PYTHON_VERSION=3.11 >/dev/null 2>&1; then
-        return 0
+    if [[ $VERBOSE -eq 1 ]]; then
+        if check_output=$(make -C requirements "$check_target" LOCK_PYTHON_VERSION=3.11 2>&1); then
+            return 0
+        fi
+    else
+        if make -C requirements "$check_target" LOCK_PYTHON_VERSION=3.11 >/dev/null 2>&1; then
+            return 0
+        fi
     fi
 
     echo -e "${YELLOW}⚠️  $basename: Target-owned ML lock freshness check failed${NC}"
     echo -e "   ${BOLD}WARNING:${NC} $(basename "$txt_file") could not be validated by $check_target on this authoritative lane"
+    if [[ $VERBOSE -eq 1 && -n "$check_output" ]]; then
+        echo -e "   ${BOLD}Details:${NC}"
+        while IFS= read -r output_line; do
+            echo "     $output_line"
+        done <<< "$check_output"
+    fi
     echo -e "   ${BOLD}Fix:${NC} $compile_fix\n"
     return 1
 }

--- a/tests/validation/test_validate_dependency_constraints_script.py
+++ b/tests/validation/test_validate_dependency_constraints_script.py
@@ -101,20 +101,29 @@ def _write_fake_uname(path: Path, *, system: str, machine: str) -> Path:
     )
 
 
-def _write_fake_make(path: Path, *, expected_target: str | None, exit_code: int) -> Path:
+def _write_fake_make(
+    path: Path,
+    *,
+    expected_target: str | None,
+    exit_code: int,
+    stdout_text: str = "",
+    stderr_text: str = "",
+) -> Path:
     if expected_target is None:
         content = '#!/bin/sh\necho "unexpected make invocation: $*" >&2\nexit 97\n'
         return _write_executable(path, content)
 
     content = (
         "#!/bin/sh\n"
-        'if [ "$1" != "-C" ] || [ "$2" != "requirements" ] || [ "$3" != "'
+        + 'if [ "$1" != "-C" ] || [ "$2" != "requirements" ] || [ "$3" != "'
         + expected_target
         + '" ] || [ "$4" != "LOCK_PYTHON_VERSION=3.11" ]; then\n'
-        '  echo "unexpected make args: $*" >&2\n'
-        "  exit 98\n"
-        "fi\n"
-        f"exit {exit_code}\n"
+        + '  echo "unexpected make args: $*" >&2\n'
+        + "  exit 98\n"
+        + "fi\n"
+        + (f"printf '%s\\n' {shlex.quote(stdout_text)}\n" if stdout_text else "")
+        + (f"printf '%s\\n' {shlex.quote(stderr_text)} >&2\n" if stderr_text else "")
+        + f"exit {exit_code}\n"
     )
     return _write_executable(path, content)
 
@@ -279,6 +288,51 @@ def test_target_owned_ml_inputs_warn_when_authoritative_lane_check_fails(
     assert "Target-owned ML lock freshness check failed" in result.stdout
     assert check_target in result.stdout
     assert compile_fix in result.stdout
+    assert "unexpected make" not in result.stdout
+
+
+@pytest.mark.parametrize(
+    ("input_name", "lock_name", "system", "machine", "check_target"),
+    (
+        ("ml-core-darwin-arm64.in", "ml-core-darwin-arm64.txt", "Darwin", "arm64", "check-ml-darwin-arm64"),
+        ("ml-core-linux.in", "ml-core-linux.txt", "Linux", "x86_64", "check-ml-linux-x86_64"),
+    ),
+)
+def test_target_owned_ml_inputs_surface_lane_check_output_in_verbose_mode(
+    tmp_path: Path,
+    input_name: str,
+    lock_name: str,
+    system: str,
+    machine: str,
+    check_target: str,
+) -> None:
+    repo_root = tmp_path / "repo"
+    _prepare_validator_repo(repo_root)
+
+    requirements_dir = repo_root / "requirements"
+    requirements_dir.mkdir(parents=True, exist_ok=True)
+    in_path = requirements_dir / input_name
+    txt_path = requirements_dir / lock_name
+    in_path.write_text("numpy>=1.24,<2.5  # Verbose delegated failure coverage\n", encoding="utf-8")
+    _write_lockfile(txt_path)
+    _make_stale(in_path, txt_path)
+
+    fakebin = tmp_path / "fakebin"
+    _write_fake_uname(fakebin / "uname", system=system, machine=machine)
+    _write_fake_make(
+        fakebin / "make",
+        expected_target=check_target,
+        exit_code=1,
+        stdout_text="delegated stdout detail",
+        stderr_text="delegated stderr detail",
+    )
+
+    result = _run_validator(repo_root, path=f"{fakebin}:{DEFAULT_PATH}", verbose=True)
+
+    assert result.returncode == 2, result.stdout + result.stderr
+    assert "Details:" in result.stdout
+    assert "delegated stdout detail" in result.stdout
+    assert "delegated stderr detail" in result.stdout
 
 
 def test_validator_uses_repo_resolved_python_instead_of_path_python3(tmp_path: Path) -> None:

--- a/tests/validation/test_validate_dependency_constraints_script.py
+++ b/tests/validation/test_validate_dependency_constraints_script.py
@@ -17,6 +17,26 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT_PATH = PROJECT_ROOT / "scripts" / "validate_dependency_constraints.sh"
 BANNED_REGISTRY_PATH = PROJECT_ROOT / "scripts" / "security" / "banned_dependencies.json"
 RESOLVER_PATH = PROJECT_ROOT / "scripts" / "setup" / "resolve_python_311.sh"
+DEFAULT_PATH = "/usr/bin:/bin"
+
+TARGET_OWNED_LANE_CASES = (
+    (
+        "ml-core-darwin-arm64.in",
+        "ml-core-darwin-arm64.txt",
+        "Darwin",
+        "arm64",
+        "check-ml-darwin-arm64",
+        "Run 'cd requirements && make compile-ml-darwin-arm64' on native Darwin arm64.",
+    ),
+    (
+        "ml-core-linux.in",
+        "ml-core-linux.txt",
+        "Linux",
+        "x86_64",
+        "check-ml-linux-x86_64",
+        "Run 'cd requirements && make compile-ml-linux-x86_64' on native Linux x86_64.",
+    ),
+)
 
 
 def _copy_repo_file(source: Path, destination: Path) -> Path:
@@ -58,25 +78,54 @@ def _write_lockfile(path: Path) -> None:
     )
 
 
-def test_target_owned_ml_stale_warning_uses_lane_specific_fix(tmp_path: Path) -> None:
-    repo_root = tmp_path / "repo"
+def _prepare_validator_repo(repo_root: Path) -> None:
     _copy_repo_file(SCRIPT_PATH, repo_root / "scripts" / "validate_dependency_constraints.sh")
     _copy_repo_file(BANNED_REGISTRY_PATH, repo_root / "scripts" / "security" / "banned_dependencies.json")
     _prepare_repo_python(repo_root)
 
-    requirements_dir = repo_root / "requirements"
-    requirements_dir.mkdir(parents=True, exist_ok=True)
-    in_path = requirements_dir / "ml-core-linux.in"
-    txt_path = requirements_dir / "ml-core-linux.txt"
-    in_path.write_text("numpy>=1.24,<2.5  # Test dependency\n", encoding="utf-8")
-    _write_lockfile(txt_path)
 
+def _make_stale(in_path: Path, txt_path: Path) -> None:
     txt_stat = txt_path.stat()
     os.utime(in_path, (txt_stat.st_atime + 10, txt_stat.st_mtime + 10))
 
-    env = {**os.environ, "PATH": "/usr/bin:/bin"}
-    result = subprocess.run(
-        ["bash", str(repo_root / "scripts" / "validate_dependency_constraints.sh")],
+
+def _write_fake_uname(path: Path, *, system: str, machine: str) -> Path:
+    return _write_executable(
+        path,
+        "#!/bin/sh\n"
+        'case "$1" in\n'
+        f"  -s) echo {shlex.quote(system)} ;;\n"
+        f"  -m) echo {shlex.quote(machine)} ;;\n"
+        '  *) echo "unsupported uname arg: $1" >&2; exit 1 ;;\n'
+        "esac\n",
+    )
+
+
+def _write_fake_make(path: Path, *, expected_target: str | None, exit_code: int) -> Path:
+    if expected_target is None:
+        content = '#!/bin/sh\necho "unexpected make invocation: $*" >&2\nexit 97\n'
+        return _write_executable(path, content)
+
+    content = (
+        "#!/bin/sh\n"
+        'if [ "$1" != "-C" ] || [ "$2" != "requirements" ] || [ "$3" != "'
+        + expected_target
+        + '" ] || [ "$4" != "LOCK_PYTHON_VERSION=3.11" ]; then\n'
+        '  echo "unexpected make args: $*" >&2\n'
+        "  exit 98\n"
+        "fi\n"
+        f"exit {exit_code}\n"
+    )
+    return _write_executable(path, content)
+
+
+def _run_validator(repo_root: Path, *, path: str = DEFAULT_PATH, verbose: bool = False) -> subprocess.CompletedProcess[str]:
+    command = ["bash", str(repo_root / "scripts" / "validate_dependency_constraints.sh")]
+    if verbose:
+        command.append("--verbose")
+    env = {**os.environ, "PATH": path}
+    return subprocess.run(
+        command,
         cwd=repo_root,
         env=env,
         capture_output=True,
@@ -84,17 +133,30 @@ def test_target_owned_ml_stale_warning_uses_lane_specific_fix(tmp_path: Path) ->
         check=False,
     )
 
+
+def test_generic_stale_warning_preserves_make_compile_guidance(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    _prepare_validator_repo(repo_root)
+
+    requirements_dir = repo_root / "requirements"
+    requirements_dir.mkdir(parents=True, exist_ok=True)
+    in_path = requirements_dir / "base.in"
+    txt_path = requirements_dir / "base.txt"
+    in_path.write_text("Pillow>=10.3.0,<13  # Generic stale warning regression coverage\n", encoding="utf-8")
+    _write_lockfile(txt_path)
+    _make_stale(in_path, txt_path)
+
+    result = _run_validator(repo_root)
+
     assert result.returncode == 2, result.stdout + result.stderr
-    assert "ml-core-linux.in: Compiled .txt file is stale" in result.stdout
-    assert "Run 'cd requirements && make compile-ml-linux-x86_64' on native Linux x86_64." in result.stdout
+    assert "base.in: Compiled .txt file is stale" in result.stdout
+    assert "Run 'cd requirements && make compile' to regenerate" in result.stdout
     assert "Consider addressing warnings for best practices." in result.stdout
 
 
-def test_frozen_target_owned_ml_stale_warning_preserves_freeze_guidance(tmp_path: Path) -> None:
+def test_frozen_target_owned_ml_input_skips_stale_warning_and_emits_verbose_note(tmp_path: Path) -> None:
     repo_root = tmp_path / "repo"
-    _copy_repo_file(SCRIPT_PATH, repo_root / "scripts" / "validate_dependency_constraints.sh")
-    _copy_repo_file(BANNED_REGISTRY_PATH, repo_root / "scripts" / "security" / "banned_dependencies.json")
-    _prepare_repo_python(repo_root)
+    _prepare_validator_repo(repo_root)
 
     requirements_dir = repo_root / "requirements"
     requirements_dir.mkdir(parents=True, exist_ok=True)
@@ -102,30 +164,126 @@ def test_frozen_target_owned_ml_stale_warning_preserves_freeze_guidance(tmp_path
     txt_path = requirements_dir / "ml-core-darwin-x86_64.txt"
     in_path.write_text("numpy<2  # Frozen lane regression coverage\n", encoding="utf-8")
     _write_lockfile(txt_path)
+    _make_stale(in_path, txt_path)
 
-    txt_stat = txt_path.stat()
-    os.utime(in_path, (txt_stat.st_atime + 10, txt_stat.st_mtime + 10))
+    result = _run_validator(repo_root, verbose=True)
 
-    env = {**os.environ, "PATH": "/usr/bin:/bin"}
-    result = subprocess.run(
-        ["bash", str(repo_root / "scripts" / "validate_dependency_constraints.sh")],
-        cwd=repo_root,
-        env=env,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Compiled .txt file is stale" not in result.stdout
+    assert "INFO: ml-core-darwin-x86_64.in is frozen and excluded from freshness regeneration checks." in result.stdout
+
+
+@pytest.mark.parametrize(
+    ("input_name", "lock_name", "system", "machine"),
+    (
+        ("ml-core-darwin-arm64.in", "ml-core-darwin-arm64.txt", "Linux", "x86_64"),
+        ("ml-core-linux.in", "ml-core-linux.txt", "Darwin", "arm64"),
+    ),
+)
+def test_target_owned_ml_inputs_skip_freshness_warning_off_lane(
+    tmp_path: Path,
+    input_name: str,
+    lock_name: str,
+    system: str,
+    machine: str,
+) -> None:
+    repo_root = tmp_path / "repo"
+    _prepare_validator_repo(repo_root)
+
+    requirements_dir = repo_root / "requirements"
+    requirements_dir.mkdir(parents=True, exist_ok=True)
+    in_path = requirements_dir / input_name
+    txt_path = requirements_dir / lock_name
+    in_path.write_text("numpy>=1.24,<2.5  # Off-lane regression coverage\n", encoding="utf-8")
+    _write_lockfile(txt_path)
+    _make_stale(in_path, txt_path)
+
+    fakebin = tmp_path / "fakebin"
+    _write_fake_uname(fakebin / "uname", system=system, machine=machine)
+    _write_fake_make(fakebin / "make", expected_target=None, exit_code=97)
+
+    result = _run_validator(repo_root, path=f"{fakebin}:{DEFAULT_PATH}")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Compiled .txt file is stale" not in result.stdout
+    assert "Target-owned ML lock freshness check failed" not in result.stdout
+
+
+@pytest.mark.parametrize(
+    ("input_name", "lock_name", "system", "machine", "check_target", "compile_fix"),
+    TARGET_OWNED_LANE_CASES,
+)
+def test_target_owned_ml_inputs_use_lane_check_on_authoritative_host_when_check_passes(
+    tmp_path: Path,
+    input_name: str,
+    lock_name: str,
+    system: str,
+    machine: str,
+    check_target: str,
+    compile_fix: str,
+) -> None:
+    repo_root = tmp_path / "repo"
+    _prepare_validator_repo(repo_root)
+
+    requirements_dir = repo_root / "requirements"
+    requirements_dir.mkdir(parents=True, exist_ok=True)
+    in_path = requirements_dir / input_name
+    txt_path = requirements_dir / lock_name
+    in_path.write_text("numpy>=1.24,<2.5  # Authoritative lane pass coverage\n", encoding="utf-8")
+    _write_lockfile(txt_path)
+    _make_stale(in_path, txt_path)
+
+    fakebin = tmp_path / "fakebin"
+    _write_fake_uname(fakebin / "uname", system=system, machine=machine)
+    _write_fake_make(fakebin / "make", expected_target=check_target, exit_code=0)
+
+    result = _run_validator(repo_root, path=f"{fakebin}:{DEFAULT_PATH}")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Compiled .txt file is stale" not in result.stdout
+    assert "Target-owned ML lock freshness check failed" not in result.stdout
+    assert compile_fix not in result.stdout
+
+
+@pytest.mark.parametrize(
+    ("input_name", "lock_name", "system", "machine", "check_target", "compile_fix"),
+    TARGET_OWNED_LANE_CASES,
+)
+def test_target_owned_ml_inputs_warn_when_authoritative_lane_check_fails(
+    tmp_path: Path,
+    input_name: str,
+    lock_name: str,
+    system: str,
+    machine: str,
+    check_target: str,
+    compile_fix: str,
+) -> None:
+    repo_root = tmp_path / "repo"
+    _prepare_validator_repo(repo_root)
+
+    requirements_dir = repo_root / "requirements"
+    requirements_dir.mkdir(parents=True, exist_ok=True)
+    in_path = requirements_dir / input_name
+    txt_path = requirements_dir / lock_name
+    in_path.write_text("numpy>=1.24,<2.5  # Authoritative lane fail coverage\n", encoding="utf-8")
+    _write_lockfile(txt_path)
+    _make_stale(in_path, txt_path)
+
+    fakebin = tmp_path / "fakebin"
+    _write_fake_uname(fakebin / "uname", system=system, machine=machine)
+    _write_fake_make(fakebin / "make", expected_target=check_target, exit_code=1)
+
+    result = _run_validator(repo_root, path=f"{fakebin}:{DEFAULT_PATH}")
 
     assert result.returncode == 2, result.stdout + result.stderr
-    assert "ml-core-darwin-x86_64.in: Compiled .txt file is stale" in result.stdout
-    assert "Darwin x86_64 is frozen; do not regenerate until an authoritative lane is defined." in result.stdout
+    assert "Target-owned ML lock freshness check failed" in result.stdout
+    assert check_target in result.stdout
+    assert compile_fix in result.stdout
 
 
 def test_validator_uses_repo_resolved_python_instead_of_path_python3(tmp_path: Path) -> None:
     repo_root = tmp_path / "repo"
-    _copy_repo_file(SCRIPT_PATH, repo_root / "scripts" / "validate_dependency_constraints.sh")
-    _copy_repo_file(BANNED_REGISTRY_PATH, repo_root / "scripts" / "security" / "banned_dependencies.json")
-    _prepare_repo_python(repo_root)
+    _prepare_validator_repo(repo_root)
 
     fakebin = tmp_path / "fakebin"
     _write_executable(
@@ -145,15 +303,7 @@ def test_validator_uses_repo_resolved_python_instead_of_path_python3(tmp_path: P
         encoding="utf-8",
     )
 
-    env = {**os.environ, "PATH": f"{fakebin}:/usr/bin:/bin"}
-    result = subprocess.run(
-        ["bash", str(repo_root / "scripts" / "validate_dependency_constraints.sh")],
-        cwd=repo_root,
-        env=env,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    result = _run_validator(repo_root, path=f"{fakebin}:{DEFAULT_PATH}")
 
     assert result.returncode == 0, result.stdout + result.stderr
     assert "broken python3 should not be used" not in (result.stdout + result.stderr)


### PR DESCRIPTION
## Summary
- Replace target-owned ML stale warnings that relied only on `.in` vs `.txt` mtimes.
- Prove freshness on the authoritative lane instead, while keeping generic lock freshness warnings unchanged.

## Changes
- Update `scripts/validate_dependency_constraints.sh` to normalize host OS/arch and handle target-owned ML inputs separately from generic lock-backed inputs.
- Delegate `ml-core-darwin-arm64.in` and `ml-core-linux.in` freshness validation to `make check-ml-darwin-arm64` or `make check-ml-linux-x86_64` only on their authoritative lanes.
- Suppress non-actionable target-owned ML freshness warnings off-lane and replace the Darwin x86_64 stale warning with a frozen-lane informational note.
- Expand `tests/validation/test_validate_dependency_constraints_script.py` to cover generic stale warnings, off-lane suppression, authoritative-lane pass/fail delegation, and frozen Darwin x86_64 behavior.
- Install `pip-tools==7.5.2` in `.github/workflows/ci-quality-firewall.yml` so the Ubuntu dependency-constraints job can run the delegated Linux lane check.

## Validation
Proven green:
- `PATH=/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin:/usr/bin:/bin .venv/bin/pre-commit run --all-files --show-diff-on-failure`
- `.venv/bin/pytest tests/validation/test_validate_dependency_constraints_script.py`
- `.venv/bin/pytest tests/test_requirements_lock_lane_makefile.py tests/test_check_lock_ownership.py tests/test_check_requirements_lock_contract.py`
- `bash scripts/validate_dependency_constraints.sh --verbose`
- `make check-ml-darwin-arm64`

Still not run:
- `make check-ml-linux-x86_64 LOCK_PYTHON_VERSION=3.11` on a native Linux x86_64 lane

Failures encountered during development:
- The first sandboxed validator/pre-commit runs could not complete the delegated Darwin arm64 lane check because network access was blocked; reruns with the repo venv on `PATH` and network access passed.

## Risk
- Bounded to dependency-validation, CI, and test coverage paths; no product runtime, route, selector, or API contract changes.
- Revert-safe because the patch only changes how target-owned ML freshness is determined and documented.