### PR TITLE
fix(requirements): bump governed pillow pins to 12.2.0

### DIFF
--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -167,7 +167,7 @@ pathspec==1.0.4
     # via
     #   black
     #   mypy
-pillow==12.1.1
+pillow==12.2.0
     # via -r base.in
 platformdirs==4.9.6
     # via

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -4,7 +4,7 @@
 
 # Core array and image processing
 numpy>=1.24,<2.5.0         # upper bound for OpenCV compatibility; see ADR-032
-Pillow>=10.3.0,<13         # Security: CVE-2024-28219 fixed in 10.3.0; allows pillow==12.1.1 in lockfiles
+Pillow>=10.3.0,<13         # Security: CVE-2024-28219 fixed in 10.3.0; current governed lock baseline is pillow==12.2.0
 scipy>=1.15,<2
 scikit-learn>=1.8.0,<2       # classical ML (used in core features)
 opencv-python>=4.8.0,<5    # required for depth_writer (core pipeline)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -80,7 +80,7 @@ opencv-python==4.13.0.92
     # via
     #   -c all.txt
     #   -r base.in
-pillow==12.1.1
+pillow==12.2.0
     # via
     #   -c all.txt
     #   -r base.in

--- a/requirements/ml-core-darwin-arm64.txt
+++ b/requirements/ml-core-darwin-arm64.txt
@@ -133,7 +133,7 @@ packaging==26.0
     #   lazy-loader
     #   scikit-image
     #   transformers
-pillow==12.1.1
+pillow==12.2.0
     # via
     #   -c base.txt
     #   controlnet-aux

--- a/requirements/ml-core-darwin-x86_64.txt
+++ b/requirements/ml-core-darwin-x86_64.txt
@@ -120,7 +120,7 @@ packaging==26.0
     #   lazy-loader
     #   scikit-image
     #   transformers
-pillow==12.1.1
+pillow==12.2.0
     # via
     #   -c base.in
     #   controlnet-aux

--- a/requirements/ml-core-linux.txt
+++ b/requirements/ml-core-linux.txt
@@ -122,7 +122,7 @@ packaging==26.0
     #   lazy-loader
     #   scikit-image
     #   transformers
-pillow==12.1.1
+pillow==12.2.0
     # via
     #   -c base.txt
     #   controlnet-aux


### PR DESCRIPTION
## Summary
- Address the Security Scans failure from April 14, 2026 by removing the stale governed `pillow==12.1.1` pin that `pip-audit` flagged as `CVE-2026-40192`.
- Keep the change limited to the owned lock surfaces that feed `requirements-ci.txt` and the target-owned ML lockfiles.

## Changes
- Update the governed Pillow baseline comment in `requirements/base.in` to reflect the current locked target.
- Bump `pillow` from `12.1.1` to `12.2.0` in `requirements/base.txt` and `requirements/all.txt`.
- Bump the same pin in the target-owned ML lockfiles: `requirements/ml-core-darwin-arm64.txt`, `requirements/ml-core-darwin-x86_64.txt`, and `requirements/ml-core-linux.txt`.
- Preserve existing requirement ranges, lockfile structure, and wrapper/CI interfaces.

## Validation
Proven green:
- `python3 -B scripts/validation/check_requirements_lock_contract.py`
- `.venv/bin/python -m venv /tmp/tp-security-audit-311 && /tmp/tp-security-audit-311/bin/python -m pip install --upgrade pip && /tmp/tp-security-audit-311/bin/pip install -r requirements/security.txt && /tmp/tp-security-audit-311/bin/pip-audit --desc -r requirements-ci.txt --ignore-vuln CVE-2026-4539`

Still failing:
- None after the pin update.

Environment/tooling notes:
- An initial repro attempt using the system `python3` created a Python 3.9 venv and could not install locked `bandit==1.9.4`; that was an interpreter mismatch in the local verification setup, not a product regression.

## Risk
- Low and bounded to dependency resolution: the allowed version range already admitted Pillow 12.2.0, and the diff only refreshes checked-in governed pins.
- Revert-safe because the change is limited to lockfile pins and a matching source comment.
- No route, selector, API envelope, CLI, or auth contract changes.