### PR TITLE
docs(frontdoor): align edge hardening standard with current contract

### DIFF
--- a/docs/architecture/PORTAL_EDGE_HARDENING_IMPLEMENTATION_STANDARD.md
+++ b/docs/architecture/PORTAL_EDGE_HARDENING_IMPLEMENTATION_STANDARD.md
@@ -1,6 +1,6 @@
 # Portal Edge Hardening Implementation Standard
 
-Date: 2026-04-13
+Date: 2026-04-13 (v2)
 
 ## Summary
 
@@ -12,17 +12,25 @@ The repo-owned request path is:
 
 `public ingress/WAF -> web/secure-landing (Next.js managed frontdoor) -> app.py (FastAPI origin)`
 
-This standard preserves the current auth, route, selector, proxy, and validation
-contracts. It does not approve an Entra access-token migration. Any future Entra
-adoption must be handled as a separate tracked change.
+This standard preserves the current auth, route, selector, proxy, cache,
+session, and validation contracts. It does not approve an Entra access-token
+migration. Any future Entra adoption must be handled as a separate tracked
+change.
+
+## Terminology
+
+- **Public ingress / upstream edge**: external edge (for example Azure Front Door or WAF)
+- **Managed frontdoor**: `web/secure-landing`
+- **Origin**: FastAPI (`app.py`)
 
 ## Boundary And Route Ownership
 
 The managed browser boundary starts at `web/secure-landing/`.
 
 - `GET /` is the public DNA homepage rendered by the managed frontdoor.
-- `GET /login` is the managed operator sign-in shell and anonymous-session/CSRF
-  entry point.
+- `GET /login` is the managed sign-in shell and anonymous-session/CSRF entry
+  point.
+- `POST /login` is the operator credential handoff path.
 - `GET /portal` proxies the FastAPI operator shell through the frontdoor.
 - `GET /portal/bootstrap` is the managed browser bootstrap/auth contract.
 - `GET /portal/assets/*` proxies the checked-in allowlisted operator assets.
@@ -32,13 +40,12 @@ The managed browser boundary starts at `web/secure-landing/`.
   FastAPI.
 - FastAPI `GET /ready` remains the backend readiness contract.
 
-Operational assumption:
+Operational assumptions:
 
-- An upstream public ingress such as Azure Front Door may sit in front of the
-  managed frontdoor.
+- An upstream public ingress may sit in front of the managed frontdoor.
 - Any upstream edge policy must preserve the application contracts below.
-- Existing Cloudflare Access verification and deployment protection remain part
-  of the current managed auth posture where configured.
+- FastAPI is not a normal public browser entry.
+- The managed frontdoor is the authoritative browser boundary.
 
 ## Cache And Compression Standard
 
@@ -50,8 +57,8 @@ Caching and compression are route-specific. Do not apply blanket edge policies.
 | `/login` | Next.js frontdoor | `no-store` | No edge caching; compression is optional but not a design goal |
 | `/portal` | Next.js proxy to FastAPI | `no-store` | No edge caching |
 | `/portal/bootstrap` | Next.js frontdoor | `no-store` | No edge caching |
-| `/portal/assets/*` | FastAPI asset manifest via Next.js proxy | Preserve origin `Cache-Control`; fingerprinted assets may be immutable, stale/unversioned fallbacks stay `no-store` | Do not force compression on range-sensitive or fallback paths |
-| `/portal/video/*` | Next.js proxy | Preserve upstream cache policy | Do not blanket-compress video or range content |
+| `/portal/assets/*` | FastAPI asset manifest via Next.js proxy | Preserve origin and manifest contract; fingerprinted assets may be immutable, stale or unversioned fallbacks stay `no-store` | Do not force compression on range-sensitive or fallback paths |
+| `/portal/video/*` | Next.js proxy | `public, max-age=86400` | Do not blanket-compress video or range content |
 | `/healthz` | Next.js frontdoor | `no-store` | No edge caching |
 | `/v1/*` | FastAPI API via Next.js proxy | `no-store` or stricter | No edge caching |
 | FastAPI direct browser paths | FastAPI origin | Not a public browser cache surface | Not a public browser cache surface |
@@ -64,24 +71,34 @@ Implementation rules:
   non-cacheable surfaces.
 - Preserve the existing portal asset manifest contract instead of inventing new
   wildcard extension routes.
-- If Azure Front Door is used upstream, route/pattern configuration should map
-  to the concrete paths above rather than generic `*.css` or `*.js` patterns.
+- If Azure Front Door is used upstream, route or pattern configuration should
+  map to the concrete paths above rather than generic `*.css` or `*.js`
+  patterns.
 
 ## Current Security Baseline
 
 ### Trusted Host And Proxy Trust
 
 FastAPI host validation is enforced in `app.py` through `TrustedHostMiddleware`.
-The managed frontdoor independently ignores untrusted forwarded host/proto
-overrides when constructing browser redirects and same-origin URLs.
+
+The managed frontdoor does not implement a trusted-hop model. It enforces an
+equivalence rule:
+
+- Forwarded host and proto values are accepted only when they match the
+  already-derived request URL surface.
+- Any mismatch between forwarded headers and the resolved request URL must be
+  ignored.
+- Redirect construction and same-origin checks must use the resolved request
+  URL, not forwarded overrides.
 
 Required posture:
 
 - Keep `TP_ENABLE_TRUSTED_HOSTS=1` outside exceptional troubleshooting.
 - Keep `TP_TRUSTED_HOSTS` aligned with the actual deployed hostnames.
-- Do not trust arbitrary `X-Forwarded-Host` or `X-Forwarded-Proto` input.
-- Do not introduce proxy-hop trust changes without updating contract tests and
-  deployment docs in the same change.
+- Do not introduce hop-count or proxy-chain trust logic.
+- Do not treat forwarded headers as authoritative input.
+- Preserve the existing equivalence-based validation behavior in the managed
+  frontdoor.
 
 ### Security Headers And CSP
 
@@ -93,7 +110,7 @@ Required posture:
 - Preserve the current enforced CSP posture for shipped routes.
 - Use `Content-Security-Policy-Report-Only` only when trialing a policy delta.
 - Keep HSTS and any outer-edge header normalization at the public ingress.
-- Do not regress to inline script/style allowances without an explicit,
+- Do not regress to inline script or style allowances without an explicit,
   reviewed exception.
 
 ### Auth Boundary
@@ -101,22 +118,93 @@ Required posture:
 Current-state auth is unchanged:
 
 - Public homepage: unauthenticated.
-- Login shell: managed entry path protected by Cloudflare Access validation
-  where configured, plus operator username/password handoff.
+- Login shell (`GET /login`): publicly renderable managed entry surface that
+  mints an anonymous session and CSRF binding.
+- Credential handoff (`POST /login`): requires verified Access context unless
+  the explicit local development bypass is active.
+- Authenticated managed surfaces: `/portal`, `/portal/bootstrap`, and `/v1/*`
+  require a current verified Access context and fail closed on auth failure.
 - Browser session: SQLite-backed frontdoor session with CSRF-bound unsafe
   requests.
-- API proxy: frontdoor injects the backend secret server-to-server; browser
+- API proxy: the frontdoor injects the backend secret server-to-server; browser
   code does not receive the backend API key in managed mode.
-- Local bypass: allowed only in explicit development flows.
+- Local bypass: allowed only in explicit development flows described below.
 
 This baseline does not introduce Entra access-token validation into the current
 browser path.
+
+### Cloudflare Access Enforcement
+
+Cloudflare Access is required for managed credential handoff and authenticated
+managed surfaces whenever the explicit local development bypass is not active.
+
+Required posture:
+
+- `GET /login` remains renderable without a verified Access JWT and may mint an
+  anonymous session.
+- `POST /login` must require verified Access before operator credential handoff
+  continues, unless the explicit local development bypass is active.
+- `/portal`, `/portal/bootstrap`, and `/v1/*` must require current verified
+  Access and fail closed on missing or invalid Access state.
+- Team domain and audience validation must be configured whenever bypass is not
+  active.
+
+Local development exception:
+
+- Local bypass is enabled only when both of the following are true:
+  - `NODE_ENV=development`
+  - `TP_ALLOW_LOCAL_ACCESS_BYPASS=1`
+- The bypass is for explicit non-public local development only.
+- Production and other managed environments must not treat
+  `TP_ALLOW_LOCAL_ACCESS_BYPASS=1` by itself as sufficient to bypass Access.
+
+### Session And Cookie Contract
+
+The browser session is SQLite-backed and server-side. The cookie and timeout
+contract is environment-aware.
+
+Cookie naming and transport:
+
+- Production cookie name: `__Host-tp_session`
+- Non-production local managed-development cookie name: `tp_session`
+- Production cookie transport: `Secure`
+- Local managed-development cookie transport: not `Secure`, so local HTTP
+  development remains functional
+- Cookie attributes:
+  - `HttpOnly`
+  - `SameSite=Lax`
+  - `Path=/`
+- The cookie must not set a `Domain` attribute.
+
+Session behavior:
+
+- `GET /login` may mint an anonymous session before credentials are posted so
+  CSRF is bound to a server-side session from the start.
+- Successful login must rotate the session identifier before redirecting to
+  `/portal`.
+- Idle timeout is enforced.
+- Absolute timeout is enforced.
+- The cookie lifetime is bounded by the absolute timeout.
+
+Current shipped timeout defaults:
+
+- Idle timeout: 8 hours
+- Absolute timeout: 24 hours
+
+CSRF:
+
+- All state-changing requests must require a valid CSRF token.
+- Requests without a valid token must fail.
+
+Do not introduce alternate session semantics without updating contract tests and
+deployment documentation in the same change.
 
 ### Runtime And Request Limits
 
 - `web/secure-landing/` is a Node 22-only application for install, dev, test,
   build, and start.
-- FastAPI request limits and path/root allowlists remain enforced in `app.py`.
+- FastAPI request limits and path or root allowlists remain enforced in
+  `app.py`.
 - Do not weaken the current session-scaling guardrails: the shipped posture is
   still single-instance SQLite unless an external session store is introduced.
 
@@ -142,7 +230,7 @@ minimum standard is:
 - HTTPS only
 - DNS and IP classification before connect
 - redirects off by default
-- short connect/read timeouts
+- short connect and read timeouts
 - network egress restrictions for private, loopback, link-local, and metadata
   targets
 - a pinned-client pattern when the transport must connect only to previously
@@ -161,8 +249,8 @@ make test-frontdoor-contract
 make validate-frontdoor-browser
 ```
 
-Use the shared-deployment posture gate when validating a real internet-reachable
-environment:
+Use the shared-deployment posture gate when validating a real
+internet-reachable environment:
 
 ```bash
 make validate-frontdoor-deployment-gate
@@ -170,13 +258,60 @@ make validate-frontdoor-deployment-gate
 
 Minimum acceptance checks:
 
-- untrusted FastAPI host header returns `400`
-- frontdoor redirects ignore untrusted host overrides
-- `/`, `/login`, `/portal`, `/portal/bootstrap`, `/healthz`, and `/v1/*`
-  preserve the documented cache posture
-- managed login/session/CSRF behavior remains intact
-- Cloudflare Access-managed enforcement remains fail-closed where configured
-- frontdoor test/build runs under Node 22.x
+### Host And Proxy
+
+- Untrusted FastAPI host header returns `400`.
+- Frontdoor redirects ignore untrusted host overrides.
+- Frontdoor redirect and same-origin behavior preserve the equivalence-based
+  proxy trust contract.
+
+### Cache Headers
+
+- `/` returns `Cache-Control: public, max-age=300, must-revalidate`
+- `GET /login` returns `Cache-Control: no-store`
+- `/portal` returns `Cache-Control: no-store`
+- `/portal/bootstrap` returns `Cache-Control: no-store`
+- `/healthz` returns `Cache-Control: no-store`
+- `/v1/*` returns `Cache-Control: no-store` or stricter
+- SSE or streaming endpoints, when present, return
+  `Cache-Control: no-store, no-transform`
+- `/portal/video/*` returns `Cache-Control: public, max-age=86400`
+- `/portal/assets/*` preserves the documented manifest and upstream cache
+  contract
+
+### Auth And Session
+
+- `GET /login` renders the managed sign-in shell and may mint an anonymous
+  session without verified Access.
+- `POST /login` rejects credential handoff without verified Access when bypass
+  is not active.
+- `/portal`, `/portal/bootstrap`, and `/v1/*` fail closed when current Access
+  verification is missing or invalid.
+- Production ignores `TP_ALLOW_LOCAL_ACCESS_BYPASS=1` without the explicit
+  development gate.
+- Local bypass works only when `NODE_ENV=development` and
+  `TP_ALLOW_LOCAL_ACCESS_BYPASS=1`.
+- Successful login rotates the session.
+- Production authenticated cookies use `__Host-tp_session`.
+- Local managed-development cookies use `tp_session`.
+- Session cookies are `HttpOnly`, production cookies are `Secure`, and cookies
+  are `SameSite=Lax`.
+- Session idle and absolute expiry remain enforced.
+- Managed login, session, and CSRF behavior remains intact.
+
+### Runtime And Surface Ownership
+
+- FastAPI is not directly accessible as a normal browser surface.
+- Frontdoor test and build runs use Node 22.x.
+- Browser auth and API proxy behavior remain same-origin at the managed
+  frontdoor.
+
+## Observability
+
+- Existing structured audit logging must be preserved.
+- Do not bypass `audit.js` or `managed-failure.js`.
+- Do not weaken existing managed-surface failure classification without updating
+  the standard and tests in the same change.
 
 ## Future Entra Migration Appendix
 
@@ -192,3 +327,15 @@ as an explicit auth migration that:
 
 Until that work is approved, treat Entra token validation guidance as future
 architecture, not as current implementation instruction.
+
+## Governance
+
+This document is the authoritative implementation standard for the managed
+browser boundary in this repo.
+
+Any deviation must record:
+
+- route or surface
+- reason
+- compensating control
+- owner


### PR DESCRIPTION
## Summary
- Replace the repo-owned portal edge hardening standard with the reviewed v2 draft.
- Align the governing document to the current managed frontdoor boundary, Access enforcement contract, session and cookie semantics, proxy trust behavior, and explicit cache and acceptance criteria already implemented in the repo.

## Changes
- Add explicit terminology for public ingress, managed frontdoor, and FastAPI origin.
- Split `GET /login` and `POST /login` semantics to match the current browser-path auth boundary.
- Make the frontdoor proxy trust contract explicit and equivalence-based instead of describing only prohibitions.
- Codify environment-aware Cloudflare Access enforcement and the local development bypass gate.
- Document the current session and cookie contract, including production vs local cookie naming, timeout defaults, and the no-`Domain` posture.
- Enumerate exact acceptance checks for host validation, route cache headers, auth and session behavior, and same-origin managed-surface ownership.
- State this document as the authoritative implementation standard for the repo-managed browser boundary.

## Validation
Proven green:
- `/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin/pre-commit install -f`
- `PATH=/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin:$PATH PRE_COMMIT_HOME=/tmp/pre-commit TP_LINT_PYTHON=/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin/python make pre-commit`
- `make test-frontdoor-contract`

Still failing:
- `make install-hooks`
  - Fails in this shell environment because `pre-commit` is not on the ambient `PATH`.
  - Classification: environment/tooling, not product logic.
  - The equivalent hook install succeeded via the repo `.venv` binary shown above.

## Risk
- Low and revert-safe.
- Documentation-only change; no runtime, selector, route, auth, proxy, or test behavior changes are introduced by this branch.
- The updated standard is bounded to one file and is aligned to the currently shipped frontdoor contract, including the explicit bypass and cookie-domain coverage already present on `main`.