### PR TITLE
fix(cli): align recipe entrypoints and batch parallelism

### DIFF
--- a/src/transformation_portal/__main__.py
+++ b/src/transformation_portal/__main__.py
@@ -36,8 +36,8 @@ except ImportError as e:
     ) from e
 
 from transformation_portal.cli_support import (
+    emit_dependency_group,
     list_recipe_summaries,
-    probe_dependency_versions,
     probe_pipeline_features,
     validate_recipe_file,
 )
@@ -48,21 +48,6 @@ app = typer.Typer(
     no_args_is_help=True,
     add_completion=False,
 )
-
-
-def _emit_dependency_group(title: str, dependency_specs: tuple[tuple[str, str], ...], unavailable_prefix: str) -> None:
-    """Render a dependency status group."""
-
-    typer.echo(f"\n{title}:")
-    for status in probe_dependency_versions(dependency_specs):
-        if status.available:
-            typer.echo(f"  ✅ {status.display_name}: {status.version}")
-            continue
-
-        line = f"  {unavailable_prefix} {status.display_name}: not installed"
-        if status.reason:
-            line = f"{line} ({status.reason})"
-        typer.echo(line)
 
 
 @app.command()
@@ -260,7 +245,7 @@ def info():
             line = f"{line}: {status.reason}"
         typer.echo(line)
 
-    _emit_dependency_group(
+    emit_dependency_group(
         "Core Dependencies",
         (
             ("NumPy", "numpy"),
@@ -270,8 +255,9 @@ def info():
             ("Typer", "typer"),
         ),
         unavailable_prefix="❌",
+        emit=typer.echo,
     )
-    _emit_dependency_group(
+    emit_dependency_group(
         "Optional Dependencies",
         (
             ("16-bit TIFF support", "tifffile"),
@@ -280,6 +266,7 @@ def info():
             ("ML models", "transformers"),
         ),
         unavailable_prefix="⚠️ ",
+        emit=typer.echo,
     )
 
 

--- a/src/transformation_portal/__main__.py
+++ b/src/transformation_portal/__main__.py
@@ -3,14 +3,14 @@
 """
 Transformation Portal - Main CLI Entry Point
 
-This module provides the primary command-line interface for the Transformation Portal,
-enabling unified access to all pipeline and processing capabilities.
+This module provides the primary command-line interface for the Transformation
+Portal, enabling unified access to all pipeline and processing capabilities.
 
 Usage:
     python -m transformation_portal --help
-    python -m transformation_portal process -i "inputs/*.jpg" -r config/recipes/signature_estate.yaml -o output/
+    python -m transformation_portal process -i "inputs/*.jpg" -r path/to/recipe.yaml -o output/
     python -m transformation_portal list-recipes
-    python -m transformation_portal validate-recipe config/recipes/signature_estate.yaml
+    python -m transformation_portal validate-recipe path/to/recipe.yaml
 
 The CLI supports:
     - Recipe-driven batch processing
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from typing import Optional
 
 try:
     import typer
@@ -34,14 +35,34 @@ except ImportError as e:
         "  pip install -e '.[dev]'"
     ) from e
 
+from transformation_portal.cli_support import (
+    list_recipe_summaries,
+    probe_dependency_versions,
+    probe_pipeline_features,
+    validate_recipe_file,
+)
 
-# Create the main application
 app = typer.Typer(
     name="transformation-portal",
     help="Professional image and video processing toolkit for luxury real estate rendering",
     no_args_is_help=True,
     add_completion=False,
 )
+
+
+def _emit_dependency_group(title: str, dependency_specs: tuple[tuple[str, str], ...], unavailable_prefix: str) -> None:
+    """Render a dependency status group."""
+
+    typer.echo(f"\n{title}:")
+    for status in probe_dependency_versions(dependency_specs):
+        if status.available:
+            typer.echo(f"  ✅ {status.display_name}: {status.version}")
+            continue
+
+        line = f"  {unavailable_prefix} {status.display_name}: not installed"
+        if status.reason:
+            line = f"{line} ({status.reason})"
+        typer.echo(line)
 
 
 @app.command()
@@ -56,15 +77,15 @@ def process(
 ):
     """Run unified enhancement pipeline.
 
-    Process images through the unified pipeline using a YAML recipe configuration.
-    Supports batch processing with dry-run preview and quality feedback.
+    Process images through the unified pipeline using a YAML recipe
+    configuration. Supports batch processing with dry-run preview, quality
+    feedback, and bounded parallel execution.
 
     Example:
-        transformation-portal process -i "renders/*.exr" -r config/recipes/signature_estate.yaml -o output/
+        transformation-portal process -i "renders/*.exr" -r path/to/recipe.yaml -o output/
     """
     import logging
 
-    # Configure logging
     log_levels = {
         "debug": logging.DEBUG,
         "info": logging.INFO,
@@ -83,6 +104,7 @@ def process(
     typer.echo(f"   Output: {output}")
     typer.echo(f"   Mode: {mode}")
     typer.echo(f"   Dry run: {dry_run}")
+    typer.echo(f"   Parallel: {parallel}")
     typer.echo()
 
     if not recipe.exists():
@@ -93,7 +115,13 @@ def process(
         from transformation_portal.pipeline_unified import UnifiedPipeline
 
         pipeline = UnifiedPipeline.from_recipe(recipe)
-        result = pipeline.process_batch(input_glob, output, mode=mode, dry_run=dry_run)
+        result = pipeline.process_batch(
+            input_glob,
+            output,
+            mode=mode,
+            dry_run=dry_run,
+            parallel=parallel,
+        )
 
         if not dry_run:
             typer.echo()
@@ -112,53 +140,48 @@ def process(
 
 @app.command("list-recipes")
 def list_recipes(
-    recipes_dir: Path = typer.Option(Path("config/recipes"), "--dir", "-d", help="Recipes directory path"),
+    recipes_dir: Optional[Path] = typer.Option(
+        None,
+        "--dir",
+        "-d",
+        help="Recipe directory path (defaults to config/recipes, then config/ recursion)",
+    ),
 ):
     """List all available recipe presets.
 
-    Scans the recipes directory and displays available pipeline recipes
-    with their descriptions and configurations.
+    Scans the preferred recipe locations and displays available UnifiedPipeline
+    recipes with their descriptions and configurations.
 
     Example:
         transformation-portal list-recipes
-        transformation-portal list-recipes -d custom/recipes/
+        transformation-portal list-recipes -d path/to/recipes/
     """
     typer.echo("📋 Available Pipeline Recipes\n")
 
-    if not recipes_dir.exists():
-        typer.echo(f"⚠️  Recipes directory not found: {recipes_dir}", err=True)
-        typer.echo("   Create recipes in config/recipes/ directory")
-        raise typer.Exit(code=1)
-
     try:
-        from transformation_portal.config_loader import list_recipes as get_recipes
-
-        recipes = get_recipes(recipes_dir)
+        recipes = list_recipe_summaries(recipes_dir)
 
         if not recipes:
-            typer.echo("No recipes found in directory")
+            if recipes_dir is not None:
+                typer.echo(f"No recipe presets found in {recipes_dir}")
+            else:
+                typer.echo("No recipe presets found under config/recipes or config/")
             raise typer.Exit(code=0)
 
         for recipe in recipes:
-            if "error" in recipe:
-                typer.echo(f"  ❌ {recipe['path']}: {recipe['error']}")
-            else:
-                name = recipe.get("name", "Unknown")
-                description = recipe.get("description", "No description")
-                stages = recipe.get("stages", [])
-                output_format = recipe.get("output_format", "tiff")
-
-                typer.echo(f"  📄 {name}")
-                typer.echo(f"     {description}")
-                typer.echo(f"     Stages: {', '.join(stages)}")
-                typer.echo(f"     Output: {output_format}")
-                typer.echo(f"     Path: {recipe['path']}")
-                typer.echo()
+            typer.echo(f"  📄 {recipe.get('name', 'Unknown')}")
+            typer.echo(f"     {recipe.get('description', 'No description')}")
+            typer.echo(f"     Stages: {', '.join(recipe.get('stages', []))}")
+            typer.echo(f"     Output: {recipe.get('output_format', 'tiff')}")
+            typer.echo(f"     Path: {recipe['path']}")
+            typer.echo()
 
         typer.echo(f"Total: {len(recipes)} recipes found")
 
-    except ImportError as e:
-        typer.echo(f"❌ Error: {e}", err=True)
+    except typer.Exit:
+        raise
+    except Exception as e:
+        typer.echo(f"❌ Error loading recipe presets: {e}", err=True)
         raise typer.Exit(code=1)
 
 
@@ -169,11 +192,11 @@ def validate_recipe(
 ):
     """Validate recipe configuration.
 
-    Validates a recipe YAML file against the schema and reports any errors
-    or warnings.
+    Validates a recipe YAML file against the schema and reports any errors or
+    warnings.
 
     Example:
-        transformation-portal validate-recipe config/recipes/signature_estate.yaml
+        transformation-portal validate-recipe path/to/recipe.yaml
         transformation-portal validate-recipe custom_recipe.yaml -v
     """
     typer.echo(f"🔍 Validating recipe: {recipe}\n")
@@ -183,17 +206,10 @@ def validate_recipe(
         raise typer.Exit(code=1)
 
     try:
-        from transformation_portal.config_loader import get_recipe_info, load_recipe
-        from transformation_portal.config_loader import validate_recipe as validate
-
-        # Load the recipe
-        loaded = load_recipe(recipe, expand_env=False, resolve_paths=False)
-
-        # Validate
-        is_valid, errors = validate(loaded)
+        validation_result = validate_recipe_file(recipe)
 
         if verbose:
-            info = get_recipe_info(loaded)
+            info = validation_result.info
             typer.echo("Recipe Information:")
             typer.echo(f"  Name: {info.get('name', 'Unknown')}")
             typer.echo(f"  Description: {info.get('description', 'None')}")
@@ -205,17 +221,16 @@ def validate_recipe(
             typer.echo(f"  Output Format: {info.get('output_format', 'unknown')}")
             typer.echo()
 
-        if is_valid:
+        if validation_result.is_valid:
             typer.echo("✅ Recipe is valid!")
         else:
             typer.echo("❌ Recipe validation failed:")
-            for error in errors:
+            for error in validation_result.errors:
                 typer.echo(f"   - {error}")
             raise typer.Exit(code=1)
 
-    except ImportError as e:
-        typer.echo(f"❌ Error: {e}", err=True)
-        raise typer.Exit(code=1)
+    except typer.Exit:
+        raise
     except Exception as e:
         typer.echo(f"❌ Error validating recipe: {e}", err=True)
         raise typer.Exit(code=1)
@@ -236,53 +251,36 @@ def version():
 def info():
     """Show system and dependency information."""
     typer.echo("Transformation Portal - System Information\n")
-
-    # Python version
     typer.echo(f"Python: {sys.version.split()[0]}")
 
-    # Check pipeline availability
-    try:
-        from transformation_portal.pipeline_unified import HAS_4K_PIPELINE, HAS_QUALITY_BRIDGE
+    typer.echo("\nPipeline Features:")
+    for status in probe_pipeline_features():
+        line = f"  {'✅' if status.available else '⚠️ '} {status.display_name}"
+        if status.reason:
+            line = f"{line}: {status.reason}"
+        typer.echo(line)
 
-        typer.echo("\nPipeline Features:")
-        typer.echo(f"  {'✅' if HAS_QUALITY_BRIDGE else '⚠️ '} RAG Quality Feedback")
-        typer.echo(f"  {'✅' if HAS_4K_PIPELINE else '⚠️ '} 4K Rendering Pipeline")
-    except ImportError:
-        typer.echo("\n⚠️  Pipeline modules not available")
-
-    # Check key dependencies
-    dependencies = [
-        ("numpy", "NumPy"),
-        ("PIL", "Pillow"),
-        ("torch", "PyTorch"),
-        ("yaml", "PyYAML"),
-        ("typer", "Typer"),
-    ]
-
-    typer.echo("\nCore Dependencies:")
-    for module_name, display_name in dependencies:
-        try:
-            module = __import__(module_name)
-            version = getattr(module, "__version__", "unknown")
-            typer.echo(f"  ✅ {display_name}: {version}")
-        except ImportError:
-            typer.echo(f"  ❌ {display_name}: not installed")
-
-    # Optional dependencies
-    optional_deps = [
-        ("tifffile", "16-bit TIFF support"),
-        ("scipy", "Advanced image processing"),
-        ("lpips", "LPIPS perceptual metrics"),
-        ("transformers", "ML models"),
-    ]
-
-    typer.echo("\nOptional Dependencies:")
-    for module_name, feature in optional_deps:
-        try:
-            __import__(module_name)
-            typer.echo(f"  ✅ {feature}")
-        except ImportError:
-            typer.echo(f"  ⚠️  {feature}: not installed")
+    _emit_dependency_group(
+        "Core Dependencies",
+        (
+            ("NumPy", "numpy"),
+            ("Pillow", "Pillow"),
+            ("PyTorch", "torch"),
+            ("PyYAML", "PyYAML"),
+            ("Typer", "typer"),
+        ),
+        unavailable_prefix="❌",
+    )
+    _emit_dependency_group(
+        "Optional Dependencies",
+        (
+            ("16-bit TIFF support", "tifffile"),
+            ("Advanced image processing", "scipy"),
+            ("LPIPS perceptual metrics", "lpips"),
+            ("ML models", "transformers"),
+        ),
+        unavailable_prefix="⚠️ ",
+    )
 
 
 def main():

--- a/src/transformation_portal/cli/__init__.py
+++ b/src/transformation_portal/cli/__init__.py
@@ -45,8 +45,8 @@ except ImportError as e:
     ) from e
 
 from transformation_portal.cli_support import (
+    emit_dependency_group,
     list_recipe_summaries,
-    probe_dependency_versions,
     probe_pipeline_features,
     validate_recipe_file,
 )
@@ -104,22 +104,6 @@ analyze_app = typer.Typer(
     help="Codebase and workflow analysis tools",
     no_args_is_help=True,
 )
-
-
-def _emit_dependency_group(title: str, dependency_specs: tuple[tuple[str, str], ...], unavailable_prefix: str) -> None:
-    """Render a dependency status group."""
-
-    typer.echo(f"\n{title}:")
-    for status in probe_dependency_versions(dependency_specs):
-        if status.available:
-            typer.echo(f"  ✅ {status.display_name}: {status.version}")
-            continue
-
-        line = f"  {unavailable_prefix} {status.display_name}: not installed"
-        if status.reason:
-            line = f"{line} ({status.reason})"
-        typer.echo(line)
-
 
 # ============================================================================
 # RENDER SUBCOMMANDS
@@ -563,7 +547,7 @@ def info():
             line = f"{line}: {status.reason}"
         typer.echo(line)
 
-    _emit_dependency_group(
+    emit_dependency_group(
         "Core Dependencies",
         (
             ("NumPy", "numpy"),
@@ -573,8 +557,9 @@ def info():
             ("Typer", "typer"),
         ),
         unavailable_prefix="❌",
+        emit=typer.echo,
     )
-    _emit_dependency_group(
+    emit_dependency_group(
         "Optional Dependencies",
         (
             ("16-bit TIFF support", "tifffile"),
@@ -583,6 +568,7 @@ def info():
             ("ML models", "transformers"),
         ),
         unavailable_prefix="⚠️ ",
+        emit=typer.echo,
     )
 
 

--- a/src/transformation_portal/cli/__init__.py
+++ b/src/transformation_portal/cli/__init__.py
@@ -44,6 +44,13 @@ except ImportError as e:
         "  pip install -e '.[dev]'"
     ) from e
 
+from transformation_portal.cli_support import (
+    list_recipe_summaries,
+    probe_dependency_versions,
+    probe_pipeline_features,
+    validate_recipe_file,
+)
+
 
 def check_module_availability(module_path: str, module_name: str) -> bool:
     """Check if a module is available for import.
@@ -97,6 +104,21 @@ analyze_app = typer.Typer(
     help="Codebase and workflow analysis tools",
     no_args_is_help=True,
 )
+
+
+def _emit_dependency_group(title: str, dependency_specs: tuple[tuple[str, str], ...], unavailable_prefix: str) -> None:
+    """Render a dependency status group."""
+
+    typer.echo(f"\n{title}:")
+    for status in probe_dependency_versions(dependency_specs):
+        if status.available:
+            typer.echo(f"  ✅ {status.display_name}: {status.version}")
+            continue
+
+        line = f"  {unavailable_prefix} {status.display_name}: not installed"
+        if status.reason:
+            line = f"{line} ({status.reason})"
+        typer.echo(line)
 
 
 # ============================================================================
@@ -363,6 +385,7 @@ def process_command(
     output_dir: Path = typer.Option(..., "--output", "-o", help="Output directory"),
     recipe: Path = typer.Option(..., "--recipe", "-r", help="Recipe YAML file path"),
     dry_run: bool = typer.Option(False, "--dry-run", "-n", help="Preview processing plan without executing"),
+    parallel: bool = typer.Option(False, "--parallel", "-p", help="Enable parallel processing"),
 ):
     """Run unified enhancement pipeline with recipe.
 
@@ -370,13 +393,14 @@ def process_command(
     Supports batch processing with dry-run preview.
 
     Example:
-        transform-process pipeline process -i "renders/*.exr" -o outputs/ -r config/recipes/signature_estate.yaml
+        transform-process pipeline process -i "renders/*.exr" -o outputs/ -r path/to/recipe.yaml
     """
     typer.echo("🚀 Running Unified Pipeline...")
     typer.echo(f"   Recipe: {recipe}")
     typer.echo(f"   Input: {input_glob}")
     typer.echo(f"   Output: {output_dir}")
     typer.echo(f"   Dry run: {dry_run}")
+    typer.echo(f"   Parallel: {parallel}")
 
     if not recipe.exists():
         typer.echo(f"❌ Error: Recipe file not found: {recipe}", err=True)
@@ -386,7 +410,12 @@ def process_command(
         from transformation_portal.pipeline_unified import UnifiedPipeline
 
         pipeline = UnifiedPipeline.from_recipe(recipe)
-        result = pipeline.process_batch(input_glob, output_dir, dry_run=dry_run)
+        result = pipeline.process_batch(
+            input_glob,
+            output_dir,
+            dry_run=dry_run,
+            parallel=parallel,
+        )
 
         if not dry_run:
             typer.echo(f"\n✅ Processed {result.successful_count} images successfully")
@@ -403,7 +432,12 @@ def process_command(
 
 @pipeline_app.command("list-recipes")
 def pipeline_list_recipes(
-    recipes_dir: Path = typer.Option(Path("config/recipes"), "--dir", "-d", help="Recipes directory path"),
+    recipes_dir: Optional[Path] = typer.Option(
+        None,
+        "--dir",
+        "-d",
+        help="Recipe directory path (defaults to config/recipes, then config/ recursion)",
+    ),
 ):
     """List all available recipe presets.
 
@@ -412,42 +446,34 @@ def pipeline_list_recipes(
 
     Example:
         transform-process pipeline list-recipes
-        transform-process pipeline list-recipes -d custom/recipes/
+        transform-process pipeline list-recipes -d path/to/recipes/
     """
     typer.echo("📋 Available Pipeline Recipes\n")
 
-    if not recipes_dir.exists():
-        typer.echo(f"⚠️  Recipes directory not found: {recipes_dir}", err=True)
-        typer.echo("   Create recipes in config/recipes/ directory")
-        raise typer.Exit(code=1)
-
     try:
-        from transformation_portal.config_loader import list_recipes
-
-        recipes = list_recipes(recipes_dir)
+        recipes = list_recipe_summaries(recipes_dir)
 
         if not recipes:
-            typer.echo("No recipes found in directory")
+            if recipes_dir is not None:
+                typer.echo(f"No recipe presets found in {recipes_dir}")
+            else:
+                typer.echo("No recipe presets found under config/recipes or config/")
             raise typer.Exit(code=0)
 
         for recipe in recipes:
-            if "error" in recipe:
-                typer.echo(f"  ❌ {recipe['path']}: {recipe['error']}")
-            else:
-                name = recipe.get("name", "Unknown")
-                description = recipe.get("description", "No description")
-                stages = recipe.get("stages", [])
-                output_format = recipe.get("output_format", "tiff")
+            typer.echo(f"  📄 {recipe.get('name', 'Unknown')}")
+            typer.echo(f"     {recipe.get('description', 'No description')}")
+            typer.echo(f"     Stages: {', '.join(recipe.get('stages', []))}")
+            typer.echo(f"     Output: {recipe.get('output_format', 'tiff')}")
+            typer.echo(f"     Path: {recipe['path']}")
+            typer.echo()
 
-                typer.echo(f"  📄 {name}")
-                typer.echo(f"     {description}")
-                typer.echo(f"     Stages: {', '.join(stages)}")
-                typer.echo(f"     Output: {output_format}")
-                typer.echo(f"     Path: {recipe['path']}")
-                typer.echo()
+        typer.echo(f"Total: {len(recipes)} recipes found")
 
-    except ImportError as e:
-        typer.echo(f"❌ Error: {e}", err=True)
+    except typer.Exit:
+        raise
+    except Exception as e:
+        typer.echo(f"❌ Error loading recipe presets: {e}", err=True)
         raise typer.Exit(code=1)
 
 
@@ -461,7 +487,7 @@ def pipeline_validate_recipe(
     Validates a recipe YAML file against the schema and reports any errors.
 
     Example:
-        transform-process pipeline validate-recipe config/recipes/signature_estate.yaml
+        transform-process pipeline validate-recipe path/to/recipe.yaml
         transform-process pipeline validate-recipe custom_recipe.yaml -v
     """
     typer.echo(f"🔍 Validating recipe: {recipe_path}\n")
@@ -471,16 +497,10 @@ def pipeline_validate_recipe(
         raise typer.Exit(code=1)
 
     try:
-        from transformation_portal.config_loader import get_recipe_info, load_recipe, validate_recipe
-
-        # Load the recipe
-        recipe = load_recipe(recipe_path, expand_env=False, resolve_paths=False)
-
-        # Validate
-        is_valid, errors = validate_recipe(recipe)
+        validation_result = validate_recipe_file(recipe_path)
 
         if verbose:
-            info = get_recipe_info(recipe)
+            info = validation_result.info
             typer.echo("Recipe Information:")
             typer.echo(f"  Name: {info.get('name', 'Unknown')}")
             typer.echo(f"  Description: {info.get('description', 'None')}")
@@ -488,20 +508,20 @@ def pipeline_validate_recipe(
             typer.echo(f"  Has Depth: {info.get('has_depth', False)}")
             typer.echo(f"  Has Material Response: {info.get('has_material_response', False)}")
             typer.echo(f"  Has Color Grading: {info.get('has_color_grading', False)}")
+            typer.echo(f"  Has Quality Feedback: {info.get('has_quality_feedback', False)}")
             typer.echo(f"  Output Format: {info.get('output_format', 'unknown')}")
             typer.echo()
 
-        if is_valid:
+        if validation_result.is_valid:
             typer.echo("✅ Recipe is valid!")
         else:
             typer.echo("❌ Recipe validation failed:")
-            for error in errors:
+            for error in validation_result.errors:
                 typer.echo(f"   - {error}")
             raise typer.Exit(code=1)
 
-    except ImportError as e:
-        typer.echo(f"❌ Error: {e}", err=True)
-        raise typer.Exit(code=1)
+    except typer.Exit:
+        raise
     except Exception as e:
         typer.echo(f"❌ Error validating recipe: {e}", err=True)
         raise typer.Exit(code=1)
@@ -534,41 +554,36 @@ def info():
     """Show system and dependency information."""
     typer.echo("Transformation Portal - System Information\n")
 
-    # Python version
     typer.echo(f"Python: {sys.version.split()[0]}")
 
-    # Check key dependencies
-    dependencies = [
-        ("numpy", "NumPy"),
-        ("PIL", "Pillow"),
-        ("torch", "PyTorch"),
-        ("diffusers", "Diffusers"),
-        ("typer", "Typer"),
-    ]
+    typer.echo("\nPipeline Features:")
+    for status in probe_pipeline_features():
+        line = f"  {'✅' if status.available else '⚠️ '} {status.display_name}"
+        if status.reason:
+            line = f"{line}: {status.reason}"
+        typer.echo(line)
 
-    typer.echo("\nDependencies:")
-    for module_name, display_name in dependencies:
-        try:
-            module = __import__(module_name)
-            version = getattr(module, "__version__", "unknown")
-            typer.echo(f"  ✅ {display_name}: {version}")
-        except ImportError:
-            typer.echo(f"  ❌ {display_name}: not installed")
-
-    # Optional dependencies
-    optional_deps = [
-        ("tifffile", "TIFF support"),
-        ("transformers", "ML models"),
-        ("cv2", "OpenCV"),
-    ]
-
-    typer.echo("\nOptional Dependencies:")
-    for module_name, feature in optional_deps:
-        try:
-            __import__(module_name)
-            typer.echo(f"  ✅ {feature}")
-        except ImportError:
-            typer.echo(f"  ⚠️  {feature}: not installed")
+    _emit_dependency_group(
+        "Core Dependencies",
+        (
+            ("NumPy", "numpy"),
+            ("Pillow", "Pillow"),
+            ("PyTorch", "torch"),
+            ("PyYAML", "PyYAML"),
+            ("Typer", "typer"),
+        ),
+        unavailable_prefix="❌",
+    )
+    _emit_dependency_group(
+        "Optional Dependencies",
+        (
+            ("16-bit TIFF support", "tifffile"),
+            ("Advanced image processing", "scipy"),
+            ("LPIPS perceptual metrics", "lpips"),
+            ("ML models", "transformers"),
+        ),
+        unavailable_prefix="⚠️ ",
+    )
 
 
 def main():

--- a/src/transformation_portal/cli_support.py
+++ b/src/transformation_portal/cli_support.py
@@ -1,0 +1,174 @@
+"""Shared helpers for Transformation Portal CLI entrypoints."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from importlib import metadata
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+from transformation_portal.config_loader import get_recipe_info, load_recipe, validate_recipe
+
+_DEFAULT_RECIPE_DIR = Path("config/recipes")
+_FALLBACK_RECIPE_DIR = Path("config")
+
+
+@dataclass(frozen=True)
+class DependencyStatus:
+    """Status for an installed distribution."""
+
+    display_name: str
+    available: bool
+    version: Optional[str] = None
+    reason: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class FeatureStatus:
+    """Status for an optional feature probe."""
+
+    display_name: str
+    available: bool
+    reason: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class RecipeValidationResult:
+    """Validation result for a recipe file."""
+
+    recipe: dict[str, Any]
+    info: dict[str, Any]
+    errors: list[str]
+
+    @property
+    def is_valid(self) -> bool:
+        return not self.errors
+
+
+def summarize_exception(exc: BaseException, limit: int = 160) -> str:
+    """Return a compact exception summary suitable for CLI output."""
+
+    message = str(exc).strip()
+    summary = type(exc).__name__ if not message else f"{type(exc).__name__}: {message}"
+    if len(summary) <= limit:
+        return summary
+    return summary[: limit - 3].rstrip() + "..."
+
+
+def discover_recipe_files(recipes_dir: Optional[Path] = None) -> list[Path]:
+    """Discover UnifiedPipeline recipe files.
+
+    When ``recipes_dir`` is omitted, search ``config/recipes`` first and then
+    fall back to a recursive search under ``config`` when no candidates exist in
+    the preferred location.
+    """
+
+    if recipes_dir is not None:
+        return _discover_recipe_candidates(Path(recipes_dir), recursive=True)
+
+    primary_candidates = _discover_recipe_candidates(_DEFAULT_RECIPE_DIR, recursive=False)
+    if primary_candidates:
+        return primary_candidates
+
+    return _discover_recipe_candidates(_FALLBACK_RECIPE_DIR, recursive=True)
+
+
+def list_recipe_summaries(recipes_dir: Optional[Path] = None) -> list[dict[str, Any]]:
+    """Return summary dictionaries for discovered recipe files."""
+
+    summaries: list[dict[str, Any]] = []
+    for recipe_path in discover_recipe_files(recipes_dir):
+        recipe = load_recipe(recipe_path, expand_env=False, resolve_paths=False)
+        info = get_recipe_info(recipe)
+        info["path"] = str(recipe_path)
+        summaries.append(info)
+    return summaries
+
+
+def validate_recipe_file(recipe_path: Path) -> RecipeValidationResult:
+    """Load a recipe file and validate it."""
+
+    loaded_recipe = load_recipe(recipe_path, expand_env=False, resolve_paths=False)
+    info = get_recipe_info(loaded_recipe)
+    is_valid, errors = validate_recipe(loaded_recipe)
+    return RecipeValidationResult(
+        recipe=loaded_recipe,
+        info=info,
+        errors=[] if is_valid else errors,
+    )
+
+
+def probe_dependency_versions(
+    dependency_specs: Iterable[tuple[str, str]],
+) -> list[DependencyStatus]:
+    """Probe installed package versions via distribution metadata."""
+
+    statuses: list[DependencyStatus] = []
+    for display_name, distribution_name in dependency_specs:
+        try:
+            version = metadata.version(distribution_name)
+            statuses.append(
+                DependencyStatus(
+                    display_name=display_name,
+                    available=True,
+                    version=version,
+                )
+            )
+        except metadata.PackageNotFoundError:
+            statuses.append(
+                DependencyStatus(
+                    display_name=display_name,
+                    available=False,
+                )
+            )
+        except Exception as exc:  # pragma: no cover - defensive runtime guard
+            statuses.append(
+                DependencyStatus(
+                    display_name=display_name,
+                    available=False,
+                    reason=summarize_exception(exc),
+                )
+            )
+    return statuses
+
+
+def probe_pipeline_features() -> list[FeatureStatus]:
+    """Best-effort probe for optional pipeline feature availability."""
+
+    try:
+        from transformation_portal.pipeline_unified import HAS_4K_PIPELINE, HAS_QUALITY_BRIDGE
+
+        return [
+            FeatureStatus("RAG Quality Feedback", HAS_QUALITY_BRIDGE),
+            FeatureStatus("4K Rendering Pipeline", HAS_4K_PIPELINE),
+        ]
+    except Exception as exc:  # pragma: no cover - defensive runtime guard
+        reason = summarize_exception(exc)
+        return [
+            FeatureStatus("RAG Quality Feedback", False, reason),
+            FeatureStatus("4K Rendering Pipeline", False, reason),
+        ]
+
+
+def _discover_recipe_candidates(root_dir: Path, recursive: bool) -> list[Path]:
+    """Return recipe-shaped YAML files from ``root_dir``."""
+
+    if not root_dir.exists() or not root_dir.is_dir():
+        return []
+
+    pattern = "**/*.y*ml" if recursive else "*.y*ml"
+    candidates: list[Path] = []
+    for recipe_path in sorted(path for path in root_dir.glob(pattern) if path.is_file()):
+        try:
+            payload = load_recipe(recipe_path, expand_env=False, resolve_paths=False)
+        except Exception:
+            continue
+        if _looks_like_recipe(payload):
+            candidates.append(recipe_path)
+    return candidates
+
+
+def _looks_like_recipe(payload: Any) -> bool:
+    """Return ``True`` when the parsed YAML resembles a UnifiedPipeline recipe."""
+
+    return isinstance(payload, dict) and "name" in payload and "stages" in payload

--- a/src/transformation_portal/cli_support.py
+++ b/src/transformation_portal/cli_support.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from importlib import metadata
 from pathlib import Path
-from typing import Any, Iterable, Optional
+from typing import Any, Callable, Iterable, Optional
 
 from transformation_portal.config_loader import get_recipe_info, load_recipe, validate_recipe
 
@@ -132,6 +132,26 @@ def probe_dependency_versions(
     return statuses
 
 
+def emit_dependency_group(
+    title: str,
+    dependency_specs: Iterable[tuple[str, str]],
+    unavailable_prefix: str,
+    emit: Callable[[str], None],
+) -> None:
+    """Render a dependency status group via the provided output function."""
+
+    emit(f"\n{title}:")
+    for status in probe_dependency_versions(dependency_specs):
+        if status.available:
+            emit(f"  ✅ {status.display_name}: {status.version}")
+            continue
+
+        line = f"  {unavailable_prefix} {status.display_name}: not installed"
+        if status.reason:
+            line = f"{line} ({status.reason})"
+        emit(line)
+
+
 def probe_pipeline_features() -> list[FeatureStatus]:
     """Best-effort probe for optional pipeline feature availability."""
 
@@ -171,4 +191,16 @@ def _discover_recipe_candidates(root_dir: Path, recursive: bool) -> list[Path]:
 def _looks_like_recipe(payload: Any) -> bool:
     """Return ``True`` when the parsed YAML resembles a UnifiedPipeline recipe."""
 
-    return isinstance(payload, dict) and "name" in payload and "stages" in payload
+    if not isinstance(payload, dict):
+        return False
+
+    name = payload.get("name")
+    stages = payload.get("stages")
+
+    return (
+        isinstance(name, str)
+        and bool(name.strip())
+        and isinstance(stages, list)
+        and bool(stages)
+        and all(isinstance(stage, str) and bool(stage.strip()) for stage in stages)
+    )

--- a/src/transformation_portal/pipeline_unified.py
+++ b/src/transformation_portal/pipeline_unified.py
@@ -31,10 +31,13 @@ Example:
 
 from __future__ import annotations
 
+import copy
 import glob
 import json
 import logging
+import os
 import time
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Union
@@ -366,11 +369,16 @@ class UnifiedPipeline:
             pass
         return "cpu"
 
-    def process_single(self, input_path: Union[str, Path]) -> ProcessingResult:
+    def process_single(
+        self,
+        input_path: Union[str, Path],
+        output_dir: Optional[Union[str, Path]] = None,
+    ) -> ProcessingResult:
         """Process a single image through the pipeline.
 
         Args:
             input_path: Path to the input image.
+            output_dir: Optional output directory override.
 
         Returns:
             ProcessingResult with processing details.
@@ -428,7 +436,7 @@ class UnifiedPipeline:
                     log.warning(f"  ⚠ {stage.display_name} failed: {e}")
 
             # Generate output
-            output_path = self._generate_output(image, input_path)
+            output_path = self._generate_output(image, input_path, output_dir=output_dir)
             result.output_path = output_path
             result.success = True
 
@@ -449,6 +457,8 @@ class UnifiedPipeline:
         output_dir: Union[str, Path],
         mode: str = "auto",
         dry_run: bool = False,
+        parallel: bool = False,
+        max_workers: Optional[int] = None,
     ) -> BatchResult:
         """Process multiple images matching a glob pattern.
 
@@ -458,6 +468,8 @@ class UnifiedPipeline:
             mode: Processing mode ("auto", "image", "video"). Currently "auto" detects
                 file type; "image" and "video" modes are reserved for future use.
             dry_run: If True, preview processing plan without executing.
+            parallel: If True, process files in parallel with isolated worker pipelines.
+            max_workers: Optional worker override for parallel execution.
 
         Returns:
             BatchResult with all processing results.
@@ -484,23 +496,25 @@ class UnifiedPipeline:
         log.info(f"  Output: {output_dir}")
         log.info(f"  Mode: {mode}")
         log.info(f"  Dry run: {dry_run}")
+        log.info(f"  Parallel: {parallel}")
 
         if dry_run:
             return self._dry_run_batch(input_files, output_dir)
 
-        # Create output directory
         output_dir.mkdir(parents=True, exist_ok=True)
-
-        # Store original output config and override
-        original_output_dir = self.recipe.get("_output_dir")
-        self.recipe["_output_dir"] = str(output_dir)
 
         batch_result = BatchResult(dry_run=dry_run)
 
-        try:
+        if parallel:
+            batch_result = self._process_batch_parallel(
+                input_files,
+                output_dir,
+                max_workers=max_workers,
+            )
+        else:
             for i, input_path in enumerate(input_files, 1):
                 log.info(f"\n[{i}/{len(input_files)}] {input_path.name}")
-                result = self.process_single(input_path)
+                result = self.process_single(input_path, output_dir=output_dir)
                 batch_result.results.append(result)
 
                 if result.success:
@@ -508,15 +522,79 @@ class UnifiedPipeline:
                 else:
                     batch_result.failed_count += 1
 
-        finally:
-            # Restore original output config
-            if original_output_dir:
-                self.recipe["_output_dir"] = original_output_dir
-
         batch_result.total_time = time.time() - batch_start
 
         log.info(batch_result.summary())
         return batch_result
+
+    def _process_batch_parallel(
+        self,
+        input_files: List[Path],
+        output_dir: Path,
+        max_workers: Optional[int] = None,
+    ) -> BatchResult:
+        """Process a batch in parallel with isolated worker pipeline instances."""
+
+        worker_count = min(4, len(input_files), os.cpu_count() or 1)
+        if max_workers is not None:
+            worker_count = max(1, min(worker_count, max_workers))
+
+        log.info(f"  Parallel workers: {worker_count}")
+
+        rag_indexing_enabled = self._rag_indexing_enabled()
+        batch_result = BatchResult(dry_run=False)
+
+        def _worker(input_path: Path) -> ProcessingResult:
+            worker_pipeline = self._create_worker_pipeline(disable_rag_indexing=rag_indexing_enabled)
+            return worker_pipeline.process_single(input_path, output_dir=output_dir)
+
+        with ThreadPoolExecutor(max_workers=worker_count) as executor:
+            for input_path, result in zip(input_files, executor.map(_worker, input_files)):
+                log.info(f"\n[done] {input_path.name}")
+                batch_result.results.append(result)
+
+                if result.success:
+                    batch_result.successful_count += 1
+                else:
+                    batch_result.failed_count += 1
+
+                if rag_indexing_enabled and result.rag_document:
+                    self._append_rag_document(result.rag_document)
+
+        return batch_result
+
+    def _create_worker_pipeline(self, disable_rag_indexing: bool = False) -> "UnifiedPipeline":
+        """Create an isolated pipeline instance for a batch worker."""
+
+        worker_recipe = copy.deepcopy(self.recipe)
+        worker_recipe.pop("_output_dir", None)
+        if disable_rag_indexing:
+            quality_config = worker_recipe.setdefault("quality_feedback", {})
+            quality_config["rag_indexing_enabled"] = False
+        return type(self)(worker_recipe)
+
+    def _rag_indexing_enabled(self) -> bool:
+        """Return True when the current recipe config enables RAG indexing."""
+
+        quality_config = self.recipe.get("quality_feedback", {})
+        return bool(
+            quality_config.get("enabled", True)
+            and quality_config.get("rag_indexing_enabled", False)
+            and quality_config.get("rag_index_path")
+        )
+
+    def _append_rag_document(self, document: Dict[str, Any]) -> None:
+        """Append a RAG document to the configured JSONL index."""
+
+        rag_index_path = self.recipe.get("quality_feedback", {}).get("rag_index_path")
+        if not rag_index_path:
+            return
+
+        output_path = Path(rag_index_path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(output_path, "a", encoding="utf-8") as handle:
+            handle.write(json.dumps(document) + "\n")
+        log.debug(f"Indexed quality document to RAG: {document.get('image_id', 'unknown')}")
 
     def _dry_run_batch(self, input_files: List[Path], output_dir: Path) -> BatchResult:
         """Generate dry-run preview of batch processing.
@@ -934,12 +1012,18 @@ class UnifiedPipeline:
 
         return canvas
 
-    def _generate_output(self, image: Image.Image, input_path: Path) -> Path:
+    def _generate_output(
+        self,
+        image: Image.Image,
+        input_path: Path,
+        output_dir: Optional[Union[str, Path]] = None,
+    ) -> Path:
         """Generate output file.
 
         Args:
             image: Processed image.
             input_path: Original input path.
+            output_dir: Optional output directory override.
 
         Returns:
             Path to output file.
@@ -949,11 +1033,14 @@ class UnifiedPipeline:
         quality = output_config.get("quality", 95)
 
         # Determine output directory
-        output_dir = self.recipe.get("_output_dir")
-        if output_dir:
+        if output_dir is not None:
             output_dir = Path(output_dir)
         else:
-            output_dir = input_path.parent / "processed"
+            configured_output_dir = self.recipe.get("_output_dir")
+            if configured_output_dir:
+                output_dir = Path(configured_output_dir)
+            else:
+                output_dir = input_path.parent / "processed"
         output_dir.mkdir(parents=True, exist_ok=True)
 
         # Generate output filename

--- a/src/transformation_portal/pipeline_unified.py
+++ b/src/transformation_portal/pipeline_unified.py
@@ -36,6 +36,7 @@ import glob
 import json
 import logging
 import os
+import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
@@ -469,7 +470,8 @@ class UnifiedPipeline:
                 file type; "image" and "video" modes are reserved for future use.
             dry_run: If True, preview processing plan without executing.
             parallel: If True, process files in parallel with isolated worker pipelines.
-            max_workers: Optional worker override for parallel execution.
+            max_workers: Optional explicit worker count for parallel execution,
+                bounded by the input count and detected CPU count.
 
         Returns:
             BatchResult with all processing results.
@@ -535,17 +537,24 @@ class UnifiedPipeline:
     ) -> BatchResult:
         """Process a batch in parallel with isolated worker pipeline instances."""
 
-        worker_count = min(4, len(input_files), os.cpu_count() or 1)
-        if max_workers is not None:
-            worker_count = max(1, min(worker_count, max_workers))
+        cpu_count = os.cpu_count() or 1
+        if max_workers is None:
+            worker_count = min(4, len(input_files), cpu_count)
+        else:
+            worker_count = max(1, min(max_workers, len(input_files), cpu_count))
 
         log.info(f"  Parallel workers: {worker_count}")
 
         rag_indexing_enabled = self._rag_indexing_enabled()
+        should_disable_rag_indexing = rag_indexing_enabled
         batch_result = BatchResult(dry_run=False)
+        worker_state = threading.local()
 
         def _worker(input_path: Path) -> ProcessingResult:
-            worker_pipeline = self._create_worker_pipeline(disable_rag_indexing=rag_indexing_enabled)
+            worker_pipeline = getattr(worker_state, "pipeline", None)
+            if worker_pipeline is None:
+                worker_pipeline = self._create_worker_pipeline(disable_rag_indexing=should_disable_rag_indexing)
+                worker_state.pipeline = worker_pipeline
             return worker_pipeline.process_single(input_path, output_dir=output_dir)
 
         with ThreadPoolExecutor(max_workers=worker_count) as executor:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,6 +8,9 @@ Coverage Target: 60% of CLI module
 
 from __future__ import annotations
 
+import sys
+import types
+
 import pytest
 from typer.testing import CliRunner
 
@@ -148,7 +151,7 @@ class TestInfoCommand:
 
         assert result.exit_code == 0
         assert "Python:" in result.stdout
-        assert "Dependencies:" in result.stdout
+        assert "Core Dependencies:" in result.stdout
 
 
 class TestRenderCommands:
@@ -380,7 +383,50 @@ class TestPipelineCommands:
             ["list-recipes", "--dir", "/nonexistent/recipes"],
         )
 
-        assert result.exit_code == 1
+        assert result.exit_code == 0
+        assert "No recipe presets found" in result.stdout
+
+    def test_pipeline_process_parallel_forwards_flag(self, runner, temp_workspace, monkeypatch):
+        """Test pipeline process forwards the parallel flag to UnifiedPipeline."""
+        from transformation_portal.cli import pipeline_app
+
+        captured: dict[str, object] = {}
+        stub_module = types.ModuleType("transformation_portal.pipeline_unified")
+
+        class StubPipeline:
+            @classmethod
+            def from_recipe(cls, recipe_path):
+                captured["recipe"] = str(recipe_path)
+                return cls()
+
+            def process_batch(self, input_glob, output_dir, **kwargs):
+                captured["input_glob"] = input_glob
+                captured["output_dir"] = str(output_dir)
+                captured["kwargs"] = kwargs
+                return types.SimpleNamespace(successful_count=1, failed_count=0, total_time=0.01)
+
+        stub_module.UnifiedPipeline = StubPipeline
+        monkeypatch.setitem(sys.modules, "transformation_portal.pipeline_unified", stub_module)
+
+        recipe_path = temp_workspace["root"] / "recipe.yaml"
+        recipe_path.write_text("name: Test Recipe\nstages:\n  - color_grading\n")
+
+        result = runner.invoke(
+            pipeline_app,
+            [
+                "process",
+                "--input",
+                "*.jpg",
+                "--output",
+                str(temp_workspace["output_dir"]),
+                "--recipe",
+                str(recipe_path),
+                "--parallel",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert captured["kwargs"]["parallel"] is True
 
     def test_pipeline_validate_recipe_missing_file(self, runner):
         """Test pipeline validate-recipe with nonexistent file."""
@@ -430,6 +476,8 @@ description: No name or stages
         )
 
         assert result.exit_code == 1
+        assert "Recipe validation failed" in result.stdout
+        assert "Error validating recipe" not in result.stdout
 
     def test_pipeline_validate_recipe_verbose(self, runner, temp_workspace):
         """Test pipeline validate-recipe with verbose flag."""

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import builtins
+import sys
+import types
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _write_recipe(path: Path, contents: str) -> Path:
+    path.write_text(contents, encoding="utf-8")
+    return path
+
+
+def test_list_recipes_default_discovery_falls_back_to_config_recursively(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from transformation_portal.__main__ import app
+
+    recipe_path = tmp_path / "config" / "nested" / "recipe.yaml"
+    recipe_path.parent.mkdir(parents=True)
+    _write_recipe(
+        recipe_path,
+        """
+name: Recursive Recipe
+description: discovered via config fallback
+stages:
+  - color_grading
+output:
+  format: png
+""".strip(),
+    )
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["list-recipes"])
+
+    assert result.exit_code == 0
+    assert "Recursive Recipe" in result.stdout
+    assert str(recipe_path.relative_to(tmp_path)) in result.stdout
+
+
+def test_list_recipes_explicit_dir_lists_only_recipe_candidates(
+    runner: CliRunner,
+    tmp_path: Path,
+) -> None:
+    from transformation_portal.__main__ import app
+
+    recipes_dir = tmp_path / "recipes"
+    recipes_dir.mkdir()
+    _write_recipe(
+        recipes_dir / "valid.yaml",
+        """
+name: Explicit Recipe
+stages:
+  - color_grading
+""".strip(),
+    )
+    _write_recipe(recipes_dir / "ignored.yaml", "description: not a recipe\n")
+
+    result = runner.invoke(app, ["list-recipes", "--dir", str(recipes_dir)])
+
+    assert result.exit_code == 0
+    assert "Explicit Recipe" in result.stdout
+    assert "ignored.yaml" not in result.stdout
+
+
+def test_list_recipes_without_candidates_exits_cleanly(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from transformation_portal.__main__ import app
+
+    (tmp_path / "config").mkdir()
+    _write_recipe(tmp_path / "config" / "manifest.yaml", "description: still not a recipe\n")
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["list-recipes"])
+
+    assert result.exit_code == 0
+    assert "No recipe presets found" in result.stdout
+
+
+def test_validate_recipe_invalid_does_not_emit_duplicate_error(
+    runner: CliRunner,
+    tmp_path: Path,
+) -> None:
+    from transformation_portal.__main__ import app
+
+    recipe_path = _write_recipe(tmp_path / "invalid.yaml", "description: missing recipe fields\n")
+
+    result = runner.invoke(app, ["validate-recipe", str(recipe_path)])
+
+    assert result.exit_code == 1
+    assert "Recipe validation failed" in result.stdout
+    assert "Error validating recipe" not in result.stdout
+
+
+def test_info_stays_green_when_pipeline_probe_hits_non_import_error(
+    runner: CliRunner,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from transformation_portal.__main__ import app
+
+    original_import = builtins.__import__
+
+    def _raising_import(name, globals=None, locals=None, fromlist=(), level=0):  # type: ignore[no-untyped-def]
+        if name == "transformation_portal.pipeline_unified":
+            raise FileNotFoundError("tempdir unavailable")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", _raising_import)
+
+    result = runner.invoke(app, ["info"])
+
+    assert result.exit_code == 0
+    assert "FileNotFoundError: tempdir unavailable" in result.stdout
+    assert "Core Dependencies:" in result.stdout
+
+
+def test_process_parallel_forwards_flag(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from transformation_portal.__main__ import app
+
+    captured: dict[str, object] = {}
+    stub_module = types.ModuleType("transformation_portal.pipeline_unified")
+
+    class StubPipeline:
+        @classmethod
+        def from_recipe(cls, recipe_path):
+            captured["recipe"] = str(recipe_path)
+            return cls()
+
+        def process_batch(self, input_glob, output_dir, **kwargs):
+            captured["input_glob"] = input_glob
+            captured["output_dir"] = str(output_dir)
+            captured["kwargs"] = kwargs
+            return types.SimpleNamespace(successful_count=1, failed_count=0, total_time=0.01)
+
+    stub_module.UnifiedPipeline = StubPipeline
+    monkeypatch.setitem(sys.modules, "transformation_portal.pipeline_unified", stub_module)
+
+    recipe_path = _write_recipe(
+        tmp_path / "recipe.yaml",
+        """
+name: Process Recipe
+stages:
+  - color_grading
+""".strip(),
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "process",
+            "--input",
+            "*.jpg",
+            "--output",
+            str(tmp_path / "outputs"),
+            "--recipe",
+            str(recipe_path),
+            "--parallel",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert captured["kwargs"]["parallel"] is True

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -67,12 +67,20 @@ stages:
 """.strip(),
     )
     _write_recipe(recipes_dir / "ignored.yaml", "description: not a recipe\n")
+    _write_recipe(
+        recipes_dir / "invalid_shape.yaml",
+        """
+name: Almost Recipe
+stages: color_grading
+""".strip(),
+    )
 
     result = runner.invoke(app, ["list-recipes", "--dir", str(recipes_dir)])
 
     assert result.exit_code == 0
     assert "Explicit Recipe" in result.stdout
     assert "ignored.yaml" not in result.stdout
+    assert "Almost Recipe" not in result.stdout
 
 
 def test_list_recipes_without_candidates_exits_cleanly(

--- a/tests/test_pipeline_unified.py
+++ b/tests/test_pipeline_unified.py
@@ -20,6 +20,7 @@ Test Categories:
 
 from __future__ import annotations
 
+import copy
 import importlib
 import json
 import logging
@@ -818,6 +819,70 @@ class TestBatchProcessing:
 
         assert batch_result.successful_count >= 1
         assert batch_result.failed_count >= 1
+
+    def test_batch_processing_parallel_preserves_order_and_recipe_state(
+        self,
+        pipeline_module,
+        minimal_recipe,
+        sample_input_directory,
+        sample_input_image,
+        tmp_path: Path,
+    ):
+        """Test parallel batch processing keeps deterministic ordering and leaves recipe unchanged."""
+        output_dir = tmp_path / "parallel_outputs"
+
+        pipeline = pipeline_module.UnifiedPipeline(minimal_recipe)
+        original_recipe = copy.deepcopy(pipeline.recipe)
+
+        batch_result = pipeline.process_batch(
+            str(sample_input_directory / "*.png"),
+            output_dir,
+            parallel=True,
+        )
+
+        assert batch_result.successful_count == 3
+        assert [result.input_path.name for result in batch_result.results] == [
+            "image_00.png",
+            "image_01.png",
+            "image_02.png",
+        ]
+        assert pipeline.recipe == original_recipe
+        assert "_output_dir" not in pipeline.recipe
+
+        single_result = pipeline.process_single(sample_input_image)
+        assert single_result.success is True
+
+    def test_batch_processing_parallel_serializes_rag_documents(
+        self,
+        pipeline_module,
+        sample_input_directory,
+        tmp_path: Path,
+    ):
+        """Test parallel batch processing writes one intact RAG document per line."""
+        rag_index_path = tmp_path / "rag-index.jsonl"
+        recipe = {
+            "name": "Quality Batch",
+            "stages": ["color_grading"],
+            "color_grading": {"enabled": True},
+            "quality_feedback": {
+                "enabled": True,
+                "rag_indexing_enabled": True,
+                "rag_index_path": str(rag_index_path),
+            },
+            "output": {"format": "png"},
+        }
+
+        pipeline = pipeline_module.UnifiedPipeline(recipe)
+        batch_result = pipeline.process_batch(
+            str(sample_input_directory / "*.png"),
+            tmp_path / "quality_outputs",
+            parallel=True,
+        )
+
+        assert batch_result.successful_count == 3
+        lines = rag_index_path.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 3
+        assert all(json.loads(line)["image_id"] == "test" for line in lines)
 
 
 # =============================================================================

--- a/tests/test_pipeline_unified.py
+++ b/tests/test_pipeline_unified.py
@@ -884,6 +884,60 @@ class TestBatchProcessing:
         assert len(lines) == 3
         assert all(json.loads(line)["image_id"] == "test" for line in lines)
 
+    def test_batch_processing_parallel_reuses_worker_pipeline_and_honors_max_workers(
+        self,
+        pipeline_module,
+        minimal_recipe,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Test parallel batch processing caches one worker pipeline per thread."""
+        input_dir = tmp_path / "parallel_inputs"
+        input_dir.mkdir()
+        for index in range(6):
+            Image.new("RGB", (32, 24), color=(40 + index, 90, 120)).save(input_dir / f"image_{index:02d}.png")
+
+        observed: dict[str, int] = {}
+
+        class RecordingExecutor:
+            def __init__(self, max_workers: int):
+                observed["max_workers"] = max_workers
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def map(self, func, iterable):
+                for item in iterable:
+                    yield func(item)
+
+        monkeypatch.setattr(pipeline_module, "ThreadPoolExecutor", RecordingExecutor)
+        monkeypatch.setattr(pipeline_module.os, "cpu_count", lambda: 8)
+
+        pipeline = pipeline_module.UnifiedPipeline(minimal_recipe)
+        create_calls = 0
+        original_create_worker_pipeline = pipeline._create_worker_pipeline
+
+        def _counting_create_worker_pipeline(*args, **kwargs):
+            nonlocal create_calls
+            create_calls += 1
+            return original_create_worker_pipeline(*args, **kwargs)
+
+        monkeypatch.setattr(pipeline, "_create_worker_pipeline", _counting_create_worker_pipeline)
+
+        batch_result = pipeline.process_batch(
+            str(input_dir / "*.png"),
+            tmp_path / "parallel_outputs",
+            parallel=True,
+            max_workers=5,
+        )
+
+        assert batch_result.successful_count == 6
+        assert observed["max_workers"] == 5
+        assert create_calls == 1
+
 
 # =============================================================================
 # Output Generation Tests


### PR DESCRIPTION
## Summary
- Fix the live recipe CLI entrypoints so discovery, validation, and info reporting match the current repo layout and degrade cleanly around optional dependencies.
- Replace the no-op `--parallel` flag with real bounded parallel batch execution that keeps deterministic ordering and avoids shared recipe mutation.

## Changes
- Added shared CLI support helpers for recipe discovery, validation, dependency metadata probing, and feature probing, then rewired both `python -m transformation_portal` and `transformation_portal.cli` to use them.
- Changed default recipe discovery to search `config/recipes` first and fall back to recursive discovery under `config/`, while ignoring unrelated YAML that does not match the UnifiedPipeline recipe shape.
- Replaced stale recipe example paths in the entrypoint help text with generic placeholders and removed the duplicate generic error emission on recipe validation failure.
- Hardened `info` to keep exit code 0 when optional pipeline imports fail, and switched dependency version reporting to `importlib.metadata` instead of importing heavy runtime-sensitive modules.
- Extended `UnifiedPipeline.process_batch(...)` with parallel execution, explicit output directory overrides, isolated worker pipeline clones, and coordinator-side serialized RAG JSONL writes.
- Added focused top-level CLI tests plus new console-script CLI and pipeline coverage for discovery fallback, validation output, flag forwarding, parallel ordering, recipe immutability, and RAG write integrity.

## Validation
- Proven green:
  - `.venv/bin/pre-commit run --all-files --show-diff-on-failure`
  - `TMPDIR=<temp> ./.venv/bin/pytest tests/test_package_version.py tests/test_cli.py tests/test_pipeline_unified.py tests/test_main_cli.py -q`
  - `TMPDIR=<temp> ./.venv/bin/python -m transformation_portal --help`
  - `TMPDIR=<temp> ./.venv/bin/python -m transformation_portal info`
  - `TMPDIR=<temp> ./.venv/bin/python -m transformation_portal list-recipes`
- Still failing:
  - None in the targeted validation set above.
- Failure classification:
  - The earlier `make pre-commit` failure was tooling, not product logic: the Make target assumes a shell-visible `pre-commit` binary, while the repo-local virtualenv binary passed cleanly.

## Risk
- Risk is bounded to the CLI entrypoints and the UnifiedPipeline batch coordinator; single-file processing and non-CLI code paths were left intact.
- Parallel execution is thread-bounded and uses deep-copied worker pipelines to avoid shared mutable recipe state, which keeps the change revert-safe if runtime characteristics need tuning later.