### PR TITLE
feat(portal): add rollout-gated artifact viewer modal

### DIFF
--- a/app.py
+++ b/app.py
@@ -101,6 +101,38 @@ def _env_float(name: str, default: float, minimum: float = 0.0) -> float:
     return max(minimum, parsed)
 
 
+def _env_rollout_percent(name: str, default: int = 0) -> int:
+    return min(100, _env_int(name, default, minimum=0))
+
+
+def _stable_rollout_bucket(key: str) -> int:
+    normalized = str(key or "").strip().lower()
+    if not normalized:
+        return 100
+    digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+    return int(digest[:8], 16) % 100
+
+
+def _portal_artifact_viewer_modal_enabled(actor: Optional[Mapping[str, Any]] = None) -> bool:
+    rollout_percent = _env_rollout_percent("TP_PORTAL_ARTIFACT_VIEWER_MODAL_ROLLOUT_PERCENT", 0)
+    if rollout_percent <= 0:
+        return False
+    actor_mapping = actor if isinstance(actor, Mapping) else {}
+    cohort_key = (
+        str(
+            actor_mapping.get("username")
+            or actor_mapping.get("accessEmail")
+            or actor_mapping.get("role")
+            or os.getenv("TP_PORTAL_DIRECT_DEBUG_COHORT_KEY", "direct-debug")
+        )
+        .strip()
+        .lower()
+    )
+    if not cohort_key:
+        return False
+    return _stable_rollout_bucket(cohort_key) < rollout_percent
+
+
 REPO_ROOT = Path(__file__).resolve().parent
 PORTAL_HTML = REPO_ROOT / "portal.html"
 PORTAL_ASSETS_DIR = REPO_ROOT / "public" / "portal-assets"
@@ -5948,6 +5980,7 @@ async def portal_bootstrap() -> JSONResponse:
             "features": {
                 "apiKeyInput": True,
                 "directDebug": True,
+                "artifactViewerModal": _portal_artifact_viewer_modal_enabled(None),
             },
         },
         headers={"Cache-Control": "no-store"},

--- a/docs/architecture/PORTAL_OPERATOR_CONSOLE_MODERNIZATION_RFC.md
+++ b/docs/architecture/PORTAL_OPERATOR_CONSOLE_MODERNIZATION_RFC.md
@@ -1,6 +1,6 @@
 # Portal Operator Console Modernization RFC
 
-**Status:** Proposed
+**Status:** Approved
 **Date:** 2026-04-14
 **Owner:** Transformation Portal Architect
 **Reviewers:** Frontdoor / Platform, Portal Frontend, Backend / Origin, Security / Privacy, QA / Validation

--- a/portal.html
+++ b/portal.html
@@ -1500,6 +1500,10 @@ Contract notes:
                                 <p class="review-provenance-label">Relative Path</p>
                                 <p id="reviewProvenancePath" class="review-provenance-value review-provenance-value-mono">Preview, metadata, and actions will appear here when outputs are indexed.</p>
                             </div>
+                            <div class="review-provenance-item review-provenance-item-wide">
+                                <p class="review-provenance-label">Integrity</p>
+                                <p id="reviewProvenanceFingerprint" class="review-provenance-value review-provenance-value-mono">Not reported</p>
+                            </div>
                             <div class="review-provenance-item">
                                 <p class="review-provenance-label">Freshness</p>
                                 <p id="reviewProvenanceFreshness" class="review-provenance-value">No live telemetry</p>
@@ -1521,6 +1525,7 @@ Contract notes:
                             <button id="openArtifactBtn" type="button" class="rounded-lg border border-slate-300 dark:border-slate-700 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wider text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors disabled:opacity-50 disabled:cursor-not-allowed" disabled>Open</button>
                             <button id="downloadArtifactBtn" type="button" class="rounded-lg border border-slate-300 dark:border-slate-700 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wider text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors disabled:opacity-50 disabled:cursor-not-allowed" disabled>Download</button>
                             <button id="copyArtifactPathBtn" type="button" class="rounded-lg border border-slate-300 dark:border-slate-700 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wider text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors disabled:opacity-50 disabled:cursor-not-allowed" disabled>Copy Relative Path</button>
+                            <button id="copyArtifactFingerprintBtn" type="button" class="rounded-lg border border-slate-300 dark:border-slate-700 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wider text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors disabled:opacity-50 disabled:cursor-not-allowed" disabled>Copy SHA-256</button>
                         </div>
                     </div>
                     <div id="runCardActions" class="hidden mb-3 items-center gap-2">
@@ -1628,6 +1633,58 @@ Contract notes:
                 <div class="panel-subtle rounded-2xl p-4">
                     <p class="text-[10px] font-bold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">Backend Argv Preview</p>
                     <pre id="effectiveArgvPreview" class="mt-3 command-frame min-h-[120px] rounded-2xl border border-slate-200 dark:border-slate-800 p-4 text-[11px] font-mono leading-relaxed text-slate-300 overflow-y-auto custom-scrollbar whitespace-pre-wrap break-words"></pre>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div id="artifactViewerModal" class="fixed inset-0 z-50 hidden items-center justify-center bg-slate-950/72 backdrop-blur-sm p-4 dark:bg-black/80 transition-opacity" aria-hidden="true" data-ui="artifact-viewer-modal">
+        <div id="artifactViewerPanel" class="artifact-viewer-panel w-full max-w-6xl rounded-[1.5rem] border border-slate-200 bg-white p-5 shadow-2xl dark:border-slate-800 dark:bg-slate-900" role="dialog" aria-modal="true" aria-labelledby="artifactViewerTitle">
+            <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                <div class="min-w-0">
+                    <p class="section-kicker">Artifact Viewer</p>
+                    <h2 id="artifactViewerTitle" class="mt-2 text-2xl font-extrabold tracking-tight text-slate-900 dark:text-white">Awaiting artifact selection</h2>
+                    <p id="artifactViewerMeta" class="mt-2 text-[12px] leading-6 text-slate-500 dark:text-slate-400">Open Review to inspect indexed outputs without leaving the operator console.</p>
+                </div>
+                <div class="flex flex-wrap items-center gap-2">
+                    <button id="artifactViewerPrevBtn" type="button" class="rounded-lg border border-slate-300 dark:border-slate-700 px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-slate-600 dark:text-slate-300 transition-colors hover:bg-slate-100 dark:hover:bg-slate-800 disabled:opacity-50 disabled:cursor-not-allowed">Previous</button>
+                    <button id="artifactViewerNextBtn" type="button" class="rounded-lg border border-slate-300 dark:border-slate-700 px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-slate-600 dark:text-slate-300 transition-colors hover:bg-slate-100 dark:hover:bg-slate-800 disabled:opacity-50 disabled:cursor-not-allowed">Next</button>
+                    <button id="artifactViewerZoomOutBtn" type="button" class="rounded-lg border border-slate-300 dark:border-slate-700 px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-slate-600 dark:text-slate-300 transition-colors hover:bg-slate-100 dark:hover:bg-slate-800 disabled:opacity-50 disabled:cursor-not-allowed">Zoom Out</button>
+                    <button id="artifactViewerZoomInBtn" type="button" class="rounded-lg border border-slate-300 dark:border-slate-700 px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-slate-600 dark:text-slate-300 transition-colors hover:bg-slate-100 dark:hover:bg-slate-800 disabled:opacity-50 disabled:cursor-not-allowed">Zoom In</button>
+                    <button id="artifactViewerResetZoomBtn" type="button" class="rounded-lg border border-slate-300 dark:border-slate-700 px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-slate-600 dark:text-slate-300 transition-colors hover:bg-slate-100 dark:hover:bg-slate-800 disabled:opacity-50 disabled:cursor-not-allowed">Reset</button>
+                    <button id="artifactViewerOpenRawBtn" type="button" class="rounded-lg border border-slate-300 dark:border-slate-700 px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-slate-600 dark:text-slate-300 transition-colors hover:bg-slate-100 dark:hover:bg-slate-800 disabled:opacity-50 disabled:cursor-not-allowed">Open Raw</button>
+                    <button id="closeArtifactViewerBtn" type="button" class="rounded-full border border-slate-300 dark:border-slate-700 px-3 py-1.5 text-[10px] font-bold uppercase tracking-[0.18em] text-slate-600 dark:text-slate-300 transition-colors hover:border-cyan-300 hover:text-cyan-700 dark:hover:border-cyan-700 dark:hover:text-cyan-300">Close</button>
+                </div>
+            </div>
+            <div id="artifactViewerStage" class="artifact-viewer-stage mt-5">
+                <img id="artifactViewerImage" alt="Artifact viewer preview" class="artifact-viewer-image hidden" />
+                <div id="artifactViewerFallback" class="artifact-viewer-fallback hidden">
+                    <p id="artifactViewerFallbackTitle" class="artifact-viewer-fallback-title">Inline preview unavailable</p>
+                    <p id="artifactViewerFallbackDetail" class="artifact-viewer-fallback-detail">This artifact stays reviewable through its retained metadata and the managed raw asset link.</p>
+                </div>
+            </div>
+            <div class="artifact-viewer-meta-grid mt-5">
+                <div class="panel-subtle rounded-2xl p-4">
+                    <p class="text-[10px] font-bold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">Relative Path</p>
+                    <p id="artifactViewerPath" class="mt-3 text-[12px] font-mono leading-6 text-slate-700 dark:text-slate-200 break-all">Not reported</p>
+                </div>
+                <div class="panel-subtle rounded-2xl p-4">
+                    <div class="flex items-start justify-between gap-3">
+                        <div>
+                            <p class="text-[10px] font-bold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">SHA-256</p>
+                            <p id="artifactViewerFingerprint" class="mt-3 text-[12px] font-mono leading-6 text-slate-700 dark:text-slate-200 break-all">Not reported</p>
+                        </div>
+                        <button id="artifactViewerCopyFingerprintBtn" type="button" class="rounded-lg border border-slate-300 dark:border-slate-700 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wider text-slate-600 dark:text-slate-300 transition-colors hover:bg-slate-100 dark:hover:bg-slate-800 disabled:opacity-50 disabled:cursor-not-allowed">Copy</button>
+                    </div>
+                </div>
+                <div class="panel-subtle rounded-2xl p-4">
+                    <div class="flex items-start justify-between gap-3">
+                        <div>
+                            <p class="text-[10px] font-bold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">Viewer State</p>
+                            <p id="artifactViewerZoomValue" class="mt-3 text-[12px] leading-6 text-slate-700 dark:text-slate-200">100% zoom</p>
+                        </div>
+                        <button id="artifactViewerCopyPathBtn" type="button" class="rounded-lg border border-slate-300 dark:border-slate-700 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wider text-slate-600 dark:text-slate-300 transition-colors hover:bg-slate-100 dark:hover:bg-slate-800 disabled:opacity-50 disabled:cursor-not-allowed">Copy Path</button>
+                    </div>
                 </div>
             </div>
         </div>

--- a/public/portal-assets/portal.css
+++ b/public/portal-assets/portal.css
@@ -1997,6 +1997,69 @@ details[open] .disclosure-chevron {
     color: var(--shell-muted);
 }
 
+.artifact-viewer-panel {
+    max-height: min(92vh, 980px);
+    overflow: hidden;
+}
+
+.artifact-viewer-stage {
+    display: flex;
+    min-height: 24rem;
+    align-items: center;
+    justify-content: center;
+    overflow: auto;
+    border-radius: 1.25rem;
+    border: 1px solid rgba(148, 163, 184, 0.18);
+    background:
+        radial-gradient(circle at top, rgba(34, 211, 238, 0.14), transparent 48%),
+        rgba(2, 6, 23, 0.94);
+    padding: 1rem;
+}
+
+.dark .artifact-viewer-stage {
+    border-color: rgba(71, 85, 105, 0.55);
+}
+
+.artifact-viewer-image {
+    display: block;
+    max-width: none;
+    max-height: 72vh;
+    width: auto;
+    border-radius: 1rem;
+    box-shadow: 0 18px 42px rgba(15, 23, 42, 0.32);
+    transform-origin: center center;
+    transition: transform 0.16s ease;
+}
+
+.artifact-viewer-fallback {
+    width: min(100%, 38rem);
+    border-radius: 1rem;
+    border: 1px dashed rgba(148, 163, 184, 0.3);
+    background: rgba(15, 23, 42, 0.52);
+    padding: 1.5rem;
+    text-align: left;
+    color: rgba(226, 232, 240, 0.94);
+}
+
+.artifact-viewer-fallback-title {
+    font-size: 0.875rem;
+    font-weight: 700;
+    color: #f8fafc;
+}
+
+.artifact-viewer-fallback-detail {
+    margin-top: 0.75rem;
+    font-size: 0.8125rem;
+    line-height: 1.7;
+    color: rgba(226, 232, 240, 0.78);
+}
+
+.artifact-viewer-meta-grid {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
 .job-chip {
     display: inline-flex;
     align-items: center;
@@ -2737,6 +2800,10 @@ textarea,
     }
 
     .runtime-briefing-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .artifact-viewer-meta-grid {
         grid-template-columns: 1fr;
     }
 

--- a/public/portal-assets/portal.js
+++ b/public/portal-assets/portal.js
@@ -155,7 +155,8 @@ var __PortalInternal = (() => {
       actor: null,
       features: {
         apiKeyInput: false,
-        directDebug: false
+        directDebug: false,
+        artifactViewerModal: false
       }
     };
   }
@@ -404,6 +405,12 @@ var __PortalInternal = (() => {
     return {
       debugBundleAcknowledged: false,
       effectiveConfigOpen: false,
+      artifactViewer: {
+        open: false,
+        jobId: "",
+        artifactPath: "",
+        zoomPercent: 100
+      },
       debugBundleGuardrailSeen: false,
       buildStep: 1,
       lastOverlayTrigger: null,
@@ -429,7 +436,8 @@ var __PortalInternal = (() => {
       actor: null,
       features: {
         apiKeyInput: false,
-        directDebug: false
+        directDebug: false,
+        artifactViewerModal: false
       }
     };
   }
@@ -842,6 +850,7 @@ const els = {
     reviewProvenanceArtifactRole: _domId('reviewProvenanceArtifactRole'),
     reviewProvenanceRunState: _domId('reviewProvenanceRunState'),
     reviewProvenancePath: _domId('reviewProvenancePath'),
+    reviewProvenanceFingerprint: _domId('reviewProvenanceFingerprint'),
     reviewProvenanceFreshness: _domId('reviewProvenanceFreshness'),
     reviewProvenanceSource: _domId('reviewProvenanceSource'),
     reviewProvenanceBatch: _domId('reviewProvenanceBatch'),
@@ -851,6 +860,7 @@ const els = {
     openArtifactBtn: _domId('openArtifactBtn'),
     downloadArtifactBtn: _domId('downloadArtifactBtn'),
     copyArtifactPathBtn: _domId('copyArtifactPathBtn'),
+    copyArtifactFingerprintBtn: _domId('copyArtifactFingerprintBtn'),
     artifactThumbnailRail: _domId('artifactThumbnailRail'),
     runCardActions: _domId('runCardActions'),
     viewRunCardBtn: _domId('viewRunCardBtn'),
@@ -881,6 +891,27 @@ const els = {
     effectiveEstimateLabel: _domId('effectiveEstimateLabel'),
     effectiveReadinessSummary: _domId('effectiveReadinessSummary'),
     effectiveArgvPreview: _domId('effectiveArgvPreview'),
+    artifactViewerModal: _domId('artifactViewerModal'),
+    artifactViewerPanel: _domId('artifactViewerPanel'),
+    artifactViewerTitle: _domId('artifactViewerTitle'),
+    artifactViewerMeta: _domId('artifactViewerMeta'),
+    artifactViewerStage: _domId('artifactViewerStage'),
+    artifactViewerImage: _domId('artifactViewerImage'),
+    artifactViewerFallback: _domId('artifactViewerFallback'),
+    artifactViewerFallbackTitle: _domId('artifactViewerFallbackTitle'),
+    artifactViewerFallbackDetail: _domId('artifactViewerFallbackDetail'),
+    artifactViewerPath: _domId('artifactViewerPath'),
+    artifactViewerFingerprint: _domId('artifactViewerFingerprint'),
+    artifactViewerZoomValue: _domId('artifactViewerZoomValue'),
+    artifactViewerPrevBtn: _domId('artifactViewerPrevBtn'),
+    artifactViewerNextBtn: _domId('artifactViewerNextBtn'),
+    artifactViewerZoomOutBtn: _domId('artifactViewerZoomOutBtn'),
+    artifactViewerZoomInBtn: _domId('artifactViewerZoomInBtn'),
+    artifactViewerResetZoomBtn: _domId('artifactViewerResetZoomBtn'),
+    artifactViewerOpenRawBtn: _domId('artifactViewerOpenRawBtn'),
+    artifactViewerCopyPathBtn: _domId('artifactViewerCopyPathBtn'),
+    artifactViewerCopyFingerprintBtn: _domId('artifactViewerCopyFingerprintBtn'),
+    closeArtifactViewerBtn: _domId('closeArtifactViewerBtn'),
 
     healthIndicator: _domId('healthIndicator'),
     healthText: _domId('healthText'),
@@ -1806,6 +1837,9 @@ function _openArtifactForSelection(job, artifact, surface = 'artifact_review') {
     if (!job || !artifact) {
         createToast('No artifact is available for this selection.', 'info');
         return false;
+    }
+    if (_artifactViewerEnabled()) {
+        return _openArtifactViewer(job, artifact);
     }
     const url = sanitizeManagedAssetUrl(buildArtifactUrl(job, artifact));
     if (!url) {
@@ -3132,6 +3166,18 @@ function buildArtifactUrl(job, artifact) {
     });
 }
 
+function artifactFingerprint(artifact) {
+    return String(artifact?.sha256 || '').trim();
+}
+
+function _artifactFingerprintLabel(artifact) {
+    return artifactFingerprint(artifact) || 'Not reported';
+}
+
+function _artifactViewerEnabled() {
+    return Boolean(state.auth?.features?.artifactViewerModal);
+}
+
 function artifactHeroScore(artifact) {
     if (!artifact || typeof artifact !== 'object') return -1;
     const info = artifactNameParts(artifact);
@@ -4338,7 +4384,8 @@ function _defaultPortalBootstrap() {
         actor: null,
         features: {
             apiKeyInput: false,
-            directDebug: false
+            directDebug: false,
+            artifactViewerModal: false
         }
     };
 }
@@ -4711,6 +4758,7 @@ function _syncBootstrapUi() {
     const selectedJob = _findJobById(state.selectedJobId);
     renderSelectedJobRecoveryActions(selectedJob);
     renderReviewStatusActions(selectedJob);
+    renderArtifactViewer();
 }
 
 function _applyPortalBootstrap(rawBootstrap, options = {}) {
@@ -4730,7 +4778,8 @@ function _applyPortalBootstrap(rawBootstrap, options = {}) {
         actor: mode === 'managed' && bootstrap.actor && typeof bootstrap.actor === 'object' ? bootstrap.actor : null,
         features: {
             apiKeyInput: mode === 'direct_debug' && bootstrap.features?.apiKeyInput !== false,
-            directDebug: mode === 'direct_debug' && bootstrap.features?.directDebug !== false
+            directDebug: mode === 'direct_debug' && bootstrap.features?.directDebug !== false,
+            artifactViewerModal: Boolean(bootstrap.features?.artifactViewerModal)
         }
     };
     _setBootstrapStatus(nextStatus, options.reason || '', options.httpStatus || 0);
@@ -5355,6 +5404,7 @@ function _renderArtifactProvenance(job, artifact) {
             els.reviewProvenancePath.textContent = 'Preview, metadata, and actions will appear here when outputs are indexed.';
             els.reviewProvenancePath.removeAttribute('title');
         }
+        if (els.reviewProvenanceFingerprint) els.reviewProvenanceFingerprint.textContent = 'Not reported';
         if (els.reviewProvenanceFreshness) els.reviewProvenanceFreshness.textContent = 'No live telemetry';
         if (els.reviewProvenanceSource) els.reviewProvenanceSource.textContent = 'Not reported';
         if (els.reviewProvenanceBatch) els.reviewProvenanceBatch.textContent = 'Not reported';
@@ -5377,6 +5427,7 @@ function _renderArtifactProvenance(job, artifact) {
         els.reviewProvenancePath.textContent = relativePath;
         els.reviewProvenancePath.title = relativePath;
     }
+    if (els.reviewProvenanceFingerprint) els.reviewProvenanceFingerprint.textContent = _artifactFingerprintLabel(artifact);
     if (els.reviewProvenanceFreshness) els.reviewProvenanceFreshness.textContent = freshnessLabel;
     if (els.reviewProvenanceSource) els.reviewProvenanceSource.textContent = sourceLabel;
     if (els.reviewProvenanceBatch) els.reviewProvenanceBatch.textContent = batchLabel;
@@ -5412,11 +5463,16 @@ function _resetArtifactActionButtons() {
         els.copyArtifactPathBtn.disabled = true;
         delete els.copyArtifactPathBtn.dataset.path;
     }
+    if (els.copyArtifactFingerprintBtn) {
+        els.copyArtifactFingerprintBtn.disabled = true;
+        delete els.copyArtifactFingerprintBtn.dataset.fingerprint;
+    }
 }
 
 function renderReviewSurfaces(payload = null) {
     const currentPayload = payload || generatePayload();
     renderArtifactPanel();
+    renderArtifactViewer();
     renderSelectedJobInspector();
     renderReconstructionRuntimeSummary(currentPayload);
     renderMissionControl(payload);
@@ -5567,6 +5623,7 @@ function renderArtifactPanel() {
 
     if (els.openArtifactBtn) {
         const openUrl = selectedArtifact ? buildArtifactUrl(selected, selectedArtifact) : '';
+        els.openArtifactBtn.textContent = _artifactViewerEnabled() ? 'Inspect' : 'Open';
         els.openArtifactBtn.disabled = !openUrl;
         els.openArtifactBtn.dataset.url = openUrl;
     }
@@ -5579,6 +5636,11 @@ function renderArtifactPanel() {
     if (els.copyArtifactPathBtn) {
         els.copyArtifactPathBtn.disabled = !selectedArtifact;
         els.copyArtifactPathBtn.dataset.path = selectedArtifact ? artifactLabel(selectedArtifact) : '';
+    }
+    if (els.copyArtifactFingerprintBtn) {
+        const fingerprint = selectedArtifact ? artifactFingerprint(selectedArtifact) : '';
+        els.copyArtifactFingerprintBtn.disabled = !fingerprint;
+        els.copyArtifactFingerprintBtn.dataset.fingerprint = fingerprint;
     }
 
     if (els.artifactCompareStage) {
@@ -9815,6 +9877,17 @@ if (els.copyArtifactPathBtn) {
     });
 }
 
+if (els.copyArtifactFingerprintBtn) {
+    els.copyArtifactFingerprintBtn.addEventListener('click', async () => {
+        const fingerprint = String(els.copyArtifactFingerprintBtn.dataset.fingerprint || '').trim();
+        if (!fingerprint) {
+            createToast('No artifact fingerprint is available for this selection.', 'error');
+            return;
+        }
+        await copyToClipboard(fingerprint);
+    });
+}
+
 if (els.viewRunCardBtn) els.viewRunCardBtn.addEventListener('click', async () => {
     const runCardUrl = sanitizeManagedAssetUrl(els.viewRunCardBtn.dataset.url);
     if (!runCardUrl) {
@@ -9971,6 +10044,9 @@ function _overlayFocusableElements(root) {
 }
 
 function _activeOverlayPanel() {
+    if (els.artifactViewerModal && !els.artifactViewerModal.classList.contains('hidden')) {
+        return els.artifactViewerPanel;
+    }
     if (els.shortcutsModal && !els.shortcutsModal.classList.contains('hidden')) {
         return els.shortcutsPanel;
     }
@@ -10010,6 +10086,176 @@ function _isTypingTarget(target) {
     if (tagName !== 'input') return false;
     const inputType = String(target.getAttribute('type') || 'text').trim().toLowerCase();
     return !['button', 'checkbox', 'color', 'file', 'hidden', 'radio', 'range', 'reset', 'submit'].includes(inputType);
+}
+
+function _artifactViewerContext() {
+    const viewerState = state.portalUi?.artifactViewer || {};
+    const requestedJobId = _normalizeSelectedJobId(viewerState.jobId || state.selectedJobId);
+    const job = requestedJobId ? _findJobById(requestedJobId) : null;
+    const artifacts = Array.isArray(job?.artifacts) ? rankArtifactsForDisplay(job.artifacts) : [];
+    if (!job || artifacts.length === 0) {
+        return {
+            job,
+            artifacts,
+            artifact: null,
+            index: -1,
+            url: '',
+            inlinePreview: false,
+            zoomPercent: 100
+        };
+    }
+    const requestedPath = _normalizeArtifactRoutePath(viewerState.artifactPath || '');
+    const artifact = artifacts.find((candidate) => _artifactRouteKey(candidate) === requestedPath)
+        || _selectedArtifactForJob(job)
+        || artifacts[0]
+        || null;
+    const index = artifact ? artifacts.findIndex((candidate) => candidate.path === artifact.path) : -1;
+    const url = artifact ? sanitizeManagedAssetUrl(buildArtifactUrl(job, artifact)) : '';
+    return {
+        job,
+        artifacts,
+        artifact,
+        index,
+        url,
+        inlinePreview: Boolean(artifact && artifactIsPreviewable(artifact) && url),
+        zoomPercent: clamp(Number(viewerState.zoomPercent || 100), 50, 250)
+    };
+}
+
+function _setArtifactViewerZoom(nextZoom) {
+    state.portalUi.artifactViewer.zoomPercent = clamp(Number(nextZoom || 100), 50, 250);
+    renderArtifactViewer();
+}
+
+function _navigateArtifactViewerSelection(direction) {
+    const context = _artifactViewerContext();
+    if (!context.job || !context.artifact) return false;
+    const nextIndex = context.index + Number(direction || 0);
+    if (nextIndex < 0 || nextIndex >= context.artifacts.length) return false;
+    const nextArtifact = context.artifacts[nextIndex];
+    const nextPath = _artifactRouteKey(nextArtifact);
+    state.portalUi.artifactViewer.jobId = _normalizeSelectedJobId(context.job.id);
+    state.portalUi.artifactViewer.artifactPath = nextPath;
+    state.portalUi.artifactViewer.zoomPercent = 100;
+    _rememberArtifactSelection(context.job.id, nextPath);
+    renderReviewSurfaces();
+    return true;
+}
+
+function renderArtifactViewer() {
+    if (!els.artifactViewerModal || !els.artifactViewerPanel) return;
+    const shouldShow = Boolean(state.portalUi?.artifactViewer?.open) && _artifactViewerEnabled();
+    els.artifactViewerModal.classList.toggle('hidden', !shouldShow);
+    els.artifactViewerModal.classList.toggle('flex', shouldShow);
+    els.artifactViewerModal.setAttribute('aria-hidden', shouldShow ? 'false' : 'true');
+    els.artifactViewerModal.dataset.overlayOpen = shouldShow ? 'true' : 'false';
+    if (!shouldShow) {
+        if (!_artifactViewerEnabled()) {
+            state.portalUi.artifactViewer.open = false;
+        }
+        if (els.artifactViewerImage) {
+            els.artifactViewerImage.classList.add('hidden');
+            els.artifactViewerImage.removeAttribute('src');
+            els.artifactViewerImage.style.transform = 'scale(1)';
+        }
+        if (els.artifactViewerFallback) els.artifactViewerFallback.classList.add('hidden');
+        return;
+    }
+
+    const context = _artifactViewerContext();
+    if (!context.job || !context.artifact) {
+        state.portalUi.artifactViewer.open = false;
+        renderArtifactViewer();
+        return;
+    }
+
+    const { artifact, index, artifacts, inlinePreview, job, url, zoomPercent } = context;
+    const relPath = artifactLabel(artifact);
+    const fingerprint = artifactFingerprint(artifact);
+    if (els.artifactViewerTitle) els.artifactViewerTitle.textContent = artifactNameParts(artifact).fileName;
+    if (els.artifactViewerMeta) {
+        els.artifactViewerMeta.textContent =
+            `${artifactDisplayLabel(artifact)} • ${artifactContentType(artifact) || 'binary'} • ${formatBytes(artifact.size_bytes)}`;
+    }
+    if (els.artifactViewerPath) els.artifactViewerPath.textContent = relPath;
+    if (els.artifactViewerFingerprint) els.artifactViewerFingerprint.textContent = _artifactFingerprintLabel(artifact);
+    if (els.artifactViewerZoomValue) {
+        els.artifactViewerZoomValue.textContent = inlinePreview ? `${zoomPercent}% zoom` : 'Inline preview unavailable';
+    }
+    if (els.artifactViewerPrevBtn) els.artifactViewerPrevBtn.disabled = index <= 0;
+    if (els.artifactViewerNextBtn) els.artifactViewerNextBtn.disabled = index >= (artifacts.length - 1);
+    if (els.artifactViewerZoomOutBtn) els.artifactViewerZoomOutBtn.disabled = !inlinePreview;
+    if (els.artifactViewerZoomInBtn) els.artifactViewerZoomInBtn.disabled = !inlinePreview;
+    if (els.artifactViewerResetZoomBtn) els.artifactViewerResetZoomBtn.disabled = !inlinePreview;
+    if (els.artifactViewerOpenRawBtn) {
+        els.artifactViewerOpenRawBtn.disabled = !url;
+        els.artifactViewerOpenRawBtn.dataset.url = url;
+    }
+    if (els.artifactViewerCopyPathBtn) {
+        els.artifactViewerCopyPathBtn.disabled = !relPath;
+        els.artifactViewerCopyPathBtn.dataset.path = relPath;
+    }
+    if (els.artifactViewerCopyFingerprintBtn) {
+        els.artifactViewerCopyFingerprintBtn.disabled = !fingerprint;
+        els.artifactViewerCopyFingerprintBtn.dataset.fingerprint = fingerprint;
+    }
+
+    if (inlinePreview && els.artifactViewerImage) {
+        els.artifactViewerImage.src = url;
+        els.artifactViewerImage.classList.remove('hidden');
+        els.artifactViewerImage.style.transform = `scale(${zoomPercent / 100})`;
+        if (els.artifactViewerFallback) els.artifactViewerFallback.classList.add('hidden');
+        return;
+    }
+
+    if (els.artifactViewerImage) {
+        els.artifactViewerImage.classList.add('hidden');
+        els.artifactViewerImage.removeAttribute('src');
+        els.artifactViewerImage.style.transform = 'scale(1)';
+    }
+    if (els.artifactViewerFallback) {
+        els.artifactViewerFallback.classList.remove('hidden');
+    }
+    if (els.artifactViewerFallbackTitle) {
+        els.artifactViewerFallbackTitle.textContent = url ? 'Inline preview unavailable' : 'Artifact URL unavailable';
+    }
+    if (els.artifactViewerFallbackDetail) {
+        els.artifactViewerFallbackDetail.textContent = url
+            ? 'This artifact stays reviewable through retained metadata, integrity fingerprints, and the managed raw asset link.'
+            : 'The browser cannot resolve a managed asset URL for this artifact, so review stays pinned to the retained metadata above.';
+    }
+}
+
+function _closeArtifactViewer(restoreFocus = true) {
+    state.portalUi.artifactViewer.open = false;
+    renderArtifactViewer();
+    if (restoreFocus) {
+        _restoreOverlayFocus();
+    }
+}
+
+function _openArtifactViewer(job, artifact, trigger = document.activeElement) {
+    if (!_artifactViewerEnabled() || !els.artifactViewerModal) return false;
+    if (!job || !artifact) {
+        createToast('No artifact is available for this selection.', 'info');
+        return false;
+    }
+    state.portalUi.artifactViewer.open = true;
+    state.portalUi.artifactViewer.jobId = _normalizeSelectedJobId(job.id);
+    state.portalUi.artifactViewer.artifactPath = _artifactRouteKey(artifact);
+    state.portalUi.artifactViewer.zoomPercent = 100;
+    _rememberOverlayTrigger(trigger);
+    renderArtifactViewer();
+    if (els.closeArtifactViewerBtn) els.closeArtifactViewerBtn.focus();
+    void emitPortalEvent('artifact_viewer_opened', {
+        surface: 'artifact_viewer_modal',
+        metadata: {
+            job_id: String(job.id || ''),
+            media_kind: String(artifact.media_kind || 'file'),
+            pipeline: String(job.pipeline || '')
+        }
+    });
+    return true;
 }
 
 const toggleModal = (show, trigger = document.activeElement) => {
@@ -10081,6 +10327,69 @@ if (els.effectiveConfigDrawer) {
         if (e.target === els.effectiveConfigDrawer) toggleEffectiveConfigDrawer(false);
     });
 }
+if (els.closeArtifactViewerBtn) {
+    els.closeArtifactViewerBtn.addEventListener('click', () => _closeArtifactViewer());
+}
+if (els.artifactViewerModal) {
+    els.artifactViewerModal.addEventListener('click', (event) => {
+        if (event.target === els.artifactViewerModal) _closeArtifactViewer();
+    });
+}
+if (els.artifactViewerPrevBtn) {
+    els.artifactViewerPrevBtn.addEventListener('click', () => {
+        _navigateArtifactViewerSelection(-1);
+    });
+}
+if (els.artifactViewerNextBtn) {
+    els.artifactViewerNextBtn.addEventListener('click', () => {
+        _navigateArtifactViewerSelection(1);
+    });
+}
+if (els.artifactViewerZoomOutBtn) {
+    els.artifactViewerZoomOutBtn.addEventListener('click', () => {
+        _setArtifactViewerZoom((state.portalUi?.artifactViewer?.zoomPercent || 100) - 25);
+    });
+}
+if (els.artifactViewerZoomInBtn) {
+    els.artifactViewerZoomInBtn.addEventListener('click', () => {
+        _setArtifactViewerZoom((state.portalUi?.artifactViewer?.zoomPercent || 100) + 25);
+    });
+}
+if (els.artifactViewerResetZoomBtn) {
+    els.artifactViewerResetZoomBtn.addEventListener('click', () => {
+        _setArtifactViewerZoom(100);
+    });
+}
+if (els.artifactViewerOpenRawBtn) {
+    els.artifactViewerOpenRawBtn.addEventListener('click', () => {
+        const url = sanitizeManagedAssetUrl(els.artifactViewerOpenRawBtn.dataset.url);
+        if (!url) {
+            createToast('No artifact URL is available for this selection.', 'error');
+            return;
+        }
+        window.open(url, '_blank', 'noopener,noreferrer');
+    });
+}
+if (els.artifactViewerCopyPathBtn) {
+    els.artifactViewerCopyPathBtn.addEventListener('click', async () => {
+        const path = String(els.artifactViewerCopyPathBtn.dataset.path || '').trim();
+        if (!path) {
+            createToast('No artifact path is available for this selection.', 'error');
+            return;
+        }
+        await copyToClipboard(path);
+    });
+}
+if (els.artifactViewerCopyFingerprintBtn) {
+    els.artifactViewerCopyFingerprintBtn.addEventListener('click', async () => {
+        const fingerprint = String(els.artifactViewerCopyFingerprintBtn.dataset.fingerprint || '').trim();
+        if (!fingerprint) {
+            createToast('No artifact fingerprint is available for this selection.', 'error');
+            return;
+        }
+        await copyToClipboard(fingerprint);
+    });
+}
 
 document.addEventListener('keydown', (e) => {
     if (_trapOverlayFocus(e)) {
@@ -10088,6 +10397,11 @@ document.addEventListener('keydown', (e) => {
     }
     const key = String(e.key || '');
     const isPlainShortcut = !e.ctrlKey && !e.metaKey && !e.altKey && !_isTypingTarget(e.target);
+    if (e.key === "Escape" && els.artifactViewerModal && !els.artifactViewerModal.classList.contains("hidden")) {
+        e.preventDefault();
+        _closeArtifactViewer();
+        return;
+    }
     if (e.key === "Escape" && els.effectiveConfigDrawer && !els.effectiveConfigDrawer.classList.contains("hidden")) {
         e.preventDefault();
         toggleEffectiveConfigDrawer(false);
@@ -10115,6 +10429,33 @@ document.addEventListener('keydown', (e) => {
         e.preventDefault();
         navigateConsoleView(nextView);
         return;
+    }
+    if (isPlainShortcut && els.artifactViewerModal && !els.artifactViewerModal.classList.contains('hidden')) {
+        if (key === 'ArrowLeft') {
+            e.preventDefault();
+            _navigateArtifactViewerSelection(-1);
+            return;
+        }
+        if (key === 'ArrowRight') {
+            e.preventDefault();
+            _navigateArtifactViewerSelection(1);
+            return;
+        }
+        if (key === '+' || key === '=') {
+            e.preventDefault();
+            _setArtifactViewerZoom((state.portalUi?.artifactViewer?.zoomPercent || 100) + 25);
+            return;
+        }
+        if (key === '-') {
+            e.preventDefault();
+            _setArtifactViewerZoom((state.portalUi?.artifactViewer?.zoomPercent || 100) - 25);
+            return;
+        }
+        if (key === '0') {
+            e.preventDefault();
+            _setArtifactViewerZoom(100);
+            return;
+        }
     }
     if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
         e.preventDefault();

--- a/public/portal-assets/portal.js
+++ b/public/portal-assets/portal.js
@@ -1839,7 +1839,10 @@ function _openArtifactForSelection(job, artifact, surface = 'artifact_review') {
         return false;
     }
     if (_artifactViewerEnabled()) {
-        return _openArtifactViewer(job, artifact);
+        const openedInViewer = _openArtifactViewer(job, artifact);
+        if (openedInViewer) {
+            return true;
+        }
     }
     const url = sanitizeManagedAssetUrl(buildArtifactUrl(job, artifact));
     if (!url) {

--- a/tests/test_app_orchestrator_contract_http.py
+++ b/tests/test_app_orchestrator_contract_http.py
@@ -117,6 +117,20 @@ def test_portal_bootstrap_reports_direct_debug_mode(client: TestClient) -> None:
     assert body["actor"] is None
     assert body["features"]["apiKeyInput"] is True
     assert body["features"]["directDebug"] is True
+    assert body["features"]["artifactViewerModal"] is False
+
+
+def test_portal_bootstrap_exposes_artifact_viewer_rollout_flag_when_enabled(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TP_PORTAL_ARTIFACT_VIEWER_MODAL_ROLLOUT_PERCENT", "100")
+    monkeypatch.setenv("TP_PORTAL_DIRECT_DEBUG_COHORT_KEY", "contract-smoke")
+
+    response = client.get("/portal/bootstrap")
+
+    assert response.status_code == 200
+    assert response.json()["features"]["artifactViewerModal"] is True
 
 
 def test_root_ui_response_is_not_cached(client: TestClient) -> None:

--- a/tests/test_app_orchestrator_runtime.py
+++ b/tests/test_app_orchestrator_runtime.py
@@ -682,6 +682,7 @@ def test_portal_bootstrap_loader_uses_abortable_timeout_and_state_contract() -> 
     assert "authMode: 'managed_unavailable'" in default_body
     assert "apiKeyInput: false" in default_body
     assert "directDebug: false" in default_body
+    assert "artifactViewerModal: false" in default_body
     assert "const BOOTSTRAP_TIMEOUT_MS = 3500;" in content
     assert "const BOOTSTRAP_RETRY_BASE_DELAY_MS = 1000;" in content
     assert "const BOOTSTRAP_RETRY_MAX_DELAY_MS = 12000;" in content
@@ -712,6 +713,7 @@ def test_portal_bootstrap_loader_uses_abortable_timeout_and_state_contract() -> 
     assert "_finalizeBootstrapRetry('terminal_invalid_json', { reason: 'invalid_json' });" in body
     assert "_finalizeBootstrapRetry('succeeded', {" in body
     assert "_applyPortalBootstrap(payload, { status: 'ready' });" in body
+    assert "artifactViewerModal: Boolean(bootstrap.features?.artifactViewerModal)" in content
     assert "previousHealthEndpointPath !== nextHealthEndpointPath" in body
     assert "_queueBootstrapOnlineFollowup();" in body
     assert "_flushBootstrapOnlineFollowup();" in body
@@ -881,6 +883,7 @@ def test_portal_artifact_gallery_renders_visual_review_controls() -> None:
     assert 'id="openArtifactBtn"' in content
     assert 'id="downloadArtifactBtn"' in content
     assert 'id="copyArtifactPathBtn"' in content
+    assert 'id="copyArtifactFingerprintBtn"' in content
     assert "artifactHeroScore" in content
     assert "findCompareArtifact" in content
     assert "artifactDisplayHint" in content
@@ -902,9 +905,11 @@ def test_portal_artifact_gallery_renders_visual_review_controls() -> None:
     assert "delete els.openArtifactBtn.dataset.url;" in reset_body
     assert "delete els.downloadArtifactBtn.dataset.filename;" in reset_body
     assert "delete els.copyArtifactPathBtn.dataset.path;" in reset_body
+    assert "delete els.copyArtifactFingerprintBtn.dataset.fingerprint;" in reset_body
     assert "parsed.origin !== window.location.origin" in sanitize_body
     assert "parsed.pathname.startsWith('/v1/jobs/')" in sanitize_body
-    assert "sanitizeManagedAssetUrl(buildArtifactUrl(job, artifact))" in open_artifact_body
+    assert "_artifactViewerEnabled()" in open_artifact_body
+    assert "_openArtifactViewer(job, artifact);" in open_artifact_body
     assert "sanitizeManagedAssetUrl(els.downloadArtifactBtn.dataset.url)" in content
 
 
@@ -922,6 +927,7 @@ def test_portal_review_surface_exposes_warning_banner_and_provenance_contract() 
     assert 'id="reviewProvenanceArtifactRole"' in content
     assert 'id="reviewProvenanceRunState"' in content
     assert 'id="reviewProvenancePath"' in content
+    assert 'id="reviewProvenanceFingerprint"' in content
     assert 'id="reviewProvenanceFreshness"' in content
     assert 'id="reviewProvenanceSource"' in content
     assert 'id="reviewProvenanceBatch"' in content
@@ -945,9 +951,59 @@ def test_portal_review_surface_exposes_warning_banner_and_provenance_contract() 
     assert "els.reviewStatusBanner.dataset.tone = snapshot.tone;" in banner_body
     assert "artifactDisplayLabel(artifact)" in provenance_body
     assert "artifactLabel(artifact)" in provenance_body
+    assert "_artifactFingerprintLabel(artifact)" in provenance_body
     assert "titleCaseToken(job.state, 'Unknown')" in provenance_body
     assert "summary?.batch_id" in provenance_body
     assert "summary?.source" in provenance_body
+
+
+def test_portal_artifact_viewer_modal_is_feature_flagged_and_keyboard_complete() -> None:
+    content = _portal_bundle_content()
+    active_overlay_body = _extract_js_function_body(content, "_activeOverlayPanel")
+    render_body = _extract_js_function_body(content, "renderArtifactViewer")
+    open_body = _extract_js_function_body(content, "_openArtifactViewer")
+    navigate_body = _extract_js_function_body(content, "_navigateArtifactViewerSelection")
+    close_body = _extract_js_function_body(content, "_closeArtifactViewer")
+
+    assert 'id="artifactViewerModal"' in content
+    assert 'id="artifactViewerPanel"' in content
+    assert 'id="artifactViewerTitle"' in content
+    assert 'id="artifactViewerImage"' in content
+    assert 'id="artifactViewerFallback"' in content
+    assert 'id="artifactViewerPrevBtn"' in content
+    assert 'id="artifactViewerNextBtn"' in content
+    assert 'id="artifactViewerZoomOutBtn"' in content
+    assert 'id="artifactViewerZoomInBtn"' in content
+    assert 'id="artifactViewerResetZoomBtn"' in content
+    assert 'id="artifactViewerOpenRawBtn"' in content
+    assert 'id="artifactViewerCopyPathBtn"' in content
+    assert 'id="artifactViewerCopyFingerprintBtn"' in content
+    assert "return Boolean(state.auth?.features?.artifactViewerModal);" in content
+    assert "if (els.artifactViewerModal && !els.artifactViewerModal.classList.contains('hidden'))" in active_overlay_body
+    assert "state.portalUi.artifactViewer.open = true;" in open_body
+    assert "_rememberOverlayTrigger(trigger);" in open_body
+    assert "els.closeArtifactViewerBtn.focus();" in open_body
+    assert "artifact_viewer_opened" in open_body
+    assert "state.portalUi.artifactViewer.open = false;" in close_body
+    assert "_restoreOverlayFocus();" in close_body
+    assert "els.artifactViewerModal.classList.toggle('hidden', !shouldShow);" in render_body
+    assert "els.artifactViewerImage.style.transform = `scale(${zoomPercent / 100})`;" in render_body
+    assert (
+        "els.artifactViewerFallbackTitle.textContent = url ? 'Inline preview unavailable' : 'Artifact URL unavailable';"
+        in render_body
+    )
+    assert "els.artifactViewerCopyFingerprintBtn.dataset.fingerprint = fingerprint;" in render_body
+    assert "_rememberArtifactSelection(context.job.id, nextPath);" in navigate_body
+    assert "renderReviewSurfaces();" in navigate_body
+    assert (
+        'if (e.key === "Escape" && els.artifactViewerModal && !els.artifactViewerModal.classList.contains("hidden"))'
+        in content
+    )
+    assert "if (key === 'ArrowLeft')" in content
+    assert "if (key === 'ArrowRight')" in content
+    assert "if (key === '+' || key === '=')" in content
+    assert "if (key === '-')" in content
+    assert "if (key === '0')" in content
 
 
 def test_portal_review_surface_supports_compare_summary_and_keyboard_selection() -> None:

--- a/tests/test_app_orchestrator_runtime.py
+++ b/tests/test_app_orchestrator_runtime.py
@@ -909,7 +909,10 @@ def test_portal_artifact_gallery_renders_visual_review_controls() -> None:
     assert "parsed.origin !== window.location.origin" in sanitize_body
     assert "parsed.pathname.startsWith('/v1/jobs/')" in sanitize_body
     assert "_artifactViewerEnabled()" in open_artifact_body
-    assert "_openArtifactViewer(job, artifact);" in open_artifact_body
+    assert "const openedInViewer = _openArtifactViewer(job, artifact);" in open_artifact_body
+    assert "if (openedInViewer) {" in open_artifact_body
+    assert "return true;" in open_artifact_body
+    assert "const url = sanitizeManagedAssetUrl(buildArtifactUrl(job, artifact));" in open_artifact_body
     assert "sanitizeManagedAssetUrl(els.downloadArtifactBtn.dataset.url)" in content
 
 

--- a/web/secure-landing/app/portal/bootstrap/route.js
+++ b/web/secure-landing/app/portal/bootstrap/route.js
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import { NextResponse } from "next/server.js";
 
 import { revokeSessionOnAccessFailure, resolveAuthenticatedAccessSession } from "../../../lib/access.js";
@@ -10,6 +12,35 @@ import {
 import { clearSessionCookie } from "../../../lib/sessions.js";
 
 export const runtime = "nodejs";
+
+function parseRolloutPercent(rawValue) {
+  const parsed = Number.parseInt(String(rawValue || "").trim(), 10);
+  if (!Number.isFinite(parsed)) {
+    return 0;
+  }
+  return Math.max(0, Math.min(100, parsed));
+}
+
+function stableRolloutBucket(key) {
+  const normalized = String(key || "").trim().toLowerCase();
+  if (!normalized) {
+    return 100;
+  }
+  const digest = createHash("sha256").update(normalized).digest("hex");
+  return Number.parseInt(digest.slice(0, 8), 16) % 100;
+}
+
+function resolveArtifactViewerModal(session, env = process.env) {
+  const rolloutPercent = parseRolloutPercent(env.TP_PORTAL_ARTIFACT_VIEWER_MODAL_ROLLOUT_PERCENT);
+  if (rolloutPercent <= 0) {
+    return false;
+  }
+  const cohortKey = String(session?.username || session?.accessEmail || session?.role || "").trim().toLowerCase();
+  if (!cohortKey) {
+    return false;
+  }
+  return stableRolloutBucket(cohortKey) < rolloutPercent;
+}
 
 export async function GET(request) {
   const authState = await resolveAuthenticatedAccessSession(request, { touch: true });
@@ -59,7 +90,8 @@ export async function GET(request) {
         },
         features: {
           apiKeyInput: false,
-          directDebug: false
+          directDebug: false,
+          artifactViewerModal: resolveArtifactViewerModal(session)
         }
       },
       {

--- a/web/secure-landing/portal-src/internal/bootstrap-auth.js
+++ b/web/secure-landing/portal-src/internal/bootstrap-auth.js
@@ -5,7 +5,8 @@ export function defaultPortalBootstrapPayload() {
     actor: null,
     features: {
       apiKeyInput: false,
-      directDebug: false
+      directDebug: false,
+      artifactViewerModal: false
     }
   };
 }

--- a/web/secure-landing/portal-src/internal/state.js
+++ b/web/secure-landing/portal-src/internal/state.js
@@ -99,6 +99,12 @@ export function createPortalUiState() {
   return {
     debugBundleAcknowledged: false,
     effectiveConfigOpen: false,
+    artifactViewer: {
+      open: false,
+      jobId: "",
+      artifactPath: "",
+      zoomPercent: 100
+    },
     debugBundleGuardrailSeen: false,
     buildStep: 1,
     lastOverlayTrigger: null,
@@ -126,7 +132,8 @@ export function createPortalAuthState() {
     actor: null,
     features: {
       apiKeyInput: false,
-      directDebug: false
+      directDebug: false,
+      artifactViewerModal: false
     }
   };
 }

--- a/web/secure-landing/portal-src/portal.template.js
+++ b/web/secure-landing/portal-src/portal.template.js
@@ -446,6 +446,7 @@ const els = {
     reviewProvenanceArtifactRole: _domId('reviewProvenanceArtifactRole'),
     reviewProvenanceRunState: _domId('reviewProvenanceRunState'),
     reviewProvenancePath: _domId('reviewProvenancePath'),
+    reviewProvenanceFingerprint: _domId('reviewProvenanceFingerprint'),
     reviewProvenanceFreshness: _domId('reviewProvenanceFreshness'),
     reviewProvenanceSource: _domId('reviewProvenanceSource'),
     reviewProvenanceBatch: _domId('reviewProvenanceBatch'),
@@ -455,6 +456,7 @@ const els = {
     openArtifactBtn: _domId('openArtifactBtn'),
     downloadArtifactBtn: _domId('downloadArtifactBtn'),
     copyArtifactPathBtn: _domId('copyArtifactPathBtn'),
+    copyArtifactFingerprintBtn: _domId('copyArtifactFingerprintBtn'),
     artifactThumbnailRail: _domId('artifactThumbnailRail'),
     runCardActions: _domId('runCardActions'),
     viewRunCardBtn: _domId('viewRunCardBtn'),
@@ -485,6 +487,27 @@ const els = {
     effectiveEstimateLabel: _domId('effectiveEstimateLabel'),
     effectiveReadinessSummary: _domId('effectiveReadinessSummary'),
     effectiveArgvPreview: _domId('effectiveArgvPreview'),
+    artifactViewerModal: _domId('artifactViewerModal'),
+    artifactViewerPanel: _domId('artifactViewerPanel'),
+    artifactViewerTitle: _domId('artifactViewerTitle'),
+    artifactViewerMeta: _domId('artifactViewerMeta'),
+    artifactViewerStage: _domId('artifactViewerStage'),
+    artifactViewerImage: _domId('artifactViewerImage'),
+    artifactViewerFallback: _domId('artifactViewerFallback'),
+    artifactViewerFallbackTitle: _domId('artifactViewerFallbackTitle'),
+    artifactViewerFallbackDetail: _domId('artifactViewerFallbackDetail'),
+    artifactViewerPath: _domId('artifactViewerPath'),
+    artifactViewerFingerprint: _domId('artifactViewerFingerprint'),
+    artifactViewerZoomValue: _domId('artifactViewerZoomValue'),
+    artifactViewerPrevBtn: _domId('artifactViewerPrevBtn'),
+    artifactViewerNextBtn: _domId('artifactViewerNextBtn'),
+    artifactViewerZoomOutBtn: _domId('artifactViewerZoomOutBtn'),
+    artifactViewerZoomInBtn: _domId('artifactViewerZoomInBtn'),
+    artifactViewerResetZoomBtn: _domId('artifactViewerResetZoomBtn'),
+    artifactViewerOpenRawBtn: _domId('artifactViewerOpenRawBtn'),
+    artifactViewerCopyPathBtn: _domId('artifactViewerCopyPathBtn'),
+    artifactViewerCopyFingerprintBtn: _domId('artifactViewerCopyFingerprintBtn'),
+    closeArtifactViewerBtn: _domId('closeArtifactViewerBtn'),
 
     healthIndicator: _domId('healthIndicator'),
     healthText: _domId('healthText'),
@@ -1410,6 +1433,9 @@ function _openArtifactForSelection(job, artifact, surface = 'artifact_review') {
     if (!job || !artifact) {
         createToast('No artifact is available for this selection.', 'info');
         return false;
+    }
+    if (_artifactViewerEnabled()) {
+        return _openArtifactViewer(job, artifact);
     }
     const url = sanitizeManagedAssetUrl(buildArtifactUrl(job, artifact));
     if (!url) {
@@ -2736,6 +2762,18 @@ function buildArtifactUrl(job, artifact) {
     });
 }
 
+function artifactFingerprint(artifact) {
+    return String(artifact?.sha256 || '').trim();
+}
+
+function _artifactFingerprintLabel(artifact) {
+    return artifactFingerprint(artifact) || 'Not reported';
+}
+
+function _artifactViewerEnabled() {
+    return Boolean(state.auth?.features?.artifactViewerModal);
+}
+
 function artifactHeroScore(artifact) {
     if (!artifact || typeof artifact !== 'object') return -1;
     const info = artifactNameParts(artifact);
@@ -3942,7 +3980,8 @@ function _defaultPortalBootstrap() {
         actor: null,
         features: {
             apiKeyInput: false,
-            directDebug: false
+            directDebug: false,
+            artifactViewerModal: false
         }
     };
 }
@@ -4315,6 +4354,7 @@ function _syncBootstrapUi() {
     const selectedJob = _findJobById(state.selectedJobId);
     renderSelectedJobRecoveryActions(selectedJob);
     renderReviewStatusActions(selectedJob);
+    renderArtifactViewer();
 }
 
 function _applyPortalBootstrap(rawBootstrap, options = {}) {
@@ -4334,7 +4374,8 @@ function _applyPortalBootstrap(rawBootstrap, options = {}) {
         actor: mode === 'managed' && bootstrap.actor && typeof bootstrap.actor === 'object' ? bootstrap.actor : null,
         features: {
             apiKeyInput: mode === 'direct_debug' && bootstrap.features?.apiKeyInput !== false,
-            directDebug: mode === 'direct_debug' && bootstrap.features?.directDebug !== false
+            directDebug: mode === 'direct_debug' && bootstrap.features?.directDebug !== false,
+            artifactViewerModal: Boolean(bootstrap.features?.artifactViewerModal)
         }
     };
     _setBootstrapStatus(nextStatus, options.reason || '', options.httpStatus || 0);
@@ -4959,6 +5000,7 @@ function _renderArtifactProvenance(job, artifact) {
             els.reviewProvenancePath.textContent = 'Preview, metadata, and actions will appear here when outputs are indexed.';
             els.reviewProvenancePath.removeAttribute('title');
         }
+        if (els.reviewProvenanceFingerprint) els.reviewProvenanceFingerprint.textContent = 'Not reported';
         if (els.reviewProvenanceFreshness) els.reviewProvenanceFreshness.textContent = 'No live telemetry';
         if (els.reviewProvenanceSource) els.reviewProvenanceSource.textContent = 'Not reported';
         if (els.reviewProvenanceBatch) els.reviewProvenanceBatch.textContent = 'Not reported';
@@ -4981,6 +5023,7 @@ function _renderArtifactProvenance(job, artifact) {
         els.reviewProvenancePath.textContent = relativePath;
         els.reviewProvenancePath.title = relativePath;
     }
+    if (els.reviewProvenanceFingerprint) els.reviewProvenanceFingerprint.textContent = _artifactFingerprintLabel(artifact);
     if (els.reviewProvenanceFreshness) els.reviewProvenanceFreshness.textContent = freshnessLabel;
     if (els.reviewProvenanceSource) els.reviewProvenanceSource.textContent = sourceLabel;
     if (els.reviewProvenanceBatch) els.reviewProvenanceBatch.textContent = batchLabel;
@@ -5016,11 +5059,16 @@ function _resetArtifactActionButtons() {
         els.copyArtifactPathBtn.disabled = true;
         delete els.copyArtifactPathBtn.dataset.path;
     }
+    if (els.copyArtifactFingerprintBtn) {
+        els.copyArtifactFingerprintBtn.disabled = true;
+        delete els.copyArtifactFingerprintBtn.dataset.fingerprint;
+    }
 }
 
 function renderReviewSurfaces(payload = null) {
     const currentPayload = payload || generatePayload();
     renderArtifactPanel();
+    renderArtifactViewer();
     renderSelectedJobInspector();
     renderReconstructionRuntimeSummary(currentPayload);
     renderMissionControl(payload);
@@ -5171,6 +5219,7 @@ function renderArtifactPanel() {
 
     if (els.openArtifactBtn) {
         const openUrl = selectedArtifact ? buildArtifactUrl(selected, selectedArtifact) : '';
+        els.openArtifactBtn.textContent = _artifactViewerEnabled() ? 'Inspect' : 'Open';
         els.openArtifactBtn.disabled = !openUrl;
         els.openArtifactBtn.dataset.url = openUrl;
     }
@@ -5183,6 +5232,11 @@ function renderArtifactPanel() {
     if (els.copyArtifactPathBtn) {
         els.copyArtifactPathBtn.disabled = !selectedArtifact;
         els.copyArtifactPathBtn.dataset.path = selectedArtifact ? artifactLabel(selectedArtifact) : '';
+    }
+    if (els.copyArtifactFingerprintBtn) {
+        const fingerprint = selectedArtifact ? artifactFingerprint(selectedArtifact) : '';
+        els.copyArtifactFingerprintBtn.disabled = !fingerprint;
+        els.copyArtifactFingerprintBtn.dataset.fingerprint = fingerprint;
     }
 
     if (els.artifactCompareStage) {
@@ -9419,6 +9473,17 @@ if (els.copyArtifactPathBtn) {
     });
 }
 
+if (els.copyArtifactFingerprintBtn) {
+    els.copyArtifactFingerprintBtn.addEventListener('click', async () => {
+        const fingerprint = String(els.copyArtifactFingerprintBtn.dataset.fingerprint || '').trim();
+        if (!fingerprint) {
+            createToast('No artifact fingerprint is available for this selection.', 'error');
+            return;
+        }
+        await copyToClipboard(fingerprint);
+    });
+}
+
 if (els.viewRunCardBtn) els.viewRunCardBtn.addEventListener('click', async () => {
     const runCardUrl = sanitizeManagedAssetUrl(els.viewRunCardBtn.dataset.url);
     if (!runCardUrl) {
@@ -9575,6 +9640,9 @@ function _overlayFocusableElements(root) {
 }
 
 function _activeOverlayPanel() {
+    if (els.artifactViewerModal && !els.artifactViewerModal.classList.contains('hidden')) {
+        return els.artifactViewerPanel;
+    }
     if (els.shortcutsModal && !els.shortcutsModal.classList.contains('hidden')) {
         return els.shortcutsPanel;
     }
@@ -9614,6 +9682,176 @@ function _isTypingTarget(target) {
     if (tagName !== 'input') return false;
     const inputType = String(target.getAttribute('type') || 'text').trim().toLowerCase();
     return !['button', 'checkbox', 'color', 'file', 'hidden', 'radio', 'range', 'reset', 'submit'].includes(inputType);
+}
+
+function _artifactViewerContext() {
+    const viewerState = state.portalUi?.artifactViewer || {};
+    const requestedJobId = _normalizeSelectedJobId(viewerState.jobId || state.selectedJobId);
+    const job = requestedJobId ? _findJobById(requestedJobId) : null;
+    const artifacts = Array.isArray(job?.artifacts) ? rankArtifactsForDisplay(job.artifacts) : [];
+    if (!job || artifacts.length === 0) {
+        return {
+            job,
+            artifacts,
+            artifact: null,
+            index: -1,
+            url: '',
+            inlinePreview: false,
+            zoomPercent: 100
+        };
+    }
+    const requestedPath = _normalizeArtifactRoutePath(viewerState.artifactPath || '');
+    const artifact = artifacts.find((candidate) => _artifactRouteKey(candidate) === requestedPath)
+        || _selectedArtifactForJob(job)
+        || artifacts[0]
+        || null;
+    const index = artifact ? artifacts.findIndex((candidate) => candidate.path === artifact.path) : -1;
+    const url = artifact ? sanitizeManagedAssetUrl(buildArtifactUrl(job, artifact)) : '';
+    return {
+        job,
+        artifacts,
+        artifact,
+        index,
+        url,
+        inlinePreview: Boolean(artifact && artifactIsPreviewable(artifact) && url),
+        zoomPercent: clamp(Number(viewerState.zoomPercent || 100), 50, 250)
+    };
+}
+
+function _setArtifactViewerZoom(nextZoom) {
+    state.portalUi.artifactViewer.zoomPercent = clamp(Number(nextZoom || 100), 50, 250);
+    renderArtifactViewer();
+}
+
+function _navigateArtifactViewerSelection(direction) {
+    const context = _artifactViewerContext();
+    if (!context.job || !context.artifact) return false;
+    const nextIndex = context.index + Number(direction || 0);
+    if (nextIndex < 0 || nextIndex >= context.artifacts.length) return false;
+    const nextArtifact = context.artifacts[nextIndex];
+    const nextPath = _artifactRouteKey(nextArtifact);
+    state.portalUi.artifactViewer.jobId = _normalizeSelectedJobId(context.job.id);
+    state.portalUi.artifactViewer.artifactPath = nextPath;
+    state.portalUi.artifactViewer.zoomPercent = 100;
+    _rememberArtifactSelection(context.job.id, nextPath);
+    renderReviewSurfaces();
+    return true;
+}
+
+function renderArtifactViewer() {
+    if (!els.artifactViewerModal || !els.artifactViewerPanel) return;
+    const shouldShow = Boolean(state.portalUi?.artifactViewer?.open) && _artifactViewerEnabled();
+    els.artifactViewerModal.classList.toggle('hidden', !shouldShow);
+    els.artifactViewerModal.classList.toggle('flex', shouldShow);
+    els.artifactViewerModal.setAttribute('aria-hidden', shouldShow ? 'false' : 'true');
+    els.artifactViewerModal.dataset.overlayOpen = shouldShow ? 'true' : 'false';
+    if (!shouldShow) {
+        if (!_artifactViewerEnabled()) {
+            state.portalUi.artifactViewer.open = false;
+        }
+        if (els.artifactViewerImage) {
+            els.artifactViewerImage.classList.add('hidden');
+            els.artifactViewerImage.removeAttribute('src');
+            els.artifactViewerImage.style.transform = 'scale(1)';
+        }
+        if (els.artifactViewerFallback) els.artifactViewerFallback.classList.add('hidden');
+        return;
+    }
+
+    const context = _artifactViewerContext();
+    if (!context.job || !context.artifact) {
+        state.portalUi.artifactViewer.open = false;
+        renderArtifactViewer();
+        return;
+    }
+
+    const { artifact, index, artifacts, inlinePreview, job, url, zoomPercent } = context;
+    const relPath = artifactLabel(artifact);
+    const fingerprint = artifactFingerprint(artifact);
+    if (els.artifactViewerTitle) els.artifactViewerTitle.textContent = artifactNameParts(artifact).fileName;
+    if (els.artifactViewerMeta) {
+        els.artifactViewerMeta.textContent =
+            `${artifactDisplayLabel(artifact)} • ${artifactContentType(artifact) || 'binary'} • ${formatBytes(artifact.size_bytes)}`;
+    }
+    if (els.artifactViewerPath) els.artifactViewerPath.textContent = relPath;
+    if (els.artifactViewerFingerprint) els.artifactViewerFingerprint.textContent = _artifactFingerprintLabel(artifact);
+    if (els.artifactViewerZoomValue) {
+        els.artifactViewerZoomValue.textContent = inlinePreview ? `${zoomPercent}% zoom` : 'Inline preview unavailable';
+    }
+    if (els.artifactViewerPrevBtn) els.artifactViewerPrevBtn.disabled = index <= 0;
+    if (els.artifactViewerNextBtn) els.artifactViewerNextBtn.disabled = index >= (artifacts.length - 1);
+    if (els.artifactViewerZoomOutBtn) els.artifactViewerZoomOutBtn.disabled = !inlinePreview;
+    if (els.artifactViewerZoomInBtn) els.artifactViewerZoomInBtn.disabled = !inlinePreview;
+    if (els.artifactViewerResetZoomBtn) els.artifactViewerResetZoomBtn.disabled = !inlinePreview;
+    if (els.artifactViewerOpenRawBtn) {
+        els.artifactViewerOpenRawBtn.disabled = !url;
+        els.artifactViewerOpenRawBtn.dataset.url = url;
+    }
+    if (els.artifactViewerCopyPathBtn) {
+        els.artifactViewerCopyPathBtn.disabled = !relPath;
+        els.artifactViewerCopyPathBtn.dataset.path = relPath;
+    }
+    if (els.artifactViewerCopyFingerprintBtn) {
+        els.artifactViewerCopyFingerprintBtn.disabled = !fingerprint;
+        els.artifactViewerCopyFingerprintBtn.dataset.fingerprint = fingerprint;
+    }
+
+    if (inlinePreview && els.artifactViewerImage) {
+        els.artifactViewerImage.src = url;
+        els.artifactViewerImage.classList.remove('hidden');
+        els.artifactViewerImage.style.transform = `scale(${zoomPercent / 100})`;
+        if (els.artifactViewerFallback) els.artifactViewerFallback.classList.add('hidden');
+        return;
+    }
+
+    if (els.artifactViewerImage) {
+        els.artifactViewerImage.classList.add('hidden');
+        els.artifactViewerImage.removeAttribute('src');
+        els.artifactViewerImage.style.transform = 'scale(1)';
+    }
+    if (els.artifactViewerFallback) {
+        els.artifactViewerFallback.classList.remove('hidden');
+    }
+    if (els.artifactViewerFallbackTitle) {
+        els.artifactViewerFallbackTitle.textContent = url ? 'Inline preview unavailable' : 'Artifact URL unavailable';
+    }
+    if (els.artifactViewerFallbackDetail) {
+        els.artifactViewerFallbackDetail.textContent = url
+            ? 'This artifact stays reviewable through retained metadata, integrity fingerprints, and the managed raw asset link.'
+            : 'The browser cannot resolve a managed asset URL for this artifact, so review stays pinned to the retained metadata above.';
+    }
+}
+
+function _closeArtifactViewer(restoreFocus = true) {
+    state.portalUi.artifactViewer.open = false;
+    renderArtifactViewer();
+    if (restoreFocus) {
+        _restoreOverlayFocus();
+    }
+}
+
+function _openArtifactViewer(job, artifact, trigger = document.activeElement) {
+    if (!_artifactViewerEnabled() || !els.artifactViewerModal) return false;
+    if (!job || !artifact) {
+        createToast('No artifact is available for this selection.', 'info');
+        return false;
+    }
+    state.portalUi.artifactViewer.open = true;
+    state.portalUi.artifactViewer.jobId = _normalizeSelectedJobId(job.id);
+    state.portalUi.artifactViewer.artifactPath = _artifactRouteKey(artifact);
+    state.portalUi.artifactViewer.zoomPercent = 100;
+    _rememberOverlayTrigger(trigger);
+    renderArtifactViewer();
+    if (els.closeArtifactViewerBtn) els.closeArtifactViewerBtn.focus();
+    void emitPortalEvent('artifact_viewer_opened', {
+        surface: 'artifact_viewer_modal',
+        metadata: {
+            job_id: String(job.id || ''),
+            media_kind: String(artifact.media_kind || 'file'),
+            pipeline: String(job.pipeline || '')
+        }
+    });
+    return true;
 }
 
 const toggleModal = (show, trigger = document.activeElement) => {
@@ -9685,6 +9923,69 @@ if (els.effectiveConfigDrawer) {
         if (e.target === els.effectiveConfigDrawer) toggleEffectiveConfigDrawer(false);
     });
 }
+if (els.closeArtifactViewerBtn) {
+    els.closeArtifactViewerBtn.addEventListener('click', () => _closeArtifactViewer());
+}
+if (els.artifactViewerModal) {
+    els.artifactViewerModal.addEventListener('click', (event) => {
+        if (event.target === els.artifactViewerModal) _closeArtifactViewer();
+    });
+}
+if (els.artifactViewerPrevBtn) {
+    els.artifactViewerPrevBtn.addEventListener('click', () => {
+        _navigateArtifactViewerSelection(-1);
+    });
+}
+if (els.artifactViewerNextBtn) {
+    els.artifactViewerNextBtn.addEventListener('click', () => {
+        _navigateArtifactViewerSelection(1);
+    });
+}
+if (els.artifactViewerZoomOutBtn) {
+    els.artifactViewerZoomOutBtn.addEventListener('click', () => {
+        _setArtifactViewerZoom((state.portalUi?.artifactViewer?.zoomPercent || 100) - 25);
+    });
+}
+if (els.artifactViewerZoomInBtn) {
+    els.artifactViewerZoomInBtn.addEventListener('click', () => {
+        _setArtifactViewerZoom((state.portalUi?.artifactViewer?.zoomPercent || 100) + 25);
+    });
+}
+if (els.artifactViewerResetZoomBtn) {
+    els.artifactViewerResetZoomBtn.addEventListener('click', () => {
+        _setArtifactViewerZoom(100);
+    });
+}
+if (els.artifactViewerOpenRawBtn) {
+    els.artifactViewerOpenRawBtn.addEventListener('click', () => {
+        const url = sanitizeManagedAssetUrl(els.artifactViewerOpenRawBtn.dataset.url);
+        if (!url) {
+            createToast('No artifact URL is available for this selection.', 'error');
+            return;
+        }
+        window.open(url, '_blank', 'noopener,noreferrer');
+    });
+}
+if (els.artifactViewerCopyPathBtn) {
+    els.artifactViewerCopyPathBtn.addEventListener('click', async () => {
+        const path = String(els.artifactViewerCopyPathBtn.dataset.path || '').trim();
+        if (!path) {
+            createToast('No artifact path is available for this selection.', 'error');
+            return;
+        }
+        await copyToClipboard(path);
+    });
+}
+if (els.artifactViewerCopyFingerprintBtn) {
+    els.artifactViewerCopyFingerprintBtn.addEventListener('click', async () => {
+        const fingerprint = String(els.artifactViewerCopyFingerprintBtn.dataset.fingerprint || '').trim();
+        if (!fingerprint) {
+            createToast('No artifact fingerprint is available for this selection.', 'error');
+            return;
+        }
+        await copyToClipboard(fingerprint);
+    });
+}
 
 document.addEventListener('keydown', (e) => {
     if (_trapOverlayFocus(e)) {
@@ -9692,6 +9993,11 @@ document.addEventListener('keydown', (e) => {
     }
     const key = String(e.key || '');
     const isPlainShortcut = !e.ctrlKey && !e.metaKey && !e.altKey && !_isTypingTarget(e.target);
+    if (e.key === "Escape" && els.artifactViewerModal && !els.artifactViewerModal.classList.contains("hidden")) {
+        e.preventDefault();
+        _closeArtifactViewer();
+        return;
+    }
     if (e.key === "Escape" && els.effectiveConfigDrawer && !els.effectiveConfigDrawer.classList.contains("hidden")) {
         e.preventDefault();
         toggleEffectiveConfigDrawer(false);
@@ -9719,6 +10025,33 @@ document.addEventListener('keydown', (e) => {
         e.preventDefault();
         navigateConsoleView(nextView);
         return;
+    }
+    if (isPlainShortcut && els.artifactViewerModal && !els.artifactViewerModal.classList.contains('hidden')) {
+        if (key === 'ArrowLeft') {
+            e.preventDefault();
+            _navigateArtifactViewerSelection(-1);
+            return;
+        }
+        if (key === 'ArrowRight') {
+            e.preventDefault();
+            _navigateArtifactViewerSelection(1);
+            return;
+        }
+        if (key === '+' || key === '=') {
+            e.preventDefault();
+            _setArtifactViewerZoom((state.portalUi?.artifactViewer?.zoomPercent || 100) + 25);
+            return;
+        }
+        if (key === '-') {
+            e.preventDefault();
+            _setArtifactViewerZoom((state.portalUi?.artifactViewer?.zoomPercent || 100) - 25);
+            return;
+        }
+        if (key === '0') {
+            e.preventDefault();
+            _setArtifactViewerZoom(100);
+            return;
+        }
     }
     if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
         e.preventDefault();

--- a/web/secure-landing/portal-src/portal.template.js
+++ b/web/secure-landing/portal-src/portal.template.js
@@ -1435,7 +1435,10 @@ function _openArtifactForSelection(job, artifact, surface = 'artifact_review') {
         return false;
     }
     if (_artifactViewerEnabled()) {
-        return _openArtifactViewer(job, artifact);
+        const openedInViewer = _openArtifactViewer(job, artifact);
+        if (openedInViewer) {
+            return true;
+        }
     }
     const url = sanitizeManagedAssetUrl(buildArtifactUrl(job, artifact));
     if (!url) {

--- a/web/secure-landing/tests/routes.test.mjs
+++ b/web/secure-landing/tests/routes.test.mjs
@@ -20,7 +20,8 @@ const ENV_KEYS = [
   "TP_FRONTDOOR_SESSION_SCALING_MODE",
   "TP_CF_ACCESS_TEAM_DOMAIN",
   "TP_CF_ACCESS_AUD",
-  "TP_ALLOW_LOCAL_ACCESS_BYPASS"
+  "TP_ALLOW_LOCAL_ACCESS_BYPASS",
+  "TP_PORTAL_ARTIFACT_VIEWER_MODAL_ROLLOUT_PERCENT"
 ];
 
 const TEST_CF_ACCESS_TEAM_DOMAIN = "https://tp-frontdoor-tests.cloudflareaccess.com";
@@ -97,6 +98,13 @@ function withTempEnvironment(overrides = {}) {
     process.env.TP_ALLOW_LOCAL_ACCESS_BYPASS = overrides.TP_ALLOW_LOCAL_ACCESS_BYPASS;
   } else {
     delete process.env.TP_ALLOW_LOCAL_ACCESS_BYPASS;
+  }
+
+  if (typeof overrides.TP_PORTAL_ARTIFACT_VIEWER_MODAL_ROLLOUT_PERCENT === "string") {
+    process.env.TP_PORTAL_ARTIFACT_VIEWER_MODAL_ROLLOUT_PERCENT =
+      overrides.TP_PORTAL_ARTIFACT_VIEWER_MODAL_ROLLOUT_PERCENT;
+  } else {
+    delete process.env.TP_PORTAL_ARTIFACT_VIEWER_MODAL_ROLLOUT_PERCENT;
   }
 
   resetDbCache();
@@ -1098,10 +1106,46 @@ test("managed bootstrap returns actor metadata and CSRF for authenticated sessio
       assert.equal(body.actor.accessEmail, "admin@example.com");
       assert.equal(body.features.apiKeyInput, false);
       assert.equal(body.features.directDebug, false);
+      assert.equal(body.features.artifactViewerModal, false);
       assert.equal(body.csrfToken, authenticatedSession.csrfToken);
     } finally {
       restoreFetch();
     }
+  } finally {
+    env.cleanup();
+  }
+});
+
+test("managed bootstrap enables the artifact viewer modal for rollout cohorts", async () => {
+  const env = withTempEnvironment({
+    TP_PORTAL_ARTIFACT_VIEWER_MODAL_ROLLOUT_PERCENT: "100"
+  });
+
+  try {
+    const sessions = await importFresh("../lib/sessions.js");
+    const { GET } = await importFresh("../app/portal/bootstrap/route.js");
+    const authenticatedSession = sessions.rotateAuthenticatedSession(
+      sessions.createAnonymousSession(),
+      {
+        username: "admin",
+        accessEmail: "admin@example.com",
+        role: "admin"
+      }
+    );
+
+    const request = buildRequest("https://portal.example.com/portal/bootstrap", {
+      method: "GET",
+      headers: new Headers({
+        cookie: `__Host-tp_session=${authenticatedSession.id}`,
+        "Cf-Access-Jwt-Assertion": createAccessJwt()
+      })
+    });
+
+    const response = await GET(request);
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(body.features.artifactViewerModal, true);
   } finally {
     env.cleanup();
   }


### PR DESCRIPTION
## Summary
- Start the approved portal operator console modernization with an in-console artifact viewer that preserves the current review flow by default.
- Add the smallest safe slice: a default-off, rollout-gated modal viewer wired through direct-debug and managed bootstrap surfaces.

## Changes
- Add backend rollout helpers and expose `features.artifactViewerModal` from `/portal/bootstrap` in direct-debug mode.
- Add managed frontdoor rollout resolution in `web/secure-landing/app/portal/bootstrap/route.js` using a stable cohort hash derived from authenticated session identity.
- Add portal UI state, modal rendering, keyboard/focus handling, navigation, zoom controls, raw-open fallback, and degraded metadata-only states for non-previewable artifacts.
- Add artifact SHA-256 visibility and copy actions to the review provenance/actions surface.
- Update the checked-in portal HTML/CSS and regenerate `public/portal-assets/portal.js` from source.
- Extend Python and Node contract coverage for the new bootstrap feature flag and artifact viewer selectors/behavior.

## Validation
Proven green
- `.venv/bin/pytest -p no:cacheprovider tests/test_app_orchestrator_contract_http.py tests/test_app_orchestrator_runtime.py`
- `source ~/.nvm/nvm.sh && nvm use 22 >/dev/null && npm test` (run in `web/secure-landing`)
- `source ~/.nvm/nvm.sh && nvm use 22 >/dev/null && npm run build` (run in `web/secure-landing`)
- `make validate-frontdoor-browser`

Still failing
- None in the validation scope above.

## Risk
- Rollout is bounded by `TP_PORTAL_ARTIFACT_VIEWER_MODAL_ROLLOUT_PERCENT`, which defaults to `0`, so existing operator behavior remains unchanged until explicitly enabled.
- Portal/frontdoor selectors and route contracts were preserved and revalidated; browser-smoke critical path stayed green after the change.
- The change is revert-safe: disabling the rollout env or reverting this branch removes the new behavior without altering existing job or auth envelopes.