### PR TITLE
feat(portal): preserve route and draft across reauth

### DIFF
--- a/public/portal-assets/portal.js
+++ b/public/portal-assets/portal.js
@@ -60,6 +60,7 @@ const SSE_RECONNECT_JITTER_MS = 250;
 const SSE_STALL_CHECK_INTERVAL_MS = 10000;
 const SSE_STALL_THRESHOLD_MS = 45000;
 const CONFIG_PREVIEW_DEBOUNCE_MS = 250;
+const TRANSIENT_DRAFT_PERSIST_DEBOUNCE_MS = 200;
 const DISPATCH_BACKEND_OFFLINE_MESSAGE = 'Backend is offline. Dispatch is disabled until connectivity is restored.';
 const CONFIG_PREVIEW_SUPPORTED_PIPELINES = new Set([
     'lux-depth-v3',
@@ -82,6 +83,8 @@ let sseWatchdogIntervalId = null;
 let healthCheckInFlight = false;
 let lastHealthCheckAt = 0;
 let configPreviewTimerId = null;
+let transientDraftPersistTimerId = null;
+let transientDraftPersistIdleId = null;
 
 var __PortalInternal = (() => {
   var __defProp = Object.defineProperty;
@@ -1502,6 +1505,47 @@ function _persistTransientPortalDraft() {
     }
 }
 
+function _cancelScheduledTransientPortalDraftPersist() {
+    if (transientDraftPersistTimerId !== null) {
+        window.clearTimeout(transientDraftPersistTimerId);
+        transientDraftPersistTimerId = null;
+    }
+    if (transientDraftPersistIdleId !== null && typeof window.cancelIdleCallback === 'function') {
+        window.cancelIdleCallback(transientDraftPersistIdleId);
+    }
+    transientDraftPersistIdleId = null;
+}
+
+function _flushPendingTransientPortalDraftPersist() {
+    _cancelScheduledTransientPortalDraftPersist();
+    return _persistTransientPortalDraft();
+}
+
+function _scheduleTransientPortalDraftPersist(options) {
+    const settings = options && typeof options === 'object' ? options : {};
+    if (settings.immediate) return _flushPendingTransientPortalDraftPersist();
+    _cancelScheduledTransientPortalDraftPersist();
+
+    const commitSnapshot = () => {
+        transientDraftPersistTimerId = null;
+        transientDraftPersistIdleId = null;
+        _persistTransientPortalDraft();
+    };
+    const scheduleCommit = () => {
+        transientDraftPersistTimerId = null;
+        if (typeof window.requestIdleCallback === 'function') {
+            transientDraftPersistIdleId = window.requestIdleCallback(() => {
+                commitSnapshot();
+            }, { timeout: TRANSIENT_DRAFT_PERSIST_DEBOUNCE_MS });
+            return;
+        }
+        commitSnapshot();
+    };
+
+    transientDraftPersistTimerId = window.setTimeout(scheduleCommit, TRANSIENT_DRAFT_PERSIST_DEBOUNCE_MS);
+    return true;
+}
+
 function _restoreTransientPortalDraft() {
     const snapshot = _readTransientPortalDraft();
     if (!snapshot) return false;
@@ -2072,6 +2116,7 @@ function handleOperatorActionClick(event) {
             _retryPortalStatus(job);
             break;
         case 'restore_access':
+            _flushPendingTransientPortalDraftPersist();
             window.location.assign(_managedLoginUrlForCurrentRoute());
             break;
         default:
@@ -4987,6 +5032,7 @@ async function loadPortalBootstrap(options = null) {
             _finalizeBootstrapRetry('terminal_auth_redirect', { reason: failure.reason, httpStatus: res.status });
             _applyPortalBootstrap(fallback, { status: 'unavailable', reason: failure.reason, httpStatus: res.status });
             createToast(failure.toastMessage, 'error');
+            _flushPendingTransientPortalDraftPersist();
             window.location.assign(_managedLoginUrlForCurrentRoute());
             return;
         }
@@ -8522,7 +8568,7 @@ function bindInputs() {
         el.addEventListener('input', (e) => {
             if (category) state.config[category][key] = e.target.value;
             else state.config[key] = e.target.value;
-            _persistTransientPortalDraft();
+            _scheduleTransientPortalDraftPersist();
             renderCLI();
             if (trackedTelemetryField(category, key)) {
                 scheduleConfigPreview();
@@ -8530,7 +8576,7 @@ function bindInputs() {
         });
         el.addEventListener('change', (e) => {
             const field = trackedTelemetryField(category, key);
-            _persistTransientPortalDraft();
+            _scheduleTransientPortalDraftPersist({ immediate: true });
             if (field) {
                 void emitPortalEvent('field_commit', {
                     surface: telemetrySurfaceFor(category),
@@ -10676,7 +10722,9 @@ portalRenderSurfaces.register('jobQueue', {
     }
 });
 
+window.addEventListener('beforeunload', _flushPendingTransientPortalDraftPersist);
 window.addEventListener('beforeunload', cleanupActiveJobHandles);
+window.addEventListener('pagehide', _flushPendingTransientPortalDraftPersist);
 window.addEventListener('pagehide', cleanupActiveJobHandles);
 window.addEventListener('pageshow', () => {
     reconcileBuildSurfaceFromDom();

--- a/public/portal-assets/portal.js
+++ b/public/portal-assets/portal.js
@@ -35,6 +35,8 @@
 const API_BASE = '';
 const STORAGE_KEY = 'tp_orchestrator_profiles_final';
 const API_KEY_STORAGE_KEY = 'tp_api_key';
+const TRANSIENT_DRAFT_STORAGE_KEY = 'tp_portal_transient_draft';
+const TRANSIENT_DRAFT_SCHEMA = 'tp.portal.transient_draft.v1';
 const THEME_STORAGE_KEY = 'tp_theme';
 const THEME_STORAGE_VERSION_KEY = 'tp_theme_version';
 const THEME_STORAGE_VERSION = '2';
@@ -1393,6 +1395,127 @@ function _syncConsoleRoute(replace = false) {
     window.history[method]({ view: state.currentView, jobId: state.selectedJobId || '' }, '', nextHref);
 }
 
+function _managedReturnToPath() {
+    const url = new URL(window.location.href);
+    if (url.pathname !== '/portal') return '/portal';
+    return `${url.pathname}${url.search}`;
+}
+
+function _managedLoginUrlForCurrentRoute() {
+    return `/login?returnTo=${encodeURIComponent(_managedReturnToPath())}`;
+}
+
+function _copyTransientDraftConfig(config = state.config) {
+    return JSON.parse(JSON.stringify(config && typeof config === 'object' ? config : portalInternals.createPortalConfigState()));
+}
+
+function _managedDraftOwnerKey() {
+    const actor = state.auth && state.auth.actor && typeof state.auth.actor === 'object' ? state.auth.actor : null;
+    const accessEmail = String(actor?.accessEmail || '').trim().toLowerCase();
+    if (accessEmail) return `managed:${accessEmail}`;
+    const username = String(actor?.username || '').trim().toLowerCase();
+    const role = String(actor?.role || '').trim().toLowerCase();
+    if (!username && !role) return '';
+    return `managed:${[username, role].filter(Boolean).join(':')}`;
+}
+
+function _transientDraftOwnerKey() {
+    if (!_isBootstrapReady()) return '';
+    if (_isManagedAuthMode()) return _managedDraftOwnerKey();
+    return 'direct_debug';
+}
+
+function _clearTransientPortalDraft() {
+    try {
+        sessionStorage.removeItem(TRANSIENT_DRAFT_STORAGE_KEY);
+    } catch {
+        // Ignore storage access failures during teardown or quota exhaustion.
+    }
+}
+
+function _readTransientPortalDraft() {
+    let raw = '';
+    try {
+        raw = sessionStorage.getItem(TRANSIENT_DRAFT_STORAGE_KEY) || '';
+    } catch {
+        return null;
+    }
+    if (!raw) return null;
+
+    let parsed = null;
+    try {
+        parsed = JSON.parse(raw);
+    } catch {
+        _clearTransientPortalDraft();
+        return null;
+    }
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        _clearTransientPortalDraft();
+        return null;
+    }
+
+    const schema = String(parsed.schema || '').trim();
+    const ownerKey = String(parsed.ownerKey || '').trim();
+    const savedAt = Number(parsed.savedAt || 0);
+    const pipeline = String(parsed.pipeline || '').trim();
+    const config = parsed.config;
+    if (
+        schema !== TRANSIENT_DRAFT_SCHEMA
+        || !ownerKey
+        || !Number.isFinite(savedAt)
+        || savedAt <= 0
+        || !pipeline
+        || !config
+        || typeof config !== 'object'
+        || Array.isArray(config)
+    ) {
+        _clearTransientPortalDraft();
+        return null;
+    }
+
+    return {
+        schema,
+        ownerKey,
+        savedAt,
+        pipeline,
+        config: _copyTransientDraftConfig(config),
+        buildStep: resolveBuildStep(parsed.buildStep)
+    };
+}
+
+function _persistTransientPortalDraft() {
+    const ownerKey = _transientDraftOwnerKey();
+    if (!ownerKey) return false;
+    const snapshot = {
+        schema: TRANSIENT_DRAFT_SCHEMA,
+        pipeline: String(state.pipeline || '').trim() || 'lux-depth-v3',
+        config: _copyTransientDraftConfig(),
+        buildStep: resolveBuildStep(state.portalUi.buildStep),
+        savedAt: Date.now(),
+        ownerKey
+    };
+    try {
+        sessionStorage.setItem(TRANSIENT_DRAFT_STORAGE_KEY, JSON.stringify(snapshot));
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+function _restoreTransientPortalDraft() {
+    const snapshot = _readTransientPortalDraft();
+    if (!snapshot) return false;
+    const ownerKey = _transientDraftOwnerKey();
+    if (!ownerKey || snapshot.ownerKey !== ownerKey) {
+        _clearTransientPortalDraft();
+        return false;
+    }
+    state.pipeline = snapshot.pipeline;
+    state.config = _copyTransientDraftConfig(snapshot.config);
+    state.portalUi.buildStep = resolveBuildStep(snapshot.buildStep);
+    return true;
+}
+
 function _jobFreshnessLabel(job) {
     if (!job) return 'No live telemetry';
     const lastActivityAt = Number(job.lastEventAt || job.updatedAt || job.finishedAt || job.createdAt || 0);
@@ -1949,7 +2072,7 @@ function handleOperatorActionClick(event) {
             _retryPortalStatus(job);
             break;
         case 'restore_access':
-            window.location.assign('/login');
+            window.location.assign(_managedLoginUrlForCurrentRoute());
             break;
         default:
             break;
@@ -2929,12 +3052,14 @@ function syncBuildStepUi() {
     renderBuildStepPulse(generatePayload());
 }
 
-function setBuildStep(nextStep, options = {}) {
+function setBuildStep(nextStep, options) {
+    const settings = options && typeof options === 'object' ? options : {};
     const previous = resolveBuildStep(state.portalUi.buildStep);
     const resolved = resolveBuildStep(nextStep);
     state.portalUi.buildStep = resolved;
     syncBuildStepUi();
-    if (!options.silent && resolved > previous) {
+    _persistTransientPortalDraft();
+    if (!settings.silent && resolved > previous) {
         void emitPortalEvent('step_completed', {
             surface: 'build_stepper',
             metadata: { step: previous, next_step: resolved }
@@ -4862,7 +4987,7 @@ async function loadPortalBootstrap(options = null) {
             _finalizeBootstrapRetry('terminal_auth_redirect', { reason: failure.reason, httpStatus: res.status });
             _applyPortalBootstrap(fallback, { status: 'unavailable', reason: failure.reason, httpStatus: res.status });
             createToast(failure.toastMessage, 'error');
-            window.location.assign('/login');
+            window.location.assign(_managedLoginUrlForCurrentRoute());
             return;
         }
         if (!res.ok) {
@@ -8372,11 +8497,13 @@ function bindInputs() {
             else state[key] = e.target.value;
             if (key === 'pipeline') {
                 updateUIFromState();
+                _persistTransientPortalDraft();
                 void fetchPresetsForPipeline(state.pipeline, true);
                 void fetchReadiness(true);
                 void fetchConfigMetadata(state.pipeline, true);
             }
             else {
+                _persistTransientPortalDraft();
                 const field = trackedTelemetryField(category, key);
                 if (field) {
                     void emitPortalEvent('field_commit', {
@@ -8395,6 +8522,7 @@ function bindInputs() {
         el.addEventListener('input', (e) => {
             if (category) state.config[category][key] = e.target.value;
             else state.config[key] = e.target.value;
+            _persistTransientPortalDraft();
             renderCLI();
             if (trackedTelemetryField(category, key)) {
                 scheduleConfigPreview();
@@ -8402,6 +8530,7 @@ function bindInputs() {
         });
         el.addEventListener('change', (e) => {
             const field = trackedTelemetryField(category, key);
+            _persistTransientPortalDraft();
             if (field) {
                 void emitPortalEvent('field_commit', {
                     surface: telemetrySurfaceFor(category),
@@ -8447,6 +8576,7 @@ function bindInputs() {
                 state.portalUi.debugBundleGuardrailSeen = false;
                 if (els.debugBundleAcknowledge) els.debugBundleAcknowledge.checked = false;
             }
+            _persistTransientPortalDraft();
             renderCLI();
             scheduleConfigPreview();
         });
@@ -8459,6 +8589,7 @@ function bindInputs() {
             state.config.preset = nextPreset;
             applyPresetRecommendedArgs(nextPreset);
             updateUIFromState();
+            _persistTransientPortalDraft();
         });
     }
     safeBindInput(els.inputDir, null, 'inputDir');
@@ -9620,6 +9751,7 @@ if (els.profileSelect) els.profileSelect.addEventListener('change', (e) => {
         state.pipeline = profiles[name].pipeline;
         state.config = JSON.parse(JSON.stringify(profiles[name].config));
         updateUIFromState();
+        _persistTransientPortalDraft();
         void fetchPresetsForPipeline(state.pipeline, true);
         createToast(`Profile ${name} loaded.`);
     }
@@ -9794,6 +9926,7 @@ if (els.fileInput) els.fileInput.addEventListener('change', async (e) => {
         state.portalUi.debugBundleAcknowledged = false;
         state.portalUi.debugBundleGuardrailSeen = false;
         updateUIFromState();
+        _persistTransientPortalDraft();
         void fetchPresetsForPipeline(state.pipeline, true);
         void fetchConfigMetadata(state.pipeline, true);
         createToast("Configuration imported.", "success");
@@ -10590,11 +10723,14 @@ async function init() {
     setupSectionRail();
     _syncBootstrapUi();
     renderJobQueue();
-    void checkBackend(true);
-    void fetchConfigMetadata(state.pipeline, true);
     startHealthPolling();
     await bootstrapPromise;
+    _restoreTransientPortalDraft();
+    updateUIFromState();
+    _persistTransientPortalDraft();
     portalRenderSurfaces.render('jobQueue', state);
+    void checkBackend(true);
+    void fetchConfigMetadata(state.pipeline, true);
 }
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/scripts/validation/validate_frontdoor_browser_smoke.py
+++ b/scripts/validation/validate_frontdoor_browser_smoke.py
@@ -10,7 +10,7 @@ Coverage:
 1. Homepage loads and renders the public DNA hero.
 2. Login loads with the operator form and front-door video shell.
 3. Username/password authentication succeeds.
-4. Managed portal entry lands on `/portal` with browser-side API key input hidden.
+4. Managed portal entry honors a validated `/portal?view=build` returnTo and keeps browser-side API key input hidden.
 
 Run via:
     python scripts/validation/validate_frontdoor_browser_smoke.py
@@ -399,6 +399,7 @@ def _frontdoor_state_probe_expression() -> str:
     title: document.title,
     readyState: document.readyState,
     pathname: window.location.pathname,
+    locationSearch: window.location.search,
     homepageHeroReady: !!document.querySelector('[data-ui="homepage-hero-title"]'),
     homepageEntryRailReady: !!document.querySelector('[data-ui="homepage-entry-rail"]'),
     homepageLearnLinkReady: !!document.querySelector('[data-ui="homepage-learn-link"]'),
@@ -523,11 +524,9 @@ def _navigate_expression(pathname: str) -> str:
     encoded = json.dumps(pathname)
     return f"""
 (() => {{
-  const url = new URL(window.location.href);
-  url.pathname = {encoded};
-  url.search = '';
+  const url = new URL({encoded}, window.location.origin);
   window.location.assign(url.toString());
-  return url.toString();
+  return `${{url.pathname}}${{url.search}}`;
 }})()
 """
 
@@ -691,7 +690,7 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
         )
 
         print("frontdoor-browser-smoke: opening login", flush=True)
-        connection.evaluate(_navigate_expression("/login"))
+        connection.evaluate(_navigate_expression("/login?returnTo=%2Fportal%3Fview%3Dbuild"))
         login_state = _poll(
             connection,
             _frontdoor_state_probe_expression(),
@@ -699,6 +698,7 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
                 isinstance(value, dict)
                 and str(value.get("readyState", "")) == "complete"
                 and str(value.get("pathname", "")) == "/login"
+                and "returnTo=%2Fportal%3Fview%3Dbuild" in str(value.get("locationSearch", ""))
                 and bool(value.get("loginTitleReady"))
                 and bool(value.get("loginEntryStateReady"))
                 and bool(value.get("loginSequenceReady"))
@@ -763,7 +763,8 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
                 isinstance(value, dict)
                 and str(value.get("readyState", "")) == "complete"
                 and str(value.get("pathname", "")) == "/portal"
-                and str(value.get("currentView", "")) == "overview"
+                and str(value.get("currentView", "")) == "build"
+                and "view=build" in str(value.get("locationSearch", ""))
                 and bool(value.get("apiKeySectionHidden"))
                 and bool(value.get("portalAccessStateReady"))
                 and str(value.get("authModeBadge", "")).lower() == "managed"

--- a/scripts/validation/validate_portal_browser_smoke.py
+++ b/scripts/validation/validate_portal_browser_smoke.py
@@ -1110,6 +1110,7 @@ def _set_pipeline_form_expression(
     output_dir: str,
     archive_index: str = "",
     manifest_jsonl: str = "",
+    build_step: str = "",
 ) -> str:
     payload = json.dumps(
         {
@@ -1119,6 +1120,7 @@ def _set_pipeline_form_expression(
             "output_dir": output_dir,
             "archive_index": archive_index,
             "manifest_jsonl": manifest_jsonl,
+            "build_step": build_step,
         }
     )
     return f"""
@@ -1143,8 +1145,19 @@ def _set_pipeline_form_expression(
   setValue('outputDir', cfg.output_dir);
   setValue('archiveIndexPath', cfg.archive_index);
   setValue('rightsManifestPath', cfg.manifest_jsonl);
+  if (cfg.build_step) {{
+    if (typeof setBuildStep === 'function') {{
+      setBuildStep(cfg.build_step, {{ silent: true }});
+    }} else {{
+      const buildStepButton = document.querySelector(`[data-build-step-target="${{cfg.build_step}}"]`);
+      if (buildStepButton) buildStepButton.click();
+    }}
+  }}
   return {{
+    currentView: document.body ? String(document.body.dataset.consoleView || '') : '',
     pipeline: document.getElementById('pipelineSelect').value,
+    inputDir: document.getElementById('inputDir').value,
+    outputDir: document.getElementById('outputDir').value,
     archiveFieldsVisible: !document.getElementById('fieldsArchiveGate').classList.contains('hidden'),
     luxFieldsVisible: !document.getElementById('fieldsLuxDepth').classList.contains('hidden'),
     flagsShellVisible: !document.getElementById('flags-shell').classList.contains('hidden'),
@@ -1560,6 +1573,54 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
             f"Sticky portal chrome obscured focused controls: {build_accessibility}",
         )
 
+        draft_input_dir = f"{archive_root}-session-draft"
+        draft_output_dir = f"{output_dir}-session-draft"
+        print("portal-browser-smoke: verifying transient build draft restore after reload", flush=True)
+        draft_state = _poll(
+            connection,
+            _set_pipeline_form_expression(
+                api_key="",
+                pipeline="lux-depth-v3",
+                input_dir=draft_input_dir,
+                output_dir=draft_output_dir,
+                build_step="3",
+            ),
+            predicate=lambda value: (
+                isinstance(value, dict)
+                and str(value.get("currentView", "")) == "build"
+                and str(value.get("pipeline", "")) == "lux-depth-v3"
+                and str(value.get("inputDir", "")) == draft_input_dir
+                and str(value.get("outputDir", "")) == draft_output_dir
+                and str(value.get("activeBuildStep", "")) == "3"
+            ),
+            timeout_seconds=args.timeout_seconds,
+            description="transient draft state to persist before reload",
+        )
+        _expect(
+            str(draft_state.get("activeBuildStep", "")) == "3",
+            f"Transient draft setup did not advance the builder to step 3: {draft_state}",
+        )
+        connection.call("Page.reload", {"ignoreCache": True})
+        restored_draft_state = _poll(
+            connection,
+            _state_probe_expression(),
+            predicate=lambda value: (
+                isinstance(value, dict)
+                and str(value.get("readyState", "")) == "complete"
+                and str(value.get("currentView", "")) == "build"
+                and str(value.get("pipeline", "")) == "lux-depth-v3"
+                and str(value.get("inputDir", "")) == draft_input_dir
+                and str(value.get("outputDir", "")) == draft_output_dir
+                and str(value.get("activeBuildStep", "")) == "3"
+            ),
+            timeout_seconds=args.timeout_seconds,
+            description="transient draft state to restore after reload",
+        )
+        _expect(
+            "view=build" in str(restored_draft_state.get("locationSearch", "")),
+            f"Transient draft reload should preserve the build route context: {restored_draft_state}",
+        )
+
         print("portal-browser-smoke: checking reduced motion", flush=True)
         connection.call(
             "Emulation.setEmulatedMedia",
@@ -1593,6 +1654,7 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
                 pipeline="lux-depth-v3",
                 input_dir=str(archive_root),
                 output_dir=str(output_dir),
+                build_step="1",
             )
         )
         _expect(isinstance(lux_state, dict), f"Unexpected lux portal state: {lux_state!r}")

--- a/scripts/validation/validate_portal_browser_smoke.py
+++ b/scripts/validation/validate_portal_browser_smoke.py
@@ -1573,7 +1573,7 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
             f"Sticky portal chrome obscured focused controls: {build_accessibility}",
         )
 
-        draft_input_dir = f"{archive_root}-session-draft"
+        draft_input_dir = str(archive_root)
         draft_output_dir = f"{output_dir}-session-draft"
         print("portal-browser-smoke: verifying transient build draft restore after reload", flush=True)
         draft_state = _poll(

--- a/tests/test_app_orchestrator_runtime.py
+++ b/tests/test_app_orchestrator_runtime.py
@@ -862,6 +862,8 @@ def test_portal_transient_draft_restore_is_scoped_to_the_current_owner_and_exclu
     clear_body = _extract_js_function_body(content, "_clearTransientPortalDraft")
     read_body = _extract_js_function_body(content, "_readTransientPortalDraft")
     persist_body = _extract_js_function_body(content, "_persistTransientPortalDraft")
+    schedule_body = _extract_js_function_body(content, "_scheduleTransientPortalDraftPersist")
+    flush_body = _extract_js_function_body(content, "_flushPendingTransientPortalDraftPersist")
     restore_body = _extract_js_function_body(content, "_restoreTransientPortalDraft")
 
     assert "const url = new URL(window.location.href);" in route_body
@@ -878,6 +880,11 @@ def test_portal_transient_draft_restore_is_scoped_to_the_current_owner_and_exclu
     assert "ownerKey" in persist_body
     assert "savedAt: Date.now()" in persist_body
     assert "buildStep: resolveBuildStep(state.portalUi.buildStep)" in persist_body
+    assert "window.setTimeout(scheduleCommit, TRANSIENT_DRAFT_PERSIST_DEBOUNCE_MS);" in schedule_body
+    assert "window.requestIdleCallback" in schedule_body
+    assert "_persistTransientPortalDraft();" in schedule_body
+    assert "_cancelScheduledTransientPortalDraftPersist();" in flush_body
+    assert "return _persistTransientPortalDraft();" in flush_body
     assert "API_KEY_STORAGE_KEY" not in persist_body
     assert "csrfToken" not in persist_body
     assert "state.jobs" not in persist_body
@@ -896,8 +903,11 @@ def test_portal_transient_draft_restores_before_preview_and_readiness_hydration(
 
     assert "_restoreTransientPortalDraft();" in body
     assert "_persistTransientPortalDraft();" in body
-    assert "_persistTransientPortalDraft();" in bind_body
+    assert "_scheduleTransientPortalDraftPersist();" in bind_body
+    assert "_scheduleTransientPortalDraftPersist({ immediate: true });" in bind_body
     assert "_persistTransientPortalDraft();" in set_build_step_body
+    assert "window.addEventListener('pagehide', _flushPendingTransientPortalDraftPersist);" in content
+    assert "window.addEventListener('beforeunload', _flushPendingTransientPortalDraftPersist);" in content
 
     restore_index = body.index("_restoreTransientPortalDraft();")
     update_index = body.index("updateUIFromState();", restore_index)

--- a/tests/test_app_orchestrator_runtime.py
+++ b/tests/test_app_orchestrator_runtime.py
@@ -671,6 +671,7 @@ def test_portal_resumes_blocked_streams_after_api_key_update() -> None:
 def test_portal_bootstrap_loader_uses_abortable_timeout_and_state_contract() -> None:
     content = _portal_bundle_content()
     default_body = _extract_js_function_body(content, "_defaultPortalBootstrap")
+    login_url_body = _extract_js_function_body(content, "_managedLoginUrlForCurrentRoute")
     body = _extract_js_function_body(content, "loadPortalBootstrap")
     failure_details_body = _extract_js_function_body(content, "_bootstrapFailureDetails")
     followup_body = _extract_js_function_body(content, "_flushBootstrapOnlineFollowup")
@@ -688,8 +689,11 @@ def test_portal_bootstrap_loader_uses_abortable_timeout_and_state_contract() -> 
     assert "const BOOTSTRAP_RETRY_MAX_DELAY_MS = 12000;" in content
     assert "const BOOTSTRAP_RETRY_MAX_ATTEMPTS = 4;" in content
     assert "const BOOTSTRAP_RETRY_MAX_WINDOW_MS = 60000;" in content
+    assert "const TRANSIENT_DRAFT_STORAGE_KEY = 'tp_portal_transient_draft';" in content
+    assert "const TRANSIENT_DRAFT_SCHEMA = 'tp.portal.transient_draft.v1';" in content
     assert "const BOOTSTRAP_RETRIABLE_HTTP_STATUSES = new Set([500, 502, 503, 504]);" in content
     assert "fetchWithTimeout(" in body
+    assert "return `/login?returnTo=${encodeURIComponent(_managedReturnToPath())}`;" in login_url_body
     assert "`${API_BASE}/portal/bootstrap`" in body
     assert "BOOTSTRAP_TIMEOUT_MS" in body
     assert "const bootstrapOptions = options && typeof options === 'object' ? options : null;" in body
@@ -706,7 +710,7 @@ def test_portal_bootstrap_loader_uses_abortable_timeout_and_state_contract() -> 
     assert "let payloadParsed = false;" in body
     assert "const failure = _bootstrapFailureDetails(" in body
     assert "_finalizeBootstrapRetry('terminal_auth_redirect', { reason: failure.reason, httpStatus: res.status });" in body
-    assert "window.location.assign('/login');" in body
+    assert "window.location.assign(_managedLoginUrlForCurrentRoute());" in body
     assert "const status = failure.retryable ? 'degraded' : 'unavailable';" in body
     assert "const retryScheduled = failure.retryable && _scheduleBootstrapRetry(failure.reason, res.status);" in body
     assert "const retryScheduled = failure.retryable && _scheduleBootstrapRetry(failure.reason, 0);" in body
@@ -848,6 +852,59 @@ def test_portal_health_checks_route_to_front_door_in_managed_mode() -> None:
     assert "fetchWithTimeout(`${API_BASE}${healthEndpointPath}`" in check_body
     assert "_queueBootstrapOnlineFollowup();" in check_body
     assert "_flushBootstrapOnlineFollowup(force);" in check_body
+
+
+def test_portal_transient_draft_restore_is_scoped_to_the_current_owner_and_excludes_auth_state() -> None:
+    content = _portal_bundle_content()
+    route_body = _extract_js_function_body(content, "_managedReturnToPath")
+    owner_body = _extract_js_function_body(content, "_transientDraftOwnerKey")
+    managed_owner_body = _extract_js_function_body(content, "_managedDraftOwnerKey")
+    clear_body = _extract_js_function_body(content, "_clearTransientPortalDraft")
+    read_body = _extract_js_function_body(content, "_readTransientPortalDraft")
+    persist_body = _extract_js_function_body(content, "_persistTransientPortalDraft")
+    restore_body = _extract_js_function_body(content, "_restoreTransientPortalDraft")
+
+    assert "const url = new URL(window.location.href);" in route_body
+    assert "return `${url.pathname}${url.search}`;" in route_body
+    assert "if (_isManagedAuthMode()) return _managedDraftOwnerKey();" in owner_body
+    assert "return 'direct_debug';" in owner_body
+    assert "managed:" in managed_owner_body
+    assert "sessionStorage.removeItem(TRANSIENT_DRAFT_STORAGE_KEY);" in clear_body
+    assert "sessionStorage.getItem(TRANSIENT_DRAFT_STORAGE_KEY)" in read_body
+    assert "schema !== TRANSIENT_DRAFT_SCHEMA" in read_body
+    assert "config: _copyTransientDraftConfig(config)" in read_body
+    assert "sessionStorage.setItem(TRANSIENT_DRAFT_STORAGE_KEY, JSON.stringify(snapshot));" in persist_body
+    assert "schema: TRANSIENT_DRAFT_SCHEMA" in persist_body
+    assert "ownerKey" in persist_body
+    assert "savedAt: Date.now()" in persist_body
+    assert "buildStep: resolveBuildStep(state.portalUi.buildStep)" in persist_body
+    assert "API_KEY_STORAGE_KEY" not in persist_body
+    assert "csrfToken" not in persist_body
+    assert "state.jobs" not in persist_body
+    assert "snapshot.ownerKey !== ownerKey" in restore_body
+    assert "_clearTransientPortalDraft();" in restore_body
+    assert "state.pipeline = snapshot.pipeline;" in restore_body
+    assert "state.config = _copyTransientDraftConfig(snapshot.config);" in restore_body
+    assert "state.portalUi.buildStep = resolveBuildStep(snapshot.buildStep);" in restore_body
+
+
+def test_portal_transient_draft_restores_before_preview_and_readiness_hydration() -> None:
+    content = _portal_bundle_content()
+    body = _extract_js_function_body(content, "init")
+    bind_body = _extract_js_function_body(content, "bindInputs")
+    set_build_step_body = _extract_js_function_body(content, "setBuildStep")
+
+    assert "_restoreTransientPortalDraft();" in body
+    assert "_persistTransientPortalDraft();" in body
+    assert "_persistTransientPortalDraft();" in bind_body
+    assert "_persistTransientPortalDraft();" in set_build_step_body
+
+    restore_index = body.index("_restoreTransientPortalDraft();")
+    update_index = body.index("updateUIFromState();", restore_index)
+    check_index = body.index("void checkBackend(true);")
+    metadata_index = body.index("void fetchConfigMetadata(state.pipeline, true);")
+
+    assert restore_index < update_index < check_index < metadata_index
 
 
 def test_portal_managed_unavailable_mode_blocks_dispatch_and_api_key_recovery_prompts() -> None:
@@ -1319,7 +1376,8 @@ def test_portal_build_stepper_and_quick_actions_drive_task_first_navigation() ->
     assert "panel.setAttribute('data-step-active', active ? 'true' : 'false');" in stepper_body
     assert "panel.setAttribute('data-step-hidden', active ? 'false' : 'true');" in stepper_body
     assert "panel.classList.toggle('hidden', !active);" not in stepper_body
-    assert "function setBuildStep(nextStep, options = {}) {" in content
+    assert "function setBuildStep(nextStep, options) {" in content
+    assert "const settings = options && typeof options === 'object' ? options : {};" in content
     assert "emitPortalEvent('step_completed'" in content
     assert "state.pipeline !== 'lux-depth-v3' && state.portalUi.buildStep < 2" in update_body
     assert "setupBuildStepper();" in init_body
@@ -1755,7 +1813,7 @@ def test_portal_contextual_action_rail_reuses_existing_route_and_recovery_contra
     assert "_openArtifactForSelection(job, context.heroArtifact || context.selectedArtifact, 'action_rail');" in handler_body
     assert "_toggleCompareSurface(job, 'action_rail');" in handler_body
     assert "_retryPortalStatus(job);" in handler_body
-    assert "window.location.assign('/login');" in handler_body
+    assert "window.location.assign(_managedLoginUrlForCurrentRoute());" in handler_body
     assert "_rememberArtifactSelection(explicitJobId, '');" in content
     assert "_rememberArtifactSelection(preferredJobId, '');" in content
     assert "url.searchParams.set('action'" not in content

--- a/tests/validation/test_portal_smoke_scripts.py
+++ b/tests/validation/test_portal_smoke_scripts.py
@@ -457,6 +457,7 @@ def test_frontdoor_browser_waits_for_managed_portal_bootstrap_before_passing():
     assert 'and str(value.get("readyState", "")) == "complete"' in content
     assert content.count('and str(value.get("readyState", "")) == "complete"') >= 3
     assert 'and str(value.get("authModeBadge", "")).lower() == "managed"' in content
+    assert "locationSearch: window.location.search" in content
     assert "homepageHeroReady" in content
     assert "homepageEntryRailReady" in content
     assert "homepageLearnLinkReady" in content
@@ -476,6 +477,10 @@ def test_frontdoor_browser_waits_for_managed_portal_bootstrap_before_passing():
     assert "def _click_expression" in content
     assert "connection.evaluate(_populate_login_expression(username, password))" in content
     assert "connection.evaluate(_click_expression('[data-ui=\"login-submit\"]'))" in content
+    assert "/login?returnTo=%2Fportal%3Fview%3Dbuild" in content
+    assert 'and "returnTo=%2Fportal%3Fview%3Dbuild" in str(value.get("locationSearch", ""))' in content
+    assert 'and str(value.get("currentView", "")) == "build"' in content
+    assert 'and "view=build" in str(value.get("locationSearch", ""))' in content
     assert "/healthz" in content
     assert "--spawn-local-frontdoor" in content
     assert "--spawn-local-backend" in content
@@ -566,6 +571,17 @@ def test_portal_browser_smoke_tracks_archive_readiness_fields_and_canonical_comm
     assert "view=operate&job=" in content
     assert "artifact=" in content
     assert "compare=1" in content
+
+
+def test_portal_browser_smoke_restores_transient_build_draft_after_reload():
+    content = PORTAL_BROWSER_SCRIPT_PATH.read_text(encoding="utf-8")
+
+    assert "session-draft" in content
+    assert 'build_step="3"' in content
+    assert 'str(value.get("activeBuildStep", "")) == "3"' in content
+    assert 'connection.call("Page.reload", {"ignoreCache": True})' in content
+    assert "transient draft state to restore after reload" in content
+    assert 'build_step="1"' in content
 
 
 def test_portal_browser_smoke_probes_review_warning_and_provenance_contract():

--- a/web/secure-landing/app/login/route.js
+++ b/web/secure-landing/app/login/route.js
@@ -4,8 +4,8 @@ import { resolveAccessContext, resolveAuthenticatedAccessSession, revokeSessionO
 import { escapeHtml, FRONTDOOR_ASSETS, renderBrandAsset } from "../../lib/brand.js";
 import { audit } from "../../lib/audit.js";
 import { applySecurityHeaders, buildRequestUrl, FRONTDOOR_CSP } from "../../lib/http.js";
+import { applyPortalReturnTo, resolvePortalReturnTo, validatePortalReturnTo } from "../../lib/return-to.js";
 import {
-  clearSessionCookie,
   createAnonymousSession,
   destroySession,
   getRemoteAddress,
@@ -68,7 +68,7 @@ function resolveEntryState({ accessEmail, errorCode, bypass = false }) {
   };
 }
 
-function renderLoginPage({ csrfToken, accessEmail, errorCode, bypass = false }) {
+function renderLoginPage({ csrfToken, accessEmail, errorCode, bypass = false, returnTo = "" }) {
   const errorMessage = errorCode ? resolveLoginMessage(errorCode) : "";
   const entryState = resolveEntryState({ accessEmail, errorCode, bypass });
   const hasAccessContext = Boolean(bypass || accessEmail);
@@ -215,6 +215,7 @@ function renderLoginPage({ csrfToken, accessEmail, errorCode, bypass = false }) 
             </details>
             <form method="post" action="/login" autocomplete="on" data-ui="login-form">
               <input type="hidden" name="csrf_token" value="${escapeHtml(csrfToken)}" />
+              ${returnTo ? `<input type="hidden" name="returnTo" value="${escapeHtml(returnTo)}" />` : ""}
               <label data-ui="login-username-field">
                 Username
                 <input type="text" name="username" autocomplete="username" required />
@@ -239,9 +240,10 @@ function renderLoginPage({ csrfToken, accessEmail, errorCode, bypass = false }) 
 </html>`;
 }
 
-function redirectToLogin(request, errorCode, session) {
+function redirectToLogin(request, errorCode, session, returnTo = "") {
   const url = buildRequestUrl(request, "/login");
   if (errorCode) url.searchParams.set("error", errorCode);
+  applyPortalReturnTo(url, returnTo);
   const response = applySecurityHeaders(NextResponse.redirect(url, 303));
   if (session?.id) {
     setSessionCookie(response, session.id);
@@ -250,12 +252,15 @@ function redirectToLogin(request, errorCode, session) {
 }
 
 export async function GET(request) {
+  const requestedReturnTo = validatePortalReturnTo(request.nextUrl.searchParams.get("returnTo"));
   const currentSession = getSessionFromRequest(request, { touch: false });
   let session = currentSession;
   if (currentSession?.authenticated) {
     const authState = await resolveAuthenticatedAccessSession(request, { touch: false });
     if (authState.ok) {
-      return applySecurityHeaders(NextResponse.redirect(buildRequestUrl(request, "/portal"), 302));
+      return applySecurityHeaders(
+        NextResponse.redirect(buildRequestUrl(request, resolvePortalReturnTo(requestedReturnTo)), 302)
+      );
     }
     if (authState.revokeSession) {
       revokeSessionOnAccessFailure(currentSession, authState.errorCode);
@@ -271,7 +276,8 @@ export async function GET(request) {
     csrfToken: session.csrfToken,
     accessEmail: accessContext.accessEmail,
     errorCode: request.nextUrl.searchParams.get("error"),
-    bypass: accessContext.bypass
+    bypass: accessContext.bypass,
+    returnTo: requestedReturnTo || ""
   });
   const response = new NextResponse(html, {
     status: 200,
@@ -299,23 +305,24 @@ export async function POST(request) {
   }
 
   const formData = await request.formData();
+  const requestedReturnTo = validatePortalReturnTo(formData.get("returnTo"));
   const csrfToken = String(formData.get("csrf_token") || "");
   if (!validateCsrfToken(session, csrfToken)) {
     audit("csrf_failure", {
       path: "/login",
       remoteAddr: getRemoteAddress(request)
     });
-    return redirectToLogin(request, "csrf", session);
+    return redirectToLogin(request, "csrf", session, requestedReturnTo);
   }
 
   const config = getConfig();
   if (!config.users.length) {
-    return redirectToLogin(request, "configuration", session);
+    return redirectToLogin(request, "configuration", session, requestedReturnTo);
   }
 
   const accessContext = await resolveAccessContext(request);
   if (accessContext.errorCode === "configuration") {
-    return redirectToLogin(request, "configuration", session);
+    return redirectToLogin(request, "configuration", session, requestedReturnTo);
   }
   if (!accessContext.accessEmail && !accessContext.bypass) {
     audit("access_validation_failure", {
@@ -324,7 +331,7 @@ export async function POST(request) {
       assertedEmail: accessContext.assertedEmail,
       errorCode: accessContext.errorCode
     });
-    return redirectToLogin(request, "access", session);
+    return redirectToLogin(request, "access", session, requestedReturnTo);
   }
 
   const username = String(formData.get("username") || "").trim();
@@ -338,7 +345,7 @@ export async function POST(request) {
       accessEmail: accessContext.accessEmail,
       remoteAddr
     });
-    return redirectToLogin(request, "throttled", session);
+    return redirectToLogin(request, "throttled", session, requestedReturnTo);
   }
 
   const user = await verifyUserCredentials({
@@ -360,7 +367,7 @@ export async function POST(request) {
       remoteAddr,
       bypass: accessContext.bypass
     });
-    return redirectToLogin(request, "invalid", session);
+    return redirectToLogin(request, "invalid", session, requestedReturnTo);
   }
 
   const authenticatedSession = rotateAuthenticatedSession(session, user);
@@ -376,7 +383,9 @@ export async function POST(request) {
     bypass: accessContext.bypass
   });
 
-  const response = applySecurityHeaders(NextResponse.redirect(buildRequestUrl(request, "/portal"), 303));
+  const response = applySecurityHeaders(
+    NextResponse.redirect(buildRequestUrl(request, resolvePortalReturnTo(requestedReturnTo)), 303)
+  );
   setSessionCookie(response, authenticatedSession.id);
   return response;
 }

--- a/web/secure-landing/app/portal/route.js
+++ b/web/secure-landing/app/portal/route.js
@@ -4,6 +4,7 @@ import { resolveAuthenticatedAccessSession, revokeSessionOnAccessFailure } from 
 import { escapeHtml, FRONTDOOR_ASSETS, renderBrandAsset } from "../../lib/brand.js";
 import { applySecurityHeaders, buildRequestUrl, LOGIN_CSP } from "../../lib/http.js";
 import { copyUpstreamResponseHeaders } from "../../lib/proxy.js";
+import { applyPortalReturnTo, currentPortalReturnToFromRequest } from "../../lib/return-to.js";
 import { getConfig } from "../../lib/config.js";
 import {
   auditManagedSurfaceFailure,
@@ -42,7 +43,7 @@ function resolveManagedRecoveryContent(reason, message) {
   };
 }
 
-function renderManagedPortalRecoveryPage({ reason, message }) {
+function renderManagedPortalRecoveryPage({ reason, message, loginHref }) {
   const resolvedReason = reason || MANAGED_FAILURE_REASON.UPSTREAM_UNAVAILABLE;
   const content = resolveManagedRecoveryContent(resolvedReason, message);
   const safeReason = escapeHtml(resolvedReason);
@@ -114,7 +115,7 @@ function renderManagedPortalRecoveryPage({ reason, message }) {
               </div>
             </div>
             <div class="login-actions" data-ui="managed-recovery-actions">
-              <a class="login-secondary-link" href="/login">Return to login</a>
+              <a class="login-secondary-link" href="${escapeHtml(loginHref)}">Return to login</a>
               <a class="login-secondary-link" href="/">Review public proof surface</a>
             </div>
           </div>
@@ -126,6 +127,9 @@ function renderManagedPortalRecoveryPage({ reason, message }) {
 }
 
 export async function GET(request) {
+  const currentReturnTo = currentPortalReturnToFromRequest(request) || "/portal";
+  const loginUrl = buildRequestUrl(request, "/login");
+  applyPortalReturnTo(loginUrl, currentReturnTo);
   const authState = await resolveAuthenticatedAccessSession(request, { touch: true });
   if (!authState.ok) {
     const reason = classifyManagedAccessFailure(authState.errorCode);
@@ -143,7 +147,8 @@ export async function GET(request) {
       return applySecurityHeaders(
         new Response(renderManagedPortalRecoveryPage({
           reason,
-          message: getManagedFailureMessage("portal", reason)
+          message: getManagedFailureMessage("portal", reason),
+          loginHref: `${loginUrl.pathname}${loginUrl.search}`
         }), {
           status: 503,
           headers
@@ -156,7 +161,7 @@ export async function GET(request) {
       revokeSessionOnAccessFailure(authState.session, authState.errorCode);
     }
 
-    const response = applySecurityHeaders(NextResponse.redirect(buildRequestUrl(request, "/login"), 302));
+    const response = applySecurityHeaders(NextResponse.redirect(loginUrl, 302));
     if (authState.revokeSession) {
       clearSessionCookie(response);
     }
@@ -184,12 +189,13 @@ export async function GET(request) {
     headers.set("Cache-Control", "no-store");
     headers.set("Content-Type", "text/html; charset=utf-8");
     return applySecurityHeaders(
-      new Response(renderManagedPortalRecoveryPage({
-        reason: MANAGED_FAILURE_REASON.UPSTREAM_UNAVAILABLE,
-        message: getManagedFailureMessage("portal", MANAGED_FAILURE_REASON.UPSTREAM_UNAVAILABLE)
-      }), {
-        status: 503,
-        headers
+        new Response(renderManagedPortalRecoveryPage({
+          reason: MANAGED_FAILURE_REASON.UPSTREAM_UNAVAILABLE,
+          message: getManagedFailureMessage("portal", MANAGED_FAILURE_REASON.UPSTREAM_UNAVAILABLE),
+          loginHref: `${loginUrl.pathname}${loginUrl.search}`
+        }), {
+          status: 503,
+          headers
       }),
       { csp: LOGIN_CSP }
     );
@@ -211,7 +217,8 @@ export async function GET(request) {
       return applySecurityHeaders(
         new Response(renderManagedPortalRecoveryPage({
           reason,
-          message: getManagedFailureMessage("portal", reason)
+          message: getManagedFailureMessage("portal", reason),
+          loginHref: `${loginUrl.pathname}${loginUrl.search}`
         }), {
           status: 503,
           headers

--- a/web/secure-landing/lib/return-to.js
+++ b/web/secure-landing/lib/return-to.js
@@ -1,0 +1,99 @@
+const DEFAULT_PORTAL_RETURN_TO = "/portal";
+const ALLOWED_PORTAL_VIEWS = new Set(["overview", "build", "operate", "review"]);
+const ALLOWED_QUERY_KEYS = ["view", "job", "artifact", "compare"];
+
+function _valueOrEmpty(rawValue) {
+  return String(rawValue || "").trim();
+}
+
+export function validatePortalReturnTo(rawValue) {
+  const value = _valueOrEmpty(rawValue);
+  if (!value || !value.startsWith("/") || value.startsWith("//")) {
+    return null;
+  }
+
+  let parsed;
+  try {
+    parsed = new URL(value, "https://portal.invalid");
+  } catch {
+    return null;
+  }
+
+  if (parsed.origin !== "https://portal.invalid" || parsed.pathname !== DEFAULT_PORTAL_RETURN_TO || parsed.hash) {
+    return null;
+  }
+
+  const params = parsed.searchParams;
+  const seenKeys = new Set();
+  for (const key of params.keys()) {
+    if (seenKeys.has(key)) {
+      return null;
+    }
+    seenKeys.add(key);
+    if (!ALLOWED_QUERY_KEYS.includes(key)) {
+      return null;
+    }
+  }
+
+  const view = params.get("view");
+  const job = params.get("job");
+  const artifact = params.get("artifact");
+  const compare = params.get("compare");
+
+  if (view !== null && !ALLOWED_PORTAL_VIEWS.has(view)) {
+    return null;
+  }
+  if (job !== null && !_valueOrEmpty(job)) {
+    return null;
+  }
+  if (artifact !== null && !_valueOrEmpty(artifact)) {
+    return null;
+  }
+  if (compare !== null && compare !== "1") {
+    return null;
+  }
+
+  const hasJobContext = job !== null || artifact !== null || compare !== null;
+  if (hasJobContext) {
+    if (!view || (view !== "operate" && view !== "review")) {
+      return null;
+    }
+    if (!job) {
+      return null;
+    }
+  }
+
+  const normalized = new URL(DEFAULT_PORTAL_RETURN_TO, "https://portal.invalid");
+  if (view) {
+    normalized.searchParams.set("view", view);
+  }
+  if (job) {
+    normalized.searchParams.set("job", _valueOrEmpty(job));
+  }
+  if (artifact) {
+    normalized.searchParams.set("artifact", _valueOrEmpty(artifact));
+  }
+  if (compare === "1") {
+    normalized.searchParams.set("compare", "1");
+  }
+
+  return `${normalized.pathname}${normalized.search}`;
+}
+
+export function resolvePortalReturnTo(rawValue, fallback = DEFAULT_PORTAL_RETURN_TO) {
+  return validatePortalReturnTo(rawValue) || fallback;
+}
+
+export function applyPortalReturnTo(url, rawValue) {
+  const validated = validatePortalReturnTo(rawValue);
+  if (validated) {
+    url.searchParams.set("returnTo", validated);
+  } else {
+    url.searchParams.delete("returnTo");
+  }
+  return url;
+}
+
+export function currentPortalReturnToFromRequest(request) {
+  return validatePortalReturnTo(`${request.nextUrl.pathname || ""}${request.nextUrl.search || ""}`);
+}

--- a/web/secure-landing/portal-src/portal.template.js
+++ b/web/secure-landing/portal-src/portal.template.js
@@ -35,6 +35,8 @@
 const API_BASE = '';
 const STORAGE_KEY = 'tp_orchestrator_profiles_final';
 const API_KEY_STORAGE_KEY = 'tp_api_key';
+const TRANSIENT_DRAFT_STORAGE_KEY = 'tp_portal_transient_draft';
+const TRANSIENT_DRAFT_SCHEMA = 'tp.portal.transient_draft.v1';
 const THEME_STORAGE_KEY = 'tp_theme';
 const THEME_STORAGE_VERSION_KEY = 'tp_theme_version';
 const THEME_STORAGE_VERSION = '2';
@@ -989,6 +991,127 @@ function _syncConsoleRoute(replace = false) {
     window.history[method]({ view: state.currentView, jobId: state.selectedJobId || '' }, '', nextHref);
 }
 
+function _managedReturnToPath() {
+    const url = new URL(window.location.href);
+    if (url.pathname !== '/portal') return '/portal';
+    return `${url.pathname}${url.search}`;
+}
+
+function _managedLoginUrlForCurrentRoute() {
+    return `/login?returnTo=${encodeURIComponent(_managedReturnToPath())}`;
+}
+
+function _copyTransientDraftConfig(config = state.config) {
+    return JSON.parse(JSON.stringify(config && typeof config === 'object' ? config : portalInternals.createPortalConfigState()));
+}
+
+function _managedDraftOwnerKey() {
+    const actor = state.auth && state.auth.actor && typeof state.auth.actor === 'object' ? state.auth.actor : null;
+    const accessEmail = String(actor?.accessEmail || '').trim().toLowerCase();
+    if (accessEmail) return `managed:${accessEmail}`;
+    const username = String(actor?.username || '').trim().toLowerCase();
+    const role = String(actor?.role || '').trim().toLowerCase();
+    if (!username && !role) return '';
+    return `managed:${[username, role].filter(Boolean).join(':')}`;
+}
+
+function _transientDraftOwnerKey() {
+    if (!_isBootstrapReady()) return '';
+    if (_isManagedAuthMode()) return _managedDraftOwnerKey();
+    return 'direct_debug';
+}
+
+function _clearTransientPortalDraft() {
+    try {
+        sessionStorage.removeItem(TRANSIENT_DRAFT_STORAGE_KEY);
+    } catch {
+        // Ignore storage access failures during teardown or quota exhaustion.
+    }
+}
+
+function _readTransientPortalDraft() {
+    let raw = '';
+    try {
+        raw = sessionStorage.getItem(TRANSIENT_DRAFT_STORAGE_KEY) || '';
+    } catch {
+        return null;
+    }
+    if (!raw) return null;
+
+    let parsed = null;
+    try {
+        parsed = JSON.parse(raw);
+    } catch {
+        _clearTransientPortalDraft();
+        return null;
+    }
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        _clearTransientPortalDraft();
+        return null;
+    }
+
+    const schema = String(parsed.schema || '').trim();
+    const ownerKey = String(parsed.ownerKey || '').trim();
+    const savedAt = Number(parsed.savedAt || 0);
+    const pipeline = String(parsed.pipeline || '').trim();
+    const config = parsed.config;
+    if (
+        schema !== TRANSIENT_DRAFT_SCHEMA
+        || !ownerKey
+        || !Number.isFinite(savedAt)
+        || savedAt <= 0
+        || !pipeline
+        || !config
+        || typeof config !== 'object'
+        || Array.isArray(config)
+    ) {
+        _clearTransientPortalDraft();
+        return null;
+    }
+
+    return {
+        schema,
+        ownerKey,
+        savedAt,
+        pipeline,
+        config: _copyTransientDraftConfig(config),
+        buildStep: resolveBuildStep(parsed.buildStep)
+    };
+}
+
+function _persistTransientPortalDraft() {
+    const ownerKey = _transientDraftOwnerKey();
+    if (!ownerKey) return false;
+    const snapshot = {
+        schema: TRANSIENT_DRAFT_SCHEMA,
+        pipeline: String(state.pipeline || '').trim() || 'lux-depth-v3',
+        config: _copyTransientDraftConfig(),
+        buildStep: resolveBuildStep(state.portalUi.buildStep),
+        savedAt: Date.now(),
+        ownerKey
+    };
+    try {
+        sessionStorage.setItem(TRANSIENT_DRAFT_STORAGE_KEY, JSON.stringify(snapshot));
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+function _restoreTransientPortalDraft() {
+    const snapshot = _readTransientPortalDraft();
+    if (!snapshot) return false;
+    const ownerKey = _transientDraftOwnerKey();
+    if (!ownerKey || snapshot.ownerKey !== ownerKey) {
+        _clearTransientPortalDraft();
+        return false;
+    }
+    state.pipeline = snapshot.pipeline;
+    state.config = _copyTransientDraftConfig(snapshot.config);
+    state.portalUi.buildStep = resolveBuildStep(snapshot.buildStep);
+    return true;
+}
+
 function _jobFreshnessLabel(job) {
     if (!job) return 'No live telemetry';
     const lastActivityAt = Number(job.lastEventAt || job.updatedAt || job.finishedAt || job.createdAt || 0);
@@ -1545,7 +1668,7 @@ function handleOperatorActionClick(event) {
             _retryPortalStatus(job);
             break;
         case 'restore_access':
-            window.location.assign('/login');
+            window.location.assign(_managedLoginUrlForCurrentRoute());
             break;
         default:
             break;
@@ -2525,12 +2648,14 @@ function syncBuildStepUi() {
     renderBuildStepPulse(generatePayload());
 }
 
-function setBuildStep(nextStep, options = {}) {
+function setBuildStep(nextStep, options) {
+    const settings = options && typeof options === 'object' ? options : {};
     const previous = resolveBuildStep(state.portalUi.buildStep);
     const resolved = resolveBuildStep(nextStep);
     state.portalUi.buildStep = resolved;
     syncBuildStepUi();
-    if (!options.silent && resolved > previous) {
+    _persistTransientPortalDraft();
+    if (!settings.silent && resolved > previous) {
         void emitPortalEvent('step_completed', {
             surface: 'build_stepper',
             metadata: { step: previous, next_step: resolved }
@@ -4458,7 +4583,7 @@ async function loadPortalBootstrap(options = null) {
             _finalizeBootstrapRetry('terminal_auth_redirect', { reason: failure.reason, httpStatus: res.status });
             _applyPortalBootstrap(fallback, { status: 'unavailable', reason: failure.reason, httpStatus: res.status });
             createToast(failure.toastMessage, 'error');
-            window.location.assign('/login');
+            window.location.assign(_managedLoginUrlForCurrentRoute());
             return;
         }
         if (!res.ok) {
@@ -7968,11 +8093,13 @@ function bindInputs() {
             else state[key] = e.target.value;
             if (key === 'pipeline') {
                 updateUIFromState();
+                _persistTransientPortalDraft();
                 void fetchPresetsForPipeline(state.pipeline, true);
                 void fetchReadiness(true);
                 void fetchConfigMetadata(state.pipeline, true);
             }
             else {
+                _persistTransientPortalDraft();
                 const field = trackedTelemetryField(category, key);
                 if (field) {
                     void emitPortalEvent('field_commit', {
@@ -7991,6 +8118,7 @@ function bindInputs() {
         el.addEventListener('input', (e) => {
             if (category) state.config[category][key] = e.target.value;
             else state.config[key] = e.target.value;
+            _persistTransientPortalDraft();
             renderCLI();
             if (trackedTelemetryField(category, key)) {
                 scheduleConfigPreview();
@@ -7998,6 +8126,7 @@ function bindInputs() {
         });
         el.addEventListener('change', (e) => {
             const field = trackedTelemetryField(category, key);
+            _persistTransientPortalDraft();
             if (field) {
                 void emitPortalEvent('field_commit', {
                     surface: telemetrySurfaceFor(category),
@@ -8043,6 +8172,7 @@ function bindInputs() {
                 state.portalUi.debugBundleGuardrailSeen = false;
                 if (els.debugBundleAcknowledge) els.debugBundleAcknowledge.checked = false;
             }
+            _persistTransientPortalDraft();
             renderCLI();
             scheduleConfigPreview();
         });
@@ -8055,6 +8185,7 @@ function bindInputs() {
             state.config.preset = nextPreset;
             applyPresetRecommendedArgs(nextPreset);
             updateUIFromState();
+            _persistTransientPortalDraft();
         });
     }
     safeBindInput(els.inputDir, null, 'inputDir');
@@ -9216,6 +9347,7 @@ if (els.profileSelect) els.profileSelect.addEventListener('change', (e) => {
         state.pipeline = profiles[name].pipeline;
         state.config = JSON.parse(JSON.stringify(profiles[name].config));
         updateUIFromState();
+        _persistTransientPortalDraft();
         void fetchPresetsForPipeline(state.pipeline, true);
         createToast(`Profile ${name} loaded.`);
     }
@@ -9390,6 +9522,7 @@ if (els.fileInput) els.fileInput.addEventListener('change', async (e) => {
         state.portalUi.debugBundleAcknowledged = false;
         state.portalUi.debugBundleGuardrailSeen = false;
         updateUIFromState();
+        _persistTransientPortalDraft();
         void fetchPresetsForPipeline(state.pipeline, true);
         void fetchConfigMetadata(state.pipeline, true);
         createToast("Configuration imported.", "success");
@@ -10186,11 +10319,14 @@ async function init() {
     setupSectionRail();
     _syncBootstrapUi();
     renderJobQueue();
-    void checkBackend(true);
-    void fetchConfigMetadata(state.pipeline, true);
     startHealthPolling();
     await bootstrapPromise;
+    _restoreTransientPortalDraft();
+    updateUIFromState();
+    _persistTransientPortalDraft();
     portalRenderSurfaces.render('jobQueue', state);
+    void checkBackend(true);
+    void fetchConfigMetadata(state.pipeline, true);
 }
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/web/secure-landing/portal-src/portal.template.js
+++ b/web/secure-landing/portal-src/portal.template.js
@@ -60,6 +60,7 @@ const SSE_RECONNECT_JITTER_MS = 250;
 const SSE_STALL_CHECK_INTERVAL_MS = 10000;
 const SSE_STALL_THRESHOLD_MS = 45000;
 const CONFIG_PREVIEW_DEBOUNCE_MS = 250;
+const TRANSIENT_DRAFT_PERSIST_DEBOUNCE_MS = 200;
 const DISPATCH_BACKEND_OFFLINE_MESSAGE = 'Backend is offline. Dispatch is disabled until connectivity is restored.';
 const CONFIG_PREVIEW_SUPPORTED_PIPELINES = new Set([
     'lux-depth-v3',
@@ -82,6 +83,8 @@ let sseWatchdogIntervalId = null;
 let healthCheckInFlight = false;
 let lastHealthCheckAt = 0;
 let configPreviewTimerId = null;
+let transientDraftPersistTimerId = null;
+let transientDraftPersistIdleId = null;
 
 /* __PORTAL_INTERNALS__ */
 
@@ -1098,6 +1101,47 @@ function _persistTransientPortalDraft() {
     }
 }
 
+function _cancelScheduledTransientPortalDraftPersist() {
+    if (transientDraftPersistTimerId !== null) {
+        window.clearTimeout(transientDraftPersistTimerId);
+        transientDraftPersistTimerId = null;
+    }
+    if (transientDraftPersistIdleId !== null && typeof window.cancelIdleCallback === 'function') {
+        window.cancelIdleCallback(transientDraftPersistIdleId);
+    }
+    transientDraftPersistIdleId = null;
+}
+
+function _flushPendingTransientPortalDraftPersist() {
+    _cancelScheduledTransientPortalDraftPersist();
+    return _persistTransientPortalDraft();
+}
+
+function _scheduleTransientPortalDraftPersist(options) {
+    const settings = options && typeof options === 'object' ? options : {};
+    if (settings.immediate) return _flushPendingTransientPortalDraftPersist();
+    _cancelScheduledTransientPortalDraftPersist();
+
+    const commitSnapshot = () => {
+        transientDraftPersistTimerId = null;
+        transientDraftPersistIdleId = null;
+        _persistTransientPortalDraft();
+    };
+    const scheduleCommit = () => {
+        transientDraftPersistTimerId = null;
+        if (typeof window.requestIdleCallback === 'function') {
+            transientDraftPersistIdleId = window.requestIdleCallback(() => {
+                commitSnapshot();
+            }, { timeout: TRANSIENT_DRAFT_PERSIST_DEBOUNCE_MS });
+            return;
+        }
+        commitSnapshot();
+    };
+
+    transientDraftPersistTimerId = window.setTimeout(scheduleCommit, TRANSIENT_DRAFT_PERSIST_DEBOUNCE_MS);
+    return true;
+}
+
 function _restoreTransientPortalDraft() {
     const snapshot = _readTransientPortalDraft();
     if (!snapshot) return false;
@@ -1668,6 +1712,7 @@ function handleOperatorActionClick(event) {
             _retryPortalStatus(job);
             break;
         case 'restore_access':
+            _flushPendingTransientPortalDraftPersist();
             window.location.assign(_managedLoginUrlForCurrentRoute());
             break;
         default:
@@ -4583,6 +4628,7 @@ async function loadPortalBootstrap(options = null) {
             _finalizeBootstrapRetry('terminal_auth_redirect', { reason: failure.reason, httpStatus: res.status });
             _applyPortalBootstrap(fallback, { status: 'unavailable', reason: failure.reason, httpStatus: res.status });
             createToast(failure.toastMessage, 'error');
+            _flushPendingTransientPortalDraftPersist();
             window.location.assign(_managedLoginUrlForCurrentRoute());
             return;
         }
@@ -8118,7 +8164,7 @@ function bindInputs() {
         el.addEventListener('input', (e) => {
             if (category) state.config[category][key] = e.target.value;
             else state.config[key] = e.target.value;
-            _persistTransientPortalDraft();
+            _scheduleTransientPortalDraftPersist();
             renderCLI();
             if (trackedTelemetryField(category, key)) {
                 scheduleConfigPreview();
@@ -8126,7 +8172,7 @@ function bindInputs() {
         });
         el.addEventListener('change', (e) => {
             const field = trackedTelemetryField(category, key);
-            _persistTransientPortalDraft();
+            _scheduleTransientPortalDraftPersist({ immediate: true });
             if (field) {
                 void emitPortalEvent('field_commit', {
                     surface: telemetrySurfaceFor(category),
@@ -10272,7 +10318,9 @@ portalRenderSurfaces.register('jobQueue', {
     }
 });
 
+window.addEventListener('beforeunload', _flushPendingTransientPortalDraftPersist);
 window.addEventListener('beforeunload', cleanupActiveJobHandles);
+window.addEventListener('pagehide', _flushPendingTransientPortalDraftPersist);
 window.addEventListener('pagehide', cleanupActiveJobHandles);
 window.addEventListener('pageshow', () => {
     reconcileBuildSurfaceFromDom();

--- a/web/secure-landing/tests/routes.test.mjs
+++ b/web/secure-landing/tests/routes.test.mjs
@@ -363,6 +363,57 @@ test("login POST rotates the session and redirects authenticated users to /porta
   }
 });
 
+test("login POST redirects authenticated users to a validated returnTo route", async () => {
+  const passwordHash = await argon2.hash("correct horse battery staple");
+  const env = withTempEnvironment({
+    usersFileEntries: [
+      {
+        username: "admin",
+        password_hash: passwordHash,
+        access_email: "admin@example.com",
+        role: "admin"
+      }
+    ]
+  });
+
+  try {
+    const sessions = await importFresh("../lib/sessions.js");
+    const { POST } = await importFresh("../app/login/route.js");
+    const restoreFetch = withMockedAccessCerts();
+
+    try {
+      const anonymousSession = sessions.createAnonymousSession();
+      const form = new URLSearchParams({
+        username: "admin",
+        password: "correct horse battery staple",
+        csrf_token: anonymousSession.csrfToken,
+        returnTo: "/portal?view=build"
+      });
+
+      const request = buildRequest("https://portal.example.com/login", {
+        method: "POST",
+        headers: new Headers({
+          origin: "https://portal.example.com",
+          "content-type": "application/x-www-form-urlencoded",
+          cookie: `__Host-tp_session=${anonymousSession.id}`,
+          "Cf-Access-Jwt-Assertion": createAccessJwt(),
+          "cf-access-authenticated-user-email": "admin@example.com"
+        }),
+        body: form
+      });
+
+      const response = await POST(request);
+
+      assert.equal(response.status, 303);
+      assert.equal(response.headers.get("location"), "https://portal.example.com/portal?view=build");
+    } finally {
+      restoreFetch();
+    }
+  } finally {
+    env.cleanup();
+  }
+});
+
 test("login GET serves a minimal branded sign-in shell and boots an anonymous session", async () => {
   const env = withTempEnvironment({
     NODE_ENV: "development",
@@ -412,6 +463,64 @@ test("login GET serves a minimal branded sign-in shell and boots an anonymous se
     assert.doesNotMatch(html, /TP_CF_ACCESS_TEAM_DOMAIN/);
     assert.ok(sessionCookie.value);
     assert.equal(sessions.getSessionById(sessionCookie.value, { touch: false })?.authenticated, false);
+  } finally {
+    env.cleanup();
+  }
+});
+
+test("login GET preserves a validated returnTo in the rendered form", async () => {
+  const env = withTempEnvironment({
+    NODE_ENV: "development",
+    TP_ALLOW_LOCAL_ACCESS_BYPASS: "1"
+  });
+
+  try {
+    const { GET } = await importFresh("../app/login/route.js");
+    const request = buildRequest("http://localhost:3000/login?returnTo=%2Fportal%3Fview%3Dbuild");
+
+    const response = await GET(request);
+    const html = await response.text();
+
+    assert.equal(response.status, 200);
+    assert.match(html, /name="returnTo" value="\/portal\?view=build"/);
+  } finally {
+    env.cleanup();
+  }
+});
+
+test("login GET redirects authenticated sessions to a validated returnTo route", async () => {
+  const env = withTempEnvironment();
+
+  try {
+    const sessions = await importFresh("../lib/sessions.js");
+    const { GET } = await importFresh("../app/login/route.js");
+    const restoreFetch = withMockedAccessCerts();
+
+    try {
+      const authenticatedSession = sessions.rotateAuthenticatedSession(
+        sessions.createAnonymousSession(),
+        {
+          username: "admin",
+          accessEmail: "admin@example.com",
+          role: "admin"
+        }
+      );
+
+      const request = buildRequest("https://portal.example.com/login?returnTo=%2Fportal%3Fview%3Dreview", {
+        method: "GET",
+        headers: new Headers({
+          cookie: `__Host-tp_session=${authenticatedSession.id}`,
+          "Cf-Access-Jwt-Assertion": createAccessJwt()
+        })
+      });
+
+      const response = await GET(request);
+
+      assert.equal(response.status, 302);
+      assert.equal(response.headers.get("location"), "https://portal.example.com/portal?view=review");
+    } finally {
+      restoreFetch();
+    }
   } finally {
     env.cleanup();
   }
@@ -646,6 +755,58 @@ test("login POST keeps failures generic when Access email does not match the con
       assert.equal(response.status, 303);
       assert.equal(response.headers.get("location"), "https://portal.example.com/login?error=invalid");
       assert.equal(sessions.getSessionById(anonymousSession.id, { touch: false })?.authenticated, false);
+    } finally {
+      restoreFetch();
+    }
+  } finally {
+    env.cleanup();
+  }
+});
+
+test("login POST preserves a validated returnTo when sign-in fails", async () => {
+  const passwordHash = await argon2.hash("correct horse battery staple");
+  const env = withTempEnvironment({
+    usersFileEntries: [
+      {
+        username: "admin",
+        password_hash: passwordHash,
+        access_email: "admin@example.com",
+        role: "admin"
+      }
+    ]
+  });
+
+  try {
+    const sessions = await importFresh("../lib/sessions.js");
+    const { POST } = await importFresh("../app/login/route.js");
+    const restoreFetch = withMockedAccessCerts();
+
+    try {
+      const anonymousSession = sessions.createAnonymousSession();
+      const request = buildRequest("https://portal.example.com/login", {
+        method: "POST",
+        headers: new Headers({
+          origin: "https://portal.example.com",
+          "content-type": "application/x-www-form-urlencoded",
+          cookie: `__Host-tp_session=${anonymousSession.id}`,
+          "Cf-Access-Jwt-Assertion": createAccessJwt(),
+          "cf-access-authenticated-user-email": "admin@example.com"
+        }),
+        body: new URLSearchParams({
+          username: "admin",
+          password: "wrong password",
+          csrf_token: anonymousSession.csrfToken,
+          returnTo: "/portal?view=review"
+        })
+      });
+
+      const response = await POST(request);
+
+      assert.equal(response.status, 303);
+      assert.equal(
+        response.headers.get("location"),
+        "https://portal.example.com/login?error=invalid&returnTo=%2Fportal%3Fview%3Dreview"
+      );
     } finally {
       restoreFetch();
     }
@@ -1002,14 +1163,59 @@ test("login POST ignores untrusted host overrides when building redirect targets
       body: new URLSearchParams({
         username: "admin",
         password: "correct horse battery staple",
-        csrf_token: anonymousSession.csrfToken
+        csrf_token: anonymousSession.csrfToken,
+        returnTo: "/portal?view=build"
       })
     });
 
     const response = await POST(request);
 
     assert.equal(response.status, 303);
-    assert.equal(response.headers.get("location"), "https://portal.example.com/portal");
+    assert.equal(response.headers.get("location"), "https://portal.example.com/portal?view=build");
+  } finally {
+    env.cleanup();
+  }
+});
+
+test("login POST rejects invalid returnTo values and falls back to /portal", async () => {
+  const passwordHash = await argon2.hash("correct horse battery staple");
+  const env = withTempEnvironment({
+    NODE_ENV: "development",
+    TP_ALLOW_LOCAL_ACCESS_BYPASS: "1",
+    usersFileEntries: [
+      {
+        username: "admin",
+        password_hash: passwordHash,
+        access_email: "admin@example.com",
+        role: "admin"
+      }
+    ]
+  });
+
+  try {
+    const sessions = await importFresh("../lib/sessions.js");
+    const { POST } = await importFresh("../app/login/route.js");
+
+    const anonymousSession = sessions.createAnonymousSession();
+    const request = buildRequest("http://127.0.0.1:3000/login", {
+      method: "POST",
+      headers: new Headers({
+        host: "127.0.0.1:3000",
+        "content-type": "application/x-www-form-urlencoded",
+        cookie: `tp_session=${anonymousSession.id}`
+      }),
+      body: new URLSearchParams({
+        username: "admin",
+        password: "correct horse battery staple",
+        csrf_token: anonymousSession.csrfToken,
+        returnTo: "https://evil.example.com/portal"
+      })
+    });
+
+    const response = await POST(request);
+
+    assert.equal(response.status, 303);
+    assert.equal(response.headers.get("location"), "http://127.0.0.1:3000/portal");
   } finally {
     env.cleanup();
   }
@@ -1300,7 +1506,7 @@ test("portal returns 503 with no-store when the FastAPI UI origin is unavailable
     });
 
     try {
-      const request = buildRequest("https://portal.example.com/portal", {
+      const request = buildRequest("https://portal.example.com/portal?view=build", {
         method: "GET",
         headers: new Headers({
           cookie: `__Host-tp_session=${authenticatedSession.id}`,
@@ -1317,7 +1523,7 @@ test("portal returns 503 with no-store when the FastAPI UI origin is unavailable
       assert.match(html, /data-ui="managed-recovery-shell"/);
       assert.match(html, /data-reason="upstream_unavailable"/);
       assert.match(html, /Portal upstream unavailable/);
-      assert.match(html, /Return to login/);
+      assert.match(html, /href="\/login\?returnTo=%2Fportal%3Fview%3Dbuild"/);
     } finally {
       restoreFetch();
     }
@@ -1369,6 +1575,7 @@ test("portal renders waiting recovery posture for Access outages", async () => {
       assert.match(html, /class="[^"]*\blogin-status-card\b[^"]*"/);
       assert.match(html, /data-state="waiting"/);
       assert.match(html, /Retry when Access recovers/);
+      assert.match(html, /href="\/login\?returnTo=%2Fportal"/);
     } finally {
       global.fetch = originalFetch;
     }
@@ -1412,6 +1619,7 @@ test("portal returns configuration guidance when managed access config is incomp
       assert.match(html, /data-reason="config_failure"/);
       assert.match(html, /Managed front door configuration unavailable/);
       assert.match(html, /Managed boundary stays fail-closed/);
+      assert.match(html, /href="\/login\?returnTo=%2Fportal"/);
       assert.equal(events.length, 1);
       assert.equal(events[0].surface, "portal");
       assert.equal(events[0].reason, "config_failure");
@@ -1422,7 +1630,7 @@ test("portal returns configuration guidance when managed access config is incomp
   }
 });
 
-test("portal redirects to login and clears the session when Access verification is missing", async () => {
+test("portal redirects to login with route context and clears the session when Access verification is missing", async () => {
   const env = withTempEnvironment();
 
   try {
@@ -1437,17 +1645,23 @@ test("portal redirects to login and clears the session when Access verification 
       }
     );
 
-    const request = buildRequest("https://portal.example.com/portal", {
-      method: "GET",
-      headers: new Headers({
-        cookie: `__Host-tp_session=${authenticatedSession.id}`
-      })
-    });
+    const request = buildRequest(
+      "https://portal.example.com/portal?view=review&job=job_demo&artifact=synthetic%2Freview-primary.png&compare=1",
+      {
+        method: "GET",
+        headers: new Headers({
+          cookie: `__Host-tp_session=${authenticatedSession.id}`
+        })
+      }
+    );
 
     const response = await GET(request);
 
     assert.equal(response.status, 302);
-    assert.equal(response.headers.get("location"), "https://portal.example.com/login");
+    assert.equal(
+      response.headers.get("location"),
+      "https://portal.example.com/login?returnTo=%2Fportal%3Fview%3Dreview%26job%3Djob_demo%26artifact%3Dsynthetic%252Freview-primary.png%26compare%3D1"
+    );
     assert.match(response.headers.get("set-cookie") || "", /__Host-tp_session=/);
     assert.equal(sessions.getSessionById(authenticatedSession.id, { touch: false }), null);
   } finally {


### PR DESCRIPTION
## Summary
- Preserve canonical `/portal` route context through managed login and re-auth flows.
- Add bounded transient build-draft restore in the portal without changing `/v1/*` envelopes, selectors, or direct-debug auth semantics.

## Changes
- Added strict `/portal`-only `returnTo` validation and reused it in the frontdoor login route and portal route recovery redirects.
- Preserved validated `returnTo` through login GET/POST success and failure paths, authenticated `/login` bounce-forward behavior, and managed recovery "Return to login" links.
- Added `tp_portal_transient_draft` sessionStorage restore/persist helpers scoped by owner key, excluding auth/session/job/telemetry state, and wired them into build-step and draft-config mutations plus managed re-auth actions.
- Rebuilt `public/portal-assets/portal.js` from the updated portal source.
- Extended frontdoor route tests, portal runtime tests, script-level smoke tests, and live browser smoke coverage for route-preserving login and same-tab draft restore.

## Validation
Proven green
- `PATH=/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin:$PATH .venv/bin/pre-commit run --all-files --show-diff-on-failure`
- `source ~/.nvm/nvm.sh && nvm use 22 >/dev/null && make test-frontdoor-contract`
- `source ~/.nvm/nvm.sh && nvm use 22 >/dev/null && make test-portal-contract`
- `source ~/.nvm/nvm.sh && nvm use 22 >/dev/null && make validate-frontdoor-browser`
- `make validate-portal-browser`

Still failing
- None.

## Risk
- Bounded to managed frontdoor `/login` and `/portal` handling plus build-draft session persistence in the current tab.
- Keeps the existing `/portal?view=overview|build|operate|review` contract and leaves `/v1/*` envelopes, selector contracts, and managed-origin trust rules unchanged.
- Revert-safe because the change is additive and concentrated in frontdoor route handling, portal draft helpers, and their validation coverage.
