### PR TITLE
fix(ci): centralize gitleaks contract for firewall scans

### DIFF
--- a/.github/workflows/ci-quality-firewall.yml
+++ b/.github/workflows/ci-quality-firewall.yml
@@ -210,7 +210,7 @@ jobs:
           rm -f "${archive}"
 
           # Run gitleaks scan on repository
-          "${RUNNER_TEMP}/gitleaks-bin/gitleaks" detect --source . --verbose --no-git --exit-code 1 || {
+          "${RUNNER_TEMP}/gitleaks-bin/gitleaks" detect --config .gitleaks.toml --source . --verbose --no-git --exit-code 1 || {
             echo "⚠️  Secrets detected - review gitleaks output above"
             exit 1
           }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,7 @@ jobs:
         uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7  # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_CONFIG: .gitleaks.toml
 
       - name: Upload security reports
         if: always()

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -11,6 +11,6 @@ id = "generic-api-key"
 [[rules.allowlists]]
 description = "Ignore the generated portal auth failure branch false positive"
 condition = "AND"
-regexTarget = "secret"
-regexes = ['''^(uth_failure"\|\|normalizedReason==="a|normalizedReason===)$''']
+regexTarget = "line"
+regexes = ['''return normalizedReason==="auth_failure"\|\|normalizedReason==="auth"\|\|normalizedStatus===401\|\|normalizedStatus===403\?\{reason:"auth_failure"''']
 paths = ['''(^|/)public/portal-assets/portal\.js$''']

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,16 @@
+title = "Transformation Portal gitleaks config"
+
+[extend]
+useDefault = true
+
+# Keep this compatible with the manual firewall scan, which currently runs
+# gitleaks v8.21.x and does not support global allowlist targetRules.
+[[rules]]
+id = "generic-api-key"
+
+[[rules.allowlists]]
+description = "Ignore the generated portal auth failure branch false positive"
+condition = "AND"
+regexTarget = "secret"
+regexes = ['''^(uth_failure"\|\|normalizedReason==="a|normalizedReason===)$''']
+paths = ['''(^|/)public/portal-assets/portal\.js$''']

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ Quick reference for common workflows and commands in this repo.
 - `make check-quality` dry-run quality auto-fix checks (`scripts/auto_fix_quality.py --dry-run`).
 - `make check-environment` run pre-flight environment validation through the resolved repo interpreter.
 - `make check-worktree` check if git worktree is clean after builds (`scripts/validation/check_worktree_clean.sh`).
-- `make validate-ci` validate GitHub Actions configs plus dependency-update and Dependabot contracts.
+- `make validate-ci` validate GitHub Actions configs plus gitleaks, dependency-update, and Dependabot workflow contracts.
 - `make check-json-serialization` fail when raw `json.dump`/`json.dumps` usage is detected outside approved modules.
 - `make check-yaml-governance` fail when raw `yaml.safe_load` usage appears outside the shared preset loader or explicitly exempt non-preset loaders.
 - `make check-piptools-cache` fail if `requirements/.pip-tools-cache` is tracked in git.

--- a/Makefile
+++ b/Makefile
@@ -404,6 +404,8 @@ check-stale-docs:
 validate-ci:
 	@echo "Validating GitHub Actions workflows..."
 	@"$(PY)" scripts/validate_ci_config.py
+	@echo "Validating gitleaks workflow contract..."
+	@"$(PY)" scripts/validation/check_gitleaks_workflow_contract.py
 	@echo "Validating dependency-update workflow contract..."
 	@"$(PY)" scripts/validation/check_dependency_update_workflow.py
 	@echo "Validating Dependabot config contract..."

--- a/scripts/validation/check_gitleaks_workflow_contract.py
+++ b/scripts/validation/check_gitleaks_workflow_contract.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Validate the shared gitleaks workflow contract."""
+
+from __future__ import annotations
+
+import sys
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONFIG_PATH = REPO_ROOT / ".gitleaks.toml"
+CI_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+FIREWALL_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "ci-quality-firewall.yml"
+
+EXPECTED_RULE_ID = "generic-api-key"
+EXPECTED_PATH_REGEX = r"(^|/)public/portal-assets/portal\.js$"
+EXPECTED_SECRET_REGEX = r'^(uth_failure"\|\|normalizedReason==="a|normalizedReason===)$'
+EXPECTED_CI_SNIPPET = "GITLEAKS_CONFIG: .gitleaks.toml"
+EXPECTED_FIREWALL_SNIPPET = "detect --config .gitleaks.toml --source . --verbose --no-git --exit-code 1"
+
+
+def validate_gitleaks_contract(
+    config_text: str,
+    ci_workflow_text: str,
+    firewall_workflow_text: str,
+) -> list[str]:
+    """Return contract violations for the shared gitleaks setup."""
+    errors: list[str] = []
+
+    try:
+        config = tomllib.loads(config_text)
+    except tomllib.TOMLDecodeError as exc:
+        return [f"gitleaks config is not valid TOML: {exc}"]
+
+    errors.extend(_validate_config(config))
+
+    if EXPECTED_CI_SNIPPET not in ci_workflow_text:
+        errors.append("ci workflow must set GITLEAKS_CONFIG to .gitleaks.toml")
+
+    if EXPECTED_FIREWALL_SNIPPET not in firewall_workflow_text:
+        errors.append("ci-quality-firewall workflow must pass --config .gitleaks.toml to gitleaks detect")
+
+    return errors
+
+
+def _validate_config(config: dict[str, object]) -> list[str]:
+    errors: list[str] = []
+
+    extend = config.get("extend")
+    if not isinstance(extend, dict) or extend.get("useDefault") is not True:
+        errors.append("gitleaks config must extend the default ruleset with useDefault = true")
+
+    disabled_rules = extend.get("disabledRules", []) if isinstance(extend, dict) else []
+    if EXPECTED_RULE_ID in disabled_rules:
+        errors.append("gitleaks config must not disable the generic-api-key rule")
+
+    global_allowlists = config.get("allowlists", [])
+    if isinstance(global_allowlists, list):
+        for allowlist in global_allowlists:
+            if not isinstance(allowlist, dict):
+                continue
+            for path_regex in allowlist.get("paths", []):
+                if "public/portal-assets" in str(path_regex):
+                    errors.append("gitleaks config must not define a global allowlist for portal assets")
+
+    matching_rules = [
+        rule for rule in config.get("rules", []) if isinstance(rule, dict) and rule.get("id") == EXPECTED_RULE_ID
+    ]
+    if len(matching_rules) != 1:
+        return errors + ["gitleaks config must define exactly one generic-api-key rule extension"]
+
+    allowlists = matching_rules[0].get("allowlists", [])
+    if not isinstance(allowlists, list) or len(allowlists) != 1:
+        return errors + ["generic-api-key rule extension must define exactly one allowlist"]
+
+    allowlist = allowlists[0]
+    if not isinstance(allowlist, dict):
+        return errors + ["generic-api-key allowlist must be a TOML table"]
+
+    if allowlist.get("condition") != "AND":
+        errors.append("generic-api-key allowlist must require AND semantics")
+
+    if allowlist.get("regexTarget") != "secret":
+        errors.append("generic-api-key allowlist must target the extracted secret")
+
+    path_patterns = allowlist.get("paths", [])
+    if path_patterns != [EXPECTED_PATH_REGEX]:
+        errors.append("generic-api-key allowlist must be scoped only to public/portal-assets/portal.js")
+
+    secret_patterns = allowlist.get("regexes", [])
+    if secret_patterns != [EXPECTED_SECRET_REGEX]:
+        errors.append("generic-api-key allowlist must match only the generated auth failure false positive")
+
+    return errors
+
+
+def main() -> int:
+    missing_paths = [path for path in (CONFIG_PATH, CI_WORKFLOW_PATH, FIREWALL_WORKFLOW_PATH) if not path.is_file()]
+    if missing_paths:
+        print("ERROR: gitleaks workflow contract files are missing:", file=sys.stderr)
+        for path in missing_paths:
+            print(f"  - {path}", file=sys.stderr)
+        return 1
+
+    errors = validate_gitleaks_contract(
+        config_text=CONFIG_PATH.read_text(encoding="utf-8"),
+        ci_workflow_text=CI_WORKFLOW_PATH.read_text(encoding="utf-8"),
+        firewall_workflow_text=FIREWALL_WORKFLOW_PATH.read_text(encoding="utf-8"),
+    )
+    if errors:
+        print("ERROR: gitleaks workflow contract validation failed:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+
+    print("gitleaks workflow contract passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validation/check_gitleaks_workflow_contract.py
+++ b/scripts/validation/check_gitleaks_workflow_contract.py
@@ -14,7 +14,8 @@ FIREWALL_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "ci-quality-firew
 
 EXPECTED_RULE_ID = "generic-api-key"
 EXPECTED_PATH_REGEX = r"(^|/)public/portal-assets/portal\.js$"
-EXPECTED_SECRET_REGEX = r'^(uth_failure"\|\|normalizedReason==="a|normalizedReason===)$'
+EXPECTED_REGEX_TARGET = "line"
+EXPECTED_MATCH_REGEX = r'return normalizedReason==="auth_failure"\|\|normalizedReason==="auth"\|\|normalizedStatus===401\|\|normalizedStatus===403\?\{reason:"auth_failure"'
 EXPECTED_CI_SNIPPET = "GITLEAKS_CONFIG: .gitleaks.toml"
 EXPECTED_FIREWALL_SNIPPET = "detect --config .gitleaks.toml --source . --verbose --no-git --exit-code 1"
 
@@ -80,16 +81,16 @@ def _validate_config(config: dict[str, object]) -> list[str]:
     if allowlist.get("condition") != "AND":
         errors.append("generic-api-key allowlist must require AND semantics")
 
-    if allowlist.get("regexTarget") != "secret":
-        errors.append("generic-api-key allowlist must target the extracted secret")
+    if allowlist.get("regexTarget") != EXPECTED_REGEX_TARGET:
+        errors.append("generic-api-key allowlist must target the portal source line")
 
     path_patterns = allowlist.get("paths", [])
     if path_patterns != [EXPECTED_PATH_REGEX]:
         errors.append("generic-api-key allowlist must be scoped only to public/portal-assets/portal.js")
 
-    secret_patterns = allowlist.get("regexes", [])
-    if secret_patterns != [EXPECTED_SECRET_REGEX]:
-        errors.append("generic-api-key allowlist must match only the generated auth failure false positive")
+    match_patterns = allowlist.get("regexes", [])
+    if match_patterns != [EXPECTED_MATCH_REGEX]:
+        errors.append("generic-api-key allowlist must match only the generated auth failure false-positive branch")
 
     return errors
 

--- a/tests/test_check_gitleaks_workflow_contract.py
+++ b/tests/test_check_gitleaks_workflow_contract.py
@@ -26,8 +26,8 @@ id = "{gitleaks_contract.EXPECTED_RULE_ID}"
 [[rules.allowlists]]
 description = "Ignore the generated portal auth failure branch false positive"
 condition = "AND"
-regexTarget = "secret"
-regexes = ['''{gitleaks_contract.EXPECTED_SECRET_REGEX}''']
+regexTarget = "{gitleaks_contract.EXPECTED_REGEX_TARGET}"
+regexes = ['''{gitleaks_contract.EXPECTED_MATCH_REGEX}''']
 paths = ['''{gitleaks_contract.EXPECTED_PATH_REGEX}''']
 """
 
@@ -108,10 +108,10 @@ def test_broad_rule_path_allowlist_is_reported() -> None:
     assert "generic-api-key allowlist must be scoped only to public/portal-assets/portal.js" in errors
 
 
-def test_wrong_secret_regex_is_reported() -> None:
+def test_wrong_regex_target_is_reported() -> None:
     config_text = valid_config_text().replace(
-        f"regexes = ['''{gitleaks_contract.EXPECTED_SECRET_REGEX}''']",
-        "regexes = ['''auth_failure''']",
+        f'regexTarget = "{gitleaks_contract.EXPECTED_REGEX_TARGET}"',
+        'regexTarget = "secret"',
         1,
     )
     errors = gitleaks_contract.validate_gitleaks_contract(
@@ -119,4 +119,18 @@ def test_wrong_secret_regex_is_reported() -> None:
         ci_workflow_text=valid_ci_workflow_text(),
         firewall_workflow_text=valid_firewall_workflow_text(),
     )
-    assert "generic-api-key allowlist must match only the generated auth failure false positive" in errors
+    assert "generic-api-key allowlist must target the portal source line" in errors
+
+
+def test_wrong_match_regex_is_reported() -> None:
+    config_text = valid_config_text().replace(
+        f"regexes = ['''{gitleaks_contract.EXPECTED_MATCH_REGEX}''']",
+        "regexes = ['''normalizedReason===auth_failure''']",
+        1,
+    )
+    errors = gitleaks_contract.validate_gitleaks_contract(
+        config_text=config_text,
+        ci_workflow_text=valid_ci_workflow_text(),
+        firewall_workflow_text=valid_firewall_workflow_text(),
+    )
+    assert "generic-api-key allowlist must match only the generated auth failure false-positive branch" in errors

--- a/tests/test_check_gitleaks_workflow_contract.py
+++ b/tests/test_check_gitleaks_workflow_contract.py
@@ -1,0 +1,122 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+TOOL_PATH = PROJECT_ROOT / "scripts" / "validation" / "check_gitleaks_workflow_contract.py"
+SPEC = importlib.util.spec_from_file_location("check_gitleaks_workflow_contract", TOOL_PATH)
+assert SPEC is not None and SPEC.loader is not None
+gitleaks_contract = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(gitleaks_contract)
+
+
+def valid_config_text() -> str:
+    return f"""
+title = "Transformation Portal gitleaks config"
+
+[extend]
+useDefault = true
+
+[[rules]]
+id = "{gitleaks_contract.EXPECTED_RULE_ID}"
+
+[[rules.allowlists]]
+description = "Ignore the generated portal auth failure branch false positive"
+condition = "AND"
+regexTarget = "secret"
+regexes = ['''{gitleaks_contract.EXPECTED_SECRET_REGEX}''']
+paths = ['''{gitleaks_contract.EXPECTED_PATH_REGEX}''']
+"""
+
+
+def valid_ci_workflow_text() -> str:
+    return """
+      - name: Check for secrets with gitleaks
+        uses: gitleaks/gitleaks-action@sha
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_CONFIG: .gitleaks.toml
+"""
+
+
+def valid_firewall_workflow_text() -> str:
+    return """
+          "${RUNNER_TEMP}/gitleaks-bin/gitleaks" detect --config .gitleaks.toml --source . --verbose --no-git --exit-code 1 || {
+            echo "⚠️  Secrets detected - review gitleaks output above"
+            exit 1
+          }
+"""
+
+
+def test_repo_gitleaks_workflow_contract_passes() -> None:
+    errors = gitleaks_contract.validate_gitleaks_contract(
+        config_text=(PROJECT_ROOT / ".gitleaks.toml").read_text(encoding="utf-8"),
+        ci_workflow_text=(PROJECT_ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8"),
+        firewall_workflow_text=(PROJECT_ROOT / ".github" / "workflows" / "ci-quality-firewall.yml").read_text(
+            encoding="utf-8"
+        ),
+    )
+    assert errors == []
+
+
+def test_missing_ci_config_reference_is_reported() -> None:
+    errors = gitleaks_contract.validate_gitleaks_contract(
+        config_text=valid_config_text(),
+        ci_workflow_text=valid_ci_workflow_text().replace("          GITLEAKS_CONFIG: .gitleaks.toml\n", "", 1),
+        firewall_workflow_text=valid_firewall_workflow_text(),
+    )
+    assert "ci workflow must set GITLEAKS_CONFIG to .gitleaks.toml" in errors
+
+
+def test_missing_firewall_config_reference_is_reported() -> None:
+    errors = gitleaks_contract.validate_gitleaks_contract(
+        config_text=valid_config_text(),
+        ci_workflow_text=valid_ci_workflow_text(),
+        firewall_workflow_text=valid_firewall_workflow_text().replace("--config .gitleaks.toml ", "", 1),
+    )
+    assert "ci-quality-firewall workflow must pass --config .gitleaks.toml to gitleaks detect" in errors
+
+
+def test_global_portal_allowlist_is_reported() -> None:
+    config_text = valid_config_text() + """
+[[allowlists]]
+description = "too broad"
+paths = ['''^public/portal-assets/''']
+"""
+    errors = gitleaks_contract.validate_gitleaks_contract(
+        config_text=config_text,
+        ci_workflow_text=valid_ci_workflow_text(),
+        firewall_workflow_text=valid_firewall_workflow_text(),
+    )
+    assert "gitleaks config must not define a global allowlist for portal assets" in errors
+
+
+def test_broad_rule_path_allowlist_is_reported() -> None:
+    config_text = valid_config_text().replace(
+        f"paths = ['''{gitleaks_contract.EXPECTED_PATH_REGEX}''']",
+        "paths = ['''^public/portal-assets/''']",
+        1,
+    )
+    errors = gitleaks_contract.validate_gitleaks_contract(
+        config_text=config_text,
+        ci_workflow_text=valid_ci_workflow_text(),
+        firewall_workflow_text=valid_firewall_workflow_text(),
+    )
+    assert "generic-api-key allowlist must be scoped only to public/portal-assets/portal.js" in errors
+
+
+def test_wrong_secret_regex_is_reported() -> None:
+    config_text = valid_config_text().replace(
+        f"regexes = ['''{gitleaks_contract.EXPECTED_SECRET_REGEX}''']",
+        "regexes = ['''auth_failure''']",
+        1,
+    )
+    errors = gitleaks_contract.validate_gitleaks_contract(
+        config_text=config_text,
+        ci_workflow_text=valid_ci_workflow_text(),
+        firewall_workflow_text=valid_firewall_workflow_text(),
+    )
+    assert "generic-api-key allowlist must match only the generated auth failure false positive" in errors


### PR DESCRIPTION
## Summary
- Root cause: the main-branch firewall push workflow used implicit/default gitleaks behavior, which flagged the checked-in generated portal bundle as a `generic-api-key` false positive.
- Change: add one shared repo-root gitleaks contract and point both firewall workflows at it so push and post-CI scans stay aligned.

## Changes
- Add `.gitleaks.toml` as the single secret-scan contract, extending default rules with one narrow `generic-api-key` allowlist scoped to `public/portal-assets/portal.js` and the generated auth-failure signature family.
- Update `.github/workflows/ci.yml` to set `GITLEAKS_CONFIG=.gitleaks.toml` for the gitleaks action.
- Update `.github/workflows/ci-quality-firewall.yml` to pass `--config .gitleaks.toml` to the manual gitleaks invocation.
- Add `scripts/validation/check_gitleaks_workflow_contract.py` and `tests/test_check_gitleaks_workflow_contract.py`, and wire the validator into `make validate-ci`.
- Update `AGENTS.md` so the documented `make validate-ci` contract matches the enforced workflow validation surface.

## Validation
Proven green:
- `.venv/bin/pytest -p no:cacheprovider tests/test_check_gitleaks_workflow_contract.py`
- `.venv/bin/python scripts/validation/check_gitleaks_workflow_contract.py`
- `.venv/bin/python scripts/validate_ci_config.py`
- `.venv/bin/python scripts/validation/check_dependency_update_workflow.py`
- `.venv/bin/python scripts/validation/check_dependabot_config.py`
- `make validate-ci`
- `gitleaks detect --config .gitleaks.toml --redact -v --exit-code 2 --log-level debug --log-opts=-1`
- `gitleaks detect --config /Users/richardcheetham/Desktop/Transformation_Portal/.gitleaks.toml --source <clean tracked-file tree> --verbose --no-git --exit-code 1`

Still failing:
- No scoped local validation failures remain.
- GitHub Actions rerun on this branch has not been observed yet from this client.

Classification:
- The original main-branch failure was CI scanner configuration drift, not product logic.
- The broad local full-tree gitleaks hits came from dirty/untracked generated artifacts outside the tracked-tree CI scan contract.

## Risk
- Bounded to CI secret-scanning contract files only; no runtime portal, route, selector, API, or schema behavior changes.
- The allowlist is intentionally narrow and revert-safe: one rule, one tracked bundle path, one false-positive signature family.
- The change preserves scanner coverage for the rest of the repository and prevents push vs post-CI drift between firewall workflows.