### PR TITLE
feat(portal): add modernization evidence package

### DIFF
--- a/app.py
+++ b/app.py
@@ -3502,6 +3502,8 @@ def _portal_sanitize_metadata(metadata: Any) -> Dict[str, Any]:
         key_text = str(key or "").strip().lower()
         if not _portal_is_token(key_text):
             continue
+        if key_text == "pipeline":
+            continue
         if isinstance(value, bool):
             sanitized[key_text] = value
             continue

--- a/app.py
+++ b/app.py
@@ -970,6 +970,8 @@ PORTAL_ALLOWED_EVENT_TYPES = {
     "job_submitted",
     "job_selected",
     "artifact_opened",
+    "artifact_viewer_opened",
+    "artifact_viewer_fallback",
     "artifact_compared",
     "run_details_opened",
     "cancel_requested",

--- a/docs/architecture/PORTAL_OPERATOR_CONSOLE_MODERNIZATION_EVIDENCE.md
+++ b/docs/architecture/PORTAL_OPERATOR_CONSOLE_MODERNIZATION_EVIDENCE.md
@@ -1,0 +1,90 @@
+# Portal Operator Console Modernization Evidence
+
+**Status:** Working evidence register
+**Date:** 2026-04-14
+**Owner:** Frontdoor / Platform
+
+This note tracks the repo-owned evidence package for the portal modernization RFC. It does not create human approval or invent pilot results. It records what the repo can prove now, how pilot measurements should be collected, and which gates remain open.
+
+## Repo-Backed Evidence Available Now
+
+### Boundary and Rollout Controls
+
+- Deterministic rollout helpers back portal RUM, the artifact viewer modal, and deferred review-surface loading in `app.py`.
+- The managed frontdoor quickstart already documents the rollout knobs for portal RUM and review-surface pilots.
+
+### Measurement Path
+
+- `/v1/portal/rum` accepts the portal RUM schema, records a stable cohort bucket, and emits trace correlation fields.
+- `tools/portal_rum_summary.py` remains the RUM-only summary tool.
+- `tools/portal_modernization_evidence.py` summarizes RUM plus optional portal event logs for repo-measurable M1, M4, and M5 evidence.
+
+### M2 Accessibility Contract
+
+- The accepted M2 contract is the existing repo-native browser-probe coverage for `/login` and `/portal`, plus manual keyboard and reduced-motion verification.
+- This RFC refresh does not require `axe` or another broader automated suite to keep M2 implemented.
+
+### M3 Resilience Contract
+
+- Managed `returnTo` validation, same-route recovery, and transient build-draft restore are already covered by browser and contract validation.
+
+### M4 Performance Contract
+
+- Portal asset budgets are enforced in repo validation.
+- Deferred review loading and related portal performance work are shipped, but M4 still needs measured pilot evidence before formal closure.
+
+### M5 Current Shipped Scope
+
+- Deferred review loading
+- Modal artifact viewer
+- Keyboard-only navigation and zoom controls
+- Integrity metadata visibility and fingerprint copy
+- Explicit non-preview fallback states
+- Viewer open and fallback telemetry
+
+Optional review-time segmentation refinement is not part of the shipped scope captured by this evidence note.
+
+## Pilot Collection Procedure
+
+1. Enable the pilot sinks:
+
+```bash
+export TP_PORTAL_RUM_ENABLED=1
+export TP_PORTAL_RUM_ROLLOUT_PERCENT=100
+export TP_PORTAL_RUM_LOG_PATH="/absolute/path/to/portal-rum.jsonl"
+export TP_PORTAL_EVENT_LOG_PATH="/absolute/path/to/portal-events.jsonl"
+```
+
+2. Run the current browser validation backbone:
+
+```bash
+make validate-frontdoor-browser
+make validate-portal-browser
+```
+
+3. Summarize the pilot logs:
+
+```bash
+python tools/portal_modernization_evidence.py \
+  --rum-log /absolute/path/to/portal-rum.jsonl \
+  --event-log /absolute/path/to/portal-events.jsonl \
+  --operator-hours 8
+```
+
+4. Attach the command output and the pilot date range to the rollout notes or architecture review packet.
+
+## Evidence Slots
+
+| Gate | Repo-Owned Input | Current State |
+| --- | --- | --- |
+| M1 visibility | `portal_rum_summary.py`, `portal_modernization_evidence.py` | Implemented, waiting for pilot capture |
+| M1 telemetry sign-off | `docs/compliance/PORTAL_TELEMETRY_PRIVACY_SIGNOFF.md` | Open human approval |
+| M4 pilot metrics | `portal_modernization_evidence.py` plus browser validation | Open |
+| M5 viewer evidence | `portal_modernization_evidence.py` plus browser validation | Open |
+| ADR-050 rewrite evidence | `docs/decisions/ADR-050-portal-react-migration.md` | Open |
+
+## Remaining Open Gates
+
+- Security / Privacy approval of telemetry schema, retention, and disposal posture
+- Pilot measurements for CWV, queue latency, SSE reconnect rate, and artifact-viewer success
+- ADR-050 evidence that compares rewrite vs no-rewrite delivery, quality, and developer-experience tradeoffs

--- a/docs/architecture/PORTAL_OPERATOR_CONSOLE_MODERNIZATION_RFC.md
+++ b/docs/architecture/PORTAL_OPERATOR_CONSOLE_MODERNIZATION_RFC.md
@@ -4,28 +4,27 @@
 **Date:** 2026-04-14
 **Owner:** Transformation Portal Architect
 **Reviewers:** Frontdoor / Platform, Portal Frontend, Backend / Origin, Security / Privacy, QA / Validation
-**Related:** `docs/decisions/ADR-050-portal-react-migration.md`, `docs/architecture/DNA_UX_UI_STRATEGY_REBASELINE_2026-04-08.md`, `docs/architecture/PORTAL_EDGE_HARDENING_IMPLEMENTATION_STANDARD.md`
+**Related:** `docs/decisions/ADR-050-portal-react-migration.md`, `docs/architecture/DNA_UX_UI_STRATEGY_REBASELINE_2026-04-08.md`, `docs/architecture/PORTAL_EDGE_HARDENING_IMPLEMENTATION_STANDARD.md`, `docs/architecture/PORTAL_OPERATOR_CONSOLE_MODERNIZATION_EVIDENCE.md`, `docs/compliance/PORTAL_TELEMETRY_PRIVACY_SIGNOFF.md`
 
 ## Summary
 
-The Transformation Portal operator console should be modernized through bounded, low-risk tranches rather than a framework rewrite. This RFC preserves the current trust boundaries, keeps the FastAPI origin private behind the managed frontdoor, treats the native web platform as the default implementation path, and requires deterministic feature flags plus explicit validation gates for all material runtime and UX changes.
+This approved RFC records the portal modernization decision: continue improving the existing FastAPI-served operator console through bounded, low-risk tranches, keep the managed frontdoor as the authoritative browser boundary, and keep native web primitives as the default implementation path.
 
-This RFC proposes an incremental modernization path for review and approval. It does **not** itself approve a React or Next.js rewrite of the operator console, a new identity model, or any change that weakens the current browser-to-origin security boundary.
+This RFC does not approve a React or Next.js migration of the operator console. `ADR-050` remains the separate future decision gate for any rewrite or boundary change.
 
 ## Decision
 
-The following proposed direction is submitted for approval:
-
-1. **FastAPI remains private behind the managed frontdoor.** Direct public exposure of the origin is out of scope for this RFC.
-2. **The managed frontdoor remains the authoritative browser boundary.** Public homepage, login, proxying, route enforcement, and same-origin browser behavior continue to terminate there.
-3. **Native web primitives remain the default implementation path.** Vanilla HTML, CSS, and JavaScript are preferred unless a targeted dependency is justified by a clear operational benefit.
-4. **All material UX, runtime, and observability changes must ship behind deterministic feature flags.** Assignment must remain stable for a given viewer or operator over the supported lifetime of the assigned cohort key.
-5. **Rollout proceeds by bounded tranches with explicit entry and exit criteria.** A tranche does not close merely because telemetry looks acceptable after deployment.
-6. **This RFC is a non-binding interim implementation direction that remains compatible with proposed `ADR-050` pending its acceptance, revision, or rejection; it does not prejudge that ADR's outcome.** Any future React or Next.js migration of the operator console requires a separate, evidence-based decision.
+1. FastAPI remains private behind the managed frontdoor.
+2. The managed frontdoor remains the authoritative browser boundary for `/`, `/login`, `/portal`, `/portal/bootstrap`, and same-origin `/v1/*` proxy behavior.
+3. Native web primitives remain the default implementation path unless a targeted dependency has a clear operational benefit.
+4. Material UX, runtime, review-surface, and observability changes ship behind deterministic feature flags with stable cohort assignment.
+5. Milestones may be implemented without being formally closed; close status still requires the named sign-off and evidence gates.
+6. Route, query-parameter, cache, auth, and selector contracts remain stable unless a separate approved decision changes them.
+7. Any future React or Next.js migration remains blocked on the still-open evidence checklist in `ADR-050`.
 
 ## Normative Interpretation
 
-The following sections are normative and define the binding requirements that would apply if this RFC is accepted:
+The following sections are normative:
 
 - `Decision`
 - `Decision Drivers`
@@ -35,32 +34,59 @@ The following sections are normative and define the binding requirements that wo
 - `Feature Flag and Rollback Contract`
 - `Milestones and Rollout`
 - `Acceptance Criteria`
-- any subsection labeled `In Scope`, `Out of Scope`, `Exit Criteria`, `Close Conditions`, `Unconditional Validation`, `Conditional Browser Validation`, `Required Validation Backbone`, or `Rollback Posture`
+- `Risks and Future Decision Gates`
+- any subsection labeled `In Scope`, `Out of Scope`, `Acceptance Gate`, `Rollback Posture`, `Required Validation Backbone`, or `Status`
 
-The following content is non-normative:
+The following sections are non-normative:
 
-- `Appendix C: Reference Implementation Notes`
-- library examples, implementation patterns, and tooling suggestions unless they are explicitly restated in a normative section
+- `Implementation Status (2026-04-14)`
+- `Outstanding TODOs`
+- `Appendix C: Reference Notes`
+
+## Implementation Status (2026-04-14)
+
+### Implemented
+
+- Deterministic rollout controls exist for portal RUM, the artifact viewer modal, and deferred review-surface loading.
+- Portal RUM ingest, backend trace propagation, and the repo-owned summary path in `tools/portal_rum_summary.py` are implemented.
+- Managed `returnTo` validation and transient build-draft restore behavior are implemented and covered in repo-native validation.
+- Portal asset budget enforcement and deferred review loading are implemented.
+- The in-portal artifact viewer, keyboard controls, fingerprint copy affordance, and explicit non-preview fallback behavior are implemented.
+- M2's accepted contract is the current repo-native browser-probe accessibility coverage for `/login` and `/portal`, plus manual keyboard and reduced-motion validation. A broader automated suite is not required to keep this RFC approved.
+- M3 resilience behavior is implemented for the currently supported managed recovery path.
+
+### Partial
+
+- M1 Measurement Foundation is implemented but not formally closed pending Security / Privacy schema and retention sign-off plus measured pilot evidence.
+- M4 Performance and Rendering is implemented but not formally closed pending measured pilot evidence against the provisional CWV, queue-latency, and SSE targets.
+- M5 Artifact Review is implemented for deferred review loading, modal viewer behavior, metadata visibility, fingerprint copy, and explicit fallback states, but it is not formally closed pending measured pilot evidence.
+- M5's optional segmentation refinement is not counted as shipped in this RFC. Current shipped scope is the viewer and fallback path only.
+
+### Open Gate
+
+- Security / Privacy sign-off for the telemetry schema, retention posture, and disposal procedure remains open.
+- Repo-owned pilot evidence for M1, M4, and M5 remains open until measurements are captured and attached.
+- The ADR-050 rewrite evidence checklist remains open and is not resolved by this RFC.
 
 ## Decision Drivers
 
-- Preserve the existing security and proxy boundary.
+- Preserve the existing trust boundary and managed proxy model.
 - Improve time to first useful action for operators.
-- Increase resilience during authentication interruption and infrastructure turbulence.
-- Achieve stronger WCAG 2.2 AA-oriented behavior for dense, asynchronous workflows.
-- Establish measurable evidence before performance claims are accepted.
-- Avoid the delivery risk of a framework rewrite when targeted native-web improvements can address immediate bottlenecks.
+- Increase resilience during authentication interruption and transient transport failures.
+- Achieve WCAG 2.2 AA-oriented behavior for dense asynchronous workflows.
+- Tie performance and review claims to measured evidence instead of anecdote.
+- Avoid rewrite risk while targeted native-web improvements continue to land safely.
 
 ## Non-Goals
 
 This RFC does not approve:
 
-- a React or Next.js rewrite of the operator console in this tranche
-- a new identity model or token model
+- a React or Next.js rewrite of the operator console
+- a new identity model
 - direct browser access to backend API keys or protected origin headers
-- reopening the current route and query-parameter contract unless approved separately
+- route or query-parameter contract changes unless separately approved
 - broad product analytics or employee-performance analytics
-- broad visual redesign unrelated to the outcomes in this RFC
+- silent degraded review states
 
 ## Architecture Constraints and Repo Truth
 
@@ -80,7 +106,7 @@ Current-state boundary rules remain in force:
 - FastAPI remains the origin for the operator shell and backend APIs
 - browser-side code must not receive backend API keys in managed mode
 - the operator console view contract remains `?view=overview|build|operate|review`
-- route, cache, header, and auth behavior must remain aligned with the managed frontdoor and edge hardening standard
+- route, cache, header, auth, and selector behavior must remain aligned with the managed frontdoor and edge hardening standard
 
 Current repo-native validation remains authoritative:
 
@@ -98,10 +124,10 @@ Move portal performance and reliability work from anecdotal assessment to measur
 
 **In Scope**
 
-- lightweight Real User Monitoring for portal shell and key interaction milestones
+- lightweight RUM for portal shell and key interaction milestones
 - backend trace correlation for bootstrap and queue actions
 - SSE health, reconnect counts, and bootstrap latency visibility
-- a configuration-level kill switch for telemetry collection
+- configuration-level telemetry kill switches
 - approved schemas that minimize operator-identifying data
 
 **Out of Scope**
@@ -118,20 +144,12 @@ Frontdoor / Platform
 - Backend / Origin
 - Security / Privacy
 
-**Dependencies**
+**Acceptance Gate**
 
-- telemetry schema review
-- ingestion path agreement across managed frontdoor and origin surfaces
-- feature-flag wiring for observe-only rollout
-
-**Exit Criteria**
-
-- p75 LCP, INP, and CLS are visible by route and cohort
-- `portal_shell_rendered`, `bootstrap_ready`, and `first_view_interactive` are measurable
-- bootstrap and queue timings can be correlated across frontend and backend surfaces
-- SSE reconnect counts and bootstrap latency are queryable
+- telemetry is visible in pilot or non-production environments
 - collection can be disabled by configuration without code changes
-- approved schemas emit no plain-text usernames or email addresses
+- no plain-text usernames or email addresses are emitted in the approved schema
+- measured pilot evidence is attached before M1 is marked closed
 
 ### 2. Accessibility Hardening
 
@@ -145,13 +163,14 @@ Achieve WCAG 2.2 AA-oriented hardening for dense, keyboard-first, asynchronous o
 - target-size improvements for dense controls
 - live-region semantics for asynchronous job and toast updates
 - `prefers-reduced-motion` compliance
-- automated accessibility coverage for `/login` and `/portal`
+- repo-native browser-probe accessibility coverage for `/login` and `/portal`
+- manual keyboard-only validation for review, modal, and queue flows
 
 **Out of Scope**
 
 - broad redesign unrelated to accessibility outcomes
 - introduction of a new component framework
-- replacement of working keyboard shortcuts with a new command model
+- a broader automated accessibility suite unless separately approved as follow-on work
 
 **Primary Owner**
 Portal Frontend
@@ -160,19 +179,11 @@ Portal Frontend
 
 - QA / Validation
 
-**Dependencies**
+**Acceptance Gate**
 
-- stable selectors and accessibility roles in current portal and frontdoor views
-- managed browser validation coverage for `/login` and `/portal`
-
-**Exit Criteria**
-
-- no blocking accessibility regressions are present on `/login` or `/portal`
-- focused controls remain visible under sticky UI
-- modal interactions are keyboard-complete and restore focus correctly
-- asynchronous status updates are announced without focus theft
-- reduced-motion behavior is preserved across all touched surfaces
+- current browser-probe accessibility checks for `/login` and `/portal` stay green
 - manual keyboard-only verification passes for modal open/close, queue interaction, and review flow
+- reduced-motion behavior is preserved across touched surfaces
 
 ### 3. Session Resilience and State Preservation
 
@@ -200,18 +211,12 @@ Frontdoor / Platform
 - Portal Frontend
 - Backend / Origin
 
-**Dependencies**
-
-- managed login and portal proxy remain authoritative
-- origin and frontdoor agree on auth failure behavior and recovery contract
-
-**Exit Criteria**
+**Acceptance Gate**
 
 - forced 401 flows return operators to the same route context after re-authentication
 - supported transient drafts recover from `sessionStorage`
 - invalid `returnTo` values are rejected server-side and fail closed
 - SSE recovery preserves operator context without destructive reset
-- recovery behavior passes browser validation for supported flows
 
 ### 4. Performance and Rendering
 
@@ -220,7 +225,7 @@ Reduce time to first useful action and preserve responsiveness during large queu
 
 **In Scope**
 
-- route- or view-based code splitting where the current portal shell loads heavy, non-critical review tooling too early
+- route- or view-based code splitting where the portal shell loads heavy non-critical review tooling too early
 - native rendering optimizations such as `content-visibility`, reserved dimensions, and deferred non-critical work
 - delegated event handling for large lists
 - main-thread protection and watchdog refinement
@@ -239,18 +244,12 @@ Portal Frontend
 
 - Frontdoor / Platform
 
-**Dependencies**
-
-- baseline telemetry from Workstream 1
-- alignment with the portal edge hardening standard
-
-**Exit Criteria**
+**Acceptance Gate**
 
 - the portal shell remains within a documented bundle budget enforced in CI
-- queue interaction latency stays within a documented provisional threshold
-- large queues and long logs remain usable without sustained responsiveness collapse or uncontrolled long-task spikes
-- static assets and bootstrap endpoints exhibit the intended cache behavior
-- targeted performance scenarios pass required validation
+- queue interaction latency stays within the provisional threshold
+- large queues and long logs remain usable without sustained responsiveness collapse
+- targeted pilot evidence is attached before M4 is marked closed
 
 ### 5. Artifact Review and Operator Tooling
 
@@ -262,14 +261,14 @@ Improve operator review speed and precision without disrupting the main dispatch
 - an in-portal modal artifact viewer with keyboard support
 - integrity metadata presentation for artifacts already emitted by the backend
 - optional diagnostic-mode affordances where backend data already exists
-- optional segmentation refinement when supported by the active backend
-- explicit degraded-state handling when refinement or model assets are unavailable
+- explicit degraded-state handling for non-previewable artifacts and missing managed URLs
+- repo-owned telemetry for viewer opens and explicit fallback states
 
 **Out of Scope**
 
 - replacing the review workflow with a separate application
 - mandatory interactive segmentation dependencies for all review cases
-- silent fallback behavior that hides degraded or stubbed review states
+- claiming review-time segmentation refinement as shipped work in the current tranche
 
 **Primary Owner**
 Portal Frontend
@@ -279,23 +278,19 @@ Portal Frontend
 - Backend / Origin
 - QA / Validation
 
-**Dependencies**
+**Acceptance Gate**
 
-- integrity and artifact metadata are exposed by origin contracts
-- viewer interactions comply with accessibility and reduced-motion requirements from earlier tranches
-
-**Exit Criteria**
-
-- standard artifact review does not require opening a new browser tab for supported cases
+- standard artifact review does not require a new browser tab for supported cases
 - keyboard-only inspection is possible for open, close, next/previous, and zoom controls
 - integrity metadata is visible and copyable for supported artifacts
-- degraded segmentation or refinement states are rendered explicitly and non-fatally
+- explicit non-preview fallback states remain visible and non-fatal
+- targeted pilot evidence is attached before M5 is marked closed
 
 ## Feature Flag and Rollback Contract
 
 The following controls are required for all material tranche rollouts:
 
-- deterministic flag assignment derived from a stable, documented cohort key
+- deterministic flag assignment derived from a stable documented cohort key
 - a tranche-level kill switch or equivalent rollback control
 - documented default-off posture for pilot release where feasible
 - no user should flip between variants unpredictably across the supported life of the cohort key
@@ -307,31 +302,21 @@ For `/portal`, `/portal/bootstrap`, and other authenticated managed flows:
 
 - assignment must derive from a stable internal operator identifier
 - acceptable identifiers include a server-known operator ID, verified access identity, or another backend-controlled stable actor key
-- raw browser-generated random assignment is not acceptable for authenticated operator cohorts
+- raw browser-generated random assignment is not acceptable
 
 ### Pre-Auth Managed Surfaces
 
 For `/` and `/login` before operator authentication:
 
-- assignment must derive from a managed frontdoor-controlled anonymous session identifier or a dedicated rollout cookie
+- assignment must derive from a managed frontdoor-controlled anonymous session identifier or dedicated rollout cookie
 - the assignment key must remain stable across reloads for the supported life of that anonymous session or rollout cookie
 - IP address, user agent alone, or other unstable heuristics must not be used as the deterministic assignment key
-
-### Required Implementation Contract
-
-- if a pre-auth surface participates in a flagged rollout, the managed frontdoor must mint the anonymous session or rollout cookie before flag evaluation
-- anonymous-session or rollout-cookie assignment must not leak backend secrets or operator identifiers to the browser
-- if an experience spans pre-auth and post-auth surfaces, reassignment after login must be deterministic and documented
-- production expansion beyond pilot requires:
-  - the assignment key to be documented
-  - the kill switch to be documented
-  - the rollback owner to be documented
-  - the cohort expansion criteria to be documented
 
 ## Milestones and Rollout
 
 ### M1: Measurement Foundation
 
+**Status:** Partial - implemented but not formally closed
 **Owner:** Frontdoor / Platform
 **Depends On:** None
 
@@ -341,24 +326,22 @@ For `/` and `/login` before operator authentication:
 - backend trace correlation for bootstrap and queue actions
 - SSE reconnect and bootstrap latency visibility
 - telemetry disable switch
+- repo-owned evidence commands in `tools/portal_rum_summary.py` and `tools/portal_modernization_evidence.py`
 
-**Close Conditions**
+**Acceptance Gate**
 
-- Workstream 1 exit criteria are met
-- unconditional validation passes
-- conditional browser validation passes only if M1 changes browser-observable frontdoor or portal behavior
-- privacy and schema review is complete for pilot rollout
+- Workstream 1 acceptance gate is met
+- Security / Privacy sign-off is attached
+- measured pilot evidence is attached
 
 **Rollback Posture**
 
 - feature-flag off
 - ingestion disable by configuration
 
-**Live Browser Validation Required Before Close**
-Only if M1 changes browser-observable frontdoor or portal behavior
-
 ### M2: Accessibility Tranche
 
+**Status:** Implemented
 **Owner:** Portal Frontend
 **Depends On:** M1 baseline instrumentation available for before/after comparison
 
@@ -368,26 +351,23 @@ Only if M1 changes browser-observable frontdoor or portal behavior
 - modal focus discipline
 - live-region semantics
 - reduced-motion parity
-- automated accessibility coverage for `/login` and `/portal`
+- accepted repo-native browser-probe coverage for `/login` and `/portal`
 
-**Close Conditions**
+**Acceptance Gate**
 
-- Workstream 2 exit criteria are met
-- unconditional validation passes
-- conditional browser validation passes for each touched browser surface
+- Workstream 2 acceptance gate is met
+- `make test-frontdoor-contract`, `make test-portal-contract`, `make validate-frontdoor-browser`, and `make validate-portal-browser` remain green for touched flows
 
 **Rollback Posture**
 
 - feature-flag off for tranche-specific UI deltas where feasible
 - revert CSS or semantic changes that regress required validation
 
-**Live Browser Validation Required Before Close**
-Yes
-
 ### M3: Resilience Tranche
 
+**Status:** Implemented
 **Owner:** Frontdoor / Platform
-**Depends On:** M1, and M2 where recovery UI overlaps modal or focus behavior
+**Depends On:** M1 and M2 where recovery UI overlaps modal or focus behavior
 
 **Outputs**
 
@@ -396,22 +376,18 @@ Yes
 - redirect hardening
 - documented auth interruption recovery behavior
 
-**Close Conditions**
+**Acceptance Gate**
 
-- Workstream 3 exit criteria are met
-- unconditional validation passes
-- conditional browser validation passes for each touched browser surface
+- Workstream 3 acceptance gate is met
 
 **Rollback Posture**
 
 - feature-flag off
-- preserve prior login and portal recovery behavior until tranche close
-
-**Live Browser Validation Required Before Close**
-Yes
+- preserve prior login and portal recovery behavior until revert completes
 
 ### M4: Performance Tranche
 
+**Status:** Partial - implemented but not formally closed
 **Owner:** Portal Frontend
 **Depends On:** M1 baseline telemetry
 
@@ -423,22 +399,19 @@ Yes
 - cache and header improvements that preserve route ownership
 - watchdog timing refinement
 
-**Close Conditions**
+**Acceptance Gate**
 
-- Workstream 4 exit criteria are met
-- unconditional validation passes
-- conditional browser validation passes for each touched browser surface
+- Workstream 4 acceptance gate is met
+- measured pilot evidence is attached
 
 **Rollback Posture**
 
 - feature-flag off for view-level performance changes where feasible
 - revert to prior loading strategy if required validation or operational behavior regresses
 
-**Live Browser Validation Required Before Close**
-Yes when frontdoor or portal browser-observable behavior changes
-
 ### M5: Artifact Review Tranche
 
+**Status:** Partial - implemented but not formally closed
 **Owner:** Portal Frontend
 **Depends On:** M2 and M4
 
@@ -447,64 +420,36 @@ Yes when frontdoor or portal browser-observable behavior changes
 - modal artifact viewer
 - integrity dashboard surface
 - diagnostic affordances for existing backend metadata
-- optional segmentation refinement path
+- explicit non-preview fallback states
+- viewer open and fallback telemetry
 
-**Close Conditions**
+**Acceptance Gate**
 
-- Workstream 5 exit criteria are met
-- unconditional validation passes
-- `make validate-portal-browser` passes
-- `make validate-frontdoor-browser` passes if M5 changes frontdoor-managed review entry or proxy behavior
+- Workstream 5 acceptance gate is met
+- measured pilot evidence is attached
+- segmentation refinement remains excluded from close criteria unless separately shipped and documented
 
 **Rollback Posture**
 
-- feature-flag off for new viewer and refinement paths
-- preserve the current review path as fallback until tranche close
-
-**Live Browser Validation Required Before Close**
-Yes
+- feature-flag off for new viewer and deferred review paths
+- preserve the current review path as fallback until revert completes
 
 ## Acceptance Criteria
 
 ### Cross-Tranche Rules
 
-- a milestone closes only when its close conditions are met
+- a milestone closes only when its acceptance gate is met
 - acceptance criteria must be measurable and tied to repo-native validation where possible
 - tracked metrics after rollout do not substitute for close criteria
 - production expansion beyond pilot cohorts requires rollback instructions and feature-flag controls to be documented
-- if there is uncertainty whether a change is browser-observable, the default is to run the relevant browser validation
+- if there is uncertainty whether a change is browser-observable, run the relevant browser validation
 
 ### Required Validation Backbone
 
-#### Unconditional Validation
-
-The following checks are required before any milestone closes:
-
 - `make test-frontdoor-contract`
 - `make test-portal-contract`
-
-#### Conditional Browser Validation
-
-Run `make validate-frontdoor-browser` when a tranche changes any of:
-
-- `/`
-- `/login`
-- managed auth behavior
-- frontdoor proxy behavior
-- cache or header behavior observable through the managed frontdoor
-- feature-flagged UI on frontdoor-managed surfaces
-
-Run `make validate-portal-browser` when a tranche changes any of:
-
-- `/portal`
-- `/portal/bootstrap`
-- portal assets
-- portal routing or view-state behavior
-- portal review or artifact-inspection behavior
-- SSE-driven UI behavior
-- session recovery behavior observable in the portal
-
-Browser validation is not required for telemetry-only or backend-correlation changes that do not change browser-observable behavior.
+- `make validate-frontdoor-browser`
+- `make validate-portal-browser`
 
 ### Tranche-Specific Closure Checks
 
@@ -515,8 +460,8 @@ Browser validation is not required for telemetry-only or backend-correlation cha
 
 **Accessibility**
 
-- no blocking accessibility regressions are present on `/login` or `/portal`
-- focus, modal, and live-region behaviors pass required validation and manual keyboard review
+- current browser-probe accessibility checks stay green on `/login` and `/portal`
+- focus, modal, live-region, keyboard, and reduced-motion behaviors pass required validation
 
 **Resilience**
 
@@ -532,7 +477,21 @@ Browser validation is not required for telemetry-only or backend-correlation cha
 
 - the keyboard-only artifact review path is complete for supported cases
 - integrity metadata is visible
-- segmentation fallback states are explicit
+- explicit fallback states are visible and non-fatal
+- viewer pilot evidence includes open count, fallback count, and success rate
+
+## Outstanding TODOs
+
+Resolved during this refresh:
+
+- M2 coverage uses the current browser-probe and manual keyboard contract; a broader automated suite is not required for this RFC.
+- M5 shipped scope is the viewer and explicit fallback path; optional segmentation refinement is not treated as shipped work.
+
+Still open:
+
+- Security / Privacy must approve the telemetry schema, retention posture, and disposal procedure captured in `docs/compliance/PORTAL_TELEMETRY_PRIVACY_SIGNOFF.md`.
+- M1, M4, and M5 still need measured pilot evidence for CWV, queue latency, SSE reconnect rate, and artifact-viewer success before they can be marked closed.
+- ADR-050 still needs its separate delivery, quality, and developer-experience evidence checklist before any rewrite decision can be made.
 
 ## Risks and Future Decision Gates
 
@@ -558,17 +517,17 @@ Broad telemetry rollout must not proceed beyond pilot cohorts until Security / P
 
 ## Appendix A: Ownership Matrix
 
-| Workstream | Primary Owner | Dependent Systems | Primary Metrics | Closure Signal |
+| Workstream | Primary Owner | Dependent Systems | Primary Metrics | Close Signal |
 | --- | --- | --- | --- | --- |
-| Telemetry and Observability | Frontdoor / Platform | managed frontdoor, FastAPI origin, telemetry ingestion | p75 CWV visibility, bootstrap latency, SSE reconnect counts | Workstream 1 exit criteria met |
-| Accessibility Hardening | Portal Frontend | portal shell, login shell, browser validation | accessibility regressions, focus visibility, modal keyboard completion | Workstream 2 exit criteria met |
-| Session Resilience and State Preservation | Frontdoor / Platform | login flow, portal routing, auth proxy, browser storage | recovery success, redirect rejection, draft restore success | Workstream 3 exit criteria met |
-| Performance and Rendering | Portal Frontend | portal shell, static assets, proxy and cache behavior | shell bundle budget, interaction latency, long-task behavior | Workstream 4 exit criteria met |
-| Artifact Review and Operator Tooling | Portal Frontend | review UI, artifact metadata, optional segmentation backends | viewer success, keyboard-only review success, metadata visibility | Workstream 5 exit criteria met |
+| Telemetry and Observability | Frontdoor / Platform | managed frontdoor, FastAPI origin, telemetry ingestion | p75 CWV visibility, bootstrap latency, SSE reconnect counts | schema sign-off plus pilot evidence attached |
+| Accessibility Hardening | Portal Frontend | portal shell, login shell, browser validation | browser-probe regressions, focus visibility, modal keyboard completion | validation remains green under accepted contract |
+| Session Resilience and State Preservation | Frontdoor / Platform | login flow, portal routing, auth proxy, browser storage | recovery success, redirect rejection, draft restore success | recovery validation remains green |
+| Performance and Rendering | Portal Frontend | portal shell, static assets, proxy and cache behavior | shell bundle budget, interaction latency, long-task behavior | pilot evidence attached |
+| Artifact Review and Operator Tooling | Portal Frontend | review UI, artifact metadata | viewer success, keyboard-only review success, metadata visibility | pilot evidence attached |
 
 ## Appendix B: Initial Metric Targets
 
-These are provisional targets and should be confirmed or adjusted after M1 baseline capture.
+These are provisional targets and should be confirmed or adjusted after pilot capture.
 
 | Metric | Initial Target |
 | --- | --- |
@@ -577,18 +536,12 @@ These are provisional targets and should be confirmed or adjusted after M1 basel
 | p75 CLS | <= 0.1 |
 | Queue interaction latency | p75 <= 150ms for standard row selection and action affordances |
 | SSE reconnect rate | < 1 reconnect per operator-hour in steady-state managed usage |
-| Accessibility regressions | 0 blocking accessibility regressions on `/login` and `/portal` |
-| Artifact viewer interaction success | >= 95% successful open and basic inspect completion in pilot validation scenarios |
+| Accessibility regressions | 0 blocking browser-probe regressions on `/login` and `/portal` |
+| Artifact viewer interaction success | >= 95% successful open without fallback in pilot validation scenarios |
 
-## Appendix C: Reference Implementation Notes (Non-Normative)
+## Appendix C: Reference Notes
 
-These notes are intentionally non-binding. They describe acceptable implementation paths without converting them into hard architectural commitments.
-
-- `web-vitals`, `PerformanceObserver`, and OpenTelemetry-compatible traces are acceptable defaults for telemetry.
-- `sessionStorage` is preferred over `localStorage` for transient draft recovery tied to a single browser tab.
-- `encodeURIComponent()` is the correct primitive for encoding dynamic `returnTo` values; validation must still occur server-side.
-- `content-visibility` and reserved dimensions are preferred before introducing complex JavaScript virtualization.
-- delegated event handling is preferred for large, dynamic lists.
-- a lightweight DOM-native viewer is preferred for artifact review; `panzoom` is an acceptable default if a dependency is needed.
-- view-based dynamic imports are acceptable where the portal shell currently loads heavy review code too early.
-- Playwright tests should prefer resilient user-facing locators such as `getByRole` and `getByLabel`.
+- `tools/portal_rum_summary.py` remains the contract-stable RUM-only summary path.
+- `tools/portal_modernization_evidence.py` is the repo-owned pilot evidence path for M1, M4, and M5.
+- `docs/architecture/PORTAL_OPERATOR_CONSOLE_MODERNIZATION_EVIDENCE.md` records the evidence collection workflow and open gates.
+- `docs/compliance/PORTAL_TELEMETRY_PRIVACY_SIGNOFF.md` is the pending human approval packet for telemetry schema, retention, and disposal.

--- a/docs/compliance/PORTAL_TELEMETRY_PRIVACY_SIGNOFF.md
+++ b/docs/compliance/PORTAL_TELEMETRY_PRIVACY_SIGNOFF.md
@@ -1,0 +1,129 @@
+# Portal Telemetry Privacy Sign-Off Packet
+
+**Status:** Pending Human Approval
+**Date:** 2026-04-14
+**Owner:** Frontdoor / Platform
+**Review Required From:** Security / Privacy
+
+This packet inventories the current portal telemetry contract and the proposed pilot retention posture. It is a preparation document for human approval. It is not itself an approval record.
+
+## Purpose
+
+Approve or reject the telemetry schema, retention posture, and disposal procedure used for bounded portal modernization pilots.
+
+## Current Repo-Backed Data Collection
+
+### Portal RUM Sink
+
+Endpoint: `/v1/portal/rum`
+
+Current schema fields captured by repo code:
+
+- `schema`
+- `timestamp`
+- `event_type`
+- `route`
+- `view`
+- `metric`
+- `value`
+- `unit`
+- `metadata` after token-safe sanitization
+- `trace_id`
+- `cohort_bucket`
+- `auth_mode`
+
+Current supported event families:
+
+- `portal_shell_rendered`
+- `bootstrap_ready`
+- `first_view_interactive`
+- `core_web_vital`
+- `queue_request`
+- `sse_reconnect`
+
+### Portal Event Sink
+
+Endpoint: `/v1/portal/events`
+
+Current review-relevant event families:
+
+- `artifact_viewer_opened`
+- `artifact_viewer_fallback`
+- `artifact_opened`
+- `artifact_compared`
+- `run_details_opened`
+- `stream_reconnected`
+
+Current review-relevant metadata keys emitted by repo code:
+
+- `job_id`
+- `pipeline`
+- `media_kind`
+- `artifact_fingerprint`
+- `viewer_mode`
+- `fallback_reason`
+
+## Sanitization and Excluded Data
+
+Repo-backed sanitization currently guarantees:
+
+- metadata keys must be token-safe
+- metadata string values must be token-safe
+- unsupported keys and values are dropped
+- raw paths are dropped
+- plain-text usernames are not persisted in the RUM sink
+- plain-text access emails are not persisted in the RUM sink
+
+The pilot is not intended to capture:
+
+- message content
+- source file paths
+- plain-text email addresses
+- plain-text usernames
+- browser-entered secrets
+- free-form notes
+
+## Rollout and Sink Controls
+
+Current rollout and sink knobs:
+
+```bash
+export TP_PORTAL_RUM_ENABLED=0
+export TP_PORTAL_RUM_ROLLOUT_PERCENT=0
+export TP_PORTAL_RUM_LOG_PATH="/absolute/path/to/portal-rum.jsonl"
+export TP_PORTAL_EVENT_LOG_PATH="/absolute/path/to/portal-events.jsonl"
+```
+
+Observed sink behavior:
+
+- both sinks are optional
+- both sinks append JSONL records when enabled
+- the repo does not currently implement automatic retention, rotation, or deletion
+- the sinks must therefore be treated as short-lived pilot artifacts, not long-term ledgers
+
+## Proposed Pilot Retention and Disposal Procedure
+
+Proposed for approval:
+
+1. Keep raw pilot JSONL logs only in an operator-owned restricted path.
+2. Retain raw JSONL for no longer than 14 calendar days after pilot end.
+3. Extract aggregate evidence with `tools/portal_modernization_evidence.py`.
+4. Preserve only the aggregate evidence output needed for RFC or rollout review.
+5. Delete raw JSONL once the aggregate evidence has been attached and reviewed.
+
+## Questions Requiring Human Approval
+
+- Is the current schema sufficiently minimized for bounded pilot use?
+- Is the proposed 14-day raw-log retention window acceptable?
+- Are additional masking or field removals required before any rollout expansion?
+- Is the current disposal procedure sufficient, or is a stronger deletion control required?
+
+## Approval Block
+
+Pending reviewer completion:
+
+- Reviewer:
+- Role:
+- Review date:
+- Decision:
+- Conditions or required changes:

--- a/docs/decisions/ADR-050-portal-react-migration.md
+++ b/docs/decisions/ADR-050-portal-react-migration.md
@@ -2,61 +2,75 @@
 
 ## Status
 
-**Proposed** — Pending evidence gathering and team discussion.
+**Proposed** - Pending evidence gathering and team discussion.
 
 ## Context
 
 The operator console (`portal.html`, `portal.js`, `portal.css`) is currently a FastAPI-served HTML/JS application that provides the full operator workflow surface for the Transformation Portal. It supports:
 
-- Multi-view navigation (`?view=overview|build|operate|review`)
-- Real-time job updates via SSE
-- Managed authentication mode (via frontdoor proxy)
-- Direct-debug mode (browser-side API key)
-- Full keyboard accessibility
-- Reduced-motion support
+- multi-view navigation (`?view=overview|build|operate|review`)
+- real-time job updates via SSE
+- managed authentication mode via the frontdoor proxy
+- direct-debug mode
+- keyboard accessibility
+- reduced-motion support
 
 The managed frontdoor (`web/secure-landing/`) is a separate Next.js application that handles:
 
-- Public homepage
-- Authentication/login
-- Portal proxy in managed mode
+- the public homepage
+- authentication and login
+- the managed portal proxy
 
-This ADR addresses whether the operator console should be migrated into the React/Next.js stack as part of the managed frontdoor, or whether it should remain as a FastAPI-served HTML/JS application.
+This ADR remains the only decision gate for whether the operator console should migrate into the React/Next.js stack. The portal modernization RFC does not answer this ADR.
 
-## Evidence Required
+## Evidence Inventory
 
-Before making a decision, the following evidence should be gathered:
+Current repo-backed sources:
 
-### 1. Delivery Velocity Metrics
+- `docs/architecture/PORTAL_OPERATOR_CONSOLE_MODERNIZATION_RFC.md`
+- `docs/architecture/PORTAL_OPERATOR_CONSOLE_MODERNIZATION_EVIDENCE.md`
+- `tools/portal_modernization_evidence.py`
+- `scripts/validation/validate_portal_browser_smoke.py`
+- `tests/test_app_orchestrator_runtime.py`
 
-- [ ] Average PR merge time for portal-related changes vs. frontdoor changes
-- [ ] Lines of code changed per feature in each surface
-- [ ] Number of iterations required for typical portal changes
+### 1. Delivery Velocity
 
-### 2. Quality Metrics
+| Evidence Item | State | Notes |
+| --- | --- | --- |
+| Average PR merge time for portal-related changes vs frontdoor changes | Still missing | Requires repository history analysis or external reporting |
+| Lines of code changed per feature in each surface | Still missing | Requires historical sampling |
+| Number of iterations required for typical portal changes | Still missing | Requires PR review-history analysis |
 
-- [ ] Bug count per KLOC in `portal.js` vs. frontdoor code
-- [ ] Test coverage comparison (portal contract tests vs. frontdoor tests)
-- [ ] Regression frequency in each surface
+### 2. Quality
+
+| Evidence Item | State | Notes |
+| --- | --- | --- |
+| Browser contract and runtime coverage for the current portal | Repo-backed now | Current portal validation is strong, but it is not a rewrite comparison by itself |
+| Bug count per KLOC in portal vs frontdoor code | Still missing | Requires issue or incident tagging by surface |
+| Test coverage comparison between portal and frontdoor surfaces | Still missing | Requires explicit comparative measurement |
+| Regression frequency in each surface | Still missing | Requires incident or bug history by surface |
 
 ### 3. Developer Experience
 
-- [ ] Developer friction survey results (if available)
-- [ ] Onboarding time for new contributors to each surface
-- [ ] IDE/tooling support comparison
+| Evidence Item | State | Notes |
+| --- | --- | --- |
+| Current repo structure and workflow split are documented | Repo-backed now | The split boundary is clear, but this is not enough to justify migration |
+| Developer friction survey results | Still missing | Needs human input |
+| Onboarding time for new contributors to each surface | Still missing | Needs observed contributor data |
+| IDE/tooling support comparison | Still missing | Needs an explicit comparison write-up |
 
 ### 4. Migration Requirements
 
-| Current Capability | Next.js Equivalent | Complexity | Notes |
-|-------------------|-------------------|------------|-------|
-| `portal.html` static serve | `app/portal/page.js` | Low | Route handler required |
-| `/portal/assets/*` | `public/` or Next.js static imports | Low | Path mapping needed |
-| Query param routing `?view=` | Client state or dynamic routes | Medium | URL contract preservation |
-| `portal.js` state management | React state + context/reducer | High | Significant refactor |
-| SSE via EventSource | Same API or React Query | Medium | Connection management |
-| Direct-debug bootstrap | API route + middleware | Medium | Auth flow adaptation |
-| Managed auth proxy | Already exists in frontdoor | Low | Integration needed |
-| Browser smoke tests | Playwright/Cypress adaptation | Medium | Test rewrite needed |
+| Current Capability | Next.js Equivalent | Complexity | State |
+| --- | --- | --- | --- |
+| `portal.html` static serve | `app/portal/page.js` | Low | Still hypothetical |
+| `/portal/assets/*` | `public/` or static imports | Low | Still hypothetical |
+| Query param routing `?view=` | client state or dynamic routes | Medium | Still hypothetical |
+| `portal.js` state management | React state plus reducer or context | High | Still hypothetical |
+| SSE via `EventSource` | same API or React data layer | Medium | Still hypothetical |
+| Direct-debug bootstrap | API route plus middleware | Medium | Still hypothetical |
+| Managed auth proxy | already exists in frontdoor | Low | Partial reuse available |
+| Browser smoke tests | Playwright adaptation | Medium | Still hypothetical |
 
 ## Decision
 
@@ -64,98 +78,76 @@ Before making a decision, the following evidence should be gathered:
 
 Options:
 
-1. **Proceed with migration** — Move operator console into Next.js
-2. **Defer migration** — Continue with Phase 5 modularization and revisit in 6 months
-3. **Reject migration** — Commit to FastAPI/HTML architecture long-term
+1. Proceed with migration.
+2. Defer migration and continue with the native-web portal.
+3. Reject migration and commit to the FastAPI/HTML architecture long term.
 
 ## Consequences
 
 ### If Migrating
 
-**Benefits:**
-- Unified codebase for all browser surfaces
-- Modern React tooling and ecosystem
-- Better component reusability
-- Stronger type safety with TypeScript (optional)
+**Benefits**
 
-**Costs:**
-- 3-6 month migration timeline (estimated)
-- Two UIs to maintain during transition
-- Test coverage gap during migration
-- Risk of regression in tested behavior
+- unified browser stack
+- React and Next.js tooling
+- stronger component reuse opportunities
 
-**Migration Phases (if approved):**
+**Costs**
 
-1. **Phase M1: Minimal Viable Portal** (4-6 weeks)
-   - Basic route structure in Next.js
-   - Static page rendering
-   - Managed auth integration
-
-2. **Phase M2: Feature Parity** (6-8 weeks)
-   - All four views implemented
-   - State management ported
-   - SSE/real-time support
-
-3. **Phase M3: Deprecation** (2-4 weeks)
-   - Test coverage validation
-   - FastAPI route deprecation
-   - Documentation update
+- migration delivery risk
+- dual-surface maintenance during transition
+- test rewrite and parity work
+- regression risk against a stable validated portal
 
 ### If Not Migrating
 
-**Benefits:**
-- No migration risk
-- Continued focus on operator workflow improvements
-- Simpler architecture with clear separation
+**Benefits**
 
-**Costs:**
-- Continued maintenance of two codebases
-- Different patterns between surfaces
-- Potential missed ecosystem benefits
+- no migration risk
+- continued focus on operator workflow improvements
+- simpler incremental change model
 
-**Continued Improvement Path:**
-- Complete Phase 5 modularization
-- Phase 6 workflow acceleration
-- Phase 7 shared token layer
-- Revisit migration decision in 6 months
+**Costs**
 
-## Go/No-Go Criteria
+- continued maintenance of two browser codebases
+- different implementation patterns across surfaces
+- potential missed ecosystem benefits
 
-### Go if:
+## Go / No-Go Criteria
 
-- [ ] Portal changes taking >2x longer than similar complexity elsewhere
-- [ ] Bug rate significantly higher than frontdoor (>2x per KLOC)
-- [ ] Team has React expertise available for migration
-- [ ] Clear 3-month window in roadmap for migration work
-- [ ] Test coverage gap can be closed within timeline
+### Go if
 
-### No-Go if:
+- portal changes are materially slower than comparable frontdoor work
+- portal defect rates are materially worse than comparable frontdoor work
+- the team has clear React and Next.js migration ownership
+- roadmap capacity exists for parity and migration hardening
+- rewrite test coverage can reach current portal parity
 
-- [ ] Current portal meeting delivery needs adequately
-- [ ] Migration would block higher-priority work
-- [ ] Test coverage gap cannot be closed in timeline
-- [ ] No clear ownership of migrated surface
-- [ ] Team prefers current architecture
+### No-Go if
+
+- current portal delivery remains adequate
+- migration would block higher-priority operator work
+- test parity cannot be reached in the migration window
+- ownership of the migrated surface is unclear
 
 ## Acceptance Criteria for Migration
 
-If migration is approved, the following must be met before deprecating the FastAPI-served portal:
+If migration is approved, the following must be true before deprecating the FastAPI-served portal:
 
-- [ ] All existing browser smoke tests pass on new surface
-- [ ] Direct-debug mode works identically
-- [ ] Managed auth mode works identically
-- [ ] All four views fully functional
-- [ ] Query param routing contract preserved
-- [ ] No regression in keyboard accessibility
-- [ ] No regression in reduced-motion support
-- [ ] CI coverage equivalent or better
-- [ ] Performance parity (page load, interaction latency)
-- [ ] Documentation updated
+- all existing browser smoke tests pass on the new surface
+- direct-debug mode works identically
+- managed auth mode works identically
+- all four views remain fully functional
+- the query-parameter routing contract is preserved
+- keyboard accessibility and reduced-motion behavior do not regress
+- CI coverage is equivalent or better
+- page load and interaction latency remain at parity or better
+- documentation is updated
 
 ## References
 
-- Phase 5 plan: Portal Shell Modularization
-- `portal.html`, `portal.js`, `portal.css` — current implementation
-- `web/secure-landing/` — managed frontdoor
-- Browser smoke tests: `scripts/validation/validate_portal_browser_smoke.py`
-- Contract tests: `tests/test_app_orchestrator_runtime.py`
+- `docs/architecture/PORTAL_OPERATOR_CONSOLE_MODERNIZATION_RFC.md`
+- `docs/architecture/PORTAL_OPERATOR_CONSOLE_MODERNIZATION_EVIDENCE.md`
+- `web/secure-landing/`
+- `scripts/validation/validate_portal_browser_smoke.py`
+- `tests/test_app_orchestrator_runtime.py`

--- a/docs/guides/PORTAL_SECURE_FRONTDOOR_QUICKSTART.md
+++ b/docs/guides/PORTAL_SECURE_FRONTDOOR_QUICKSTART.md
@@ -72,14 +72,17 @@ and a deterministic rollout percentage.
 export TP_PORTAL_RUM_ENABLED=0
 export TP_PORTAL_RUM_ROLLOUT_PERCENT=0
 export TP_PORTAL_RUM_LOG_PATH="/absolute/path/to/portal-rum.jsonl"
+export TP_PORTAL_EVENT_LOG_PATH="/absolute/path/to/portal-events.jsonl"
 ```
 
 Notes:
 - `TP_PORTAL_RUM_ENABLED=0` keeps `/v1/portal/rum` in success/no-op mode and keeps `features.rumTelemetry=false` on both bootstrap surfaces.
 - `TP_PORTAL_RUM_ROLLOUT_PERCENT=0` keeps collection disabled even when the hard flag is on.
 - `TP_PORTAL_RUM_LOG_PATH` is optional. When set, FastAPI appends PII-free JSONL records for the pilot summary CLI.
+- `TP_PORTAL_EVENT_LOG_PATH` is optional. When set, FastAPI appends PII-free portal event JSONL for viewer, review, and stream telemetry evidence.
 - Direct-debug rollout stability reuses `TP_PORTAL_DIRECT_DEBUG_COHORT_KEY`.
 - Managed rollout stability uses the authenticated actor identity already present on the front door; raw usernames and emails are not stored in the RUM sink.
+- Rollout expansion remains blocked until `docs/compliance/PORTAL_TELEMETRY_PRIVACY_SIGNOFF.md` has explicit Security / Privacy approval.
 
 ## Optional Review Surface Pilot Knobs
 
@@ -256,6 +259,15 @@ python tools/portal_rum_summary.py --input /absolute/path/to/portal-rum.jsonl
 
 The summary groups by auth mode, route, view, and cohort bucket, then prints p75
 LCP/INP/CLS, bootstrap timings, queue request timings, and SSE reconnect counts.
+
+For the RFC evidence package, summarize RUM plus optional viewer-event evidence with:
+
+```bash
+python tools/portal_modernization_evidence.py \
+  --rum-log /absolute/path/to/portal-rum.jsonl \
+  --event-log /absolute/path/to/portal-events.jsonl \
+  --operator-hours 8
+```
 
 Manual shared-deployment posture gate:
 

--- a/public/portal-assets/portal-review.js
+++ b/public/portal-assets/portal-review.js
@@ -54,7 +54,6 @@ function createDeferredReviewSurfaceApi(host) {
   function _artifactViewerEventMetadata(job, artifact, extra = {}) {
     const metadata = {
       job_id: _normalizeSelectedJobId(job?.id),
-      pipeline: String(job?.pipeline || ""),
       media_kind: String(artifact?.media_kind || "file"),
       artifact_fingerprint: artifactFingerprint(artifact).toLowerCase(),
       viewer_mode: "modal"

--- a/public/portal-assets/portal-review.js
+++ b/public/portal-assets/portal-review.js
@@ -50,6 +50,37 @@ function createDeferredReviewSurfaceApi(host) {
   let artifactViewerPreviewPath = "";
   let artifactViewerPreviewSource = "";
   let artifactViewerPreviewRequestId = 0;
+  let artifactViewerFallbackEventKey = "";
+  function _artifactViewerEventMetadata(job, artifact, extra = {}) {
+    const metadata = {
+      job_id: _normalizeSelectedJobId(job?.id),
+      pipeline: String(job?.pipeline || ""),
+      media_kind: String(artifact?.media_kind || "file"),
+      artifact_fingerprint: artifactFingerprint(artifact).toLowerCase(),
+      viewer_mode: "modal"
+    };
+    Object.entries(extra).forEach(([key, value]) => {
+      if (value === void 0 || value === null || value === "") return;
+      metadata[key] = value;
+    });
+    return metadata;
+  }
+  function _emitArtifactViewerFallback(context, fallbackReason) {
+    if (!context?.job || !context?.artifact || !fallbackReason) return;
+    const fallbackKey = [
+      _normalizeSelectedJobId(context.job.id),
+      _artifactRouteKey(context.artifact),
+      fallbackReason
+    ].filter(Boolean).join(":");
+    if (fallbackKey && fallbackKey === artifactViewerFallbackEventKey) return;
+    artifactViewerFallbackEventKey = fallbackKey;
+    void emitPortalEvent("artifact_viewer_fallback", {
+      surface: "artifact_review",
+      metadata: _artifactViewerEventMetadata(context.job, context.artifact, {
+        fallback_reason: fallbackReason
+      })
+    });
+  }
   function _revokeArtifactViewerObjectUrl() {
     if (!artifactViewerObjectUrl) return;
     URL.revokeObjectURL(artifactViewerObjectUrl);
@@ -61,7 +92,9 @@ function createDeferredReviewSurfaceApi(host) {
     artifactViewerPreviewSource = "";
     _revokeArtifactViewerObjectUrl();
   }
-  function _showArtifactViewerFallback(url, artifactName) {
+  function _showArtifactViewerFallback(context, artifactName) {
+    const url = context?.url || "";
+    const fallbackReason = url ? "inline_preview_unavailable" : "asset_url_unavailable";
     if (els.artifactViewerImage) {
       els.artifactViewerImage.classList.add("hidden");
       els.artifactViewerImage.removeAttribute("src");
@@ -79,6 +112,7 @@ function createDeferredReviewSurfaceApi(host) {
     _setArtifactViewerStatus(
       url ? `${artifactName} is open with metadata fallback because an inline preview is unavailable.` : `${artifactName} is open with metadata fallback because the managed asset URL is unavailable.`
     );
+    _emitArtifactViewerFallback(context, fallbackReason);
   }
   function _renderArtifactViewerInlineImage(src, zoomPercent) {
     if (!els.artifactViewerImage) return;
@@ -90,7 +124,7 @@ function createDeferredReviewSurfaceApi(host) {
   async function _loadArtifactViewerInlinePreview(context, artifactName) {
     const artifactPath = _artifactRouteKey(context.artifact);
     if (!context.url || !artifactPath) {
-      _showArtifactViewerFallback(context.url, artifactName);
+      _showArtifactViewerFallback(context, artifactName);
       return;
     }
     if (artifactViewerObjectUrl && artifactViewerPreviewPath === artifactPath && artifactViewerPreviewSource === context.url) {
@@ -124,7 +158,7 @@ function createDeferredReviewSurfaceApi(host) {
       _setArtifactViewerStatus(`${artifactName} preview open at ${context.zoomPercent}% zoom.`);
     } catch {
       if (requestId !== artifactViewerPreviewRequestId) return;
-      _showArtifactViewerFallback(context.url, artifactName);
+      _showArtifactViewerFallback(context, artifactName);
     }
   }
   function getRunCardArtifact(job) {
@@ -714,7 +748,7 @@ function createDeferredReviewSurfaceApi(host) {
           const activeContext = _artifactViewerContext();
           if (!activeContext.artifact) return;
           if (_artifactRouteKey(activeContext.artifact) !== artifactPath) return;
-          _showArtifactViewerFallback(url, artifactName);
+          _showArtifactViewerFallback(activeContext, artifactName);
         };
       }
       if (state.auth?.mode !== "direct_debug") {
@@ -733,7 +767,7 @@ function createDeferredReviewSurfaceApi(host) {
       return;
     }
     _clearArtifactViewerPreviewCache();
-    _showArtifactViewerFallback(url, artifactName);
+    _showArtifactViewerFallback(context, artifactName);
     void job;
   }
   function _closeArtifactViewer(restoreFocus = true) {
@@ -753,16 +787,13 @@ function createDeferredReviewSurfaceApi(host) {
     state.portalUi.artifactViewer.jobId = _normalizeSelectedJobId(job.id);
     state.portalUi.artifactViewer.artifactPath = _artifactRouteKey(artifact);
     state.portalUi.artifactViewer.zoomPercent = 100;
+    artifactViewerFallbackEventKey = "";
     _rememberOverlayTrigger(trigger);
     renderArtifactViewer();
     if (els.closeArtifactViewerBtn) els.closeArtifactViewerBtn.focus();
     void emitPortalEvent("artifact_viewer_opened", {
-      surface: "artifact_viewer_modal",
-      metadata: {
-        job_id: String(job.id || ""),
-        media_kind: String(artifact.media_kind || "file"),
-        pipeline: String(job.pipeline || "")
-      }
+      surface: "artifact_review",
+      metadata: _artifactViewerEventMetadata(job, artifact)
     });
     return true;
   }

--- a/tests/test_app_orchestrator_contract_http.py
+++ b/tests/test_app_orchestrator_contract_http.py
@@ -867,6 +867,7 @@ def test_portal_events_accept_artifact_viewer_review_events(
             "surface": "artifact_review",
             "metadata": {
                 "job_id": "job_1234abcd",
+                "pipeline": "lux-depth-v3",
                 "media_kind": "image",
                 "artifact_fingerprint": "abcdef1234",
                 "viewer_mode": "modal",

--- a/tests/test_app_orchestrator_contract_http.py
+++ b/tests/test_app_orchestrator_contract_http.py
@@ -854,6 +854,44 @@ def test_portal_events_allow_operator_console_review_and_stream_events(client: T
     assert event["metadata"] == {"attempt": 2, "job_id": "job_1234abcd", "transport": "fetch"}
 
 
+@pytest.mark.parametrize("event_type", ["artifact_viewer_opened", "artifact_viewer_fallback"])
+def test_portal_events_accept_artifact_viewer_review_events(
+    client: TestClient,
+    event_type: str,
+) -> None:
+    response = client.post(
+        "/v1/portal/events",
+        json={
+            "event_type": event_type,
+            "pipeline": "lux-depth-v3",
+            "surface": "artifact_review",
+            "metadata": {
+                "job_id": "job_1234abcd",
+                "media_kind": "image",
+                "artifact_fingerprint": "abcdef1234",
+                "viewer_mode": "modal",
+                "fallback_reason": "inline_preview_unavailable",
+                "email": "admin@example.com",
+                "raw_path": "/private/tmp/should-not-pass",
+            },
+        },
+    )
+    body = response.json()
+
+    assert response.status_code == 200
+    assert body["success"] is True
+    event = body["data"]["event"]
+    assert event["event_type"] == event_type
+    assert event["surface"] == "artifact_review"
+    assert event["metadata"] == {
+        "artifact_fingerprint": "abcdef1234",
+        "fallback_reason": "inline_preview_unavailable",
+        "job_id": "job_1234abcd",
+        "media_kind": "image",
+        "viewer_mode": "modal",
+    }
+
+
 def test_portal_events_contract_ignores_log_sink_write_failures(
     client: TestClient,
     tmp_path: Path,

--- a/tests/test_app_orchestrator_runtime.py
+++ b/tests/test_app_orchestrator_runtime.py
@@ -1191,6 +1191,8 @@ def test_portal_artifact_viewer_modal_is_feature_flagged_and_keyboard_complete()
     content = _portal_bundle_content()
     review_content = _portal_review_source_content()
     active_overlay_body = _extract_js_function_body(content, "_activeOverlayPanel")
+    fallback_event_body = _extract_js_function_body(review_content, "_emitArtifactViewerFallback")
+    show_fallback_body = _extract_js_function_body(review_content, "_showArtifactViewerFallback")
     render_body = _extract_js_function_body(review_content, "renderArtifactViewer")
     preview_load_body = _extract_js_function_body(review_content, "_loadArtifactViewerInlinePreview")
     open_body = _extract_js_function_body(review_content, "_openArtifactViewer")
@@ -1220,11 +1222,19 @@ def test_portal_artifact_viewer_modal_is_feature_flagged_and_keyboard_complete()
     assert "_rememberOverlayTrigger(trigger);" in open_body
     assert "els.closeArtifactViewerBtn.focus();" in open_body
     assert "artifact_viewer_opened" in open_body
+    assert 'surface: "artifact_review"' in open_body
+    assert "_artifactViewerEventMetadata(job, artifact)" in open_body
     assert "state.portalUi.artifactViewer.open = false;" in close_body
     assert "_restoreOverlayFocus();" in close_body
+    assert 'viewer_mode: "modal"' in review_content
+    assert "artifact_fingerprint" in review_content
+    assert "artifact_viewer_fallback" in fallback_event_body
+    assert 'surface: "artifact_review"' in fallback_event_body
+    assert "fallback_reason: fallbackReason" in fallback_event_body
+    assert "_emitArtifactViewerFallback(context, fallbackReason);" in show_fallback_body
     assert 'els.artifactViewerModal.classList.toggle("hidden", !shouldShow);' in render_body
     assert "els.artifactViewerImage.style.transform = `scale(${zoomPercent / 100})`;" in render_body
-    assert "_showArtifactViewerFallback(url, artifactName);" in render_body
+    assert "_showArtifactViewerFallback(context, artifactName);" in render_body
     assert (
         'headers: _buildAuthHeaders({ Accept: artifactContentType(context.artifact) || "*/*" }, "GET"),' in preview_load_body
     )

--- a/tests/test_app_orchestrator_runtime.py
+++ b/tests/test_app_orchestrator_runtime.py
@@ -1198,6 +1198,7 @@ def test_portal_artifact_viewer_modal_is_feature_flagged_and_keyboard_complete()
     open_body = _extract_js_function_body(review_content, "_openArtifactViewer")
     navigate_body = _extract_js_function_body(review_content, "_navigateArtifactViewerSelection")
     close_body = _extract_js_function_body(review_content, "_closeArtifactViewer")
+    viewer_metadata_body = _extract_js_function_body(review_content, "_artifactViewerEventMetadata")
 
     assert 'id="artifactViewerModal"' in content
     assert 'id="artifactViewerPanel"' in content
@@ -1228,6 +1229,7 @@ def test_portal_artifact_viewer_modal_is_feature_flagged_and_keyboard_complete()
     assert "_restoreOverlayFocus();" in close_body
     assert 'viewer_mode: "modal"' in review_content
     assert "artifact_fingerprint" in review_content
+    assert 'pipeline: String(job?.pipeline || "")' not in viewer_metadata_body
     assert "artifact_viewer_fallback" in fallback_event_body
     assert 'surface: "artifact_review"' in fallback_event_body
     assert "fallback_reason: fallbackReason" in fallback_event_body

--- a/tests/test_portal_modernization_evidence.py
+++ b/tests/test_portal_modernization_evidence.py
@@ -245,6 +245,65 @@ def test_portal_modernization_evidence_skips_non_object_json_lines(tmp_path: Pat
     assert "skipped non-object json line" in result.stderr
 
 
+def test_portal_modernization_evidence_keeps_m1_visible_when_thresholds_fail(tmp_path: Path) -> None:
+    rum_path = tmp_path / "portal-rum.jsonl"
+    _write_jsonl(
+        rum_path,
+        [
+            {
+                "schema": "tp.orchestrator.portal_rum.v1",
+                "event_type": "core_web_vital",
+                "metric": "lcp",
+                "value": 4100.0,
+            },
+            {
+                "schema": "tp.orchestrator.portal_rum.v1",
+                "event_type": "core_web_vital",
+                "metric": "inp",
+                "value": 320.0,
+            },
+            {
+                "schema": "tp.orchestrator.portal_rum.v1",
+                "event_type": "core_web_vital",
+                "metric": "cls",
+                "value": 0.22,
+            },
+            {
+                "schema": "tp.orchestrator.portal_rum.v1",
+                "event_type": "bootstrap_ready",
+                "value": 180.0,
+            },
+            {
+                "schema": "tp.orchestrator.portal_rum.v1",
+                "event_type": "first_view_interactive",
+                "value": 240.0,
+            },
+            {
+                "schema": "tp.orchestrator.portal_rum.v1",
+                "event_type": "portal_shell_rendered",
+                "value": 95.0,
+            },
+            {
+                "schema": "tp.orchestrator.portal_rum.v1",
+                "event_type": "queue_request",
+                "metric": "submit",
+                "value": 225.0,
+            },
+        ],
+    )
+
+    result = _run_cli("--rum-log", str(rum_path), "--format", "json")
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["milestones"]["m1_measurement_foundation"] == {
+        "rum_visibility_confirmed": True,
+        "status": "pass",
+    }
+    assert payload["metrics"]["lcp_p75_ms"]["status"] == "fail"
+    assert payload["milestones"]["m4_performance"]["status"] == "fail"
+
+
 def test_portal_modernization_evidence_marks_m5_fail_when_viewer_success_rate_misses_target(tmp_path: Path) -> None:
     rum_path = tmp_path / "portal-rum.jsonl"
     event_path = tmp_path / "portal-events.jsonl"

--- a/tests/test_portal_modernization_evidence.py
+++ b/tests/test_portal_modernization_evidence.py
@@ -25,7 +25,7 @@ def _run_cli(*args: str) -> subprocess.CompletedProcess[str]:
     )
 
 
-def _write_jsonl(path: Path, records: list[dict[str, object]]) -> None:
+def _write_jsonl(path: Path, records: list[object]) -> None:
     path.write_text("\n".join(json.dumps(record) for record in records) + "\n", encoding="utf-8")
 
 
@@ -187,6 +187,62 @@ def test_portal_modernization_evidence_json_marks_sse_threshold_insufficient_wit
     assert payload["milestones"]["m1_measurement_foundation"]["status"] == "pass"
     assert payload["metrics"]["sse_reconnect_rate_per_operator_hour"]["status"] == "insufficient_data"
     assert payload["milestones"]["m5_artifact_review"]["status"] == "insufficient_data"
+
+
+def test_portal_modernization_evidence_skips_non_object_json_lines(tmp_path: Path) -> None:
+    rum_path = tmp_path / "portal-rum.jsonl"
+    _write_jsonl(
+        rum_path,
+        [
+            {
+                "schema": "tp.orchestrator.portal_rum.v1",
+                "event_type": "core_web_vital",
+                "metric": "lcp",
+                "value": 2200.0,
+            },
+            {
+                "schema": "tp.orchestrator.portal_rum.v1",
+                "event_type": "core_web_vital",
+                "metric": "inp",
+                "value": 150.0,
+            },
+            {
+                "schema": "tp.orchestrator.portal_rum.v1",
+                "event_type": "core_web_vital",
+                "metric": "cls",
+                "value": 0.04,
+            },
+            {
+                "schema": "tp.orchestrator.portal_rum.v1",
+                "event_type": "bootstrap_ready",
+                "value": 180.0,
+            },
+            {
+                "schema": "tp.orchestrator.portal_rum.v1",
+                "event_type": "first_view_interactive",
+                "value": 240.0,
+            },
+            {
+                "schema": "tp.orchestrator.portal_rum.v1",
+                "event_type": "portal_shell_rendered",
+                "value": 95.0,
+            },
+            {
+                "schema": "tp.orchestrator.portal_rum.v1",
+                "event_type": "queue_request",
+                "metric": "submit",
+                "value": 70.0,
+            },
+            ["not", "an", "object"],
+        ],
+    )
+
+    result = _run_cli("--rum-log", str(rum_path), "--format", "json")
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["milestones"]["m1_measurement_foundation"]["status"] == "pass"
+    assert "skipped non-object json line" in result.stderr
 
 
 def test_portal_modernization_evidence_marks_m5_fail_when_viewer_success_rate_misses_target(tmp_path: Path) -> None:

--- a/tests/test_portal_modernization_evidence.py
+++ b/tests/test_portal_modernization_evidence.py
@@ -1,0 +1,275 @@
+"""Tests for tools/portal_modernization_evidence.py."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+TOOL_PATH = PROJECT_ROOT / "tools" / "portal_modernization_evidence.py"
+
+
+def _run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(TOOL_PATH), *args],
+        cwd=str(PROJECT_ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _write_jsonl(path: Path, records: list[dict[str, object]]) -> None:
+    path.write_text("\n".join(json.dumps(record) for record in records) + "\n", encoding="utf-8")
+
+
+def test_portal_modernization_evidence_reports_repo_gates_in_text_output(tmp_path: Path) -> None:
+    rum_path = tmp_path / "portal-rum.jsonl"
+    event_path = tmp_path / "portal-events.jsonl"
+    _write_jsonl(
+        rum_path,
+        [
+            {
+                "schema": "tp.orchestrator.portal_rum.v1",
+                "event_type": "core_web_vital",
+                "metric": "lcp",
+                "value": 2200.0,
+            },
+            {
+                "schema": "tp.orchestrator.portal_rum.v1",
+                "event_type": "core_web_vital",
+                "metric": "inp",
+                "value": 150.0,
+            },
+            {
+                "schema": "tp.orchestrator.portal_rum.v1",
+                "event_type": "core_web_vital",
+                "metric": "cls",
+                "value": 0.04,
+            },
+            {
+                "schema": "tp.orchestrator.portal_rum.v1",
+                "event_type": "bootstrap_ready",
+                "metric": "duration",
+                "value": 180.0,
+            },
+            {
+                "schema": "tp.orchestrator.portal_rum.v1",
+                "event_type": "first_view_interactive",
+                "metric": "duration",
+                "value": 240.0,
+            },
+            {
+                "schema": "tp.orchestrator.portal_rum.v1",
+                "event_type": "portal_shell_rendered",
+                "metric": "duration",
+                "value": 95.0,
+            },
+            {
+                "schema": "tp.orchestrator.portal_rum.v1",
+                "event_type": "queue_request",
+                "metric": "submit",
+                "value": 70.0,
+            },
+            {
+                "schema": "tp.orchestrator.portal_rum.v1",
+                "event_type": "sse_reconnect",
+                "value": 1.0,
+            },
+            {
+                "schema": "tp.orchestrator.portal_event.v1",
+                "event_type": "ignored_in_rum_sink",
+            },
+        ],
+    )
+    event_records = [
+        {
+            "schema": "tp.orchestrator.portal_event.v1",
+            "event_type": "artifact_viewer_opened",
+            "surface": "artifact_review",
+            "metadata": {"job_id": f"job_{index:04d}", "viewer_mode": "modal"},
+        }
+        for index in range(20)
+    ]
+    event_records.append(
+        {
+            "schema": "tp.orchestrator.portal_event.v1",
+            "event_type": "artifact_viewer_fallback",
+            "surface": "artifact_review",
+            "metadata": {"job_id": "job_0001", "viewer_mode": "modal", "fallback_reason": "inline_preview_unavailable"},
+        }
+    )
+    event_records.append(
+        {
+            "schema": "tp.orchestrator.portal_rum.v1",
+            "event_type": "ignored_in_event_sink",
+        }
+    )
+    _write_jsonl(event_path, event_records)
+
+    result = _run_cli("--rum-log", str(rum_path), "--event-log", str(event_path), "--operator-hours", "4")
+
+    assert result.returncode == 0, result.stderr
+    assert "m1_measurement_foundation status=pass" in result.stdout
+    assert "m4_performance status=pass" in result.stdout
+    assert "metric name=sse_reconnect_rate_per_operator_hour status=pass value=0.25" in result.stdout
+    assert (
+        "m5_artifact_review status=pass viewer_open_count=20 viewer_fallback_count=1 viewer_success_rate_pct=95.00"
+        in result.stdout
+    )
+    assert "m5_fallback_reason reason=inline_preview_unavailable count=1" in result.stdout
+
+
+def test_portal_modernization_evidence_json_marks_sse_threshold_insufficient_without_operator_hours(
+    tmp_path: Path,
+) -> None:
+    rum_path = tmp_path / "portal-rum.jsonl"
+    _write_jsonl(
+        rum_path,
+        [
+            {
+                "schema": "tp.orchestrator.portal_rum.v1",
+                "event_type": "core_web_vital",
+                "metric": "lcp",
+                "value": 2200.0,
+            },
+            {
+                "schema": "tp.orchestrator.portal_rum.v1",
+                "event_type": "core_web_vital",
+                "metric": "inp",
+                "value": 150.0,
+            },
+            {
+                "schema": "tp.orchestrator.portal_rum.v1",
+                "event_type": "core_web_vital",
+                "metric": "cls",
+                "value": 0.04,
+            },
+            {
+                "schema": "tp.orchestrator.portal_rum.v1",
+                "event_type": "bootstrap_ready",
+                "value": 180.0,
+            },
+            {
+                "schema": "tp.orchestrator.portal_rum.v1",
+                "event_type": "first_view_interactive",
+                "value": 240.0,
+            },
+            {
+                "schema": "tp.orchestrator.portal_rum.v1",
+                "event_type": "portal_shell_rendered",
+                "value": 95.0,
+            },
+            {
+                "schema": "tp.orchestrator.portal_rum.v1",
+                "event_type": "queue_request",
+                "metric": "submit",
+                "value": 70.0,
+            },
+            {
+                "schema": "tp.orchestrator.portal_rum.v1",
+                "event_type": "sse_reconnect",
+                "value": 1.0,
+            },
+        ],
+    )
+
+    result = _run_cli("--rum-log", str(rum_path), "--format", "json")
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["milestones"]["m1_measurement_foundation"]["status"] == "pass"
+    assert payload["metrics"]["sse_reconnect_rate_per_operator_hour"]["status"] == "insufficient_data"
+    assert payload["milestones"]["m5_artifact_review"]["status"] == "insufficient_data"
+
+
+def test_portal_modernization_evidence_marks_m5_fail_when_viewer_success_rate_misses_target(tmp_path: Path) -> None:
+    rum_path = tmp_path / "portal-rum.jsonl"
+    event_path = tmp_path / "portal-events.jsonl"
+    _write_jsonl(
+        rum_path,
+        [
+            {
+                "schema": "tp.orchestrator.portal_rum.v1",
+                "event_type": "core_web_vital",
+                "metric": "lcp",
+                "value": 2200.0,
+            },
+            {
+                "schema": "tp.orchestrator.portal_rum.v1",
+                "event_type": "core_web_vital",
+                "metric": "inp",
+                "value": 150.0,
+            },
+            {
+                "schema": "tp.orchestrator.portal_rum.v1",
+                "event_type": "core_web_vital",
+                "metric": "cls",
+                "value": 0.04,
+            },
+            {
+                "schema": "tp.orchestrator.portal_rum.v1",
+                "event_type": "bootstrap_ready",
+                "value": 180.0,
+            },
+            {
+                "schema": "tp.orchestrator.portal_rum.v1",
+                "event_type": "first_view_interactive",
+                "value": 240.0,
+            },
+            {
+                "schema": "tp.orchestrator.portal_rum.v1",
+                "event_type": "portal_shell_rendered",
+                "value": 95.0,
+            },
+            {
+                "schema": "tp.orchestrator.portal_rum.v1",
+                "event_type": "queue_request",
+                "metric": "submit",
+                "value": 70.0,
+            },
+        ],
+    )
+    event_records = [
+        {
+            "schema": "tp.orchestrator.portal_event.v1",
+            "event_type": "artifact_viewer_opened",
+            "surface": "artifact_review",
+            "metadata": {"job_id": f"job_{index:04d}", "viewer_mode": "modal"},
+        }
+        for index in range(10)
+    ]
+    event_records.extend(
+        [
+            {
+                "schema": "tp.orchestrator.portal_event.v1",
+                "event_type": "artifact_viewer_fallback",
+                "surface": "artifact_review",
+                "metadata": {"job_id": "job_0001", "viewer_mode": "modal", "fallback_reason": "inline_preview_unavailable"},
+            },
+            {
+                "schema": "tp.orchestrator.portal_event.v1",
+                "event_type": "artifact_viewer_fallback",
+                "surface": "artifact_review",
+                "metadata": {"job_id": "job_0002", "viewer_mode": "modal", "fallback_reason": "asset_url_unavailable"},
+            },
+        ]
+    )
+    _write_jsonl(event_path, event_records)
+
+    result = _run_cli("--rum-log", str(rum_path), "--event-log", str(event_path), "--format", "json")
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["milestones"]["m5_artifact_review"]["status"] == "fail"
+    assert payload["milestones"]["m5_artifact_review"]["viewer_success_rate_pct"] == 80.0
+    assert payload["milestones"]["m5_artifact_review"]["fallback_reasons"] == {
+        "asset_url_unavailable": 1,
+        "inline_preview_unavailable": 1,
+    }

--- a/tools/portal_modernization_evidence.py
+++ b/tools/portal_modernization_evidence.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""Summarize repo-owned portal modernization evidence from JSONL telemetry sinks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+RUM_SCHEMA = "tp.orchestrator.portal_rum.v1"
+EVENT_SCHEMA = "tp.orchestrator.portal_event.v1"
+PASS = "pass"
+FAIL = "fail"
+INSUFFICIENT = "insufficient_data"
+
+
+def _percentile(values: List[float], percentile: float) -> Optional[float]:
+    if not values:
+        return None
+    ordered = sorted(float(value) for value in values)
+    if len(ordered) == 1:
+        return ordered[0]
+    index = (percentile / 100.0) * (len(ordered) - 1)
+    lower = math.floor(index)
+    upper = math.ceil(index)
+    if lower == upper:
+        return ordered[lower]
+    fraction = index - lower
+    return ordered[lower] + ((ordered[upper] - ordered[lower]) * fraction)
+
+
+def _read_records(path: Path, schema: str) -> List[Dict[str, Any]]:
+    records: List[Dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line_number, raw_line in enumerate(handle, start=1):
+            line = raw_line.strip()
+            if not line:
+                continue
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError as exc:
+                print(
+                    f"portal modernization evidence: skipped invalid json line {line_number} in {path}: {exc.msg}",
+                    file=sys.stderr,
+                )
+                continue
+            if payload.get("schema") != schema:
+                continue
+            records.append(payload)
+    return records
+
+
+def _values_for(records: Iterable[Dict[str, Any]], *, event_type: str, metric: str = "") -> List[float]:
+    values: List[float] = []
+    for record in records:
+        if str(record.get("event_type") or "") != event_type:
+            continue
+        if metric and str(record.get("metric") or "") != metric:
+            continue
+        value = record.get("value")
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            values.append(float(value))
+    return values
+
+
+def _metric_result(
+    name: str,
+    value: Optional[float],
+    *,
+    target_lte: Optional[float] = None,
+    target_lt: Optional[float] = None,
+    target_gte: Optional[float] = None,
+) -> Dict[str, Any]:
+    result: Dict[str, Any] = {"name": name, "value": value}
+    if target_lte is not None:
+        result["target_lte"] = target_lte
+    if target_lt is not None:
+        result["target_lt"] = target_lt
+    if target_gte is not None:
+        result["target_gte"] = target_gte
+    if value is None:
+        result["status"] = INSUFFICIENT
+        return result
+    if target_lte is not None:
+        result["status"] = PASS if value <= target_lte else FAIL
+        return result
+    if target_lt is not None:
+        result["status"] = PASS if value < target_lt else FAIL
+        return result
+    if target_gte is not None:
+        result["status"] = PASS if value >= target_gte else FAIL
+        return result
+    result["status"] = PASS
+    return result
+
+
+def _overall_status(results: Iterable[Dict[str, Any]]) -> str:
+    statuses = [str(result.get("status") or INSUFFICIENT) for result in results]
+    if not statuses:
+        return INSUFFICIENT
+    if any(status == FAIL for status in statuses):
+        return FAIL
+    if any(status == INSUFFICIENT for status in statuses):
+        return INSUFFICIENT
+    return PASS
+
+
+def build_report(
+    rum_records: List[Dict[str, Any]],
+    event_records: List[Dict[str, Any]],
+    *,
+    operator_hours: Optional[float],
+) -> Dict[str, Any]:
+    lcp_p75 = _percentile(_values_for(rum_records, event_type="core_web_vital", metric="lcp"), 75)
+    inp_p75 = _percentile(_values_for(rum_records, event_type="core_web_vital", metric="inp"), 75)
+    cls_p75 = _percentile(_values_for(rum_records, event_type="core_web_vital", metric="cls"), 75)
+    bootstrap_ready_p75 = _percentile(_values_for(rum_records, event_type="bootstrap_ready"), 75)
+    first_view_interactive_p75 = _percentile(_values_for(rum_records, event_type="first_view_interactive"), 75)
+    portal_shell_rendered_p75 = _percentile(_values_for(rum_records, event_type="portal_shell_rendered"), 75)
+    queue_submit_p75 = _percentile(_values_for(rum_records, event_type="queue_request", metric="submit"), 75)
+    queue_cancel_p75 = _percentile(_values_for(rum_records, event_type="queue_request", metric="cancel"), 75)
+    sse_reconnect_count = len(_values_for(rum_records, event_type="sse_reconnect"))
+
+    metric_results = {
+        "lcp_p75_ms": _metric_result("lcp_p75_ms", lcp_p75, target_lte=2500.0),
+        "inp_p75_ms": _metric_result("inp_p75_ms", inp_p75, target_lte=200.0),
+        "cls_p75": _metric_result("cls_p75", cls_p75, target_lte=0.1),
+        "bootstrap_ready_p75_ms": _metric_result("bootstrap_ready_p75_ms", bootstrap_ready_p75),
+        "first_view_interactive_p75_ms": _metric_result("first_view_interactive_p75_ms", first_view_interactive_p75),
+        "portal_shell_rendered_p75_ms": _metric_result("portal_shell_rendered_p75_ms", portal_shell_rendered_p75),
+        "queue_submit_p75_ms": _metric_result("queue_submit_p75_ms", queue_submit_p75, target_lte=150.0),
+        "queue_cancel_p75_ms": _metric_result("queue_cancel_p75_ms", queue_cancel_p75, target_lte=150.0),
+        "sse_reconnect_count": _metric_result("sse_reconnect_count", float(sse_reconnect_count)),
+    }
+    if operator_hours is None or operator_hours <= 0:
+        metric_results["sse_reconnect_rate_per_operator_hour"] = _metric_result(
+            "sse_reconnect_rate_per_operator_hour",
+            None,
+            target_lt=1.0,
+        )
+    else:
+        metric_results["sse_reconnect_rate_per_operator_hour"] = _metric_result(
+            "sse_reconnect_rate_per_operator_hour",
+            sse_reconnect_count / operator_hours,
+            target_lt=1.0,
+        )
+
+    viewer_open_count = 0
+    viewer_fallback_count = 0
+    fallback_reasons: Counter[str] = Counter()
+    for record in event_records:
+        if str(record.get("surface") or "") != "artifact_review":
+            continue
+        event_type = str(record.get("event_type") or "")
+        metadata = record.get("metadata") or {}
+        if event_type == "artifact_viewer_opened":
+            viewer_open_count += 1
+        elif event_type == "artifact_viewer_fallback":
+            viewer_fallback_count += 1
+            fallback_reason = str(metadata.get("fallback_reason") or "").strip().lower()
+            if fallback_reason:
+                fallback_reasons[fallback_reason] += 1
+    viewer_success_rate = None
+    if viewer_open_count > 0:
+        viewer_success_rate = max(viewer_open_count - viewer_fallback_count, 0) / viewer_open_count * 100.0
+
+    m1_inputs = [
+        metric_results["lcp_p75_ms"],
+        metric_results["inp_p75_ms"],
+        metric_results["cls_p75"],
+        metric_results["bootstrap_ready_p75_ms"],
+        metric_results["first_view_interactive_p75_ms"],
+        metric_results["portal_shell_rendered_p75_ms"],
+    ]
+    if queue_submit_p75 is not None:
+        m1_inputs.append(metric_results["queue_submit_p75_ms"])
+    elif queue_cancel_p75 is not None:
+        m1_inputs.append(metric_results["queue_cancel_p75_ms"])
+    else:
+        m1_inputs.append(_metric_result("queue_interaction_visibility", None))
+
+    m4_inputs = [
+        metric_results["lcp_p75_ms"],
+        metric_results["inp_p75_ms"],
+        metric_results["cls_p75"],
+    ]
+    if queue_submit_p75 is not None:
+        m4_inputs.append(metric_results["queue_submit_p75_ms"])
+    if queue_cancel_p75 is not None:
+        m4_inputs.append(metric_results["queue_cancel_p75_ms"])
+    if len(m4_inputs) == 3:
+        m4_inputs.append(_metric_result("queue_interaction_thresholds", None))
+
+    m5_result = _metric_result("viewer_success_rate_pct", viewer_success_rate, target_gte=95.0)
+    if viewer_open_count == 0:
+        m5_result["status"] = INSUFFICIENT
+
+    return {
+        "inputs": {
+            "rum_samples": len(rum_records),
+            "event_samples": len(event_records),
+            "operator_hours": operator_hours,
+        },
+        "metrics": metric_results,
+        "milestones": {
+            "m1_measurement_foundation": {
+                "status": _overall_status(m1_inputs),
+                "rum_visibility_confirmed": _overall_status(m1_inputs) != INSUFFICIENT,
+            },
+            "m4_performance": {
+                "status": _overall_status(m4_inputs),
+            },
+            "m5_artifact_review": {
+                "status": m5_result["status"],
+                "viewer_open_count": viewer_open_count,
+                "viewer_fallback_count": viewer_fallback_count,
+                "viewer_success_rate_pct": viewer_success_rate,
+                "fallback_reasons": dict(sorted(fallback_reasons.items())),
+                "target_gte": 95.0,
+            },
+        },
+    }
+
+
+def _format_metric_value(value: Any) -> str:
+    if value is None:
+        return "n/a"
+    if isinstance(value, float):
+        return f"{value:.2f}"
+    return str(value)
+
+
+def _text_report(report: Dict[str, Any]) -> List[str]:
+    lines = [
+        (
+            "inputs "
+            f"rum_samples={report['inputs']['rum_samples']} "
+            f"event_samples={report['inputs']['event_samples']} "
+            f"operator_hours={_format_metric_value(report['inputs']['operator_hours'])}"
+        )
+    ]
+    lines.append("m1_measurement_foundation " f"status={report['milestones']['m1_measurement_foundation']['status']}")
+    for metric_name in (
+        "lcp_p75_ms",
+        "inp_p75_ms",
+        "cls_p75",
+        "bootstrap_ready_p75_ms",
+        "first_view_interactive_p75_ms",
+        "portal_shell_rendered_p75_ms",
+        "queue_submit_p75_ms",
+        "queue_cancel_p75_ms",
+        "sse_reconnect_count",
+        "sse_reconnect_rate_per_operator_hour",
+    ):
+        metric = report["metrics"][metric_name]
+        lines.append(f"metric name={metric_name} status={metric['status']} value={_format_metric_value(metric['value'])}")
+    lines.append(f"m4_performance status={report['milestones']['m4_performance']['status']}")
+    m5 = report["milestones"]["m5_artifact_review"]
+    lines.append(
+        "m5_artifact_review "
+        f"status={m5['status']} "
+        f"viewer_open_count={m5['viewer_open_count']} "
+        f"viewer_fallback_count={m5['viewer_fallback_count']} "
+        f"viewer_success_rate_pct={_format_metric_value(m5['viewer_success_rate_pct'])}"
+    )
+    for reason, count in sorted(m5["fallback_reasons"].items()):
+        lines.append(f"m5_fallback_reason reason={reason} count={count}")
+    return lines
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Summarize repo-owned portal modernization evidence.")
+    parser.add_argument("--rum-log", required=True, help="Path to the portal RUM JSONL log file.")
+    parser.add_argument("--event-log", help="Optional path to the portal event JSONL log file.")
+    parser.add_argument(
+        "--operator-hours",
+        type=float,
+        help="Optional operator-hour denominator for SSE reconnect rate evaluation.",
+    )
+    parser.add_argument("--format", choices=("text", "json"), default="text", help="Output format.")
+    args = parser.parse_args()
+
+    rum_records = _read_records(Path(args.rum_log), RUM_SCHEMA)
+    event_records = _read_records(Path(args.event_log), EVENT_SCHEMA) if args.event_log else []
+    report = build_report(rum_records, event_records, operator_hours=args.operator_hours)
+
+    if args.format == "json":
+        print(json.dumps(report, indent=2, sort_keys=True))
+        return 0
+    for line in _text_report(report):
+        print(line)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/portal_modernization_evidence.py
+++ b/tools/portal_modernization_evidence.py
@@ -48,6 +48,12 @@ def _read_records(path: Path, schema: str) -> List[Dict[str, Any]]:
                     file=sys.stderr,
                 )
                 continue
+            if not isinstance(payload, dict):
+                print(
+                    f"portal modernization evidence: skipped non-object json line {line_number} in {path}",
+                    file=sys.stderr,
+                )
+                continue
             if payload.get("schema") != schema:
                 continue
             records.append(payload)

--- a/tools/portal_modernization_evidence.py
+++ b/tools/portal_modernization_evidence.py
@@ -104,6 +104,10 @@ def _metric_result(
     return result
 
 
+def _visibility_result(name: str, value: Optional[float]) -> Dict[str, Any]:
+    return _metric_result(name, value)
+
+
 def _overall_status(results: Iterable[Dict[str, Any]]) -> str:
     statuses = [str(result.get("status") or INSUFFICIENT) for result in results]
     if not statuses:
@@ -175,19 +179,22 @@ def build_report(
         viewer_success_rate = max(viewer_open_count - viewer_fallback_count, 0) / viewer_open_count * 100.0
 
     m1_inputs = [
-        metric_results["lcp_p75_ms"],
-        metric_results["inp_p75_ms"],
-        metric_results["cls_p75"],
-        metric_results["bootstrap_ready_p75_ms"],
-        metric_results["first_view_interactive_p75_ms"],
-        metric_results["portal_shell_rendered_p75_ms"],
+        _visibility_result("lcp_p75_visible", lcp_p75),
+        _visibility_result("inp_p75_visible", inp_p75),
+        _visibility_result("cls_p75_visible", cls_p75),
+        _visibility_result("bootstrap_ready_p75_visible", bootstrap_ready_p75),
+        _visibility_result("first_view_interactive_p75_visible", first_view_interactive_p75),
+        _visibility_result("portal_shell_rendered_p75_visible", portal_shell_rendered_p75),
+        _visibility_result("sse_reconnect_count_visible", float(sse_reconnect_count)),
     ]
     if queue_submit_p75 is not None:
-        m1_inputs.append(metric_results["queue_submit_p75_ms"])
+        m1_inputs.append(_visibility_result("queue_submit_p75_visible", queue_submit_p75))
     elif queue_cancel_p75 is not None:
-        m1_inputs.append(metric_results["queue_cancel_p75_ms"])
+        m1_inputs.append(_visibility_result("queue_cancel_p75_visible", queue_cancel_p75))
     else:
-        m1_inputs.append(_metric_result("queue_interaction_visibility", None))
+        m1_inputs.append(_visibility_result("queue_interaction_visibility", None))
+
+    m1_status = _overall_status(m1_inputs)
 
     m4_inputs = [
         metric_results["lcp_p75_ms"],
@@ -214,8 +221,8 @@ def build_report(
         "metrics": metric_results,
         "milestones": {
             "m1_measurement_foundation": {
-                "status": _overall_status(m1_inputs),
-                "rum_visibility_confirmed": _overall_status(m1_inputs) != INSUFFICIENT,
+                "status": m1_status,
+                "rum_visibility_confirmed": m1_status != INSUFFICIENT,
             },
             "m4_performance": {
                 "status": _overall_status(m4_inputs),

--- a/web/secure-landing/portal-src/review-surface-deferred.js
+++ b/web/secure-landing/portal-src/review-surface-deferred.js
@@ -54,7 +54,6 @@ export function createDeferredReviewSurfaceApi(host) {
   function _artifactViewerEventMetadata(job, artifact, extra = {}) {
     const metadata = {
       job_id: _normalizeSelectedJobId(job?.id),
-      pipeline: String(job?.pipeline || ""),
       media_kind: String(artifact?.media_kind || "file"),
       artifact_fingerprint: artifactFingerprint(artifact).toLowerCase(),
       viewer_mode: "modal",

--- a/web/secure-landing/portal-src/review-surface-deferred.js
+++ b/web/secure-landing/portal-src/review-surface-deferred.js
@@ -49,6 +49,41 @@ export function createDeferredReviewSurfaceApi(host) {
   let artifactViewerPreviewPath = "";
   let artifactViewerPreviewSource = "";
   let artifactViewerPreviewRequestId = 0;
+  let artifactViewerFallbackEventKey = "";
+
+  function _artifactViewerEventMetadata(job, artifact, extra = {}) {
+    const metadata = {
+      job_id: _normalizeSelectedJobId(job?.id),
+      pipeline: String(job?.pipeline || ""),
+      media_kind: String(artifact?.media_kind || "file"),
+      artifact_fingerprint: artifactFingerprint(artifact).toLowerCase(),
+      viewer_mode: "modal",
+    };
+    Object.entries(extra).forEach(([key, value]) => {
+      if (value === undefined || value === null || value === "") return;
+      metadata[key] = value;
+    });
+    return metadata;
+  }
+
+  function _emitArtifactViewerFallback(context, fallbackReason) {
+    if (!context?.job || !context?.artifact || !fallbackReason) return;
+    const fallbackKey = [
+      _normalizeSelectedJobId(context.job.id),
+      _artifactRouteKey(context.artifact),
+      fallbackReason,
+    ]
+      .filter(Boolean)
+      .join(":");
+    if (fallbackKey && fallbackKey === artifactViewerFallbackEventKey) return;
+    artifactViewerFallbackEventKey = fallbackKey;
+    void emitPortalEvent("artifact_viewer_fallback", {
+      surface: "artifact_review",
+      metadata: _artifactViewerEventMetadata(context.job, context.artifact, {
+        fallback_reason: fallbackReason,
+      }),
+    });
+  }
 
   function _revokeArtifactViewerObjectUrl() {
     if (!artifactViewerObjectUrl) return;
@@ -63,7 +98,9 @@ export function createDeferredReviewSurfaceApi(host) {
     _revokeArtifactViewerObjectUrl();
   }
 
-  function _showArtifactViewerFallback(url, artifactName) {
+  function _showArtifactViewerFallback(context, artifactName) {
+    const url = context?.url || "";
+    const fallbackReason = url ? "inline_preview_unavailable" : "asset_url_unavailable";
     if (els.artifactViewerImage) {
       els.artifactViewerImage.classList.add("hidden");
       els.artifactViewerImage.removeAttribute("src");
@@ -85,6 +122,7 @@ export function createDeferredReviewSurfaceApi(host) {
         ? `${artifactName} is open with metadata fallback because an inline preview is unavailable.`
         : `${artifactName} is open with metadata fallback because the managed asset URL is unavailable.`
     );
+    _emitArtifactViewerFallback(context, fallbackReason);
   }
 
   function _renderArtifactViewerInlineImage(src, zoomPercent) {
@@ -98,7 +136,7 @@ export function createDeferredReviewSurfaceApi(host) {
   async function _loadArtifactViewerInlinePreview(context, artifactName) {
     const artifactPath = _artifactRouteKey(context.artifact);
     if (!context.url || !artifactPath) {
-      _showArtifactViewerFallback(context.url, artifactName);
+      _showArtifactViewerFallback(context, artifactName);
       return;
     }
     if (artifactViewerObjectUrl && artifactViewerPreviewPath === artifactPath && artifactViewerPreviewSource === context.url) {
@@ -139,7 +177,7 @@ export function createDeferredReviewSurfaceApi(host) {
       _setArtifactViewerStatus(`${artifactName} preview open at ${context.zoomPercent}% zoom.`);
     } catch {
       if (requestId !== artifactViewerPreviewRequestId) return;
-      _showArtifactViewerFallback(context.url, artifactName);
+      _showArtifactViewerFallback(context, artifactName);
     }
   }
 
@@ -809,7 +847,7 @@ export function createDeferredReviewSurfaceApi(host) {
           const activeContext = _artifactViewerContext();
           if (!activeContext.artifact) return;
           if (_artifactRouteKey(activeContext.artifact) !== artifactPath) return;
-          _showArtifactViewerFallback(url, artifactName);
+          _showArtifactViewerFallback(activeContext, artifactName);
         };
       }
       if (state.auth?.mode !== "direct_debug") {
@@ -829,7 +867,7 @@ export function createDeferredReviewSurfaceApi(host) {
     }
 
     _clearArtifactViewerPreviewCache();
-    _showArtifactViewerFallback(url, artifactName);
+    _showArtifactViewerFallback(context, artifactName);
     void job;
   }
 
@@ -851,16 +889,13 @@ export function createDeferredReviewSurfaceApi(host) {
     state.portalUi.artifactViewer.jobId = _normalizeSelectedJobId(job.id);
     state.portalUi.artifactViewer.artifactPath = _artifactRouteKey(artifact);
     state.portalUi.artifactViewer.zoomPercent = 100;
+    artifactViewerFallbackEventKey = "";
     _rememberOverlayTrigger(trigger);
     renderArtifactViewer();
     if (els.closeArtifactViewerBtn) els.closeArtifactViewerBtn.focus();
     void emitPortalEvent("artifact_viewer_opened", {
-      surface: "artifact_viewer_modal",
-      metadata: {
-        job_id: String(job.id || ""),
-        media_kind: String(artifact.media_kind || "file"),
-        pipeline: String(job.pipeline || "")
-      }
+      surface: "artifact_review",
+      metadata: _artifactViewerEventMetadata(job, artifact),
     });
     return true;
   }


### PR DESCRIPTION
## Summary
- Convert the portal modernization RFC from an open TODO list into an approved architecture record with explicit implemented, partial, and open-gate status.
- Add the repo-owned evidence and compliance artifacts needed to track pilot closure work without inventing human approvals, live pilot metrics, or a rewrite decision.
- Add the minimal viewer telemetry contract needed to measure M5 artifact-review success while preserving the existing route, selector, and browser-contract surface.

## Changes
- Refresh the portal modernization RFC, add a companion evidence register, add a pending telemetry privacy sign-off packet, update ADR-050 to an evidence inventory, and update the frontdoor quickstart with the new evidence flow.
- Add tools/portal_modernization_evidence.py plus focused tests for RUM and portal-event evidence, including explicit insufficient_data handling for SSE rate checks that need operator-hour input.
- Accept and emit artifact_viewer_opened and artifact_viewer_fallback on the artifact_review surface with token-safe, PII-free metadata, then regenerate the shipped review-surface bundle.
- Preserve the managed frontdoor boundary, the /portal?view= route contract, and existing browser validation selectors while keeping segmentation refinement outside the shipped M5 scope.

## Validation
- Proven green
  - .venv/bin/pre-commit run --files app.py docs/architecture/PORTAL_OPERATOR_CONSOLE_MODERNIZATION_RFC.md docs/architecture/PORTAL_OPERATOR_CONSOLE_MODERNIZATION_EVIDENCE.md docs/compliance/PORTAL_TELEMETRY_PRIVACY_SIGNOFF.md docs/decisions/ADR-050-portal-react-migration.md docs/guides/PORTAL_SECURE_FRONTDOOR_QUICKSTART.md public/portal-assets/portal-review.js tests/test_app_orchestrator_contract_http.py tests/test_app_orchestrator_runtime.py tests/test_portal_modernization_evidence.py tools/portal_modernization_evidence.py web/secure-landing/portal-src/review-surface-deferred.js
  - .venv/bin/pytest tests/test_portal_rum_summary.py tests/test_portal_modernization_evidence.py tests/test_app_orchestrator_contract_http.py tests/test_app_orchestrator_runtime.py tests/validation/test_portal_smoke_scripts.py
  - make test-portal-contract
  - make test-frontdoor-contract
- Still failing
  - None

## Risk
- Security / Privacy telemetry approval and live pilot measurements remain open by design; this PR adds the repo-owned package for those gates but does not claim closure.
- The viewer telemetry contract is additive and bounded to the existing review surface, so the change is revert-safe without altering the managed auth, proxy, route, or selector contracts.
