### PR TITLE
chore(requirements): batch generic lock refresh

### DIFF
--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -53,9 +53,7 @@ colorama==0.4.6
 coverage[toml]==7.13.5
     # via pytest-cov
 cryptography==46.0.7
-    # via
-    #   -r dev.in
-    #   secretstorage
+    # via -r dev.in
 dill==0.4.1
     # via pylint
 distlib==0.4.0
@@ -81,7 +79,7 @@ httpcore==1.0.9
     # via httpx
 httpx==0.28.1
     # via -r dev.in
-hypothesis==6.151.13
+hypothesis==6.152.1
     # via -r dev.in
 id==1.6.1
     # via twine
@@ -202,7 +200,7 @@ pygments==2.20.0
     #   rich
 pylint==4.0.5
     # via -r dev.in
-pypdf==6.10.0
+pypdf==6.10.1
     # via -r ci.in
 pyproject-api==1.10.0
     # via tox
@@ -288,7 +286,7 @@ tomli-w==1.2.0
     # via tox
 tomlkit==0.14.0
     # via pylint
-tox==4.52.1
+tox==4.53.0
     # via -r ci.in
 tqdm==4.67.3
     # via -r base.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -130,7 +130,7 @@ pygments==2.20.0
     #   -c all.txt
     #   readme-renderer
     #   rich
-pypdf==6.10.0
+pypdf==6.10.1
     # via
     #   -c all.txt
     #   -r ci.in
@@ -185,7 +185,7 @@ tomli-w==1.2.0
     # via
     #   -c all.txt
     #   tox
-tox==4.52.1
+tox==4.53.0
     # via
     #   -c all.txt
     #   -r ci.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -70,7 +70,7 @@ httpx==0.28.1
     # via
     #   -c all.txt
     #   -r dev.in
-hypothesis==6.151.13
+hypothesis==6.152.1
     # via
     #   -c all.txt
     #   -r dev.in


### PR DESCRIPTION
## Summary
- Replace overlapping Dependabot lockfile PRs #1466, #1470, and #1471 with one curated generic refresh.
- Keep the pydantic update out of scope so #1474 remains a separate follow-up with its own validation window.

## Changes
- Update the checked-in generic lockfiles for `hypothesis==6.152.1`, `pypdf==6.10.1`, and `tox==4.53.0`.
- Preserve the Linux keyring-chain pins required by the checked-in lock contract while batching those upgrades together.

## Validation
- Proven green:
  - `make check-requirements-lock-contract`
  - `make check-piptools-cache`
  - `make ci-quick`
- Still failing: none locally.
- Note: the workflow-pin merge lane is still being worked separately; this branch may need a trivial rebase after those PRs land.

## Risk
- Bounded to `requirements/all.txt`, `requirements/ci.txt`, and `requirements/dev.txt`.
- No runtime/API/route/selector changes.
- Revert-safe by reverting the lockfile-only commit.