### PR TITLE
chore(requirements): refresh darwin arm64 sentence-transformers lock

### DIFF
--- a/requirements/ml-core-darwin-arm64.txt
+++ b/requirements/ml-core-darwin-arm64.txt
@@ -8,11 +8,11 @@
 
 accelerate==1.13.0
     # via -r ml-core-darwin-arm64.in
-anyio==4.12.1
+anyio==4.13.0
     # via
     #   -c base.txt
     #   httpx
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   -c base.txt
     #   cattrs
@@ -102,7 +102,7 @@ networkx==3.6.1
     # via
     #   scikit-image
     #   torch
-numpy==2.4.3
+numpy==2.4.4
     # via
     #   -c base.txt
     #   accelerate
@@ -192,7 +192,7 @@ scipy==1.17.1
     #   scikit-image
     #   scikit-learn
     #   sentence-transformers
-sentence-transformers==5.3.0
+sentence-transformers==5.4.1
     # via -r ml-core-darwin-arm64.in
 sympy==1.14.0
     # via


### PR DESCRIPTION
## Summary
- Replace the non-compliant Dependabot ML lane update with a narrow Darwin arm64 sentence-transformers lock refresh.
- Keep transformers<5 and the existing torch baseline unchanged.

## Changes
- Regenerated requirements/ml-core-darwin-arm64.txt from current main on the authoritative Darwin arm64 lane.
- Bumped sentence-transformers to 5.4.1 and accepted the resolver's minimal transitive refresh (anyio, attrs, numpy).
- Left requirements/ml-core-linux.txt and requirements/ml-core-darwin-x86_64.txt unchanged; the former was not regenerated here, and the latter remains frozen.

## Validation
Proven green
- ./scripts/validate_dependency_constraints.sh --verbose
- .venv/bin/python scripts/validation/check_requirements_lock_contract.py
- cd requirements && make check-ml-darwin-arm64 LOCK_PYTHON_VERSION=3.11
- pre-commit hooks during git commit

Still failing / not run
- make test-integration not run; this lock-only change did not modify runtime code paths and the local environment may require HF credentials.
- Linux x86_64 authoritative lock regeneration was not attempted in this PR because requirements/ml-core-linux.txt is unchanged.

## Risk
- Bounded to the Darwin arm64 checked-in ML lock.
- No product/API/CLI/env contract changes.
- Revert-safe because it only updates one generated lockfile on the supported authoritative lane.