### PR TITLE
fix(lux-depth): demote borderline scaled apex low saturation

### DIFF
--- a/docs/architecture/PHASE4_PORTAL_INTEGRATION.md
+++ b/docs/architecture/PHASE4_PORTAL_INTEGRATION.md
@@ -57,7 +57,7 @@ In `_archive_gate_readiness()`:
 ```python
 if command == "phase4-verify":
     notes.append("Phase 4 chain verification requires all Phase 4C/4D/4E artifacts.")
-    
+
     # Check schema availability
     for schema_path in PHASE4_REQUIRED_SCHEMAS:
         if not schema_path.is_file():
@@ -68,7 +68,7 @@ if command == "phase4-verify":
                     message=f"Phase 4 schema missing: {schema_path.name}",
                 )
             )
-    
+
     if require_dispatch_inputs:
         # Validate required artifact paths
         for field, keys, desc in [

--- a/src/transformation_portal/lux_depth_v3/config.py
+++ b/src/transformation_portal/lux_depth_v3/config.py
@@ -314,6 +314,10 @@ class EnhanceConfig:
     # when gate normalization scales metric depth
     # via percentile_1_99.
     apex_depth_scaled_saturation_margin: float = 0.0025
+    # Warning-only grace band for isolated
+    # low-end saturation when the structural
+    # APEX depth checks otherwise pass.
+    apex_depth_low_saturation_warning_band: float = 0.0075
     apex_depth_saturation_high_value: float = 0.999
     apex_depth_saturation_low_value: float = 0.001
     apex_depth_min_gradient_energy: float = 5e-4

--- a/src/transformation_portal/lux_depth_v3/config.py
+++ b/src/transformation_portal/lux_depth_v3/config.py
@@ -423,6 +423,14 @@ class EnhanceConfig:
             warn=True,
             warning_context="EnhanceConfig.depth_operational_fallback_chain",
         )
+        self.apex_depth_scaled_saturation_margin = max(
+            float(self.apex_depth_scaled_saturation_margin),
+            0.0,
+        )
+        self.apex_depth_low_saturation_warning_band = max(
+            float(self.apex_depth_low_saturation_warning_band),
+            0.0,
+        )
 
     @property
     def enable_pbr(self) -> bool:

--- a/src/transformation_portal/lux_depth_v3/config_resolver.py
+++ b/src/transformation_portal/lux_depth_v3/config_resolver.py
@@ -410,6 +410,9 @@ def build_apex_depth_gate_fingerprint_payload(config: EnhanceConfig) -> Dict[str
         "max_high_saturation_fraction": float(config.apex_depth_max_high_saturation_fraction),
         "max_low_saturation_fraction": float(config.apex_depth_max_low_saturation_fraction),
         "scaled_saturation_margin": float(config.apex_depth_scaled_saturation_margin),
+        "low_saturation_warning_band": float(
+            config.apex_depth_low_saturation_warning_band,
+        ),
         "saturation_high_value": float(config.apex_depth_saturation_high_value),
         "saturation_low_value": float(config.apex_depth_saturation_low_value),
         "min_gradient_energy": float(config.apex_depth_min_gradient_energy),

--- a/src/transformation_portal/lux_depth_v3/orchestrator.py
+++ b/src/transformation_portal/lux_depth_v3/orchestrator.py
@@ -4418,9 +4418,24 @@ class EnhanceOrchestrator:
             ),
             0.0,
         )
+        low_saturation_warning_band = max(
+            float(
+                getattr(
+                    _cfg,
+                    "apex_depth_low_saturation_warning_band",
+                    0.0,
+                ),
+            ),
+            0.0,
+        )
         gate_normalization = metrics.get("gate_normalization")
         normalization_scaled = bool(
             isinstance(gate_normalization, dict) and gate_normalization.get("scaled"),
+        )
+        percentile_scaled_gate = bool(
+            isinstance(gate_normalization, dict)
+            and gate_normalization.get("scaled") is True
+            and gate_normalization.get("mode") == "percentile_1_99"
         )
         effective_high_saturation_max = thresholds["saturation_high_fraction_max"] + (
             scaled_saturation_margin if normalization_scaled else 0.0
@@ -4428,10 +4443,17 @@ class EnhanceOrchestrator:
         effective_low_saturation_max = thresholds["saturation_low_fraction_max"] + (
             scaled_saturation_margin if normalization_scaled else 0.0
         )
+        effective_low_saturation_warning_max = effective_low_saturation_max + (
+            low_saturation_warning_band if percentile_scaled_gate else 0.0
+        )
         thresholds["comparison_epsilon"] = comparison_epsilon
         thresholds["scaled_saturation_margin"] = scaled_saturation_margin if normalization_scaled else 0.0
         thresholds["saturation_high_fraction_max_effective"] = effective_high_saturation_max
         thresholds["saturation_low_fraction_max_effective"] = effective_low_saturation_max
+        thresholds["saturation_low_fraction_warning_band"] = low_saturation_warning_band if percentile_scaled_gate else 0.0
+        thresholds["saturation_low_fraction_warning_max_effective"] = (
+            effective_low_saturation_warning_max if percentile_scaled_gate else effective_low_saturation_max
+        )
 
         finite_fail = float(metrics.get("finite_pct") or 0.0) < (thresholds["finite_pct_min"] - comparison_epsilon)
         plateau_fail = (metrics.get("upper_iqr") is None) or (float(metrics["upper_iqr"]) <= thresholds["upper_iqr_min"])
@@ -4464,10 +4486,45 @@ class EnhanceOrchestrator:
         # Stable ordering for deterministic payloads across runs/processes.
         failure_codes = sorted(failure_codes)
 
+        warnings: List[str] = []
+        demoted_failure_codes: List[str] = []
+        if low_gradient:
+            warnings.append("APEX_DEPTH_GRADIENT_LOW")
+
+        low_saturation_metric = metrics.get("saturation_low_fraction")
+        low_saturation_value = float(low_saturation_metric) if isinstance(low_saturation_metric, (int, float)) else None
+        borderline_low_saturation = (
+            percentile_scaled_gate
+            and low_saturation_fail
+            and low_saturation_value is not None
+            and low_saturation_value <= (effective_low_saturation_warning_max + comparison_epsilon)
+        )
+        can_demote_low_saturation = (
+            failure_codes == ["APEX_DEPTH_SATURATION_LOW"] and borderline_low_saturation and not low_gradient
+        )
+
+        if can_demote_low_saturation:
+            demoted_failure_codes = ["APEX_DEPTH_SATURATION_LOW"]
+            warnings.append("APEX_DEPTH_SATURATION_LOW_BORDERLINE")
+            logger.warning(
+                "APEX depth validity warning: borderline low saturation demoted "
+                "to warning (value=%.10f, limit=%.10f, metrics=%s, thresholds=%s)",
+                low_saturation_value,
+                effective_low_saturation_warning_max,
+                metrics,
+                thresholds,
+            )
+            failure_codes = []
+
+        warnings = sorted(warnings)
+        demoted_failure_codes = sorted(demoted_failure_codes)
+
         if failure_codes:
             details = {
                 "passed": False,
                 "failure_codes": failure_codes,
+                "warnings": warnings,
+                "demoted_failure_codes": demoted_failure_codes,
                 "metrics": metrics,
                 "thresholds": thresholds,
                 "shape_context": shape_context,
@@ -4478,20 +4535,18 @@ class EnhanceOrchestrator:
                 details=details,
             )
 
-        warnings: List[str] = []
         if low_gradient:
-            warnings.append("APEX_DEPTH_GRADIENT_LOW")
             logger.warning(
                 "APEX depth validity" " warning: low gradient" " energy (metrics=%s," " thresholds=%s)",
                 metrics,
                 thresholds,
             )
-        warnings = sorted(warnings)
 
         return {
             "passed": True,
             "failure_codes": [],
             "warnings": warnings,
+            "demoted_failure_codes": demoted_failure_codes,
             "metrics": metrics,
             "thresholds": thresholds,
             "shape_context": shape_context,

--- a/tests/lux_depth_v3/test_config_resolver.py
+++ b/tests/lux_depth_v3/test_config_resolver.py
@@ -473,6 +473,24 @@ class TestBuildFingerprintPayloads:
 
         assert fingerprint_a.to_sha256() != fingerprint_b.to_sha256()
 
+    def test_apex_depth_gate_fingerprint_normalizes_negative_warning_band(self):
+        """Negative warning bands should fingerprint as the effective non-negative policy."""
+        from transformation_portal.lux_depth_v3.config import EnhanceConfig
+        from transformation_portal.lux_depth_v3.config_resolver import (
+            build_apex_depth_gate_fingerprint_payload,
+            compute_config_fingerprint,
+        )
+
+        negative_config = EnhanceConfig(apex_depth_low_saturation_warning_band=-0.01)
+        zero_config = EnhanceConfig(apex_depth_low_saturation_warning_band=0.0)
+
+        negative_payload = build_apex_depth_gate_fingerprint_payload(negative_config)
+        zero_payload = build_apex_depth_gate_fingerprint_payload(zero_config)
+
+        assert negative_payload["low_saturation_warning_band"] == pytest.approx(0.0)
+        assert negative_payload == zero_payload
+        assert compute_config_fingerprint(negative_config).to_sha256() == compute_config_fingerprint(zero_config).to_sha256()
+
     def test_depth_cache_payload_ignores_low_saturation_warning_band(self):
         """Depth cache payload should not depend on gate demotion policy."""
         from transformation_portal.lux_depth_v3.config import EnhanceConfig

--- a/tests/lux_depth_v3/test_config_resolver.py
+++ b/tests/lux_depth_v3/test_config_resolver.py
@@ -456,6 +456,38 @@ class TestBuildFingerprintPayloads:
         assert payload["quality_tier"] == "apex"
         assert "min_finite_pct" in payload
         assert "min_gradient_energy" in payload
+        assert payload["low_saturation_warning_band"] == pytest.approx(0.0075)
+
+    def test_fingerprint_changes_when_low_saturation_warning_band_changes(self):
+        """APEX gate fingerprint should change when the warning band changes."""
+        from transformation_portal.lux_depth_v3.config import EnhanceConfig
+        from transformation_portal.lux_depth_v3.config_resolver import (
+            compute_config_fingerprint,
+        )
+
+        config_a = EnhanceConfig(apex_depth_low_saturation_warning_band=0.0075)
+        config_b = EnhanceConfig(apex_depth_low_saturation_warning_band=0.01)
+
+        fingerprint_a = compute_config_fingerprint(config_a)
+        fingerprint_b = compute_config_fingerprint(config_b)
+
+        assert fingerprint_a.to_sha256() != fingerprint_b.to_sha256()
+
+    def test_depth_cache_payload_ignores_low_saturation_warning_band(self):
+        """Depth cache payload should not depend on gate demotion policy."""
+        from transformation_portal.lux_depth_v3.config import EnhanceConfig
+        from transformation_portal.lux_depth_v3.config_resolver import (
+            build_depth_cache_payload,
+        )
+
+        payload_a = build_depth_cache_payload(
+            EnhanceConfig(apex_depth_low_saturation_warning_band=0.0075),
+        )
+        payload_b = build_depth_cache_payload(
+            EnhanceConfig(apex_depth_low_saturation_warning_band=0.01),
+        )
+
+        assert payload_a == payload_b
 
 
 class TestBuildRunCardConfigFingerprint:

--- a/tests/materials/test_materials_v3_orchestrator_integration.py
+++ b/tests/materials/test_materials_v3_orchestrator_integration.py
@@ -840,14 +840,16 @@ def test_apex_depth_validity_gate_allows_scaled_metric_near_low_saturation_limit
 
     assert verdict is not None
     assert verdict["passed"] is True
+    assert verdict["warnings"] == []
+    assert verdict["demoted_failure_codes"] == []
     assert verdict["thresholds"]["saturation_low_fraction_max"] == pytest.approx(0.02)
     assert verdict["thresholds"]["saturation_low_fraction_max_effective"] == pytest.approx(0.0225)
+    assert verdict["thresholds"]["saturation_low_fraction_warning_band"] == pytest.approx(0.0075)
+    assert verdict["thresholds"]["saturation_low_fraction_warning_max_effective"] == pytest.approx(0.03)
 
 
-def test_apex_depth_validity_gate_rejects_scaled_metric_beyond_low_saturation_margin(
-    tmp_path, mock_depth_backend, mock_da3_available
-):
-    """Scaled metric normalization still fails when low saturation exceeds effective margin."""
+def test_apex_depth_validity_gate_demotes_borderline_scaled_low_saturation(tmp_path, mock_depth_backend, mock_da3_available):
+    """Borderline low saturation is demoted only for percentile-scaled gates."""
     config = EnhanceConfig(
         quality_tier="apex",
         depth_device="cpu",
@@ -859,13 +861,92 @@ def test_apex_depth_validity_gate_rejects_scaled_metric_beyond_low_saturation_ma
         "finite_pct": 1.0,
         "upper_iqr": 0.2,
         "saturation_high_fraction": 0.01,
-        "saturation_low_fraction": 0.023,
+        "saturation_low_fraction": 0.0293756755038464,
+        "gradient_energy": 0.001,
+        "gate_normalization": {"scaled": True, "mode": "percentile_1_99"},
+    }
+    with patch.object(orchestrator, "_compute_depth_validity_metrics", return_value=metrics):
+        verdict = orchestrator._enforce_apex_depth_validity_gate(np.ones((8, 8), dtype=np.float32), depth_units="meters")
+
+    assert verdict is not None
+    assert verdict["passed"] is True
+    assert "APEX_DEPTH_SATURATION_LOW_BORDERLINE" in verdict["warnings"]
+    assert verdict["demoted_failure_codes"] == ["APEX_DEPTH_SATURATION_LOW"]
+    assert verdict["thresholds"]["saturation_low_fraction_max_effective"] == pytest.approx(0.0225)
+    assert verdict["thresholds"]["saturation_low_fraction_warning_max_effective"] == pytest.approx(0.03)
+
+
+def test_apex_depth_validity_gate_rejects_scaled_metric_beyond_low_saturation_warning_band(
+    tmp_path, mock_depth_backend, mock_da3_available
+):
+    """Scaled metric normalization still fails above the warning-band ceiling."""
+    config = EnhanceConfig(
+        quality_tier="apex",
+        depth_device="cpu",
+        enable_v2=False,
+    )
+    orchestrator = EnhanceOrchestrator(config, tmp_path)
+
+    metrics = {
+        "finite_pct": 1.0,
+        "upper_iqr": 0.2,
+        "saturation_high_fraction": 0.01,
+        "saturation_low_fraction": 0.031,
         "gradient_energy": 0.001,
         "gate_normalization": {"scaled": True, "mode": "percentile_1_99"},
     }
     with patch.object(orchestrator, "_compute_depth_validity_metrics", return_value=metrics):
         with pytest.raises(RuntimeError, match="APEX_DEPTH_SATURATION_LOW"):
             orchestrator._enforce_apex_depth_validity_gate(np.ones((8, 8), dtype=np.float32), depth_units="meters")
+
+
+def test_apex_depth_validity_gate_rejects_borderline_relative_low_saturation(tmp_path, mock_depth_backend, mock_da3_available):
+    """Relative-depth low saturation remains a hard failure without demotion."""
+    config = EnhanceConfig(
+        quality_tier="apex",
+        depth_device="cpu",
+        enable_v2=False,
+    )
+    orchestrator = EnhanceOrchestrator(config, tmp_path)
+
+    metrics = {
+        "finite_pct": 1.0,
+        "upper_iqr": 0.2,
+        "saturation_high_fraction": 0.01,
+        "saturation_low_fraction": 0.0293756755038464,
+        "gradient_energy": 0.001,
+        "gate_normalization": {"scaled": False, "mode": "identity_relative"},
+    }
+    with patch.object(orchestrator, "_compute_depth_validity_metrics", return_value=metrics):
+        with pytest.raises(RuntimeError, match="APEX_DEPTH_SATURATION_LOW"):
+            orchestrator._enforce_apex_depth_validity_gate(np.ones((8, 8), dtype=np.float32), depth_units="relative")
+
+
+def test_apex_depth_validity_gate_rejects_borderline_scaled_low_saturation_with_low_gradient(
+    tmp_path, mock_depth_backend, mock_da3_available
+):
+    """Low gradient blocks demotion for borderline scaled low saturation."""
+    config = EnhanceConfig(
+        quality_tier="apex",
+        depth_device="cpu",
+        enable_v2=False,
+    )
+    orchestrator = EnhanceOrchestrator(config, tmp_path)
+
+    metrics = {
+        "finite_pct": 1.0,
+        "upper_iqr": 0.2,
+        "saturation_high_fraction": 0.01,
+        "saturation_low_fraction": 0.0293756755038464,
+        "gradient_energy": 1e-4,
+        "gate_normalization": {"scaled": True, "mode": "percentile_1_99"},
+    }
+    with patch.object(orchestrator, "_compute_depth_validity_metrics", return_value=metrics):
+        with pytest.raises(RuntimeError, match="APEX_DEPTH_SATURATION_LOW") as exc_info:
+            orchestrator._enforce_apex_depth_validity_gate(np.ones((8, 8), dtype=np.float32), depth_units="meters")
+
+    assert exc_info.value.details["warnings"] == ["APEX_DEPTH_GRADIENT_LOW"]
+    assert exc_info.value.details["demoted_failure_codes"] == []
 
 
 def test_apex_depth_validity_gate_rejects_nonfinite(tmp_path, mock_depth_backend, mock_da3_available):
@@ -945,6 +1026,7 @@ def test_apex_depth_validity_gate_returns_thresholds_and_metrics_on_pass(tmp_pat
     assert "metrics" in verdict
     assert "failure_codes" in verdict
     assert verdict["failure_codes"] == []
+    assert verdict["demoted_failure_codes"] == []
 
 
 def test_apex_depth_validity_gate_gradient_epsilon_ignores_small_positive_jitter(

--- a/tests/test_lux_depth_v3_config.py
+++ b/tests/test_lux_depth_v3_config.py
@@ -138,6 +138,18 @@ class TestEnhanceConfig:
         assert hasattr(config, "depth_fallback")
         assert hasattr(config, "verify_depth_writes")
 
+    def test_enhance_config_clamps_negative_apex_scaled_saturation_margin(self):
+        """Negative scaled saturation margins should normalize to the effective runtime floor."""
+        config = EnhanceConfig(apex_depth_scaled_saturation_margin=-0.25)
+
+        assert config.apex_depth_scaled_saturation_margin == 0.0
+
+    def test_enhance_config_clamps_negative_apex_low_saturation_warning_band(self):
+        """Negative warning bands should normalize to the effective runtime floor."""
+        config = EnhanceConfig(apex_depth_low_saturation_warning_band=-0.25)
+
+        assert config.apex_depth_low_saturation_warning_band == 0.0
+
         # V2 configuration
         assert hasattr(config, "v2_preset")
         assert hasattr(config, "v2_device")


### PR DESCRIPTION
## Summary
- Root cause: the APEX depth validity gate hard-failed borderline low-end saturation after `percentile_1_99` normalization, with no typed warning-band policy and no fingerprint signal when that policy changed.
- Smallest safe change: add a typed low-saturation warning band, fingerprint it in the APEX gate config, and demote only sole low-saturation failures for percentile-scaled gate inputs while making the demotion explicit in gate telemetry.

## Changes
- Added `EnhanceConfig.apex_depth_low_saturation_warning_band` beside the existing scaled saturation margin.
- Added `low_saturation_warning_band` to `build_apex_depth_gate_fingerprint_payload()` and left `build_depth_cache_payload()` unchanged.
- Updated `_enforce_apex_depth_validity_gate()` to:
  - derive an explicit `percentile_scaled_gate` predicate
  - compute warning-band thresholds only for that regime
  - demote only `failure_codes == ["APEX_DEPTH_SATURATION_LOW"]` when the value remains within the warning ceiling and gradient energy is not low
  - return and raise additive `demoted_failure_codes` / `warnings` metadata without changing the existing hard-fail message shape
- Extended focused coverage for:
  - clean pass below the scaled margin
  - borderline demotion at `0.0293756755038464`
  - hard fail above the warning ceiling
  - hard fail for the same borderline value on relative depth
  - hard fail when low gradient blocks demotion
  - fingerprint hash changes and depth-cache-payload invariance
- `pre-commit` normalized trailing whitespace in `docs/architecture/PHASE4_PORTAL_INTEGRATION.md` during the required all-files hook run.

## Validation
### Proven green
- `.venv/bin/pytest tests/materials/test_materials_v3_orchestrator_integration.py tests/lux_depth_v3/test_config_resolver.py -k "apex_depth_validity_gate or low_saturation_warning_band or depth_cache_payload_ignores_low_saturation_warning_band or test_apex_depth_gate_fingerprint_payload"`
- `/bin/zsh -lc 'PRE_COMMIT_HOME=/tmp/pre-commit PATH=/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin:$PATH .venv/bin/pre-commit run --all-files --show-diff-on-failure'`
- `/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin/pre-commit install -f`

### Still failing
- `make pre-commit` from the default shell environment initially failed in `auto-format-staged` because bare `python` was not on `PATH`.

### Failure type
- The `make pre-commit` failure is environment/tooling, not product logic. The repo venv-backed pre-commit command and the commit hook path both passed.

## Risk
- Behavior change is narrowly scoped to percentile-scaled APEX gate inputs; nonfinite, plateau, high-saturation, low-gradient, and larger low-saturation excursions still hard-fail.
- Cache/repro semantics remain bounded: the APEX gate fingerprint changes with the new policy, while depth cache keys stay tied to depth-generation inputs.
- The change is revert-safe because it is additive config plus telemetry around one demotion path; route shapes, selectors, backend choice, and existing failure codes remain stable.