### PR TITLE
fix(ci): restore main parity and stabilize artifact writes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -406,8 +406,8 @@ jobs:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
-          # lint_runner.sh performs its own targeted fetch for diff-based pylint selection.
-          fetch-depth: 1
+          # Keep full history so diff-based pylint selection can resolve the PR merge-base reliably.
+          fetch-depth: 0
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:

--- a/scripts/lint_runner.sh
+++ b/scripts/lint_runner.sh
@@ -52,10 +52,40 @@ require_module() {
 
 collect_filtered_pyfiles_from_diff_range() {
     local diff_range="$1"
-    git diff --diff-filter=d --name-only "$diff_range" \
+    local diff_output=""
+
+    if ! diff_output=$(git diff --diff-filter=d --name-only "$diff_range" 2>/dev/null); then
+        return 1
+    fi
+
+    if [ -z "$diff_output" ]; then
+        return 0
+    fi
+
+    printf '%s\n' "$diff_output" \
         | grep -E '\.py$' \
         | grep -vE "$PYLINT_EXCLUDE_REGEX" \
         || true
+}
+
+collect_pylint_files_from_diff_range() {
+    local diff_range="$1"
+    local diff_candidates=""
+    local candidate=""
+
+    if ! diff_candidates=$(collect_filtered_pyfiles_from_diff_range "$diff_range"); then
+        return 1
+    fi
+
+    if [ -z "$diff_candidates" ]; then
+        return 0
+    fi
+
+    while IFS= read -r candidate; do
+        [ -n "$candidate" ] && PYLINT_FILES+=("$candidate")
+    done <<< "$diff_candidates"
+
+    return 0
 }
 
 resolve_local_diff_range() {
@@ -76,13 +106,15 @@ resolve_pr_diff_range() {
 
     case "$event_name" in
         pull_request)
-            git fetch --depth=1 origin main >/dev/null 2>&1 || true
-            diff_range="origin/main...HEAD"
+            git fetch --quiet --no-tags origin main:refs/remotes/origin/main >/dev/null 2>&1 || true
+            if git rev-parse --verify origin/main >/dev/null 2>&1 && git merge-base origin/main HEAD >/dev/null 2>&1; then
+                diff_range="origin/main...HEAD"
+            fi
             ;;
         push)
             if [ -n "$before_sha" ] && [ "$before_sha" != "0000000000000000000000000000000000000000" ]; then
-                git fetch --depth=1 origin "$before_sha" >/dev/null 2>&1 || true
-                if git cat-file -e "${before_sha}^{commit}" 2>/dev/null; then
+                git fetch --quiet --no-tags --depth=1 origin "$before_sha" >/dev/null 2>&1 || true
+                if git cat-file -e "${before_sha}^{commit}" 2>/dev/null && git cat-file -e "${current_sha}^{commit}" 2>/dev/null; then
                     diff_range="${before_sha}..${current_sha}"
                 fi
             fi
@@ -122,6 +154,7 @@ run_flake8() {
 select_pylint_files() {
     local diff_range=""
     local candidate=""
+    local diff_reliable=0
 
     PYLINT_ACTION=""
     PYLINT_FILES=()
@@ -129,13 +162,13 @@ select_pylint_files() {
     case "$MODE" in
         local|advisory)
             diff_range=$(resolve_local_diff_range)
-            if [ -n "$diff_range" ]; then
-                while IFS= read -r candidate; do
-                    [ -n "$candidate" ] && PYLINT_FILES+=("$candidate")
-                done < <(collect_filtered_pyfiles_from_diff_range "$diff_range")
+            if [ -n "$diff_range" ] && collect_pylint_files_from_diff_range "$diff_range"; then
+                diff_reliable=1
+            elif [ -n "$diff_range" ]; then
+                log "unable to diff range '$diff_range'; using fallback lint surface"
             fi
 
-            if [ "${#PYLINT_FILES[@]}" -eq 0 ]; then
+            if [ "$diff_reliable" -eq 0 ] || [ "${#PYLINT_FILES[@]}" -eq 0 ]; then
                 PYLINT_FILES=("${PYLINT_FALLBACK[@]}")
                 PYLINT_ACTION="fallback pylint"
             else
@@ -144,13 +177,18 @@ select_pylint_files() {
             ;;
         pr)
             diff_range=$(resolve_pr_diff_range)
-            if [ -n "$diff_range" ]; then
-                while IFS= read -r candidate; do
-                    [ -n "$candidate" ] && PYLINT_FILES+=("$candidate")
-                done < <(collect_filtered_pyfiles_from_diff_range "$diff_range")
+            if [ -n "$diff_range" ] && collect_pylint_files_from_diff_range "$diff_range"; then
+                diff_reliable=1
+            elif [ -n "$diff_range" ]; then
+                log "unable to diff range '$diff_range'; using fallback lint surface"
+            else
+                log "no reliable PR diff range available; using fallback lint surface"
             fi
 
-            if [ "${#PYLINT_FILES[@]}" -eq 0 ]; then
+            if [ "$diff_reliable" -eq 0 ]; then
+                PYLINT_FILES=("${PYLINT_FALLBACK[@]}")
+                PYLINT_ACTION="fallback pylint"
+            elif [ "${#PYLINT_FILES[@]}" -eq 0 ]; then
                 PYLINT_ACTION="no eligible Python files changed; skipping pylint"
             else
                 PYLINT_ACTION="running pylint"

--- a/src/transformation_portal/spatial_ai/orchestration/graph/artifact_store.py
+++ b/src/transformation_portal/spatial_ai/orchestration/graph/artifact_store.py
@@ -728,28 +728,32 @@ class ArtifactStore:
             tmp_artifact_path: Optional[Path] = None
             tmp_prov_path: Optional[Path] = None
             tmp_marker_path: Optional[Path] = None
+            tmp_artifact_fd: Optional[int] = None
+            tmp_prov_fd: Optional[int] = None
+            marker_fd: Optional[int] = None
 
             # Atomic write: temp file + rename
             try:
-                # Write artifact (NumPy archive)
-                with tempfile.NamedTemporaryFile(
-                    mode="wb", dir=artifact_path.parent, delete=False, suffix=".npz"
-                ) as tmp_artifact:
-                    tmp_artifact_path = Path(tmp_artifact.name)
+                # Use explicit file descriptors for payload/provenance temp files so
+                # the path remains stable after close across concurrent Linux CI runs.
+                tmp_artifact_fd, tmp_artifact_path = _mkstemp_path(
+                    artifact_path.parent,
+                    prefix=".artifact_tmp_",
+                    suffix=".npz",
+                )
+                with os.fdopen(tmp_artifact_fd, "wb") as tmp_artifact:
+                    tmp_artifact_fd = None
                     np.savez_compressed(tmp_artifact, **np_dict)
                     tmp_artifact.flush()
                     os.fsync(tmp_artifact.fileno())
 
-                # Write provenance (JSON)
-                with tempfile.NamedTemporaryFile(
-                    mode="w",
-                    dir=artifact_path.parent,
-                    delete=False,
+                tmp_prov_fd, tmp_prov_path = _mkstemp_path(
+                    artifact_path.parent,
+                    prefix=".provenance_tmp_",
                     suffix=".json",
-                    encoding="utf-8",
-                    newline="\n",
-                ) as tmp_prov:
-                    tmp_prov_path = Path(tmp_prov.name)
+                )
+                with os.fdopen(tmp_prov_fd, "w", encoding="utf-8", newline="\n") as tmp_prov:
+                    tmp_prov_fd = None
                     dump_json(
                         asdict(provenance),
                         tmp_prov,
@@ -768,17 +772,18 @@ class ArtifactStore:
                 # Atomic commit marker (Issue #929: transactional visibility)
                 # Only after both artifact and provenance are in place,
                 # atomically create the .committed marker via temp+fsync+rename.
-                # Use mkstemp here instead of NamedTemporaryFile so the marker
-                # path stays stable after close on Linux CI under concurrent load.
+                # Write a small sentinel payload before rename so marker creation
+                # does not rely on zero-byte temp-file behavior under concurrency.
                 marker_fd, tmp_marker_path = _mkstemp_path(
                     artifact_path.parent,
                     prefix=".commit_tmp_",
                     suffix=".committed_tmp",
                 )
-                try:
-                    os.fsync(marker_fd)
-                finally:
-                    os.close(marker_fd)
+                with os.fdopen(marker_fd, "w", encoding="utf-8", newline="\n") as marker_file:
+                    marker_fd = None
+                    marker_file.write("committed\n")
+                    marker_file.flush()
+                    os.fsync(marker_file.fileno())
                 tmp_marker_path.replace(committed_path)
 
                 # Optional: fsync containing directory for crash durability
@@ -788,6 +793,12 @@ class ArtifactStore:
             except Exception as e:
                 # Clean up temp files AND uncommitted artifacts on failure
                 # Without marker, these are by definition uncommitted junk
+                if tmp_artifact_fd is not None:
+                    os.close(tmp_artifact_fd)
+                if tmp_prov_fd is not None:
+                    os.close(tmp_prov_fd)
+                if marker_fd is not None:
+                    os.close(marker_fd)
                 if tmp_artifact_path is not None:
                     tmp_artifact_path.unlink(missing_ok=True)
                 if tmp_prov_path is not None:

--- a/tests/lux_depth_v3/test_config_resolver.py
+++ b/tests/lux_depth_v3/test_config_resolver.py
@@ -89,7 +89,7 @@ class TestDiscoverPresets:
         from transformation_portal.lux_depth_v3.config_resolver import discover_presets
 
         presets = discover_presets("unknown_pipeline")
-        assert presets == []
+        assert not presets
 
 
 class TestResolvePreset:
@@ -148,7 +148,7 @@ class TestEffectiveDa3RuntimeResolution:
 
     def test_repo_local_runtime_path_discovers_repo_root_via_markers(self, monkeypatch, tmp_path):
         """Repo-local path discovery should use repo markers instead of fixed depth."""
-        import transformation_portal.lux_depth_v3.config_resolver as config_resolver
+        from transformation_portal.lux_depth_v3 import config_resolver
 
         module_path = tmp_path / "packages" / "src" / "transformation_portal" / "lux_depth_v3" / "config_resolver.py"
         module_path.parent.mkdir(parents=True)

--- a/tests/materials/test_materials_v3_orchestrator_integration.py
+++ b/tests/materials/test_materials_v3_orchestrator_integration.py
@@ -131,7 +131,7 @@ def test_run_materials_v3_stage_aligns_v2_handoff_artifacts_and_sets_metadata(
     preprocessed_array = np.zeros((8, 8, 3), dtype=np.float32)
     depth_map = np.ones((8, 8), dtype=np.float32)
     glass_mask = np.ones((8, 8), dtype=np.float32)
-    enhanced_image = np.linspace(0.0, 1.0, 8 * 8 * 3, dtype=np.float32).reshape(8, 8, 3)
+    enhanced_image = np.linspace(0.0, 1.0, 8 * 8 * 3, dtype=np.float32).reshape((8, 8, 3))
     output_key = Path("nested/image_01")
 
     materials_result = {

--- a/tests/spatial_ai/orchestration/graph/test_artifact_store_multiprocess.py
+++ b/tests/spatial_ai/orchestration/graph/test_artifact_store_multiprocess.py
@@ -46,6 +46,20 @@ def _make_cache_key(seed: str) -> str:
     return hashlib.sha256(seed.encode()).hexdigest()
 
 
+def _make_cache_keys_with_shared_prefix(prefix: str, count: int) -> list[str]:
+    """Generate multiple valid cache keys that share the same 2-char prefix."""
+    cache_keys = []
+    counter = 0
+
+    while len(cache_keys) < count:
+        candidate = _make_cache_key(f"{prefix}_seed_{counter}")
+        if candidate.startswith(prefix):
+            cache_keys.append(candidate)
+        counter += 1
+
+    return cache_keys
+
+
 def _store_worker(
     cache_dir: Path,
     cache_key: str,
@@ -346,6 +360,46 @@ class TestArtifactStoreMultiProcess:
             assert result["success"], f"Worker {result['worker_id']} failed: {result['error']}"
 
         # Verify all artifacts exist and are correct
+        store = ArtifactStore(cache_dir=cache_dir)
+        for i, cache_key in enumerate(cache_keys):
+            assert store.exists(cache_key), f"Artifact {i} does not exist"
+            artifact = store.load(cache_key)
+            assert artifact["worker_id"] == i, f"Artifact {i} has wrong worker_id"
+            assert len(artifact["data"]) == 100, f"Artifact {i} data wrong length"
+
+    def test_concurrent_writes_different_keys_same_prefix_directory(self, cache_dir: Path):
+        """Different keys sharing one prefix directory should not lose temp files."""
+        num_workers = 4
+        result_queue = multiprocessing.Queue()
+        cache_keys = _make_cache_keys_with_shared_prefix("a4", num_workers)
+
+        assert {cache_key[:2] for cache_key in cache_keys} == {"a4"}
+
+        processes = []
+        for i, cache_key in enumerate(cache_keys):
+            process = multiprocessing.Process(
+                target=_store_worker,
+                args=(cache_dir, cache_key, i, result_queue),
+            )
+            process.start()
+            processes.append(process)
+
+        for process in processes:
+            process.join(timeout=10.0)
+            assert not process.is_alive(), f"Process {process.pid} did not complete in time"
+
+        results = []
+        for i in range(num_workers):
+            try:
+                result = result_queue.get(timeout=5.0)
+                results.append(result)
+            except queue.Empty:
+                pytest.fail(f"Expected {num_workers} results but only got {i}")
+
+        assert len(results) == num_workers, f"Expected {num_workers} results, got {len(results)}"
+        for result in results:
+            assert result["success"], f"Worker {result['worker_id']} failed: {result['error']}"
+
         store = ArtifactStore(cache_dir=cache_dir)
         for i, cache_key in enumerate(cache_keys):
             assert store.exists(cache_key), f"Artifact {i} does not exist"

--- a/tests/test_lux_depth_v3_config.py
+++ b/tests/test_lux_depth_v3_config.py
@@ -5,13 +5,13 @@ Tests validation logic for depth_fallback and other config fields.
 
 import pytest
 
+from transformation_portal.lux_depth_v3.config import EnhanceConfig
+from transformation_portal.lux_depth_v3.security import validate_depth_fallback
+
 # Pytest markers
 pytestmark = [
     pytest.mark.unit,
 ]
-
-from transformation_portal.lux_depth_v3.config import EnhanceConfig
-from transformation_portal.lux_depth_v3.security import validate_depth_fallback
 
 
 class TestDepthFallbackValidation:

--- a/tests/validation/test_lint_runner.py
+++ b/tests/validation/test_lint_runner.py
@@ -1,0 +1,129 @@
+"""Regression tests for the shared lint runner shell script."""
+
+from __future__ import annotations
+
+import os
+import shlex
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = PROJECT_ROOT / "scripts" / "lint_runner.sh"
+
+
+def _write_executable(path: Path, content: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return path
+
+
+def _run_git(repo_root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+def _init_repo(repo_root: Path) -> None:
+    repo_root.mkdir(parents=True, exist_ok=True)
+    _run_git(repo_root, "init", "-b", "main")
+    _run_git(repo_root, "config", "user.name", "Lint Runner Test")
+    _run_git(repo_root, "config", "user.email", "lint-runner@example.com")
+    (repo_root / "README.md").write_text("base\n", encoding="utf-8")
+    _run_git(repo_root, "add", "README.md")
+    _run_git(repo_root, "commit", "-m", "base")
+
+
+def _write_fake_python(path: Path, log_path: Path) -> Path:
+    script = (
+        "\n".join(
+            [
+                "#!/usr/bin/env bash",
+                "set -euo pipefail",
+                f"printf '%s\\n' \"$*\" >> {shlex.quote(str(log_path))}",
+                "exit 0",
+            ]
+        )
+        + "\n"
+    )
+    return _write_executable(path, script)
+
+
+def _run_lint_runner(repo_root: Path, fake_python: Path) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHON_BIN"] = str(fake_python)
+    env["LINT_RUNNER_GITHUB_EVENT_NAME"] = "pull_request"
+    return subprocess.run(
+        ["bash", str(SCRIPT_PATH), "pr"],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_pr_mode_falls_back_when_diff_range_is_unavailable(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    _init_repo(repo_root)
+
+    log_path = tmp_path / "lint.log"
+    fake_python = _write_fake_python(tmp_path / "fake-python", log_path)
+
+    result = _run_lint_runner(repo_root, fake_python)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "pylint candidates=3" in result.stdout
+    assert "fallback pylint" in result.stdout
+
+    pylint_invocation = next(
+        line for line in log_path.read_text(encoding="utf-8").splitlines() if line.startswith("-m pylint --jobs=1")
+    )
+    assert "src/tp/phase4/verify_phase4_chain.py" in pylint_invocation
+    assert "tests/test_material_response.py" in pylint_invocation
+    assert "tests/test_depth_tools.py" in pylint_invocation
+
+
+def test_pr_mode_uses_changed_python_files_when_origin_main_is_available(tmp_path: Path) -> None:
+    origin_root = tmp_path / "origin.git"
+    subprocess.run(
+        ["git", "init", "--bare", str(origin_root)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    repo_root = tmp_path / "repo"
+    _init_repo(repo_root)
+    _run_git(repo_root, "remote", "add", "origin", str(origin_root))
+    _run_git(repo_root, "push", "-u", "origin", "main")
+    _run_git(repo_root, "checkout", "-b", "feature/lint-runner")
+
+    changed_python = repo_root / "tests" / "changed_for_lint_runner.py"
+    changed_python.parent.mkdir(parents=True, exist_ok=True)
+    changed_python.write_text("def lint_target() -> int:\n    return 1\n", encoding="utf-8")
+    _run_git(repo_root, "add", str(changed_python.relative_to(repo_root)))
+    _run_git(repo_root, "commit", "-m", "add python change")
+
+    log_path = tmp_path / "lint.log"
+    fake_python = _write_fake_python(tmp_path / "fake-python", log_path)
+
+    result = _run_lint_runner(repo_root, fake_python)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "fallback pylint" not in result.stdout
+    assert "pylint candidates=1" in result.stdout
+
+    pylint_invocation = next(
+        line for line in log_path.read_text(encoding="utf-8").splitlines() if line.startswith("-m pylint --jobs=1")
+    )
+    assert "tests/changed_for_lint_runner.py" in pylint_invocation


### PR DESCRIPTION
## Summary
- Restore `main` CI parity by making PR lint diff selection fail closed and by giving the lint job enough history to resolve the same file set that post-merge push runs see.
- Stabilize `ArtifactStore.store()` temp-file writes under concurrent same-prefix multiprocess workloads without changing cache layout or public APIs.

## Changes
- Clear the three blocking pylint findings in the touched Lux/materials tests without changing behavior.
- Harden `scripts/lint_runner.sh` so PR-mode diff selection validates `origin/main` and the merge base, and falls back to the safe pylint surface when a reliable diff cannot be computed.
- Update `.github/workflows/build.yml` lint checkout history to `fetch-depth: 0` for PR/push parity.
- Replace the `NamedTemporaryFile(delete=False)` artifact/provenance write path in `artifact_store.py` with explicit `mkstemp` fd handling, and keep commit-marker creation atomic under concurrent writers.
- Add regression coverage for shallow-history PR lint fallback and concurrent ArtifactStore writes to different keys sharing one prefix directory.

## Validation
Proven green
- `make validate-ci`
- `PYTHON_BIN=.venv-lint/bin/python LINT_RUNNER_GITHUB_EVENT_NAME=push LINT_RUNNER_GITHUB_BEFORE=da478f825d56b9fc1864a00c55a274fd5a632b51 LINT_RUNNER_GITHUB_SHA=450024c12cf8b0cdb8bd439418a3bb7f49e372d1 ./scripts/lint_runner.sh pr`
- `TP_LINT_VENV=/tmp/tp-lint-312 TP_LINT_PYTHON=/opt/homebrew/bin/python3.12 ./scripts/setup/run_lint_tool.sh parity`
- `.venv/bin/pytest -p no:cacheprovider tests/validation/test_lint_runner.py`
- `.venv/bin/pytest -p no:cacheprovider tests/spatial_ai/orchestration/graph/test_artifact_store_multiprocess.py`
- `/bin/zsh -lc 'PRE_COMMIT_HOME=/tmp/pre-commit PATH=/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin:$PATH .venv/bin/pre-commit run --all-files --show-diff-on-failure'`

Still failing
- `.venv/bin/pytest -p no:cacheprovider tests/ -m "not ml and not slow and not benchmark" --maxfail=1`
- Fails at `tests/test_lux_depth_v3_cli.py::TestCLIValidation::test_raw_inputs_fail_fast_when_rawpy_unavailable`.
- Current failure appears unrelated to the lint parity gap or ArtifactStore temp-file race; it reads like stale CLI copy expectation versus the actual runtime message.

## Risk
- Bounded to CI diff selection, workflow checkout depth, and ArtifactStore temp-file creation.
- Cache key format, artifact/provenance filenames, committed-marker path, and public interfaces are unchanged.
- Revert-safe because the change does not alter route shapes, selectors, CLI flags, or cache layout.
