### PR TITLE
chore(deps): curate fastapi 0.136.0 upgrade

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "tqdm>=4.66,<5",
     # Web stack ranges are intentionally bounded here.
     # Exact versions are enforced in requirements/base.in and compiled lockfiles.
-    "fastapi>=0.121.0,<0.136",
+    "fastapi>=0.121.0,<0.137",
     "starlette>=0.49.1,<1.1",  # direct runtime import + curated Starlette 1.x validation window
     "uvicorn>=0.29.0,<0.43",
     "aiofiles>=23.2.1,<26",

--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -64,7 +64,7 @@ docutils==0.22.4
     # via readme-renderer
 execnet==2.1.2
     # via pytest-xdist
-fastapi==0.135.3
+fastapi==0.136.0
     # via -r base.in
 filelock==3.25.2
     # via

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -15,7 +15,7 @@ tqdm>=4.66,<5              # progress bar utility
 
 # Web orchestration service stack (exact pins for API/UI parity)
 # Security: keep FastAPI + Starlette on patched baseline for CVE-2025-62727.
-fastapi==0.135.3           # orchestrator API framework (validated against curated Starlette 1.x upgrade)
+fastapi==0.136.0           # orchestrator API framework (validated against curated Starlette 1.x upgrade)
 starlette==1.0.0           # direct runtime import + curated Starlette 1.x validation target
 uvicorn==0.42.0            # ASGI server runtime pin
 aiofiles==25.1.0           # async file I/O support for FastAPI file responses

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,37 +5,162 @@
 #    pip-compile --constraint=all.txt --output-file=base.txt base.in
 #
 aiofiles==25.1.0
+    # via
+    #   -c all.txt
+    #   -r base.in
 annotated-doc==0.0.4
+    # via
+    #   -c all.txt
+    #   fastapi
+    #   typer
 annotated-types==0.7.0
+    # via
+    #   -c all.txt
+    #   pydantic
 anyio==4.13.0
+    # via
+    #   -c all.txt
+    #   starlette
 attrs==26.1.0
+    # via
+    #   -c all.txt
+    #   jsonschema
+    #   referencing
 click==8.3.2
-fastapi==0.135.3
+    # via
+    #   -c all.txt
+    #   typer
+    #   uvicorn
+fastapi==0.136.0
+    # via
+    #   -c all.txt
+    #   -r base.in
 h11==0.16.0
+    # via
+    #   -c all.txt
+    #   uvicorn
 idna==3.11
+    # via
+    #   -c all.txt
+    #   anyio
 imagecodecs==2026.3.6
+    # via
+    #   -c all.txt
+    #   -r base.in
 joblib==1.5.3
+    # via
+    #   -c all.txt
+    #   scikit-learn
 jsonschema==4.26.0
+    # via
+    #   -c all.txt
+    #   -r base.in
 jsonschema-specifications==2025.9.1
+    # via
+    #   -c all.txt
+    #   jsonschema
 markdown-it-py==4.0.0
+    # via
+    #   -c all.txt
+    #   rich
 mdurl==0.1.2
+    # via
+    #   -c all.txt
+    #   markdown-it-py
 numpy==2.4.4
+    # via
+    #   -c all.txt
+    #   -r base.in
+    #   imagecodecs
+    #   opencv-python
+    #   scikit-learn
+    #   scipy
+    #   tifffile
 opencv-python==4.13.0.92
+    # via
+    #   -c all.txt
+    #   -r base.in
 pillow==12.2.0
+    # via
+    #   -c all.txt
+    #   -r base.in
 pydantic==2.13.1
+    # via
+    #   -c all.txt
+    #   -r base.in
+    #   fastapi
 pydantic-core==2.46.1
+    # via
+    #   -c all.txt
+    #   pydantic
 pygments==2.20.0
+    # via
+    #   -c all.txt
+    #   rich
 referencing==0.37.0
+    # via
+    #   -c all.txt
+    #   jsonschema
+    #   jsonschema-specifications
 rich==15.0.0
+    # via
+    #   -c all.txt
+    #   typer
 rpds-py==0.30.0
+    # via
+    #   -c all.txt
+    #   jsonschema
+    #   referencing
 scikit-learn==1.8.0
+    # via
+    #   -c all.txt
+    #   -r base.in
 scipy==1.17.1
+    # via
+    #   -c all.txt
+    #   -r base.in
+    #   scikit-learn
 shellingham==1.5.4
+    # via
+    #   -c all.txt
+    #   typer
 starlette==1.0.0
+    # via
+    #   -c all.txt
+    #   -r base.in
+    #   fastapi
 threadpoolctl==3.6.0
+    # via
+    #   -c all.txt
+    #   scikit-learn
 tifffile==2026.3.3
+    # via
+    #   -c all.txt
+    #   -r base.in
 tqdm==4.67.3
+    # via
+    #   -c all.txt
+    #   -r base.in
 typer==0.24.1
+    # via
+    #   -c all.txt
+    #   -r base.in
 typing-extensions==4.15.0
+    # via
+    #   -c all.txt
+    #   anyio
+    #   fastapi
+    #   pydantic
+    #   pydantic-core
+    #   referencing
+    #   starlette
+    #   typing-inspection
 typing-inspection==0.4.2
+    # via
+    #   -c all.txt
+    #   fastapi
+    #   pydantic
 uvicorn==0.42.0
+    # via
+    #   -c all.txt
+    #   -r base.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -5,49 +5,205 @@
 #    pip-compile --constraint=all.txt --output-file=ci.txt ci.in
 #
 backports-tarfile==1.2.0
+    # via
+    #   -c all.txt
+    #   jaraco-context
 bandit==1.9.4
+    # via
+    #   -c all.txt
+    #   -r ci.in
 build==1.4.3
+    # via
+    #   -c all.txt
+    #   -r ci.in
 cachetools==7.0.5
+    # via
+    #   -c all.txt
+    #   tox
 certifi==2026.2.25
+    # via
+    #   -c all.txt
+    #   requests
 cffi==2.0.0
+    # via
+    #   -c all.txt
+    #   cryptography
 charset-normalizer==3.4.7
+    # via
+    #   -c all.txt
+    #   requests
 colorama==0.4.6
+    # via
+    #   -c all.txt
+    #   tox
 cryptography==46.0.7
+    # via
+    #   -c all.txt
+    #   secretstorage
 distlib==0.4.0
+    # via
+    #   -c all.txt
+    #   virtualenv
 docutils==0.22.4
+    # via
+    #   -c all.txt
+    #   readme-renderer
 filelock==3.25.2
+    # via
+    #   -c all.txt
+    #   python-discovery
+    #   tox
+    #   virtualenv
 id==1.6.1
+    # via
+    #   -c all.txt
+    #   twine
 idna==3.11
+    # via
+    #   -c all.txt
+    #   requests
 importlib-metadata==9.0.0
+    # via
+    #   -c all.txt
+    #   keyring
 jaraco-classes==3.4.0
+    # via
+    #   -c all.txt
+    #   keyring
 jaraco-context==6.1.2
+    # via
+    #   -c all.txt
+    #   keyring
 jaraco-functools==4.4.0
+    # via
+    #   -c all.txt
+    #   keyring
 jeepney==0.9.0
+    # via
+    #   -c all.txt
+    #   keyring
+    #   secretstorage
 keyring==25.7.0
+    # via
+    #   -c all.txt
+    #   twine
 markdown-it-py==4.0.0
+    # via
+    #   -c all.txt
+    #   rich
 mdurl==0.1.2
+    # via
+    #   -c all.txt
+    #   markdown-it-py
 more-itertools==11.0.2
+    # via
+    #   -c all.txt
+    #   jaraco-classes
+    #   jaraco-functools
 nh3==0.3.4
+    # via
+    #   -c all.txt
+    #   readme-renderer
 packaging==26.0
+    # via
+    #   -c all.txt
+    #   build
+    #   pyproject-api
+    #   tox
+    #   twine
 platformdirs==4.9.6
+    # via
+    #   -c all.txt
+    #   python-discovery
+    #   tox
+    #   virtualenv
 pluggy==1.6.0
+    # via
+    #   -c all.txt
+    #   tox
 pycparser==3.0
+    # via
+    #   -c all.txt
+    #   cffi
 pygments==2.20.0
+    # via
+    #   -c all.txt
+    #   readme-renderer
+    #   rich
 pypdf==6.10.2
+    # via
+    #   -c all.txt
+    #   -r ci.in
 pyproject-api==1.10.0
+    # via
+    #   -c all.txt
+    #   tox
 pyproject-hooks==1.2.0
+    # via
+    #   -c all.txt
+    #   build
 python-discovery==1.2.2
+    # via
+    #   -c all.txt
+    #   tox
+    #   virtualenv
 pyyaml==6.0.3
+    # via
+    #   -c all.txt
+    #   bandit
 readme-renderer==44.0
+    # via
+    #   -c all.txt
+    #   twine
 requests==2.33.1
+    # via
+    #   -c all.txt
+    #   requests-toolbelt
+    #   twine
 requests-toolbelt==1.0.0
+    # via
+    #   -c all.txt
+    #   twine
 rfc3986==2.0.0
+    # via
+    #   -c all.txt
+    #   twine
 rich==15.0.0
+    # via
+    #   -c all.txt
+    #   bandit
+    #   twine
 secretstorage==3.5.0
+    # via
+    #   -c all.txt
+    #   keyring
 stevedore==5.7.0
+    # via
+    #   -c all.txt
+    #   bandit
 tomli-w==1.2.0
+    # via
+    #   -c all.txt
+    #   tox
 tox==4.53.0
+    # via
+    #   -c all.txt
+    #   -r ci.in
 twine==6.2.0
+    # via
+    #   -c all.txt
+    #   -r ci.in
 urllib3==2.6.3
+    # via
+    #   -c all.txt
+    #   id
+    #   requests
+    #   twine
 virtualenv==21.2.1
+    # via
+    #   -c all.txt
+    #   tox
 zipp==3.23.0
+    # via
+    #   -c all.txt
+    #   importlib-metadata


### PR DESCRIPTION
## Summary
- Replace the blocked Dependabot FastAPI bump with a curated upgrade that keeps the governed manifest and lockfile surfaces in sync.
- Advance FastAPI to 0.136.0 with the smallest safe dependency changes, while preserving existing orchestrator and frontdoor contracts.

## Changes
- Update `requirements/base.in` to pin `fastapi==0.136.0`.
- Widen the `pyproject.toml` FastAPI range from `<0.136` to `<0.137`.
- Regenerate the checked-in generic lockfiles affected by the governed FastAPI surface: `requirements/base.txt`, `requirements/all.txt`, and `requirements/ci.txt`.
- Restore the required Linux keyring-chain transitive entries in the generic lockfiles after the Darwin compile lane dropped them, so the repository lock contract remains satisfied.

## Validation
- Proven green:
  - `PATH=/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin:$PATH make check`
  - `make PY=/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin/python test-orchestrator-contract`
  - `source ~/.nvm/nvm.sh && nvm use 22 >/dev/null && make PY=/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin/python test-frontdoor-contract`
  - `source ~/.nvm/nvm.sh && nvm use 22 >/dev/null && make PY=/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin/python ci`
- Also verified:
  - `/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin/python scripts/validation/check_requirements_lock_contract.py`
- Still failing:
  - None.
- Environment notes:
  - Frontdoor contract and `make ci` require Node 22 for `web/secure-landing`; the initial Node 25 run failed closed as expected before rerunning under Node 22.
  - The frontdoor worktree needed `npm ci` under Node 22 before the contract build could load `better-sqlite3`.

## Risk
- Risk is bounded to the FastAPI dependency surface and the regenerated generic lockfiles.
- No route, selector, API envelope, or frontdoor/orchestrator contract changes were introduced.
- The change is revert-safe because it is isolated to the dependency manifests and checked-in locks.