### PR TITLE
fix(ci): refresh upload-artifact v7 pin assertions

### DIFF
--- a/.github/workflows/apex_performance.yml
+++ b/.github/workflows/apex_performance.yml
@@ -139,7 +139,7 @@ jobs:
 
       - name: Upload Results
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
         with:
           name: apex-results-${{ matrix.workflow_version }}-${{ matrix.zone }}
           path: ${{ env.APEX_RESULTS_DIR }}/
@@ -325,7 +325,7 @@ jobs:
 
       - name: Upload Ledger Artifact
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
         with:
           name: apex-ledger
           path: ${{ env.APEX_LEDGER_DB }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -693,7 +693,7 @@ jobs:
 
       - name: Upload coverage reports
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: coverage-${{ matrix.python-version }}-${{ matrix.test-type }}
           path: |
@@ -836,7 +836,7 @@ jobs:
 
       - name: Upload manifest artifact
         if: ${{ steps.manifest.outputs.manifest_path != '' }}
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: montecito-manifest
           path: ${{ steps.manifest.outputs.manifest_path }}
@@ -845,7 +845,7 @@ jobs:
 
       - name: Upload governance artifacts
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: dataset-governance-telemetry
           path: |

--- a/.github/workflows/ci-quality-firewall.yml
+++ b/.github/workflows/ci-quality-firewall.yml
@@ -217,7 +217,7 @@ jobs:
 
       - name: Upload security reports
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: security-reports
           path: |
@@ -331,7 +331,7 @@ jobs:
 
       - name: Upload validation report
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: dependency-validation-report
           path: |
@@ -371,7 +371,7 @@ jobs:
 
       - name: Upload resolver report
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: resolver-report-py${{ matrix.python-version }}
           path: resolver-report-py${{ matrix.python-version }}.json
@@ -444,7 +444,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: test-results-core-py${{ matrix.python-version }}
           path: test-results/
@@ -475,7 +475,7 @@ jobs:
 
       - name: Upload coverage reports
         if: matrix.python-version == '3.12'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: coverage-core-py${{ matrix.python-version }}
           include-hidden-files: true
@@ -565,7 +565,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: test-results-ml-py3.11
           path: test-results/
@@ -593,7 +593,7 @@ jobs:
           fi
 
       - name: Upload coverage reports
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: coverage-ml-py3.11
           include-hidden-files: true
@@ -702,7 +702,7 @@ jobs:
           python -c "import transformation_portal; print(transformation_portal.__version__)"
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: dist-packages
           path: dist/
@@ -882,7 +882,7 @@ jobs:
 
       - name: Upload flake ledger
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: flake-ledger
           path: tests/flake_ledger.json
@@ -890,7 +890,7 @@ jobs:
 
       - name: Upload flake report
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: flake-report
           path: flake-report.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
 
       - name: Upload security reports
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: security-reports
           path: |
@@ -270,7 +270,7 @@ jobs:
 
       - name: Upload coverage reports
         if: matrix.python-version == '3.12'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: coverage-core-py${{ matrix.python-version }}
           include-hidden-files: true
@@ -386,7 +386,7 @@ jobs:
           fi
 
       - name: Upload coverage reports
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: coverage-ml-py3.11
           include-hidden-files: true
@@ -501,7 +501,7 @@ jobs:
           python -c "import transformation_portal; print(transformation_portal.__version__)"
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: dist-packages
           path: dist/

--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -123,7 +123,7 @@ jobs:
           done
 
       - name: Upload pip-audit report
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: pip-audit-report
           path: ${{ runner.temp }}/dependency-update-audit-reports/

--- a/.github/workflows/ml-slow-suite.yml
+++ b/.github/workflows/ml-slow-suite.yml
@@ -112,7 +112,7 @@ jobs:
 
       - name: Upload slow-suite artifacts
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.0
         with:
           name: ml-slow-suite-artifacts
           path: test-results/

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Upload stress test logs
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.0
         with:
           name: stress-test-logs
           path: |
@@ -197,7 +197,7 @@ jobs:
           fi
 
       - name: Upload benchmark results
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.0
         with:
           name: benchmark-results
           path: benchmark-results.json
@@ -295,7 +295,7 @@ jobs:
 
       - name: Upload memory profile
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.0
         with:
           name: memory-profile
           path: |
@@ -348,7 +348,7 @@ jobs:
           fi
 
       - name: Upload SBOM and audit reports
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.0
         with:
           name: dependency-audit
           path: |

--- a/.github/workflows/performance-monitor.yml
+++ b/.github/workflows/performance-monitor.yml
@@ -174,7 +174,7 @@ jobs:
 
       - name: Upload results
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.0
         with:
           name: performance-results
           path: |

--- a/.github/workflows/secure-install-pilot.yml
+++ b/.github/workflows/secure-install-pilot.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Upload secure-install pilot artifacts
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: secure-install-pilot-locks
           path: requirements/.hash-pilot/

--- a/.github/workflows/security-unified.yml
+++ b/.github/workflows/security-unified.yml
@@ -169,7 +169,7 @@ jobs:
 
       - name: Upload Security Reports
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.0
         with:
           name: security-reports-${{ github.sha }}
           path: |

--- a/.github/workflows/submit-pypi.yml
+++ b/.github/workflows/submit-pypi.yml
@@ -62,7 +62,7 @@ jobs:
         tar -tzf dist/*.tar.gz | head -30
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: dist
         path: dist/

--- a/tests/test_secure_install_pilot_workflow.py
+++ b/tests/test_secure_install_pilot_workflow.py
@@ -13,7 +13,7 @@ REQUIREMENTS_README_PATH = REPO_ROOT / "requirements" / "README.md"
 ROADMAP_PATH = REPO_ROOT / "docs" / "architecture" / "transformation_portal_roadmap_rereview_2026-04-07.md"
 CHECKOUT_SHA = "de0fac2e4500dabe0009e67214ff5f5447ce83dd"
 SETUP_PYTHON_SHA = "a309ff8b426b58ec0e2a45f0f869d46889d02405"
-UPLOAD_ARTIFACT_SHA = "bbbca2ddaa5d8feaa63e36b76fdaad77386f024f"
+UPLOAD_ARTIFACT_SHA = "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
 
 
 def _load_workflow() -> dict:


### PR DESCRIPTION
## Summary
- Replace the stale `actions/upload-artifact` v7 pin with the current Dependabot-targeted SHA on top of the latest merged workflow updates.
- Keep the repository contract aligned by updating only the secure-install pilot workflow assertion that hard-codes that SHA.

## Changes
- Advance every checked-in `actions/upload-artifact` v7 pin from `bbbca2ddaa5d8feaa63e36b76fdaad77386f024f` to `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a`.
- Update `tests/test_secure_install_pilot_workflow.py` so the pinned-action assertion matches the workflow file.
- Preserve workflow semantics; no job logic, trigger surface, or artifact contract changes were introduced.

## Validation
- Proven green:
  - `/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin/pytest tests/test_secure_install_pilot_workflow.py -q`
  - `make PY=/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin/python validate-ci`
- Still failing:
  - None.
- Environment notes:
  - Validation used the shared repo Python via `/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin/python`.

## Risk
- Risk is bounded to GitHub Actions pin metadata and the matching repository assertion.
- No application runtime behavior, routes, selectors, API envelopes, or deployment posture changed.
- The change is revert-safe because it only refreshes an action SHA and its corresponding contract test.