### PR TITLE
chore(repo): consolidate FastAPI 0.136 and upload-artifact v7 updates

### DIFF
--- a/.github/workflows/apex_performance.yml
+++ b/.github/workflows/apex_performance.yml
@@ -139,7 +139,7 @@ jobs:
 
       - name: Upload Results
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
         with:
           name: apex-results-${{ matrix.workflow_version }}-${{ matrix.zone }}
           path: ${{ env.APEX_RESULTS_DIR }}/
@@ -325,7 +325,7 @@ jobs:
 
       - name: Upload Ledger Artifact
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
         with:
           name: apex-ledger
           path: ${{ env.APEX_LEDGER_DB }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -693,7 +693,7 @@ jobs:
 
       - name: Upload coverage reports
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: coverage-${{ matrix.python-version }}-${{ matrix.test-type }}
           path: |
@@ -836,7 +836,7 @@ jobs:
 
       - name: Upload manifest artifact
         if: ${{ steps.manifest.outputs.manifest_path != '' }}
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: montecito-manifest
           path: ${{ steps.manifest.outputs.manifest_path }}
@@ -845,7 +845,7 @@ jobs:
 
       - name: Upload governance artifacts
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: dataset-governance-telemetry
           path: |

--- a/.github/workflows/ci-quality-firewall.yml
+++ b/.github/workflows/ci-quality-firewall.yml
@@ -217,7 +217,7 @@ jobs:
 
       - name: Upload security reports
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: security-reports
           path: |
@@ -331,7 +331,7 @@ jobs:
 
       - name: Upload validation report
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: dependency-validation-report
           path: |
@@ -371,7 +371,7 @@ jobs:
 
       - name: Upload resolver report
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: resolver-report-py${{ matrix.python-version }}
           path: resolver-report-py${{ matrix.python-version }}.json
@@ -444,7 +444,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: test-results-core-py${{ matrix.python-version }}
           path: test-results/
@@ -475,7 +475,7 @@ jobs:
 
       - name: Upload coverage reports
         if: matrix.python-version == '3.12'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: coverage-core-py${{ matrix.python-version }}
           include-hidden-files: true
@@ -565,7 +565,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: test-results-ml-py3.11
           path: test-results/
@@ -593,7 +593,7 @@ jobs:
           fi
 
       - name: Upload coverage reports
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: coverage-ml-py3.11
           include-hidden-files: true
@@ -702,7 +702,7 @@ jobs:
           python -c "import transformation_portal; print(transformation_portal.__version__)"
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: dist-packages
           path: dist/
@@ -882,7 +882,7 @@ jobs:
 
       - name: Upload flake ledger
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: flake-ledger
           path: tests/flake_ledger.json
@@ -890,7 +890,7 @@ jobs:
 
       - name: Upload flake report
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: flake-report
           path: flake-report.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
 
       - name: Upload security reports
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: security-reports
           path: |
@@ -270,7 +270,7 @@ jobs:
 
       - name: Upload coverage reports
         if: matrix.python-version == '3.12'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: coverage-core-py${{ matrix.python-version }}
           include-hidden-files: true
@@ -386,7 +386,7 @@ jobs:
           fi
 
       - name: Upload coverage reports
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: coverage-ml-py3.11
           include-hidden-files: true
@@ -501,7 +501,7 @@ jobs:
           python -c "import transformation_portal; print(transformation_portal.__version__)"
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: dist-packages
           path: dist/

--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -123,7 +123,7 @@ jobs:
           done
 
       - name: Upload pip-audit report
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: pip-audit-report
           path: ${{ runner.temp }}/dependency-update-audit-reports/

--- a/.github/workflows/ml-slow-suite.yml
+++ b/.github/workflows/ml-slow-suite.yml
@@ -112,7 +112,7 @@ jobs:
 
       - name: Upload slow-suite artifacts
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.0
         with:
           name: ml-slow-suite-artifacts
           path: test-results/

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Upload stress test logs
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.0
         with:
           name: stress-test-logs
           path: |
@@ -197,7 +197,7 @@ jobs:
           fi
 
       - name: Upload benchmark results
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.0
         with:
           name: benchmark-results
           path: benchmark-results.json
@@ -295,7 +295,7 @@ jobs:
 
       - name: Upload memory profile
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.0
         with:
           name: memory-profile
           path: |
@@ -348,7 +348,7 @@ jobs:
           fi
 
       - name: Upload SBOM and audit reports
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.0
         with:
           name: dependency-audit
           path: |

--- a/.github/workflows/performance-monitor.yml
+++ b/.github/workflows/performance-monitor.yml
@@ -174,7 +174,7 @@ jobs:
 
       - name: Upload results
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.0
         with:
           name: performance-results
           path: |

--- a/.github/workflows/secure-install-pilot.yml
+++ b/.github/workflows/secure-install-pilot.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Upload secure-install pilot artifacts
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: secure-install-pilot-locks
           path: requirements/.hash-pilot/

--- a/.github/workflows/security-unified.yml
+++ b/.github/workflows/security-unified.yml
@@ -169,7 +169,7 @@ jobs:
 
       - name: Upload Security Reports
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.0
         with:
           name: security-reports-${{ github.sha }}
           path: |

--- a/.github/workflows/submit-pypi.yml
+++ b/.github/workflows/submit-pypi.yml
@@ -62,7 +62,7 @@ jobs:
         tar -tzf dist/*.tar.gz | head -30
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: dist
         path: dist/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,12 @@
 
 Quick reference for common workflows and commands in this repo.
 
+## Canonical worktree discipline
+- `origin/main` is the canonical repository baseline and the only standing source of truth on Desktop.
+- Desktop siblings such as `Transformation_Portal__fastapi` or `Transformation_Portal__upload` are temporary git worktrees, not independent repos.
+- When parallel work needs consolidation, first fast-forward local `main` to `origin/main`, then create a single integration branch from that updated base and replay the intended commits there.
+- After validation lands, retire obsolete Desktop worktrees and prune their local-only branches so `Transformation_Portal/` remains the canonical checkout.
+
 ## Common commands (Makefile)
 - `make venv` create local `.venv` with a Python 3.11+ interpreter, or fail closed if an existing `.venv` is unsupported.
 - `make setup` install package in editable mode.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "tqdm>=4.66,<5",
     # Web stack ranges are intentionally bounded here.
     # Exact versions are enforced in requirements/base.in and compiled lockfiles.
-    "fastapi>=0.121.0,<0.136",
+    "fastapi>=0.121.0,<0.137",
     "starlette>=0.49.1,<1.1",  # direct runtime import + curated Starlette 1.x validation window
     "uvicorn>=0.29.0,<0.43",
     "aiofiles>=23.2.1,<26",

--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -64,7 +64,7 @@ docutils==0.22.4
     # via readme-renderer
 execnet==2.1.2
     # via pytest-xdist
-fastapi==0.135.3
+fastapi==0.136.0
     # via -r base.in
 filelock==3.25.2
     # via

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -15,7 +15,7 @@ tqdm>=4.66,<5              # progress bar utility
 
 # Web orchestration service stack (exact pins for API/UI parity)
 # Security: keep FastAPI + Starlette on patched baseline for CVE-2025-62727.
-fastapi==0.135.3           # orchestrator API framework (validated against curated Starlette 1.x upgrade)
+fastapi==0.136.0           # orchestrator API framework (validated against curated Starlette 1.x upgrade)
 starlette==1.0.0           # direct runtime import + curated Starlette 1.x validation target
 uvicorn==0.42.0            # ASGI server runtime pin
 aiofiles==25.1.0           # async file I/O support for FastAPI file responses

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,37 +5,162 @@
 #    pip-compile --constraint=all.txt --output-file=base.txt base.in
 #
 aiofiles==25.1.0
+    # via
+    #   -c all.txt
+    #   -r base.in
 annotated-doc==0.0.4
+    # via
+    #   -c all.txt
+    #   fastapi
+    #   typer
 annotated-types==0.7.0
+    # via
+    #   -c all.txt
+    #   pydantic
 anyio==4.13.0
+    # via
+    #   -c all.txt
+    #   starlette
 attrs==26.1.0
+    # via
+    #   -c all.txt
+    #   jsonschema
+    #   referencing
 click==8.3.2
-fastapi==0.135.3
+    # via
+    #   -c all.txt
+    #   typer
+    #   uvicorn
+fastapi==0.136.0
+    # via
+    #   -c all.txt
+    #   -r base.in
 h11==0.16.0
+    # via
+    #   -c all.txt
+    #   uvicorn
 idna==3.11
+    # via
+    #   -c all.txt
+    #   anyio
 imagecodecs==2026.3.6
+    # via
+    #   -c all.txt
+    #   -r base.in
 joblib==1.5.3
+    # via
+    #   -c all.txt
+    #   scikit-learn
 jsonschema==4.26.0
+    # via
+    #   -c all.txt
+    #   -r base.in
 jsonschema-specifications==2025.9.1
+    # via
+    #   -c all.txt
+    #   jsonschema
 markdown-it-py==4.0.0
+    # via
+    #   -c all.txt
+    #   rich
 mdurl==0.1.2
+    # via
+    #   -c all.txt
+    #   markdown-it-py
 numpy==2.4.4
+    # via
+    #   -c all.txt
+    #   -r base.in
+    #   imagecodecs
+    #   opencv-python
+    #   scikit-learn
+    #   scipy
+    #   tifffile
 opencv-python==4.13.0.92
+    # via
+    #   -c all.txt
+    #   -r base.in
 pillow==12.2.0
+    # via
+    #   -c all.txt
+    #   -r base.in
 pydantic==2.13.1
+    # via
+    #   -c all.txt
+    #   -r base.in
+    #   fastapi
 pydantic-core==2.46.1
+    # via
+    #   -c all.txt
+    #   pydantic
 pygments==2.20.0
+    # via
+    #   -c all.txt
+    #   rich
 referencing==0.37.0
+    # via
+    #   -c all.txt
+    #   jsonschema
+    #   jsonschema-specifications
 rich==15.0.0
+    # via
+    #   -c all.txt
+    #   typer
 rpds-py==0.30.0
+    # via
+    #   -c all.txt
+    #   jsonschema
+    #   referencing
 scikit-learn==1.8.0
+    # via
+    #   -c all.txt
+    #   -r base.in
 scipy==1.17.1
+    # via
+    #   -c all.txt
+    #   -r base.in
+    #   scikit-learn
 shellingham==1.5.4
+    # via
+    #   -c all.txt
+    #   typer
 starlette==1.0.0
+    # via
+    #   -c all.txt
+    #   -r base.in
+    #   fastapi
 threadpoolctl==3.6.0
+    # via
+    #   -c all.txt
+    #   scikit-learn
 tifffile==2026.3.3
+    # via
+    #   -c all.txt
+    #   -r base.in
 tqdm==4.67.3
+    # via
+    #   -c all.txt
+    #   -r base.in
 typer==0.24.1
+    # via
+    #   -c all.txt
+    #   -r base.in
 typing-extensions==4.15.0
+    # via
+    #   -c all.txt
+    #   anyio
+    #   fastapi
+    #   pydantic
+    #   pydantic-core
+    #   referencing
+    #   starlette
+    #   typing-inspection
 typing-inspection==0.4.2
+    # via
+    #   -c all.txt
+    #   fastapi
+    #   pydantic
 uvicorn==0.42.0
+    # via
+    #   -c all.txt
+    #   -r base.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -5,49 +5,205 @@
 #    pip-compile --constraint=all.txt --output-file=ci.txt ci.in
 #
 backports-tarfile==1.2.0
+    # via
+    #   -c all.txt
+    #   jaraco-context
 bandit==1.9.4
+    # via
+    #   -c all.txt
+    #   -r ci.in
 build==1.4.3
+    # via
+    #   -c all.txt
+    #   -r ci.in
 cachetools==7.0.5
+    # via
+    #   -c all.txt
+    #   tox
 certifi==2026.2.25
+    # via
+    #   -c all.txt
+    #   requests
 cffi==2.0.0
+    # via
+    #   -c all.txt
+    #   cryptography
 charset-normalizer==3.4.7
+    # via
+    #   -c all.txt
+    #   requests
 colorama==0.4.6
+    # via
+    #   -c all.txt
+    #   tox
 cryptography==46.0.7
+    # via
+    #   -c all.txt
+    #   secretstorage
 distlib==0.4.0
+    # via
+    #   -c all.txt
+    #   virtualenv
 docutils==0.22.4
+    # via
+    #   -c all.txt
+    #   readme-renderer
 filelock==3.25.2
+    # via
+    #   -c all.txt
+    #   python-discovery
+    #   tox
+    #   virtualenv
 id==1.6.1
+    # via
+    #   -c all.txt
+    #   twine
 idna==3.11
+    # via
+    #   -c all.txt
+    #   requests
 importlib-metadata==9.0.0
+    # via
+    #   -c all.txt
+    #   keyring
 jaraco-classes==3.4.0
+    # via
+    #   -c all.txt
+    #   keyring
 jaraco-context==6.1.2
+    # via
+    #   -c all.txt
+    #   keyring
 jaraco-functools==4.4.0
+    # via
+    #   -c all.txt
+    #   keyring
 jeepney==0.9.0
+    # via
+    #   -c all.txt
+    #   keyring
+    #   secretstorage
 keyring==25.7.0
+    # via
+    #   -c all.txt
+    #   twine
 markdown-it-py==4.0.0
+    # via
+    #   -c all.txt
+    #   rich
 mdurl==0.1.2
+    # via
+    #   -c all.txt
+    #   markdown-it-py
 more-itertools==11.0.2
+    # via
+    #   -c all.txt
+    #   jaraco-classes
+    #   jaraco-functools
 nh3==0.3.4
+    # via
+    #   -c all.txt
+    #   readme-renderer
 packaging==26.0
+    # via
+    #   -c all.txt
+    #   build
+    #   pyproject-api
+    #   tox
+    #   twine
 platformdirs==4.9.6
+    # via
+    #   -c all.txt
+    #   python-discovery
+    #   tox
+    #   virtualenv
 pluggy==1.6.0
+    # via
+    #   -c all.txt
+    #   tox
 pycparser==3.0
+    # via
+    #   -c all.txt
+    #   cffi
 pygments==2.20.0
+    # via
+    #   -c all.txt
+    #   readme-renderer
+    #   rich
 pypdf==6.10.2
+    # via
+    #   -c all.txt
+    #   -r ci.in
 pyproject-api==1.10.0
+    # via
+    #   -c all.txt
+    #   tox
 pyproject-hooks==1.2.0
+    # via
+    #   -c all.txt
+    #   build
 python-discovery==1.2.2
+    # via
+    #   -c all.txt
+    #   tox
+    #   virtualenv
 pyyaml==6.0.3
+    # via
+    #   -c all.txt
+    #   bandit
 readme-renderer==44.0
+    # via
+    #   -c all.txt
+    #   twine
 requests==2.33.1
+    # via
+    #   -c all.txt
+    #   requests-toolbelt
+    #   twine
 requests-toolbelt==1.0.0
+    # via
+    #   -c all.txt
+    #   twine
 rfc3986==2.0.0
+    # via
+    #   -c all.txt
+    #   twine
 rich==15.0.0
+    # via
+    #   -c all.txt
+    #   bandit
+    #   twine
 secretstorage==3.5.0
+    # via
+    #   -c all.txt
+    #   keyring
 stevedore==5.7.0
+    # via
+    #   -c all.txt
+    #   bandit
 tomli-w==1.2.0
+    # via
+    #   -c all.txt
+    #   tox
 tox==4.53.0
+    # via
+    #   -c all.txt
+    #   -r ci.in
 twine==6.2.0
+    # via
+    #   -c all.txt
+    #   -r ci.in
 urllib3==2.6.3
+    # via
+    #   -c all.txt
+    #   id
+    #   requests
+    #   twine
 virtualenv==21.2.1
+    # via
+    #   -c all.txt
+    #   tox
 zipp==3.23.0
+    # via
+    #   -c all.txt
+    #   importlib-metadata

--- a/tests/test_secure_install_pilot_workflow.py
+++ b/tests/test_secure_install_pilot_workflow.py
@@ -13,7 +13,7 @@ REQUIREMENTS_README_PATH = REPO_ROOT / "requirements" / "README.md"
 ROADMAP_PATH = REPO_ROOT / "docs" / "architecture" / "transformation_portal_roadmap_rereview_2026-04-07.md"
 CHECKOUT_SHA = "de0fac2e4500dabe0009e67214ff5f5447ce83dd"
 SETUP_PYTHON_SHA = "a309ff8b426b58ec0e2a45f0f869d46889d02405"
-UPLOAD_ARTIFACT_SHA = "bbbca2ddaa5d8feaa63e36b76fdaad77386f024f"
+UPLOAD_ARTIFACT_SHA = "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
 
 
 def _load_workflow() -> dict:


### PR DESCRIPTION
## Summary
- Consolidate the validated FastAPI `0.136.0` dependency curation, the `upload-artifact` v7 workflow pin refresh, and the canonical Desktop worktree guidance into one reviewable branch.
- Supersede draft PRs #1491 and #1492 with a single integration PR while leaving those drafts open for historical context until this PR is reviewed.

## Changes
- Widen the FastAPI allowance to admit the curated `0.136.x` line and update the compiled lockfiles that track the checked-in runtime and CI dependency surfaces.
- Refresh GitHub Actions workflow references plus the secure-install pilot assertion so the repo contract matches the `upload-artifact` v7 pin posture.
- Document `origin/main` as the canonical baseline and the single Desktop checkout policy in `AGENTS.md`.

## Validation
Proven green:
- `make install-core`
- `make validate-ci`
- `make ci`
- `make validate-frontdoor-browser`
- `make check-worktree`

Still failing:
- `make check-environment` soft-failed locally because ports `3000` and `8000` were already occupied by running services.

Failure classification:
- `make check-environment`: environment/tooling state only; not a product regression.

## Risk
- Bounded to dependency pins, workflow references, compiled lockfiles, and operator guidance.
- No intentional route, API envelope, selector, auth-flow, or CLI contract changes.
- Revert-safe because the change is limited to one dependency curation line, aligned workflow contract updates, and documentation of the Desktop worktree operating model.