### PR TITLE
fix(hardening): tighten validation and runtime contracts

### DIFF
--- a/app.py
+++ b/app.py
@@ -54,6 +54,7 @@ from transformation_portal.lux_depth_v3.run_card_contract import infer_run_card_
 
 LOGGER = logging.getLogger(__name__)
 _PORTAL_EVENT_LOG_WRITE_LOCK = threading.Lock()
+_MANAGED_SAM2_CHECKSUM_CACHE_LOCK = threading.Lock()
 
 
 @dataclass(frozen=True)
@@ -77,6 +78,18 @@ class PortalRenderedTextAsset:
     text: str
     content_bytes: bytes
     fingerprint: str
+
+
+@dataclass(frozen=True)
+class ManagedSam2CheckpointValidationResult:
+    normalized_path: Optional[str]
+    reason: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class _ManagedSam2ChecksumCacheEntry:
+    digest: Optional[str]
+    reason: Optional[str]
 
 
 def _env_csv(name: str, default: List[str]) -> List[str]:
@@ -570,45 +583,105 @@ def _ensure_safe_regular_file_path(path_value: Path, allowed_roots: List[Path]) 
     return trusted_entry
 
 
-def _compute_file_sha256(path: Path, chunk_size: int = 1024 * 1024) -> str:
-    trusted_roots = [*MANAGED_SAM2_TRUSTED_ROOTS, *ALLOWED_INPUT_ROOTS]
-    try:
-        resolved_path = _resolve_allowed_request_path(str(path), trusted_roots)
-    except _PortalValidationReasonError:
-        raise
-    except (OSError, RuntimeError, ValueError) as exc:
-        raise _PortalValidationReasonError("Invalid path value", reason="invalid_path_value") from exc
-    trusted_entry = _trusted_allowed_entry(resolved_path, trusted_roots)
-    if trusted_entry is None:
-        raise _PortalValidationReasonError("Invalid path value", reason="invalid_path_value")
-    try:
-        if not trusted_entry.is_file():
-            raise _PortalValidationReasonError("Invalid path value", reason="invalid_path_value")
-        size_bytes = trusted_entry.stat().st_size
-    except OSError as exc:
-        raise _PortalValidationReasonError("Invalid path value", reason="invalid_path_value") from exc
-    if size_bytes > MANAGED_SAM2_CHECKSUM_MAX_BYTES:
-        raise _PortalValidationReasonError(
-            "SAM2 checkpoint path exceeds checksum verification size limit",
-            reason="checkpoint_file_too_large",
-        )
+_MANAGED_SAM2_REASON_MESSAGES = {
+    "checkpoint_file_too_large": "SAM2 checkpoint path exceeds checksum verification size limit",
+    "invalid_path_value": "Invalid path value",
+    "path_outside_allowed_roots": "Path outside allowed roots",
+    "path_shorthand_traversal_disallowed": "Path shorthand traversal disallowed",
+    "untrusted_checkpoint_path": "SAM2 checkpoint path is not trusted",
+}
+_MANAGED_SAM2_CHECKSUM_CACHE: Dict[Tuple[str, int, int], _ManagedSam2ChecksumCacheEntry] = {}
+
+
+def _managed_sam2_reason_message(reason: str) -> str:
+    """Return the canonical internal validation message for a SAM2 reason code."""
+    return _MANAGED_SAM2_REASON_MESSAGES.get(reason, "Invalid path value")
+
+
+def _managed_sam2_checksum_cache_key(path: Path) -> Tuple[str, int, int]:
+    """Build the checksum cache key for a trusted SAM2 checkpoint path."""
+    stat_result = path.stat()
+    return str(path), stat_result.st_size, stat_result.st_mtime_ns
+
+
+def _clear_managed_sam2_checksum_cache() -> None:
+    """Clear the in-process SAM2 checksum cache."""
+    with _MANAGED_SAM2_CHECKSUM_CACHE_LOCK:
+        _MANAGED_SAM2_CHECKSUM_CACHE.clear()
+
+
+def _hash_file_sha256(path: Path, chunk_size: int = 1024 * 1024) -> str:
+    """Return the SHA-256 digest for a local file."""
     digest = hashlib.sha256()
-    with trusted_entry.open("rb") as handle:
+    with path.open("rb") as handle:
         for chunk in iter(lambda: handle.read(chunk_size), b""):
             digest.update(chunk)
     return digest.hexdigest()
 
 
-def _validate_managed_sam2_checkpoint_path(path_value: str) -> str:
-    resolved = _resolve_allowed_request_path(path_value, ALLOWED_INPUT_ROOTS)
+def _cached_managed_sam2_checksum_result(path: Path) -> _ManagedSam2ChecksumCacheEntry:
+    """Return the cached or newly computed trust result for an external SAM2 checkpoint."""
+    try:
+        cache_key = _managed_sam2_checksum_cache_key(path)
+    except OSError as exc:
+        raise _PortalValidationReasonError("Invalid path value", reason="invalid_path_value") from exc
+
+    with _MANAGED_SAM2_CHECKSUM_CACHE_LOCK:
+        cached = _MANAGED_SAM2_CHECKSUM_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+
+    _, size_bytes, _ = cache_key
+    if size_bytes > MANAGED_SAM2_CHECKSUM_MAX_BYTES:
+        entry = _ManagedSam2ChecksumCacheEntry(digest=None, reason="checkpoint_file_too_large")
+    else:
+        digest = _hash_file_sha256(path)
+        reason = None if digest in MANAGED_SAM2_TRUSTED_SHA256 else "untrusted_checkpoint_path"
+        entry = _ManagedSam2ChecksumCacheEntry(digest=digest, reason=reason)
+
+    with _MANAGED_SAM2_CHECKSUM_CACHE_LOCK:
+        _MANAGED_SAM2_CHECKSUM_CACHE[cache_key] = entry
+    return entry
+
+
+def _resolve_managed_sam2_checkpoint_validation(path_value: str) -> ManagedSam2CheckpointValidationResult:
+    """Resolve a managed SAM2 checkpoint path and preserve the exact failure reason."""
+    try:
+        resolved = _resolve_allowed_request_path(path_value, ALLOWED_INPUT_ROOTS)
+    except _PortalValidationReasonError as exc:
+        return ManagedSam2CheckpointValidationResult(
+            normalized_path=None,
+            reason=_portal_reason_from_exception(exc, default="invalid_path_value"),
+        )
+    except (OSError, RuntimeError, ValueError):
+        return ManagedSam2CheckpointValidationResult(normalized_path=None, reason="invalid_path_value")
+
     # Repo-controlled checkpoints remain valid even before the artifact exists locally.
     if any(_path_is_within_root(resolved, root) for root in MANAGED_SAM2_TRUSTED_ROOTS):
-        return str(resolved)
-    safe_file = _ensure_safe_regular_file_path(resolved, ALLOWED_INPUT_ROOTS)
-    digest = _compute_file_sha256(safe_file)
-    if digest in MANAGED_SAM2_TRUSTED_SHA256:
-        return str(safe_file)
-    raise _PortalValidationReasonError("SAM2 checkpoint path is not trusted", reason="untrusted_checkpoint_path")
+        return ManagedSam2CheckpointValidationResult(normalized_path=str(resolved), reason=None)
+
+    try:
+        safe_file = _ensure_safe_regular_file_path(resolved, ALLOWED_INPUT_ROOTS)
+    except _PortalValidationReasonError as exc:
+        return ManagedSam2CheckpointValidationResult(
+            normalized_path=None,
+            reason=_portal_reason_from_exception(exc, default="invalid_path_value"),
+        )
+
+    checksum_result = _cached_managed_sam2_checksum_result(safe_file)
+    if checksum_result.reason is not None:
+        return ManagedSam2CheckpointValidationResult(normalized_path=None, reason=checksum_result.reason)
+    return ManagedSam2CheckpointValidationResult(normalized_path=str(safe_file), reason=None)
+
+
+def _validate_managed_sam2_checkpoint_path(path_value: str) -> str:
+    validation = _resolve_managed_sam2_checkpoint_validation(path_value)
+    if validation.reason is not None:
+        raise _PortalValidationReasonError(
+            _managed_sam2_reason_message(validation.reason),
+            reason=validation.reason,
+        )
+    return str(validation.normalized_path or "")
 
 
 LOG_TAIL_LIMIT = 2000
@@ -3311,37 +3384,34 @@ def _build_lux_config_preview(
     )
     if sam2_checkpoint_path:
         if segmentation_backend == "sam2":
-            try:
-                _validate_managed_sam2_checkpoint_path(sam2_checkpoint_path)
-            except _PortalValidationReasonError as exc:
-                reason = _portal_reason_from_exception(exc, default="invalid_path_value")
-                if reason == "untrusted_checkpoint_path":
-                    errors.append(
-                        _portal_issue(
-                            "sam2_checkpoint_path",
-                            "untrusted_checkpoint_path",
-                            "SAM2 checkpoint overrides must use a repo-controlled or checksum-verified file.",
-                            suggestion=(
-                                "Use ./models/sam2/... or ./checkpoints/... for repo-managed checkpoints, "
-                                "or provide a file whose SHA-256 matches the governed SAM2 checkpoint manifest."
-                            ),
-                        )
+            validation = _resolve_managed_sam2_checkpoint_validation(sam2_checkpoint_path)
+            if validation.reason == "untrusted_checkpoint_path":
+                errors.append(
+                    _portal_issue(
+                        "sam2_checkpoint_path",
+                        "untrusted_checkpoint_path",
+                        "SAM2 checkpoint overrides must use a repo-controlled or checksum-verified file.",
+                        suggestion=(
+                            "Use ./models/sam2/... or ./checkpoints/... for repo-managed checkpoints, "
+                            "or provide a file whose SHA-256 matches the governed SAM2 checkpoint manifest."
+                        ),
                     )
-                else:
-                    message = _portal_safe_error_message(
-                        reason,
-                        field="sam2_checkpoint_path",
+                )
+            elif validation.reason is not None:
+                message = _portal_safe_error_message(
+                    validation.reason,
+                    field="sam2_checkpoint_path",
+                )
+                errors.append(
+                    _portal_issue(
+                        "sam2_checkpoint_path",
+                        validation.reason,
+                        message,
+                        suggestion=("Choose an existing checkpoint file under the configured repository or temp roots."),
                     )
-                    errors.append(
-                        _portal_issue(
-                            "sam2_checkpoint_path",
-                            reason,
-                            message,
-                            suggestion=("Choose an existing checkpoint file under the configured repository or temp roots."),
-                        )
-                    )
+                )
             else:
-                normalized_args["sam2_checkpoint_path"] = sam2_checkpoint_path
+                normalized_args["sam2_checkpoint_path"] = str(validation.normalized_path or sam2_checkpoint_path)
         else:
             normalized_args["sam2_checkpoint_path"] = sam2_checkpoint_path
     normalized_args["sam2_tiling_enabled"] = _as_bool(
@@ -6105,12 +6175,19 @@ def _argv_from_request(
 
         sam2_checkpoint_path = ""
         if sam2_checkpoint_path_raw is not None and str(sam2_checkpoint_path_raw).strip():
-            sam2_checkpoint_path = _validate_path_against_roots(
-                str(sam2_checkpoint_path_raw),
-                ALLOWED_INPUT_ROOTS,
-            )
             if segmentation_backend == "sam2":
-                sam2_checkpoint_path = _validate_managed_sam2_checkpoint_path(sam2_checkpoint_path)
+                validation = _resolve_managed_sam2_checkpoint_validation(str(sam2_checkpoint_path_raw))
+                if validation.reason is not None:
+                    raise _PortalValidationReasonError(
+                        _managed_sam2_reason_message(validation.reason),
+                        reason=validation.reason,
+                    )
+                sam2_checkpoint_path = str(validation.normalized_path or "")
+            else:
+                sam2_checkpoint_path = _validate_path_against_roots(
+                    str(sam2_checkpoint_path_raw),
+                    ALLOWED_INPUT_ROOTS,
+                )
 
         cameras_sidecar_path = ""
         if cameras_sidecar_path_raw is not None and str(cameras_sidecar_path_raw).strip():

--- a/app.py
+++ b/app.py
@@ -92,6 +92,36 @@ class _ManagedSam2ChecksumCacheEntry:
     reason: Optional[str]
 
 
+_MANAGED_SAM2_CHECKSUM_CACHE_MAX_ENTRIES = 128
+
+
+class _ManagedSam2BoundedChecksumCache(Dict[Tuple[str, int, int, int, int, int], _ManagedSam2ChecksumCacheEntry]):
+    """Bounded FIFO cache for SAM2 checkpoint trust results."""
+
+    def __init__(self, max_entries: int = _MANAGED_SAM2_CHECKSUM_CACHE_MAX_ENTRIES) -> None:
+        super().__init__()
+        if max_entries < 1:
+            raise ValueError("max_entries must be at least 1")
+        self._max_entries = max_entries
+        self._insertion_order: Deque[Tuple[str, int, int, int, int, int]] = deque()
+
+    def __setitem__(
+        self,
+        key: Tuple[str, int, int, int, int, int],
+        value: _ManagedSam2ChecksumCacheEntry,
+    ) -> None:
+        if key not in self:
+            self._insertion_order.append(key)
+            while len(self._insertion_order) > self._max_entries:
+                oldest = self._insertion_order.popleft()
+                super().pop(oldest, None)
+        super().__setitem__(key, value)
+
+    def clear(self) -> None:
+        super().clear()
+        self._insertion_order.clear()
+
+
 def _env_csv(name: str, default: List[str]) -> List[str]:
     raw = os.getenv(name)
     if raw is None:
@@ -590,7 +620,7 @@ _MANAGED_SAM2_REASON_MESSAGES = {
     "path_shorthand_traversal_disallowed": "Path shorthand traversal disallowed",
     "untrusted_checkpoint_path": "SAM2 checkpoint path is not trusted",
 }
-_MANAGED_SAM2_CHECKSUM_CACHE: Dict[Tuple[str, int, int], _ManagedSam2ChecksumCacheEntry] = {}
+_MANAGED_SAM2_CHECKSUM_CACHE: _ManagedSam2BoundedChecksumCache = _ManagedSam2BoundedChecksumCache()
 
 
 def _managed_sam2_reason_message(reason: str) -> str:
@@ -598,10 +628,17 @@ def _managed_sam2_reason_message(reason: str) -> str:
     return _MANAGED_SAM2_REASON_MESSAGES.get(reason, "Invalid path value")
 
 
-def _managed_sam2_checksum_cache_key(path: Path) -> Tuple[str, int, int]:
+def _managed_sam2_checksum_cache_key(path: Path) -> Tuple[str, int, int, int, int, int]:
     """Build the checksum cache key for a trusted SAM2 checkpoint path."""
     stat_result = path.stat()
-    return str(path), stat_result.st_size, stat_result.st_mtime_ns
+    return (
+        str(path),
+        stat_result.st_size,
+        stat_result.st_mtime_ns,
+        stat_result.st_dev,
+        stat_result.st_ino,
+        stat_result.st_ctime_ns,
+    )
 
 
 def _clear_managed_sam2_checksum_cache() -> None:
@@ -631,7 +668,7 @@ def _cached_managed_sam2_checksum_result(path: Path) -> _ManagedSam2ChecksumCach
     if cached is not None:
         return cached
 
-    _, size_bytes, _ = cache_key
+    _, size_bytes, _, _, _, _ = cache_key
     if size_bytes > MANAGED_SAM2_CHECKSUM_MAX_BYTES:
         entry = _ManagedSam2ChecksumCacheEntry(digest=None, reason="checkpoint_file_too_large")
     else:

--- a/app.py
+++ b/app.py
@@ -24,7 +24,7 @@ from email.policy import default as email_policy
 from functools import lru_cache
 from importlib.util import find_spec
 from pathlib import Path, PurePosixPath
-from typing import Any, AsyncGenerator, Callable, Deque, Dict, List, Mapping, Optional, Tuple
+from typing import Any, AsyncGenerator, Callable, Deque, Dict, List, Mapping, NamedTuple, Optional, Tuple
 from urllib.parse import quote
 
 from fastapi import FastAPI, HTTPException, Request
@@ -92,10 +92,21 @@ class _ManagedSam2ChecksumCacheEntry:
     reason: Optional[str]
 
 
+class _Sam2CacheKey(NamedTuple):
+    """Cache key for SAM2 checkpoint trust results."""
+
+    path: str
+    size: int
+    mtime_ns: int
+    dev: int
+    ino: int
+    ctime_ns: int
+
+
 _MANAGED_SAM2_CHECKSUM_CACHE_MAX_ENTRIES = 128
 
 
-class _ManagedSam2BoundedChecksumCache(Dict[Tuple[str, int, int, int, int, int], _ManagedSam2ChecksumCacheEntry]):
+class _ManagedSam2BoundedChecksumCache(Dict[_Sam2CacheKey, _ManagedSam2ChecksumCacheEntry]):
     """Bounded FIFO cache for SAM2 checkpoint trust results."""
 
     def __init__(self, max_entries: int = _MANAGED_SAM2_CHECKSUM_CACHE_MAX_ENTRIES) -> None:
@@ -103,16 +114,16 @@ class _ManagedSam2BoundedChecksumCache(Dict[Tuple[str, int, int, int, int, int],
         if max_entries < 1:
             raise ValueError("max_entries must be at least 1")
         self._max_entries = max_entries
-        self._insertion_order: Deque[Tuple[str, int, int, int, int, int]] = deque()
+        self._insertion_order: Deque[_Sam2CacheKey] = deque()
 
     def __setitem__(
         self,
-        key: Tuple[str, int, int, int, int, int],
+        key: _Sam2CacheKey,
         value: _ManagedSam2ChecksumCacheEntry,
     ) -> None:
         if key not in self:
             self._insertion_order.append(key)
-            while len(self._insertion_order) > self._max_entries:
+            if len(self._insertion_order) > self._max_entries:
                 oldest = self._insertion_order.popleft()
                 super().pop(oldest, None)
         super().__setitem__(key, value)
@@ -628,16 +639,16 @@ def _managed_sam2_reason_message(reason: str) -> str:
     return _MANAGED_SAM2_REASON_MESSAGES.get(reason, "Invalid path value")
 
 
-def _managed_sam2_checksum_cache_key(path: Path) -> Tuple[str, int, int, int, int, int]:
+def _managed_sam2_checksum_cache_key(path: Path) -> _Sam2CacheKey:
     """Build the checksum cache key for a trusted SAM2 checkpoint path."""
     stat_result = path.stat()
-    return (
-        str(path),
-        stat_result.st_size,
-        stat_result.st_mtime_ns,
-        stat_result.st_dev,
-        stat_result.st_ino,
-        stat_result.st_ctime_ns,
+    return _Sam2CacheKey(
+        path=str(path),
+        size=stat_result.st_size,
+        mtime_ns=stat_result.st_mtime_ns,
+        dev=stat_result.st_dev,
+        ino=stat_result.st_ino,
+        ctime_ns=stat_result.st_ctime_ns,
     )
 
 
@@ -668,8 +679,7 @@ def _cached_managed_sam2_checksum_result(path: Path) -> _ManagedSam2ChecksumCach
     if cached is not None:
         return cached
 
-    _, size_bytes, _, _, _, _ = cache_key
-    if size_bytes > MANAGED_SAM2_CHECKSUM_MAX_BYTES:
+    if cache_key.size > MANAGED_SAM2_CHECKSUM_MAX_BYTES:
         entry = _ManagedSam2ChecksumCacheEntry(digest=None, reason="checkpoint_file_too_large")
     else:
         digest = _hash_file_sha256(path)

--- a/docs/governance/DEPENDABOT_PR_GOVERNANCE.md
+++ b/docs/governance/DEPENDABOT_PR_GOVERNANCE.md
@@ -3,7 +3,7 @@
 **Purpose**: Define triage policy and merge criteria for Dependabot-generated pull requests
 **Owner**: Transformation Portal Architect
 **Created**: 2026-03-26
-**Last Updated**: 2026-03-26
+**Last Updated**: 2026-04-16
 
 ---
 
@@ -141,9 +141,28 @@ Dependabot PRs that bump exact-pinned dependencies **must not be merged as routi
 
 #### #1278 - curated Starlette compatibility (MERGED)
 - **Scope**: `pyproject.toml`, `requirements/base.in`, `requirements/base.txt`, `requirements/all.txt`
-- **Validated Set**: FastAPI `0.135.1`, Starlette `1.0.0`, Uvicorn `0.42.0`
+- **Validated Set**: FastAPI `0.136.0`, Starlette `1.0.0`, Uvicorn `0.42.0`
 - **Validation**: `make test-orchestrator-contract`, `make ci`, curated live orchestrator smoke
 - **Governance Lesson**: Exact-pinned web stack updates require issue-first / PR-second handling when Dependabot crosses a compatibility boundary
+
+---
+
+## "Dep Pin Changed" Checklist
+
+Use this checklist whenever a governed dependency pin changes, especially under
+`requirements/base.in` or the compiled lock contract:
+
+- [ ] Update the manifest input first (`requirements/*.in`, and `pyproject.toml`
+      only when the compatibility bound must move with it).
+- [ ] Regenerate only the affected governed lockfiles through the existing lock
+      workflow; do not hand-edit compiled lock output.
+- [ ] Re-run `make check-requirements-lock-contract` after regeneration.
+- [ ] Update workflow or contract tests that encode action pins, lock paths, or
+      compatibility expectations.
+- [ ] Update the relevant dependency-governance docs so the recorded baseline,
+      validation path, and runtime/toolchain requirements stay current.
+- [ ] Re-run the validation path for the touched surface (`make ci` at minimum;
+      add frontdoor or browser validation when the web/runtime boundary moved).
 
 ---
 
@@ -182,6 +201,7 @@ Before merging any Dependabot PR:
 |------|--------|--------|
 | 2026-03-26 | Initial creation with PR #1270-#1275 assessment | Architect |
 | 2026-03-26 | Updated after #1275 closure and curated Starlette merge via #1278 | Architect |
+| 2026-04-16 | Recorded the FastAPI 0.136.0 curated baseline and the "dep pin changed" checklist | Architect |
 | 2026-04-16 | Added ML alert dismissal/remediation governance for supported vs frozen target-owned lanes | Architect |
 
 ---

--- a/docs/guides/LOCAL_VALIDATION_QUICKSTART.md
+++ b/docs/guides/LOCAL_VALIDATION_QUICKSTART.md
@@ -26,6 +26,24 @@ This validates:
 - Chrome/Chromium availability
 - Port availability (3000, 8000)
 - Frontdoor npm dependencies
+- Validation smoke classification for the Python header guard
+
+### Validation Smoke Classification
+
+The pre-flight check now includes a bounded `validation-smoke` pass that runs the
+Python header validator and classifies failures as one of:
+
+- `pass` — the tracked Python header scan is clean
+- `environment_failure` — local tooling failed (for example `git ls-files` could
+  not run), so repair the environment before treating it as a code regression
+- `product_regression` — the validator found a real header violation or crashed
+  in a repo-owned validation path
+
+To inspect only that check in machine-readable form:
+
+```bash
+make check-environment CHECK_ENV_ARGS="--check validation-smoke --json"
+```
 
 ### Node.js Version (Important)
 

--- a/docs/guides/LUX_DEPTH_CONFIG_KNOB_CHECKLIST.md
+++ b/docs/guides/LUX_DEPTH_CONFIG_KNOB_CHECKLIST.md
@@ -1,0 +1,20 @@
+# Lux Depth Config Knob Checklist
+
+Use this checklist whenever a new `EnhanceConfig` knob is added or an existing
+one changes behavior.
+
+- Normalize or clamp the value in `EnhanceConfig.__post_init__` when the runtime
+  treats part of the input domain as equivalent.
+- Decide whether the knob changes the APEX gate fingerprint, the broader config
+  fingerprint, or neither, and add focused tests for that decision.
+- Keep cache keys narrow: if the knob changes review or policy behavior but does
+  not change depth output generation, prove the depth-cache payload stays
+  unchanged.
+- Check telemetry and preview/readout surfaces so the effective normalized value
+  is what operators see in diagnostics and review output.
+- Update the contributor-facing docs when the knob changes normalization rules,
+  fingerprint behavior, cache scope, or validation expectations.
+
+Current representative example: `apex_depth_threshold_epsilon` now normalizes at
+config construction so runtime gate math and fingerprint generation use the same
+effective policy surface.

--- a/public/portal-assets/portal-review.js
+++ b/public/portal-assets/portal-review.js
@@ -211,98 +211,132 @@ function createDeferredReviewSurfaceApi(host) {
     }
     els.artifactMetadataCard.appendChild(detail);
   }
-  function _reviewStatusSnapshot(job, artifact) {
-    if (!job) {
-      return {
-        visible: false,
-        tone: "info",
-        title: "Awaiting completed run",
-        detail: "Select a job to review related warnings, completion state, and output readiness.",
-        action: "Next action: use the selected run state, warning context, and freshness above to decide whether to recover or open review."
-      };
-    }
-    const summary = normalizeRunSummary(job.run_summary);
-    const reviewableOutputs = _jobHasReviewableOutputs(job);
-    const artifactCount = Array.isArray(job.artifacts) ? job.artifacts.length : 0;
-    const readableError = getReadableError(job.error);
-    const visibleWarning = _latestVisibleTransportWarning(job);
-    const freshnessLabel = _jobFreshnessLabel(job);
-    const outcomeSummary = typeof summary?.outcome_summary === "string" ? summary.outcome_summary.trim() : "";
-    if (job.state === "partial") {
-      return {
-        visible: true,
-        tone: "warning",
-        title: "Run partially completed",
-        detail: outcomeSummary ? `${outcomeSummary}. Updated ${freshnessLabel}.` : "Some inputs failed, but outputs remain reviewable.",
-        action: "Next action: open review for the retained outputs before rerunning failed inputs."
-      };
-    }
-    if (job.state === "failed") {
-      return {
-        visible: true,
-        tone: reviewableOutputs ? "warning" : "error",
-        title: reviewableOutputs ? "Run failed after indexing reviewable outputs" : "Run failed before outputs were ready",
-        detail: readableError || (reviewableOutputs ? `${artifactCount} artifact${artifactCount === 1 ? "" : "s"} remain available for review. Updated ${freshnessLabel}.` : "No reviewable outputs were indexed before the failure was reported."),
-        action: reviewableOutputs ? "Next action: open review for the retained outputs, then decide whether this run needs a retry." : "Next action: inspect the latest warning and failure context in Operate before retrying the run."
-      };
-    }
-    if (job.state === "canceled") {
-      return {
-        visible: true,
-        tone: reviewableOutputs ? "warning" : "error",
-        title: reviewableOutputs ? "Run canceled after partial output capture" : "Run canceled before review outputs were ready",
-        detail: reviewableOutputs ? `${artifactCount} artifact${artifactCount === 1 ? "" : "s"} remain available for review despite cancellation. Updated ${freshnessLabel}.` : "Execution was canceled before reviewable outputs were indexed.",
-        action: reviewableOutputs ? "Next action: review the retained outputs before deciding whether to rerun the canceled work." : "Next action: reopen Build or restore the run context before dispatching again."
-      };
-    }
-    if (job.state === "offline") {
-      return {
-        visible: true,
-        tone: "warning",
-        title: reviewableOutputs ? "Run is offline with reviewable outputs" : "Run is offline",
-        detail: reviewableOutputs ? `${artifactCount} artifact${artifactCount === 1 ? "" : "s"} remain available, but live backend status is stale until connectivity is restored.` : "Live backend status is stale until connectivity is restored.",
-        action: reviewableOutputs ? "Next action: review the cached outputs while backend connectivity recovers." : "Next action: restore backend connectivity before depending on this run state."
-      };
-    }
-    if (job.reconnectBlocked) {
-      return {
-        visible: true,
-        tone: "warning",
-        title: "Transport warning recorded",
-        detail: "Authentication must be restored before live event transport can reconnect.",
-        action: "Next action: restore authentication so live transport and freshness can recover."
-      };
-    }
-    if (visibleWarning) {
-      return {
-        visible: true,
-        tone: visibleWarning.tone === "error" ? "error" : "warning",
-        title: "Transport warning recorded",
-        detail: String(visibleWarning.detail || "Live transport reported an operator-visible warning."),
-        action: "Next action: inspect the latest transport warning in Operate before continuing into review."
-      };
-    }
-    if (job.state === "running" || job.state === "queued") {
-      return {
-        visible: true,
-        tone: "info",
-        title: "Run still in progress",
-        detail: artifactCount > 0 ? `${artifactCount} artifact${artifactCount === 1 ? "" : "s"} already indexed. Updated ${freshnessLabel}.` : "Artifacts and provenance will populate here as outputs arrive.",
-        action: artifactCount > 0 ? "Next action: keep review open only if you need the early artifacts; Operate remains the primary live surface." : "Next action: stay in Operate until indexed outputs or a blocking warning arrives."
-      };
-    }
-    return {
+  const REVIEW_STATUS_BUILDERS = Object.freeze({
+    awaiting_job: () => ({
+      visible: false,
+      tone: "info",
+      title: "Awaiting completed run",
+      detail: "Select a job to review related warnings, completion state, and output readiness.",
+      action: "Next action: use the selected run state, warning context, and freshness above to decide whether to recover or open review."
+    }),
+    partial_reviewable: ({ outcomeSummary, freshnessLabel }) => ({
+      visible: true,
+      tone: "warning",
+      title: "Run partially completed",
+      detail: outcomeSummary ? `${outcomeSummary}. Updated ${freshnessLabel}.` : "Some inputs failed, but outputs remain reviewable.",
+      action: "Next action: open review for the retained outputs before rerunning failed inputs."
+    }),
+    failed_reviewable: ({ readableError, artifactCount, freshnessLabel }) => ({
+      visible: true,
+      tone: "warning",
+      title: "Run failed after indexing reviewable outputs",
+      detail: readableError || `${artifactCount} artifact${artifactCount === 1 ? "" : "s"} remain available for review. Updated ${freshnessLabel}.`,
+      action: "Next action: open review for the retained outputs, then decide whether this run needs a retry."
+    }),
+    failed_unreviewable: ({ readableError }) => ({
+      visible: true,
+      tone: "error",
+      title: "Run failed before outputs were ready",
+      detail: readableError || "No reviewable outputs were indexed before the failure was reported.",
+      action: "Next action: inspect the latest warning and failure context in Operate before retrying the run."
+    }),
+    canceled_reviewable: ({ artifactCount, freshnessLabel }) => ({
+      visible: true,
+      tone: "warning",
+      title: "Run canceled after partial output capture",
+      detail: `${artifactCount} artifact${artifactCount === 1 ? "" : "s"} remain available for review despite cancellation. Updated ${freshnessLabel}.`,
+      action: "Next action: review the retained outputs before deciding whether to rerun the canceled work."
+    }),
+    canceled_unreviewable: () => ({
+      visible: true,
+      tone: "error",
+      title: "Run canceled before review outputs were ready",
+      detail: "Execution was canceled before reviewable outputs were indexed.",
+      action: "Next action: reopen Build or restore the run context before dispatching again."
+    }),
+    offline_reviewable: ({ artifactCount }) => ({
+      visible: true,
+      tone: "warning",
+      title: "Run is offline with reviewable outputs",
+      detail: `${artifactCount} artifact${artifactCount === 1 ? "" : "s"} remain available, but live backend status is stale until connectivity is restored.`,
+      action: "Next action: review the cached outputs while backend connectivity recovers."
+    }),
+    offline_unreviewable: () => ({
+      visible: true,
+      tone: "warning",
+      title: "Run is offline",
+      detail: "Live backend status is stale until connectivity is restored.",
+      action: "Next action: restore backend connectivity before depending on this run state."
+    }),
+    transport_blocked: () => ({
+      visible: true,
+      tone: "warning",
+      title: "Transport warning recorded",
+      detail: "Authentication must be restored before live event transport can reconnect.",
+      action: "Next action: restore authentication so live transport and freshness can recover."
+    }),
+    transport_warning: ({ visibleWarning }) => ({
+      visible: true,
+      tone: visibleWarning.tone === "error" ? "error" : "warning",
+      title: "Transport warning recorded",
+      detail: String(visibleWarning.detail || "Live transport reported an operator-visible warning."),
+      action: "Next action: inspect the latest transport warning in Operate before continuing into review."
+    }),
+    in_progress: ({ artifactCount, freshnessLabel }) => ({
+      visible: true,
+      tone: "info",
+      title: "Run still in progress",
+      detail: artifactCount > 0 ? `${artifactCount} artifact${artifactCount === 1 ? "" : "s"} already indexed. Updated ${freshnessLabel}.` : "Artifacts and provenance will populate here as outputs arrive.",
+      action: artifactCount > 0 ? "Next action: keep review open only if you need the early artifacts; Operate remains the primary live surface." : "Next action: stay in Operate until indexed outputs or a blocking warning arrives."
+    }),
+    ready: ({ artifact, artifactCount, outcomeSummary, freshnessLabel }) => ({
       visible: true,
       tone: "ready",
       title: artifact ? "Outputs ready for review" : "Run ready for review",
       detail: outcomeSummary ? `${outcomeSummary}. Updated ${freshnessLabel}.` : `${artifactCount} artifact${artifactCount === 1 ? "" : "s"} indexed and ready for operator review.`,
       action: "Next action: use the selected run state, warning context, and freshness above to decide whether to recover or open review."
+    })
+  });
+  function _reviewStatusState(job, reviewableOutputs, visibleWarning) {
+    if (!job) return "awaiting_job";
+    if (job.state === "partial") return "partial_reviewable";
+    if (job.state === "failed") return reviewableOutputs ? "failed_reviewable" : "failed_unreviewable";
+    if (job.state === "canceled") return reviewableOutputs ? "canceled_reviewable" : "canceled_unreviewable";
+    if (job.state === "offline") return reviewableOutputs ? "offline_reviewable" : "offline_unreviewable";
+    if (job.reconnectBlocked) return "transport_blocked";
+    if (visibleWarning) return "transport_warning";
+    if (job.state === "running" || job.state === "queued") return "in_progress";
+    return "ready";
+  }
+  function _reviewStatusSnapshot(job, artifact) {
+    const summary = job ? normalizeRunSummary(job.run_summary) : {};
+    const reviewableOutputs = _jobHasReviewableOutputs(job);
+    const artifactCount = job && Array.isArray(job.artifacts) ? job.artifacts.length : 0;
+    const readableError = job ? getReadableError(job.error) : "";
+    const visibleWarning = _latestVisibleTransportWarning(job);
+    const freshnessLabel = _jobFreshnessLabel(job);
+    const outcomeSummary = typeof summary?.outcome_summary === "string" ? summary.outcome_summary.trim() : "";
+    const stateToken = _reviewStatusState(job, reviewableOutputs, visibleWarning);
+    const builder = REVIEW_STATUS_BUILDERS[stateToken] || REVIEW_STATUS_BUILDERS.ready;
+    return {
+      state: stateToken,
+      ...builder({
+        artifact,
+        artifactCount,
+        freshnessLabel,
+        outcomeSummary,
+        readableError,
+        reviewableOutputs,
+        summary,
+        visibleWarning
+      })
     };
   }
   function _renderReviewStatusBanner(job, artifact) {
     if (!els.reviewStatusBanner || !els.reviewStatusTitle || !els.reviewStatusDetail) return;
     const snapshot = _reviewStatusSnapshot(job, artifact);
     els.reviewStatusBanner.dataset.tone = snapshot.tone;
+    els.reviewStatusBanner.dataset.reviewState = snapshot.state;
     if (!snapshot.visible) {
       els.reviewStatusBanner.classList.add("hidden");
       els.reviewStatusTitle.textContent = snapshot.title;

--- a/requirements/README.md
+++ b/requirements/README.md
@@ -126,11 +126,11 @@ The repository's governed web stack currently resolves to:
 
 | Dependency | Source of Truth | Current Version |
 |-----------|-----------------|-----------------|
-| FastAPI | `requirements/base.in` | `0.135.1` |
+| FastAPI | `requirements/base.in` | `0.136.0` |
 | Starlette | `requirements/base.in` + `pyproject.toml` bound | `1.0.0` |
 | Uvicorn | `requirements/base.in` | `0.42.0` |
 
-This baseline was validated and merged via the curated compatibility path on 2026-03-26. Do not treat future updates to these exact pins as routine dependency bumps; use the governance flow documented in `docs/governance/DEPENDABOT_PR_GOVERNANCE.md`.
+This baseline was validated and merged via the curated compatibility path on 2026-04-15. Do not treat future updates to these exact pins as routine dependency bumps; use the governance flow documented in `docs/governance/DEPENDABOT_PR_GOVERNANCE.md`.
 
 ### Layered ML Strategy
 

--- a/scripts/validation/check_local_environment.py
+++ b/scripts/validation/check_local_environment.py
@@ -23,6 +23,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import os
 import re
 import shutil
@@ -52,10 +53,12 @@ class CheckResult:
     message: str
     is_hard_requirement: bool = True
     guidance: Optional[str] = None
+    classification: Optional[str] = None
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 FRONTDOOR_ROOT = REPO_ROOT / "web" / "secure-landing"
+CHECK_PYTHON_HEADERS_PATH = Path(__file__).resolve().with_name("check_python_headers.py")
 # Platform-aware venv interpreter path
 if sys.platform == "win32":
     REPO_VENV_PYTHON = REPO_ROOT / ".venv" / "Scripts" / "python.exe"
@@ -440,6 +443,66 @@ def check_dependency_health() -> CheckResult:
     )
 
 
+def _load_python_header_validator():
+    """Load the Python header validator module from the local validation scripts."""
+    spec = importlib.util.spec_from_file_location("tp_check_python_headers", CHECK_PYTHON_HEADERS_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load validation helper at {CHECK_PYTHON_HEADERS_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def check_validation_smoke() -> CheckResult:
+    """Run a bounded validation smoke check and classify failure source."""
+    try:
+        validator = _load_python_header_validator()
+    except Exception as exc:
+        return CheckResult(
+            name="Validation smoke",
+            passed=False,
+            message=f"Could not load Python header validator: {exc}",
+            guidance="Treat this as a product regression in the validation path and inspect `scripts/validation/check_python_headers.py`.",
+            classification="product_regression",
+        )
+
+    tooling_error_type = getattr(validator, "PythonHeaderToolingError", RuntimeError)
+    try:
+        violations = validator.find_violations()
+    except tooling_error_type as exc:
+        return CheckResult(
+            name="Validation smoke",
+            passed=False,
+            message=str(exc),
+            guidance='Repair local git/tooling availability, then rerun `make check-environment CHECK_ENV_ARGS="--check validation-smoke --json"`.',
+            classification="environment_failure",
+        )
+    except Exception as exc:
+        return CheckResult(
+            name="Validation smoke",
+            passed=False,
+            message=f"Python header validation crashed: {exc}",
+            guidance="Treat this as a product regression in the validation path and inspect `scripts/validation/check_python_headers.py`.",
+            classification="product_regression",
+        )
+
+    if violations:
+        return CheckResult(
+            name="Validation smoke",
+            passed=False,
+            message=f"Python header validation found {len(violations)} violation(s); first: {violations[0]}",
+            guidance="Fix the reported header violations, then rerun `make check-python-headers`.",
+            classification="product_regression",
+        )
+
+    return CheckResult(
+        name="Validation smoke",
+        passed=True,
+        message="Python header validation passed on tracked files",
+        classification="pass",
+    )
+
+
 def run_all_checks(
     checks: Optional[list[str]] = None,
 ) -> tuple[list[CheckResult], ExitCode]:
@@ -454,6 +517,7 @@ def run_all_checks(
         "frontdoor": check_frontdoor_dependencies,
         "venv": check_venv_active,
         "dependency-health": check_dependency_health,
+        "validation-smoke": check_validation_smoke,
         "env": check_env_vars,
     }
 
@@ -501,6 +565,8 @@ def print_results(results: list[CheckResult], exit_code: ExitCode) -> None:
         req = "" if result.is_hard_requirement else " (optional)"
         print(f"  {status} {result.name}{req}")
         print(f"      {result.message}")
+        if result.classification:
+            print(f"      Classification: {result.classification}")
         if result.guidance and not result.passed:
             print(f"      → {result.guidance}")
         print()
@@ -533,6 +599,7 @@ Examples:
     %(prog)s --check chrome  Check only Chrome availability
     %(prog)s --check ports   Check only port availability
     %(prog)s --check dependency-health  Check pip dependency health
+    %(prog)s --check validation-smoke  Classify validation smoke failures as environment vs product issues
     %(prog)s --quiet         Only output failures
         """,
     )
@@ -543,7 +610,7 @@ Examples:
     )
     parser.add_argument(
         "--check",
-        choices=["python", "node", "chrome", "ports", "frontdoor", "venv", "dependency-health", "env"],
+        choices=["python", "node", "chrome", "ports", "frontdoor", "venv", "dependency-health", "validation-smoke", "env"],
         action="append",
         help="Run only specified check(s)",
     )
@@ -576,6 +643,7 @@ Examples:
                     "message": r.message,
                     "is_hard_requirement": r.is_hard_requirement,
                     "guidance": r.guidance,
+                    "classification": r.classification,
                 }
                 for r in results
             ],
@@ -590,6 +658,8 @@ Examples:
         if failed:
             for result in failed:
                 print(f"✗ {result.name}: {result.message}")
+                if result.classification:
+                    print(f"  Classification: {result.classification}")
                 if result.guidance:
                     print(f"  → {result.guidance}")
     else:

--- a/scripts/validation/check_python_headers.py
+++ b/scripts/validation/check_python_headers.py
@@ -23,6 +23,20 @@ HEADER_COOKIE_PATTERN = re.compile(r"\b(?:coding|encoding)\s*[:=]\s*([-\w.]+)")
 PEP263_PATTERN = re.compile(r"coding[:=]\s*([-\w.]+)")
 
 
+class PythonHeaderToolingError(RuntimeError):
+    """Deterministic tooling failure raised while discovering tracked files."""
+
+    def __init__(self, code: str, message: str):
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+def _format_tooling_error(exc: PythonHeaderToolingError) -> str:
+    """Return a machine-parsable tooling error string for CLI output."""
+    return f"TOOLING_ERROR[{exc.code}]: {exc.message}"
+
+
 def iter_python_files(roots: Iterable[Path]) -> list[Path]:
     """Return Python source files under the supplied roots."""
     files: list[Path] = []
@@ -39,16 +53,25 @@ def iter_python_files(roots: Iterable[Path]) -> list[Path]:
 
 def iter_tracked_python_files(project_root: Path = PROJECT_ROOT) -> list[Path]:
     """Return tracked Python files from git."""
-    result = subprocess.run(
-        ["git", "ls-files", "--", "*.py"],
-        cwd=project_root,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    try:
+        result = subprocess.run(
+            ["git", "ls-files", "--", "*.py"],
+            cwd=project_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError as exc:
+        raise PythonHeaderToolingError(
+            "git_ls_files_invocation_failed",
+            f"git ls-files could not run: {exc}",
+        ) from exc
     if result.returncode != 0:
         stderr = result.stderr.strip()
-        raise RuntimeError(f"git ls-files failed: {stderr or 'unknown error'}")
+        raise PythonHeaderToolingError(
+            "git_ls_files_failed",
+            f"git ls-files failed: {stderr or 'unknown error'}",
+        )
     files = [project_root / line for line in result.stdout.splitlines() if line.strip()]
     return sorted(path.resolve() for path in files)
 
@@ -112,7 +135,11 @@ def main() -> int:
     args = parser.parse_args()
 
     roots = tuple(Path(path) for path in args.paths) if args.paths else None
-    violations = find_violations(roots)
+    try:
+        violations = find_violations(roots)
+    except PythonHeaderToolingError as exc:
+        print(_format_tooling_error(exc))
+        return 1
     if not violations:
         print("OK: Python header declarations are valid")
         return 0

--- a/scripts/validation/validate_portal_browser_smoke.py
+++ b/scripts/validation/validate_portal_browser_smoke.py
@@ -750,6 +750,10 @@ def _state_probe_expression() -> str:
       const el = document.getElementById('reviewStatusBanner');
       return el ? String(el.dataset.tone || '') : '';
     })(),
+    reviewStatusState: (() => {
+      const el = document.getElementById('reviewStatusBanner');
+      return el ? String(el.dataset.reviewState || '') : '';
+    })(),
     reviewStatusVisible: (() => {
       const el = document.getElementById('reviewStatusBanner');
       return !!(el && !el.classList.contains('hidden'));
@@ -2352,6 +2356,10 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
         _expect(
             str(run_state.get("reviewStatusTone", "")).strip().lower() == "ready",
             f"Review workspace should expose a ready status banner after a successful run: {run_state}",
+        )
+        _expect(
+            str(run_state.get("reviewStatusState", "")).strip() == "ready",
+            f"Review workspace should expose the machine-readable review state token: {run_state}",
         )
         _expect(
             "Outputs ready for review" in str(run_state.get("reviewStatusTitle", "")),

--- a/src/transformation_portal/lux_depth_v3/config.py
+++ b/src/transformation_portal/lux_depth_v3/config.py
@@ -431,6 +431,10 @@ class EnhanceConfig:
             float(self.apex_depth_low_saturation_warning_band),
             0.0,
         )
+        self.apex_depth_threshold_epsilon = max(
+            float(self.apex_depth_threshold_epsilon),
+            0.0,
+        )
 
     @property
     def enable_pbr(self) -> bool:

--- a/tests/lux_depth_v3/test_config_resolver.py
+++ b/tests/lux_depth_v3/test_config_resolver.py
@@ -457,6 +457,7 @@ class TestBuildFingerprintPayloads:
         assert "min_finite_pct" in payload
         assert "min_gradient_energy" in payload
         assert payload["low_saturation_warning_band"] == pytest.approx(0.0075)
+        assert payload["threshold_epsilon"] == pytest.approx(1e-6)
 
     def test_fingerprint_changes_when_low_saturation_warning_band_changes(self):
         """APEX gate fingerprint should change when the warning band changes."""
@@ -503,6 +504,55 @@ class TestBuildFingerprintPayloads:
         )
         payload_b = build_depth_cache_payload(
             EnhanceConfig(apex_depth_low_saturation_warning_band=0.01),
+        )
+
+        assert payload_a == payload_b
+
+    def test_apex_depth_gate_fingerprint_normalizes_negative_threshold_epsilon(self):
+        """Negative threshold epsilon should fingerprint as the effective non-negative policy."""
+        from transformation_portal.lux_depth_v3.config import EnhanceConfig
+        from transformation_portal.lux_depth_v3.config_resolver import (
+            build_apex_depth_gate_fingerprint_payload,
+            compute_config_fingerprint,
+        )
+
+        negative_config = EnhanceConfig(apex_depth_threshold_epsilon=-1e-3)
+        zero_config = EnhanceConfig(apex_depth_threshold_epsilon=0.0)
+
+        negative_payload = build_apex_depth_gate_fingerprint_payload(negative_config)
+        zero_payload = build_apex_depth_gate_fingerprint_payload(zero_config)
+
+        assert negative_payload["threshold_epsilon"] == pytest.approx(0.0)
+        assert negative_payload == zero_payload
+        assert compute_config_fingerprint(negative_config).to_sha256() == compute_config_fingerprint(zero_config).to_sha256()
+
+    def test_fingerprint_changes_when_threshold_epsilon_changes(self):
+        """APEX gate fingerprint should change when threshold epsilon changes."""
+        from transformation_portal.lux_depth_v3.config import EnhanceConfig
+        from transformation_portal.lux_depth_v3.config_resolver import (
+            compute_config_fingerprint,
+        )
+
+        config_a = EnhanceConfig(apex_depth_threshold_epsilon=1e-6)
+        config_b = EnhanceConfig(apex_depth_threshold_epsilon=1e-4)
+
+        fingerprint_a = compute_config_fingerprint(config_a)
+        fingerprint_b = compute_config_fingerprint(config_b)
+
+        assert fingerprint_a.to_sha256() != fingerprint_b.to_sha256()
+
+    def test_depth_cache_payload_ignores_threshold_epsilon(self):
+        """Depth cache payload should not change when only gate epsilon changes."""
+        from transformation_portal.lux_depth_v3.config import EnhanceConfig
+        from transformation_portal.lux_depth_v3.config_resolver import (
+            build_depth_cache_payload,
+        )
+
+        payload_a = build_depth_cache_payload(
+            EnhanceConfig(apex_depth_threshold_epsilon=1e-6),
+        )
+        payload_b = build_depth_cache_payload(
+            EnhanceConfig(apex_depth_threshold_epsilon=1e-4),
         )
 
         assert payload_a == payload_b

--- a/tests/test_app_orchestrator_runtime.py
+++ b/tests/test_app_orchestrator_runtime.py
@@ -2688,6 +2688,56 @@ def test_managed_sam2_checkpoint_validation_reuses_cached_hash_result(
     assert hash_calls == [checkpoint_path]
 
 
+def test_managed_sam2_bounded_checksum_cache_eviction() -> None:
+    """Verify bounded cache evicts oldest entries when capacity is exceeded (FIFO)."""
+    cache = orchestrator_app._ManagedSam2BoundedChecksumCache(max_entries=3)
+
+    # Insert 3 entries at capacity
+    key1 = ("/path/a.pt", 100, 1000, 1, 1001, 2000)
+    key2 = ("/path/b.pt", 200, 1000, 1, 1002, 2000)
+    key3 = ("/path/c.pt", 300, 1000, 1, 1003, 2000)
+    entry = orchestrator_app._ManagedSam2ChecksumCacheEntry(digest="abc", reason=None)
+
+    cache[key1] = entry
+    cache[key2] = entry
+    cache[key3] = entry
+
+    assert len(cache) == 3
+    assert key1 in cache
+    assert key2 in cache
+    assert key3 in cache
+
+    # Insert a 4th entry, should evict the oldest (key1)
+    key4 = ("/path/d.pt", 400, 1000, 1, 1004, 2000)
+    cache[key4] = entry
+
+    assert len(cache) == 3
+    assert key1 not in cache  # evicted (oldest)
+    assert key2 in cache
+    assert key3 in cache
+    assert key4 in cache
+
+    # Insert a 5th entry, should evict key2
+    key5 = ("/path/e.pt", 500, 1000, 1, 1005, 2000)
+    cache[key5] = entry
+
+    assert len(cache) == 3
+    assert key2 not in cache  # evicted
+    assert key3 in cache
+    assert key4 in cache
+    assert key5 in cache
+
+    # Updating an existing key should not evict
+    cache[key3] = orchestrator_app._ManagedSam2ChecksumCacheEntry(digest="updated", reason=None)
+    assert len(cache) == 3
+    assert cache[key3].digest == "updated"
+
+    # Clear should empty both dict and deque
+    cache.clear()
+    assert len(cache) == 0
+    assert len(cache._insertion_order) == 0
+
+
 @pytest.mark.parametrize(
     ("artifact_name", "artifact_bytes", "size_limit", "expected_reason"),
     [

--- a/tests/test_app_orchestrator_runtime.py
+++ b/tests/test_app_orchestrator_runtime.py
@@ -1205,6 +1205,7 @@ def test_portal_review_surface_exposes_warning_banner_and_provenance_contract() 
     content = _portal_bundle_content()
     review_content = _portal_review_source_content()
     render_body = _extract_js_function_body(review_content, "renderArtifactPanel")
+    state_body = _extract_js_function_body(review_content, "_reviewStatusState")
     status_body = _extract_js_function_body(review_content, "_reviewStatusSnapshot")
     banner_body = _extract_js_function_body(review_content, "_renderReviewStatusBanner")
     provenance_body = _extract_js_function_body(review_content, "_renderArtifactProvenance")
@@ -1222,20 +1223,37 @@ def test_portal_review_surface_exposes_warning_banner_and_provenance_contract() 
     assert 'id="reviewProvenanceBatch"' in content
     assert 'data-ui="review-status-banner"' in content
     assert 'data-ui="review-provenance-grid"' in content
+    assert "function _reviewStatusState(job, reviewableOutputs, visibleWarning) {" in review_content
     assert "_renderReviewStatusBanner(selected, selectedArtifact);" in render_body
     assert "_renderArtifactProvenance(selected, selectedArtifact);" in render_body
     assert "_renderReviewStatusBanner(selected, null);" in render_body
     assert "_renderArtifactProvenance(selected, null);" in render_body
     assert "_renderReviewStatusBanner(null, null);" in render_body
     assert "_renderArtifactProvenance(null, null);" in render_body
+    for state_token in (
+        "awaiting_job",
+        "partial_reviewable",
+        "failed_reviewable",
+        "failed_unreviewable",
+        "canceled_reviewable",
+        "canceled_unreviewable",
+        "offline_reviewable",
+        "offline_unreviewable",
+        "transport_blocked",
+        "transport_warning",
+        "in_progress",
+        "ready",
+    ):
+        assert f'"{state_token}"' in state_body
     for job_state in ("partial", "failed", "canceled", "offline"):
-        assert re.search(rf"job\.state === [\"']{job_state}[\"']", status_body)
-    assert "job.reconnectBlocked" in status_body
-    assert "Outputs ready for review" in status_body
-    assert "Run canceled after partial output capture" in status_body
-    assert "Run is offline with reviewable outputs" in status_body
+        assert re.search(rf"job\.state === [\"']{job_state}[\"']", state_body)
+    assert "job.reconnectBlocked" in state_body
+    assert "Outputs ready for review" in review_content
+    assert "Run canceled after partial output capture" in review_content
+    assert "Run is offline with reviewable outputs" in review_content
     assert "_jobFreshnessLabel(job)" in status_body
     assert "els.reviewStatusBanner.dataset.tone = snapshot.tone;" in banner_body
+    assert "els.reviewStatusBanner.dataset.reviewState = snapshot.state;" in banner_body
     assert "artifactDisplayLabel(artifact)" in provenance_body
     assert "artifactLabel(artifact)" in provenance_body
     assert "_artifactFingerprintLabel(artifact)" in provenance_body
@@ -2062,9 +2080,10 @@ def test_portal_runtime_briefing_and_recovery_surfaces_stay_additive_and_selecto
         r"action:\s*[\"\']Next action: inspect the selected run in Operate or wait for indexed outputs before reopening review\.[\"\']",
         artifact_empty_body,
     )
-    assert re.search(
-        r"action:\s*[\"\']Next action: use the selected run state, warning context, and freshness above to decide whether to recover or open review\.[\"\']",
-        review_status_body,
+    assert "const builder = REVIEW_STATUS_BUILDERS[stateToken] || REVIEW_STATUS_BUILDERS.ready;" in review_status_body
+    assert (
+        "Next action: use the selected run state, warning context, and freshness above to decide whether to recover or open review."
+        in review_content
     )
     assert "els.reviewStatusAction.textContent = snapshot.action;" in review_content
     assert "els.selectedJobRecoveryTitle.textContent = recovery.title;" in inspector_body
@@ -2535,6 +2554,17 @@ def test_validate_managed_sam2_checkpoint_path_allows_repo_controlled_missing_pa
     assert normalized.endswith("models/sam2/sam2.1_hiera_large.pt")
 
 
+def test_resolve_managed_sam2_checkpoint_validation_preserves_untrusted_reason(tmp_path: Path) -> None:
+    checkpoint_path = tmp_path / "sam2-untrusted.pt"
+    checkpoint_path.write_bytes(b"untrusted checkpoint bytes")
+    orchestrator_app._clear_managed_sam2_checksum_cache()
+
+    validation = orchestrator_app._resolve_managed_sam2_checkpoint_validation(str(checkpoint_path))
+
+    assert validation.normalized_path is None
+    assert validation.reason == "untrusted_checkpoint_path"
+
+
 def test_argv_rejects_untrusted_sam2_checkpoint_path(tmp_path: Path) -> None:
     input_dir = tmp_path / "input"
     output_dir = tmp_path / "output"
@@ -2554,8 +2584,10 @@ def test_argv_rejects_untrusted_sam2_checkpoint_path(tmp_path: Path) -> None:
         },
     }
 
-    with pytest.raises(ValueError, match="SAM2 checkpoint path is not trusted"):
+    with pytest.raises(orchestrator_app._PortalValidationReasonError, match="SAM2 checkpoint path is not trusted") as exc_info:
         orchestrator_app._argv_from_request(payload)
+
+    assert exc_info.value.reason == "untrusted_checkpoint_path"
 
 
 def test_ensure_safe_regular_file_path_preserves_outside_root_reason(tmp_path: Path) -> None:
@@ -2591,8 +2623,10 @@ def test_argv_rejects_non_file_sam2_checkpoint_path(tmp_path: Path) -> None:
         },
     }
 
-    with pytest.raises(ValueError, match="Invalid path value"):
+    with pytest.raises(orchestrator_app._PortalValidationReasonError, match="Invalid path value") as exc_info:
         orchestrator_app._argv_from_request(payload)
+
+    assert exc_info.value.reason == "invalid_path_value"
 
 
 def test_argv_rejects_oversized_sam2_checkpoint_path(
@@ -2618,8 +2652,90 @@ def test_argv_rejects_oversized_sam2_checkpoint_path(
         },
     }
 
-    with pytest.raises(ValueError, match="checksum verification size limit"):
+    with pytest.raises(
+        orchestrator_app._PortalValidationReasonError,
+        match="checksum verification size limit",
+    ) as exc_info:
         orchestrator_app._argv_from_request(payload)
+
+    assert exc_info.value.reason == "checkpoint_file_too_large"
+
+
+def test_managed_sam2_checkpoint_validation_reuses_cached_hash_result(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    checkpoint_path = (tmp_path / "sam2-governed.pt").resolve()
+    checkpoint_path.write_bytes(b"trusted checkpoint bytes")
+    digest = hashlib.sha256(b"trusted checkpoint bytes").hexdigest()
+    orchestrator_app._clear_managed_sam2_checksum_cache()
+    monkeypatch.setattr(orchestrator_app, "MANAGED_SAM2_TRUSTED_SHA256", {digest})
+
+    hash_calls: list[Path] = []
+    original_hash = orchestrator_app._hash_file_sha256
+
+    def _counting_hash(path: Path, chunk_size: int = 1024 * 1024) -> str:
+        hash_calls.append(path)
+        return original_hash(path, chunk_size)
+
+    monkeypatch.setattr(orchestrator_app, "_hash_file_sha256", _counting_hash)
+
+    first = orchestrator_app._validate_managed_sam2_checkpoint_path(str(checkpoint_path))
+    second = orchestrator_app._validate_managed_sam2_checkpoint_path(str(checkpoint_path))
+
+    assert first == str(checkpoint_path)
+    assert second == str(checkpoint_path)
+    assert hash_calls == [checkpoint_path]
+
+
+@pytest.mark.parametrize(
+    ("artifact_name", "artifact_bytes", "size_limit", "expected_reason"),
+    [
+        ("sam2-untrusted.pt", b"untrusted checkpoint bytes", None, "untrusted_checkpoint_path"),
+        ("sam2-checkpoint-dir", None, None, "invalid_path_value"),
+        ("sam2-oversized.pt", b"oversized", 1, "checkpoint_file_too_large"),
+    ],
+)
+def test_sam2_checkpoint_preview_and_dispatch_share_reason_codes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    artifact_name: str,
+    artifact_bytes: bytes | None,
+    size_limit: int | None,
+    expected_reason: str,
+) -> None:
+    input_dir = (tmp_path / "input").resolve()
+    output_dir = (tmp_path / "output").resolve()
+    input_dir.mkdir()
+    output_dir.mkdir()
+    checkpoint_path = (tmp_path / artifact_name).resolve()
+    if artifact_bytes is None:
+        checkpoint_path.mkdir()
+    else:
+        checkpoint_path.write_bytes(artifact_bytes)
+    if size_limit is not None:
+        monkeypatch.setattr(orchestrator_app, "MANAGED_SAM2_CHECKSUM_MAX_BYTES", size_limit)
+    orchestrator_app._clear_managed_sam2_checksum_cache()
+
+    payload: Dict[str, object] = {
+        "pipeline": "lux-depth-v3",
+        "args": {
+            "input_dir": str(input_dir),
+            "output_dir": str(output_dir),
+            "enable_segmentation": True,
+            "segmentation_backend": "sam2",
+            "sam2_checkpoint_path": str(checkpoint_path),
+        },
+    }
+
+    preview = orchestrator_app._build_config_preview(payload)
+    preview_error = next(item for item in preview["field_errors"] if item["field"] == "sam2_checkpoint_path")
+
+    with pytest.raises(orchestrator_app._PortalValidationReasonError) as exc_info:
+        orchestrator_app._argv_from_request(payload)
+
+    assert preview_error["code"] == expected_reason
+    assert exc_info.value.reason == expected_reason
 
 
 def test_argv_rejects_invalid_raw_ingest_mode() -> None:

--- a/tests/test_lux_depth_v3_config.py
+++ b/tests/test_lux_depth_v3_config.py
@@ -150,6 +150,16 @@ class TestEnhanceConfig:
 
         assert config.apex_depth_low_saturation_warning_band == 0.0
 
+    def test_enhance_config_clamps_negative_apex_threshold_epsilon(self):
+        """Negative threshold epsilon values should normalize at config construction."""
+        config = EnhanceConfig(apex_depth_threshold_epsilon=-1e-3)
+
+        assert config.apex_depth_threshold_epsilon == 0.0
+
+    def test_enhance_config_exposes_v2_and_flag_fields(self):
+        """V2 and flag fields should remain available on the public config surface."""
+        config = EnhanceConfig()
+
         # V2 configuration
         assert hasattr(config, "v2_preset")
         assert hasattr(config, "v2_device")

--- a/tests/test_secure_install_pilot_workflow.py
+++ b/tests/test_secure_install_pilot_workflow.py
@@ -10,6 +10,7 @@ pytestmark = pytest.mark.unit
 REPO_ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "secure-install-pilot.yml"
 REQUIREMENTS_README_PATH = REPO_ROOT / "requirements" / "README.md"
+DEPENDABOT_GOVERNANCE_PATH = REPO_ROOT / "docs" / "governance" / "DEPENDABOT_PR_GOVERNANCE.md"
 ROADMAP_PATH = REPO_ROOT / "docs" / "architecture" / "transformation_portal_roadmap_rereview_2026-04-07.md"
 CHECKOUT_SHA = "de0fac2e4500dabe0009e67214ff5f5447ce83dd"
 SETUP_PYTHON_SHA = "a309ff8b426b58ec0e2a45f0f869d46889d02405"
@@ -97,6 +98,25 @@ def test_secure_install_pilot_readme_records_explicit_hash_policy() -> None:
     assert "`requirements-dev.txt` remain outside this hash-enforced policy decision" in readme
     assert "Promotion to mandatory `--require-hashes` enforcement requires a separate" in readme
     assert "policy decision." in readme
+
+
+def test_requirements_readme_records_current_curated_web_runtime_baseline() -> None:
+    readme = REQUIREMENTS_README_PATH.read_text(encoding="utf-8")
+
+    assert "| FastAPI | `requirements/base.in` | `0.136.0` |" in readme
+    assert "| Starlette | `requirements/base.in` + `pyproject.toml` bound | `1.0.0` |" in readme
+    assert "| Uvicorn | `requirements/base.in` | `0.42.0` |" in readme
+    assert "curated compatibility path on 2026-04-15" in readme
+
+
+def test_dependabot_governance_doc_includes_dep_pin_changed_checklist() -> None:
+    governance_doc = DEPENDABOT_GOVERNANCE_PATH.read_text(encoding="utf-8")
+
+    assert '## "Dep Pin Changed" Checklist' in governance_doc
+    assert "Regenerate only the affected governed lockfiles through the existing lock" in governance_doc
+    assert "make check-requirements-lock-contract" in governance_doc
+    assert "runtime/toolchain requirements stay current" in governance_doc
+    assert "make ci" in governance_doc
 
 
 def test_hash_policy_roadmap_refresh_closes_csp_unlock_and_records_policy_decision() -> None:

--- a/tests/validation/test_check_python_headers.py
+++ b/tests/validation/test_check_python_headers.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import importlib.util
+import subprocess
+import sys
 from pathlib import Path
 from types import ModuleType
 
@@ -72,3 +74,57 @@ def test_ma_state_header_is_now_safe() -> None:
     module = _load_module()
 
     assert module.find_violations([MA_STATE_PATH]) == []
+
+
+def test_iter_tracked_python_files_raises_machine_parsable_tooling_error_on_git_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_module()
+
+    monkeypatch.setattr(
+        module.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(args=args, returncode=2, stdout="", stderr="fatal: no git"),
+    )
+
+    with pytest.raises(module.PythonHeaderToolingError) as exc_info:
+        module.find_violations()
+
+    assert exc_info.value.code == "git_ls_files_failed"
+    assert exc_info.value.message == "git ls-files failed: fatal: no git"
+
+
+def test_iter_tracked_python_files_raises_machine_parsable_tooling_error_on_invocation_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_module()
+
+    def _boom(*args, **kwargs):
+        raise OSError("git executable missing")
+
+    monkeypatch.setattr(module.subprocess, "run", _boom)
+
+    with pytest.raises(module.PythonHeaderToolingError) as exc_info:
+        module.find_violations()
+
+    assert exc_info.value.code == "git_ls_files_invocation_failed"
+    assert "git executable missing" in exc_info.value.message
+
+
+def test_main_emits_tooling_error_identifier_for_git_discovery_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = _load_module()
+
+    monkeypatch.setattr(
+        module.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(args=args, returncode=2, stdout="", stderr="fatal: no git"),
+    )
+    monkeypatch.setattr(sys, "argv", ["check_python_headers.py"])
+
+    exit_code = module.main()
+
+    assert exit_code == 1
+    assert capsys.readouterr().out.strip() == "TOOLING_ERROR[git_ls_files_failed]: git ls-files failed: fatal: no git"

--- a/tests/validation/test_environment_preflight.py
+++ b/tests/validation/test_environment_preflight.py
@@ -7,6 +7,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -183,6 +184,64 @@ class TestCheckLocalEnvironment:
         assert len(results) >= 2
         assert all("Port" in r.name for r in results)
 
+    def test_validation_smoke_passes_with_explicit_classification(self, env_module, monkeypatch):
+        validator = SimpleNamespace(
+            PythonHeaderToolingError=RuntimeError,
+            find_violations=lambda: [],
+        )
+        monkeypatch.setattr(env_module, "_load_python_header_validator", lambda: validator)
+
+        result = env_module.check_validation_smoke()
+
+        assert result.passed is True
+        assert result.classification == "pass"
+        assert result.name == "Validation smoke"
+
+    def test_validation_smoke_classifies_product_regression(self, env_module, monkeypatch):
+        validator = SimpleNamespace(
+            PythonHeaderToolingError=RuntimeError,
+            find_violations=lambda: ["file.py:1: header contains cookie-like text 'encoding: Local'"],
+        )
+        monkeypatch.setattr(env_module, "_load_python_header_validator", lambda: validator)
+
+        result = env_module.check_validation_smoke()
+
+        assert result.passed is False
+        assert result.classification == "product_regression"
+        assert "file.py:1" in result.message
+
+    def test_validation_smoke_classifies_environment_failure_for_tooling_error(self, env_module, monkeypatch):
+        class FakeToolingError(RuntimeError):
+            pass
+
+        def _raise_tooling_error():
+            raise FakeToolingError("git ls-files failed: fatal: no git")
+
+        validator = SimpleNamespace(
+            PythonHeaderToolingError=FakeToolingError,
+            find_violations=_raise_tooling_error,
+        )
+        monkeypatch.setattr(env_module, "_load_python_header_validator", lambda: validator)
+
+        result = env_module.check_validation_smoke()
+
+        assert result.passed is False
+        assert result.classification == "environment_failure"
+        assert "fatal: no git" in result.message
+
+    def test_run_specific_check_validation_smoke(self, env_module, monkeypatch):
+        validator = SimpleNamespace(
+            PythonHeaderToolingError=RuntimeError,
+            find_violations=lambda: [],
+        )
+        monkeypatch.setattr(env_module, "_load_python_header_validator", lambda: validator)
+
+        results, exit_code = env_module.run_all_checks(["validation-smoke"])
+
+        assert exit_code == env_module.ExitCode.PASS
+        assert len(results) == 1
+        assert results[0].classification == "pass"
+
     def test_check_result_has_guidance_on_failure(self, env_module):
         """Failed checks should include guidance when available."""
         # Mock a failing check
@@ -261,6 +320,20 @@ class TestCheckLocalEnvironmentCLI:
         output = json.loads(result.stdout)
         assert len(output["results"]) == 1
         assert output["results"][0]["name"] == "Python dependency health"
+
+    def test_script_check_specific_validation_smoke(self):
+        """Script should accept validation-smoke as a specific check."""
+        result = subprocess.run(
+            [sys.executable, str(CHECK_LOCAL_ENVIRONMENT_PATH), "--check", "validation-smoke", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode in (0, 1, 2)
+        output = json.loads(result.stdout)
+        assert len(output["results"]) == 1
+        assert output["results"][0]["name"] == "Validation smoke"
+        assert output["results"][0]["classification"] in {"pass", "environment_failure", "product_regression"}
 
     def test_script_quiet_mode(self):
         """Quiet mode should reduce output."""

--- a/tests/validation/test_portal_smoke_scripts.py
+++ b/tests/validation/test_portal_smoke_scripts.py
@@ -160,6 +160,7 @@ def test_portal_browser_state_probe_tracks_contextual_action_controls():
     assert "actionSecondary2Key" in expression
     assert "selectedRecoveryPrimaryKey" in expression
     assert "reviewStatusPrimaryKey" in expression
+    assert "reviewStatusState" in expression
     assert "connectionDetailsVisible" in expression
     assert "dispatchChecklistRows" in expression
     assert "queueEmptyStateVisible" in expression

--- a/web/secure-landing/portal-src/review-surface-deferred.js
+++ b/web/secure-landing/portal-src/review-surface-deferred.js
@@ -240,114 +240,89 @@ export function createDeferredReviewSurfaceApi(host) {
     els.artifactMetadataCard.appendChild(detail);
   }
 
-  function _reviewStatusSnapshot(job, artifact) {
-    if (!job) {
-      return {
-        visible: false,
-        tone: "info",
-        title: "Awaiting completed run",
-        detail: "Select a job to review related warnings, completion state, and output readiness.",
-        action: "Next action: use the selected run state, warning context, and freshness above to decide whether to recover or open review."
-      };
-    }
-
-    const summary = normalizeRunSummary(job.run_summary);
-    const reviewableOutputs = _jobHasReviewableOutputs(job);
-    const artifactCount = Array.isArray(job.artifacts) ? job.artifacts.length : 0;
-    const readableError = getReadableError(job.error);
-    const visibleWarning = _latestVisibleTransportWarning(job);
-    const freshnessLabel = _jobFreshnessLabel(job);
-    const outcomeSummary = typeof summary?.outcome_summary === "string" ? summary.outcome_summary.trim() : "";
-
-    if (job.state === "partial") {
-      return {
-        visible: true,
-        tone: "warning",
-        title: "Run partially completed",
-        detail: outcomeSummary ? `${outcomeSummary}. Updated ${freshnessLabel}.` : "Some inputs failed, but outputs remain reviewable.",
-        action: "Next action: open review for the retained outputs before rerunning failed inputs."
-      };
-    }
-
-    if (job.state === "failed") {
-      return {
-        visible: true,
-        tone: reviewableOutputs ? "warning" : "error",
-        title: reviewableOutputs ? "Run failed after indexing reviewable outputs" : "Run failed before outputs were ready",
-        detail:
-          readableError ||
-          (reviewableOutputs
-            ? `${artifactCount} artifact${artifactCount === 1 ? "" : "s"} remain available for review. Updated ${freshnessLabel}.`
-            : "No reviewable outputs were indexed before the failure was reported."),
-        action: reviewableOutputs
-          ? "Next action: open review for the retained outputs, then decide whether this run needs a retry."
-          : "Next action: inspect the latest warning and failure context in Operate before retrying the run."
-      };
-    }
-
-    if (job.state === "canceled") {
-      return {
-        visible: true,
-        tone: reviewableOutputs ? "warning" : "error",
-        title: reviewableOutputs ? "Run canceled after partial output capture" : "Run canceled before review outputs were ready",
-        detail: reviewableOutputs
-          ? `${artifactCount} artifact${artifactCount === 1 ? "" : "s"} remain available for review despite cancellation. Updated ${freshnessLabel}.`
-          : "Execution was canceled before reviewable outputs were indexed.",
-        action: reviewableOutputs
-          ? "Next action: review the retained outputs before deciding whether to rerun the canceled work."
-          : "Next action: reopen Build or restore the run context before dispatching again."
-      };
-    }
-
-    if (job.state === "offline") {
-      return {
-        visible: true,
-        tone: "warning",
-        title: reviewableOutputs ? "Run is offline with reviewable outputs" : "Run is offline",
-        detail: reviewableOutputs
-          ? `${artifactCount} artifact${artifactCount === 1 ? "" : "s"} remain available, but live backend status is stale until connectivity is restored.`
-          : "Live backend status is stale until connectivity is restored.",
-        action: reviewableOutputs
-          ? "Next action: review the cached outputs while backend connectivity recovers."
-          : "Next action: restore backend connectivity before depending on this run state."
-      };
-    }
-
-    if (job.reconnectBlocked) {
-      return {
-        visible: true,
-        tone: "warning",
-        title: "Transport warning recorded",
-        detail: "Authentication must be restored before live event transport can reconnect.",
-        action: "Next action: restore authentication so live transport and freshness can recover."
-      };
-    }
-
-    if (visibleWarning) {
-      return {
-        visible: true,
-        tone: visibleWarning.tone === "error" ? "error" : "warning",
-        title: "Transport warning recorded",
-        detail: String(visibleWarning.detail || "Live transport reported an operator-visible warning."),
-        action: "Next action: inspect the latest transport warning in Operate before continuing into review."
-      };
-    }
-
-    if (job.state === "running" || job.state === "queued") {
-      return {
-        visible: true,
-        tone: "info",
-        title: "Run still in progress",
-        detail: artifactCount > 0
-          ? `${artifactCount} artifact${artifactCount === 1 ? "" : "s"} already indexed. Updated ${freshnessLabel}.`
-          : "Artifacts and provenance will populate here as outputs arrive.",
-        action: artifactCount > 0
-          ? "Next action: keep review open only if you need the early artifacts; Operate remains the primary live surface."
-          : "Next action: stay in Operate until indexed outputs or a blocking warning arrives."
-      };
-    }
-
-    return {
+  const REVIEW_STATUS_BUILDERS = Object.freeze({
+    awaiting_job: () => ({
+      visible: false,
+      tone: "info",
+      title: "Awaiting completed run",
+      detail: "Select a job to review related warnings, completion state, and output readiness.",
+      action: "Next action: use the selected run state, warning context, and freshness above to decide whether to recover or open review."
+    }),
+    partial_reviewable: ({ outcomeSummary, freshnessLabel }) => ({
+      visible: true,
+      tone: "warning",
+      title: "Run partially completed",
+      detail: outcomeSummary ? `${outcomeSummary}. Updated ${freshnessLabel}.` : "Some inputs failed, but outputs remain reviewable.",
+      action: "Next action: open review for the retained outputs before rerunning failed inputs."
+    }),
+    failed_reviewable: ({ readableError, artifactCount, freshnessLabel }) => ({
+      visible: true,
+      tone: "warning",
+      title: "Run failed after indexing reviewable outputs",
+      detail: readableError || `${artifactCount} artifact${artifactCount === 1 ? "" : "s"} remain available for review. Updated ${freshnessLabel}.`,
+      action: "Next action: open review for the retained outputs, then decide whether this run needs a retry."
+    }),
+    failed_unreviewable: ({ readableError }) => ({
+      visible: true,
+      tone: "error",
+      title: "Run failed before outputs were ready",
+      detail: readableError || "No reviewable outputs were indexed before the failure was reported.",
+      action: "Next action: inspect the latest warning and failure context in Operate before retrying the run."
+    }),
+    canceled_reviewable: ({ artifactCount, freshnessLabel }) => ({
+      visible: true,
+      tone: "warning",
+      title: "Run canceled after partial output capture",
+      detail: `${artifactCount} artifact${artifactCount === 1 ? "" : "s"} remain available for review despite cancellation. Updated ${freshnessLabel}.`,
+      action: "Next action: review the retained outputs before deciding whether to rerun the canceled work."
+    }),
+    canceled_unreviewable: () => ({
+      visible: true,
+      tone: "error",
+      title: "Run canceled before review outputs were ready",
+      detail: "Execution was canceled before reviewable outputs were indexed.",
+      action: "Next action: reopen Build or restore the run context before dispatching again."
+    }),
+    offline_reviewable: ({ artifactCount }) => ({
+      visible: true,
+      tone: "warning",
+      title: "Run is offline with reviewable outputs",
+      detail: `${artifactCount} artifact${artifactCount === 1 ? "" : "s"} remain available, but live backend status is stale until connectivity is restored.`,
+      action: "Next action: review the cached outputs while backend connectivity recovers."
+    }),
+    offline_unreviewable: () => ({
+      visible: true,
+      tone: "warning",
+      title: "Run is offline",
+      detail: "Live backend status is stale until connectivity is restored.",
+      action: "Next action: restore backend connectivity before depending on this run state."
+    }),
+    transport_blocked: () => ({
+      visible: true,
+      tone: "warning",
+      title: "Transport warning recorded",
+      detail: "Authentication must be restored before live event transport can reconnect.",
+      action: "Next action: restore authentication so live transport and freshness can recover."
+    }),
+    transport_warning: ({ visibleWarning }) => ({
+      visible: true,
+      tone: visibleWarning.tone === "error" ? "error" : "warning",
+      title: "Transport warning recorded",
+      detail: String(visibleWarning.detail || "Live transport reported an operator-visible warning."),
+      action: "Next action: inspect the latest transport warning in Operate before continuing into review."
+    }),
+    in_progress: ({ artifactCount, freshnessLabel }) => ({
+      visible: true,
+      tone: "info",
+      title: "Run still in progress",
+      detail: artifactCount > 0
+        ? `${artifactCount} artifact${artifactCount === 1 ? "" : "s"} already indexed. Updated ${freshnessLabel}.`
+        : "Artifacts and provenance will populate here as outputs arrive.",
+      action: artifactCount > 0
+        ? "Next action: keep review open only if you need the early artifacts; Operate remains the primary live surface."
+        : "Next action: stay in Operate until indexed outputs or a blocking warning arrives."
+    }),
+    ready: ({ artifact, artifactCount, outcomeSummary, freshnessLabel }) => ({
       visible: true,
       tone: "ready",
       title: artifact ? "Outputs ready for review" : "Run ready for review",
@@ -355,6 +330,43 @@ export function createDeferredReviewSurfaceApi(host) {
         ? `${outcomeSummary}. Updated ${freshnessLabel}.`
         : `${artifactCount} artifact${artifactCount === 1 ? "" : "s"} indexed and ready for operator review.`,
       action: "Next action: use the selected run state, warning context, and freshness above to decide whether to recover or open review."
+    })
+  });
+
+  function _reviewStatusState(job, reviewableOutputs, visibleWarning) {
+    if (!job) return "awaiting_job";
+    if (job.state === "partial") return "partial_reviewable";
+    if (job.state === "failed") return reviewableOutputs ? "failed_reviewable" : "failed_unreviewable";
+    if (job.state === "canceled") return reviewableOutputs ? "canceled_reviewable" : "canceled_unreviewable";
+    if (job.state === "offline") return reviewableOutputs ? "offline_reviewable" : "offline_unreviewable";
+    if (job.reconnectBlocked) return "transport_blocked";
+    if (visibleWarning) return "transport_warning";
+    if (job.state === "running" || job.state === "queued") return "in_progress";
+    return "ready";
+  }
+
+  function _reviewStatusSnapshot(job, artifact) {
+    const summary = job ? normalizeRunSummary(job.run_summary) : {};
+    const reviewableOutputs = _jobHasReviewableOutputs(job);
+    const artifactCount = job && Array.isArray(job.artifacts) ? job.artifacts.length : 0;
+    const readableError = job ? getReadableError(job.error) : "";
+    const visibleWarning = _latestVisibleTransportWarning(job);
+    const freshnessLabel = _jobFreshnessLabel(job);
+    const outcomeSummary = typeof summary?.outcome_summary === "string" ? summary.outcome_summary.trim() : "";
+    const stateToken = _reviewStatusState(job, reviewableOutputs, visibleWarning);
+    const builder = REVIEW_STATUS_BUILDERS[stateToken] || REVIEW_STATUS_BUILDERS.ready;
+    return {
+      state: stateToken,
+      ...builder({
+        artifact,
+        artifactCount,
+        freshnessLabel,
+        outcomeSummary,
+        readableError,
+        reviewableOutputs,
+        summary,
+        visibleWarning
+      })
     };
   }
 
@@ -362,6 +374,7 @@ export function createDeferredReviewSurfaceApi(host) {
     if (!els.reviewStatusBanner || !els.reviewStatusTitle || !els.reviewStatusDetail) return;
     const snapshot = _reviewStatusSnapshot(job, artifact);
     els.reviewStatusBanner.dataset.tone = snapshot.tone;
+    els.reviewStatusBanner.dataset.reviewState = snapshot.state;
     if (!snapshot.visible) {
       els.reviewStatusBanner.classList.add("hidden");
       els.reviewStatusTitle.textContent = snapshot.title;


### PR DESCRIPTION
## Summary
- Tighten five related hardening surfaces that were still drifting across validation tooling, governed dependency guidance, SAM2 trust checks, portal review-state modeling, and APEX config normalization.
- Keep existing public envelopes, routes, selectors, and reason codes stable while making the smallest additive changes needed to expose deterministic machine-readable contracts and remove repeated runtime drift.

## Changes
### Slice 1 — Deterministic validation-system design
- Add deterministic tooling-error identifiers to `scripts/validation/check_python_headers.py` when tracked-file discovery or `git ls-files` execution fails.
- Add `validation-smoke` to `scripts/validation/check_local_environment.py` with additive JSON and human-readable classification output: `pass`, `environment_failure`, or `product_regression`.
- Cover clean pass, real header violations, and git/subprocess failure paths in focused tests, and document operator guidance in `docs/guides/LOCAL_VALIDATION_QUICKSTART.md`.

### Slice 2 — Governed dependency and lockfile curation
- Reconcile governance docs and secure-install workflow tests around the already-curated FastAPI `0.136.0` governed web baseline.
- Add a repeatable dep-pin checklist covering manifest input, lock regeneration, workflow/test alignment, docs updates, and runtime/toolchain requirements.
- Keep the lock contract authoritative through `make check-requirements-lock-contract` rather than hand-editing generated output.

### Slice 3 — Fail-closed trust-boundary hardening
- Introduce shared managed SAM2 checkpoint validation in `app.py` that returns a normalized path plus the exact failure reason used by both config preview and dispatch.
- Preserve the existing reason codes `invalid_path_value`, `untrusted_checkpoint_path`, and `checkpoint_file_too_large` across both surfaces.
- Add bounded-cost checksum caching keyed by `(realpath, size, mtime_ns)` and cover repo-controlled, non-file, oversize, untrusted, reason-parity, and cache-reuse paths.

### Slice 4 — Contract-driven portal/frontdoor state modeling
- Convert the review banner status mapping into an explicit table-driven state contract and return a stable `state` token.
- Expose `data-review-state` on the review-status banner without changing routes, existing selectors, or review-surface copy.
- Update runtime/browser contract coverage and rebuild the shipped `public/portal-assets/portal-review.js` bundle under Node 22 so the live smoke matches the edited source.

### Slice 5 — Deterministic config normalization and fingerprint design
- Normalize `apex_depth_threshold_epsilon` in `EnhanceConfig.__post_init__` so negative values clamp before runtime gate logic or fingerprint generation.
- Add fingerprint coverage proving effective-policy equality for negative vs zero epsilon, policy change detection when epsilon changes, and depth-cache payload stability when unrelated config stays constant.
- Add a reusable config-knob checklist covering normalization, fingerprint impact, cache impact, telemetry/readout impact, and docs expectations.

## Validation
### Proven green
- `.venv/bin/pytest -q tests/validation/test_check_python_headers.py tests/validation/test_environment_preflight.py tests/test_secure_install_pilot_workflow.py tests/test_app_orchestrator_runtime.py::test_resolve_managed_sam2_checkpoint_validation_preserves_untrusted_reason tests/test_app_orchestrator_runtime.py::test_managed_sam2_checkpoint_validation_reuses_cached_hash_result tests/test_app_orchestrator_runtime.py::test_sam2_checkpoint_preview_and_dispatch_share_reason_codes tests/test_app_orchestrator_runtime.py::test_portal_review_surface_exposes_warning_banner_and_provenance_contract tests/validation/test_portal_smoke_scripts.py::test_portal_browser_state_probe_tracks_contextual_action_controls tests/test_lux_depth_v3_config.py tests/lux_depth_v3/test_config_resolver.py`
- `make check-python-headers`
- `./.venv/bin/python scripts/validation/check_local_environment.py --check validation-smoke --json`
- `make check-requirements-lock-contract`
- `make test-portal-contract`
- `make validate-portal-browser`
- `make ci`
- `make validate-quick`

### Still failing
- None in the canonical gates above.

### Failure classification
- `make ci` still emits an advisory pylint finding in `tests/test_depth_tools.py`; that lane remained green and the finding is outside this diff.
- One intermediate `make test-portal-contract` failure was stale test logic tied to the old branchy review-status implementation; the test was updated to assert the new table-driven contract.
- One intermediate `make validate-portal-browser` failure was environment/tooling drift: the shipped `portal-review.js` bundle had not yet been rebuilt under Node 22. Rebuilding the asset resolved it without product logic changes.

## Risk
- The diff is bounded and revert-safe: behavior changes are additive or contract-preserving on existing envelopes, selectors, and reason codes.
- Selector and contract stability remain explicit for the portal review surface through the new `data-review-state` hook and matching runtime/browser assertions.
- The frontdoor asset path depends on rebuilding `portal-review.js` under Node 22 whenever `web/secure-landing/portal-src/review-surface-deferred.js` changes; this PR validates that path explicitly.
- The SAM2 checksum cache is in-process and keyed by file signature, which reduces repeated hash cost without widening trust policy or accepted inputs.
