### PR TITLE
fix(core): harden shared core utilities

### DIFF
--- a/src/transformation_portal/core/_cas_helpers.py
+++ b/src/transformation_portal/core/_cas_helpers.py
@@ -8,7 +8,6 @@ execution wrapper and DAG executor. Public compatibility aliases remain in
 from __future__ import annotations
 
 import hashlib
-import json
 import os
 import platform
 import re
@@ -17,6 +16,7 @@ from pathlib import Path
 from typing import Any
 
 from transformation_portal.determinism.jcs import dumpb as jcs_dumpb
+from transformation_portal.ingest.canonical_json import dump_json
 
 
 class CASObjectMissingError(Exception):
@@ -47,7 +47,7 @@ def atomic_write_json(path: Path, data: dict[str, Any]) -> None:
 
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as handle:
-            json.dump(data, handle, indent=2, sort_keys=True)
+            dump_json(data, handle, indent=2, sort_keys=True)
             handle.flush()
             os.fsync(handle.fileno())
 

--- a/src/transformation_portal/core/_cas_helpers.py
+++ b/src/transformation_portal/core/_cas_helpers.py
@@ -1,0 +1,200 @@
+"""Shared CAS serialization and cache write helpers.
+
+This private module centralizes helper routines that are shared by the
+execution wrapper and DAG executor. Public compatibility aliases remain in
+``execution_wrapper`` for existing callers and tests.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import platform
+import re
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from transformation_portal.determinism.jcs import dumpb as jcs_dumpb
+
+
+class CASObjectMissingError(Exception):
+    """Raised when a referenced CAS object is missing during cache load."""
+
+    def __init__(self, sha256: str):
+        self.sha256 = sha256
+        super().__init__(f"CAS object missing: {sha256}")
+
+
+def sanitize_cas_id_for_filename(cas_id: str) -> str:
+    """Extract the hex digest from a CAS ID for safe filename usage."""
+    if cas_id.startswith("sha256:"):
+        return cas_id[7:]
+    return cas_id
+
+
+def atomic_write_json(path: Path, data: dict[str, Any]) -> None:
+    """Atomically write JSON data to a file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    fd, tmp_path_str = tempfile.mkstemp(
+        suffix=".tmp",
+        prefix=".cache_write_",
+        dir=path.parent,
+    )
+    tmp_path = Path(tmp_path_str)
+
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(data, handle, indent=2, sort_keys=True)
+            handle.flush()
+            os.fsync(handle.fileno())
+
+        os.replace(tmp_path, path)
+
+        if platform.system() != "Windows" and hasattr(os, "O_DIRECTORY"):
+            try:
+                dir_fd = os.open(str(path.parent), os.O_RDONLY | os.O_DIRECTORY)
+                try:
+                    os.fsync(dir_fd)
+                finally:
+                    os.close(dir_fd)
+            except OSError:
+                pass
+
+    except Exception:
+        if tmp_path.exists():
+            tmp_path.unlink()
+        raise
+
+
+def compute_numpy_array_id(arr: Any) -> str:
+    """Compute a deterministic identity for a NumPy array."""
+    array_manifest = {
+        "dtype": str(arr.dtype),
+        "shape": list(arr.shape),
+        "data_sha256": hashlib.sha256(arr.tobytes()).hexdigest(),
+    }
+    return hashlib.sha256(jcs_dumpb(array_manifest)).hexdigest()
+
+
+def sanitize_key_for_filename(key: str) -> str:
+    """Sanitize an artifact key for safe filename usage."""
+    result = re.sub(r'[/\\:*?"<>|]', "_", key)
+    result = result.replace("..", "_")
+    result = result.strip(". \t\n\r")
+    return result if result else "_key_"
+
+
+def make_serializable(
+    outputs: dict[str, Any],
+    artifact_store: Any,
+    base_path: Path,
+    cas_id: str,
+) -> dict[str, Any]:
+    """Convert outputs to JSON-serializable format recursively."""
+    import numpy as np
+
+    safe_cas_id = sanitize_cas_id_for_filename(cas_id)
+    result = {}
+    for key, value in outputs.items():
+        safe_key = sanitize_key_for_filename(key)
+        if isinstance(value, np.ndarray):
+            array_path = base_path / f"{safe_cas_id}_{safe_key}.npy"
+            array_path.parent.mkdir(parents=True, exist_ok=True)
+            np.save(array_path, value)
+
+            try:
+                cas_obj = artifact_store.add_file(array_path)
+                result[key] = {
+                    "__numpy__": True,
+                    "sha256": cas_obj.sha256,
+                    "shape": list(value.shape),
+                    "dtype": str(value.dtype),
+                }
+            finally:
+                if array_path.exists():
+                    array_path.unlink()
+        elif isinstance(value, dict):
+            result[key] = make_serializable(value, artifact_store, base_path, f"{cas_id}_{safe_key}")
+        elif isinstance(value, (list, tuple)):
+            result[key] = serialize_list_recursive(value, artifact_store, base_path, f"{cas_id}_{safe_key}")
+        else:
+            result[key] = value
+
+    return result
+
+
+def serialize_list_recursive(
+    items: list | tuple,
+    artifact_store: Any,
+    base_path: Path,
+    cas_id: str,
+) -> list:
+    """Serialize a list/tuple, handling nested arrays and dictionaries."""
+    import numpy as np
+
+    result = []
+    for index, item in enumerate(items):
+        if isinstance(item, np.ndarray):
+            serialized = make_serializable({"item": item}, artifact_store, base_path, f"{cas_id}_{index}")
+            result.append(serialized["item"])
+        elif isinstance(item, dict):
+            result.append(make_serializable(item, artifact_store, base_path, f"{cas_id}_{index}"))
+        elif isinstance(item, (list, tuple)):
+            result.append(serialize_list_recursive(item, artifact_store, base_path, f"{cas_id}_{index}"))
+        else:
+            result.append(item)
+    return result
+
+
+def load_serializable(
+    data: dict[str, Any],
+    artifact_store: Any,
+) -> dict[str, Any]:
+    """Reconstruct outputs from serialized format recursively."""
+    import numpy as np
+
+    result = {}
+    for key, value in data.items():
+        if isinstance(value, dict) and value.get("__numpy__"):
+            sha256 = value["sha256"]
+            cas_obj = artifact_store.get_object(sha256)
+            if cas_obj:
+                result[key] = np.load(cas_obj.path)
+            else:
+                raise CASObjectMissingError(sha256)
+        elif isinstance(value, dict):
+            result[key] = load_serializable(value, artifact_store)
+        elif isinstance(value, list):
+            result[key] = load_list_recursive(value, artifact_store)
+        else:
+            result[key] = value
+
+    return result
+
+
+def load_list_recursive(
+    items: list,
+    artifact_store: Any,
+) -> list:
+    """Reconstruct a list, handling nested arrays and dictionaries."""
+    import numpy as np
+
+    result = []
+    for item in items:
+        if isinstance(item, dict) and item.get("__numpy__"):
+            sha256 = item["sha256"]
+            cas_obj = artifact_store.get_object(sha256)
+            if cas_obj:
+                result.append(np.load(cas_obj.path))
+            else:
+                raise CASObjectMissingError(sha256)
+        elif isinstance(item, dict):
+            result.append(load_serializable(item, artifact_store))
+        elif isinstance(item, list):
+            result.append(load_list_recursive(item, artifact_store))
+        else:
+            result.append(item)
+    return result

--- a/src/transformation_portal/core/batch/__init__.py
+++ b/src/transformation_portal/core/batch/__init__.py
@@ -2,6 +2,8 @@
 Batch processing with checkpoint/resume capability.
 
 Provides robust batch processing with automatic recovery.
+Compatibility note: retained as an internal/shared helper surface with
+direct smoke coverage, but it currently has no production imports.
 """
 
 from .job import BatchJob, BatchProcessor, JobItem, JobStatus

--- a/src/transformation_portal/core/cas_dag_executor.py
+++ b/src/transformation_portal/core/cas_dag_executor.py
@@ -45,6 +45,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set
 
+from transformation_portal.core._cas_helpers import CASObjectMissingError
+from transformation_portal.core._cas_helpers import atomic_write_json as _atomic_write_json
+from transformation_portal.core._cas_helpers import compute_numpy_array_id as _compute_numpy_array_id
+from transformation_portal.core._cas_helpers import load_serializable, make_serializable
+from transformation_portal.core._cas_helpers import sanitize_cas_id_for_filename as _sanitize_cas_id_for_filename
 from transformation_portal.core.execution_identity import (
     ArtifactMetadata,
     ExecutionIdentity,
@@ -54,14 +59,8 @@ from transformation_portal.core.execution_identity import (
     is_compatible,
     resolve_platform_lockfile,
 )
-from transformation_portal.core.execution_wrapper import _atomic_write_json  # Shared atomic cache writes
-from transformation_portal.core.execution_wrapper import _compute_numpy_array_id  # Shared NumPy identity computation
-from transformation_portal.core.execution_wrapper import _sanitize_cas_id_for_filename  # Shared filename sanitization
-from transformation_portal.core.execution_wrapper import load_serializable  # Shared recursive deserialization
-from transformation_portal.core.execution_wrapper import make_serializable  # Shared recursive serialization
 from transformation_portal.core.execution_wrapper import (
     CASExecutor,
-    CASObjectMissingError,
     ExecutorConfig,
     FileLock,
 )

--- a/src/transformation_portal/core/config/schemas.py
+++ b/src/transformation_portal/core/config/schemas.py
@@ -8,7 +8,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Union
 
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class DeviceType(str, Enum):
@@ -31,7 +31,8 @@ class DeviceConfig(BaseModel):
     gpu_id: int = Field(default=0, ge=0, description="CUDA device index")
     enable_cudnn_benchmark: bool = True
 
-    @validator("device")
+    @field_validator("device")
+    @classmethod
     def validate_device_availability(cls, v):
         # In a real app, we might check torch.cuda.is_available() here
         # keeping it pure config for now.
@@ -59,7 +60,8 @@ class PerformanceConfig(BaseModel):
     tile_overlap: int = Field(default=64, ge=0, description="Overlap between tiles in pixels")
     memory_limit_gb: float = Field(default=8.0, gt=0, description="VRAM limit hint")
 
-    @validator("tile_size")
+    @field_validator("tile_size")
+    @classmethod
     def validate_tile_size(cls, v):
         if 0 < v < 256:
             raise ValueError("tile_size must be 0 or at least 256 pixels")
@@ -104,5 +106,4 @@ class ConfigSchema(BaseModel):
     # Allow arbitrary extra fields for pipeline-specific params (e.g. 'skygan')
     pipeline_params: Dict[str, Any] = Field(default_factory=dict)
 
-    class Config:
-        extra = "ignore"  # Ignore unknown fields to allow forward compatibility
+    model_config = ConfigDict(extra="ignore")

--- a/src/transformation_portal/core/device/__init__.py
+++ b/src/transformation_portal/core/device/__init__.py
@@ -3,6 +3,8 @@ Core Device Management Module
 
 Unified device detection, profiling, and memory management.
 Consolidates patterns from foundation.device_manager and multiple pipelines.
+Compatibility note: retained as an internal/shared helper surface with
+direct smoke coverage, but it currently has no production imports.
 
 Note:
 - ``torch`` and ``psutil`` are optional runtime dependencies.

--- a/src/transformation_portal/core/execution_wrapper.py
+++ b/src/transformation_portal/core/execution_wrapper.py
@@ -31,15 +31,21 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
-import os
-import re
-import tempfile
 import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Optional, Protocol, TypeVar, Union
 
+from transformation_portal.core._cas_helpers import CASObjectMissingError
+from transformation_portal.core._cas_helpers import atomic_write_json as _shared_atomic_write_json
+from transformation_portal.core._cas_helpers import compute_numpy_array_id as _shared_compute_numpy_array_id
+from transformation_portal.core._cas_helpers import load_list_recursive as _shared_load_list_recursive
+from transformation_portal.core._cas_helpers import load_serializable as _shared_load_serializable
+from transformation_portal.core._cas_helpers import make_serializable as _shared_make_serializable
+from transformation_portal.core._cas_helpers import sanitize_cas_id_for_filename as _shared_sanitize_cas_id_for_filename
+from transformation_portal.core._cas_helpers import sanitize_key_for_filename as _shared_sanitize_key_for_filename
+from transformation_portal.core._cas_helpers import serialize_list_recursive as _shared_serialize_list_recursive
 from transformation_portal.core.execution_identity import (
     ArtifactMetadata,
     ExecutionIdentity,
@@ -50,7 +56,7 @@ from transformation_portal.core.execution_identity import (
     should_execute,
 )
 from transformation_portal.determinism.jcs import dumpb as jcs_dumpb
-from transformation_portal.storage.cas_store import ArtifactStore, CASObject
+from transformation_portal.storage.cas_store import ArtifactStore
 
 logger = logging.getLogger(__name__)
 
@@ -58,123 +64,23 @@ T = TypeVar("T")
 
 
 def _sanitize_cas_id_for_filename(cas_id: str) -> str:
-    """Extract the hex digest from a CAS ID for use in filenames.
-
-    CAS IDs have the format 'sha256:<hex_digest>'. The colon is invalid
-    on Windows filesystems. This extracts just the hex digest part.
-
-    Args:
-        cas_id: Full CAS ID (e.g., 'sha256:abc123...')
-
-    Returns:
-        Just the hex digest portion (e.g., 'abc123...')
-    """
-    if cas_id.startswith("sha256:"):
-        return cas_id[7:]  # len("sha256:") == 7
-    return cas_id
+    """Compatibility wrapper for shared CAS filename sanitization."""
+    return _shared_sanitize_cas_id_for_filename(cas_id)
 
 
 def _atomic_write_json(path: Path, data: dict[str, Any]) -> None:
-    """Atomically write JSON data to a file.
-
-    Uses temp-file + fsync + atomic-rename discipline to prevent
-    partial writes or corruption visible to concurrent readers.
-
-    Cross-platform: Works on POSIX (with directory fsync) and Windows
-    (where directory fsync is skipped as NTFS has different durability
-    semantics - renames are already durable after file fsync).
-
-    Args:
-        path: Target file path
-        data: JSON-serializable data to write
-    """
-    import platform
-
-    path.parent.mkdir(parents=True, exist_ok=True)
-
-    # Write to temp file in same directory for atomic rename
-    fd, tmp_path_str = tempfile.mkstemp(
-        suffix=".tmp",
-        prefix=".cache_write_",
-        dir=path.parent,
-    )
-    tmp_path = Path(tmp_path_str)
-
-    try:
-        # Write JSON content
-        with os.fdopen(fd, "w") as f:
-            json.dump(data, f, indent=2, sort_keys=True)
-            f.flush()
-            os.fsync(f.fileno())
-
-        # Atomic rename (works on both POSIX and Windows)
-        os.replace(tmp_path, path)
-
-        # fsync parent directory for durability (POSIX only)
-        # On Windows, NTFS provides different durability guarantees:
-        # the rename is visible after file fsync completes.
-        if platform.system() != "Windows" and hasattr(os, "O_DIRECTORY"):
-            try:
-                dir_fd = os.open(str(path.parent), os.O_RDONLY | os.O_DIRECTORY)
-                try:
-                    os.fsync(dir_fd)
-                finally:
-                    os.close(dir_fd)
-            except OSError:
-                # Directory fsync may fail on some filesystems (e.g., network drives)
-                # but the atomic rename itself already provides consistency guarantees
-                pass
-
-    except Exception:
-        # Clean up temp file on failure
-        if tmp_path.exists():
-            tmp_path.unlink()
-        raise
+    """Compatibility wrapper for shared atomic JSON writes."""
+    _shared_atomic_write_json(path, data)
 
 
 def _compute_numpy_array_id(arr: Any) -> str:
-    """Compute a unique ID for a NumPy array including dtype, shape, and data.
-
-    This prevents false cache hits between arrays with the same raw bytes
-    but different semantics (e.g., np.array([1], dtype=uint32) vs
-    np.array([1,0,0,0], dtype=uint8) both have the same 4 bytes).
-
-    Args:
-        arr: NumPy array (must have dtype, shape, and tobytes() attributes)
-
-    Returns:
-        SHA-256 hex digest of the array manifest
-    """
-    array_manifest = {
-        "dtype": str(arr.dtype),
-        "shape": list(arr.shape),
-        "data_sha256": hashlib.sha256(arr.tobytes()).hexdigest(),
-    }
-    return hashlib.sha256(jcs_dumpb(array_manifest)).hexdigest()
+    """Compatibility wrapper for shared NumPy identity computation."""
+    return _shared_compute_numpy_array_id(arr)
 
 
 def _sanitize_key_for_filename(key: str) -> str:
-    """Sanitize an artifact key for safe filename usage.
-
-    Prevents path traversal attacks by:
-    - Replacing path separators and problematic characters with underscores
-    - Removing directory traversal sequences like '..'
-    - Stripping leading/trailing dots and whitespace
-
-    Args:
-        key: Original artifact key
-
-    Returns:
-        Sanitized key safe for use in filenames
-    """
-    # Replace any path separators and other problematic characters
-    result = re.sub(r'[/\\:*?"<>|]', "_", key)
-    # Remove directory traversal sequences
-    result = result.replace("..", "_")
-    # Strip leading/trailing dots and whitespace
-    result = result.strip(". \t\n\r")
-    # If empty after sanitization, use a placeholder
-    return result if result else "_key_"
+    """Compatibility wrapper for shared artifact-key sanitization."""
+    return _shared_sanitize_key_for_filename(key)
 
 
 def make_serializable(
@@ -183,56 +89,8 @@ def make_serializable(
     base_path: Path,
     cas_id: str,
 ) -> dict[str, Any]:
-    """Convert outputs to JSON-serializable format recursively.
-
-    Handles numpy arrays by storing them as separate .npy files in CAS.
-    Temp files are cleaned up after adding to CAS.
-
-    This is a standalone function usable by both CASExecutor and CASDAGExecutor
-    for consistent recursive serialization semantics.
-
-    Args:
-        outputs: Dictionary of outputs to serialize
-        artifact_store: CAS artifact store for storing arrays
-        base_path: Base directory for temp files
-        cas_id: Base CAS ID for generating unique filenames
-
-    Returns:
-        JSON-serializable dictionary with numpy arrays stored in CAS
-    """
-    import numpy as np
-
-    safe_cas_id = _sanitize_cas_id_for_filename(cas_id)
-    result = {}
-    for key, value in outputs.items():
-        safe_key = _sanitize_key_for_filename(key)
-        if isinstance(value, np.ndarray):
-            # Store numpy array in CAS via temp file
-            array_path = base_path / f"{safe_cas_id}_{safe_key}.npy"
-            array_path.parent.mkdir(parents=True, exist_ok=True)
-            np.save(array_path, value)
-
-            try:
-                # Store reference to CAS
-                cas_obj = artifact_store.add_file(array_path)
-                result[key] = {
-                    "__numpy__": True,
-                    "sha256": cas_obj.sha256,
-                    "shape": list(value.shape),
-                    "dtype": str(value.dtype),
-                }
-            finally:
-                # Clean up temp .npy file after adding to CAS
-                if array_path.exists():
-                    array_path.unlink()
-        elif isinstance(value, dict):
-            result[key] = make_serializable(value, artifact_store, base_path, f"{cas_id}_{safe_key}")
-        elif isinstance(value, (list, tuple)):
-            result[key] = _serialize_list_recursive(value, artifact_store, base_path, f"{cas_id}_{safe_key}")
-        else:
-            result[key] = value
-
-    return result
+    """Compatibility wrapper for shared recursive serialization."""
+    return _shared_make_serializable(outputs, artifact_store, base_path, cas_id)
 
 
 def _serialize_list_recursive(
@@ -241,125 +99,24 @@ def _serialize_list_recursive(
     base_path: Path,
     cas_id: str,
 ) -> list:
-    """Serialize a list/tuple, handling nested numpy arrays and dicts.
-
-    Note: Both list and tuple inputs are converted to lists in the output.
-    This is required for JSON serialization. The original type is not preserved
-    during cache round-trip.
-
-    Args:
-        items: List or tuple of items to serialize
-        artifact_store: CAS artifact store for storing arrays
-        base_path: Base directory for temp files
-        cas_id: Base CAS ID for nested items
-
-    Returns:
-        Serialized list with numpy arrays stored in CAS (always list, even if input was tuple)
-    """
-    import numpy as np
-
-    result = []
-    for i, item in enumerate(items):
-        if isinstance(item, np.ndarray):
-            # Use make_serializable to handle the array
-            serialized = make_serializable({"item": item}, artifact_store, base_path, f"{cas_id}_{i}")
-            result.append(serialized["item"])
-        elif isinstance(item, dict):
-            result.append(make_serializable(item, artifact_store, base_path, f"{cas_id}_{i}"))
-        elif isinstance(item, (list, tuple)):
-            result.append(_serialize_list_recursive(item, artifact_store, base_path, f"{cas_id}_{i}"))
-        else:
-            result.append(item)
-    return result
+    """Compatibility wrapper for shared recursive list serialization."""
+    return _shared_serialize_list_recursive(items, artifact_store, base_path, cas_id)
 
 
 def load_serializable(
     data: dict[str, Any],
     artifact_store: Any,
 ) -> dict[str, Any]:
-    """Reconstruct outputs from serialized format recursively.
-
-    Loads numpy arrays from CAS. Raises CASObjectMissingError if any
-    referenced CAS object is missing (triggers cache miss for self-healing).
-
-    This is a standalone function usable by both CASExecutor and CASDAGExecutor
-    for consistent recursive deserialization semantics.
-
-    Args:
-        data: Serialized dictionary to reconstruct
-        artifact_store: CAS artifact store for loading arrays
-
-    Returns:
-        Reconstructed dictionary with numpy arrays loaded from CAS
-
-    Raises:
-        CASObjectMissingError: If a referenced CAS object is missing
-    """
-    import numpy as np
-
-    result = {}
-    for key, value in data.items():
-        if isinstance(value, dict) and value.get("__numpy__"):
-            # Load numpy array from CAS
-            sha256 = value["sha256"]
-            cas_obj = artifact_store.get_object(sha256)
-            if cas_obj:
-                result[key] = np.load(cas_obj.path)
-            else:
-                # Missing CAS object - fail load to trigger re-execution
-                raise CASObjectMissingError(sha256)
-        elif isinstance(value, dict):
-            result[key] = load_serializable(value, artifact_store)
-        elif isinstance(value, list):
-            result[key] = _load_list_recursive(value, artifact_store)
-        else:
-            result[key] = value
-
-    return result
+    """Compatibility wrapper for shared recursive deserialization."""
+    return _shared_load_serializable(data, artifact_store)
 
 
 def _load_list_recursive(
     items: list,
     artifact_store: Any,
 ) -> list:
-    """Reconstruct a list, handling nested numpy arrays and dicts.
-
-    Args:
-        items: Serialized list to reconstruct
-        artifact_store: CAS artifact store for loading arrays
-
-    Returns:
-        Reconstructed list with numpy arrays loaded from CAS
-
-    Raises:
-        CASObjectMissingError: If a referenced CAS object is missing
-    """
-    import numpy as np
-
-    result = []
-    for item in items:
-        if isinstance(item, dict) and item.get("__numpy__"):
-            sha256 = item["sha256"]
-            cas_obj = artifact_store.get_object(sha256)
-            if cas_obj:
-                result.append(np.load(cas_obj.path))
-            else:
-                raise CASObjectMissingError(sha256)
-        elif isinstance(item, dict):
-            result.append(load_serializable(item, artifact_store))
-        elif isinstance(item, list):
-            result.append(_load_list_recursive(item, artifact_store))
-        else:
-            result.append(item)
-    return result
-
-
-class CASObjectMissingError(Exception):
-    """Raised when a referenced CAS object is missing during cache load."""
-
-    def __init__(self, sha256: str):
-        self.sha256 = sha256
-        super().__init__(f"Missing CAS object: {sha256[:16]}...")
+    """Compatibility wrapper for shared recursive list deserialization."""
+    return _shared_load_list_recursive(items, artifact_store)
 
 
 class ExecutableStage(Protocol):
@@ -631,154 +388,28 @@ class CASExecutor:
         logger.debug("Saved result for %s", cas_id[:16])
 
     def _sanitize_key(self, key: str) -> str:
-        """Sanitize an output key for safe use in filenames.
-
-        Prevents path traversal attacks by:
-        - Replacing path separators and problematic characters with underscores
-        - Removing directory traversal sequences like '..'
-        - Stripping leading/trailing dots and whitespace
-        """
-        # Replace any path separators and other problematic characters
-        result = re.sub(r'[/\\:*?"<>|]', "_", key)
-        # Remove directory traversal sequences
-        result = result.replace("..", "_")
-        # Strip leading/trailing dots and whitespace
-        result = result.strip(". \t\n\r")
-        # If empty after sanitization, use a placeholder
-        return result if result else "_key_"
+        """Sanitize an output key for safe use in filenames."""
+        return _sanitize_key_for_filename(key)
 
     def _make_serializable(
         self,
         outputs: dict[str, Any],
         cas_id: str,
     ) -> dict[str, Any]:
-        """Convert outputs to JSON-serializable format.
-
-        Handles numpy arrays by storing them as separate .npy files in CAS.
-        Temp files are cleaned up after adding to CAS.
-        """
-        import numpy as np
-
-        safe_cas_id = _sanitize_cas_id_for_filename(cas_id)
-        result = {}
-        for key, value in outputs.items():
-            safe_key = self._sanitize_key(key)
-            if isinstance(value, np.ndarray):
-                # Store numpy array in CAS via temp file
-                array_path = self._result_path(cas_id).parent / f"{safe_cas_id}_{safe_key}.npy"
-                array_path.parent.mkdir(parents=True, exist_ok=True)
-                np.save(array_path, value)
-
-                try:
-                    # Store reference to CAS
-                    cas_obj = self.artifact_store.add_file(array_path)
-                    result[key] = {
-                        "__numpy__": True,
-                        "sha256": cas_obj.sha256,
-                        "shape": list(value.shape),
-                        "dtype": str(value.dtype),
-                    }
-                finally:
-                    # Clean up temp .npy file after adding to CAS
-                    if array_path.exists():
-                        array_path.unlink()
-            elif isinstance(value, dict):
-                result[key] = self._make_serializable(value, f"{cas_id}_{safe_key}")
-            elif isinstance(value, (list, tuple)):
-                result[key] = self._serialize_list(value, f"{cas_id}_{safe_key}")
-            else:
-                result[key] = value
-
-        return result
+        """Convert outputs to JSON-serializable format."""
+        return make_serializable(outputs, self.artifact_store, self._result_path(cas_id).parent, cas_id)
 
     def _serialize_list(self, items: list | tuple, cas_id: str) -> list:
-        """Serialize a list/tuple, handling nested numpy arrays and dicts.
-
-        Note: Both list and tuple inputs are converted to lists in the output.
-        This is required for JSON serialization. The original type is not preserved
-        during cache round-trip.
-
-        Args:
-            items: List or tuple of items to serialize
-            cas_id: Base CAS ID for nested items
-
-        Returns:
-            Serialized list with numpy arrays stored in CAS (always list, even if input was tuple)
-        """
-        import numpy as np
-
-        result = []
-        for i, item in enumerate(items):
-            if isinstance(item, np.ndarray):
-                # Use _make_serializable to handle the array
-                serialized = self._make_serializable({"item": item}, f"{cas_id}_{i}")
-                result.append(serialized["item"])
-            elif isinstance(item, dict):
-                result.append(self._make_serializable(item, f"{cas_id}_{i}"))
-            elif isinstance(item, (list, tuple)):
-                result.append(self._serialize_list(item, f"{cas_id}_{i}"))
-            else:
-                result.append(item)
-        return result
+        """Serialize a list/tuple, handling nested numpy arrays and dicts."""
+        return _serialize_list_recursive(items, self.artifact_store, self._result_path(cas_id).parent, cas_id)
 
     def _load_serializable(self, data: dict[str, Any]) -> dict[str, Any]:
-        """Reconstruct outputs from serialized format.
-
-        Loads numpy arrays from CAS. Raises CASObjectMissingError if any
-        referenced CAS object is missing (triggers cache miss for self-healing).
-        """
-        import numpy as np
-
-        result = {}
-        for key, value in data.items():
-            if isinstance(value, dict) and value.get("__numpy__"):
-                # Load numpy array from CAS
-                sha256 = value["sha256"]
-                cas_obj = self.artifact_store.get_object(sha256)
-                if cas_obj:
-                    result[key] = np.load(cas_obj.path)
-                else:
-                    # Missing CAS object - fail load to trigger re-execution
-                    raise CASObjectMissingError(sha256)
-            elif isinstance(value, dict):
-                result[key] = self._load_serializable(value)
-            elif isinstance(value, list):
-                result[key] = self._load_list(value)
-            else:
-                result[key] = value
-
-        return result
+        """Reconstruct outputs from serialized format."""
+        return load_serializable(data, self.artifact_store)
 
     def _load_list(self, items: list) -> list:
-        """Reconstruct a list, handling nested numpy arrays and dicts.
-
-        Args:
-            items: Serialized list to reconstruct
-
-        Returns:
-            Reconstructed list with numpy arrays loaded from CAS
-
-        Raises:
-            CASObjectMissingError: If a referenced CAS object is missing
-        """
-        import numpy as np
-
-        result = []
-        for item in items:
-            if isinstance(item, dict) and item.get("__numpy__"):
-                sha256 = item["sha256"]
-                cas_obj = self.artifact_store.get_object(sha256)
-                if cas_obj:
-                    result.append(np.load(cas_obj.path))
-                else:
-                    raise CASObjectMissingError(sha256)
-            elif isinstance(item, dict):
-                result.append(self._load_serializable(item))
-            elif isinstance(item, list):
-                result.append(self._load_list(item))
-            else:
-                result.append(item)
-        return result
+        """Reconstruct a list, handling nested numpy arrays and dicts."""
+        return _load_list_recursive(items, self.artifact_store)
 
     def _load_result(self, cas_id: str) -> Optional[dict[str, Any]]:
         """Load result from cache if available."""

--- a/src/transformation_portal/core/observability/__init__.py
+++ b/src/transformation_portal/core/observability/__init__.py
@@ -2,6 +2,8 @@
 Core Observability Integration
 
 Re-exports from existing observability module with integration helpers.
+Compatibility note: retained as an internal/shared helper surface with
+direct smoke coverage, but it currently has no production imports.
 """
 
 from .integration import create_logger, setup_logging, setup_metrics

--- a/src/transformation_portal/core/observability/integration.py
+++ b/src/transformation_portal/core/observability/integration.py
@@ -20,6 +20,9 @@ except ImportError:
     RICH_AVAILABLE = False
 
 
+logger = logging.getLogger(__name__)
+
+
 class JsonFormatter(logging.Formatter):
     """Format logs as newline-delimited JSON."""
 
@@ -109,6 +112,10 @@ class MetricsRegistry:
 
 
 def setup_metrics() -> None:
-    """Initialize metrics collection."""
-    # Placeholder for Prometheus/StatsD init
-    pass
+    """Initialize metrics collection.
+
+    This hook is intentionally a no-op until a concrete metrics backend is
+    wired into the application. It preserves the package-level API without
+    implying that Prometheus/StatsD integration is already configured.
+    """
+    logger.debug("Metrics backend not configured; setup_metrics is a no-op")

--- a/src/transformation_portal/core/processing/__init__.py
+++ b/src/transformation_portal/core/processing/__init__.py
@@ -2,6 +2,8 @@
 Processing utilities for transformation pipelines.
 
 Provides efficient processing strategies for large images.
+Compatibility note: retained as an internal/shared helper surface with
+direct smoke coverage, but it currently has no production imports.
 """
 
 from .tiling import TileConfig, TiledProcessor

--- a/src/transformation_portal/core/processing/tiling.py
+++ b/src/transformation_portal/core/processing/tiling.py
@@ -143,10 +143,20 @@ class TiledProcessor:
 
     def _create_tile_weight(self, size: int, overlap: int, device: torch.device) -> torch.Tensor:
         """Create a 2D weight map for blending."""
+        min_weight = 1e-3
+
+        if overlap <= 0:
+            return torch.ones((1, 1, size, size), device=device)
+
         if self.config.blend_mode == "linear":
-            # Simple pyramid
-            # (Not implemented for brevity, using Gaussian as default)
-            pass
+            coords = torch.arange(size, device=device, dtype=torch.float32)
+            edge_distance = torch.minimum(coords, (size - 1) - coords)
+            ramp = torch.ones(size, device=device, dtype=torch.float32)
+            edge_mask = edge_distance < overlap
+            if edge_mask.any():
+                ramp[edge_mask] = min_weight + (1.0 - min_weight) * (edge_distance[edge_mask] / float(overlap))
+            linear_2d = ramp.unsqueeze(1) * ramp.unsqueeze(0)
+            return linear_2d.view(1, 1, size, size)
 
         # Gaussian window
         # Create 1D gaussian
@@ -160,5 +170,6 @@ class TiledProcessor:
         # Normalize to 0-1 range
         gaussian_2d -= gaussian_2d.min()
         gaussian_2d /= gaussian_2d.max()
+        gaussian_2d = gaussian_2d.clamp_min(min_weight)
 
         return gaussian_2d.view(1, 1, size, size)

--- a/src/transformation_portal/core/security/task_signing.py
+++ b/src/transformation_portal/core/security/task_signing.py
@@ -23,7 +23,7 @@ import hashlib
 import json
 import logging
 import time
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
 logger = logging.getLogger(__name__)
@@ -31,6 +31,50 @@ logger = logging.getLogger(__name__)
 
 class TaskSigningError(RuntimeError):
     """Raised for task signing/verification errors."""
+
+
+def _build_sign_payload(
+    payload: Dict[str, Any],
+    *,
+    timestamp: float,
+    nonce: str,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Build the canonical task payload used for signing and verification."""
+    sign_payload = {
+        **payload,
+        "_ts": timestamp,
+        "_nonce": nonce,
+    }
+    if metadata is not None:
+        sign_payload["_metadata"] = metadata
+    return sign_payload
+
+
+def _hash_sign_payload(sign_payload: Dict[str, Any]) -> str:
+    """Return the deterministic SHA-256 hash for a sign payload."""
+    canon = json.dumps(sign_payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canon.encode("utf-8")).hexdigest()
+
+
+def _load_serialization_module():
+    """Load the cryptography serialization module or raise a typed error."""
+    try:
+        from cryptography.hazmat.primitives import serialization
+    except ImportError as exc:
+        raise TaskSigningError("cryptography library required for task signing") from exc
+    return serialization
+
+
+def _load_ed25519_public_key_class():
+    """Load the Ed25519 public key class or raise a typed error."""
+    try:
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+            Ed25519PublicKey,
+        )
+    except ImportError as exc:
+        raise TaskSigningError("cryptography library required for task signature verification") from exc
+    return Ed25519PublicKey
 
 
 @dataclass
@@ -151,28 +195,16 @@ class TaskSigner:
         timestamp = time.time()
         nonce = secrets.token_hex(16)
 
-        # Build full signing payload (includes all signed data)
-        sign_payload = {
-            **payload,
-            "_ts": timestamp,
-            "_nonce": nonce,
-        }
+        sign_payload = _build_sign_payload(
+            payload,
+            timestamp=timestamp,
+            nonce=nonce,
+            metadata=metadata,
+        )
+        payload_hash = _hash_sign_payload(sign_payload)
 
-        if metadata:
-            sign_payload["_metadata"] = metadata
-
-        # Canonicalize for deterministic signing
-        canon = json.dumps(sign_payload, sort_keys=True, separators=(",", ":"))
-        canon_bytes = canon.encode("utf-8")
-
-        # Hash the canonical payload - this is what we sign
-        payload_hash = hashlib.sha256(canon_bytes).hexdigest()
-
-        # Sign using Ed25519 directly (not via sign_manifest which has different semantics)
         try:
-            from cryptography.hazmat.primitives import serialization
-
-            # Access private key from signer to sign directly
+            serialization = _load_serialization_module()
             signature = self.signer._priv.sign(payload_hash.encode("utf-8"))
             pub_bytes = self.signer._pub.public_bytes(
                 encoding=serialization.Encoding.Raw,
@@ -182,10 +214,12 @@ class TaskSigner:
 
             signature_b64 = _b64_encode(signature)
             public_key_b64 = _b64_encode(pub_bytes)
-        except (ImportError, AttributeError):
-            # Fallback if cryptography not available - use placeholder
-            signature_b64 = "no_crypto"
-            public_key_b64 = self.signer.public_key_b64 if hasattr(self.signer, "public_key_b64") else "no_crypto"
+        except TaskSigningError:
+            raise
+        except AttributeError as exc:
+            raise TaskSigningError("TaskSigner requires a CertificateSigner with Ed25519 key material") from exc
+        except Exception as exc:
+            raise TaskSigningError(f"Failed to sign task payload: {exc}") from exc
 
         self._sign_count += 1
 
@@ -343,48 +377,33 @@ class TaskVerifier:
         try:
             from transformation_portal.core.security.signing import _b64_decode
 
-            # Check for cryptography library
-            try:
-                from cryptography.hazmat.primitives.asymmetric.ed25519 import (
-                    Ed25519PublicKey,
-                )
-            except ImportError:
-                logger.warning("cryptography not available, skipping signature check")
-                return True
+            if task.signature == "no_crypto" or task.public_key == "no_crypto":
+                logger.warning("Rejecting unsigned task placeholder")
+                return False
 
-            # Handle placeholder signature when crypto was unavailable at signing
-            if task.signature == "no_crypto":
-                logger.warning("Task signed without crypto, skipping verification")
-                return True
-
-            # Reconstruct exact signing payload (must match TaskSigner.sign)
-            sign_payload = {
-                **task.payload,
-                "_ts": task.timestamp,
-                "_nonce": task.nonce,
-            }
-
-            # Include metadata if it was present at signing time
-            if task.metadata is not None:
-                sign_payload["_metadata"] = task.metadata
-
-            # Canonicalize and hash (same as TaskSigner)
-            canon = json.dumps(sign_payload, sort_keys=True, separators=(",", ":"))
-            canon_bytes = canon.encode("utf-8")
-            payload_hash = hashlib.sha256(canon_bytes).hexdigest()
+            sign_payload = _build_sign_payload(
+                task.payload,
+                timestamp=task.timestamp,
+                nonce=task.nonce,
+                metadata=task.metadata,
+            )
+            payload_hash = _hash_sign_payload(sign_payload)
 
             # The signature is over the hex-encoded hash
             payload_to_verify = payload_hash.encode("utf-8")
 
             # Load public key and verify
             pub_bytes = _b64_decode(task.public_key)
-            pub = Ed25519PublicKey.from_public_bytes(pub_bytes)
+            pub = _load_ed25519_public_key_class().from_public_bytes(pub_bytes)
 
             sig = _b64_decode(task.signature)
             pub.verify(sig, payload_to_verify)
 
             return True
 
+        except TaskSigningError as exc:
+            logger.warning("Task signature verification unavailable: %s", exc)
+            return False
         except Exception as e:
             logger.debug("Signature verification failed: %s", e)
             return False

--- a/src/transformation_portal/core/security/tls.py
+++ b/src/transformation_portal/core/security/tls.py
@@ -229,10 +229,9 @@ def create_tls_connection(
     """
     try:
         current_min_version = getattr(ssl_context, "minimum_version", None)
-        if current_min_version is None or current_min_version < _MINIMUM_TLS_VERSION:
-            ssl_context.minimum_version = _MINIMUM_TLS_VERSION
-        if hasattr(ssl_context, "options") and _TLS_LEGACY_DISABLE_OPTIONS:
-            ssl_context.options |= _TLS_LEGACY_DISABLE_OPTIONS
+        if current_min_version is None or current_min_version < ssl.TLSVersion.TLSv1_2:
+            ssl_context.minimum_version = ssl.TLSVersion.TLSv1_2
+        ssl_context.options |= ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1
         sock = socket.create_connection((host, port), timeout=timeout)
         return ssl_context.wrap_socket(
             sock,

--- a/src/transformation_portal/core/security/tls.py
+++ b/src/transformation_portal/core/security/tls.py
@@ -32,10 +32,23 @@ from pathlib import Path
 from typing import Optional, Tuple
 
 logger = logging.getLogger(__name__)
+_MINIMUM_TLS_VERSION = ssl.TLSVersion.TLSv1_2
 
 
 class TLSError(RuntimeError):
     """Raised for TLS configuration or connection errors."""
+
+
+def _enforce_minimum_tls_version(
+    ctx: ssl.SSLContext,
+    *,
+    min_version: ssl.TLSVersion = _MINIMUM_TLS_VERSION,
+) -> ssl.SSLContext:
+    """Ensure the SSL context enforces a minimum TLS protocol version."""
+    current_min_version = getattr(ctx, "minimum_version", None)
+    if current_min_version is None or current_min_version < min_version:
+        ctx.minimum_version = min_version
+    return ctx
 
 
 def create_server_ssl_context(
@@ -63,7 +76,7 @@ def create_server_ssl_context(
     """
     try:
         ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
-        ctx.minimum_version = min_version
+        _enforce_minimum_tls_version(ctx, min_version=min_version)
 
         # Load server certificate and key
         ctx.load_cert_chain(
@@ -115,7 +128,7 @@ def create_client_ssl_context(
     """
     try:
         ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
-        ctx.minimum_version = min_version
+        _enforce_minimum_tls_version(ctx, min_version=min_version)
 
         # Load client certificate and key
         ctx.load_cert_chain(
@@ -212,6 +225,7 @@ def create_tls_connection(
         TLSError: If connection fails
     """
     try:
+        _enforce_minimum_tls_version(ssl_context)
         sock = socket.create_connection((host, port), timeout=timeout)
         return ssl_context.wrap_socket(
             sock,

--- a/src/transformation_portal/core/security/tls.py
+++ b/src/transformation_portal/core/security/tls.py
@@ -33,6 +33,7 @@ from typing import Optional, Tuple
 
 logger = logging.getLogger(__name__)
 _MINIMUM_TLS_VERSION = ssl.TLSVersion.TLSv1_2
+_TLS_LEGACY_DISABLE_OPTIONS = getattr(ssl, "OP_NO_TLSv1", 0) | getattr(ssl, "OP_NO_TLSv1_1", 0)
 
 
 class TLSError(RuntimeError):
@@ -48,6 +49,8 @@ def _enforce_minimum_tls_version(
     current_min_version = getattr(ctx, "minimum_version", None)
     if current_min_version is None or current_min_version < min_version:
         ctx.minimum_version = min_version
+    if hasattr(ctx, "options") and _TLS_LEGACY_DISABLE_OPTIONS:
+        ctx.options |= _TLS_LEGACY_DISABLE_OPTIONS
     return ctx
 
 
@@ -225,7 +228,11 @@ def create_tls_connection(
         TLSError: If connection fails
     """
     try:
-        _enforce_minimum_tls_version(ssl_context)
+        current_min_version = getattr(ssl_context, "minimum_version", None)
+        if current_min_version is None or current_min_version < _MINIMUM_TLS_VERSION:
+            ssl_context.minimum_version = _MINIMUM_TLS_VERSION
+        if hasattr(ssl_context, "options") and _TLS_LEGACY_DISABLE_OPTIONS:
+            ssl_context.options |= _TLS_LEGACY_DISABLE_OPTIONS
         sock = socket.create_connection((host, port), timeout=timeout)
         return ssl_context.wrap_socket(
             sock,

--- a/src/transformation_portal/core/storage/__init__.py
+++ b/src/transformation_portal/core/storage/__init__.py
@@ -1,4 +1,8 @@
-"""Storage layer for export operations."""
+"""Storage layer for export operations.
+
+Compatibility note: retained as an internal/shared helper surface with
+direct smoke coverage, but it currently has no production imports.
+"""
 
 from .autotune_helpers import ImageStats, compute_image_stats
 from .export_manager import ExportConfig, ExportManager, autotune_export_config

--- a/src/transformation_portal/core/storage/export_manager.py
+++ b/src/transformation_portal/core/storage/export_manager.py
@@ -52,7 +52,7 @@ def autotune_export_config(image: np.ndarray, base_config: ExportConfig) -> Expo
         return base_config
 
     stats = compute_image_stats(image)
-    new_config = base_config.copy()
+    new_config = base_config.model_copy(deep=True)
 
     if stats.is_hdr:
         new_config.format = "exr"
@@ -107,8 +107,9 @@ class ExportManager:
         path.parent.mkdir(parents=True, exist_ok=True)
 
         # 3. Atomic Write Pattern
-        # Write to .tmp file first, then rename
-        temp_path = path.with_suffix(f".{path.suffix}.tmp")
+        # Write to a sibling temp file that keeps the real image extension so
+        # OpenCV/imageio can still select the correct encoder.
+        temp_path = path.parent / f"{path.stem}.tmp{path.suffix}"
 
         try:
             ExportManager._write_file(image, temp_path, config)

--- a/src/transformation_portal/core/validation/__init__.py
+++ b/src/transformation_portal/core/validation/__init__.py
@@ -2,6 +2,8 @@
 Validation and reproducibility tracking.
 
 Provides comprehensive reporting for all processing runs.
+Compatibility note: retained as an internal/shared helper surface with
+direct smoke coverage, but it currently has no production imports.
 """
 
 from .comparison import BaselineComparator, ComparisonResult

--- a/src/transformation_portal/core/validation/report.py
+++ b/src/transformation_portal/core/validation/report.py
@@ -5,7 +5,6 @@ Captures the full context of a processing run to ensure results can be
 reproduced or debugged later.
 """
 
-import json
 import logging
 import platform
 import subprocess
@@ -13,7 +12,12 @@ from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
-import torch
+from transformation_portal.ingest.canonical_json import dump_json
+
+try:
+    import torch
+except (ImportError, OSError):  # pragma: no cover - optional dependency boundary
+    torch = None  # type: ignore[assignment]
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +50,14 @@ class DeviceInfo:
 
     @classmethod
     def capture(cls) -> "DeviceInfo":
+        if torch is None:
+            return cls(
+                system=platform.platform(),
+                python_version=platform.python_version(),
+                pytorch_version="not-installed",
+                cuda_version=None,
+                gpu_name=None,
+            )
         gpu = torch.cuda.get_device_name(0) if torch.cuda.is_available() else None
         cuda = torch.version.cuda if torch.cuda.is_available() else None
         return cls(
@@ -88,7 +100,7 @@ class ProcessingReport:
     metrics: Dict[str, float] = field(default_factory=dict)
     output_files: List[str] = field(default_factory=list)
 
-    def save(self, path: str):
+    def save(self, path: str) -> None:
         """Save report to JSON."""
-        with open(path, "w") as f:
-            json.dump(asdict(self), f, indent=2)
+        with open(path, "w", encoding="utf-8") as handle:
+            dump_json(asdict(self), handle, indent=2, sort_keys=True)

--- a/tests/core/test_low_traffic_core_packages.py
+++ b/tests/core/test_low_traffic_core_packages.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import math
 import subprocess
 import sys
 
@@ -139,7 +138,9 @@ def test_validation_helpers_smoke(tmp_path) -> None:
     metrics = MetricsComputer.compute(image, image.copy())
     comparison = BaselineComparator().compare(image, image.copy())
 
-    assert math.isinf(metrics.psnr)
+    assert metrics.psnr >= 100.0
+    assert metrics.mse == pytest.approx(0.0)
+    assert metrics.ssim == pytest.approx(1.0)
     assert comparison.passed is True
 
     report = ProcessingReport(

--- a/tests/core/test_low_traffic_core_packages.py
+++ b/tests/core/test_low_traffic_core_packages.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import json
+import math
+
+import numpy as np
+import pytest
+
+from transformation_portal.core.batch import BatchJob, JobItem, JobStatus
+from transformation_portal.core.device import DeviceDetector, DeviceType
+from transformation_portal.core.observability import create_logger, setup_metrics
+from transformation_portal.core.observability.integration import MetricsRegistry
+from transformation_portal.core.storage import ExportConfig, ExportManager, autotune_export_config
+from transformation_portal.core.validation import BaselineComparator, MetricsComputer
+from transformation_portal.core.validation.report import DeviceInfo as ReportDeviceInfo
+from transformation_portal.core.validation.report import GitInfo, ProcessingReport
+
+pytestmark = pytest.mark.unit
+
+
+def test_batch_job_checkpoint_round_trip(tmp_path) -> None:
+    checkpoint_path = tmp_path / "batch.json"
+    job = BatchJob(
+        name="smoke",
+        output_dir=str(tmp_path / "outputs"),
+        items=[
+            JobItem(
+                id="image-1",
+                input_path="input.tif",
+                output_path="output.tif",
+                status=JobStatus.COMPLETED,
+                execution_time=1.25,
+            )
+        ],
+    )
+
+    job.save(checkpoint_path)
+    loaded = BatchJob.load(checkpoint_path)
+
+    assert loaded.get_item("image-1") is not None
+    assert loaded.progress == 1.0
+    assert loaded.stats["COMPLETED"] == 1
+
+
+def test_device_package_cpu_fallback_smoke() -> None:
+    if DeviceDetector is None:
+        pytest.skip("device optional dependencies unavailable")
+
+    info = DeviceDetector.get_optimal_device(force_cpu=True)
+
+    assert info.type == DeviceType.CPU
+    assert info.capabilities.device_name
+
+
+def test_storage_autotune_and_export_smoke(tmp_path) -> None:
+    image = np.zeros((4, 4, 4), dtype=np.uint8)
+    image[..., 3] = 255
+
+    config = ExportConfig(format="auto")
+    tuned = autotune_export_config(image, config)
+    saved_path = ExportManager.save_image(image, tmp_path / "artifact.bin", config)
+
+    assert tuned.format == "png"
+    assert saved_path.suffix == ".png"
+    assert saved_path.exists()
+
+
+@pytest.mark.ml
+def test_processing_linear_blend_mode_is_real() -> None:
+    torch = pytest.importorskip("torch")
+    from transformation_portal.core.processing import TileConfig, TiledProcessor
+
+    linear_processor = TiledProcessor(TileConfig(tile_size=8, tile_overlap=3, blend_mode="linear"))
+    gaussian_processor = TiledProcessor(TileConfig(tile_size=8, tile_overlap=3, blend_mode="gaussian"))
+
+    linear_weight = linear_processor._create_tile_weight(8, 3, torch.device("cpu"))
+    gaussian_weight = gaussian_processor._create_tile_weight(8, 3, torch.device("cpu"))
+
+    assert linear_weight.shape == (1, 1, 8, 8)
+    assert float(linear_weight[0, 0, 0, 0]) > 0.0
+    assert float(linear_weight[0, 0, 4, 4]) > float(linear_weight[0, 0, 0, 0])
+    assert torch.allclose(linear_weight, gaussian_weight) is False
+
+
+def test_observability_setup_metrics_is_explicit_no_op() -> None:
+    MetricsRegistry._metrics.clear()
+
+    assert setup_metrics() is None
+
+    logger = create_logger("transformation_portal.tests.core")
+    logger.debug("metrics hook retained")
+    MetricsRegistry.increment("jobs")
+
+    assert MetricsRegistry.get_all() == {"jobs": 1}
+
+
+def test_validation_helpers_smoke(tmp_path) -> None:
+    image = np.full((8, 8, 3), 32, dtype=np.uint8)
+    metrics = MetricsComputer.compute(image, image.copy())
+    comparison = BaselineComparator().compare(image, image.copy())
+
+    assert math.isinf(metrics.psnr)
+    assert comparison.passed is True
+
+    report = ProcessingReport(
+        job_id="job-1",
+        git=GitInfo(commit_hash="abc123", branch="main", is_dirty=False),
+        device=ReportDeviceInfo(
+            system="darwin",
+            python_version="3.11.0",
+            pytorch_version="2.x",
+            cuda_version=None,
+            gpu_name=None,
+        ),
+        metrics={"psnr": float(metrics.psnr)},
+    )
+    report_path = tmp_path / "report.json"
+    report.save(str(report_path))
+
+    payload = json.loads(report_path.read_text())
+    assert payload["job_id"] == "job-1"
+    assert payload["metrics"]["psnr"] == float(metrics.psnr)

--- a/tests/core/test_low_traffic_core_packages.py
+++ b/tests/core/test_low_traffic_core_packages.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 import math
+import subprocess
+import sys
 
 import numpy as np
 import pytest
@@ -92,6 +94,44 @@ def test_observability_setup_metrics_is_explicit_no_op() -> None:
     MetricsRegistry.increment("jobs")
 
     assert MetricsRegistry.get_all() == {"jobs": 1}
+
+
+def test_validation_package_import_is_torch_optional() -> None:
+    test_script = """
+import sys
+
+class TorchBlocker:
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == "torch" or fullname.startswith("torch."):
+            raise ImportError(f"Torch import blocked for test: {fullname}")
+        return None
+
+sys.meta_path.insert(0, TorchBlocker())
+
+import transformation_portal.core.validation as validation
+from transformation_portal.core.validation.report import DeviceInfo, ProcessingReport
+
+assert validation.MetricsComputer is not None
+device = DeviceInfo.capture()
+assert device.pytorch_version == "not-installed"
+assert device.cuda_version is None
+assert device.gpu_name is None
+report = ProcessingReport(job_id="job-1")
+assert report.device.pytorch_version == "not-installed"
+print("SUCCESS")
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", test_script],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+
+    if result.returncode != 0:
+        pytest.fail(f"validation import should not require torch\nstdout: {result.stdout}\nstderr: {result.stderr}")
+
+    assert "SUCCESS" in result.stdout
 
 
 def test_validation_helpers_smoke(tmp_path) -> None:

--- a/tests/core/test_pydantic_deprecations.py
+++ b/tests/core/test_pydantic_deprecations.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import importlib
+import warnings
+
+import numpy as np
+import pytest
+from pydantic.warnings import PydanticDeprecatedSince20
+
+pytestmark = pytest.mark.unit
+
+
+def test_core_config_and_storage_emit_no_pydantic_v2_deprecations() -> None:
+    with warnings.catch_warnings():
+        warnings.filterwarnings("error", category=PydanticDeprecatedSince20)
+
+        schemas = importlib.import_module("transformation_portal.core.config.schemas")
+        export_manager = importlib.import_module("transformation_portal.core.storage.export_manager")
+
+        importlib.reload(schemas)
+        importlib.reload(export_manager)
+
+        schemas.PerformanceConfig()
+        export_manager.autotune_export_config(np.zeros((2, 2, 3), dtype=np.uint8), export_manager.ExportConfig())

--- a/tests/security/test_signing_tls_helpers.py
+++ b/tests/security/test_signing_tls_helpers.py
@@ -92,6 +92,7 @@ def test_create_tls_connection_enforces_tls12_floor(monkeypatch: pytest.MonkeyPa
     class FakeSSLContext:
         def __init__(self) -> None:
             self.minimum_version = ssl.TLSVersion.TLSv1
+            self.options = 0
             self.wrap_calls: list[tuple[object, str]] = []
 
         def wrap_socket(self, sock, *, server_hostname):
@@ -105,4 +106,10 @@ def test_create_tls_connection_enforces_tls12_floor(monkeypatch: pytest.MonkeyPa
 
     assert wrapped == "wrapped-socket"
     assert context.minimum_version == ssl.TLSVersion.TLSv1_2
+    tlsv1_disable = getattr(ssl, "OP_NO_TLSv1", 0)
+    tlsv11_disable = getattr(ssl, "OP_NO_TLSv1_1", 0)
+    if tlsv1_disable:
+        assert context.options & tlsv1_disable
+    if tlsv11_disable:
+        assert context.options & tlsv11_disable
     assert context.wrap_calls and context.wrap_calls[0][1] == "127.0.0.1"

--- a/tests/security/test_signing_tls_helpers.py
+++ b/tests/security/test_signing_tls_helpers.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import builtins
+import json
+import socket
+import ssl
+
+import pytest
+
+from transformation_portal.core.security import signing, tls
+from transformation_portal.core.security.signing import (
+    CertificateSigner,
+    CertificateVerifier,
+    SigningError,
+    generate_ed25519_keypair,
+)
+from transformation_portal.core.security.tls import (
+    TLSError,
+    create_client_ssl_context,
+    create_server_ssl_context,
+    create_tls_connection,
+    generate_self_signed_cert,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.security]
+
+
+def test_certificate_signer_round_trip() -> None:
+    private_key, _ = generate_ed25519_keypair()
+    manifest_json = json.dumps(
+        {
+            "root_hash": "sha256:1234",
+            "artifacts": [],
+        },
+        sort_keys=True,
+    )
+
+    signer = CertificateSigner(private_key, issuer="test-suite")
+    cert = signer.sign_manifest(manifest_json, metadata={"stage": "depth"})
+
+    assert CertificateVerifier.verify(manifest_json, cert) is True
+    assert CertificateVerifier.verify_with_public_key(manifest_json, cert, signer.public_key_bytes) is True
+
+
+def test_generate_ed25519_keypair_requires_crypto(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(signing, "_CRYPTO_AVAILABLE", False)
+
+    with pytest.raises(SigningError, match="cryptography library required"):
+        generate_ed25519_keypair()
+
+
+def test_tls_context_helpers_support_generated_certificates(tmp_path) -> None:
+    cert_path, key_path = generate_self_signed_cert("localhost", tmp_path)
+
+    server_ctx = create_server_ssl_context(cert_path, key_path, cert_path, verify_client=False)
+    client_ctx = create_client_ssl_context(cert_path, key_path, cert_path, verify_hostname=False)
+
+    assert isinstance(server_ctx, ssl.SSLContext)
+    assert isinstance(client_ctx, ssl.SSLContext)
+    assert server_ctx.verify_mode == ssl.CERT_OPTIONAL
+    assert client_ctx.verify_mode == ssl.CERT_REQUIRED
+
+
+def test_generate_self_signed_cert_requires_cryptography(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    real_import = builtins.__import__
+
+    def _fake_import(name, *args, **kwargs):
+        if name.startswith("cryptography"):
+            raise ImportError("missing cryptography")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_import)
+
+    with pytest.raises(TLSError, match="cryptography library required"):
+        tls.generate_self_signed_cert("localhost", tmp_path)
+
+
+def test_create_tls_connection_wraps_socket_failures(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _raise_connection(*args, **kwargs):
+        raise OSError("connection refused")
+
+    monkeypatch.setattr(socket, "create_connection", _raise_connection)
+
+    with pytest.raises(TLSError, match="Failed to create TLS connection"):
+        create_tls_connection("127.0.0.1", 443, ssl.create_default_context(), timeout=0.01)
+
+
+def test_create_tls_connection_enforces_tls12_floor(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeSocket:
+        pass
+
+    class FakeSSLContext:
+        def __init__(self) -> None:
+            self.minimum_version = ssl.TLSVersion.TLSv1
+            self.wrap_calls: list[tuple[object, str]] = []
+
+        def wrap_socket(self, sock, *, server_hostname):
+            self.wrap_calls.append((sock, server_hostname))
+            return "wrapped-socket"
+
+    monkeypatch.setattr(socket, "create_connection", lambda *args, **kwargs: FakeSocket())
+
+    context = FakeSSLContext()
+    wrapped = create_tls_connection("127.0.0.1", 443, context, timeout=0.01)
+
+    assert wrapped == "wrapped-socket"
+    assert context.minimum_version == ssl.TLSVersion.TLSv1_2
+    assert context.wrap_calls and context.wrap_calls[0][1] == "127.0.0.1"

--- a/tests/security/test_task_signing.py
+++ b/tests/security/test_task_signing.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from transformation_portal.core.security import task_signing
+from transformation_portal.core.security.signing import CertificateSigner, generate_ed25519_keypair
+from transformation_portal.core.security.task_signing import SignedTask, TaskSigner, TaskSigningError, TaskVerifier
+
+pytestmark = [pytest.mark.unit, pytest.mark.security]
+
+
+def test_task_signing_round_trip_verifies() -> None:
+    private_key, _ = generate_ed25519_keypair()
+    signer = TaskSigner(CertificateSigner(private_key))
+
+    signed = signer.sign(
+        {
+            "node_cls": "ProcessNode",
+            "inputs": {"artifact": "sha256:abc123"},
+        },
+        metadata={"queue": "default"},
+    )
+
+    verifier = TaskVerifier(authorized_keys={signed.public_key})
+
+    assert verifier.verify(signed) is True
+    assert verifier.get_stats()["verified"] == 1
+
+
+def test_task_signer_requires_crypto_backed_signer() -> None:
+    class BrokenSigner:
+        pass
+
+    with pytest.raises(TaskSigningError, match="CertificateSigner"):
+        TaskSigner(BrokenSigner()).sign({"node_cls": "Broken"})
+
+
+def test_task_verifier_rejects_placeholder_signature() -> None:
+    placeholder = SignedTask(
+        payload={"node_cls": "Unsigned"},
+        signature="no_crypto",
+        public_key="no_crypto",
+        timestamp=time.time(),
+        nonce="abc123",
+    )
+
+    assert TaskVerifier().verify(placeholder) is False
+
+
+def test_task_verifier_fails_closed_when_crypto_verification_is_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    private_key, _ = generate_ed25519_keypair()
+    signer = TaskSigner(CertificateSigner(private_key))
+    signed = signer.sign({"node_cls": "ProcessNode"})
+
+    def _raise_missing_crypto():
+        raise TaskSigningError("cryptography library required for task signature verification")
+
+    monkeypatch.setattr(task_signing, "_load_ed25519_public_key_class", _raise_missing_crypto)
+
+    verifier = TaskVerifier(authorized_keys={signed.public_key})
+
+    assert verifier.verify(signed) is False


### PR DESCRIPTION
## Summary
- Harden fail-closed task signing behavior in the retained core security surface.
- Remove Pydantic 2 deprecation drift and complete advertised low-traffic core helper behavior without changing import paths.

## Changes
- Extract shared CAS serialization and atomic-write helpers into `src/transformation_portal/core/_cas_helpers.py`, with compatibility wrappers preserved in `execution_wrapper.py`.
- Make `TaskSigner` raise `TaskSigningError` when crypto-backed signing is unavailable and make `TaskVerifier` reject placeholder or unverifiable signatures.
- Migrate retained core config/storage internals to Pydantic 2-native validators and `model_copy()`.
- Implement linear tile blending, make `setup_metrics()` an explicit no-op hook, and keep low-traffic package surfaces marked as internal/shared compatibility modules.
- Add focused tests for task signing, signing/TLS helpers, low-traffic core package smoke coverage, and Pydantic deprecation enforcement.

## Validation
Proven green
- `.venv/bin/pytest tests/security/test_task_signing.py tests/security/test_signing_tls_helpers.py tests/core/test_low_traffic_core_packages.py tests/core/test_pydantic_deprecations.py -q`
- `.venv/bin/pytest tests/determinism/test_execution_identity.py tests/determinism/test_execution_wrapper.py tests/test_ml_dependency_health.py tests/test_raw_runtime.py tests/test_core_config_presets.py tests/test_preset_health.py tests/core/geometry/test_multiview_request.py tests/security/test_fs_guard.py tests/security/test_path_safety_global.py tests/security/test_platform_security_profile.py tests/test_model_lock.py tests/security/test_task_signing.py tests/security/test_signing_tls_helpers.py tests/core/test_low_traffic_core_packages.py tests/core/test_pydantic_deprecations.py -q`

Still failing
- None in the validated scope.

## Risk
- Import paths remain stable; the helper extraction is bounded to internal implementation plumbing.
- The only intentional contract tightening is that unverifiable task signatures now fail closed.
- Revert is straightforward because the change is scoped to `transformation_portal.core` helpers and their direct tests.