### PR TITLE
fix(reporting): harden truthfulness reporting contracts

### DIFF
--- a/docs/schemas/run_card/run_card.v1.schema.json
+++ b/docs/schemas/run_card/run_card.v1.schema.json
@@ -500,6 +500,109 @@
               "string",
               "null"
             ]
+          },
+          "quality_gate": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "minLength": 1
+              },
+              "passed": {
+                "type": "boolean"
+              },
+              "failure_codes": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "warnings": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "details": {
+                "type": "object",
+                "properties": {
+                  "metrics": {
+                    "type": "object"
+                  },
+                  "thresholds": {
+                    "type": "object"
+                  },
+                  "shape_context": {
+                    "type": "object"
+                  }
+                },
+                "additionalProperties": true
+              }
+            },
+            "additionalProperties": true
+          },
+          "capability": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "requested_backend": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "executed_backend": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "availability_state": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reason": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "synthetic_output": {
+                "type": "boolean"
+              },
+              "stub_mode": {
+                "type": "boolean"
+              },
+              "fallback_executed": {
+                "type": "boolean"
+              },
+              "model_repo_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "model_revision": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "asset_bundle_version": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "additionalProperties": true
           }
         },
         "additionalProperties": true

--- a/docs/schemas/run_card/run_card.v2.schema.json
+++ b/docs/schemas/run_card/run_card.v2.schema.json
@@ -500,6 +500,109 @@
               "string",
               "null"
             ]
+          },
+          "quality_gate": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "minLength": 1
+              },
+              "passed": {
+                "type": "boolean"
+              },
+              "failure_codes": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "warnings": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "details": {
+                "type": "object",
+                "properties": {
+                  "metrics": {
+                    "type": "object"
+                  },
+                  "thresholds": {
+                    "type": "object"
+                  },
+                  "shape_context": {
+                    "type": "object"
+                  }
+                },
+                "additionalProperties": true
+              }
+            },
+            "additionalProperties": true
+          },
+          "capability": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "requested_backend": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "executed_backend": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "availability_state": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reason": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "synthetic_output": {
+                "type": "boolean"
+              },
+              "stub_mode": {
+                "type": "boolean"
+              },
+              "fallback_executed": {
+                "type": "boolean"
+              },
+              "model_repo_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "model_revision": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "asset_bundle_version": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "additionalProperties": true
           }
         },
         "additionalProperties": true

--- a/src/transformation_portal/depth/models/__init__.py
+++ b/src/transformation_portal/depth/models/__init__.py
@@ -7,7 +7,7 @@ does not eagerly pull in optional ML stacks like torch-backed depth models.
 from __future__ import annotations
 
 from importlib import import_module
-from typing import Dict, Tuple
+from typing import Dict, Optional, Tuple
 
 
 class CoreMLExporter:
@@ -42,6 +42,7 @@ __all__ = [
     "DepthAnythingV2Model",
     "ModelBackend",
     "ModelVariant",
+    "load_depth_model",
     "CoreMLDepthModel",
     "CoreMLExporter",
     "CoreMLDepthEstimator",
@@ -62,3 +63,40 @@ def __getattr__(name: str) -> object:
 
 def __dir__() -> list[str]:
     return sorted(set(globals()) | set(__all__))
+
+
+def load_depth_model(
+    *,
+    model_size: str = "base",
+    device: Optional[str] = None,
+    model_revision: Optional[str] = None,
+) -> object:
+    """Compatibility loader for the repo-local Depth Anything V2 wrapper."""
+    depth_model_cls = __getattr__("DepthAnythingV2Model")
+    model_backend_cls = __getattr__("ModelBackend")
+    model_variant_cls = __getattr__("ModelVariant")
+
+    normalized_size = str(model_size or "base").strip().lower()
+    variant_map = {
+        "small": model_variant_cls.SMALL,
+        "base": model_variant_cls.BASE,
+        "large": model_variant_cls.LARGE,
+    }
+    try:
+        variant = variant_map[normalized_size]
+    except KeyError as exc:
+        raise ValueError(f"Unsupported depth model_size {model_size!r}. Expected one of: small, base, large.") from exc
+
+    normalized_device = str(device or "").strip().lower()
+    backend = None
+    if normalized_device == "mps":
+        backend = model_backend_cls.PYTORCH_MPS
+    elif normalized_device in {"cpu", "cuda"}:
+        backend = model_backend_cls.PYTORCH_CPU
+
+    return depth_model_cls(
+        variant=variant,
+        backend=backend,
+        device=(normalized_device or None),
+        model_revision=model_revision,
+    )

--- a/src/transformation_portal/execution_graph/nodes/base.py
+++ b/src/transformation_portal/execution_graph/nodes/base.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
+from transformation_portal.stage_graph.stage import StageStatus
+
 
 @dataclass
 class NodeResult:
@@ -29,11 +31,17 @@ class NodeResult:
     outputs: dict[str, Any] = field(default_factory=dict)
     metadata: dict[str, Any] = field(default_factory=dict)
     error: Optional[str] = None
+    status: StageStatus = StageStatus.COMPLETED
+
+    def __post_init__(self) -> None:
+        """Normalize legacy error-only construction onto shared stage status."""
+        if self.error is not None and self.status in {StageStatus.COMPLETED, StageStatus.CACHED}:
+            self.status = StageStatus.FAILED
 
     @property
     def success(self) -> bool:
         """Check if execution succeeded."""
-        return self.error is None
+        return self.status in {StageStatus.COMPLETED, StageStatus.CACHED}
 
 
 class DAGNode:

--- a/src/transformation_portal/execution_graph/nodes/nvdiffrec_node.py
+++ b/src/transformation_portal/execution_graph/nodes/nvdiffrec_node.py
@@ -16,6 +16,8 @@ from pathlib import Path
 from typing import Any, Optional
 
 from transformation_portal.execution_graph.nodes.base import DAGNode, NodeResult
+from transformation_portal.reporting.contracts import build_capability_report
+from transformation_portal.stage_graph.stage import StageStatus
 
 logger = logging.getLogger(__name__)
 
@@ -138,22 +140,25 @@ class NVDiffRecNode(DAGNode):
 
         output_dir.mkdir(parents=True, exist_ok=True)
 
-        # Return stub outputs indicating backend is not available
         return NodeResult(
-            outputs={
-                "albedo": None,
-                "normal": None,
-                "roughness": None,
-                "metallic": None,
-                "mesh": None,
-                "diagnostics": None,
-                "backend_available": False,
-            },
+            outputs={},
             metadata={
                 "num_input_images": len(image_paths),
                 "output_dir": str(output_dir),
+                "backend_available": False,
                 "stub_mode": True,
+                "capability": build_capability_report(
+                    requested_backend="nvdiffrec",
+                    executed_backend=None,
+                    availability_state="backend_unwired",
+                    reason=(
+                        "NVDiffRec backend is not wired for this execution node. "
+                        "Provide a concrete backend or use the supported multiview reconstruction surface."
+                    ),
+                    stub_mode=True,
+                ),
             },
+            status=StageStatus.UNAVAILABLE,
         )
 
     def _run_with_backend(
@@ -187,7 +192,13 @@ class NVDiffRecNode(DAGNode):
                 metadata={
                     "num_input_images": len(image_paths),
                     "output_dir": str(output_dir),
+                    "backend_available": True,
                     "stub_mode": False,
+                    "capability": build_capability_report(
+                        requested_backend="nvdiffrec",
+                        executed_backend="nvdiffrec",
+                        availability_state="available",
+                    ),
                 },
             )
 

--- a/src/transformation_portal/lux_depth_v3/orchestrator.py
+++ b/src/transformation_portal/lux_depth_v3/orchestrator.py
@@ -45,6 +45,11 @@ from ..core.ml_dependency_health import (
 from ..depth.backends.protocol import DepthBackend, LicenseRestrictionError
 from ..depth.backends.registry import DepthBackendRegistry
 from ..ingest.canonical_json import dump_json, dumps_json
+from ..reporting.contracts import (
+    build_orchestrator_result_capability_report,
+    build_quality_gate_report,
+    resolve_result_quality_gate,
+)
 from ..spatial_ai.reconstruction.contracts import (  # noqa: E501
     LicenseRestrictionError as ReconstructionLicenseRestrictionError,
 )
@@ -3903,6 +3908,7 @@ class EnhanceOrchestrator:
                     ),
                     "attempts": depth_attempts,
                     "selected_attempt_index": None,
+                    "quality_gate": None,
                 }
 
         # Runtime invariant checks for attempt-selection consistency.
@@ -4056,6 +4062,9 @@ class EnhanceOrchestrator:
             "v2_output_path": v2_output_path,
             "segmentation_mask_path": segmentation_mask_path,
             "runtime_s": (pipeline_end_time - pipeline_start_time),
+            "quality_gate": build_quality_gate_report(
+                getattr(depth_metadata, "stats", {}).get("apex_depth_validity") if depth_metadata is not None else None
+            ),
         }
 
     def _verify_pbr_outputs(
@@ -4893,9 +4902,11 @@ class EnhanceOrchestrator:
                     "_active_selected_attempt_index",
                     None,
                 )
+                error_payload["quality_gate"] = None
                 if isinstance(e, ApexStrictGateError):
                     error_payload["error_code"] = e.code
                     error_payload["error_details"] = e.details
+                    error_payload["quality_gate"] = build_quality_gate_report(e.details)
                 results.append(error_payload)
 
         return results
@@ -5031,9 +5042,11 @@ class EnhanceOrchestrator:
                         "_active_selected_attempt_index",
                         None,
                     )
+                    error_payload["quality_gate"] = None
                     if isinstance(e, ApexStrictGateError):
                         error_payload["error_code"] = e.code
                         error_payload["error_details"] = e.details
+                        error_payload["quality_gate"] = build_quality_gate_report(e.details)
                     results.append(error_payload)
 
         if getattr(self.config, "enable_reconstruction", False):
@@ -6012,6 +6025,20 @@ class EnhanceOrchestrator:
                     "error_message": result.get("error"),
                     "error_details": result.get("error_details"),
                     "segmentation_metadata": segmentation_metadata,
+                    "quality_gate": resolve_result_quality_gate(result),
+                    "capability": build_orchestrator_result_capability_report(
+                        result,
+                        requested_backend=getattr(
+                            getattr(self, "_backend_metadata", None),
+                            "requested_backend",
+                            None,
+                        ),
+                        resolution_reason=getattr(
+                            getattr(self, "_backend_metadata", None),
+                            "resolution_reason",
+                            None,
+                        ),
+                    ),
                 }
             )
         return summary_rows

--- a/src/transformation_portal/reporting/__init__.py
+++ b/src/transformation_portal/reporting/__init__.py
@@ -1,0 +1,21 @@
+"""Shared reporting contracts and helpers."""
+
+from .contracts import (
+    build_capability_report,
+    build_orchestrator_result_capability_report,
+    build_quality_gate_report,
+    build_stage_report,
+    derive_stage_report_map,
+    resolve_result_quality_gate,
+    select_result_attempt,
+)
+
+__all__ = [
+    "build_capability_report",
+    "build_orchestrator_result_capability_report",
+    "build_quality_gate_report",
+    "build_stage_report",
+    "derive_stage_report_map",
+    "resolve_result_quality_gate",
+    "select_result_attempt",
+]

--- a/src/transformation_portal/reporting/contracts.py
+++ b/src/transformation_portal/reporting/contracts.py
@@ -1,0 +1,210 @@
+"""Small shared reporting builders for capability, quality-gate, and stage status payloads."""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, Mapping, Optional
+
+
+def _copy_mapping(value: Any) -> Optional[dict[str, Any]]:
+    """Return a deep-copied dict when the input is mapping-like."""
+    if isinstance(value, Mapping):
+        return copy.deepcopy(dict(value))
+    return None
+
+
+def _normalize_optional_string(value: Any) -> Optional[str]:
+    """Normalize values to stripped strings or None."""
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def build_quality_gate_report(
+    gate_payload: Any,
+    *,
+    default_kind: str = "apex_depth",
+) -> Optional[dict[str, Any]]:
+    """Project gate payloads into a stable serialized quality-gate shape."""
+    if not isinstance(gate_payload, Mapping):
+        return None
+
+    details = {
+        "metrics": _copy_mapping(gate_payload.get("metrics")) or {},
+        "thresholds": _copy_mapping(gate_payload.get("thresholds")) or {},
+        "shape_context": _copy_mapping(gate_payload.get("shape_context")) or {},
+    }
+    demoted_failure_codes = gate_payload.get("demoted_failure_codes")
+    if demoted_failure_codes not in (None, [], {}):
+        details["demoted_failure_codes"] = copy.deepcopy(demoted_failure_codes)
+
+    return {
+        "kind": _normalize_optional_string(gate_payload.get("kind")) or default_kind,
+        "passed": bool(gate_payload.get("passed", False)),
+        "failure_codes": list(gate_payload.get("failure_codes") or []),
+        "warnings": list(gate_payload.get("warnings") or []),
+        "details": details,
+    }
+
+
+def build_capability_report(
+    *,
+    requested_backend: Any,
+    executed_backend: Any,
+    availability_state: Any,
+    reason: Any = None,
+    synthetic_output: bool = False,
+    stub_mode: bool = False,
+    fallback_executed: bool = False,
+    model_repo_id: Any = None,
+    model_revision: Any = None,
+    asset_bundle_version: Any = None,
+) -> dict[str, Any]:
+    """Build a normalized backend capability report."""
+    return {
+        "requested_backend": _normalize_optional_string(requested_backend),
+        "executed_backend": _normalize_optional_string(executed_backend),
+        "availability_state": _normalize_optional_string(availability_state),
+        "reason": _normalize_optional_string(reason),
+        "synthetic_output": bool(synthetic_output),
+        "stub_mode": bool(stub_mode),
+        "fallback_executed": bool(fallback_executed),
+        "model_repo_id": _normalize_optional_string(model_repo_id),
+        "model_revision": _normalize_optional_string(model_revision),
+        "asset_bundle_version": _normalize_optional_string(asset_bundle_version),
+    }
+
+
+def select_result_attempt(result: Mapping[str, Any]) -> Optional[dict[str, Any]]:
+    """Return the selected attempt for a result row when available."""
+    attempts = result.get("attempts")
+    if not isinstance(attempts, list) or not attempts:
+        return None
+
+    selected_attempt_index = result.get("selected_attempt_index")
+    if isinstance(selected_attempt_index, int) and 0 <= selected_attempt_index < len(attempts):
+        attempt = attempts[selected_attempt_index]
+        if isinstance(attempt, Mapping):
+            return copy.deepcopy(dict(attempt))
+
+    backend = result.get("backend")
+    for attempt in attempts:
+        if not isinstance(attempt, Mapping):
+            continue
+        if backend and attempt.get("backend") != backend:
+            continue
+        if attempt.get("status") == "success":
+            return copy.deepcopy(dict(attempt))
+
+    for attempt in attempts:
+        if isinstance(attempt, Mapping):
+            return copy.deepcopy(dict(attempt))
+
+    return None
+
+
+def build_orchestrator_result_capability_report(
+    result: Mapping[str, Any],
+    *,
+    requested_backend: Any = None,
+    resolution_reason: Any = None,
+) -> dict[str, Any]:
+    """Build the normalized capability record for an orchestrator result row."""
+    selected_attempt = select_result_attempt(result)
+    requested = (
+        result.get("requested_backend")
+        or requested_backend
+        or result.get("backend")
+        or (selected_attempt.get("backend") if isinstance(selected_attempt, Mapping) else None)
+        or "auto"
+    )
+    executed_backend = result.get("backend") or (
+        selected_attempt.get("backend") if isinstance(selected_attempt, Mapping) else None
+    )
+    fallback_executed = bool(result.get("fallback_used"))
+    status = result.get("status")
+
+    if status == "skipped":
+        availability_state = "skipped"
+        reason = result.get("reason")
+    elif status == "error":
+        availability_state = "failed"
+        reason = result.get("error_code") or result.get("error")
+    elif fallback_executed:
+        availability_state = "fallback_executed"
+        reason = resolution_reason or None
+        if not reason:
+            attempts = result.get("attempts")
+            if isinstance(attempts, list):
+                for attempt in attempts:
+                    if not isinstance(attempt, Mapping):
+                        continue
+                    if attempt.get("status") == "failed":
+                        reason = attempt.get("error_message") or attempt.get("error_code")
+                        if reason:
+                            break
+    elif executed_backend:
+        availability_state = "available"
+        reason = None
+    else:
+        availability_state = "unknown"
+        reason = None
+
+    model_repo_id = result.get("model_id")
+    if not model_repo_id and isinstance(selected_attempt, Mapping):
+        model_repo_id = selected_attempt.get("model_id")
+
+    model_revision = selected_attempt.get("model_revision") if isinstance(selected_attempt, Mapping) else None
+    asset_bundle_version = selected_attempt.get("asset_bundle_version") if isinstance(selected_attempt, Mapping) else None
+
+    return build_capability_report(
+        requested_backend=requested,
+        executed_backend=executed_backend,
+        availability_state=availability_state,
+        reason=reason,
+        synthetic_output=False,
+        stub_mode=False,
+        fallback_executed=fallback_executed,
+        model_repo_id=model_repo_id,
+        model_revision=model_revision,
+        asset_bundle_version=asset_bundle_version,
+    )
+
+
+def resolve_result_quality_gate(
+    result: Mapping[str, Any],
+    *,
+    default_kind: str = "apex_depth",
+) -> Optional[dict[str, Any]]:
+    """Resolve the normalized quality gate for a result row."""
+    normalized = build_quality_gate_report(result.get("quality_gate"), default_kind=default_kind)
+    if normalized is not None:
+        return normalized
+    return build_quality_gate_report(result.get("error_details"), default_kind=default_kind)
+
+
+def build_stage_report(
+    *,
+    stage: str,
+    status: str,
+    capability: Optional[Mapping[str, Any]] = None,
+    quality_gate: Optional[Mapping[str, Any]] = None,
+) -> dict[str, Any]:
+    """Build a normalized stage-report payload."""
+    return {
+        "stage": stage,
+        "status": status,
+        "capability": _copy_mapping(capability),
+        "quality_gate": _copy_mapping(quality_gate),
+    }
+
+
+def derive_stage_report_map(stage_reports: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    """Index stage reports by stage name, preserving the last report per stage."""
+    report_map: dict[str, dict[str, Any]] = {}
+    for report in stage_reports:
+        stage_name = report.get("stage")
+        if isinstance(stage_name, str) and stage_name:
+            report_map[stage_name] = copy.deepcopy(report)
+    return report_map

--- a/src/transformation_portal/reporting/contracts.py
+++ b/src/transformation_portal/reporting/contracts.py
@@ -1,4 +1,8 @@
-"""Small shared reporting builders for capability, quality-gate, and stage status payloads."""
+"""Small shared reporting builders for capability, quality-gate, and stage status payloads.
+
+Capability describes backend availability/execution truth. Quality-gate describes
+output-validity truth. Result-row status captures the final artifact outcome.
+"""
 
 from __future__ import annotations
 
@@ -104,14 +108,101 @@ def select_result_attempt(result: Mapping[str, Any]) -> Optional[dict[str, Any]]
     return None
 
 
+def _list_result_attempts(result: Mapping[str, Any]) -> list[dict[str, Any]]:
+    """Return deep-copied attempt records for rows with structured history."""
+    attempts = result.get("attempts")
+    if not isinstance(attempts, list):
+        return []
+    return [copy.deepcopy(dict(attempt)) for attempt in attempts if isinstance(attempt, Mapping)]
+
+
+def _find_failed_attempt_for_backend(
+    attempts: list[dict[str, Any]],
+    executed_backend: Optional[str],
+) -> Optional[dict[str, Any]]:
+    """Return the most relevant failed attempt for the executed backend."""
+    if executed_backend:
+        for attempt in reversed(attempts):
+            if attempt.get("status") == "failed" and attempt.get("backend") == executed_backend:
+                return attempt
+    for attempt in reversed(attempts):
+        if attempt.get("status") == "failed":
+            return attempt
+    return None
+
+
+def _is_semantic_gate_failure(
+    failed_attempt: Optional[dict[str, Any]],
+    gate_report: Optional[Mapping[str, Any]],
+) -> bool:
+    """Return True when a failed row reflects output-quality rejection, not backend loss."""
+    if isinstance(failed_attempt, Mapping) and failed_attempt.get("failure_kind") == "semantic":
+        return True
+    if isinstance(gate_report, Mapping) and gate_report.get("passed") is False and isinstance(failed_attempt, Mapping):
+        return failed_attempt.get("failure_kind") == "semantic"
+    return False
+
+
+def _resolve_fallback_reason(
+    attempts: list[dict[str, Any]],
+    resolution_reason: Any,
+) -> Optional[str]:
+    """Return the best available explanation for backend fallback execution."""
+    normalized_reason = _normalize_optional_string(resolution_reason)
+    if normalized_reason:
+        return normalized_reason
+
+    for attempt in attempts:
+        if attempt.get("status") != "failed":
+            continue
+        if attempt.get("failure_kind") not in {"operational", "license"}:
+            continue
+        reason = _normalize_optional_string(attempt.get("error_message")) or _normalize_optional_string(
+            attempt.get("error_code")
+        )
+        if reason:
+            return reason
+
+    for attempt in attempts:
+        if attempt.get("status") != "failed":
+            continue
+        reason = _normalize_optional_string(attempt.get("error_message")) or _normalize_optional_string(
+            attempt.get("error_code")
+        )
+        if reason:
+            return reason
+
+    return None
+
+
+def _select_capability_metadata_attempt(
+    selected_attempt: Optional[dict[str, Any]],
+    failed_attempt: Optional[dict[str, Any]],
+    executed_backend: Optional[str],
+) -> Optional[dict[str, Any]]:
+    """Return the attempt that best represents executed-backend provenance."""
+    if isinstance(selected_attempt, Mapping) and (
+        executed_backend is None or selected_attempt.get("backend") == executed_backend
+    ):
+        return selected_attempt
+    if isinstance(failed_attempt, Mapping):
+        return failed_attempt
+    return selected_attempt
+
+
 def build_orchestrator_result_capability_report(
     result: Mapping[str, Any],
     *,
     requested_backend: Any = None,
     resolution_reason: Any = None,
 ) -> dict[str, Any]:
-    """Build the normalized capability record for an orchestrator result row."""
+    """Build the normalized capability record for an orchestrator result row.
+
+    Capability describes backend truth. Quality-gate and row status carry the
+    separate question of whether the produced output was ultimately accepted.
+    """
     selected_attempt = select_result_attempt(result)
+    attempts = _list_result_attempts(result)
     requested = (
         result.get("requested_backend")
         or requested_backend
@@ -124,26 +215,33 @@ def build_orchestrator_result_capability_report(
     )
     fallback_executed = bool(result.get("fallback_used"))
     status = result.get("status")
+    gate_report = resolve_result_quality_gate(result)
+    failed_attempt = _find_failed_attempt_for_backend(attempts, executed_backend)
+    semantic_gate_failure = _is_semantic_gate_failure(failed_attempt, gate_report)
+    selected_attempt_succeeded = isinstance(selected_attempt, Mapping) and selected_attempt.get("status") == "success"
+    metadata_attempt = _select_capability_metadata_attempt(
+        selected_attempt,
+        failed_attempt,
+        _normalize_optional_string(executed_backend),
+    )
 
     if status == "skipped":
         availability_state = "skipped"
         reason = result.get("reason")
+    elif fallback_executed and (selected_attempt_succeeded or semantic_gate_failure):
+        availability_state = "fallback_executed"
+        reason = _resolve_fallback_reason(attempts, resolution_reason)
+    elif selected_attempt_succeeded or semantic_gate_failure:
+        availability_state = "available"
+        reason = None
     elif status == "error":
         availability_state = "failed"
-        reason = result.get("error_code") or result.get("error")
-    elif fallback_executed:
-        availability_state = "fallback_executed"
-        reason = resolution_reason or None
-        if not reason:
-            attempts = result.get("attempts")
-            if isinstance(attempts, list):
-                for attempt in attempts:
-                    if not isinstance(attempt, Mapping):
-                        continue
-                    if attempt.get("status") == "failed":
-                        reason = attempt.get("error_message") or attempt.get("error_code")
-                        if reason:
-                            break
+        reason = (
+            (_normalize_optional_string(failed_attempt.get("error_message")) if isinstance(failed_attempt, Mapping) else None)
+            or (_normalize_optional_string(failed_attempt.get("error_code")) if isinstance(failed_attempt, Mapping) else None)
+            or _normalize_optional_string(result.get("error_code"))
+            or _normalize_optional_string(result.get("error"))
+        )
     elif executed_backend:
         availability_state = "available"
         reason = None
@@ -152,11 +250,11 @@ def build_orchestrator_result_capability_report(
         reason = None
 
     model_repo_id = result.get("model_id")
-    if not model_repo_id and isinstance(selected_attempt, Mapping):
-        model_repo_id = selected_attempt.get("model_id")
+    if not model_repo_id and isinstance(metadata_attempt, Mapping):
+        model_repo_id = metadata_attempt.get("model_id")
 
-    model_revision = selected_attempt.get("model_revision") if isinstance(selected_attempt, Mapping) else None
-    asset_bundle_version = selected_attempt.get("asset_bundle_version") if isinstance(selected_attempt, Mapping) else None
+    model_revision = metadata_attempt.get("model_revision") if isinstance(metadata_attempt, Mapping) else None
+    asset_bundle_version = metadata_attempt.get("asset_bundle_version") if isinstance(metadata_attempt, Mapping) else None
 
     return build_capability_report(
         requested_backend=requested,

--- a/src/transformation_portal/schemas/run_card/run_card.v1.schema.json
+++ b/src/transformation_portal/schemas/run_card/run_card.v1.schema.json
@@ -500,6 +500,109 @@
               "string",
               "null"
             ]
+          },
+          "quality_gate": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "minLength": 1
+              },
+              "passed": {
+                "type": "boolean"
+              },
+              "failure_codes": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "warnings": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "details": {
+                "type": "object",
+                "properties": {
+                  "metrics": {
+                    "type": "object"
+                  },
+                  "thresholds": {
+                    "type": "object"
+                  },
+                  "shape_context": {
+                    "type": "object"
+                  }
+                },
+                "additionalProperties": true
+              }
+            },
+            "additionalProperties": true
+          },
+          "capability": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "requested_backend": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "executed_backend": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "availability_state": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reason": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "synthetic_output": {
+                "type": "boolean"
+              },
+              "stub_mode": {
+                "type": "boolean"
+              },
+              "fallback_executed": {
+                "type": "boolean"
+              },
+              "model_repo_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "model_revision": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "asset_bundle_version": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "additionalProperties": true
           }
         },
         "additionalProperties": true

--- a/src/transformation_portal/schemas/run_card/run_card.v2.schema.json
+++ b/src/transformation_portal/schemas/run_card/run_card.v2.schema.json
@@ -500,6 +500,109 @@
               "string",
               "null"
             ]
+          },
+          "quality_gate": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "minLength": 1
+              },
+              "passed": {
+                "type": "boolean"
+              },
+              "failure_codes": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "warnings": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "details": {
+                "type": "object",
+                "properties": {
+                  "metrics": {
+                    "type": "object"
+                  },
+                  "thresholds": {
+                    "type": "object"
+                  },
+                  "shape_context": {
+                    "type": "object"
+                  }
+                },
+                "additionalProperties": true
+              }
+            },
+            "additionalProperties": true
+          },
+          "capability": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "requested_backend": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "executed_backend": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "availability_state": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reason": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "synthetic_output": {
+                "type": "boolean"
+              },
+              "stub_mode": {
+                "type": "boolean"
+              },
+              "fallback_executed": {
+                "type": "boolean"
+              },
+              "model_repo_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "model_revision": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "asset_bundle_version": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "additionalProperties": true
           }
         },
         "additionalProperties": true

--- a/src/transformation_portal/spatial_ai/orchestration/pipeline.py
+++ b/src/transformation_portal/spatial_ai/orchestration/pipeline.py
@@ -50,6 +50,7 @@ from transformation_portal.compliance import (
     validate_non_commercial_preset,
 )
 from transformation_portal.ingest.canonical_json import dump_json
+from transformation_portal.reporting.contracts import build_stage_report, derive_stage_report_map
 from transformation_portal.spatial_ai.ingest.linear_decoder import LinearDecoder, LinearIngestResult
 from transformation_portal.spatial_ai.materials.contracts import MaterialInput, PBRTextures
 from transformation_portal.spatial_ai.materials.material_backend import (
@@ -298,6 +299,7 @@ if "PipelineResult" not in globals():
         errors: List[str] = field(default_factory=list)
         warnings: List[str] = field(default_factory=list)
         metadata: Dict[str, Any] = field(default_factory=dict)
+        stage_reports: List[Dict[str, Any]] = field(default_factory=list)
 
         def save_summary(self, path: Path) -> None:
             """Save execution summary as JSON.
@@ -305,6 +307,8 @@ if "PipelineResult" not in globals():
             Args:
                 path: Output path for summary JSON.
             """
+            stage_reports = list(self.stage_reports)
+            stage_report_map = derive_stage_report_map(stage_reports)
             summary = {
                 "input": str(self.input_path),
                 "output_dir": str(self.output_dir),
@@ -313,18 +317,31 @@ if "PipelineResult" not in globals():
                 "peak_memory_mb": self.peak_memory_mb,
                 "errors": self.errors,
                 "warnings": self.warnings,
+                "stage_reports": stage_reports,
                 "results": {
                     "linear_image": self.linear_image is not None,
                     "segmentation": {
-                        "completed": self.segmentation is not None,
+                        "completed": (
+                            stage_report_map.get("segmentation", {}).get("status") in {"completed", "cached"}
+                            if "segmentation" in stage_report_map
+                            else self.segmentation is not None
+                        ),
                         "num_masks": len(self.segmentation.masks) if self.segmentation else 0,
                     },
                     "materials": {
-                        "completed": self.materials is not None,
+                        "completed": (
+                            stage_report_map.get("materials", {}).get("status") in {"completed", "cached"}
+                            if "materials" in stage_report_map
+                            else self.materials is not None
+                        ),
                         "num_segments": len(self.materials) if self.materials else 0,
                     },
                     "scene_3d": {
-                        "completed": self.scene_3d is not None,
+                        "completed": (
+                            stage_report_map.get("reconstruction", {}).get("status") in {"completed", "cached"}
+                            if "reconstruction" in stage_report_map
+                            else self.scene_3d is not None
+                        ),
                         "num_gaussians": self.scene_3d.splats.num_gaussians if self.scene_3d else 0,
                         "rmse": self.scene_3d.rmse if self.scene_3d else None,
                     },
@@ -367,6 +384,7 @@ if "MultiViewReconstructionResult" not in globals():
         request_metadata: Dict[str, Any] = field(default_factory=dict)
         errors: List[str] = field(default_factory=list)
         warnings: List[str] = field(default_factory=list)
+        stage_reports: List[Dict[str, Any]] = field(default_factory=list)
 
         def save_summary(self, path: Path) -> None:
             """Save reconstruction summary as JSON.
@@ -383,6 +401,7 @@ if "MultiViewReconstructionResult" not in globals():
                 "peak_memory_mb": self.peak_memory_mb,
                 "errors": self.errors,
                 "warnings": self.warnings,
+                "stage_reports": self.stage_reports,
                 "scene": {
                     "num_gaussians": self.scene.splats.num_gaussians,
                     "rmse": self.scene.rmse,
@@ -554,6 +573,12 @@ class SpatialAIPipeline:
         if not input_path.exists():
             raise FileNotFoundError(f"Input file not found: {input_path}")
 
+        if "reconstruction" in self.config.stages:
+            raise ValueError(
+                "Single-image pipeline does not support reconstruction. "
+                "Use process_multiview() with a MultiViewReconstructionRequest."
+            )
+
         # ADR-026 §2.3: Reset stateful backends at sequence boundaries
         if sequence_id is not None:
             self.reset_sequence(sequence_id)
@@ -581,6 +606,7 @@ class SpatialAIPipeline:
                 if "ingest" in self.config.stages:
                     result.linear_image = self._run_ingest(input_path, output_dir, save_intermediates)
                     result.stages_completed.append("ingest")
+                    result.stage_reports.append(build_stage_report(stage="ingest", status="completed"))
 
                 # Phase 2.1: Segmentation
                 if "segment" in self.config.stages or "segmentation" in self.config.stages:
@@ -589,6 +615,7 @@ class SpatialAIPipeline:
 
                     result.segmentation = self._run_segmentation(result.linear_image, output_dir, save_intermediates)
                     result.stages_completed.append("segmentation")
+                    result.stage_reports.append(build_stage_report(stage="segmentation", status="completed"))
 
                 # Phase 2.2: Materials
                 if "materials" in self.config.stages:
@@ -599,6 +626,7 @@ class SpatialAIPipeline:
                         result.linear_image, result.segmentation, output_dir, save_intermediates
                     )
                     result.stages_completed.append("materials")
+                    result.stage_reports.append(build_stage_report(stage="materials", status="completed"))
 
                 # Phase 2.3: Reconstruction
                 if "reconstruction" in self.config.stages:
@@ -819,6 +847,10 @@ class SpatialAIPipeline:
                 peak_memory_mb=peak_memory,
                 stages_completed=["reconstruction", "export"],
                 request_metadata=request.to_metadata_dict(),
+                stage_reports=[
+                    build_stage_report(stage="reconstruction", status="completed"),
+                    build_stage_report(stage="export", status="completed"),
+                ],
             )
 
             self.progress_tracker.complete_pipeline(success=True)
@@ -1503,6 +1535,13 @@ class SpatialAIPipeline:
                 stages_completed=[sr.stage_id for sr in exec_result.stage_results],
                 execution_time=exec_result.total_time_ms / 1000.0,
                 peak_memory_mb=self.resource_manager.get_peak_memory_mb(),
+                stage_reports=[
+                    build_stage_report(
+                        stage=sr.stage_id,
+                        status=("cached" if getattr(sr, "cache_hit", False) else "completed"),
+                    )
+                    for sr in exec_result.stage_results
+                ],
             )
 
             # Extract outputs from graph results

--- a/src/transformation_portal/spatial_ai/orchestration/pipeline.py
+++ b/src/transformation_portal/spatial_ai/orchestration/pipeline.py
@@ -574,9 +574,10 @@ class SpatialAIPipeline:
             raise FileNotFoundError(f"Input file not found: {input_path}")
 
         if "reconstruction" in self.config.stages:
-            raise ValueError(
+            raise PipelineError(
+                "reconstruction",
                 "Single-image pipeline does not support reconstruction. "
-                "Use process_multiview() with a MultiViewReconstructionRequest."
+                "Use process_multiview() with a MultiViewReconstructionRequest.",
             )
 
         # ADR-026 §2.3: Reset stateful backends at sequence boundaries

--- a/src/transformation_portal/stage_graph/stage.py
+++ b/src/transformation_portal/stage_graph/stage.py
@@ -33,6 +33,7 @@ class StageStatus(str, Enum):
     CACHED = "cached"
     COMPLETED = "completed"
     FAILED = "failed"
+    UNAVAILABLE = "unavailable"
     SKIPPED = "skipped"
 
 

--- a/src/transformation_portal/streaming/stages.py
+++ b/src/transformation_portal/streaming/stages.py
@@ -32,6 +32,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
+from transformation_portal.reporting.contracts import build_capability_report
+
 from .async_pipeline import AsyncStage, DeviceType, WorkerPool
 
 
@@ -320,6 +322,9 @@ class DepthEstimationStage(AsyncStage[ImageData, ImageData]):
         >>> depth_map = result.data.depth_map
     """
 
+    class DepthBackendUnavailableError(RuntimeError):
+        """Raised when the real depth backend is unavailable and synthetic output is disabled."""
+
     def __init__(
         self,
         device: DeviceType = DeviceType.AUTO,
@@ -327,6 +332,8 @@ class DepthEstimationStage(AsyncStage[ImageData, ImageData]):
         max_concurrent: int = 1,
         cache_model: bool = True,
         worker_pool: Optional[WorkerPool] = None,
+        allow_synthetic_depth: bool = False,
+        model_revision: Optional[str] = None,
     ):
         """Initialize depth estimation stage.
 
@@ -336,6 +343,8 @@ class DepthEstimationStage(AsyncStage[ImageData, ImageData]):
             max_concurrent: Maximum concurrent estimations
             cache_model: Keep model loaded in memory
             worker_pool: Shared worker pool
+            allow_synthetic_depth: Enable synthetic fallback for dev/test only
+            model_revision: Optional pinned model revision
         """
         super().__init__(
             name="depth_estimation",
@@ -348,6 +357,8 @@ class DepthEstimationStage(AsyncStage[ImageData, ImageData]):
         self._model = None
         self._torch_device = None
         self._worker_pool = worker_pool
+        self._allow_synthetic_depth = allow_synthetic_depth
+        self._model_revision = model_revision
 
     def _detect_device(self) -> str:
         """Detect best available device."""
@@ -388,12 +399,19 @@ class DepthEstimationStage(AsyncStage[ImageData, ImageData]):
             return
 
         try:
-            # Try to import from transformation_portal depth module
             from transformation_portal.depth.models import load_depth_model
 
-            self._model = load_depth_model(model_size=self._model_size, device=self._torch_device)
-        except ImportError:
-            # Fallback: create a placeholder that returns mock depth
+            self._model = load_depth_model(
+                model_size=self._model_size,
+                device=self._torch_device,
+                model_revision=self._model_revision,
+            )
+        except Exception as exc:
+            if not self._allow_synthetic_depth:
+                raise self.DepthBackendUnavailableError(
+                    "Depth backend unavailable. Install the repo depth runtime or enable "
+                    "allow_synthetic_depth=True for dev/test instrumentation."
+                ) from exc
             self._model = self._create_mock_model()
 
     def _create_mock_model(self) -> Callable:
@@ -440,11 +458,33 @@ class DepthEstimationStage(AsyncStage[ImageData, ImageData]):
         if self._model is None:
             self._load_model()
 
-        depth_map = self._model(image_data.array)
+        synthetic_output = not hasattr(self._model, "estimate_depth")
+        if synthetic_output:
+            depth_map = self._model(image_data.array)
+            capability = build_capability_report(
+                requested_backend="depth_anything_v2",
+                executed_backend="synthetic",
+                availability_state="synthetic_opt_in",
+                reason="Synthetic depth enabled explicitly for dev/test.",
+                synthetic_output=True,
+            )
+        else:
+            result = self._model.estimate_depth(image_data.array)
+            depth_map = result["depth"]
+            metadata = result.get("metadata") if isinstance(result, dict) else {}
+            capability = build_capability_report(
+                requested_backend="depth_anything_v2",
+                executed_backend=metadata.get("backend", "depth_anything_v2"),
+                availability_state="available",
+                model_repo_id=getattr(getattr(self._model, "variant", None), "value", None),
+                model_revision=getattr(self._model, "model_revision", None),
+            )
 
         image_data.depth_map = depth_map
         image_data.metadata["depth_estimated"] = True
         image_data.metadata["depth_device"] = self._torch_device
+        image_data.metadata["depth_capability"] = capability
+        image_data.metadata["synthetic_output"] = synthetic_output
 
         return image_data
 

--- a/src/transformation_portal/streaming/stages.py
+++ b/src/transformation_portal/streaming/stages.py
@@ -32,6 +32,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
+from transformation_portal.core.ml_dependency_health import OPTIONAL_IMPORT_EXCEPTIONS
 from transformation_portal.reporting.contracts import build_capability_report
 
 from .async_pipeline import AsyncStage, DeviceType, WorkerPool
@@ -406,13 +407,41 @@ class DepthEstimationStage(AsyncStage[ImageData, ImageData]):
                 device=self._torch_device,
                 model_revision=self._model_revision,
             )
-        except Exception as exc:
+        except OPTIONAL_IMPORT_EXCEPTIONS as exc:
+            if not self._is_runtime_unavailable_error(exc):
+                raise
             if not self._allow_synthetic_depth:
                 raise self.DepthBackendUnavailableError(
                     "Depth backend unavailable. Install the repo depth runtime or enable "
                     "allow_synthetic_depth=True for dev/test instrumentation."
                 ) from exc
             self._model = self._create_mock_model()
+
+    @staticmethod
+    def _is_runtime_unavailable_error(exc: BaseException) -> bool:
+        """Return True when depth model load failed due to optional runtime availability."""
+        known_runtime_markers = (
+            "no backend available",
+            "outside the repository's supported runtime envelope",
+            "install with: pip install",
+            "package is installed but not importable",
+            "required for pytorch backend",
+            "required for onnx backend",
+            "required for coreml backend",
+            "required for resizing",
+        )
+        current: Optional[BaseException] = exc
+        visited: set[int] = set()
+        while current is not None and id(current) not in visited:
+            visited.add(id(current))
+            if isinstance(current, (ImportError, ModuleNotFoundError)):
+                return True
+            if isinstance(current, RuntimeError):
+                message = str(current).lower()
+                if any(marker in message for marker in known_runtime_markers):
+                    return True
+            current = current.__cause__ or current.__context__
+        return False
 
     def _create_mock_model(self) -> Callable:
         """Create mock depth model for testing/fallback."""

--- a/src/transformation_portal/style_transfer/ip_adapter.py
+++ b/src/transformation_portal/style_transfer/ip_adapter.py
@@ -17,28 +17,91 @@ Reference:
     Text-to-Image Diffusion Models" (2023)
 """
 
+from __future__ import annotations
+
 import logging
+from contextlib import nullcontext
 from pathlib import Path
-from typing import List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union
 
 import numpy as np
-import torch
 from PIL import Image
 
 from transformation_portal.core.security.model_lock import resolve_model_lock_revision
 from transformation_portal.reporting.contracts import build_capability_report
 
-try:
+if TYPE_CHECKING:
+    import torch
     from diffusers import FluxPipeline
     from transformers import CLIPImageProcessor, CLIPVisionModelWithProjection
-
-    IPADAPTER_AVAILABLE = True
-except ImportError:
-    IPADAPTER_AVAILABLE = False
-    logging.warning("IP-Adapter dependencies not available")
+else:
+    torch = None  # type: ignore[assignment]
+    FluxPipeline = Any  # type: ignore[assignment]
+    CLIPImageProcessor = Any  # type: ignore[assignment]
+    CLIPVisionModelWithProjection = Any  # type: ignore[assignment]
 
 
 logger = logging.getLogger(__name__)
+
+_TORCH_IMPORT_ERROR: Optional[Exception] = None
+_RUNTIME_IMPORT_ERROR: Optional[Exception] = None
+
+try:
+    import torch as _torch
+except Exception as exc:  # pragma: no cover - depends on optional runtime
+    _torch = None
+    _TORCH_IMPORT_ERROR = exc
+
+if _torch is not None:
+    torch = _torch  # type: ignore[assignment]
+
+
+def _missing_runtime_import_error() -> ImportError:
+    if _TORCH_IMPORT_ERROR is not None:
+        return ImportError(
+            "IP-Adapter requires torch, transformers, and diffusers. "
+            "Install the optional style-transfer runtime before using this surface."
+        )
+    if _RUNTIME_IMPORT_ERROR is not None:
+        return ImportError(
+            "IP-Adapter requires a compatible torch + transformers + diffusers runtime. "
+            "The optional style-transfer dependencies could not be imported."
+        )
+    return ImportError(
+        "IP-Adapter requires torch, transformers, and diffusers. "
+        "Install the optional style-transfer runtime before using this surface."
+    )
+
+
+def _require_torch_runtime() -> Any:
+    if torch is None:  # type: ignore[truthy-function]
+        raise _missing_runtime_import_error() from _TORCH_IMPORT_ERROR
+    return torch
+
+
+def _load_ip_adapter_runtime() -> tuple[type[Any], type[Any], type[Any]]:
+    global FluxPipeline, CLIPImageProcessor, CLIPVisionModelWithProjection, _RUNTIME_IMPORT_ERROR
+
+    _require_torch_runtime()
+
+    if (
+        not isinstance(FluxPipeline, type)
+        or not isinstance(CLIPImageProcessor, type)
+        or not isinstance(CLIPVisionModelWithProjection, type)
+    ):
+        try:
+            from diffusers import FluxPipeline as flux_pipeline_cls
+            from transformers import CLIPImageProcessor as clip_image_processor_cls
+            from transformers import CLIPVisionModelWithProjection as clip_vision_model_cls
+        except Exception as exc:  # pragma: no cover - depends on optional runtime
+            _RUNTIME_IMPORT_ERROR = exc
+            raise _missing_runtime_import_error() from exc
+
+        FluxPipeline = flux_pipeline_cls  # type: ignore[assignment]
+        CLIPImageProcessor = clip_image_processor_cls  # type: ignore[assignment]
+        CLIPVisionModelWithProjection = clip_vision_model_cls  # type: ignore[assignment]
+
+    return FluxPipeline, CLIPImageProcessor, CLIPVisionModelWithProjection  # type: ignore[return-value]
 
 
 class IPAdapterStyleTransfer:
@@ -76,7 +139,7 @@ class IPAdapterStyleTransfer:
     def __init__(
         self,
         device: Optional[str] = None,
-        torch_dtype: torch.dtype = torch.bfloat16,
+        torch_dtype: Optional["torch.dtype"] = None,
         enable_cpu_offload: bool = False,
         *,
         clip_vision_revision: Optional[str] = None,
@@ -97,11 +160,11 @@ class IPAdapterStyleTransfer:
         Raises:
             ImportError: If required dependencies not available
         """
-        if not IPADAPTER_AVAILABLE:
-            raise ImportError(
-                "IP-Adapter requires transformers and diffusers. "
-                "Install with: pip install transformers>=4.38.0 diffusers>=0.30.0"
-            )
+        runtime_torch = _require_torch_runtime()
+        flux_pipeline_cls, clip_image_processor_cls, clip_vision_model_cls = _load_ip_adapter_runtime()
+
+        if torch_dtype is None:
+            torch_dtype = runtime_torch.bfloat16
 
         self.device = device or self._detect_device()
         self.torch_dtype = torch_dtype
@@ -115,19 +178,19 @@ class IPAdapterStyleTransfer:
         logger.info(f"Initializing IP-Adapter on {self.device}")
 
         # Load CLIP vision model for reference encoding
-        self.image_encoder = CLIPVisionModelWithProjection.from_pretrained(  # nosec B615
+        self.image_encoder = clip_vision_model_cls.from_pretrained(  # nosec B615
             self.CLIP_VISION_MODEL,
             revision=self.clip_vision_revision,
             torch_dtype=torch_dtype,
         ).to(self.device)
 
-        self.image_processor = CLIPImageProcessor.from_pretrained(  # nosec B615
+        self.image_processor = clip_image_processor_cls.from_pretrained(  # nosec B615
             self.CLIP_VISION_MODEL,
             revision=self.clip_vision_revision,
         )
 
         # Load FLUX pipeline
-        self.flux_pipe = FluxPipeline.from_pretrained(  # nosec B615
+        self.flux_pipe = flux_pipeline_cls.from_pretrained(  # nosec B615
             self.FLUX_MODEL,
             revision=self.flux_model_revision,
             torch_dtype=torch_dtype,
@@ -157,13 +220,22 @@ class IPAdapterStyleTransfer:
 
     def _detect_device(self) -> str:
         """Auto-detect optimal device."""
-        if torch.cuda.is_available():
+        runtime_torch = torch
+        if runtime_torch is None:
+            return "cpu"
+        if runtime_torch.cuda.is_available():
             return "cuda"
-        elif torch.backends.mps.is_available():
+        elif runtime_torch.backends.mps.is_available():
             return "mps"
         return "cpu"
 
-    def encode_reference_image(self, image: Union[str, Path, Image.Image, np.ndarray]) -> torch.Tensor:
+    def _inference_mode(self) -> Any:
+        runtime_torch = torch
+        if runtime_torch is None:
+            return nullcontext()
+        return runtime_torch.inference_mode()
+
+    def encode_reference_image(self, image: Union[str, Path, Image.Image, np.ndarray]) -> "torch.Tensor":
         """Encode reference image to style features.
 
         Args:
@@ -179,7 +251,8 @@ class IPAdapterStyleTransfer:
         inputs = self.image_processor(images=pil_image, return_tensors="pt").to(self.device)
 
         # Encode
-        with torch.inference_mode():
+        runtime_torch = _require_torch_runtime()
+        with runtime_torch.inference_mode():
             image_features = self.image_encoder(**inputs).image_embeds
 
         logger.info(f"Encoded reference image: {image_features.shape}")
@@ -227,7 +300,8 @@ class IPAdapterStyleTransfer:
         # Prepare for diffusion
         generator = None
         if seed is not None:
-            generator = torch.Generator(device=self.device).manual_seed(seed)
+            runtime_torch = _require_torch_runtime()
+            generator = runtime_torch.Generator(device=self.device).manual_seed(seed)
 
         # NOTE: Full IP-Adapter integration would inject style_features
         # into the UNet cross-attention layers. This is a framework showing
@@ -238,7 +312,7 @@ class IPAdapterStyleTransfer:
 
         # For now, use FLUX img2img as foundation
         # (IP-Adapter weights for FLUX are in development)
-        with torch.inference_mode():
+        with self._inference_mode():
             # The style_features would be passed to a custom pipeline
             # that injects them into cross-attention
             result = self.flux_pipe(
@@ -308,7 +382,8 @@ class IPAdapterStyleTransfer:
             weights.append(weight)
 
         # Normalize weights
-        weights = torch.tensor(weights, device=self.device)
+        runtime_torch = _require_torch_runtime()
+        weights = runtime_torch.tensor(weights, device=self.device)
         weights = weights / weights.sum()
 
         # Blend style features
@@ -325,12 +400,12 @@ class IPAdapterStyleTransfer:
 
         generator = None
         if seed is not None:
-            generator = torch.Generator(device=self.device).manual_seed(seed)
+            generator = runtime_torch.Generator(device=self.device).manual_seed(seed)
 
         # Calculate average strength from weights
         avg_strength = 0.7  # Default
 
-        with torch.inference_mode():
+        with runtime_torch.inference_mode():
             result = self.flux_pipe(
                 prompt=prompt,
                 image=content_pil,
@@ -395,7 +470,7 @@ class IPAdapterStyleTransfer:
         self,
         reference_images: List[Union[str, Path, Image.Image]],
         weights: Optional[List[float]] = None,
-    ) -> torch.Tensor:
+    ) -> "torch.Tensor":
         """Extract averaged style from collection of reference images.
 
         Useful for learning a "house style" from multiple examples.
@@ -416,7 +491,8 @@ class IPAdapterStyleTransfer:
         if weights is None:
             weights = [1.0 / len(reference_images)] * len(reference_images)
 
-        weights = torch.tensor(weights, device=self.device)
+        runtime_torch = _require_torch_runtime()
+        weights = runtime_torch.tensor(weights, device=self.device)
         weights = weights / weights.sum()
 
         # Average with weights
@@ -445,7 +521,8 @@ class IPAdapterStyleTransfer:
         features2 = self.encode_reference_image(image2)
 
         # Compute cosine similarity
-        similarity = torch.nn.functional.cosine_similarity(features1, features2, dim=-1).item()
+        runtime_torch = _require_torch_runtime()
+        similarity = runtime_torch.nn.functional.cosine_similarity(features1, features2, dim=-1).item()
 
         # Normalize to 0-1
         similarity = (similarity + 1) / 2
@@ -479,7 +556,8 @@ class IPAdapterStyleTransfer:
         features2 = self.encode_reference_image(style2)
 
         # Create interpolation weights
-        alphas = torch.linspace(0, 1, num_steps, device=self.device)
+        runtime_torch = _require_torch_runtime()
+        alphas = runtime_torch.linspace(0, 1, num_steps, device=self.device)
 
         interpolated_images = []
 

--- a/src/transformation_portal/style_transfer/ip_adapter.py
+++ b/src/transformation_portal/style_transfer/ip_adapter.py
@@ -26,6 +26,7 @@ import torch
 from PIL import Image
 
 from transformation_portal.core.security.model_lock import resolve_model_lock_revision
+from transformation_portal.reporting.contracts import build_capability_report
 
 try:
     from diffusers import FluxPipeline
@@ -107,6 +108,7 @@ class IPAdapterStyleTransfer:
         self.clip_vision_revision = clip_vision_revision
         self.flux_model_revision = flux_model_revision
         self.strict_model_lock = strict_model_lock
+        self.last_capability_report = None
 
         self._resolve_model_revisions()
 
@@ -249,6 +251,14 @@ class IPAdapterStyleTransfer:
             )
 
         styled_image = result.images[0]
+        self.last_capability_report = build_capability_report(
+            requested_backend="ip_adapter",
+            executed_backend="flux_img2img",
+            availability_state="available",
+            reason="Style transfer currently executes through FLUX img2img without adapter injection.",
+            model_repo_id=self.FLUX_MODEL,
+            model_revision=self.flux_model_revision,
+        )
 
         logger.info("Style transfer complete")
 
@@ -331,6 +341,14 @@ class IPAdapterStyleTransfer:
             )
 
         styled_image = result.images[0]
+        self.last_capability_report = build_capability_report(
+            requested_backend="ip_adapter",
+            executed_backend="flux_img2img",
+            availability_state="available",
+            reason="Style transfer currently executes through FLUX img2img without adapter injection.",
+            model_repo_id=self.FLUX_MODEL,
+            model_revision=self.flux_model_revision,
+        )
 
         logger.info("Multi-reference style transfer complete")
 
@@ -362,12 +380,12 @@ class IPAdapterStyleTransfer:
         preset_config = ArchitecturalStylePresets.get_preset(preset)
 
         # Load reference image from preset
-        reference_path = preset_config["reference_image"]
+        reference_path = ArchitecturalStylePresets.resolve_reference_image(preset)
 
         # Transfer style
         return self.transfer_style(
             content_image=content_image,
-            style_reference=reference_path,
+            style_reference=str(reference_path),
             style_strength=strength,
             prompt=preset_config.get("prompt"),
             **kwargs,

--- a/src/transformation_portal/style_transfer/style_presets.py
+++ b/src/transformation_portal/style_transfer/style_presets.py
@@ -408,9 +408,20 @@ class ArchitecturalStylePresets:
     ) -> Path:
         """Resolve and validate a preset reference image inside the bundled asset pack."""
         preset = cls.get_preset(name)
-        base_root = Path(assets_root) if assets_root is not None else cls.ASSETS_ROOT
+        base_root = (Path(assets_root) if assets_root is not None else cls.ASSETS_ROOT).resolve()
         candidate = Path(preset["reference_image"])
-        resolved = candidate if candidate.is_absolute() else base_root / candidate
+        if candidate.is_absolute():
+            raise PresetAssetsNotBundledError(
+                f"Preset '{name}' assets must live inside the bundled asset pack. "
+                f"Absolute reference paths are not allowed: {candidate}"
+            )
+        resolved = (base_root / candidate).resolve()
+        try:
+            resolved.relative_to(base_root)
+        except ValueError as exc:
+            raise PresetAssetsNotBundledError(
+                f"Preset '{name}' assets must stay within the bundled asset pack: {resolved}"
+            ) from exc
         if not resolved.exists():
             raise PresetAssetsNotBundledError(f"Preset '{name}' assets are not bundled. Missing reference image: {resolved}")
         return resolved

--- a/src/transformation_portal/style_transfer/style_presets.py
+++ b/src/transformation_portal/style_transfer/style_presets.py
@@ -20,9 +20,16 @@ Each preset includes:
 
 import logging
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Dict, List, Optional
 
 logger = logging.getLogger(__name__)
+
+
+class PresetAssetsNotBundledError(FileNotFoundError):
+    """Raised when a preset references an asset that is not bundled locally."""
+
+    error_code = "asset_bundle_missing"
 
 
 @dataclass
@@ -359,6 +366,8 @@ class ArchitecturalStylePresets:
         ),
     }
 
+    ASSETS_ROOT = Path(__file__).resolve().parent / "preset_assets"
+
     @classmethod
     def get_preset(cls, name: str) -> Dict[str, any]:
         """Get style preset by name.
@@ -389,6 +398,22 @@ class ArchitecturalStylePresets:
             "contrast": preset.contrast,
             "tags": preset.tags,
         }
+
+    @classmethod
+    def resolve_reference_image(
+        cls,
+        name: str,
+        *,
+        assets_root: Optional[Path] = None,
+    ) -> Path:
+        """Resolve and validate a preset reference image inside the bundled asset pack."""
+        preset = cls.get_preset(name)
+        base_root = Path(assets_root) if assets_root is not None else cls.ASSETS_ROOT
+        candidate = Path(preset["reference_image"])
+        resolved = candidate if candidate.is_absolute() else base_root / candidate
+        if not resolved.exists():
+            raise PresetAssetsNotBundledError(f"Preset '{name}' assets are not bundled. Missing reference image: {resolved}")
+        return resolved
 
     @classmethod
     def list_presets(cls, category: Optional[str] = None, tags: Optional[List[str]] = None) -> List[str]:
@@ -455,4 +480,4 @@ class ArchitecturalStylePresets:
 
 
 # Export
-__all__ = ["StylePreset", "ArchitecturalStylePresets"]
+__all__ = ["StylePreset", "ArchitecturalStylePresets", "PresetAssetsNotBundledError"]

--- a/tests/execution_graph/nodes/test_nvdiffrec_node.py
+++ b/tests/execution_graph/nodes/test_nvdiffrec_node.py
@@ -1,0 +1,36 @@
+"""Tests for execution-graph NVDiffRec node truthfulness semantics."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from transformation_portal.execution_graph.nodes.base import NodeResult
+from transformation_portal.execution_graph.nodes.nvdiffrec_node import NVDiffRecNode
+from transformation_portal.stage_graph.stage import StageStatus
+
+pytestmark = pytest.mark.unit
+
+
+def test_node_result_error_defaults_to_failed() -> None:
+    result = NodeResult(error="boom")
+
+    assert result.status == StageStatus.FAILED
+    assert result.success is False
+
+
+def test_unwired_nvdiffrec_node_returns_unavailable(tmp_path: Path) -> None:
+    node = NVDiffRecNode()
+
+    result = node.run(
+        image_paths=[tmp_path / "view1.png", tmp_path / "view2.png"],
+        output_dir=tmp_path / "out",
+    )
+
+    assert result.status == StageStatus.UNAVAILABLE
+    assert result.success is False
+    assert result.outputs == {}
+    assert result.metadata["backend_available"] is False
+    assert result.metadata["capability"]["availability_state"] == "backend_unwired"
+    assert result.metadata["capability"]["stub_mode"] is True

--- a/tests/spatial_ai/orchestration/test_multiview_pipeline.py
+++ b/tests/spatial_ai/orchestration/test_multiview_pipeline.py
@@ -198,6 +198,10 @@ class TestMultiviewPipelineExecution:
         assert summary["scene"]["num_gaussians"] > 0
         assert "stages_completed" in summary
         assert "reconstruction" in summary["stages_completed"]
+        assert summary["stage_reports"] == [
+            {"stage": "reconstruction", "status": "completed", "capability": None, "quality_gate": None},
+            {"stage": "export", "status": "completed", "capability": None, "quality_gate": None},
+        ]
 
     def test_accepts_synthetic_with_override(self, tmp_path):
         """Synthetic cameras work with explicit override."""

--- a/tests/spatial_ai/orchestration/test_pipeline.py
+++ b/tests/spatial_ai/orchestration/test_pipeline.py
@@ -1171,12 +1171,14 @@ class TestSpatialAIPipelineE2E:
         input_path = tmp_path / "input.tiff"
         input_path.touch()
 
-        with pytest.raises(ValueError, match="process_multiview"):
+        with pytest.raises(PipelineError, match="process_multiview") as exc_info:
             pipeline.process(
                 input_path=input_path,
                 output_dir=tmp_path / "output",
                 save_intermediates=False,
             )
+
+        assert exc_info.value.stage == "reconstruction"
 
     def test_process_input_not_found(self, tmp_path):
         """Test process raises error when input file not found."""
@@ -1394,12 +1396,13 @@ class TestGraphModeExecution:
         input_path = tmp_path / "input.tiff"
         input_path.touch()
 
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(PipelineError) as exc_info:
             pipeline.process(
                 input_path=input_path,
                 output_dir=tmp_path / "output",
             )
 
+        assert exc_info.value.stage == "reconstruction"
         assert "process_multiview" in str(exc_info.value)
 
     def test_graph_mode_delegates_to_executor(self, tmp_path):

--- a/tests/spatial_ai/orchestration/test_pipeline.py
+++ b/tests/spatial_ai/orchestration/test_pipeline.py
@@ -204,6 +204,7 @@ class TestPipelineResult:
         assert result.errors == []
         assert result.warnings == []
         assert result.metadata == {}
+        assert result.stage_reports == []
 
     def test_full_result_creation(self):
         """Test creating result with all fields."""
@@ -233,6 +234,7 @@ class TestPipelineResult:
         assert result.errors == ["Error 1"]
         assert result.warnings == ["Warning 1"]
         assert result.metadata == {"key": "value"}
+        assert result.stage_reports == []
 
     def test_save_summary(self, tmp_path):
         """Test saving execution summary as JSON."""
@@ -261,6 +263,12 @@ class TestPipelineResult:
             errors=["Error 1", "Error 2"],
             warnings=["Warning 1"],
             metadata={"custom": "data"},
+            stage_reports=[
+                {"stage": "ingest", "status": "completed", "capability": None, "quality_gate": None},
+                {"stage": "segmentation", "status": "completed", "capability": None, "quality_gate": None},
+                {"stage": "materials", "status": "completed", "capability": None, "quality_gate": None},
+                {"stage": "reconstruction", "status": "completed", "capability": None, "quality_gate": None},
+            ],
         )
 
         summary_path = tmp_path / "summary.json"
@@ -278,6 +286,7 @@ class TestPipelineResult:
         assert summary["peak_memory_mb"] == 4096.0
         assert summary["errors"] == ["Error 1", "Error 2"]
         assert summary["warnings"] == ["Warning 1"]
+        assert len(summary["stage_reports"]) == 4
 
         # Check results section
         assert summary["results"]["linear_image"] is True
@@ -300,6 +309,10 @@ class TestPipelineResult:
             linear_image=MagicMock(),
             execution_time=10.0,
             peak_memory_mb=512.0,
+            stage_reports=[
+                {"stage": "ingest", "status": "completed", "capability": None, "quality_gate": None},
+                {"stage": "segmentation", "status": "skipped", "capability": None, "quality_gate": None},
+            ],
         )
 
         summary_path = tmp_path / "partial.json"
@@ -313,6 +326,7 @@ class TestPipelineResult:
         assert summary["results"]["segmentation"]["num_masks"] == 0
         assert summary["results"]["materials"]["completed"] is False
         assert summary["results"]["scene_3d"]["completed"] is False
+        assert summary["stage_reports"][1]["status"] == "skipped"
 
 
 class TestSpatialAIPipelineInitialization:
@@ -1146,6 +1160,24 @@ class TestSpatialAIPipelineE2E:
         summary_path = output_dir / "pipeline_summary.json"
         assert summary_path.exists()
 
+    def test_process_rejects_single_image_reconstruction_at_entrypoint(self, tmp_path):
+        """Single-image reconstruction should fail before execution begins."""
+        config = PipelineConfig(
+            tier="apex_research",
+            stages=["ingest", "reconstruction"],
+        )
+        pipeline = SpatialAIPipeline(config)
+
+        input_path = tmp_path / "input.tiff"
+        input_path.touch()
+
+        with pytest.raises(ValueError, match="process_multiview"):
+            pipeline.process(
+                input_path=input_path,
+                output_dir=tmp_path / "output",
+                save_intermediates=False,
+            )
+
     def test_process_input_not_found(self, tmp_path):
         """Test process raises error when input file not found."""
         config = PipelineConfig(tier="standard", stages=["ingest"])
@@ -1351,7 +1383,7 @@ class TestGraphModeExecution:
     """Test graph-mode execution path (ADR-029)."""
 
     def test_graph_mode_rejects_reconstruction(self, tmp_path):
-        """Graph mode should fail explicitly if reconstruction is requested."""
+        """Single-image process() should reject reconstruction before graph execution."""
         config = PipelineConfig(
             tier="apex_research",  # Use research tier (3DGS license requires it)
             stages=["ingest", "segment", "reconstruction"],
@@ -1362,14 +1394,13 @@ class TestGraphModeExecution:
         input_path = tmp_path / "input.tiff"
         input_path.touch()
 
-        with pytest.raises(PipelineError) as exc_info:
+        with pytest.raises(ValueError) as exc_info:
             pipeline.process(
                 input_path=input_path,
                 output_dir=tmp_path / "output",
             )
 
-        assert "reconstruction" in str(exc_info.value).lower()
-        assert "graph mode" in str(exc_info.value).lower()
+        assert "process_multiview" in str(exc_info.value)
 
     def test_graph_mode_delegates_to_executor(self, tmp_path):
         """Graph mode should delegate to Executor.execute()."""

--- a/tests/style_transfer/test_style_presets.py
+++ b/tests/style_transfer/test_style_presets.py
@@ -29,6 +29,40 @@ def test_resolve_reference_image_fails_when_asset_bundle_missing(tmp_path, monke
     assert exc_info.value.error_code == "asset_bundle_missing"
 
 
+def test_resolve_reference_image_rejects_absolute_reference_paths(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(ArchitecturalStylePresets, "ASSETS_ROOT", tmp_path)
+    absolute_reference = tmp_path / "outside.jpg"
+    monkeypatch.setattr(
+        ArchitecturalStylePresets.PRESETS["architectural_digest"],
+        "reference_image",
+        str(absolute_reference),
+    )
+
+    with pytest.raises(PresetAssetsNotBundledError, match="Absolute reference paths are not allowed"):
+        ArchitecturalStylePresets.resolve_reference_image("architectural_digest")
+
+
+def test_resolve_reference_image_rejects_paths_outside_asset_bundle(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(ArchitecturalStylePresets, "ASSETS_ROOT", tmp_path / "bundle")
+    escape_root = tmp_path / "escape"
+    escape_root.mkdir(parents=True, exist_ok=True)
+    Image.new("RGB", (4, 4), color="white").save(escape_root / "architectural_digest.jpg")
+    monkeypatch.setattr(
+        ArchitecturalStylePresets.PRESETS["architectural_digest"],
+        "reference_image",
+        "../escape/architectural_digest.jpg",
+    )
+
+    with pytest.raises(PresetAssetsNotBundledError, match="must stay within the bundled asset pack"):
+        ArchitecturalStylePresets.resolve_reference_image("architectural_digest")
+
+
 def test_apply_preset_style_resolves_bundled_reference_asset(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     asset_path = tmp_path / "references" / "editorial" / "architectural_digest.jpg"
     asset_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/style_transfer/test_style_presets.py
+++ b/tests/style_transfer/test_style_presets.py
@@ -1,0 +1,65 @@
+"""Tests for style preset asset validation and reporting."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+from PIL import Image
+
+from transformation_portal.style_transfer.ip_adapter import IPAdapterStyleTransfer
+from transformation_portal.style_transfer.style_presets import (
+    ArchitecturalStylePresets,
+    PresetAssetsNotBundledError,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_resolve_reference_image_fails_when_asset_bundle_missing(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ArchitecturalStylePresets, "ASSETS_ROOT", tmp_path)
+
+    with pytest.raises(PresetAssetsNotBundledError, match="not bundled") as exc_info:
+        ArchitecturalStylePresets.resolve_reference_image("architectural_digest")
+
+    assert exc_info.value.error_code == "asset_bundle_missing"
+
+
+def test_apply_preset_style_resolves_bundled_reference_asset(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    asset_path = tmp_path / "references" / "editorial" / "architectural_digest.jpg"
+    asset_path.parent.mkdir(parents=True, exist_ok=True)
+    Image.new("RGB", (4, 4), color="white").save(asset_path)
+    monkeypatch.setattr(ArchitecturalStylePresets, "ASSETS_ROOT", tmp_path)
+
+    style_transfer = object.__new__(IPAdapterStyleTransfer)
+    style_transfer.transfer_style = Mock(return_value="styled")
+
+    result = IPAdapterStyleTransfer.apply_preset_style(
+        style_transfer,
+        content_image="content.png",
+        preset="architectural_digest",
+        strength=0.55,
+    )
+
+    assert result == "styled"
+    assert style_transfer.transfer_style.call_args.kwargs["style_reference"] == str(asset_path)
+
+
+def test_transfer_style_reports_flux_img2img_backend() -> None:
+    style_transfer = object.__new__(IPAdapterStyleTransfer)
+    style_transfer.device = "cpu"
+    style_transfer.flux_model_revision = "rev-123"
+    style_transfer.last_capability_report = None
+    style_transfer._load_image = lambda image: Image.new("RGB", (4, 4), color="white")
+    style_transfer.encode_reference_image = lambda image: object()
+    style_transfer.flux_pipe = Mock(return_value=type("Result", (), {"images": [Image.new("RGB", (4, 4), color="black")]})())
+
+    result = IPAdapterStyleTransfer.transfer_style(
+        style_transfer,
+        content_image=Image.new("RGB", (4, 4), color="white"),
+        style_reference=Image.new("RGB", (4, 4), color="black"),
+    )
+
+    assert isinstance(result, Image.Image)
+    assert style_transfer.last_capability_report["executed_backend"] == "flux_img2img"
+    assert style_transfer.last_capability_report["model_revision"] == "rev-123"

--- a/tests/style_transfer/test_style_presets.py
+++ b/tests/style_transfer/test_style_presets.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import builtins
+import importlib.util
+from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
 from PIL import Image
 
+import transformation_portal.style_transfer.ip_adapter as ip_adapter_module
 from transformation_portal.style_transfer.ip_adapter import IPAdapterStyleTransfer
 from transformation_portal.style_transfer.style_presets import (
     ArchitecturalStylePresets,
@@ -63,3 +67,36 @@ def test_transfer_style_reports_flux_img2img_backend() -> None:
     assert isinstance(result, Image.Image)
     assert style_transfer.last_capability_report["executed_backend"] == "flux_img2img"
     assert style_transfer.last_capability_report["model_revision"] == "rev-123"
+
+
+def test_ip_adapter_module_import_stays_lazy_without_optional_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module_path = Path(ip_adapter_module.__file__).resolve()
+    original_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "torch":
+            raise ModuleNotFoundError("No module named 'torch'")
+        if name in {"diffusers", "transformers"}:
+            raise ModuleNotFoundError(f"No module named '{name}'")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    spec = importlib.util.spec_from_file_location("test_ip_adapter_lazy_import", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    assert module.IPAdapterStyleTransfer.__name__ == "IPAdapterStyleTransfer"
+
+
+def test_ip_adapter_init_fails_closed_when_optional_runtime_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(ip_adapter_module, "torch", None)
+    monkeypatch.setattr(ip_adapter_module, "_TORCH_IMPORT_ERROR", ModuleNotFoundError("No module named 'torch'"))
+
+    with pytest.raises(ImportError, match="requires torch, transformers, and diffusers"):
+        IPAdapterStyleTransfer()

--- a/tests/test_batch_processing.py
+++ b/tests/test_batch_processing.py
@@ -1093,6 +1093,17 @@ class TestEnhanceBatch:
                 assert results[0]["status"] == "error"
                 assert results[0]["error_code"] == "APEX_DEPTH_PLATEAU"
                 assert results[0]["error_details"] == expected_details
+                assert results[0]["quality_gate"] == {
+                    "kind": "apex_depth",
+                    "passed": False,
+                    "failure_codes": ["APEX_DEPTH_PLATEAU"],
+                    "warnings": [],
+                    "details": {
+                        "metrics": {"upper_iqr": 0.0},
+                        "thresholds": {"upper_iqr_min": 1e-4},
+                        "shape_context": {},
+                    },
+                }
 
     def test_enhance_batch_sequential_enriches_apex_gate_error_payload(self, batch_temp_workspace):
         """Sequential batch path should emit structured ApexStrictGateError fields."""
@@ -1141,6 +1152,17 @@ class TestEnhanceBatch:
                     assert result["status"] == "error"
                     assert result["error_code"] == "APEX_DEPTH_SATURATION_HIGH"
                     assert result["error_details"] == expected_details
+                    assert result["quality_gate"] == {
+                        "kind": "apex_depth",
+                        "passed": False,
+                        "failure_codes": ["APEX_DEPTH_SATURATION_HIGH"],
+                        "warnings": [],
+                        "details": {
+                            "metrics": {"saturation_high_fraction": 0.4},
+                            "thresholds": {"saturation_high_fraction_max": 0.02},
+                            "shape_context": {},
+                        },
+                    }
 
     def test_enhance_batch_sequential_preserves_attempt_history_for_apex_gate_failures(self, batch_temp_workspace):
         """Sequential batch errors should retain the failed attempt provenance from Stage A."""
@@ -1217,3 +1239,18 @@ class TestEnhanceBatch:
                     assert result["attempts"][0]["failure_kind"] == "semantic"
                     assert result["attempts"][0]["error_code"] == "APEX_DEPTH_SATURATION_LOW"
                     assert result["attempts"][0]["error_details"] == expected_details
+                    assert result["quality_gate"] == {
+                        "kind": "apex_depth",
+                        "passed": False,
+                        "failure_codes": ["APEX_DEPTH_SATURATION_LOW"],
+                        "warnings": [],
+                        "details": {
+                            "metrics": {"saturation_low_fraction": 0.031},
+                            "thresholds": {"saturation_low_fraction_max": 0.02},
+                            "shape_context": {
+                                "gate_evaluated_shape": [64, 64],
+                                "native_shape": [64, 64],
+                                "artifact_shape": [100, 100],
+                            },
+                        },
+                    }

--- a/tests/test_reporting_contracts.py
+++ b/tests/test_reporting_contracts.py
@@ -1,0 +1,90 @@
+"""Unit tests for shared reporting contract helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from transformation_portal.reporting.contracts import (
+    build_capability_report,
+    build_orchestrator_result_capability_report,
+    build_quality_gate_report,
+    build_stage_report,
+    derive_stage_report_map,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_build_quality_gate_report_projects_expected_shape() -> None:
+    report = build_quality_gate_report(
+        {
+            "passed": False,
+            "failure_codes": ["APEX_DEPTH_PLATEAU"],
+            "warnings": ["APEX_DEPTH_GRADIENT_LOW"],
+            "metrics": {"upper_iqr": 0.0},
+            "thresholds": {"upper_iqr_min": 1e-4},
+            "shape_context": {"native_shape": [64, 64]},
+            "demoted_failure_codes": ["APEX_DEPTH_SATURATION_LOW"],
+        }
+    )
+
+    assert report == {
+        "kind": "apex_depth",
+        "passed": False,
+        "failure_codes": ["APEX_DEPTH_PLATEAU"],
+        "warnings": ["APEX_DEPTH_GRADIENT_LOW"],
+        "details": {
+            "metrics": {"upper_iqr": 0.0},
+            "thresholds": {"upper_iqr_min": 1e-4},
+            "shape_context": {"native_shape": [64, 64]},
+            "demoted_failure_codes": ["APEX_DEPTH_SATURATION_LOW"],
+        },
+    }
+
+
+def test_build_orchestrator_result_capability_report_uses_selected_attempt_and_fallback_reason() -> None:
+    report = build_orchestrator_result_capability_report(
+        {
+            "status": "ok",
+            "backend": "depth_pro",
+            "fallback_used": True,
+            "selected_attempt_index": 1,
+            "attempts": [
+                {"backend": "da3", "status": "failed", "error_code": "BACKEND_RUNTIME_ERROR"},
+                {"backend": "depth_pro", "status": "success", "model_id": "apple/ml-depth-pro", "model_revision": "rev-123"},
+            ],
+        },
+        requested_backend="da3",
+        resolution_reason="Fallback from da3 to depth_pro after startup failure",
+    )
+
+    assert report == {
+        "requested_backend": "da3",
+        "executed_backend": "depth_pro",
+        "availability_state": "fallback_executed",
+        "reason": "Fallback from da3 to depth_pro after startup failure",
+        "synthetic_output": False,
+        "stub_mode": False,
+        "fallback_executed": True,
+        "model_repo_id": "apple/ml-depth-pro",
+        "model_revision": "rev-123",
+        "asset_bundle_version": None,
+    }
+
+
+def test_stage_report_helpers_preserve_last_stage_entry() -> None:
+    capability = build_capability_report(
+        requested_backend="depth_anything_v2",
+        executed_backend="synthetic",
+        availability_state="synthetic_opt_in",
+        synthetic_output=True,
+    )
+    reports = [
+        build_stage_report(stage="depth", status="skipped"),
+        build_stage_report(stage="depth", status="completed", capability=capability),
+    ]
+
+    report_map = derive_stage_report_map(reports)
+
+    assert report_map["depth"]["status"] == "completed"
+    assert report_map["depth"]["capability"]["synthetic_output"] is True

--- a/tests/test_reporting_contracts.py
+++ b/tests/test_reporting_contracts.py
@@ -72,6 +72,180 @@ def test_build_orchestrator_result_capability_report_uses_selected_attempt_and_f
     }
 
 
+def test_build_orchestrator_result_capability_report_keeps_semantic_gate_failure_available() -> None:
+    report = build_orchestrator_result_capability_report(
+        {
+            "status": "error",
+            "backend": "da3",
+            "fallback_used": False,
+            "error_code": "APEX_DEPTH_SATURATION_LOW",
+            "quality_gate": {
+                "passed": False,
+                "failure_codes": ["APEX_DEPTH_SATURATION_LOW"],
+                "warnings": [],
+                "metrics": {"saturation_low_fraction": 0.031},
+                "thresholds": {"saturation_low_fraction_max": 0.02},
+                "shape_context": {"native_shape": [64, 64]},
+            },
+            "attempts": [
+                {
+                    "backend": "da3",
+                    "status": "failed",
+                    "failure_kind": "semantic",
+                    "error_code": "APEX_DEPTH_SATURATION_LOW",
+                    "error_message": "APEX depth validity gate failed: APEX_DEPTH_SATURATION_LOW",
+                    "model_id": "depth-anything/Depth-Anything-V2-Small-hf",
+                    "model_revision": "rev-semantic",
+                }
+            ],
+        },
+        requested_backend="da3",
+    )
+
+    assert report == {
+        "requested_backend": "da3",
+        "executed_backend": "da3",
+        "availability_state": "available",
+        "reason": None,
+        "synthetic_output": False,
+        "stub_mode": False,
+        "fallback_executed": False,
+        "model_repo_id": "depth-anything/Depth-Anything-V2-Small-hf",
+        "model_revision": "rev-semantic",
+        "asset_bundle_version": None,
+    }
+
+
+def test_build_orchestrator_result_capability_report_preserves_fallback_for_semantic_failure() -> None:
+    report = build_orchestrator_result_capability_report(
+        {
+            "status": "error",
+            "backend": "depth_pro",
+            "fallback_used": True,
+            "error_code": "APEX_DEPTH_PLATEAU",
+            "quality_gate": {
+                "passed": False,
+                "failure_codes": ["APEX_DEPTH_PLATEAU"],
+                "warnings": [],
+                "metrics": {"upper_iqr": 0.0},
+                "thresholds": {"upper_iqr_min": 1e-4},
+                "shape_context": {"native_shape": [64, 64]},
+            },
+            "attempts": [
+                {
+                    "backend": "da3",
+                    "status": "failed",
+                    "failure_kind": "operational",
+                    "error_code": "BACKEND_RUNTIME_ERROR",
+                    "error_message": "da3 runtime crashed",
+                    "model_id": "depth-anything/Depth-Anything-V2-Small-hf",
+                    "model_revision": "rev-da3",
+                },
+                {
+                    "backend": "depth_pro",
+                    "status": "failed",
+                    "failure_kind": "semantic",
+                    "error_code": "APEX_DEPTH_PLATEAU",
+                    "error_message": "APEX depth validity gate failed: APEX_DEPTH_PLATEAU",
+                    "model_id": "apple/ml-depth-pro",
+                    "model_revision": "rev-depth-pro",
+                },
+            ],
+        },
+        requested_backend="da3",
+        resolution_reason="Fallback from da3 to depth_pro after startup failure",
+    )
+
+    assert report == {
+        "requested_backend": "da3",
+        "executed_backend": "depth_pro",
+        "availability_state": "fallback_executed",
+        "reason": "Fallback from da3 to depth_pro after startup failure",
+        "synthetic_output": False,
+        "stub_mode": False,
+        "fallback_executed": True,
+        "model_repo_id": "apple/ml-depth-pro",
+        "model_revision": "rev-depth-pro",
+        "asset_bundle_version": None,
+    }
+
+
+def test_build_orchestrator_result_capability_report_marks_operational_failure_failed() -> None:
+    report = build_orchestrator_result_capability_report(
+        {
+            "status": "error",
+            "backend": "da3",
+            "fallback_used": False,
+            "error_code": "BACKEND_RUNTIME_ERROR",
+            "error": "backend failed",
+            "attempts": [
+                {
+                    "backend": "da3",
+                    "status": "failed",
+                    "failure_kind": "operational",
+                    "error_code": "BACKEND_RUNTIME_ERROR",
+                    "error_message": "backend failed",
+                    "model_id": "depth-anything/Depth-Anything-V2-Small-hf",
+                }
+            ],
+        },
+        requested_backend="da3",
+    )
+
+    assert report == {
+        "requested_backend": "da3",
+        "executed_backend": "da3",
+        "availability_state": "failed",
+        "reason": "backend failed",
+        "synthetic_output": False,
+        "stub_mode": False,
+        "fallback_executed": False,
+        "model_repo_id": "depth-anything/Depth-Anything-V2-Small-hf",
+        "model_revision": None,
+        "asset_bundle_version": None,
+    }
+
+
+def test_build_orchestrator_result_capability_report_marks_skipped_rows_skipped() -> None:
+    report = build_orchestrator_result_capability_report(
+        {
+            "status": "skipped",
+            "reason": "stage disabled",
+        },
+        requested_backend="depth_pro",
+    )
+
+    assert report == {
+        "requested_backend": "depth_pro",
+        "executed_backend": None,
+        "availability_state": "skipped",
+        "reason": "stage disabled",
+        "synthetic_output": False,
+        "stub_mode": False,
+        "fallback_executed": False,
+        "model_repo_id": None,
+        "model_revision": None,
+        "asset_bundle_version": None,
+    }
+
+
+def test_build_orchestrator_result_capability_report_marks_malformed_rows_unknown() -> None:
+    report = build_orchestrator_result_capability_report({}, requested_backend="depth_pro")
+
+    assert report == {
+        "requested_backend": "depth_pro",
+        "executed_backend": None,
+        "availability_state": "unknown",
+        "reason": None,
+        "synthetic_output": False,
+        "stub_mode": False,
+        "fallback_executed": False,
+        "model_repo_id": None,
+        "model_revision": None,
+        "asset_bundle_version": None,
+    }
+
+
 def test_stage_report_helpers_preserve_last_stage_entry() -> None:
     capability = build_capability_report(
         requested_backend="depth_anything_v2",

--- a/tests/test_run_card_schema.py
+++ b/tests/test_run_card_schema.py
@@ -474,6 +474,75 @@ def test_build_run_card_result_summary_projects_quality_gate_and_capability(tmp_
     }
 
 
+def test_build_run_card_result_summary_keeps_semantic_gate_failure_available(tmp_path: Path) -> None:
+    output_root = tmp_path / "output"
+    orch = object.__new__(EnhanceOrchestrator)
+    orch.output_root = output_root
+    orch._active_run_card_segmentation_metadata = {}
+    orch._backend_metadata = SimpleNamespace(
+        requested_backend="da3",
+        resolution_reason=None,
+    )
+
+    summary = orch._build_run_card_result_summary(
+        [
+            {
+                "image": str(tmp_path / "inputs" / "image_03.png"),
+                "status": "error",
+                "backend": "da3",
+                "runtime_s": 1.11,
+                "manifest": None,
+                "fallback_used": False,
+                "error_code": "APEX_DEPTH_SATURATION_LOW",
+                "error": "APEX depth validity gate failed: APEX_DEPTH_SATURATION_LOW",
+                "error_details": {
+                    "passed": False,
+                    "failure_codes": ["APEX_DEPTH_SATURATION_LOW"],
+                    "warnings": [],
+                    "metrics": {"saturation_low_fraction": 0.031},
+                    "thresholds": {"saturation_low_fraction_max": 0.02},
+                    "shape_context": {"native_shape": [64, 64]},
+                },
+                "attempts": [
+                    {
+                        "backend": "da3",
+                        "status": "failed",
+                        "failure_kind": "semantic",
+                        "error_code": "APEX_DEPTH_SATURATION_LOW",
+                        "error_message": "APEX depth validity gate failed: APEX_DEPTH_SATURATION_LOW",
+                        "model_id": "depth-anything/Depth-Anything-V2-Small-hf",
+                        "model_revision": "rev-semantic",
+                    }
+                ],
+            }
+        ]
+    )
+
+    assert summary[0]["quality_gate"] == {
+        "kind": "apex_depth",
+        "passed": False,
+        "failure_codes": ["APEX_DEPTH_SATURATION_LOW"],
+        "warnings": [],
+        "details": {
+            "metrics": {"saturation_low_fraction": 0.031},
+            "thresholds": {"saturation_low_fraction_max": 0.02},
+            "shape_context": {"native_shape": [64, 64]},
+        },
+    }
+    assert summary[0]["capability"] == {
+        "requested_backend": "da3",
+        "executed_backend": "da3",
+        "availability_state": "available",
+        "reason": None,
+        "synthetic_output": False,
+        "stub_mode": False,
+        "fallback_executed": False,
+        "model_repo_id": "depth-anything/Depth-Anything-V2-Small-hf",
+        "model_revision": "rev-semantic",
+        "asset_bundle_version": None,
+    }
+
+
 @pytest.mark.parametrize("version", ["v1", "v2"])
 def test_run_card_schema_accepts_additive_quality_gate_and_capability(version: str) -> None:
     pytest.importorskip("jsonschema")

--- a/tests/test_run_card_schema.py
+++ b/tests/test_run_card_schema.py
@@ -403,8 +403,124 @@ def test_build_run_card_result_summary_uses_cached_segmentation_metadata(tmp_pat
                 "mask_artifact_format": "npz",
                 "tile_size": 1024,
             },
+            "quality_gate": None,
+            "capability": {
+                "requested_backend": "da3",
+                "executed_backend": "da3",
+                "availability_state": "available",
+                "reason": None,
+                "synthetic_output": False,
+                "stub_mode": False,
+                "fallback_executed": False,
+                "model_repo_id": None,
+                "model_revision": None,
+                "asset_bundle_version": None,
+            },
         }
     ]
+
+
+def test_build_run_card_result_summary_projects_quality_gate_and_capability(tmp_path: Path) -> None:
+    output_root = tmp_path / "output"
+    orch = object.__new__(EnhanceOrchestrator)
+    orch.output_root = output_root
+    orch._active_run_card_segmentation_metadata = {}
+    orch._backend_metadata = SimpleNamespace(requested_backend="depth_pro", resolution_reason=None)
+
+    summary = orch._build_run_card_result_summary(
+        [
+            {
+                "image": str(tmp_path / "inputs" / "image_02.png"),
+                "status": "ok",
+                "backend": "depth_pro",
+                "runtime_s": 2.34,
+                "manifest": None,
+                "fallback_used": False,
+                "model_id": "apple/ml-depth-pro",
+                "quality_gate": {
+                    "passed": True,
+                    "failure_codes": [],
+                    "warnings": ["APEX_DEPTH_GRADIENT_LOW"],
+                    "metrics": {"finite_pct": 1.0},
+                    "thresholds": {"finite_pct_min": 0.999},
+                    "shape_context": {"native_shape": [64, 64]},
+                },
+            }
+        ]
+    )
+
+    assert summary[0]["quality_gate"] == {
+        "kind": "apex_depth",
+        "passed": True,
+        "failure_codes": [],
+        "warnings": ["APEX_DEPTH_GRADIENT_LOW"],
+        "details": {
+            "metrics": {"finite_pct": 1.0},
+            "thresholds": {"finite_pct_min": 0.999},
+            "shape_context": {"native_shape": [64, 64]},
+        },
+    }
+    assert summary[0]["capability"] == {
+        "requested_backend": "depth_pro",
+        "executed_backend": "depth_pro",
+        "availability_state": "available",
+        "reason": None,
+        "synthetic_output": False,
+        "stub_mode": False,
+        "fallback_executed": False,
+        "model_repo_id": "apple/ml-depth-pro",
+        "model_revision": None,
+        "asset_bundle_version": None,
+    }
+
+
+@pytest.mark.parametrize("version", ["v1", "v2"])
+def test_run_card_schema_accepts_additive_quality_gate_and_capability(version: str) -> None:
+    pytest.importorskip("jsonschema")
+    payload = _valid_run_card_payload()
+    payload["run_card_version"] = version
+    payload["result_summary"] = [
+        {
+            "image": "image_01.png",
+            "status": "ok",
+            "backend": "depth_pro",
+            "runtime_s": 1.25,
+            "quality_gate": {
+                "kind": "apex_depth",
+                "passed": True,
+                "failure_codes": [],
+                "warnings": [],
+                "details": {
+                    "metrics": {"finite_pct": 1.0},
+                    "thresholds": {"finite_pct_min": 0.999},
+                    "shape_context": {"native_shape": [64, 64]},
+                },
+            },
+            "capability": {
+                "requested_backend": "depth_pro",
+                "executed_backend": "depth_pro",
+                "availability_state": "available",
+                "reason": None,
+                "synthetic_output": False,
+                "stub_mode": False,
+                "fallback_executed": False,
+                "model_repo_id": "apple/ml-depth-pro",
+                "model_revision": "rev-123",
+                "asset_bundle_version": None,
+            },
+        }
+    ]
+    if version == "v2":
+        payload.pop("artifact_merkle_root", None)
+        payload["artifact_tree"] = {
+            "algorithm": "ct-sha256-v1",
+            "leaf_format": "tp.run_card.artifact_leaf.v1",
+            "leaf_count": 0,
+            "root_sha256": "e" * 64,
+            "artifacts": [],
+        }
+
+    _validate_run_card_payload(payload, _run_card_schema_path(version))
 
 
 def test_collect_run_card_artifacts_includes_reconstruction_report(tmp_path: Path):

--- a/tests/test_streaming_stages.py
+++ b/tests/test_streaming_stages.py
@@ -14,7 +14,8 @@ pytestmark = [
     pytest.mark.unit,
 ]
 
-from transformation_portal.streaming.stages import ImageData, ImageLoadStage, ImageSaveStage
+import transformation_portal.depth.models as depth_models
+from transformation_portal.streaming.stages import DepthEstimationStage, ImageData, ImageLoadStage, ImageSaveStage
 
 
 def test_image_load_stage_loads_rgb_image_and_metadata(tmp_path: Path) -> None:
@@ -75,5 +76,91 @@ def test_image_save_stage_writes_expected_output_suffix(tmp_path: Path) -> None:
         with Image.open(output_path) as saved:
             assert saved.mode == "RGB"
             assert saved.size == (2, 2)
+
+    asyncio.run(runner())
+
+
+def test_depth_stage_missing_runtime_fails_closed_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _raise_import_error(**_kwargs):
+        raise ImportError("missing depth runtime")
+
+    monkeypatch.setattr(depth_models, "load_depth_model", _raise_import_error)
+
+    async def runner() -> None:
+        stage = DepthEstimationStage()
+        with pytest.raises(DepthEstimationStage.DepthBackendUnavailableError, match="Depth backend unavailable"):
+            await stage.startup()
+
+    asyncio.run(runner())
+
+
+def test_depth_stage_allows_synthetic_only_with_explicit_opt_in(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    def _raise_import_error(**_kwargs):
+        raise ImportError("missing depth runtime")
+
+    monkeypatch.setattr(depth_models, "load_depth_model", _raise_import_error)
+
+    image_data = ImageData(
+        array=np.ones((4, 4, 3), dtype=np.float32),
+        path=tmp_path / "frame.png",
+    )
+
+    async def runner() -> None:
+        stage = DepthEstimationStage(allow_synthetic_depth=True)
+        await stage.startup()
+        try:
+            result = await stage(image_data)
+        finally:
+            await stage.shutdown()
+
+        assert result.success
+        assert result.data is not None
+        assert result.data.metadata["synthetic_output"] is True
+        assert result.data.metadata["depth_capability"]["executed_backend"] == "synthetic"
+        assert result.data.metadata["depth_capability"]["availability_state"] == "synthetic_opt_in"
+
+    asyncio.run(runner())
+
+
+def test_depth_stage_uses_estimate_depth_contract_when_real_model_present(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    calls = {"estimate_depth": 0}
+
+    class FakeDepthModel:
+        model_revision = "rev-123"
+
+        class variant:
+            value = "depth-anything/Depth-Anything-V2-Small-hf"
+
+        def estimate_depth(self, image: np.ndarray) -> dict:
+            calls["estimate_depth"] += 1
+            return {
+                "depth": np.full(image.shape[:2], 0.5, dtype=np.float32),
+                "depth_raw": np.full(image.shape[:2], 12.0, dtype=np.float32),
+                "metadata": {"backend": "pytorch_cpu"},
+            }
+
+    monkeypatch.setattr(depth_models, "load_depth_model", lambda **_kwargs: FakeDepthModel())
+
+    image_data = ImageData(
+        array=np.ones((4, 4, 3), dtype=np.float32),
+        path=tmp_path / "frame.png",
+    )
+
+    async def runner() -> None:
+        stage = DepthEstimationStage(cache_model=False)
+        await stage.startup()
+        try:
+            result = await stage(image_data)
+        finally:
+            await stage.shutdown()
+
+        assert result.success
+        assert calls["estimate_depth"] == 1
+        assert np.allclose(result.data.depth_map, 0.5)
+        assert result.data.metadata["depth_capability"]["executed_backend"] == "pytorch_cpu"
+        assert result.data.metadata["depth_capability"]["model_repo_id"] == "depth-anything/Depth-Anything-V2-Small-hf"
 
     asyncio.run(runner())

--- a/tests/test_streaming_stages.py
+++ b/tests/test_streaming_stages.py
@@ -122,6 +122,22 @@ def test_depth_stage_allows_synthetic_only_with_explicit_opt_in(monkeypatch: pyt
     asyncio.run(runner())
 
 
+def test_depth_stage_invalid_model_size_propagates_validation_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _raise_value_error(**_kwargs):
+        raise ValueError("Unsupported depth model_size 'giant'. Expected one of: small, base, large.")
+
+    monkeypatch.setattr(depth_models, "load_depth_model", _raise_value_error)
+
+    async def runner() -> None:
+        stage = DepthEstimationStage(model_size="giant", allow_synthetic_depth=True)
+        with pytest.raises(ValueError, match="Unsupported depth model_size 'giant'"):
+            await stage.startup()
+
+    asyncio.run(runner())
+
+
 def test_depth_stage_uses_estimate_depth_contract_when_real_model_present(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- Normalize truthfulness reporting on the hot run-card and batch path without changing artifact filenames or row status values.
- Centralize quality_gate, capability, and stage_report shaping, and close the remaining synthetic and unavailable false-success paths.

## Changes
- Add shared reporting builders for `quality_gate`, `capability`, attempt selection, and `stage_reports`.
- Backport optional `result_summary[*].quality_gate` and `capability` fields to packaged and docs `run_card` v1/v2 schemas; add top-level batch `quality_gate` normalization only.
- Normalize orchestrator per-result gate and capability output while preserving raw `attempts[*]`, fallback provenance, artifact index, Merkle root, git revision, runtime stats, and `ok` / `error` row semantics.
- Route `DepthEstimationStage` through the repo depth wrapper, fail closed by default, and require explicit synthetic opt-in.
- Add `StageStatus.UNAVAILABLE`, make `NodeResult.success` status-driven, and return unwired `NVDiffRecNode` results as unavailable.
- Reject single-image reconstruction at the single-image pipeline surface while keeping multiview config flows intact.
- Add truthful `stage_reports` to pipeline summaries and preset-asset preflight with honest `flux_img2img` capability reporting.

## Validation
- Proven green:
  - `PATH=/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin:$PATH make pre-commit`
  - `.venv/bin/pytest tests/test_reporting_contracts.py tests/test_run_card_schema.py tests/test_batch_processing.py tests/test_streaming_stages.py tests/execution_graph/nodes/test_nvdiffrec_node.py tests/style_transfer/test_style_presets.py tests/spatial_ai/orchestration/test_pipeline.py -q`
  - `.venv/bin/pytest tests/spatial_ai/orchestration/test_multiview_pipeline.py -q -k reconstruction_saves_summary`
  - `make test-fast`
  - `make test-orchestrator-contract`
- Notes:
  - `make test-orchestrator-contract` first failed inside the desktop sandbox because no writable temp directory was available; the same command passed when rerun outside the sandbox.
- Still failing:
  - None observed in the executed validation set.
- Not run:
  - `make test-full`
  - Full `tests/spatial_ai/orchestration/test_multiview_pipeline.py`; the touched summary and reconstruction path was run directly.

## Risk
- Run-card and batch changes are additive and preserve existing artifact filenames plus `ok` / `error` row semantics.
- `DepthEstimationStage` now fails closed unless synthetic output is explicitly enabled for dev/test.
- Callers that treated unwired NVDiffRec stubs as success must now handle `unavailable` explicitly.
- Revert-safe: payload shaping is centralized in a small reporting module rather than duplicated across artifact writers.
