### PR TITLE
fix(lux-depth-v3): enforce registry-based DA3 model contracts

### DIFF
--- a/.github/workflows/determinism-gate.yml
+++ b/.github/workflows/determinism-gate.yml
@@ -97,6 +97,7 @@ jobs:
           python -m transformation_portal.lux_depth_v3 \
             --input-dir output/run_card_gate_input \
             --output-dir output/run_card_gate_output \
+            --model-key da3-metric \
             --depth-device cpu \
             --enable-v2 off \
             --emit-run-card on \

--- a/README.md
+++ b/README.md
@@ -100,17 +100,17 @@ Transformation Portal supports depth models across two tiers with different lice
 
 ### Production Path
 - **DA3 (`da3` backend):** Primary production backend for Lux Depth V3
-- **Use for:** The default governed depth workflow, with a commercial-safe model tier
+- **Use for:** The governed depth workflow surface. Select `model_key="da3-metric"` for the Apache-2.0 DA3 path, or `model_key="da3"` / `model_key="da3-research"` for the research-default selector.
 - **Requirement:** Install a trusted ML core profile for actual DA3 inference. These trusted ML install flows are currently supported on macOS and Linux only; Windows users should use WSL2 or another Unix-like environment. For example: `make install-ml-core` or `./scripts/bootstrap/install_ml_stack.sh --profile core-cpu`. CUDA-accelerated profiles are Linux-only.
 - **Default:** Standard CLI flows resolve here unless a research-only backend is explicitly requested
 
 ### Research & Non-Commercial
-- **Depth Anything V3.1 preset:** `depth-anything-v3.1-research-m4`
+- **DA3 research selector:** `model_key="da3"` or `model_key="da3-research"`
 - **Depth Pro backend:** `depth_pro`
 - **Use for:** Explicitly acknowledged research and non-commercial evaluation paths
 - **Requirements:** `non_commercial_ok=True`, plus Apple license acceptance for `depth_pro`
 
-**Important:** Research-only models are not part of the default commercial-safe path. See [ADR-0015: DA3 1.1 Non-Commercial Research Tier](docs/architecture/adr-0015-da3-1-1-non-commercial-research-tier.md) for governance details.
+**Important:** The research-default DA3 selector is not part of the Apache-2.0 path. See [ADR-0015: DA3 1.1 Non-Commercial Research Tier](docs/architecture/adr-0015-da3-1-1-non-commercial-research-tier.md) for governance details.
 
 ### Research Preset Example
 

--- a/config/model_lock_manifest.yaml
+++ b/config/model_lock_manifest.yaml
@@ -61,9 +61,41 @@ repositories:
   onnx-community/depth-anything-v2-large:
     revision: "58f6f567efd3eacfeddec1dcc21cf77f67e4eaa9"
     owner: "depth pipeline"
+  depth-anything/DA3NESTED-GIANT-LARGE-1.1:
+    revision: "b2359bdf726fb44ef62acca04d629dcf158053e7"
+    owner: "depth pipeline"
+    canonical_key: "da3_research"
+    license: "cc-by-nc-4.0"
+    usage_class: "non_commercial_only"
+    backend_kind: "da3_api"
+  depth-anything/DA3METRIC-LARGE:
+    revision: "4010e39f3634a45bc60553321fb49fb760bd594e"
+    owner: "depth pipeline"
+    canonical_key: "da3_metric"
+    license: "apache-2.0"
+    usage_class: "commercial_ok"
+    backend_kind: "da3_api"
+  depth-anything/DA3-BASE:
+    revision: "f4a6c9b3c95e41c82048423d3493a81ec3fa810e"
+    owner: "depth pipeline"
+    canonical_key: "da3_base"
+    license: "apache-2.0"
+    usage_class: "commercial_ok"
+    backend_kind: "da3_api"
+  depth-anything/DA3-SMALL:
+    revision: "e08cab65ca0ec38e7826075418411ab90cab4da3"
+    owner: "depth pipeline"
+    canonical_key: "da3_small"
+    license: "apache-2.0"
+    usage_class: "commercial_ok"
+    backend_kind: "da3_api"
   apple/coreml-depth-anything-v2-small:
     revision: "cfef6f6f2a70783dedc0bfae40cecbc2052285d3"
     owner: "depth pipeline"
+    canonical_key: "coreml_depth_anything_v2_small"
+    license: "apache-2.0"
+    usage_class: "commercial_ok"
+    backend_kind: "coreml_published"
 
   # --- Lux Render Pipeline Models ---
   runwayml/stable-diffusion-v1-5:

--- a/docs/cli/LUX_DEPTH_V3_CLI_GUIDE.md
+++ b/docs/cli/LUX_DEPTH_V3_CLI_GUIDE.md
@@ -1,10 +1,10 @@
 # Lux Depth V3 CLI - APEX Command Variants
 
-This document provides usage examples for the `lux-depth-v3` CLI with APEX quality tier support, including both commercial-safe and research-only variants.
+This document provides usage examples for the `lux-depth-v3` CLI with APEX quality tier support, including the current Apache-2.0 DA3 selector for the Lux V3 relative-depth surface and the research-only variants.
 
 ## Table of Contents
 - [Installation](#installation)
-- [Commercial-Safe APEX Mode](#commercial-safe-apex-mode)
+- [Apache APEX Mode](#apache-apex-mode)
 - [Research-Only APEX+ Variants](#research-only-apex-variants)
 - [Command Options Reference](#command-options-reference)
 - [Quality Tiers](#quality-tiers)
@@ -24,9 +24,9 @@ The `lux-depth-v3` command should now be available on your PATH. Alternatively, 
 python -m transformation_portal.lux_depth_v3 [options]
 ```
 
-## Commercial-Safe APEX Mode
+## Apache APEX Mode
 
-The commercial-safe APEX mode uses the canonical `da3` production backend and provides the highest quality output for production use.
+For the current Lux V3 relative-depth surface, the Apache-2.0 APEX path uses `--model-key "da3-metric"`. The bare `da3` selector is now the research-default DA3 path and requires `--non-commercial-ok "true"`.
 
 ### Basic APEX Command
 
@@ -37,6 +37,7 @@ lux-depth-v3 \
   --preset "premium" \
   --quality-tier "apex" \
   --depth-backend "da3" \
+  --model-key "da3-metric" \
   --materials-v3 "on" \
   --pbr "on" \
   --cache-depth "on" \
@@ -57,6 +58,7 @@ lux-depth-v3 \
   --output-dir "./output/apex_cuda" \
   --preset "premium" \
   --quality-tier "apex" \
+  --model-key "da3-metric" \
   --depth-device "cuda" \
   --materials-v3 "on" \
   --pbr "on" \
@@ -72,6 +74,7 @@ lux-depth-v3 \
   --output-dir "./output/apex_mps" \
   --preset "premium" \
   --quality-tier "apex" \
+  --model-key "da3-metric" \
   --depth-device "mps" \
   --materials-v3 "on" \
   --pbr "on" \
@@ -108,6 +111,26 @@ lux-depth-v3 \
 
 **License**: CC BY-NC 4.0 (Non-Commercial)
 **Use Cases**: Research, academic projects, non-commercial portfolio work
+
+### Variant A2: DA3 Research Default
+
+The `da3` selector resolves to the research-default nested DA3 checkpoint and requires non-commercial acknowledgement.
+
+```bash
+lux-depth-v3 \
+  --input-dir "./input_images" \
+  --output-dir "./output/lux_depth_v3_apex_da3_research" \
+  --preset "premium" \
+  --quality-tier "apex" \
+  --depth-backend "da3" \
+  --model-key "da3" \
+  --non-commercial-ok "true" \
+  --materials-v3 "on" \
+  --pbr "on"
+```
+
+**License**: CC BY-NC 4.0 (Non-Commercial)
+**Output Contract**: Current Lux V3 relative-depth surface
 
 ### Variant B: Apple Depth Pro (AMLR Research License)
 
@@ -156,7 +179,11 @@ lux-depth-v3 \
 ### Depth Backend Configuration
 
 - `--depth-backend TEXT`: Depth estimation backend
-  - Options: `da3` (default, commercial-safe), `depth_pro` (research-only)
+  - Options: `da3` (default backend family), `depth_pro` (research-only)
+- `--model-key TEXT`: Canonical model selector within the chosen backend family
+  - Public options in this release: `da3`, `da3-research`, `da3-metric`
+  - `da3` / `da3-research`: Research-default DA3 selector; requires `--non-commercial-ok "true"`
+  - `da3-metric`: Apache-2.0 DA3 selector for the current Lux V3 relative-depth surface
 - `--depth-device TEXT`: Device for depth inference (default: `cpu`)
   - Options: `cpu`, `cuda`, `mps`
 
@@ -194,7 +221,7 @@ lux-depth-v3 \
 ### License Acknowledgements
 
 - `--non-commercial-ok TEXT`: Acknowledge non-commercial license restrictions (default: `false`)
-  - Required for: Depth Anything V3.1, Depth Pro
+  - Required for: `da3` / `da3-research`, Depth Anything V3.1, Depth Pro
 - `--accept-apple-depth-pro-research-license TEXT`: Accept Apple Depth Pro research license (default: `false`)
   - Required for: Depth Pro backend
 

--- a/docs/guides/LUX_DEPTH_V3_TROUBLESHOOTING.md
+++ b/docs/guides/LUX_DEPTH_V3_TROUBLESHOOTING.md
@@ -229,12 +229,13 @@ Output Deliverables
 
 **Solution:**
 ```bash
-# ✅ Omit research flags for commercial workflows
+# ✅ Use the Apache DA3 selector for commercial workflows
 --quality-tier "apex" \
---depth-backend "da3"
+--depth-backend "da3" \
+--model-key "da3-metric"
 ```
 
-**Explanation:** The canonical commercial-safe backend is `da3`; it does not require research license flags.
+**Explanation:** `da3` is now the research-default selector. Use `--model-key "da3-metric"` for the Apache-2.0 DA3 path on the current Lux V3 relative-depth surface.
 
 ---
 

--- a/docs/migration/MIGRATION_GUIDE.md
+++ b/docs/migration/MIGRATION_GUIDE.md
@@ -48,7 +48,8 @@ result = pipeline.run(image)
 ```
 
 **Available backends:**
-- `da3` (Depth Anything V3) - Default, production-safe, commercial use OK
+- `da3` (Depth Anything V3 family) - Default backend family; the bare `da3` selector now resolves to the research-default DA3 model and requires `--non-commercial-ok`
+- `da3-metric` - Apache-2.0 DA3 selector for the current Lux V3 relative-depth surface
 - `depth_pro` (Apple Depth Pro) - Research only, requires explicit license acceptance
 
 #### 3. Configuration Format

--- a/docs/schemas/run_card/run_card.v1.schema.json
+++ b/docs/schemas/run_card/run_card.v1.schema.json
@@ -278,6 +278,75 @@
       },
       "additionalProperties": false
     },
+    "model_contract": {
+      "type": "object",
+      "required": [
+        "accelerator_kind",
+        "backend_kind",
+        "canonical_model_key",
+        "fallback_chain",
+        "license_id",
+        "manifest_schema_version",
+        "non_commercial_ok",
+        "requested_model_selector",
+        "requires_non_commercial_ok",
+        "resolved_repo_id",
+        "resolved_revision",
+        "usage_class"
+      ],
+      "properties": {
+        "requested_model_selector": {
+          "type": "string",
+          "minLength": 1
+        },
+        "canonical_model_key": {
+          "type": "string",
+          "minLength": 1
+        },
+        "resolved_repo_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "resolved_revision": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{40}$"
+        },
+        "license_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "usage_class": {
+          "type": "string",
+          "minLength": 1
+        },
+        "requires_non_commercial_ok": {
+          "type": "boolean"
+        },
+        "non_commercial_ok": {
+          "type": "boolean"
+        },
+        "backend_kind": {
+          "type": "string",
+          "minLength": 1
+        },
+        "accelerator_kind": {
+          "type": "string",
+          "minLength": 1
+        },
+        "fallback_chain": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "manifest_schema_version": {
+          "type": "integer",
+          "minimum": 1
+        }
+      },
+      "additionalProperties": false
+    },
     "environment": {
       "type": "object",
       "required": [

--- a/docs/schemas/run_card/run_card.v2.schema.json
+++ b/docs/schemas/run_card/run_card.v2.schema.json
@@ -278,6 +278,75 @@
       },
       "additionalProperties": false
     },
+    "model_contract": {
+      "type": "object",
+      "required": [
+        "accelerator_kind",
+        "backend_kind",
+        "canonical_model_key",
+        "fallback_chain",
+        "license_id",
+        "manifest_schema_version",
+        "non_commercial_ok",
+        "requested_model_selector",
+        "requires_non_commercial_ok",
+        "resolved_repo_id",
+        "resolved_revision",
+        "usage_class"
+      ],
+      "properties": {
+        "requested_model_selector": {
+          "type": "string",
+          "minLength": 1
+        },
+        "canonical_model_key": {
+          "type": "string",
+          "minLength": 1
+        },
+        "resolved_repo_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "resolved_revision": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{40}$"
+        },
+        "license_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "usage_class": {
+          "type": "string",
+          "minLength": 1
+        },
+        "requires_non_commercial_ok": {
+          "type": "boolean"
+        },
+        "non_commercial_ok": {
+          "type": "boolean"
+        },
+        "backend_kind": {
+          "type": "string",
+          "minLength": 1
+        },
+        "accelerator_kind": {
+          "type": "string",
+          "minLength": 1
+        },
+        "fallback_chain": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "manifest_schema_version": {
+          "type": "integer",
+          "minimum": 1
+        }
+      },
+      "additionalProperties": false
+    },
     "environment": {
       "type": "object",
       "required": [

--- a/src/transformation_portal/attestation/model_lock_manifest.py
+++ b/src/transformation_portal/attestation/model_lock_manifest.py
@@ -57,11 +57,24 @@ def load_model_lock_manifest(path: Optional[Path] = None) -> Dict[str, Any]:
     if not isinstance(payload, dict):
         raise ValueError(f"Model lock manifest root must be an object: {manifest_path}")
 
-    repositories = payload.get("repositories")
-    if repositories is None:
-        payload["repositories"] = {}
-    elif not isinstance(repositories, dict):
-        raise ValueError(f"Model lock manifest 'repositories' must be an object: {manifest_path}")
+    if payload.get("version") == 1 or "repositories" in payload:
+        repositories = payload.get("repositories")
+        if repositories is None:
+            payload["repositories"] = {}
+        elif not isinstance(repositories, dict):
+            raise ValueError(f"Model lock manifest 'repositories' must be an object: {manifest_path}")
+        payload["manifest_schema_version"] = 1
+    elif payload.get("schema_version") == 2 and "models" in payload:
+        models = payload.get("models")
+        if not isinstance(models, dict):
+            raise ValueError(f"Model lock manifest 'models' must be an object: {manifest_path}")
+        payload["repositories"] = models
+        payload["manifest_schema_version"] = 2
+    else:
+        raise ValueError(
+            f"Unsupported model lock manifest shape: {manifest_path}. "
+            "Expected v1 'version' + 'repositories' or v2 'schema_version' + 'models'."
+        )
 
     artifact_attestation = payload.get("artifact_attestation")
     if artifact_attestation is None:

--- a/src/transformation_portal/depth/backends/da3.py
+++ b/src/transformation_portal/depth/backends/da3.py
@@ -159,9 +159,10 @@ class DA3Backend:
             ModelRequest(
                 model_key=getattr(config, "model_key", None) if config is not None else None,
                 raw_model_id=getattr(config, "raw_model_id", None) if config is not None else None,
-                model_variant=self._model_variant,
+                model_variant=self._model_variant if config is not None else None,
                 use_coreml_backend=bool(getattr(config, "use_coreml_backend", False)) if config is not None else False,
                 non_commercial_ok=bool(getattr(config, "non_commercial_ok", False)) if config is not None else False,
+                enforce_license=config is not None,
             )
         )
         self._model_id = self._resolved_model_contract.spec.repo_id

--- a/src/transformation_portal/depth/backends/da3.py
+++ b/src/transformation_portal/depth/backends/da3.py
@@ -307,6 +307,10 @@ class DA3Backend:
             and CURRENT_PLATFORM.is_apple_silicon
         )
 
+    def _non_commercial_opt_in_enabled(self) -> bool:
+        """Return whether the caller acknowledged non-commercial registry selections."""
+        return bool(self._config is not None and getattr(self._config, "non_commercial_ok", False))
+
     def _cache_device_tag(self) -> str:
         """Return the cache key device/runtime tag for this backend config."""
         if self._apple_coreml_opt_in_enabled():
@@ -348,6 +352,8 @@ class DA3Backend:
             "--device",
             self._device,
         )
+        if self._non_commercial_opt_in_enabled():
+            command.append("--non-commercial-ok")
         if self._apple_coreml_opt_in_enabled():
             command.append("--use-coreml")
 
@@ -610,6 +616,8 @@ class DA3Backend:
                 "--device",
                 str(use_device),
             )
+            if self._non_commercial_opt_in_enabled():
+                command.append("--non-commercial-ok")
             if self._apple_coreml_opt_in_enabled():
                 command.append("--use-coreml")
 

--- a/src/transformation_portal/depth/backends/da3.py
+++ b/src/transformation_portal/depth/backends/da3.py
@@ -603,10 +603,12 @@ class DA3Backend:
                 str(output_depth_path),
                 "--output-json",
                 str(output_json_path),
-                "--device",
-                str(use_device),
                 "--model-variant",
                 self._model_variant.name,
+                "--model-key",
+                self._resolved_model_contract.canonical_key,
+                "--device",
+                str(use_device),
             )
             if self._apple_coreml_opt_in_enabled():
                 command.append("--use-coreml")

--- a/src/transformation_portal/depth/backends/da3.py
+++ b/src/transformation_portal/depth/backends/da3.py
@@ -34,6 +34,7 @@ from ...core.ml_dependency_health import (
     ensure_dependency_importable,
 )
 from ...core.platform_matrix import CURRENT_PLATFORM
+from ...lux_depth_v3.model_resolution import ModelRequest, resolve_model_contract
 from .protocol import DepthResult, LicenseType
 
 if TYPE_CHECKING:
@@ -73,6 +74,12 @@ def _model_requires_custom_da3_library(model_variant: "ModelVariant") -> bool:
     """Return whether the selected model requires the depth-anything-3 package."""
     model_id = _model_id_for_variant(model_variant).lower()
     return model_id.startswith("depth-anything/da3") or "da3nested" in model_id
+
+
+def _model_requires_custom_da3_library_for_model_id(model_id: str) -> bool:
+    """Return whether a model ID requires the depth-anything-3 package."""
+    normalized = str(model_id).lower()
+    return normalized.startswith("depth-anything/da3") or "da3nested" in normalized
 
 
 def _infer_source_depth_units(metadata: dict[str, Any]) -> str:
@@ -138,7 +145,7 @@ class DA3Backend:
     """Depth Anything V3 backend adapter implementing DepthBackend protocol."""
 
     name = "da3"
-    license_type = LicenseType.COMMERCIAL
+    license_type = LicenseType.MODEL_DEPENDENT
     requires_checkpoint = False
     WORKER_MODULE = "transformation_portal.depth.backends.da3_worker"
 
@@ -148,6 +155,16 @@ class DA3Backend:
         self._engine: Optional[DA3InferenceEngine] = None
         self._device = self._resolve_device(config)
         self._model_variant = self._resolve_model_variant(config)
+        self._resolved_model_contract = resolve_model_contract(
+            ModelRequest(
+                model_key=getattr(config, "model_key", None) if config is not None else None,
+                raw_model_id=getattr(config, "raw_model_id", None) if config is not None else None,
+                model_variant=self._model_variant,
+                use_coreml_backend=bool(getattr(config, "use_coreml_backend", False)) if config is not None else False,
+                non_commercial_ok=bool(getattr(config, "non_commercial_ok", False)) if config is not None else False,
+            )
+        )
+        self._model_id = self._resolved_model_contract.spec.repo_id
         self._repo_root = self._find_repo_root()
         self._repo_src = self._repo_root / "src" if self._repo_root is not None else None
         self._python_executable = self._resolve_python_executable(config)
@@ -297,7 +314,7 @@ class DA3Backend:
 
     def _ensure_local_package_available(self) -> None:
         """Ensure depth-anything-3 is installed for DA3 nested models."""
-        if not _model_requires_custom_da3_library(self._model_variant):
+        if not _model_requires_custom_da3_library_for_model_id(self._model_id):
             return
 
         try:
@@ -325,6 +342,8 @@ class DA3Backend:
             "--check",
             "--model-variant",
             self._model_variant.name,
+            "--model-key",
+            self._resolved_model_contract.canonical_key,
             "--device",
             self._device,
         )
@@ -764,10 +783,7 @@ class DA3Backend:
         else:
             image_hash = hashlib.sha256(image.tobytes()).hexdigest()[:16]
 
-        if hasattr(self._model_variant, "value"):
-            model_name = self._model_variant.value.name
-        else:
-            model_name = "metric_large"
+        model_name = self._resolved_model_contract.canonical_key
 
         runner_mode = "subp" if self._uses_subprocess() else "local"
         runner_path = self._python_executable or sys.executable
@@ -784,21 +800,23 @@ class DA3Backend:
         device_config = DeviceConfig(device=device, use_coreml=use_coreml)
         da3_config = DA3Config(
             model_variant=self._model_variant,
+            model_key=self._resolved_model_contract.canonical_key,
+            raw_model_id=self._resolved_model_contract.spec.repo_id,
+            non_commercial_ok=bool(getattr(self._config, "non_commercial_ok", False)) if self._config else False,
             device=device_config,
         )
 
-        if self._config:
-            commercial_use = not getattr(self._config, "non_commercial_ok", False)
-        else:
-            commercial_use = True
         self._engine = DA3InferenceEngine(
             config=da3_config,
-            commercial_use=commercial_use,
+            commercial_use=True,
             validate_license_strict=False,
+            model_key=self._resolved_model_contract.canonical_key,
+            raw_model_id=self._resolved_model_contract.spec.repo_id,
+            non_commercial_ok=bool(getattr(self._config, "non_commercial_ok", False)) if self._config else False,
         )
 
         logger.info(
             "Loaded DA3 backend: model=%s device=%s",
-            self._model_variant.value.name,
+            self._model_id,
             device,
         )

--- a/src/transformation_portal/depth/backends/da3_worker.py
+++ b/src/transformation_portal/depth/backends/da3_worker.py
@@ -27,6 +27,10 @@ def _build_parser() -> argparse.ArgumentParser:
         help="ModelVariant enum member name (for example METRIC_LARGE).",
     )
     parser.add_argument(
+        "--model-key",
+        help="Canonical Lux Depth V3 registry key (for example da3_metric).",
+    )
+    parser.add_argument(
         "--device",
         default="cpu",
         help="Inference device to pass to DA3.",
@@ -90,6 +94,7 @@ def _run_inference(
     output_depth: Path,
     output_json: Path,
     model_variant_name: str,
+    model_key: str | None,
     device: str,
     use_coreml: bool,
 ) -> int:
@@ -101,12 +106,14 @@ def _run_inference(
     model_variant = _resolve_model_variant(model_variant_name)
     config = DA3Config(
         model_variant=model_variant,
+        model_key=model_key,
         device=DeviceConfig(device=device, use_coreml=use_coreml),
     )
     engine = DA3InferenceEngine(
         config=config,
         commercial_use=True,
         validate_license_strict=False,
+        model_key=model_key,
     )
     result = engine.predict(image)
 
@@ -151,6 +158,7 @@ def main(argv: list[str] | None = None) -> int:
         output_depth=args.output_depth.expanduser(),
         output_json=args.output_json.expanduser(),
         model_variant_name=str(args.model_variant),
+        model_key=str(args.model_key) if args.model_key else None,
         device=str(args.device),
         use_coreml=bool(args.use_coreml),
     )

--- a/src/transformation_portal/depth/backends/da3_worker.py
+++ b/src/transformation_portal/depth/backends/da3_worker.py
@@ -41,6 +41,11 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Enable the Apple CoreML opt-in when supported.",
     )
     parser.add_argument(
+        "--non-commercial-ok",
+        action="store_true",
+        help="Acknowledge non-commercial registry-selected models for subprocess execution.",
+    )
+    parser.add_argument(
         "--input-image",
         type=Path,
         help="Input image path for inference mode.",
@@ -97,6 +102,7 @@ def _run_inference(
     model_key: str | None,
     device: str,
     use_coreml: bool,
+    non_commercial_ok: bool,
 ) -> int:
     """Run DA3 inference and persist structured outputs."""
     from ...lux_depth_v3.config import DA3Config, DeviceConfig
@@ -107,6 +113,7 @@ def _run_inference(
     config = DA3Config(
         model_variant=model_variant,
         model_key=model_key,
+        non_commercial_ok=non_commercial_ok,
         device=DeviceConfig(device=device, use_coreml=use_coreml),
     )
     engine = DA3InferenceEngine(
@@ -114,6 +121,7 @@ def _run_inference(
         commercial_use=True,
         validate_license_strict=False,
         model_key=model_key,
+        non_commercial_ok=non_commercial_ok,
     )
     result = engine.predict(image)
 
@@ -161,6 +169,7 @@ def main(argv: list[str] | None = None) -> int:
         model_key=str(args.model_key) if args.model_key else None,
         device=str(args.device),
         use_coreml=bool(args.use_coreml),
+        non_commercial_ok=bool(args.non_commercial_ok),
     )
 
 

--- a/src/transformation_portal/depth/backends/protocol.py
+++ b/src/transformation_portal/depth/backends/protocol.py
@@ -25,6 +25,7 @@ class LicenseType(Enum):
 
     COMMERCIAL = "commercial"
     RESEARCH_ONLY = "research_only"
+    MODEL_DEPENDENT = "model_dependent"
 
 
 class LicenseRestrictionError(Exception):

--- a/src/transformation_portal/lux_depth_v3/README.md
+++ b/src/transformation_portal/lux_depth_v3/README.md
@@ -5,11 +5,11 @@ Lux Depth V3 is a production-grade orchestrator for depth-aware image processing
 ## Overview
 
 The Lux Depth V3 pipeline provides:
-- **Depth Estimation** using the canonical `da3` backend (commercial-safe) or `depth_pro` (research-only)
+- **Depth Estimation** using the canonical `da3` backend surface
 - **PBR Map Generation** (normal, roughness, ambient occlusion)
 - **Materials V3** surface-aware finishing
 - **V2 Enhancement** (optional AI-powered refinement)
-- **APEX Quality Tier** support for commercial production
+- **APEX Quality Tier** support for governed production and research workflows
 
 ## Quick Start
 
@@ -21,6 +21,7 @@ lux-depth-v3 \
   --output-dir "./output/commercial" \
   --quality-tier "apex" \
   --depth-backend "da3" \
+  --model-key "da3-metric" \
   --depth-device "mps" \
   --pbr "on" \
   --enable-v2 "off" \
@@ -36,6 +37,7 @@ lux-depth-v3 \
   --output-dir "./output/enhanced" \
   --quality-tier "apex" \
   --depth-backend "da3" \
+  --model-key "da3-metric" \
   --depth-device "mps" \
   --pbr "on" \
   --materials-v3 "on" \
@@ -85,6 +87,12 @@ The V2 enhancement stage is **optional** and enabled by default for backward com
 - Research model configurations
 - Fine-tuned parameter combinations
 - Non-commercial depth models
+
+### Model Selectors
+
+- `da3` / `da3-research` - research-default DA3 selector; requires `--non-commercial-ok "true"`
+- `da3-metric` - Apache-2.0 DA3 selector for the current Lux V3 relative-depth surface
+- `da3-base` / `da3-small` - registry-supported experimental selectors, hidden from public CLI help until smoke-tested
 
 **Recommendation:** Start with `--quality-tier`, add `--preset` only when needed.
 

--- a/src/transformation_portal/lux_depth_v3/__main__.py
+++ b/src/transformation_portal/lux_depth_v3/__main__.py
@@ -8,12 +8,13 @@ APEX command variants for the lux_depth_v3 pipeline supporting:
 - Material segmentation (stub, EfficientSAM, or SAM2 backends)
 
 Usage:
-    # Commercial-safe APEX (default, no research opt-ins)
+    # Apache-2.0 DA3 path for production workflows
     lux-depth-v3 \\
         --input-dir "./input_images" \\
         --output-dir "./output/lux_depth_v3_apex" \\
         --quality-tier "apex" \\
         --depth-backend "da3" \\
+        --model-key "da3-metric" \\
         --depth-device "mps" \\
         --materials-v3 "on" \\
         --pbr "on" \\
@@ -45,12 +46,12 @@ Usage:
         --segmentation-backend "efficientsam" \\
         --depth-device "mps"
 
-    # Research-only: Depth Anything V3.1 (explicit opt-in)
+    # Research-only: DA3 research default (explicit opt-in)
     lux-depth-v3 \\
         --input-dir "./input_images" \\
         --output-dir "./output/lux_depth_v3_apex_da31" \\
         --quality-tier "apex" \\
-        --preset "depth-anything-v3.1-research-m4" \\
+        --model-key "da3" \\
         --non-commercial-ok "true" \\
         --depth-device "mps" \\
         --materials-v3 "on" \\
@@ -163,6 +164,7 @@ from ._backend_contract import backend_alias_warning, is_legacy_backend_alias, n
 from .config import EnhanceConfig, Preset
 from .config_resolver import apply_effective_raw_runtime_config
 from .ingest_adapter import RAW_PREVIEW_ESCAPE_ENV
+from .model_resolution import ModelLicenseError, ModelRequest, UnknownModelError, resolve_model_contract
 from .orchestrator import EnhanceOrchestrator
 
 logger = logging.getLogger(__name__)
@@ -319,7 +321,16 @@ def main(
     depth_backend: Optional[str] = typer.Option(
         None,
         "--depth-backend",
-        help=("Depth backend: da3 (default, commercial), depth_pro " "(research-only, metric depth)"),
+        help=("Depth backend: da3 (default) or depth_pro " "(research-only backend)"),
+    ),
+    model_key: Optional[str] = typer.Option(
+        None,
+        "--model-key",
+        help=(
+            "Model selector for the current Lux V3 relative-depth surface: "
+            "da3 (research-default, requires --non-commercial-ok), "
+            "da3-research, or da3-metric (Apache-2.0)."
+        ),
     ),
     depth_pro_python: Optional[str] = typer.Option(
         None,
@@ -900,6 +911,7 @@ def main(
         logger.warning(f"Preset '{preset}' does not map" " to a known Preset enum." " Continuing with string value.")
 
     config = EnhanceConfig(
+        model_key=model_key,
         preset=preset_enum,
         preset_requested=preset,
         depth_device=depth_device,
@@ -953,6 +965,20 @@ def main(
         allow_semantic_fallback=allow_semantic_fallback,
     )
     apply_effective_raw_runtime_config(config)
+    if depth_backend == "da3" or depth_backend is None:
+        try:
+            resolve_model_contract(
+                ModelRequest(
+                    model_key=model_key,
+                    model_variant=config.model_variant,
+                    use_coreml_backend=bool(getattr(config, "use_coreml_backend", False)),
+                    non_commercial_ok=enable_non_commercial,
+                )
+            )
+        except (ModelLicenseError, UnknownModelError) as exc:
+            logger.error(str(exc))
+            print(str(exc), file=sys.stdout)
+            raise typer.Exit(code=1)
 
     # Forward-compatible knobs: apply via setattr
     # for non-breaking config evolution.

--- a/src/transformation_portal/lux_depth_v3/config.py
+++ b/src/transformation_portal/lux_depth_v3/config.py
@@ -39,7 +39,7 @@ class ModelVariant(Enum):
         (),
         {
             "name": "depth-anything-v3-metric-large",
-            "display_name": ("Depth Anything V3 Metric Large " "(DA3 Nested Giant)"),
+            "display_name": "Depth Anything V3 Research Default (DA3 Nested Giant Large)",
             "huggingface_id": "depth-anything/DA3NESTED-GIANT-LARGE-1.1",
         },
     )()
@@ -48,8 +48,8 @@ class ModelVariant(Enum):
         (),
         {
             "name": "depth-anything-v3-metric-base",
-            "display_name": "Depth Anything V3 Metric Base",
-            "huggingface_id": ("depth-anything/" "Depth-Anything-V3-Metric-Base-hf"),
+            "display_name": "Depth Anything V3 Base Compatibility Selector",
+            "huggingface_id": "depth-anything/DA3-BASE",
         },
     )()
     METRIC_SMALL = type(
@@ -57,8 +57,8 @@ class ModelVariant(Enum):
         (),
         {
             "name": "depth-anything-v3-metric-small",
-            "display_name": "Depth Anything V3 Metric Small",
-            "huggingface_id": ("depth-anything/" "Depth-Anything-V3-Metric-Small-hf"),
+            "display_name": "Depth Anything V3 Small Compatibility Selector",
+            "huggingface_id": "depth-anything/DA3-SMALL",
         },
     )()
 
@@ -108,6 +108,9 @@ class DA3Config:
     """Depth Anything V3 configuration."""
 
     model_variant: ModelVariant = ModelVariant.METRIC_LARGE
+    model_key: Optional[str] = None
+    raw_model_id: Optional[str] = None
+    non_commercial_ok: bool = False
     device: DeviceConfig = field(default_factory=DeviceConfig)
     postprocessing: PostprocessingConfig = field(
         default_factory=PostprocessingConfig,
@@ -172,6 +175,8 @@ class EnhanceConfig:
 
     # Depth configuration
     model_variant: Optional[ModelVariant] = None
+    model_key: Optional[str] = None
+    raw_model_id: Optional[str] = None
     preset: Optional[Preset] = None
     # Raw preset string from CLI/user input
     # (captured even when preset does not map

--- a/src/transformation_portal/lux_depth_v3/config_resolver.py
+++ b/src/transformation_portal/lux_depth_v3/config_resolver.py
@@ -44,6 +44,7 @@ from ..core.raw_runtime import RAW_RUNTIME_ENV_VAR, REPO_LOCAL_RAW_PYTHON, repo_
 from ..ingest.canonical_json import canonicalize_json
 from .config import DA3Config, EnhanceConfig, ModelVariant, Preset
 from .manifest import ConfigFingerprint
+from .model_resolution import ModelRequest, ResolvedModel, resolve_model_contract
 
 logger = logging.getLogger(__name__)
 _REPO_LOCAL_DEPTH_PRO_PYTHON_PARTS = (".venv-depth-pro", "bin", "python")
@@ -225,6 +226,16 @@ class ResolvedConfig:
     model_variant: Optional[ModelVariant] = None
     quality_tier: str = "standard"
     fingerprint: Optional[ConfigFingerprint] = None
+    resolved_model_contract: Optional[ResolvedModel] = None
+
+
+def _compat_model_variant_for_resolved_key(canonical_key: str) -> ModelVariant:
+    """Map resolved registry keys back to compatibility model variants."""
+    if canonical_key == "da3_base":
+        return ModelVariant.METRIC_BASE
+    if canonical_key == "da3_small":
+        return ModelVariant.METRIC_SMALL
+    return ModelVariant.METRIC_LARGE
 
 
 def discover_presets(pipeline: str = "lux_depth_v3") -> List[PresetInfo]:
@@ -445,6 +456,8 @@ def build_depth_cache_payload(
 
     return {
         "model_variant": mv.value.name,
+        "model_key": getattr(config, "model_key", None),
+        "raw_model_id": getattr(config, "raw_model_id", None),
         "depth_device": config.depth_device,
         "preset": config.preset.value if config.preset else None,
         "depth_backend": config.depth_backend,
@@ -631,9 +644,26 @@ class ConfigResolver:
             config.preset,
             config.model_variant,
         )
+        resolved_model_contract = resolve_model_contract(
+            ModelRequest(
+                model_key=getattr(config, "model_key", None),
+                raw_model_id=getattr(config, "raw_model_id", None),
+                model_variant=config.model_variant,
+                use_coreml_backend=bool(getattr(config, "use_coreml_backend", False)),
+                non_commercial_ok=bool(getattr(config, "non_commercial_ok", False)),
+                enforce_license=False,
+            )
+        )
+        if getattr(config, "model_key", None) or getattr(config, "raw_model_id", None):
+            resolved_model = _compat_model_variant_for_resolved_key(
+                resolved_model_contract.canonical_key,
+            )
 
         # Apply device configuration
         da3_config.device.device = config.depth_device
+        da3_config.model_key = getattr(config, "model_key", None)
+        da3_config.raw_model_id = getattr(config, "raw_model_id", None)
+        da3_config.non_commercial_ok = bool(getattr(config, "non_commercial_ok", False))
 
         # Update config with resolved model variant
         config.model_variant = resolved_model
@@ -653,6 +683,7 @@ class ConfigResolver:
             model_variant=resolved_model,
             quality_tier=config.quality_tier,
             fingerprint=fingerprint,
+            resolved_model_contract=resolved_model_contract,
         )
 
     def discover_presets(self, pipeline: str = "lux_depth_v3") -> List[PresetInfo]:

--- a/src/transformation_portal/lux_depth_v3/coreml_backend.py
+++ b/src/transformation_portal/lux_depth_v3/coreml_backend.py
@@ -53,7 +53,13 @@ class CoreMLDepthEstimator:
         >>> depth = estimator.predict(image)
     """
 
-    def __init__(self, model_id: str, cache_dir: Optional[Path] = None, force_reconvert: bool = False):
+    def __init__(
+        self,
+        model_id: str,
+        cache_dir: Optional[Path] = None,
+        force_reconvert: bool = False,
+        revision: Optional[str] = None,
+    ):
         """Initialize CoreML depth estimator.
 
         Args:
@@ -75,6 +81,7 @@ class CoreMLDepthEstimator:
             )
 
         self.model_id = model_id
+        self.revision = revision
         self.cache_dir = cache_dir or Path.home() / ".cache" / "transformation_portal" / "coreml"
         self.cache_dir.mkdir(parents=True, exist_ok=True)
 
@@ -91,7 +98,10 @@ class CoreMLDepthEstimator:
         """
         # Sanitize model ID for filesystem
         model_name = self.model_id.replace("/", "_").replace("-", "_")
-        return self.cache_dir / f"{model_name}.mlpackage"
+        if not self.revision:
+            return self.cache_dir / f"{model_name}.mlpackage"
+        revision_token = self.revision.replace("/", "_").replace("-", "_")
+        return self.cache_dir / f"{model_name}_{revision_token}.mlpackage"
 
     def _load_or_convert(self, force_reconvert: bool = False) -> Any:
         """Load cached CoreML model or convert from PyTorch.
@@ -133,12 +143,25 @@ class CoreMLDepthEstimator:
         if cache_path.exists():
             return CoreMLDepthModel(cache_path)
 
-        model_path = hf_hub_download(  # nosec B615
-            repo_id=self.model_id,
-            filename="DepthAnythingV2SmallF16.mlpackage",
-            cache_dir=self.cache_dir,
+        model_path = Path(
+            hf_hub_download(  # nosec B615
+                repo_id=self.model_id,
+                filename="DepthAnythingV2SmallF16.mlpackage",
+                cache_dir=self.cache_dir,
+                revision=self.revision,
+            )
         )
-        return CoreMLDepthModel(model_path)
+        if not cache_path.exists():
+            try:
+                cache_path.symlink_to(model_path, target_is_directory=model_path.is_dir())
+            except OSError:
+                logger.debug(
+                    "CoreML cache alias unavailable for %s@%s; using Hub cache path directly",
+                    self.model_id,
+                    self.revision or "unpinned",
+                )
+        stable_path = cache_path if cache_path.exists() else model_path
+        return CoreMLDepthModel(stable_path)
 
     def _convert_pytorch_to_coreml(self, output_path: Path) -> Any:
         """Convert PyTorch depth model to CoreML with ANE optimization.

--- a/src/transformation_portal/lux_depth_v3/coreml_backend.py
+++ b/src/transformation_portal/lux_depth_v3/coreml_backend.py
@@ -1,17 +1,7 @@
-"""CoreML backend for Depth Anything V3 on Apple Silicon.
+"""CoreML backend for published Depth Anything CoreML artifacts on Apple Silicon.
 
-Provides 5x inference speedup on Apple Neural Engine (ANE) compared to PyTorch MPS.
-Converts PyTorch DA3 models to CoreML format with FP16 precision and ANE optimization.
-
-Performance (Apple M4, 1024×1024):
-- PyTorch MPS: ~400ms
-- CoreML ANE:   ~80ms (5x speedup)
-
-Architecture:
-- One-time model conversion (5-10 minutes per model)
-- Cached converted models in ~/.cache/transformation_portal/coreml/
-- Graceful fallback to PyTorch if conversion fails
-- Thread-safe concurrent inference (ANE supports multiple contexts)
+This release only supports registry-listed published CoreML packages. DA3-to-CoreML
+conversion is intentionally not part of the supported runtime surface.
 """
 
 from __future__ import annotations
@@ -24,7 +14,10 @@ from typing import Any, Dict, Optional
 
 import numpy as np
 
+from transformation_portal.depth.models.coreml_wrapper import CoreMLDepthModel
+
 logger = logging.getLogger(__name__)
+_SUPPORTED_PUBLISHED_COREML_MODEL_IDS = {"apple/coreml-depth-anything-v2-small"}
 
 # Lazy imports to avoid dependency errors
 try:
@@ -53,36 +46,33 @@ except ImportError:
 
 
 class CoreMLDepthEstimator:
-    """CoreML-optimized depth estimation for Apple Silicon.
-
-    Converts PyTorch DA3 models to CoreML format with ANE acceleration.
-    Caches converted models in ~/.cache/transformation_portal/coreml/
+    """CoreML depth estimation for published Apple Silicon artifacts.
 
     Example:
-        >>> estimator = CoreMLDepthEstimator("depth-anything/Depth-Anything-V3-Metric-Small-hf")
-        >>> depth = estimator.predict(image)  # ~80ms on M4
+        >>> estimator = CoreMLDepthEstimator("apple/coreml-depth-anything-v2-small")
+        >>> depth = estimator.predict(image)
     """
 
     def __init__(self, model_id: str, cache_dir: Optional[Path] = None, force_reconvert: bool = False):
         """Initialize CoreML depth estimator.
 
         Args:
-            model_id: HuggingFace model ID (e.g., "depth-anything/Depth-Anything-V3-Metric-Small-hf")
+            model_id: Published Hugging Face CoreML model ID.
             cache_dir: Directory for cached CoreML models (default: ~/.cache/transformation_portal/coreml/)
             force_reconvert: Force reconversion even if cached model exists
 
         Raises:
-            RuntimeError: If coremltools or dependencies unavailable
-            ValueError: If model conversion fails
+            RuntimeError: If coremltools unavailable
+            ValueError: If the model is not a supported published CoreML artifact
         """
         if not COREML_AVAILABLE:
             raise RuntimeError("coremltools not available. Install: pip install coremltools")
 
-        if not TORCH_AVAILABLE:
-            raise RuntimeError("torch not available. Install: pip install torch")
-
-        if not TRANSFORMERS_AVAILABLE:
-            raise RuntimeError("transformers not available. Install: pip install transformers")
+        if model_id not in _SUPPORTED_PUBLISHED_COREML_MODEL_IDS:
+            raise ValueError(
+                f"CoreML backend is only supported for published CoreML artifacts in this release. "
+                f"Unsupported model_id={model_id!r}."
+            )
 
         self.model_id = model_id
         self.cache_dir = cache_dir or Path.home() / ".cache" / "transformation_portal" / "coreml"
@@ -114,6 +104,9 @@ class CoreMLDepthEstimator:
         """
         cache_path = self._get_cache_path()
 
+        if self.model_id in _SUPPORTED_PUBLISHED_COREML_MODEL_IDS:
+            return self._load_published_coreml_model(cache_path)
+
         if cache_path.exists() and not force_reconvert:
             logger.info(f"Loading cached CoreML model: {cache_path}")
             try:
@@ -132,6 +125,20 @@ class CoreMLDepthEstimator:
         except Exception as e:
             logger.error(f"CoreML conversion failed: {e}")
             raise ValueError(f"Failed to convert {self.model_id} to CoreML: {e}") from e
+
+    def _load_published_coreml_model(self, cache_path: Path) -> Any:
+        """Load a published CoreML artifact from Hugging Face."""
+        from huggingface_hub import hf_hub_download  # pylint: disable=import-outside-toplevel
+
+        if cache_path.exists():
+            return CoreMLDepthModel(cache_path)
+
+        model_path = hf_hub_download(  # nosec B615
+            repo_id=self.model_id,
+            filename="DepthAnythingV2SmallF16.mlpackage",
+            cache_dir=self.cache_dir,
+        )
+        return CoreMLDepthModel(model_path)
 
     def _convert_pytorch_to_coreml(self, output_path: Path) -> Any:
         """Convert PyTorch depth model to CoreML with ANE optimization.
@@ -206,20 +213,11 @@ class CoreMLDepthEstimator:
         # Ensure float32 (CoreML input requirement)
         image = image.astype(np.float32)
 
-        # Run CoreML inference
-        output = self.coreml_model.predict({"input": image})
-
-        # Extract depth (assumes output key is "depth" or first key)
-        depth = output.get("depth")
-        if depth is None:
-            # Fallback to first output
-            depth = output[list(output.keys())[0]]
-
-        # Remove batch dimension if present
+        depth = self.coreml_model.predict(image)
         if depth.ndim == 4:
-            depth = depth[0, 0]  # BCHW → HW
+            depth = depth[0, 0]
         elif depth.ndim == 3:
-            depth = depth[0]  # CHW → HW
+            depth = depth[0]
 
         return depth
 

--- a/src/transformation_portal/lux_depth_v3/da3_model_backend.py
+++ b/src/transformation_portal/lux_depth_v3/da3_model_backend.py
@@ -1,28 +1,22 @@
-"""Direct Model Backend for DA3.
+"""Retired DA3 model backend shim.
 
-Provides a dependency-free inference path using HuggingFace hub.
-
-NOTE: DA3 Nested models (e.g., depth-anything/da3nested-giant-large)
-require custom library installation:
-    git clone https://github.com/ByteDance-Seed/depth-anything-3
-    cd depth-anything-3
-    # macOS: ensure xformers is not required in default dependencies
-    pip install -e .
+The old direct backend returned placeholder zero depth and is intentionally
+unavailable. Runtime DA3 selection must flow through the registry-resolved DA3
+API backend.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Optional
-
-import numpy as np
-import torch
+from typing import Optional
 
 
 @dataclass(frozen=True)
 class DA3ModelBackendConfig:
-    model_id: str = "depth-anything/Depth-Anything-V2-Large-hf"  # DA2 default. For DA3: depth-anything/da3nested-giant-large
+    """Deprecated compatibility shell for legacy imports."""
+
+    model_id: str = "depth-anything/DA3NESTED-GIANT-LARGE-1.1"
     device: str = "cpu"
     dtype: str = "float32"
     max_side: int = 896
@@ -30,45 +24,9 @@ class DA3ModelBackendConfig:
 
 
 class DA3ModelBackend:
+    """Retired backend shim that fails closed."""
+
     def __init__(self, config: DA3ModelBackendConfig):
-        self.cfg = config
-        self.model = None
-
-    def _load_model(self) -> None:
-        if self.model is not None:
-            return
-        # Logic to load model from hub (omitted for brevity, implies _require logic)
-        # self.model = ...
-        pass
-
-    def predict_from_tensor(self, x: torch.Tensor) -> np.ndarray:
-        """
-        Predict depth from a pre-processed tensor.
-        Args:
-            x: (1, 3, H, W) normalized tensor
-        Returns:
-            depth: (H, W) float32 array
-        """
-        self._load_model()
-        # Ensure model is on device
-        # Forward pass
-        # with torch.no_grad(): out = self.model(x)
-        # depth = out['depth']...
-        # For now, assume mock return for syntax correctness:
-        return np.zeros(x.shape[-2:], dtype=np.float32)
-
-    def predict_depth01_from_rgb01(self, rgb01: np.ndarray, preprocessor: Any = None) -> np.ndarray:
-        """
-        Legacy entry point. If preprocessor is provided, uses it.
-        Otherwise falls back to internal resizing.
-        """
-        if preprocessor:
-            tensor, _ = preprocessor.preprocess(rgb01, return_tensors=True)
-            # Add batch dim if needed
-            if tensor.ndim == 3:
-                tensor = tensor.unsqueeze(0)
-            return self.predict_from_tensor(tensor)
-
-        # Fallback (internal logic)
-        # ... existing resizing code ...
-        return np.zeros(rgb01.shape[:2], dtype=np.float32)
+        raise RuntimeError(
+            "DA3ModelBackend stub is retired and must not be used. " "Use the registry-resolved DA3 API backend."
+        )

--- a/src/transformation_portal/lux_depth_v3/inference.py
+++ b/src/transformation_portal/lux_depth_v3/inference.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import logging
 import time
+import warnings
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
@@ -31,6 +32,7 @@ from transformation_portal.core.security.model_lock import is_model_lock_strict_
 
 # noqa: F401 - Used in docstring examples
 from .config import DA3Config, ModelVariant  # noqa: F401
+from .model_resolution import ModelRequest, ResolvedModel, resolve_model_contract
 from .raw_loader import is_raw_file
 
 if TYPE_CHECKING:
@@ -186,6 +188,10 @@ class DA3InferenceEngine:
         config: Union[DA3Config, str] = "cpu",
         commercial_use: bool = True,
         validate_license_strict: bool = False,
+        *,
+        model_key: Optional[str] = None,
+        raw_model_id: Optional[str] = None,
+        non_commercial_ok: Optional[bool] = None,
     ):
         """Initialize inference engine.
 
@@ -214,9 +220,30 @@ class DA3InferenceEngine:
                 "Auto-constructed DA3Config" f" with device={device_str}",
             )
 
+        if model_key is not None:
+            config.model_key = model_key
+        if raw_model_id is not None:
+            config.raw_model_id = raw_model_id
+        if non_commercial_ok is not None:
+            config.non_commercial_ok = bool(non_commercial_ok)
+
         self.config = config
         self.commercial_use = commercial_use
         self.validate_license_strict = validate_license_strict
+        self._resolved_model_contract: Optional[ResolvedModel] = None
+        if commercial_use is not True:
+            warnings.warn(
+                "commercial_use is deprecated and no longer controls license enforcement. "
+                "Use non_commercial_ok for CC BY-NC research models.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        if validate_license_strict is not False:
+            warnings.warn(
+                "validate_license_strict is deprecated and no longer bypasses registry license enforcement.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
         # Auto-detect backend and device
         self.backend = self._auto_detect_backend()
@@ -237,12 +264,34 @@ class DA3InferenceEngine:
             self.device,
         )
 
+    def _resolve_model_contract(self, *, use_coreml_backend: Optional[bool] = None) -> ResolvedModel:
+        """Resolve and cache the registry-backed model contract."""
+        if self._resolved_model_contract is not None and (
+            use_coreml_backend is None
+            or use_coreml_backend == (self._resolved_model_contract.accelerator_kind.value == "coreml")
+        ):
+            return self._resolved_model_contract
+        resolved = resolve_model_contract(
+            ModelRequest(
+                model_key=getattr(self.config, "model_key", None),
+                raw_model_id=getattr(self.config, "raw_model_id", None),
+                model_variant=self.config.model_variant,
+                use_coreml_backend=bool(use_coreml_backend),
+                non_commercial_ok=bool(getattr(self.config, "non_commercial_ok", False)),
+            )
+        )
+        if not use_coreml_backend:
+            self._resolved_model_contract = resolved
+        return resolved
+
     def _auto_detect_backend(self) -> ModelBackend:
         """Auto-detect optimal backend for current hardware."""
         device_spec = self.config.device.device.lower()
 
         # Phase 3: Check if CoreML is explicitly requested via config
         use_coreml = getattr(self.config.device, "use_coreml", False)
+        if use_coreml:
+            self._resolve_model_contract(use_coreml_backend=True)
         if use_coreml and self._should_use_coreml():
             logger.info(
                 "CoreML backend enabled via config " "(5x speedup on Apple Silicon)",
@@ -350,14 +399,9 @@ class DA3InferenceEngine:
         """
         _ensure_optional_runtime_imports()
 
-        # Get HuggingFace model ID from config
-        model_id = self.config.model_variant.value.huggingface_id
-        model_revision = resolve_model_lock_revision(
-            model_id,
-            requested_revision=None,
-            strict=None,
-            context="DA3InferenceEngine(primary_model)",
-        )
+        resolved_contract = self._resolve_model_contract(use_coreml_backend=False)
+        model_id = resolved_contract.spec.repo_id
+        model_revision = resolved_contract.revision
 
         # Provenance
         self._requested_model_id = model_id
@@ -376,13 +420,6 @@ class DA3InferenceEngine:
             raise ImportError("transformers required for PyTorch backend. Install with: " "pip install transformers")
         if TRANSFORMERS_TORCH_BACKEND_ISSUE:
             raise RuntimeError(TRANSFORMERS_TORCH_BACKEND_ISSUE)
-
-        # Fallback mapping to V2 metric models (which exist on HuggingFace)
-        v3_to_v2_fallback = {
-            "depth-anything/Depth-Anything-V3-Metric-Large-hf": "depth-anything/Depth-Anything-V2-Metric-Indoor-Large-hf",
-            "depth-anything/Depth-Anything-V3-Metric-Base-hf": "depth-anything/Depth-Anything-V2-Metric-Indoor-Base-hf",
-            "depth-anything/Depth-Anything-V3-Metric-Small-hf": "depth-anything/Depth-Anything-V2-Metric-Indoor-Small-hf",
-        }
 
         try:
             # Determine device argument for transformers pipeline
@@ -419,64 +456,8 @@ class DA3InferenceEngine:
             logger.info("Loaded PyTorch model: %s", model_id)
 
         except Exception as e:
-            # Try fallback to V2 metric model
-            fallback_model = v3_to_v2_fallback.get(model_id)
-            if fallback_model:
-                logger.warning(
-                    "V3 model %s not available," + " falling back to V2: %s",
-                    model_id,
-                    fallback_model,
-                )
-                try:
-                    fallback_revision = resolve_model_lock_revision(
-                        fallback_model,
-                        requested_revision=None,
-                        strict=None,
-                        context="DA3InferenceEngine(fallback_model)",
-                    )
-                    device_arg = self._transformers_device_arg()
-
-                    # Determine dtype for FP16 optimization
-                    use_fp16 = getattr(self.config.device, "use_fp16", True)
-                    torch_dtype = None
-                    if use_fp16 and self.device in ("mps", "cuda") and torch is not None:
-                        torch_dtype = torch.float16
-
-                    if pipeline is None:
-                        raise RuntimeError("transformers pipeline not available")
-                    self.model = pipeline(
-                        task="depth-estimation",
-                        model=fallback_model,
-                        revision=fallback_revision,
-                        device=device_arg,
-                        torch_dtype=torch_dtype,
-                    )
-
-                    # Additional FP16 optimization for MPS
-                    if (
-                        use_fp16
-                        and self.device == "mps"
-                        and hasattr(
-                            self.model.model,
-                            "half",
-                        )
-                    ):
-                        self.model.model = self.model.model.half()
-
-                    logger.info("Loaded fallback V2 model: %s", fallback_model)
-                    self._using_fallback_model = True
-                    self._fallback_model_id = fallback_model
-                    self._resolved_model_id = fallback_model
-
-                    return
-                except Exception as fallback_error:
-                    logger.error(
-                        "Fallback model also" + " failed: %s",
-                        fallback_error,
-                    )
-
             logger.error("Failed to load PyTorch model: %s", e)
-            raise RuntimeError(f"Failed to load model" f" {model_id}" f" (and fallback): {e}") from e
+            raise RuntimeError(f"Failed to load model {model_id}: {e}") from e
 
     def _is_da3_model(self, model_id: str) -> bool:
         """Check if model ID is a DA3 Nested model."""
@@ -605,8 +586,8 @@ class DA3InferenceEngine:
     def _load_coreml_model(self) -> None:
         """Load CoreML model for Apple Neural Engine (Phase 3).
 
-        Converts PyTorch DA3 models to CoreML format with ANE optimization.
-        Provides 5x inference speedup on Apple Silicon (400ms → 80ms on M4).
+        Loads a published CoreML artifact that has already been validated for this
+        runtime surface.
         """
         _ensure_optional_runtime_imports()
         if not COREML_AVAILABLE:
@@ -614,25 +595,13 @@ class DA3InferenceEngine:
 
         from .coreml_backend import CoreMLDepthEstimator
 
-        try:
-            # Get HuggingFace model ID from config
-            model_id = self.config.model_variant.value.huggingface_id
-
-            logger.info(f"Loading CoreML model: {model_id}")
-            self.model = CoreMLDepthEstimator(model_id)
-
-            logger.info(
-                "CoreML model loaded with ANE acceleration (5x speedup)",
-            )
-
-        except Exception as e:
-            logger.error(f"CoreML model loading failed: {e}")
-            logger.warning("Falling back to PyTorch MPS backend")
-
-            # Fallback to MPS
-            self.backend = ModelBackend.PYTORCH_MPS
-            self.device = "mps"
-            self._load_pytorch_model()
+        resolved_contract = self._resolve_model_contract(use_coreml_backend=True)
+        model_id = resolved_contract.spec.repo_id
+        self._requested_model_id = model_id
+        self._resolved_model_id = model_id
+        logger.info("Loading CoreML model: %s", model_id)
+        self.model = CoreMLDepthEstimator(model_id)
+        logger.info("CoreML model loaded with published artifact acceleration")
 
     def predict(
         self,

--- a/src/transformation_portal/lux_depth_v3/inference.py
+++ b/src/transformation_portal/lux_depth_v3/inference.py
@@ -600,7 +600,10 @@ class DA3InferenceEngine:
         self._requested_model_id = model_id
         self._resolved_model_id = model_id
         logger.info("Loading CoreML model: %s", model_id)
-        self.model = CoreMLDepthEstimator(model_id)
+        self.model = CoreMLDepthEstimator(
+            model_id,
+            revision=resolved_contract.revision,
+        )
         logger.info("CoreML model loaded with published artifact acceleration")
 
     def predict(

--- a/src/transformation_portal/lux_depth_v3/inference.py
+++ b/src/transformation_portal/lux_depth_v3/inference.py
@@ -347,14 +347,6 @@ class DA3InferenceEngine:
             )
             return False
 
-        if not TORCH_AVAILABLE:
-            logger.warning("CoreML requires torch for model conversion")
-            return False
-
-        if not TRANSFORMERS_AVAILABLE:
-            logger.warning("CoreML requires transformers for model loading")
-            return False
-
         return True
 
     def _resolve_device(self) -> str:
@@ -460,8 +452,9 @@ class DA3InferenceEngine:
             raise RuntimeError(f"Failed to load model {model_id}: {e}") from e
 
     def _is_da3_model(self, model_id: str) -> bool:
-        """Check if model ID is a DA3 Nested model."""
-        return model_id.startswith("depth-anything/da3") or "da3nested" in model_id.lower()
+        """Check if model ID points at a DA3-family checkpoint."""
+        normalized_model_id = model_id.lower()
+        return normalized_model_id.startswith("depth-anything/da3") or "da3nested" in normalized_model_id
 
     def _load_da3_model(self, model_id: str) -> None:
         """Load DA3 model using custom depth-anything-3 library.

--- a/src/transformation_portal/lux_depth_v3/model_registry.py
+++ b/src/transformation_portal/lux_depth_v3/model_registry.py
@@ -1,0 +1,294 @@
+"""Central Lux Depth V3 model registry and selector metadata.
+
+This module owns the V1 runtime contract for model identity, license policy,
+backend capability, and CLI exposure. It is intentionally narrower than the
+upstream DA3 capability surface: the current Lux Depth V3 runtime consumes
+relative depth plus metadata, so advanced DA3 outputs remain informational.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Dict, FrozenSet, Literal, Optional, Tuple
+
+
+class UsageClass(str, Enum):
+    """Runtime usage policy classification."""
+
+    COMMERCIAL_OK = "commercial_ok"
+    NON_COMMERCIAL_ONLY = "non_commercial_only"
+    UNKNOWN = "unknown"
+
+
+class BackendKind(str, Enum):
+    """Canonical backend type for registry entries."""
+
+    DA3_API = "da3_api"
+    DA2_TRANSFORMERS = "da2_transformers"
+    DEPTH_PRO = "depth_pro"
+    COREML_PUBLISHED = "coreml_published"
+
+
+class AcceleratorKind(str, Enum):
+    """Accelerator lane resolved for a model selection."""
+
+    NONE = "none"
+    COREML = "coreml"
+
+
+class ConsumableOutput(str, Enum):
+    """Current Lux Depth V3 outputs enforced by the registry."""
+
+    NORMALIZED_RELATIVE_DEPTH = "normalized_relative_depth"
+    DEPTH_METADATA = "depth_metadata"
+    COREML_RELATIVE_DEPTH = "coreml_relative_depth"
+
+
+@dataclass(frozen=True)
+class ModelSpec:
+    """Resolved model contract used by Lux Depth V3 V1."""
+
+    key: str
+    repo_id: str
+    family: str
+    backend_kind: BackendKind
+    license_id: str
+    usage_class: UsageClass
+    requires_non_commercial_ok: bool
+    supports_coreml: bool
+    consumable_outputs: FrozenSet[ConsumableOutput]
+    upstream_capabilities: FrozenSet[str] = frozenset()
+    fallback_keys: Tuple[str, ...] = ()
+    lock_required: bool = True
+    exposed_in_cli: bool = True
+    maturity: Literal["stable", "compat", "experimental", "internal"] = "stable"
+
+
+DEFAULT_MODEL_KEY = "da3_research"
+
+
+MODEL_REGISTRY: Dict[str, ModelSpec] = {
+    "da3_research": ModelSpec(
+        key="da3_research",
+        repo_id="depth-anything/DA3NESTED-GIANT-LARGE-1.1",
+        family="da3",
+        backend_kind=BackendKind.DA3_API,
+        license_id="cc-by-nc-4.0",
+        usage_class=UsageClass.NON_COMMERCIAL_ONLY,
+        requires_non_commercial_ok=True,
+        supports_coreml=False,
+        consumable_outputs=frozenset(
+            {
+                ConsumableOutput.NORMALIZED_RELATIVE_DEPTH,
+                ConsumableOutput.DEPTH_METADATA,
+            }
+        ),
+        upstream_capabilities=frozenset(
+            {
+                "relative_depth",
+                "metric_depth",
+                "pose_estimation",
+                "pose_conditioning",
+                "gaussian_splat",
+                "sky_segmentation",
+            }
+        ),
+        maturity="stable",
+        exposed_in_cli=True,
+    ),
+    "da3_metric": ModelSpec(
+        key="da3_metric",
+        repo_id="depth-anything/DA3METRIC-LARGE",
+        family="da3",
+        backend_kind=BackendKind.DA3_API,
+        license_id="apache-2.0",
+        usage_class=UsageClass.COMMERCIAL_OK,
+        requires_non_commercial_ok=False,
+        supports_coreml=False,
+        consumable_outputs=frozenset(
+            {
+                ConsumableOutput.NORMALIZED_RELATIVE_DEPTH,
+                ConsumableOutput.DEPTH_METADATA,
+            }
+        ),
+        upstream_capabilities=frozenset(
+            {
+                "relative_depth",
+                "metric_depth",
+                "sky_segmentation",
+            }
+        ),
+        maturity="stable",
+        exposed_in_cli=True,
+    ),
+    "da3_base": ModelSpec(
+        key="da3_base",
+        repo_id="depth-anything/DA3-BASE",
+        family="da3",
+        backend_kind=BackendKind.DA3_API,
+        license_id="apache-2.0",
+        usage_class=UsageClass.COMMERCIAL_OK,
+        requires_non_commercial_ok=False,
+        supports_coreml=False,
+        consumable_outputs=frozenset(
+            {
+                ConsumableOutput.NORMALIZED_RELATIVE_DEPTH,
+                ConsumableOutput.DEPTH_METADATA,
+            }
+        ),
+        upstream_capabilities=frozenset(
+            {
+                "relative_depth",
+                "pose_estimation",
+                "pose_conditioning",
+            }
+        ),
+        maturity="experimental",
+        exposed_in_cli=False,
+    ),
+    "da3_small": ModelSpec(
+        key="da3_small",
+        repo_id="depth-anything/DA3-SMALL",
+        family="da3",
+        backend_kind=BackendKind.DA3_API,
+        license_id="apache-2.0",
+        usage_class=UsageClass.COMMERCIAL_OK,
+        requires_non_commercial_ok=False,
+        supports_coreml=False,
+        consumable_outputs=frozenset(
+            {
+                ConsumableOutput.NORMALIZED_RELATIVE_DEPTH,
+                ConsumableOutput.DEPTH_METADATA,
+            }
+        ),
+        upstream_capabilities=frozenset(
+            {
+                "relative_depth",
+                "pose_estimation",
+                "pose_conditioning",
+            }
+        ),
+        maturity="experimental",
+        exposed_in_cli=False,
+    ),
+    "coreml_depth_anything_v2_small": ModelSpec(
+        key="coreml_depth_anything_v2_small",
+        repo_id="apple/coreml-depth-anything-v2-small",
+        family="depth_anything_v2",
+        backend_kind=BackendKind.COREML_PUBLISHED,
+        license_id="apache-2.0",
+        usage_class=UsageClass.COMMERCIAL_OK,
+        requires_non_commercial_ok=False,
+        supports_coreml=True,
+        consumable_outputs=frozenset({ConsumableOutput.COREML_RELATIVE_DEPTH}),
+        maturity="stable",
+        exposed_in_cli=False,
+    ),
+}
+
+
+LEGACY_MODEL_VARIANT_ALIASES: Dict[str, str] = {
+    "METRIC_LARGE": "da3_research",
+    "METRIC_BASE": "da3_base",
+    "METRIC_SMALL": "da3_small",
+}
+
+
+LEGACY_MODEL_VARIANT_WARNINGS: Dict[str, str] = {
+    "METRIC_LARGE": (
+        "ModelVariant.METRIC_LARGE is deprecated. It resolves to da3_research, "
+        "which uses depth-anything/DA3NESTED-GIANT-LARGE-1.1 and requires "
+        "non_commercial_ok=True. Use model_key='da3' or model_key='da3-research' "
+        "for the research-default selector."
+    ),
+    "METRIC_BASE": (
+        "ModelVariant.METRIC_BASE is deprecated. It resolves to da3_base for "
+        "compatibility. The current Lux Depth V3 adapter emits normalized "
+        "relative depth, not guaranteed metric-depth output."
+    ),
+    "METRIC_SMALL": (
+        "ModelVariant.METRIC_SMALL is deprecated. It resolves to da3_small for "
+        "compatibility. The current Lux Depth V3 adapter emits normalized "
+        "relative depth, not guaranteed metric-depth output."
+    ),
+}
+
+
+def canonicalize_selector(selector: str) -> str:
+    """Normalize a selector for alias lookup."""
+    return selector.strip().lower()
+
+
+def canonicalize_repo_id(repo_id: str) -> str:
+    """Normalize a repo identifier for lookup."""
+    return repo_id.strip().lower()
+
+
+MODEL_ALIASES: Dict[str, str] = {
+    "da3": "da3_research",
+    "da3-research": "da3_research",
+    "da3_research": "da3_research",
+    "da3-metric": "da3_metric",
+    "da3_metric": "da3_metric",
+    "da3-base": "da3_base",
+    "da3_base": "da3_base",
+    "da3-small": "da3_small",
+    "da3_small": "da3_small",
+    "coreml-depth-anything-v2-small": "coreml_depth_anything_v2_small",
+    "coreml_depth_anything_v2_small": "coreml_depth_anything_v2_small",
+}
+MODEL_ALIASES.update({canonicalize_repo_id(spec.repo_id): spec.key for spec in MODEL_REGISTRY.values()})
+
+
+def resolve_registry_key(selector: Optional[str]) -> Optional[str]:
+    """Resolve a model selector to a canonical registry key."""
+    if selector is None:
+        return None
+
+    raw_value = selector.strip()
+    if not raw_value:
+        return None
+    if raw_value in MODEL_REGISTRY:
+        return raw_value
+    return MODEL_ALIASES.get(canonicalize_selector(raw_value))
+
+
+def get_model_spec(key: str) -> ModelSpec:
+    """Return a registry entry by canonical key."""
+    return MODEL_REGISTRY[key]
+
+
+def resolve_model_spec(selector: str) -> Optional[ModelSpec]:
+    """Resolve any selector to a registry spec."""
+    key = resolve_registry_key(selector)
+    if key is None:
+        return None
+    return get_model_spec(key)
+
+
+def resolve_legacy_model_variant_key(model_variant: Any) -> Optional[str]:
+    """Resolve a legacy ModelVariant enum member to a canonical key."""
+    variant_name = getattr(model_variant, "name", None)
+    if not isinstance(variant_name, str):
+        return None
+    return LEGACY_MODEL_VARIANT_ALIASES.get(variant_name)
+
+
+def legacy_model_variant_warning(model_variant: Any) -> Optional[str]:
+    """Return the deprecation warning text for a legacy ModelVariant."""
+    variant_name = getattr(model_variant, "name", None)
+    if not isinstance(variant_name, str):
+        return None
+    return LEGACY_MODEL_VARIANT_WARNINGS.get(variant_name)
+
+
+def visible_cli_model_specs() -> Tuple[ModelSpec, ...]:
+    """Return the public CLI-visible model choices."""
+    ordered_keys = ("da3_research", "da3_metric")
+    return tuple(MODEL_REGISTRY[key] for key in ordered_keys if MODEL_REGISTRY[key].exposed_in_cli)
+
+
+def lock_required_model_specs() -> Tuple[ModelSpec, ...]:
+    """Return all registry specs that require model-lock coverage."""
+    return tuple(spec for spec in MODEL_REGISTRY.values() if spec.lock_required)

--- a/src/transformation_portal/lux_depth_v3/model_resolution.py
+++ b/src/transformation_portal/lux_depth_v3/model_resolution.py
@@ -1,0 +1,155 @@
+"""Central Lux Depth V3 model resolver."""
+
+from __future__ import annotations
+
+import warnings
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional, Tuple
+
+from transformation_portal.core.security.model_lock import resolve_model_lock_revision
+
+from .model_registry import (
+    DEFAULT_MODEL_KEY,
+    AcceleratorKind,
+    BackendKind,
+    UsageClass,
+    get_model_spec,
+    legacy_model_variant_warning,
+    resolve_legacy_model_variant_key,
+    resolve_registry_key,
+)
+
+
+class ModelResolutionError(RuntimeError):
+    """Base error for model resolution failures."""
+
+
+class UnknownModelError(ModelResolutionError):
+    """Raised for selectors absent from the registry."""
+
+
+class ModelLicenseError(ModelResolutionError):
+    """Raised when a model selection violates the license policy."""
+
+
+class BackendCapabilityError(ModelResolutionError):
+    """Raised when the requested accelerator/backend is unsupported."""
+
+
+class DeprecatedModelSelectorWarning(DeprecationWarning):
+    """Warning emitted for legacy compatibility selectors."""
+
+
+@dataclass(frozen=True)
+class ModelRequest:
+    """Inputs to final model selection."""
+
+    model_key: Optional[str] = None
+    raw_model_id: Optional[str] = None
+    model_variant: Optional[Any] = None
+    use_coreml_backend: bool = False
+    non_commercial_ok: bool = False
+    enforce_license: bool = True
+    strict_model_lock: Optional[bool] = None
+    manifest_path: Optional[Path] = None
+
+
+@dataclass(frozen=True)
+class ResolvedModel:
+    """Resolved execution contract for a model selection."""
+
+    requested_selector: str
+    canonical_key: str
+    spec: Any
+    revision: Optional[str]
+    fallback_chain: Tuple[str, ...]
+    accelerator_kind: AcceleratorKind
+    legacy_model_variant_name: Optional[str] = None
+
+
+def _resolve_selector(
+    request: ModelRequest,
+) -> tuple[str, str, Optional[str]]:
+    if request.model_key:
+        key = resolve_registry_key(request.model_key)
+        if key is None:
+            raise UnknownModelError(f"Unknown model selector: {request.model_key}")
+        return request.model_key, key, None
+
+    if request.raw_model_id:
+        key = resolve_registry_key(request.raw_model_id)
+        if key is None:
+            raise UnknownModelError(
+                f"Unsupported model repo ID: {request.raw_model_id}. "
+                "Only registry-approved models are allowed in this release."
+            )
+        return request.raw_model_id, key, None
+
+    if request.model_variant is not None:
+        key = resolve_legacy_model_variant_key(request.model_variant)
+        if key is None:
+            raise UnknownModelError(f"Unknown model variant: {request.model_variant!r}")
+        warning_message = legacy_model_variant_warning(request.model_variant)
+        if warning_message:
+            warnings.warn(
+                warning_message,
+                DeprecatedModelSelectorWarning,
+                stacklevel=3,
+            )
+        variant_name = getattr(request.model_variant, "name", None)
+        selector = variant_name if isinstance(variant_name, str) else str(request.model_variant)
+        return selector, key, variant_name if isinstance(variant_name, str) else None
+
+    return "da3", DEFAULT_MODEL_KEY, None
+
+
+def _resolve_accelerator(spec: Any, use_coreml_backend: bool) -> AcceleratorKind:
+    if not use_coreml_backend:
+        return AcceleratorKind.NONE
+    if not spec.supports_coreml:
+        raise BackendCapabilityError(
+            f"CoreML backend is not supported for {spec.repo_id}. "
+            "Use a registry-listed published CoreML artifact or disable CoreML."
+        )
+    if spec.backend_kind != BackendKind.COREML_PUBLISHED:
+        raise BackendCapabilityError(
+            f"Invalid registry state for {spec.repo_id}: CoreML support requires " "backend_kind=coreml_published."
+        )
+    return AcceleratorKind.COREML
+
+
+def _enforce_license_policy(spec: Any, non_commercial_ok: bool) -> None:
+    if spec.usage_class == UsageClass.UNKNOWN:
+        raise ModelLicenseError(f"Model {spec.repo_id} has unknown usage policy and is not allowed.")
+    if spec.requires_non_commercial_ok and not non_commercial_ok:
+        raise ModelLicenseError(
+            f"Selected model {spec.repo_id} uses {spec.license_id} and is restricted "
+            "to non-commercial use. Re-run with --non-commercial-ok for permitted "
+            "research/non-commercial use, or select model_key='da3-metric'."
+        )
+
+
+def resolve_model_contract(request: ModelRequest) -> ResolvedModel:
+    """Resolve a model selection to the final execution contract."""
+    selector, canonical_key, legacy_variant_name = _resolve_selector(request)
+    spec = get_model_spec(canonical_key)
+    revision = resolve_model_lock_revision(
+        spec.repo_id,
+        requested_revision=None,
+        strict=request.strict_model_lock,
+        manifest_path=request.manifest_path,
+        context="lux_depth_v3 model resolution",
+    )
+    if request.enforce_license:
+        _enforce_license_policy(spec, request.non_commercial_ok)
+    accelerator_kind = _resolve_accelerator(spec, request.use_coreml_backend)
+    return ResolvedModel(
+        requested_selector=selector,
+        canonical_key=canonical_key,
+        spec=spec,
+        revision=revision,
+        fallback_chain=(),
+        accelerator_kind=accelerator_kind,
+        legacy_model_variant_name=legacy_variant_name,
+    )

--- a/src/transformation_portal/lux_depth_v3/orchestrator.py
+++ b/src/transformation_portal/lux_depth_v3/orchestrator.py
@@ -39,6 +39,8 @@ from typing import Any, Callable, Dict, List, Optional, cast
 
 import numpy as np
 
+from transformation_portal.attestation.model_lock_manifest import load_model_lock_manifest as load_model_lock_manifest_payload
+
 from ..core.ml_dependency_health import (
     detect_transformers_torch_version_issue,
 )
@@ -438,24 +440,11 @@ class EnhanceOrchestrator:
         # Note: zones_dir intentionally NOT created here
         # Will be created on-demand when zoning features are implemented
 
-        # Initialize V3 Configuration
-        # (Priority: User Override > Preset > Default)
-        if config.preset is not None:
-            da3_config = DA3Config.from_preset(config.preset)
-            if config.model_variant is not None:
-                logger.info(
-                    "Overriding preset model" + " with user choice: %s",
-                    config.model_variant.value.display_name,
-                )
-                da3_config.model_variant = config.model_variant
-            else:
-                config.model_variant = da3_config.model_variant
-        else:
-            model = config.model_variant if config.model_variant is not None else ModelVariant.METRIC_LARGE
-            da3_config = DA3Config(model_variant=model)
-            config.model_variant = model
-
-        da3_config.device.device = config.depth_device
+        resolved_config = ConfigResolver().resolve(self.config)
+        self._resolved_config = resolved_config
+        self._resolved_model_contract = resolved_config.resolved_model_contract
+        self.config = resolved_config.enhance_config
+        da3_config = resolved_config.da3_config
 
         # Initialize Depth Backend via Registry (ADR-019)
         self.depth_backend: Optional[DepthBackend] = None
@@ -714,7 +703,7 @@ class EnhanceOrchestrator:
 
         Delegates to pipeline_coordinator.default_model_id_for_backend().
         """
-        return default_model_id_for_backend(backend_id, self._model_variant)
+        return default_model_id_for_backend(backend_id, self._model_variant, config=self.config)
 
     def _derive_model_id_from_backend_instance(
         self,
@@ -743,6 +732,7 @@ class EnhanceOrchestrator:
             result_metadata=result_metadata,
             backend=backend,
             model_variant=self._model_variant,
+            config=self.config,
         )
 
     @staticmethod
@@ -5979,6 +5969,36 @@ class EnhanceOrchestrator:
         fingerprint["grouping_mode"] = str(getattr(self.config, "grouping_mode", "single"))
         return fingerprint
 
+    def _build_run_card_model_contract(self) -> Optional[Dict[str, Any]]:
+        """Build additive registry-backed model provenance for the run card."""
+        resolved_contract = getattr(self, "_resolved_model_contract", None)
+        if resolved_contract is None:
+            return None
+        try:
+            manifest_payload = load_model_lock_manifest_payload()
+            manifest_schema_version = int(
+                manifest_payload.get(
+                    "manifest_schema_version",
+                    manifest_payload.get("version", manifest_payload.get("schema_version", 1)),
+                )
+            )
+        except Exception:
+            manifest_schema_version = 1
+        return {
+            "requested_model_selector": resolved_contract.requested_selector,
+            "canonical_model_key": resolved_contract.canonical_key,
+            "resolved_repo_id": resolved_contract.spec.repo_id,
+            "resolved_revision": resolved_contract.revision,
+            "license_id": resolved_contract.spec.license_id,
+            "usage_class": resolved_contract.spec.usage_class.value,
+            "requires_non_commercial_ok": resolved_contract.spec.requires_non_commercial_ok,
+            "non_commercial_ok": bool(getattr(self.config, "non_commercial_ok", False)),
+            "backend_kind": resolved_contract.spec.backend_kind.value,
+            "accelerator_kind": resolved_contract.accelerator_kind.value,
+            "fallback_chain": list(resolved_contract.fallback_chain),
+            "manifest_schema_version": manifest_schema_version,
+        }
+
     def _run_card_output_relative_path(self, path_value: Any) -> Optional[str]:
         """Render an output-root-relative path suitable for run-card summaries."""
         return render_run_card_output_relative_path(path_value, self.output_root)
@@ -6166,6 +6186,9 @@ class EnhanceOrchestrator:
             "artifact_index": artifact_index,
             **artifact_summary_payload,
         }
+        model_contract = self._build_run_card_model_contract()
+        if model_contract is not None:
+            run_card["model_contract"] = model_contract
 
         def _json_default(obj: Any) -> Any:
             # --- ConfigFingerprint ---

--- a/src/transformation_portal/lux_depth_v3/orchestrator.py
+++ b/src/transformation_portal/lux_depth_v3/orchestrator.py
@@ -40,6 +40,7 @@ from typing import Any, Callable, Dict, List, Optional, cast
 import numpy as np
 
 from transformation_portal.attestation.model_lock_manifest import load_model_lock_manifest as load_model_lock_manifest_payload
+from transformation_portal.core.security.model_lock import is_pinned_revision
 
 from ..core.ml_dependency_health import (
     detect_transformers_torch_version_issue,
@@ -5973,6 +5974,13 @@ class EnhanceOrchestrator:
         """Build additive registry-backed model provenance for the run card."""
         resolved_contract = getattr(self, "_resolved_model_contract", None)
         if resolved_contract is None:
+            return None
+        if not is_pinned_revision(resolved_contract.revision):
+            logger.warning(
+                "Skipping run-card model_contract for %s because the resolved revision is not pinned: %r",
+                resolved_contract.spec.repo_id,
+                resolved_contract.revision,
+            )
             return None
         try:
             manifest_payload = load_model_lock_manifest_payload()

--- a/src/transformation_portal/lux_depth_v3/pipeline_coordinator.py
+++ b/src/transformation_portal/lux_depth_v3/pipeline_coordinator.py
@@ -51,6 +51,7 @@ from .config_resolver import (
     resolve_effective_depth_pro_python_executable,
 )
 from .manifest import BackendSelectionMetadata
+from .model_resolution import BackendCapabilityError, ModelLicenseError, ModelRequest, resolve_model_contract
 
 logger = logging.getLogger(__name__)
 
@@ -223,6 +224,7 @@ def expected_output_depth_units_for_backend(backend_id: str) -> str:
 def default_model_id_for_backend(
     backend_id: str,
     model_variant: Optional[ModelVariant] = None,
+    config: Optional[EnhanceConfig] = None,
 ) -> str:
     """Return canonical backend model identifier for provenance.
 
@@ -240,6 +242,23 @@ def default_model_id_for_backend(
     if normalized_backend == "da2":
         return "depth-anything/Depth-Anything-V2-Small-hf"
     if normalized_backend == "da3":
+        if config is not None:
+            try:
+                return resolve_model_contract(
+                    ModelRequest(
+                        model_key=getattr(config, "model_key", None),
+                        raw_model_id=getattr(config, "raw_model_id", None),
+                        model_variant=model_variant or getattr(config, "model_variant", None),
+                        use_coreml_backend=bool(getattr(config, "use_coreml_backend", False)),
+                        non_commercial_ok=bool(getattr(config, "non_commercial_ok", False)),
+                        enforce_license=False,
+                    )
+                ).spec.repo_id
+            except Exception:
+                logger.debug(
+                    "Falling back to legacy DA3 model ID resolution for backend provenance",
+                    exc_info=True,
+                )
         if model_variant is not None:
             return model_variant.value.huggingface_id
         return ModelVariant.METRIC_LARGE.value.huggingface_id
@@ -315,6 +334,7 @@ def resolve_backend_model_id(
     result_metadata: Optional[Dict[str, Any]] = None,
     backend: Optional[Any] = None,
     model_variant: Optional[ModelVariant] = None,
+    config: Optional[EnhanceConfig] = None,
 ) -> str:
     """Resolve stable model id for provenance and run-card semantics.
 
@@ -352,7 +372,7 @@ def resolve_backend_model_id(
         return from_backend
 
     # Fall back to default
-    return default_model_id_for_backend(backend_id, model_variant)
+    return default_model_id_for_backend(backend_id, model_variant, config=config)
 
 
 def select_backend(
@@ -426,7 +446,7 @@ def select_backend(
                 reason = f"Requested '{normalized_requested}' unavailable: {requested_error}. " f"Selected '{backend_id}'"
             break
 
-        except LicenseRestrictionError:
+        except (LicenseRestrictionError, ModelLicenseError, BackendCapabilityError):
             # Never bypass explicit license restrictions on requested backend
             if index == 0:
                 raise

--- a/src/transformation_portal/schemas/run_card/run_card.v1.schema.json
+++ b/src/transformation_portal/schemas/run_card/run_card.v1.schema.json
@@ -278,6 +278,75 @@
       },
       "additionalProperties": false
     },
+    "model_contract": {
+      "type": "object",
+      "required": [
+        "accelerator_kind",
+        "backend_kind",
+        "canonical_model_key",
+        "fallback_chain",
+        "license_id",
+        "manifest_schema_version",
+        "non_commercial_ok",
+        "requested_model_selector",
+        "requires_non_commercial_ok",
+        "resolved_repo_id",
+        "resolved_revision",
+        "usage_class"
+      ],
+      "properties": {
+        "requested_model_selector": {
+          "type": "string",
+          "minLength": 1
+        },
+        "canonical_model_key": {
+          "type": "string",
+          "minLength": 1
+        },
+        "resolved_repo_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "resolved_revision": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{40}$"
+        },
+        "license_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "usage_class": {
+          "type": "string",
+          "minLength": 1
+        },
+        "requires_non_commercial_ok": {
+          "type": "boolean"
+        },
+        "non_commercial_ok": {
+          "type": "boolean"
+        },
+        "backend_kind": {
+          "type": "string",
+          "minLength": 1
+        },
+        "accelerator_kind": {
+          "type": "string",
+          "minLength": 1
+        },
+        "fallback_chain": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "manifest_schema_version": {
+          "type": "integer",
+          "minimum": 1
+        }
+      },
+      "additionalProperties": false
+    },
     "environment": {
       "type": "object",
       "required": [

--- a/src/transformation_portal/schemas/run_card/run_card.v2.schema.json
+++ b/src/transformation_portal/schemas/run_card/run_card.v2.schema.json
@@ -278,6 +278,75 @@
       },
       "additionalProperties": false
     },
+    "model_contract": {
+      "type": "object",
+      "required": [
+        "accelerator_kind",
+        "backend_kind",
+        "canonical_model_key",
+        "fallback_chain",
+        "license_id",
+        "manifest_schema_version",
+        "non_commercial_ok",
+        "requested_model_selector",
+        "requires_non_commercial_ok",
+        "resolved_repo_id",
+        "resolved_revision",
+        "usage_class"
+      ],
+      "properties": {
+        "requested_model_selector": {
+          "type": "string",
+          "minLength": 1
+        },
+        "canonical_model_key": {
+          "type": "string",
+          "minLength": 1
+        },
+        "resolved_repo_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "resolved_revision": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{40}$"
+        },
+        "license_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "usage_class": {
+          "type": "string",
+          "minLength": 1
+        },
+        "requires_non_commercial_ok": {
+          "type": "boolean"
+        },
+        "non_commercial_ok": {
+          "type": "boolean"
+        },
+        "backend_kind": {
+          "type": "string",
+          "minLength": 1
+        },
+        "accelerator_kind": {
+          "type": "string",
+          "minLength": 1
+        },
+        "fallback_chain": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "manifest_schema_version": {
+          "type": "integer",
+          "minimum": 1
+        }
+      },
+      "additionalProperties": false
+    },
     "environment": {
       "type": "object",
       "required": [

--- a/tests/lux_depth_v3/test_model_registry_resolution.py
+++ b/tests/lux_depth_v3/test_model_registry_resolution.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import platform
 import sys
 from types import SimpleNamespace
 
@@ -197,6 +198,41 @@ def test_da3_inference_engine_accepts_positional_config(monkeypatch: pytest.Monk
     config = DA3Config(model_variant=ModelVariant.METRIC_BASE, device=DeviceConfig(device="cpu"))
     engine = DA3InferenceEngine(config)
     assert engine.config is config
+
+
+def test_da3_model_detection_is_case_insensitive(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        DA3InferenceEngine,
+        "_auto_detect_backend",
+        lambda self: ModelBackend.PYTORCH_CPU,
+    )
+    engine = DA3InferenceEngine(DA3Config(device=DeviceConfig(device="cpu")))
+
+    assert engine._is_da3_model("depth-anything/DA3METRIC-LARGE") is True
+    assert engine._is_da3_model("depth-anything/DA3-BASE") is True
+    assert engine._is_da3_model("depth-anything/DA3-SMALL") is True
+
+
+def test_coreml_backend_auto_detection_does_not_require_torch_or_transformers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import transformation_portal.lux_depth_v3.inference as inference_module
+
+    monkeypatch.setattr(inference_module, "_ensure_optional_runtime_imports", lambda: None)
+    monkeypatch.setattr(inference_module, "COREML_AVAILABLE", True)
+    monkeypatch.setattr(inference_module, "TORCH_AVAILABLE", False)
+    monkeypatch.setattr(inference_module, "TRANSFORMERS_AVAILABLE", False)
+    monkeypatch.setattr(platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(platform, "machine", lambda: "arm64")
+
+    engine = DA3InferenceEngine(
+        DA3Config(
+            model_key="coreml_depth_anything_v2_small",
+            device=DeviceConfig(device="cpu", use_coreml=True),
+        )
+    )
+
+    assert engine.backend is ModelBackend.COREML
 
 
 def test_da3_stub_backend_raises_immediately() -> None:

--- a/tests/lux_depth_v3/test_model_registry_resolution.py
+++ b/tests/lux_depth_v3/test_model_registry_resolution.py
@@ -1,0 +1,131 @@
+"""Registry and resolver contract tests for Lux Depth V3."""
+
+from __future__ import annotations
+
+import pytest
+
+from transformation_portal.lux_depth_v3.config import DA3Config, DeviceConfig, ModelVariant
+from transformation_portal.lux_depth_v3.da3_model_backend import DA3ModelBackend, DA3ModelBackendConfig
+from transformation_portal.lux_depth_v3.inference import DA3InferenceEngine, ModelBackend
+from transformation_portal.lux_depth_v3.model_registry import (
+    ConsumableOutput,
+    get_model_spec,
+    resolve_legacy_model_variant_key,
+    resolve_model_spec,
+    visible_cli_model_specs,
+)
+from transformation_portal.lux_depth_v3.model_resolution import (
+    BackendCapabilityError,
+    DeprecatedModelSelectorWarning,
+    ModelLicenseError,
+    ModelRequest,
+    UnknownModelError,
+    resolve_model_contract,
+)
+
+pytestmark = [pytest.mark.unit]
+
+
+def test_every_public_alias_resolves_to_known_spec() -> None:
+    assert resolve_model_spec("da3").key == "da3_research"
+    assert resolve_model_spec("da3-research").key == "da3_research"
+    assert resolve_model_spec("da3-metric").key == "da3_metric"
+
+
+@pytest.mark.parametrize(
+    ("variant", "expected_key"),
+    [
+        (ModelVariant.METRIC_LARGE, "da3_research"),
+        (ModelVariant.METRIC_BASE, "da3_base"),
+        (ModelVariant.METRIC_SMALL, "da3_small"),
+    ],
+)
+def test_legacy_model_variants_warn_and_map_to_registry_keys(variant: ModelVariant, expected_key: str) -> None:
+    with pytest.warns(DeprecatedModelSelectorWarning):
+        resolved = resolve_model_contract(ModelRequest(model_variant=variant, non_commercial_ok=True))
+    assert resolved.canonical_key == expected_key
+
+
+def test_legacy_model_variants_no_longer_point_to_stale_depth_anything_v3_metric_ids() -> None:
+    assert ModelVariant.METRIC_BASE.value.huggingface_id == "depth-anything/DA3-BASE"
+    assert ModelVariant.METRIC_SMALL.value.huggingface_id == "depth-anything/DA3-SMALL"
+
+
+def test_unknown_selector_fails_closed() -> None:
+    with pytest.raises(UnknownModelError):
+        resolve_model_contract(ModelRequest(model_key="depth-anything/Depth-Anything-V3-Metric-Base-hf"))
+
+
+def test_da3_requires_non_commercial_ok() -> None:
+    with pytest.raises(ModelLicenseError):
+        resolve_model_contract(ModelRequest(model_key="da3"))
+
+
+def test_metric_large_legacy_selector_requires_non_commercial_ok() -> None:
+    with pytest.warns(DeprecatedModelSelectorWarning):
+        with pytest.raises(ModelLicenseError):
+            resolve_model_contract(ModelRequest(model_variant=ModelVariant.METRIC_LARGE))
+
+
+def test_da3_metric_passes_without_non_commercial_ok() -> None:
+    resolved = resolve_model_contract(ModelRequest(model_key="da3-metric"))
+    assert resolved.spec.repo_id == "depth-anything/DA3METRIC-LARGE"
+    assert resolved.spec.consumable_outputs == frozenset(
+        {
+            ConsumableOutput.NORMALIZED_RELATIVE_DEPTH,
+            ConsumableOutput.DEPTH_METADATA,
+        }
+    )
+
+
+def test_metric_base_and_small_use_apache_policy_after_mapping() -> None:
+    with pytest.warns(DeprecatedModelSelectorWarning):
+        base = resolve_model_contract(ModelRequest(model_variant=ModelVariant.METRIC_BASE))
+    with pytest.warns(DeprecatedModelSelectorWarning):
+        small = resolve_model_contract(ModelRequest(model_variant=ModelVariant.METRIC_SMALL))
+    assert base.spec.license_id == "apache-2.0"
+    assert small.spec.license_id == "apache-2.0"
+
+
+def test_da3_coreml_fails_closed() -> None:
+    with pytest.raises(BackendCapabilityError):
+        resolve_model_contract(
+            ModelRequest(
+                model_key="da3",
+                non_commercial_ok=True,
+                use_coreml_backend=True,
+            )
+        )
+
+
+def test_only_published_coreml_artifact_is_coreml_eligible() -> None:
+    resolved = resolve_model_contract(
+        ModelRequest(
+            model_key="coreml_depth_anything_v2_small",
+            use_coreml_backend=True,
+        )
+    )
+    assert resolved.spec.repo_id == "apple/coreml-depth-anything-v2-small"
+    assert resolved.accelerator_kind.value == "coreml"
+
+
+def test_da3_inference_engine_accepts_positional_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        DA3InferenceEngine,
+        "_auto_detect_backend",
+        lambda self: ModelBackend.PYTORCH_CPU,
+    )
+    config = DA3Config(model_variant=ModelVariant.METRIC_BASE, device=DeviceConfig(device="cpu"))
+    engine = DA3InferenceEngine(config)
+    assert engine.config is config
+
+
+def test_da3_stub_backend_raises_immediately() -> None:
+    with pytest.raises(RuntimeError, match="retired"):
+        DA3ModelBackend(DA3ModelBackendConfig())
+
+
+def test_public_cli_model_visibility_is_limited_to_research_and_metric() -> None:
+    assert [spec.key for spec in visible_cli_model_specs()] == ["da3_research", "da3_metric"]
+    assert resolve_legacy_model_variant_key(ModelVariant.METRIC_BASE) == "da3_base"
+    assert get_model_spec("da3_base").exposed_in_cli is False

--- a/tests/lux_depth_v3/test_model_registry_resolution.py
+++ b/tests/lux_depth_v3/test_model_registry_resolution.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import sys
+from types import SimpleNamespace
+
 import pytest
 
 from transformation_portal.lux_depth_v3.config import DA3Config, DeviceConfig, ModelVariant
@@ -107,6 +110,82 @@ def test_only_published_coreml_artifact_is_coreml_eligible() -> None:
     )
     assert resolved.spec.repo_id == "apple/coreml-depth-anything-v2-small"
     assert resolved.accelerator_kind.value == "coreml"
+
+
+def test_coreml_estimator_cache_key_includes_revision(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    import transformation_portal.lux_depth_v3.coreml_backend as coreml_backend
+
+    monkeypatch.setattr(coreml_backend, "COREML_AVAILABLE", True)
+    monkeypatch.setattr(
+        coreml_backend.CoreMLDepthEstimator,
+        "_load_or_convert",
+        lambda self, force_reconvert=False: object(),
+    )
+
+    estimator = coreml_backend.CoreMLDepthEstimator(
+        "apple/coreml-depth-anything-v2-small",
+        cache_dir=tmp_path,
+        revision="a" * 40,
+    )
+
+    assert estimator._get_cache_path().name.endswith(f"_{'a' * 40}.mlpackage")
+
+
+def test_coreml_estimator_download_pins_hub_revision(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    import transformation_portal.lux_depth_v3.coreml_backend as coreml_backend
+
+    calls = {}
+    downloaded_path = tmp_path / "DepthAnythingV2SmallF16.mlpackage"
+    downloaded_path.write_text("stub", encoding="utf-8")
+
+    def fake_download(**kwargs):
+        calls.update(kwargs)
+        return str(downloaded_path)
+
+    monkeypatch.setitem(sys.modules, "huggingface_hub", SimpleNamespace(hf_hub_download=fake_download))
+    monkeypatch.setattr(coreml_backend, "CoreMLDepthModel", lambda model_path: model_path)
+
+    estimator = object.__new__(coreml_backend.CoreMLDepthEstimator)
+    estimator.model_id = "apple/coreml-depth-anything-v2-small"
+    estimator.cache_dir = tmp_path
+    estimator.revision = "b" * 40
+
+    estimator._load_published_coreml_model(estimator._get_cache_path())
+
+    assert calls["revision"] == "b" * 40
+
+
+def test_da3_inference_coreml_loader_receives_resolved_revision(monkeypatch: pytest.MonkeyPatch) -> None:
+    import transformation_portal.lux_depth_v3.coreml_backend as coreml_backend
+    import transformation_portal.lux_depth_v3.inference as inference_module
+
+    config = DA3Config(device=DeviceConfig(device="cpu"))
+    engine = DA3InferenceEngine(config)
+    resolved = resolve_model_contract(
+        ModelRequest(
+            model_key="coreml_depth_anything_v2_small",
+            use_coreml_backend=True,
+        )
+    )
+    captured = {}
+
+    class FakeEstimator:
+        def __init__(self, model_id, cache_dir=None, force_reconvert=False, revision=None):
+            del cache_dir, force_reconvert
+            captured["model_id"] = model_id
+            captured["revision"] = revision
+
+    monkeypatch.setattr(inference_module, "COREML_AVAILABLE", True)
+    monkeypatch.setattr(inference_module, "_ensure_optional_runtime_imports", lambda: None)
+    monkeypatch.setattr(engine, "_resolve_model_contract", lambda use_coreml_backend=None: resolved)
+    monkeypatch.setattr(coreml_backend, "CoreMLDepthEstimator", FakeEstimator)
+
+    engine._load_coreml_model()
+
+    assert captured == {
+        "model_id": "apple/coreml-depth-anything-v2-small",
+        "revision": resolved.revision,
+    }
 
 
 def test_da3_inference_engine_accepts_positional_config(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_da3_backend.py
+++ b/tests/test_da3_backend.py
@@ -211,6 +211,7 @@ def test_da3_backend_subprocess_ensure_available_skips_local_dependency_checks(t
     assert "--check" in command
     assert "METRIC_LARGE" in command
     assert "da3_research" in command
+    assert "--non-commercial-ok" in command
     assert mock_run.call_args.kwargs["timeout"] == 321
 
 
@@ -395,7 +396,58 @@ def test_da3_backend_subprocess_compute_returns_depth_result(tmp_path):
         assert command[command.index("--model-variant") + 1] == "METRIC_LARGE"
         assert "--model-key" in command
         assert command[command.index("--model-key") + 1] == "da3_research"
+        assert "--non-commercial-ok" in command
     assert seen_timeouts == [123, 123]
+
+
+def test_da3_worker_inference_propagates_non_commercial_ack(monkeypatch, tmp_path):
+    """Worker subprocess config should preserve parent non-commercial acknowledgement."""
+    import transformation_portal.depth.backends.da3_worker as da3_worker
+    import transformation_portal.lux_depth_v3.inference as inference_module
+
+    captured = {}
+    input_path = tmp_path / "input.png"
+    output_depth = tmp_path / "depth.npy"
+    output_json = tmp_path / "result.json"
+    Image.new("RGB", (4, 5), color="white").save(input_path)
+
+    class FakeEngine:
+        def __init__(self, *, config, commercial_use, validate_license_strict, model_key, non_commercial_ok):
+            captured["config_non_commercial_ok"] = config.non_commercial_ok
+            captured["engine_non_commercial_ok"] = non_commercial_ok
+            captured["model_key"] = model_key
+            captured["commercial_use"] = commercial_use
+            captured["validate_license_strict"] = validate_license_strict
+
+        def predict(self, image):
+            del image
+            return SimpleNamespace(
+                depth_map=np.full((4, 5), 0.25, dtype=np.float32),
+                metadata={"device": "cpu"},
+                original_image=np.zeros((4, 5, 3), dtype=np.uint8),
+            )
+
+    monkeypatch.setattr(inference_module, "DA3InferenceEngine", FakeEngine)
+
+    exit_code = da3_worker._run_inference(
+        input_image=input_path,
+        output_depth=output_depth,
+        output_json=output_json,
+        model_variant_name="METRIC_LARGE",
+        model_key="da3_research",
+        device="cpu",
+        use_coreml=False,
+        non_commercial_ok=True,
+    )
+
+    assert exit_code == 0
+    assert captured == {
+        "config_non_commercial_ok": True,
+        "engine_non_commercial_ok": True,
+        "model_key": "da3_research",
+        "commercial_use": True,
+        "validate_license_strict": False,
+    }
 
 
 def test_da3_backend_subprocess_compute_launch_oserror_reports_category(tmp_path):

--- a/tests/test_da3_backend.py
+++ b/tests/test_da3_backend.py
@@ -19,9 +19,21 @@ from transformation_portal.core.platform_matrix import PlatformAccel, PlatformIS
 from transformation_portal.depth.backends.da3 import DA3Backend
 from transformation_portal.depth.backends.protocol import DepthResult, LicenseType
 from transformation_portal.depth.backends.registry import DepthBackendRegistry
+from transformation_portal.lux_depth_v3.model_resolution import BackendCapabilityError
 
 # Mark all tests in this module as ML tier (require torch + transformers)
 pytestmark = pytest.mark.ml
+
+
+def _licensed_da3_config(**overrides):
+    from transformation_portal.lux_depth_v3.config import EnhanceConfig
+
+    defaults = {
+        "depth_device": "cpu",
+        "non_commercial_ok": True,
+    }
+    defaults.update(overrides)
+    return EnhanceConfig(**defaults)
 
 
 def _install_fake_depth_anything3(monkeypatch):
@@ -67,9 +79,9 @@ def _install_fake_depth_anything3(monkeypatch):
 
 def test_da3_backend_implements_protocol():
     """DA3Backend implements DepthBackend protocol."""
-    backend = DA3Backend()
+    backend = DA3Backend(_licensed_da3_config())
     assert backend.name == "da3"
-    assert backend.license_type == LicenseType.COMMERCIAL
+    assert backend.license_type == LicenseType.MODEL_DEPENDENT
     assert backend.requires_checkpoint is False
 
 
@@ -79,7 +91,7 @@ def test_da3_backend_availability():
     Verifies the method exists and is callable.
     Actual error handling is tested in test_da3_backend_availability_missing_transformers.
     """
-    backend = DA3Backend()
+    backend = DA3Backend(_licensed_da3_config())
 
     # Verify method exists
     assert hasattr(backend, "ensure_available")
@@ -95,7 +107,7 @@ def test_da3_backend_availability_missing_transformers(monkeypatch):
     monkeypatch.delitem(sys.modules, "transformers", raising=False)
     monkeypatch.setitem(sys.modules, "transformers", None)
 
-    backend = DA3Backend()
+    backend = DA3Backend(_licensed_da3_config())
 
     # This should raise ImportError when ensure_available tries to import transformers
     with pytest.raises(ImportError, match="transformers"):
@@ -104,14 +116,12 @@ def test_da3_backend_availability_missing_transformers(monkeypatch):
 
 def test_da3_backend_python_executable_resolution_from_config(tmp_path):
     """Dedicated DA3 Python path should be resolved from config."""
-    from transformation_portal.lux_depth_v3.config import EnhanceConfig
-
     python_executable = tmp_path / ".venv-da3" / "bin" / "python"
     python_executable.parent.mkdir(parents=True)
     python_executable.write_text("#!/bin/sh\n", encoding="utf-8")
 
     backend = DA3Backend(
-        EnhanceConfig(
+        _licensed_da3_config(
             depth_device="cpu",
             da3_python_executable=str(python_executable),
         )
@@ -122,8 +132,6 @@ def test_da3_backend_python_executable_resolution_from_config(tmp_path):
 
 def test_da3_backend_python_executable_preserves_venv_symlink(tmp_path):
     """Configured DA3 Python should preserve the venv launcher symlink path."""
-    from transformation_portal.lux_depth_v3.config import EnhanceConfig
-
     target_python = tmp_path / "python3.11"
     target_python.write_text("#!/bin/sh\n", encoding="utf-8")
     python_executable = tmp_path / ".venv-da3" / "bin" / "python"
@@ -131,7 +139,7 @@ def test_da3_backend_python_executable_preserves_venv_symlink(tmp_path):
     python_executable.symlink_to(target_python)
 
     backend = DA3Backend(
-        EnhanceConfig(
+        _licensed_da3_config(
             depth_device="cpu",
             da3_python_executable=str(python_executable),
         )
@@ -142,8 +150,6 @@ def test_da3_backend_python_executable_preserves_venv_symlink(tmp_path):
 
 def test_da3_backend_relative_python_executable_anchors_to_repo_root(monkeypatch, tmp_path):
     """Relative DA3 Python paths should anchor to the discovered repo root."""
-    from transformation_portal.lux_depth_v3.config import EnhanceConfig
-
     repo_root = tmp_path / "repo"
     repo_root.mkdir()
     python_executable = repo_root / ".venv-da3" / "bin" / "python"
@@ -156,7 +162,7 @@ def test_da3_backend_relative_python_executable_anchors_to_repo_root(monkeypatch
     monkeypatch.setattr(DA3Backend, "_find_repo_root", lambda self: repo_root)
 
     backend = DA3Backend(
-        EnhanceConfig(
+        _licensed_da3_config(
             depth_device="cpu",
             da3_python_executable="./.venv-da3/bin/python",
         )
@@ -176,14 +182,12 @@ def test_da3_backend_subprocess_ensure_available_skips_local_dependency_checks(t
     """Dedicated subprocess mode should not require local DA3 package imports."""
     from unittest.mock import MagicMock, patch
 
-    from transformation_portal.lux_depth_v3.config import EnhanceConfig
-
     python_executable = tmp_path / ".venv-da3" / "bin" / "python"
     python_executable.parent.mkdir(parents=True)
     python_executable.write_text("#!/bin/sh\n", encoding="utf-8")
 
     backend = DA3Backend(
-        EnhanceConfig(
+        _licensed_da3_config(
             depth_device="cpu",
             da3_python_executable=str(python_executable),
             da3_subprocess_timeout_seconds=321,
@@ -206,19 +210,18 @@ def test_da3_backend_subprocess_ensure_available_skips_local_dependency_checks(t
     command = mock_run.call_args.args[0]
     assert "--check" in command
     assert "METRIC_LARGE" in command
+    assert "da3_research" in command
     assert mock_run.call_args.kwargs["timeout"] == 321
 
 
 def test_da3_backend_runtime_required_packages_drop_transformers_in_subprocess(tmp_path):
     """Instance dependency declaration should match subprocess-backed execution."""
-    from transformation_portal.lux_depth_v3.config import EnhanceConfig
-
     python_executable = tmp_path / ".venv-da3" / "bin" / "python"
     python_executable.parent.mkdir(parents=True)
     python_executable.write_text("#!/bin/sh\n", encoding="utf-8")
 
     backend = DA3Backend(
-        EnhanceConfig(
+        _licensed_da3_config(
             depth_device="cpu",
             da3_python_executable=str(python_executable),
         )
@@ -230,7 +233,6 @@ def test_da3_backend_runtime_required_packages_drop_transformers_in_subprocess(t
 def test_da3_backend_subprocess_worker_env_sets_runtime_guards(monkeypatch, tmp_path):
     """Subprocess DA3 mode should add repo/runtime env needed on macOS."""
     import transformation_portal.depth.backends.da3 as da3_module
-    from transformation_portal.lux_depth_v3.config import EnhanceConfig
 
     python_executable = tmp_path / ".venv-da3" / "bin" / "python"
     python_executable.parent.mkdir(parents=True)
@@ -244,7 +246,7 @@ def test_da3_backend_subprocess_worker_env_sets_runtime_guards(monkeypatch, tmp_
     monkeypatch.setenv("KMP_DUPLICATE_LIB_OK", "True")
 
     backend = DA3Backend(
-        EnhanceConfig(
+        _licensed_da3_config(
             depth_device="cpu",
             da3_python_executable=str(python_executable),
         )
@@ -261,14 +263,12 @@ def test_da3_backend_subprocess_dependency_failure_reports_category(tmp_path):
     """Dependency failures should report the normalized subprocess category."""
     from unittest.mock import MagicMock, patch
 
-    from transformation_portal.lux_depth_v3.config import EnhanceConfig
-
     python_executable = tmp_path / ".venv-da3" / "bin" / "python"
     python_executable.parent.mkdir(parents=True)
     python_executable.write_text("#!/bin/sh\n", encoding="utf-8")
 
     backend = DA3Backend(
-        EnhanceConfig(
+        _licensed_da3_config(
             depth_device="cpu",
             da3_python_executable=str(python_executable),
         )
@@ -288,14 +288,12 @@ def test_da3_backend_subprocess_launch_oserror_reports_category(tmp_path):
     """Launch-time OS errors should still map to a stable failure category."""
     from unittest.mock import patch
 
-    from transformation_portal.lux_depth_v3.config import EnhanceConfig
-
     python_executable = tmp_path / ".venv-da3" / "bin" / "python"
     python_executable.parent.mkdir(parents=True)
     python_executable.write_text("#!/bin/sh\n", encoding="utf-8")
 
     backend = DA3Backend(
-        EnhanceConfig(
+        _licensed_da3_config(
             depth_device="cpu",
             da3_python_executable=str(python_executable),
             da3_subprocess_timeout_seconds=45,
@@ -316,14 +314,12 @@ def test_da3_backend_subprocess_protocol_error_reports_category(tmp_path):
     """Missing worker outputs should be normalized as protocol errors."""
     from unittest.mock import MagicMock, patch
 
-    from transformation_portal.lux_depth_v3.config import EnhanceConfig
-
     python_executable = tmp_path / ".venv-da3" / "bin" / "python"
     python_executable.parent.mkdir(parents=True)
     python_executable.write_text("#!/bin/sh\n", encoding="utf-8")
 
     backend = DA3Backend(
-        EnhanceConfig(
+        _licensed_da3_config(
             depth_device="cpu",
             da3_python_executable=str(python_executable),
         )
@@ -342,14 +338,12 @@ def test_da3_backend_subprocess_compute_returns_depth_result(tmp_path):
     """Subprocess worker output should map back to the DepthResult contract."""
     from unittest.mock import MagicMock, patch
 
-    from transformation_portal.lux_depth_v3.config import EnhanceConfig
-
     python_executable = tmp_path / ".venv-da3" / "bin" / "python"
     python_executable.parent.mkdir(parents=True)
     python_executable.write_text("#!/bin/sh\n", encoding="utf-8")
 
     backend = DA3Backend(
-        EnhanceConfig(
+        _licensed_da3_config(
             depth_device="cpu",
             da3_python_executable=str(python_executable),
             da3_subprocess_timeout_seconds=123,
@@ -400,14 +394,12 @@ def test_da3_backend_subprocess_compute_launch_oserror_reports_category(tmp_path
     """Inference launch OS errors should stay normalized for operators."""
     from unittest.mock import patch
 
-    from transformation_portal.lux_depth_v3.config import EnhanceConfig
-
     python_executable = tmp_path / ".venv-da3" / "bin" / "python"
     python_executable.parent.mkdir(parents=True)
     python_executable.write_text("#!/bin/sh\n", encoding="utf-8")
 
     backend = DA3Backend(
-        EnhanceConfig(
+        _licensed_da3_config(
             depth_device="cpu",
             da3_python_executable=str(python_executable),
             da3_subprocess_timeout_seconds=17,
@@ -427,7 +419,7 @@ def test_da3_backend_subprocess_compute_launch_oserror_reports_category(tmp_path
 
 def test_da3_backend_prepare_image_preserves_dark_uint8_arrays():
     """Dark uint8 images should not be reinterpreted as normalized floats."""
-    backend = DA3Backend()
+    backend = DA3Backend(_licensed_da3_config())
     image = np.array(
         [
             [[0, 1, 0], [1, 0, 1]],
@@ -444,7 +436,7 @@ def test_da3_backend_prepare_image_preserves_dark_uint8_arrays():
 
 def test_da3_backend_prepare_image_scales_normalized_float_arrays():
     """Normalized float images should still be scaled into uint8 pixel space."""
-    backend = DA3Backend()
+    backend = DA3Backend(_licensed_da3_config())
     image = np.array(
         [
             [[0.0, 0.5, 1.0], [0.25, 0.75, 0.1]],
@@ -469,9 +461,7 @@ def test_da3_backend_prepare_image_scales_normalized_float_arrays():
 )
 def test_da3_backend_compute():
     """DA3Backend.compute() returns DepthResult."""
-    from transformation_portal.lux_depth_v3.config import EnhanceConfig
-
-    config = EnhanceConfig(depth_device="cpu")
+    config = _licensed_da3_config(depth_device="cpu")
     backend = DA3Backend(config)
 
     # Create test image
@@ -495,7 +485,7 @@ def test_da3_backend_compute():
 )
 def test_da3_backend_compute_numpy():
     """DA3Backend.compute() accepts numpy arrays."""
-    backend = DA3Backend()
+    backend = DA3Backend(_licensed_da3_config())
 
     # Create test image as numpy array
     image_array = np.random.randint(0, 255, (64, 64, 3), dtype=np.uint8)
@@ -510,7 +500,7 @@ def test_da3_backend_compute_numpy():
 
 def test_da3_backend_cache_key():
     """DA3Backend generates consistent cache keys."""
-    backend = DA3Backend()
+    backend = DA3Backend(_licensed_da3_config())
 
     image = Image.new("RGB", (64, 64))
 
@@ -521,26 +511,10 @@ def test_da3_backend_cache_key():
     assert key1.startswith("da3_")
 
 
-def test_da3_backend_cache_key_distinguishes_apple_coreml_opt_in(monkeypatch):
-    """Apple Silicon CoreML opt-in should not collide with plain CPU cache keys."""
-    import transformation_portal.depth.backends.da3 as da3_module
-    from transformation_portal.lux_depth_v3.config import EnhanceConfig
-
-    monkeypatch.setattr(
-        da3_module,
-        "CURRENT_PLATFORM",
-        PlatformMatrix(PlatformOS.DARWIN, PlatformISA.ARM64, PlatformAccel.MPS),
-    )
-
-    image = Image.new("RGB", (64, 64))
-    cpu_backend = DA3Backend(EnhanceConfig(depth_device="cpu", use_coreml_backend=False))
-    coreml_backend = DA3Backend(EnhanceConfig(depth_device="cpu", use_coreml_backend=True))
-
-    cpu_key = cpu_backend.get_cache_key(image)
-    coreml_key = coreml_backend.get_cache_key(image)
-
-    assert cpu_key != coreml_key
-    assert "coremlopt" in coreml_key
+def test_da3_backend_coreml_opt_in_fails_closed():
+    """DA3 backends should reject CoreML opt-in during registry resolution."""
+    with pytest.raises(BackendCapabilityError, match="CoreML backend is not supported"):
+        DA3Backend(_licensed_da3_config(use_coreml_backend=True))
 
 
 def test_da3_backend_registry_integration():
@@ -549,7 +523,7 @@ def test_da3_backend_registry_integration():
 
     backends = registry.list_backends()
     assert "da3" in backends
-    assert backends["da3"]["license_type"] == "commercial"
+    assert backends["da3"]["license_type"] == "model_dependent"
     assert backends["da3"]["requires_checkpoint"] is False
 
 
@@ -559,9 +533,7 @@ def test_da3_backend_registry_integration():
 )
 def test_da3_backend_via_registry():
     """DA3Backend can be instantiated via registry."""
-    from transformation_portal.lux_depth_v3.config import EnhanceConfig
-
-    config = EnhanceConfig(depth_device="cpu")
+    config = _licensed_da3_config(depth_device="cpu")
     registry = DepthBackendRegistry()
 
     backend = registry.get_backend("da3", config)
@@ -576,9 +548,7 @@ def test_da3_backend_via_registry():
 )
 def test_da3_backend_device_override():
     """DA3Backend respects device parameter in compute()."""
-    from transformation_portal.lux_depth_v3.config import EnhanceConfig
-
-    config = EnhanceConfig(depth_device="cpu")
+    config = _licensed_da3_config(depth_device="cpu")
     backend = DA3Backend(config)
 
     image = Image.new("RGB", (64, 64))
@@ -590,9 +560,7 @@ def test_da3_backend_device_override():
 
 def test_da3_backend_unit_contract_metadata(monkeypatch):
     """DA3 adapter should expose source/output unit semantics in metadata."""
-    from transformation_portal.lux_depth_v3.config import EnhanceConfig
-
-    config = EnhanceConfig(depth_device="cpu")
+    config = _licensed_da3_config(depth_device="cpu")
     backend = DA3Backend(config)
 
     # Avoid dependency checks and heavy model loading.
@@ -615,9 +583,7 @@ def test_da3_backend_unit_contract_metadata(monkeypatch):
 
 def test_da3_backend_uses_engine_effective_device_metadata(monkeypatch):
     """DA3 adapter should report the engine's effective runtime device."""
-    from transformation_portal.lux_depth_v3.config import EnhanceConfig
-
-    config = EnhanceConfig(depth_device="cpu", use_coreml_backend=True)
+    config = _licensed_da3_config(depth_device="cpu")
     backend = DA3Backend(config)
 
     monkeypatch.setattr(backend, "ensure_available", lambda: None)
@@ -625,8 +591,8 @@ def test_da3_backend_uses_engine_effective_device_metadata(monkeypatch):
         predict=lambda _image: SimpleNamespace(
             depth_map=np.ones((32, 32), dtype=np.float32),
             metadata={
-                "backend": "coreml",
-                "device": "coreml",
+                "backend": "da3",
+                "device": "cpu",
                 "resolved_model_id": "depth-anything/DA3NESTED-GIANT-LARGE-1.1",
             },
         )
@@ -634,22 +600,21 @@ def test_da3_backend_uses_engine_effective_device_metadata(monkeypatch):
 
     result = backend.compute(Image.new("RGB", (32, 32), color="white"))
 
-    assert result.device == "coreml"
-    assert result.metadata["backend"] == "coreml"
-    assert result.metadata["device"] == "coreml"
+    assert result.device == "cpu"
+    assert result.metadata["backend"] == "da3"
+    assert result.metadata["device"] == "cpu"
 
 
 def test_da3_backend_smoke_cpu_no_hidden_cuda(monkeypatch):
     """CPU DA3 inference path should not invoke CUDA implicitly."""
     pytest.importorskip("torch")
     import transformation_portal.lux_depth_v3.inference as inference_module
-    from transformation_portal.lux_depth_v3.config import EnhanceConfig
 
     _install_fake_depth_anything3(monkeypatch)
     monkeypatch.setattr(DA3Backend, "ensure_available", lambda self: None)
     monkeypatch.setattr(inference_module, "TRANSFORMERS_AVAILABLE", True)
 
-    backend = DA3Backend(EnhanceConfig(depth_device="cpu"))
+    backend = DA3Backend(_licensed_da3_config(depth_device="cpu"))
     result = backend.compute(Image.new("RGB", (64, 64), color="white"))
 
     assert result.device == "cpu"
@@ -660,7 +625,6 @@ def test_da3_backend_smoke_mps_no_hidden_cuda(monkeypatch):
     """MPS DA3 inference path should not invoke CUDA implicitly."""
     torch = pytest.importorskip("torch")
     import transformation_portal.lux_depth_v3.inference as inference_module
-    from transformation_portal.lux_depth_v3.config import EnhanceConfig
 
     _install_fake_depth_anything3(monkeypatch)
     monkeypatch.setattr(DA3Backend, "ensure_available", lambda self: None)
@@ -672,63 +636,36 @@ def test_da3_backend_smoke_mps_no_hidden_cuda(monkeypatch):
         monkeypatch.setattr(torch.backends, "mps", SimpleNamespace(is_available=lambda: True), raising=False)
     monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
 
-    backend = DA3Backend(EnhanceConfig(depth_device="mps"))
+    backend = DA3Backend(_licensed_da3_config(depth_device="mps"))
     result = backend.compute(Image.new("RGB", (64, 64), color="white"))
 
     assert result.device == "mps"
     assert result.depth_map.shape == (64, 64)
 
 
-def test_da3_backend_passes_coreml_opt_in_on_apple_silicon(monkeypatch):
-    """Apple Silicon should forward the CoreML opt-in into the DA3 engine config."""
+def test_da3_backend_rejects_coreml_opt_in_on_apple_silicon(monkeypatch):
+    """Apple Silicon should still fail closed for DA3 CoreML requests."""
     import transformation_portal.depth.backends.da3 as da3_module
-    import transformation_portal.lux_depth_v3.inference as inference_module
-    from transformation_portal.lux_depth_v3.config import EnhanceConfig
-
-    captured = {}
-
-    class FakeEngine:
-        def __init__(self, config, commercial_use, validate_license_strict):
-            captured["config"] = config
-            captured["commercial_use"] = commercial_use
-            captured["validate_license_strict"] = validate_license_strict
 
     monkeypatch.setattr(
         da3_module,
         "CURRENT_PLATFORM",
         PlatformMatrix(PlatformOS.DARWIN, PlatformISA.ARM64, PlatformAccel.MPS),
     )
-    monkeypatch.setattr(inference_module, "DA3InferenceEngine", FakeEngine)
 
-    backend = DA3Backend(EnhanceConfig(depth_device="cpu", use_coreml_backend=True))
-    backend._load_engine("cpu")
-
-    assert captured["config"].device.use_coreml is True
-    assert captured["commercial_use"] is True
-    assert captured["validate_license_strict"] is False
+    with pytest.raises(BackendCapabilityError, match="CoreML backend is not supported"):
+        DA3Backend(_licensed_da3_config(depth_device="cpu", use_coreml_backend=True))
 
 
-def test_da3_backend_ignores_coreml_opt_in_off_apple_silicon(monkeypatch):
-    """Intel/Linux lanes should not forward the Apple-only CoreML opt-in."""
+def test_da3_backend_rejects_coreml_opt_in_off_apple_silicon(monkeypatch):
+    """Intel/Linux lanes should also fail closed for DA3 CoreML requests."""
     import transformation_portal.depth.backends.da3 as da3_module
-    import transformation_portal.lux_depth_v3.inference as inference_module
-    from transformation_portal.lux_depth_v3.config import EnhanceConfig
-
-    captured = {}
-
-    class FakeEngine:
-        def __init__(self, config, commercial_use, validate_license_strict):
-            del commercial_use, validate_license_strict
-            captured["config"] = config
 
     monkeypatch.setattr(
         da3_module,
         "CURRENT_PLATFORM",
         PlatformMatrix(PlatformOS.DARWIN, PlatformISA.X86_64, PlatformAccel.CPU),
     )
-    monkeypatch.setattr(inference_module, "DA3InferenceEngine", FakeEngine)
 
-    backend = DA3Backend(EnhanceConfig(depth_device="cpu", use_coreml_backend=True))
-    backend._load_engine("cpu")
-
-    assert captured["config"].device.use_coreml is False
+    with pytest.raises(BackendCapabilityError, match="CoreML backend is not supported"):
+        DA3Backend(_licensed_da3_config(depth_device="cpu", use_coreml_backend=True))

--- a/tests/test_da3_backend.py
+++ b/tests/test_da3_backend.py
@@ -527,6 +527,16 @@ def test_da3_backend_registry_integration():
     assert backends["da3"]["requires_checkpoint"] is False
 
 
+def test_da3_backend_registry_instantiation_without_config_defers_license_gate():
+    """Registry metadata access should not enforce DA3 research-license acknowledgement."""
+    registry = DepthBackendRegistry()
+
+    backend = registry.get_backend("da3")
+
+    assert isinstance(backend, DA3Backend)
+    assert backend._resolved_model_contract.canonical_key == "da3_research"
+
+
 @pytest.mark.skipif(
     not can_run_da3_compute(),
     reason="DA3 compute requires depth_anything_3 + transformers + online mode",

--- a/tests/test_da3_backend.py
+++ b/tests/test_da3_backend.py
@@ -350,9 +350,11 @@ def test_da3_backend_subprocess_compute_returns_depth_result(tmp_path):
         )
     )
 
+    seen_commands = []
     seen_timeouts = []
 
     def fake_run(command, **kwargs):
+        seen_commands.append(command)
         seen_timeouts.append(kwargs["timeout"])
         if "--check" in command:
             return MagicMock(returncode=0, stdout="", stderr="")
@@ -387,6 +389,12 @@ def test_da3_backend_subprocess_compute_returns_depth_result(tmp_path):
     assert result.metadata["runner"]["mode"] == "subprocess"
     assert result.metadata["runner"]["python_executable"] == backend._python_executable
     assert any("normalized to relative" in warning for warning in result.warnings)
+    assert len(seen_commands) == 2
+    for command in seen_commands:
+        assert "--model-variant" in command
+        assert command[command.index("--model-variant") + 1] == "METRIC_LARGE"
+        assert "--model-key" in command
+        assert command[command.index("--model-key") + 1] == "da3_research"
     assert seen_timeouts == [123, 123]
 
 

--- a/tests/test_lux_depth_v3_cli.py
+++ b/tests/test_lux_depth_v3_cli.py
@@ -246,6 +246,10 @@ class TestCLIValidation:
 
         monkeypatch.setattr("transformation_portal.lux_depth_v3.__main__.EnhanceOrchestrator", FakeOrchestrator)
         monkeypatch.setattr(
+            "transformation_portal.lux_depth_v3.__main__.apply_effective_raw_runtime_config",
+            lambda config: config,
+        )
+        monkeypatch.setattr(
             "transformation_portal.lux_depth_v3.__main__._canonical_raw_ingest_status",
             lambda *_args: (False, "rawpy is not installed"),
         )
@@ -263,8 +267,8 @@ class TestCLIValidation:
 
         assert result.exit_code == 1
         assert "raw inputs detected but canonical raw ingest is unavailable" in result.stdout.lower()
-        assert "rebuild that dedicated raw runtime" in result.stdout.lower()
-        assert "--raw-python" in result.stdout
+        assert 'install with: pip install -e ".[raw]" or pip install rawpy' in result.stdout.lower()
+        assert "--raw-python" not in result.stdout
 
     def test_non_raw_inputs_do_not_trigger_rawpy_preflight(self, monkeypatch, tmp_path):
         """Non-RAW batches should not be blocked by the optional RAW dependency."""
@@ -340,6 +344,10 @@ class TestCLIValidation:
 
         monkeypatch.setattr("transformation_portal.lux_depth_v3.__main__.EnhanceOrchestrator", FakeOrchestrator)
         monkeypatch.setattr(
+            "transformation_portal.lux_depth_v3.__main__.apply_effective_raw_runtime_config",
+            lambda config: config,
+        )
+        monkeypatch.setattr(
             "transformation_portal.lux_depth_v3.__main__._canonical_raw_ingest_status",
             lambda *_args: (False, "rawpy is unavailable in this environment"),
         )
@@ -358,8 +366,9 @@ class TestCLIValidation:
         assert result.exit_code == 1
         assert "rawpy is unavailable in this environment" in result.stdout.lower()
         assert "not installed" not in result.stdout.lower()
-        assert "rebuild that dedicated raw runtime" in result.stdout.lower()
-        assert "working interpreter" in result.stdout.lower()
+        assert 'install with: pip install -e ".[raw]" or pip install rawpy' in result.stdout.lower()
+        assert "inspect the import/runtime error in the logs" in result.stdout.lower()
+        assert "working interpreter" not in result.stdout.lower()
 
     def test_apex_materials_v3_requires_segmentation_enabled(self, tmp_path):
         """APEX strict gate should require explicit segmentation when Materials V3 is on."""

--- a/tests/test_lux_depth_v3_cli.py
+++ b/tests/test_lux_depth_v3_cli.py
@@ -14,6 +14,7 @@ from transformation_portal.lux_depth_v3.__main__ import _parse_bool_flag, app
 pytestmark = pytest.mark.unit
 
 runner = CliRunner()
+DEFAULT_APACHE_MODEL_ARGS = ["--model-key", "da3-metric"]
 
 
 def strip_ansi(text: str) -> str:
@@ -256,12 +257,14 @@ class TestCLIValidation:
                 str(input_dir),
                 "--output-dir",
                 str(tmp_path / "output"),
+                *DEFAULT_APACHE_MODEL_ARGS,
             ],
         )
 
         assert result.exit_code == 1
         assert "raw inputs detected but canonical raw ingest is unavailable" in result.stdout.lower()
-        assert 'pip install -e ".[raw]"' in result.stdout
+        assert "rebuild that dedicated raw runtime" in result.stdout.lower()
+        assert "--raw-python" in result.stdout
 
     def test_non_raw_inputs_do_not_trigger_rawpy_preflight(self, monkeypatch, tmp_path):
         """Non-RAW batches should not be blocked by the optional RAW dependency."""
@@ -289,6 +292,7 @@ class TestCLIValidation:
                 str(input_dir),
                 "--output-dir",
                 str(tmp_path / "output"),
+                *DEFAULT_APACHE_MODEL_ARGS,
             ],
         )
 
@@ -317,6 +321,7 @@ class TestCLIValidation:
                 str(tmp_path / "output"),
                 "--raw-ingest-mode",
                 "force_preview",
+                *DEFAULT_APACHE_MODEL_ARGS,
             ],
         )
 
@@ -346,13 +351,15 @@ class TestCLIValidation:
                 str(input_dir),
                 "--output-dir",
                 str(tmp_path / "output"),
+                *DEFAULT_APACHE_MODEL_ARGS,
             ],
         )
 
         assert result.exit_code == 1
         assert "rawpy is unavailable in this environment" in result.stdout.lower()
         assert "not installed" not in result.stdout.lower()
-        assert "inspect the import/runtime error in the logs" in result.stdout.lower()
+        assert "rebuild that dedicated raw runtime" in result.stdout.lower()
+        assert "working interpreter" in result.stdout.lower()
 
     def test_apex_materials_v3_requires_segmentation_enabled(self, tmp_path):
         """APEX strict gate should require explicit segmentation when Materials V3 is on."""
@@ -504,15 +511,15 @@ class TestCLIConfiguration:
         ("name", "args", "expected_backend", "expected_device", "expected_non_commercial"),
         [
             (
-                "commercial_safe_default",
-                [],
+                "apache_default",
+                ["--model-key", "da3-metric"],
                 "da3",
                 "cpu",
                 False,
             ),
             (
                 "apple_silicon_da3",
-                ["--depth-backend", "da3", "--depth-device", "mps"],
+                ["--depth-backend", "da3", "--depth-device", "mps", "--model-key", "da3-metric"],
                 "da3",
                 "mps",
                 False,
@@ -544,7 +551,7 @@ class TestCLIConfiguration:
         expected_device,
         expected_non_commercial,
     ):
-        """CLI should preserve the supported commercial-safe, Apple Silicon, and research tiers."""
+        """CLI should preserve the supported Apache, Apple Silicon, and research tiers."""
         from unittest.mock import MagicMock, patch
 
         input_dir = tmp_path / "input"
@@ -602,6 +609,8 @@ class TestCLIConfiguration:
                 "apex",
                 "--depth-backend",
                 "da3",
+                "--model-key",
+                "da3-metric",
                 "--materials-v3",
                 "on",
                 "--pbr",
@@ -659,6 +668,8 @@ class TestCLIConfiguration:
                     str(tmp_path / "output"),
                     "--depth-backend",
                     "depth_anything_v3",
+                    "--model-key",
+                    "da3-metric",
                 ],
             )
 
@@ -735,6 +746,7 @@ class TestCLIConfiguration:
                     str(tmp_path / "output"),
                     "--enable-v2",
                     "off",
+                    *DEFAULT_APACHE_MODEL_ARGS,
                 ],
             )
 
@@ -773,6 +785,7 @@ class TestCLIConfiguration:
                     str(tmp_path / "output"),
                     "--v2-preset",
                     "none",
+                    *DEFAULT_APACHE_MODEL_ARGS,
                 ],
             )
 
@@ -812,6 +825,7 @@ class TestCLIConfiguration:
                     "v2",
                     "--run-card-include-proofs",
                     "on",
+                    *DEFAULT_APACHE_MODEL_ARGS,
                 ],
             )
 
@@ -848,6 +862,7 @@ class TestCLIConfiguration:
                     str(tmp_path / "output"),
                     "--depth-pro-python",
                     "./.venv-depth-pro/bin/python",
+                    *DEFAULT_APACHE_MODEL_ARGS,
                 ],
             )
 
@@ -884,6 +899,7 @@ class TestCLIConfiguration:
                     str(tmp_path / "output"),
                     "--da3-python",
                     "./.venv-da3/bin/python",
+                    *DEFAULT_APACHE_MODEL_ARGS,
                 ],
             )
 
@@ -920,6 +936,7 @@ class TestCLIConfiguration:
                     str(tmp_path / "output"),
                     "--raw-python",
                     "./.venv-raw/bin/python",
+                    *DEFAULT_APACHE_MODEL_ARGS,
                 ],
             )
 
@@ -957,6 +974,7 @@ class TestCLIConfiguration:
                 str(tmp_path / "output"),
                 "--raw-python",
                 "./.venv-raw/bin/python",
+                *DEFAULT_APACHE_MODEL_ARGS,
             ],
         )
 
@@ -991,6 +1009,7 @@ class TestCLIConfiguration:
                     str(input_dir),
                     "--output-dir",
                     str(tmp_path / "output"),
+                    *DEFAULT_APACHE_MODEL_ARGS,
                 ],
             )
 
@@ -1027,6 +1046,7 @@ class TestCLIConfiguration:
                     str(tmp_path / "output"),
                     "--save-float-depth",
                     "on",
+                    *DEFAULT_APACHE_MODEL_ARGS,
                 ],
             )
 
@@ -1175,6 +1195,7 @@ class TestSegmentationCLI:
                     "efficientsam",
                     "--sam2-model-size",
                     "tiny",
+                    *DEFAULT_APACHE_MODEL_ARGS,
                 ],
             )
 
@@ -1210,6 +1231,7 @@ class TestSegmentationCLI:
                     str(input_dir),
                     "--output-dir",
                     str(tmp_path / "output"),
+                    *DEFAULT_APACHE_MODEL_ARGS,
                 ],
             )
 
@@ -1253,6 +1275,7 @@ class TestSegmentationCLI:
                     "--segmentation-backend",
                     "efficientsam",
                     "--strict-segmentation",
+                    *DEFAULT_APACHE_MODEL_ARGS,
                 ],
             )
 
@@ -1300,6 +1323,7 @@ class TestSegmentationCLI:
                     "--sam2-checkpoint-path",
                     str(tmp_path / "sam2_hiera_large.pt"),
                     "--strict-segmentation",
+                    *DEFAULT_APACHE_MODEL_ARGS,
                 ],
             )
 

--- a/tests/test_ml_dependency_health.py
+++ b/tests/test_ml_dependency_health.py
@@ -204,6 +204,7 @@ def test_da3_inference_da3_custom_path_ignores_transformers_pipeline_guard(
     engine = da3_inference.DA3InferenceEngine(
         DA3Config(
             model_variant=DA3ModelVariant.METRIC_LARGE,
+            non_commercial_ok=True,
             device=DeviceConfig(device="cpu", use_fp16=False),
         )
     )

--- a/tests/test_model_lock.py
+++ b/tests/test_model_lock.py
@@ -220,6 +220,31 @@ def test_model_lock_manifest_path_falls_back_to_cwd(tmp_path: Path, monkeypatch:
     assert model_lock_manifest_path() == manifest
 
 
+def test_load_model_lock_manifest_normalizes_v2_models_shape(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    manifest = tmp_path / "model_lock_v2.yaml"
+    manifest.write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": 2,
+                "models": {
+                    "depth-anything/DA3METRIC-LARGE": {
+                        "revision": "1" * 40,
+                        "canonical_key": "da3_metric",
+                    }
+                },
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("TP_MODEL_LOCK_MANIFEST", str(manifest))
+
+    payload = load_model_lock_manifest()
+
+    assert payload["manifest_schema_version"] == 2
+    assert payload["repositories"]["depth-anything/DA3METRIC-LARGE"]["canonical_key"] == "da3_metric"
+
+
 def test_da3_inference_pipeline_load_uses_pinned_revision_in_strict_mode(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -228,46 +253,49 @@ def test_da3_inference_pipeline_load_uses_pinned_revision_in_strict_mode(
     from transformation_portal.lux_depth_v3.config import ModelVariant as DA3ModelVariant
 
     manifest_path = tmp_path / "model_lock.yaml"
-    model_id = "depth-anything/Depth-Anything-V3-Metric-Base-hf"
+    model_id = "depth-anything/DA3-BASE"
     pinned = "7" * 40
     _write_manifest(manifest_path, {model_id: {"revision": pinned}})
 
     monkeypatch.setenv("TP_MODEL_LOCK_MANIFEST", str(manifest_path))
     monkeypatch.setenv("TP_STRICT_MODEL_LOCK", "1")
-    monkeypatch.setattr(da3_inference, "TRANSFORMERS_AVAILABLE", True)
-    monkeypatch.setattr(da3_inference, "TORCH_AVAILABLE", True)
     monkeypatch.setattr(
         da3_inference.DA3InferenceEngine,
         "_auto_detect_backend",
         lambda self: da3_inference.ModelBackend.PYTORCH_CPU,
     )
 
-    captured: dict[str, str | int | None] = {}
+    captured: dict[str, str | None] = {}
 
-    class _FakeModel:
-        pass
+    class _FakeDA3Model:
+        def to(self, device: str) -> "_FakeDA3Model":
+            captured["device"] = device
+            return self
 
-    class _FakePipeline:
-        def __init__(self) -> None:
-            self.model = _FakeModel()
+        def eval(self) -> "_FakeDA3Model":
+            captured["eval"] = "true"
+            return self
 
-    def _fake_pipeline(*, task: str, model: str, revision: str | None = None, **kwargs):
-        captured["task"] = task
-        captured["model"] = model
-        captured["revision"] = revision
-        captured["device"] = kwargs.get("device")
-        return _FakePipeline()
+    class _FakeDepthAnything3:
+        @staticmethod
+        def from_pretrained(model: str, **kwargs):
+            captured["model"] = model
+            captured["revision"] = kwargs.get("revision")
+            return _FakeDA3Model()
 
-    monkeypatch.setattr(da3_inference, "pipeline", _fake_pipeline)
+    fake_pkg = types.ModuleType("depth_anything_3")
+    fake_api = types.ModuleType("depth_anything_3.api")
+    fake_api.DepthAnything3 = _FakeDepthAnything3
+    monkeypatch.setitem(sys.modules, "depth_anything_3", fake_pkg)
+    monkeypatch.setitem(sys.modules, "depth_anything_3.api", fake_api)
 
     config = DA3Config(
         model_variant=DA3ModelVariant.METRIC_BASE,
         device=DeviceConfig(device="cpu", use_fp16=False),
     )
     engine = da3_inference.DA3InferenceEngine(config)
-    engine._load_pytorch_model()
+    engine._load_da3_model(model_id)
 
-    assert captured["task"] == "depth-estimation"
     assert captured["model"] == model_id
     assert captured["revision"] == pinned
     assert captured["device"] == "cpu"
@@ -279,46 +307,48 @@ def test_da3_inference_pipeline_load_uses_mps_device_string(tmp_path: Path, monk
     from transformation_portal.lux_depth_v3.config import ModelVariant as DA3ModelVariant
 
     manifest_path = tmp_path / "model_lock.yaml"
-    model_id = "depth-anything/Depth-Anything-V3-Metric-Base-hf"
+    model_id = "depth-anything/DA3-BASE"
     pinned = "6" * 40
     _write_manifest(manifest_path, {model_id: {"revision": pinned}})
 
     monkeypatch.setenv("TP_MODEL_LOCK_MANIFEST", str(manifest_path))
     monkeypatch.setenv("TP_STRICT_MODEL_LOCK", "1")
-    monkeypatch.setattr(da3_inference, "TRANSFORMERS_AVAILABLE", True)
-    monkeypatch.setattr(da3_inference, "TORCH_AVAILABLE", True)
     monkeypatch.setattr(
         da3_inference.DA3InferenceEngine,
         "_auto_detect_backend",
         lambda self: da3_inference.ModelBackend.PYTORCH_MPS,
     )
 
-    captured: dict[str, str | int | None] = {}
+    captured: dict[str, str | None] = {}
 
-    class _FakeModel:
-        pass
+    class _FakeDA3Model:
+        def to(self, device: str) -> "_FakeDA3Model":
+            captured["device"] = device
+            return self
 
-    class _FakePipeline:
-        def __init__(self) -> None:
-            self.model = _FakeModel()
+        def eval(self) -> "_FakeDA3Model":
+            return self
 
-    def _fake_pipeline(*, task: str, model: str, revision: str | None = None, **kwargs):
-        captured["task"] = task
-        captured["model"] = model
-        captured["revision"] = revision
-        captured["device"] = kwargs.get("device")
-        return _FakePipeline()
+    class _FakeDepthAnything3:
+        @staticmethod
+        def from_pretrained(model: str, **kwargs):
+            captured["model"] = model
+            captured["revision"] = kwargs.get("revision")
+            return _FakeDA3Model()
 
-    monkeypatch.setattr(da3_inference, "pipeline", _fake_pipeline)
+    fake_pkg = types.ModuleType("depth_anything_3")
+    fake_api = types.ModuleType("depth_anything_3.api")
+    fake_api.DepthAnything3 = _FakeDepthAnything3
+    monkeypatch.setitem(sys.modules, "depth_anything_3", fake_pkg)
+    monkeypatch.setitem(sys.modules, "depth_anything_3.api", fake_api)
 
     config = DA3Config(
         model_variant=DA3ModelVariant.METRIC_BASE,
         device=DeviceConfig(device="mps", use_fp16=False),
     )
     engine = da3_inference.DA3InferenceEngine(config)
-    engine._load_pytorch_model()
+    engine._load_da3_model(model_id)
 
-    assert captured["task"] == "depth-estimation"
     assert captured["model"] == model_id
     assert captured["revision"] == pinned
     assert captured["device"] == "mps"

--- a/tests/test_orchestrator_backend_integration.py
+++ b/tests/test_orchestrator_backend_integration.py
@@ -34,6 +34,7 @@ def test_orchestrator_uses_registry(tmp_path, mock_da3_available):
     config = EnhanceConfig(
         depth_backend="da3",
         depth_device="cpu",
+        non_commercial_ok=True,
         enable_v2=False,
     )
 
@@ -47,6 +48,7 @@ def test_orchestrator_default_backend(tmp_path, mock_da3_available):
     """Orchestrator defaults to DA3 if no backend specified."""
     config = EnhanceConfig(
         depth_device="cpu",
+        non_commercial_ok=True,
         enable_v2=False,
     )
 
@@ -332,7 +334,7 @@ def test_orchestrator_keeps_da3_default_off_apple_silicon(tmp_path):
             non_commercial_ok=True,
             accept_apple_depth_pro_research_license=True,
             enable_v2=False,
-            use_coreml_backend=True,
+            use_coreml_backend=False,
         )
 
         orchestrator = EnhanceOrchestrator(config, tmp_path)
@@ -348,6 +350,7 @@ def test_orchestrator_canonicalizes_legacy_backend_alias_in_metadata(tmp_path, m
         config = EnhanceConfig(
             depth_backend="depth_anything_v3",
             depth_device="cpu",
+            non_commercial_ok=True,
             enable_v2=False,
         )
 
@@ -376,6 +379,7 @@ def test_orchestrator_backend_metadata_capture(tmp_path, mock_da3_available):
     config = EnhanceConfig(
         depth_backend="da3",
         depth_device="cpu",
+        non_commercial_ok=True,
         enable_v2=False,
     )
 
@@ -604,6 +608,7 @@ def test_depth_metadata_uses_resolved_backend_not_config_default(tmp_path, mock_
     config = EnhanceConfig(
         depth_backend="da3",
         depth_device="cpu",
+        non_commercial_ok=True,
         enable_v2=False,
         enable_materials_v3=False,
     )
@@ -662,6 +667,7 @@ def test_get_or_create_depth_backend_prefers_active_instance_over_stale_cache(tm
     config = EnhanceConfig(
         depth_backend="da3",
         depth_device="cpu",
+        non_commercial_ok=True,
         enable_v2=False,
     )
     orchestrator = EnhanceOrchestrator(config, tmp_path)
@@ -709,6 +715,7 @@ def test_enhance_image_reuses_initialized_backend_metadata_without_recapture(tmp
     config = EnhanceConfig(
         depth_backend="da3",
         depth_device="cpu",
+        non_commercial_ok=True,
         enable_v2=False,
     )
     orchestrator = EnhanceOrchestrator(config, tmp_path)
@@ -740,6 +747,7 @@ def test_apex_gate_evaluates_native_depth_grid_before_artifact_resize(tmp_path, 
     config = EnhanceConfig(
         depth_backend="da3",
         depth_device="cpu",
+        non_commercial_ok=True,
         enable_v2=False,
         quality_tier="apex",
     )

--- a/tests/test_orchestrator_v2_validation.py
+++ b/tests/test_orchestrator_v2_validation.py
@@ -34,12 +34,17 @@ def temp_output():
     shutil.rmtree(tmpdir, ignore_errors=True)
 
 
+def _make_config(**overrides) -> EnhanceConfig:
+    """Build test configs that exercise V2 behavior without tripping DA3 license gating."""
+    return EnhanceConfig(non_commercial_ok=True, **overrides)
+
+
 class TestV2ValidationFailFast:
     """Test V2 script validation and fail-fast behavior."""
 
     def test_v2_enabled_script_missing_raises_error(self, temp_output):
         """Test fail-fast when V2 enabled but script missing."""
-        config = EnhanceConfig(enable_v2=True, v2_preset="default", depth_device="cpu")
+        config = _make_config(enable_v2=True, v2_preset="default", depth_device="cpu")
 
         # Simulate missing script (since scripts/enhance_image.py now exists)
         original_exists = Path.exists
@@ -63,7 +68,7 @@ class TestV2ValidationFailFast:
 
     def test_v2_disabled_no_error_when_script_missing(self, temp_output):
         """Test V2 disabled allows initialization without script."""
-        config = EnhanceConfig(enable_v2=False, v2_preset="default", depth_device="cpu")  # Ignored when enable_v2=False
+        config = _make_config(enable_v2=False, v2_preset="default", depth_device="cpu")  # Ignored when enable_v2=False
 
         # Should succeed even without V2 script
         orchestrator = EnhanceOrchestrator(config=config, output_root=temp_output)
@@ -73,7 +78,7 @@ class TestV2ValidationFailFast:
 
     def test_v2_preset_none_no_error_when_script_missing(self, temp_output):
         """Test v2_preset=None allows initialization without script."""
-        config = EnhanceConfig(enable_v2=True, v2_preset=None, depth_device="cpu")  # None = skip V2
+        config = _make_config(enable_v2=True, v2_preset=None, depth_device="cpu")  # None = skip V2
 
         # Should succeed even without V2 script
         orchestrator = EnhanceOrchestrator(config=config, output_root=temp_output)
@@ -83,7 +88,7 @@ class TestV2ValidationFailFast:
 
     def test_v2_disabled_overrides_preset(self, temp_output):
         """Test enable_v2=False overrides v2_preset."""
-        config = EnhanceConfig(enable_v2=False, v2_preset="premium", depth_device="cpu")  # Should be ignored
+        config = _make_config(enable_v2=False, v2_preset="premium", depth_device="cpu")  # Should be ignored
 
         # Should succeed - enable_v2 takes precedence
         orchestrator = EnhanceOrchestrator(config=config, output_root=temp_output)
@@ -95,7 +100,7 @@ class TestV2ConfigCombinations:
 
     def test_default_config_requires_v2_script(self, temp_output):
         """Test default config expects V2 script to exist."""
-        config = EnhanceConfig()  # Defaults: enable_v2=True, v2_preset="default"
+        config = _make_config()  # Defaults: enable_v2=True, v2_preset="default"
 
         # Simulate missing script
         original_exists = Path.exists
@@ -114,7 +119,7 @@ class TestV2ConfigCombinations:
 
     def test_pbr_only_config_no_v2_required(self, temp_output):
         """Test PBR-only config doesn't require V2 script."""
-        config = EnhanceConfig(enable_v2=False, generate_pbr=True, pbr_normal_strength=1.5, depth_device="cpu")
+        config = _make_config(enable_v2=False, generate_pbr=True, pbr_normal_strength=1.5, depth_device="cpu")
 
         # Should succeed
         orchestrator = EnhanceOrchestrator(config=config, output_root=temp_output)
@@ -127,7 +132,7 @@ class TestV2ErrorMessages:
 
     def test_error_message_contains_solutions(self, temp_output):
         """Test error message provides actionable solutions."""
-        config = EnhanceConfig(enable_v2=True, v2_preset="default")
+        config = _make_config(enable_v2=True, v2_preset="default")
 
         # Simulate missing script
         original_exists = Path.exists
@@ -159,7 +164,7 @@ class TestV2ErrorMessages:
 
     def test_error_message_mentions_pbr_only_workflow(self, temp_output):
         """Test error message mentions PBR-only workflow option."""
-        config = EnhanceConfig(enable_v2=True, v2_preset="default")
+        config = _make_config(enable_v2=True, v2_preset="default")
 
         # Simulate missing script
         original_exists = Path.exists
@@ -183,7 +188,7 @@ class TestV2ConfigMigration:
     def test_old_style_v2_preset_string_still_works(self, temp_output):
         """Test backward compatibility with string v2_preset."""
         # Old style: v2_preset is always a string, enable_v2 controls behavior
-        config = EnhanceConfig(
+        config = _make_config(
             enable_v2=False,
             v2_preset="default",  # Old code would set this
         )
@@ -195,7 +200,7 @@ class TestV2ConfigMigration:
     def test_new_style_v2_preset_optional(self, temp_output):
         """Test new style with Optional[str] v2_preset."""
         # New style: v2_preset=None explicitly skips V2
-        config = EnhanceConfig(
+        config = _make_config(
             enable_v2=True,
             v2_preset=None,  # Explicitly skip V2
         )

--- a/tests/test_provenance_integration.py
+++ b/tests/test_provenance_integration.py
@@ -132,7 +132,7 @@ class TestProvenanceIntegration:
 
         # Validate required fields
         assert "input" in provenance_data
-        assert provenance_data["input"]["file_path"] == str(fixture_path)
+        assert Path(provenance_data["input"]["file_path"]) == fixture_path.resolve()
         assert provenance_data["input"]["file_sha256"]
         assert provenance_data["input"]["file_size_bytes"] > 0
 

--- a/tests/test_run_card_schema.py
+++ b/tests/test_run_card_schema.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -18,6 +19,7 @@ pytestmark = [
 ]
 
 from transformation_portal.lux_depth_v3.config import EnhanceConfig, ModelVariant
+from transformation_portal.lux_depth_v3.model_resolution import ModelRequest, resolve_model_contract
 from transformation_portal.lux_depth_v3.orchestrator import (
     ApexStrictGateError,
     EnhanceOrchestrator,
@@ -622,6 +624,28 @@ def test_run_card_schema_accepts_additive_model_contract(version: str) -> None:
         "manifest_schema_version": 1,
     }
     _validate_run_card_payload(payload, _run_card_schema_path(version))
+
+
+@pytest.mark.parametrize("revision", [None, "main"])
+def test_build_run_card_model_contract_skips_unpinned_revision(
+    revision: str | None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    orch = object.__new__(EnhanceOrchestrator)
+    orch.config = SimpleNamespace(non_commercial_ok=False)
+    resolved = resolve_model_contract(ModelRequest(model_key="da3-metric"))
+    orch._resolved_model_contract = replace(resolved, revision=revision)
+
+    with patch(
+        "transformation_portal.lux_depth_v3.orchestrator.load_model_lock_manifest_payload",
+        return_value={"version": 1},
+    ):
+        with caplog.at_level("WARNING"):
+            model_contract = orch._build_run_card_model_contract()
+
+    assert model_contract is None
+    assert "Skipping run-card model_contract" in caplog.text
+    assert resolved.spec.repo_id in caplog.text
 
 
 def test_collect_run_card_artifacts_includes_reconstruction_report(tmp_path: Path):

--- a/tests/test_run_card_schema.py
+++ b/tests/test_run_card_schema.py
@@ -592,6 +592,38 @@ def test_run_card_schema_accepts_additive_quality_gate_and_capability(version: s
     _validate_run_card_payload(payload, _run_card_schema_path(version))
 
 
+@pytest.mark.parametrize("version", ["v1", "v2"])
+def test_run_card_schema_accepts_additive_model_contract(version: str) -> None:
+    payload = _valid_run_card_payload()
+    payload["run_card_version"] = version
+    if version == "v1":
+        payload["artifact_merkle_root"] = "0" * 64
+    else:
+        payload.pop("artifact_merkle_root", None)
+        payload["artifact_tree"] = {
+            "algorithm": "ct-sha256-v1",
+            "leaf_format": "tp.run_card.artifact_leaf.v1",
+            "leaf_count": 0,
+            "root_sha256": "1" * 64,
+            "artifacts": [],
+        }
+    payload["model_contract"] = {
+        "requested_model_selector": "METRIC_LARGE",
+        "canonical_model_key": "da3_research",
+        "resolved_repo_id": "depth-anything/DA3NESTED-GIANT-LARGE-1.1",
+        "resolved_revision": "b2359bdf726fb44ef62acca04d629dcf158053e7",
+        "license_id": "cc-by-nc-4.0",
+        "usage_class": "non_commercial_only",
+        "requires_non_commercial_ok": True,
+        "non_commercial_ok": True,
+        "backend_kind": "da3_api",
+        "accelerator_kind": "none",
+        "fallback_chain": [],
+        "manifest_schema_version": 1,
+    }
+    _validate_run_card_payload(payload, _run_card_schema_path(version))
+
+
 def test_collect_run_card_artifacts_includes_reconstruction_report(tmp_path: Path):
     output_root = tmp_path / "output"
     manifests_dir = output_root / "manifests"
@@ -976,6 +1008,7 @@ def test_resolve_run_card_backend_model_artifact_prefers_selected_attempt():
 def test_emit_run_card_respects_run_card_include_proofs_flag(tmp_path: Path):
     config = EnhanceConfig(
         model_variant=ModelVariant.METRIC_LARGE,
+        model_key="da3-metric",
         run_card_version="v2",
         run_card_include_proofs=False,
     )
@@ -1028,6 +1061,7 @@ def test_emit_run_card_respects_run_card_include_proofs_flag(tmp_path: Path):
 def test_emit_run_card_skips_legacy_merkle_root_for_v2(tmp_path: Path):
     config = EnhanceConfig(
         model_variant=ModelVariant.METRIC_LARGE,
+        model_key="da3-metric",
         run_card_version="v2",
     )
     orch = EnhanceOrchestrator(config, tmp_path)
@@ -1082,6 +1116,7 @@ def test_emit_run_card_skips_legacy_merkle_root_for_v2(tmp_path: Path):
 def test_build_run_card_inputs_skips_hashing_when_hash_mode_never(tmp_path: Path) -> None:
     config = EnhanceConfig(
         model_variant=ModelVariant.METRIC_LARGE,
+        model_key="da3-metric",
         hash_mode=HashMode.NEVER,
     )
     orch = EnhanceOrchestrator(config, tmp_path)
@@ -1094,7 +1129,7 @@ def test_build_run_card_inputs_skips_hashing_when_hash_mode_never(tmp_path: Path
 
 
 def test_build_run_card_inputs_reuses_result_input_sha256(tmp_path: Path) -> None:
-    config = EnhanceConfig(model_variant=ModelVariant.METRIC_LARGE)
+    config = EnhanceConfig(model_variant=ModelVariant.METRIC_LARGE, model_key="da3-metric")
     orch = EnhanceOrchestrator(config, tmp_path)
     input_path = tmp_path / "inputs" / "image_01.png"
     input_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1120,7 +1155,7 @@ def test_build_run_card_inputs_reuses_result_input_sha256(tmp_path: Path) -> Non
 
 
 def test_build_run_card_inputs_preserves_per_result_input_sha256(tmp_path: Path) -> None:
-    config = EnhanceConfig(model_variant=ModelVariant.METRIC_LARGE)
+    config = EnhanceConfig(model_variant=ModelVariant.METRIC_LARGE, model_key="da3-metric")
     orch = EnhanceOrchestrator(config, tmp_path)
     input_dir = tmp_path / "inputs"
     input_dir.mkdir(parents=True, exist_ok=True)
@@ -1161,7 +1196,7 @@ def test_build_run_card_inputs_preserves_per_result_input_sha256(tmp_path: Path)
 
 
 def test_build_run_card_inputs_omits_size_bytes_when_stat_fails(tmp_path: Path) -> None:
-    config = EnhanceConfig(model_variant=ModelVariant.METRIC_LARGE)
+    config = EnhanceConfig(model_variant=ModelVariant.METRIC_LARGE, model_key="da3-metric")
     orch = EnhanceOrchestrator(config, tmp_path)
     input_path = tmp_path / "inputs" / "image_01.png"
     input_path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- Lux Depth V3 had model-selection drift across CLI defaults, config aliases, backend metadata, and model-lock state, which left the research-default `da3` surface looking commercial-safe and allowed stale DA3/CoreML assumptions to survive in runtime paths.
- This change introduces one registry-backed DA3 model contract and routes the existing Lux Depth V3 surfaces through it while preserving compatibility for `model_variant`, positional engine construction, run-card fingerprints, and the committed v1 manifest shape.

## Changes
- Add `model_registry.py` and `model_resolution.py` with canonical model specs, alias normalization, legacy `ModelVariant` mappings, post-resolution license gating, and fail-closed CoreML eligibility.
- Wire the registry contract through CLI/config/inference/backend/orchestrator paths, preserve `EnhanceConfig.model_variant`, add `model_key` and internal raw repo-id support, and record additive `model_contract` provenance in run cards.
- Normalize model-lock loading across v1/v2 shapes while keeping `config/model_lock_manifest.yaml` committed as v1 and reconciling its DA3/CoreML entries with registry metadata.
- Retire the zero-output DA3 stub, restrict CoreML to the published `apple/coreml-depth-anything-v2-small` artifact, and update docs/tests to match the new `da3` research-default and `da3-metric` Apache relative-depth contract.

## Validation
Proven green:
- `make test-fast`
- `./.venv/bin/pytest tests/lux_depth_v3/test_model_registry_resolution.py tests/test_model_lock.py tests/test_run_card_schema.py -q -p no:cacheprovider --basetemp=/tmp/tp_pytest_registry`
- `./.venv/bin/pytest tests/lux_depth_v3/test_config_resolver.py tests/lux_depth_v3/test_orchestrator_backend_resolution.py tests/test_da3_backend.py tests/test_lux_depth_v3_cli.py tests/test_lux_depth_v3_imports.py -q -p no:cacheprovider --basetemp=/tmp/tp_pytest_registry_wide`
- `./.venv/bin/pytest tests/lux_depth_v3/test_model_registry_resolution.py tests/test_da3_backend.py -q -p no:cacheprovider --basetemp=/tmp/tp_pytest_registry_coreml_cleanup`

Still failing:
- None in the executed validation lanes.
- The full repo pytest suite was not run in this pass.

## Risk
- Compatibility risk is bounded: `model_variant` remains serialized, `DA3InferenceEngine(config)` remains valid, run-card provenance is additive, and the committed lock manifest stays on the v1 `repositories` schema.
- The main behavior change is intentional: bare `da3` now enforces non-commercial acknowledgement before model load, while `da3-metric` is the explicit Apache-2.0 selector for the current Lux V3 relative-depth surface.
- The change is revert-safe because it centralizes selection and policy logic without widening the current consumable depth contract or introducing new public output formats.