### PR TITLE
fix: restore draft preset performance and enable pinned SAM2 video tracking

### DIFF
--- a/scripts/validation/scan_todo_inventory.py
+++ b/scripts/validation/scan_todo_inventory.py
@@ -52,9 +52,7 @@ PYTHON_SCAN_ROOTS = (
 JS_TS_SCAN_ROOT = PROJECT_ROOT / "web"
 
 # TODO patterns to detect
-TODO_PATTERNS = (
-    re.compile(r"#\s*(TODO|FIXME|HACK|XXX)\s*:?\s*(.*)$", re.IGNORECASE),
-)
+TODO_PATTERNS = (re.compile(r"#\s*(TODO|FIXME|HACK|XXX)\s*:?\s*(.*)$", re.IGNORECASE),)
 
 # JS/TS TODO patterns (single-line // comments and block /** */ comments)
 JS_TODO_PATTERNS = (
@@ -65,25 +63,27 @@ JS_TODO_PATTERNS = (
 # Governance reference patterns - TODOs with proper tracking
 GOVERNANCE_REF_PATTERNS = (
     re.compile(r"\(Phase\s*\d+[A-Za-z]?\)", re.IGNORECASE),  # (Phase 3), (Phase 4A)
-    re.compile(r"\(ADR-\d+\)", re.IGNORECASE),              # (ADR-044)
-    re.compile(r"\(#\d+\)"),                                 # (#1234) - issue ref
-    re.compile(r"\(@[\w-]+\)"),                             # (@specialist) - owner
+    re.compile(r"\(ADR-\d+\)", re.IGNORECASE),  # (ADR-044)
+    re.compile(r"\(#\d+\)"),  # (#1234) - issue ref
+    re.compile(r"\(@[\w-]+\)"),  # (@specialist) - owner
     re.compile(r"\([A-Za-z]+_INVENTORY\.md(?:\s+§[\w.-]+)?\)", re.IGNORECASE),  # (TODO_INVENTORY.md), (TODO_INVENTORY.md §3.1)
 )
 
 # Excluded patterns (false positives in security code)
-EXCLUDED_PATTERNS = (
-    re.compile(r"TODO_REPLACE", re.IGNORECASE),  # Security scanner pattern
-)
+EXCLUDED_PATTERNS = (re.compile(r"TODO_REPLACE", re.IGNORECASE),)  # Security scanner pattern
 
 # Self-exclude: this scanner file contains TODO examples in docs
 SELF_EXCLUDE_FILE = "scripts/validation/scan_todo_inventory.py"
 
 # Excluded file paths (relative to project root)
 EXCLUDED_PATH_PATTERNS = (
-    "docs/",                    # Historical documentation markers
+    "docs/",  # Historical documentation markers
     "__pycache__/",
     ".git/",
+    ".next/",
+    ".next-build-verify/",
+    ".next-smoke-",
+    ".next-codex-",
     "node_modules/",
     ".venv/",
     ".runtime/",
@@ -324,9 +324,7 @@ def _extract_comment_todos(source: str, path: Path) -> tuple[list[TodoItem], lis
                     # Include context for multi-line messages (next line if continuation)
                     if lineno < len(lines):
                         next_line = lines[lineno].strip()
-                        if next_line.startswith("#") and not any(
-                            p.search(next_line) for p in TODO_PATTERNS
-                        ):
+                        if next_line.startswith("#") and not any(p.search(next_line) for p in TODO_PATTERNS):
                             continuation = next_line.lstrip("#").strip()
                             if continuation:
                                 message = f"{message} {continuation}"
@@ -493,18 +491,14 @@ def _format_human_readable(result: ScanResult, governance_mode: bool) -> str:
             lines.append("-" * 70)
             ungoverned = [item for item in result.items if not item.has_governance_ref]
             for item in ungoverned:
-                lines.append(
-                    f"  {item.path}:{item.lineno} [{item.todo_type.value}] {item.message[:60]}"
-                )
+                lines.append(f"  {item.path}:{item.lineno} [{item.todo_type.value}] {item.message[:60]}")
         else:
             lines.append("-" * 70)
             lines.append("All TODOs:")
             lines.append("-" * 70)
             for item in result.items:
                 gov_marker = "✓" if item.has_governance_ref else "⚠"
-                lines.append(
-                    f"  {gov_marker} {item.path}:{item.lineno} [{item.todo_type.value}] {item.message[:60]}"
-                )
+                lines.append(f"  {gov_marker} {item.path}:{item.lineno} [{item.todo_type.value}] {item.message[:60]}")
 
     # Errors
     if result.errors:
@@ -590,17 +584,13 @@ def main() -> int:
     # Exit 2: scan errors in governance mode (fail closed)
     if args.check_governance and result.errors:
         if not args.json:
-            print(
-                f"❌ Governance check failed: {len(result.errors)} scan error(s) encountered (fail closed)"
-            )
+            print(f"❌ Governance check failed: {len(result.errors)} scan error(s) encountered (fail closed)")
         return 2
 
     # Exit 1: ungoverned TODOs in governance mode
     if args.check_governance and result.ungoverned_count > 0:
         if not args.json:
-            print(
-                f"❌ Governance check failed: {result.ungoverned_count} ungoverned TODO(s) found"
-            )
+            print(f"❌ Governance check failed: {result.ungoverned_count} ungoverned TODO(s) found")
         return 1
 
     if not args.json:

--- a/src/transformation_portal/lux_depth_v3/pbr_presets.py
+++ b/src/transformation_portal/lux_depth_v3/pbr_presets.py
@@ -78,15 +78,16 @@ FAST_PREVIEW = EnhanceConfig(
     # PBR Generation
     generate_pbr=True,
     save_float_depth=False,  # Speed: use PNG depth (lower precision)
-    # Normal Map - Reduced detail with heavy smoothing
+    # Normal Map - Skip pre-blur to keep preview generation fast
+    # while lower strength limits visual noise.
     pbr_normal_strength=0.8,
-    pbr_normal_blur_radius=2,
-    # Roughness Map - Simplified detail
+    pbr_normal_blur_radius=0,
+    # Roughness Map - Light smoothing for fast preview reads
     pbr_roughness_strength=0.7,
-    pbr_roughness_blur_radius=5,
-    # Ambient Occlusion - Subtle, wide blur
+    pbr_roughness_blur_radius=2,
+    # Ambient Occlusion - Subtle shadows with a bounded blur budget
     pbr_ao_strength=0.8,
-    pbr_ao_blur_radius=8,
+    pbr_ao_blur_radius=4,
     pbr_ao_bias=0.50,
     # Depth Model - Base for speed
     model_variant=ModelVariant.METRIC_BASE,

--- a/src/transformation_portal/spatial_ai/orchestration/pipeline.py
+++ b/src/transformation_portal/spatial_ai/orchestration/pipeline.py
@@ -1444,7 +1444,7 @@ class SpatialAIPipeline:
             # This would require multi-view input or camera pose estimation
             raise NotImplementedError(
                 "3D reconstruction requires multi-view input. "
-                "Single-view reconstruction is not yet implemented. "
+                "Single-view reconstruction is not yet implemented. (TODO_INVENTORY.md) "
                 "Use SceneBuilder directly with multiple views for 3DGS."
             )
 

--- a/src/transformation_portal/spatial_ai/segmentation/sam2_backend.py
+++ b/src/transformation_portal/spatial_ai/segmentation/sam2_backend.py
@@ -3,7 +3,7 @@
 This module wraps Meta's Segment Anything Model 2 (SAM2) for:
 - Automatic mask generation (full image)
 - Prompted segmentation (points/bboxes)
-- Video temporal tracking (stub for future)
+- Video temporal tracking
 
 Architecture:
 - Direct checkpoint loading (not HuggingFace Hub)
@@ -211,6 +211,7 @@ class SAM2Backend:
         self._hf_mask_generator: Any = None
         self._hf_model: Any = None
         self._hf_processor: Any = None
+        self._hf_video_checkpoint_path: Optional[Path] = None
 
         # Material classification (optional)
         self.enable_material_classification = enable_material_classification
@@ -371,12 +372,12 @@ class SAM2Backend:
         """
         # Contract validation already done in SegmentationInput.__post_init__
 
-        # Lazy load model
-        self._load_model()
-
         # Execute segmentation based on mode
         if seg_input.mode == "video":
             return self._segment_video(seg_input)
+
+        # Lazy load model
+        self._load_model()
 
         if self.tiling.enabled and seg_input.mode in self.tiling.apply_to_modes:
             if self.tiled_engine is None:
@@ -782,6 +783,73 @@ class SAM2Backend:
         self._hf_model = hf_model
         self._hf_processor = hf_processor
 
+    @staticmethod
+    def _hf_offline_mode_enabled() -> bool:
+        """Return True when HuggingFace/Transformers offline flags are enabled."""
+        return os.getenv("HF_HUB_OFFLINE") == "1" or os.getenv("TRANSFORMERS_OFFLINE") == "1"
+
+    def _iter_hf_checkpoint_candidates(self) -> tuple[str, ...]:
+        """Return plausible SAM2 checkpoint filenames for pinned repo-backed loads."""
+        default_name = self.DEFAULT_CHECKPOINTS[self.model_size]
+        candidates = [default_name]
+        if default_name.startswith("sam2_"):
+            candidates.append(default_name.replace("sam2_", "sam2.1_", 1))
+        return tuple(dict.fromkeys(candidates))
+
+    def _resolve_hf_video_checkpoint_path(self) -> Path:
+        """Resolve a local checkpoint file for the official SAM2 video predictor path."""
+        if self._hf_video_checkpoint_path is not None and self._hf_video_checkpoint_path.is_file():
+            return self._hf_video_checkpoint_path
+        if not self.repo_id or not self.revision:
+            raise RuntimeError("Pinned repo_id and revision are required for SAM2 video checkpoint resolution")
+
+        try:
+            from huggingface_hub import hf_hub_download, try_to_load_from_cache
+        except ImportError as exc:
+            raise RuntimeError(
+                "repo_id-based SAM2 video tracking requires huggingface_hub to resolve the pinned checkpoint"
+            ) from exc
+
+        candidates = self._iter_hf_checkpoint_candidates()
+        failures: list[str] = []
+        offline = self._hf_offline_mode_enabled()
+
+        for filename in candidates:
+            cached_path: Any = None
+            try:
+                cached_path = try_to_load_from_cache(repo_id=self.repo_id, filename=filename, revision=self.revision)
+            except TypeError:
+                cached_path = try_to_load_from_cache(repo_id=self.repo_id, filename=filename)
+            except (OSError, ValueError) as exc:
+                failures.append(f"{filename}: cache lookup failed ({exc})")
+                cached_path = None
+
+            if isinstance(cached_path, str) and Path(cached_path).is_file():
+                self._hf_video_checkpoint_path = Path(cached_path)
+                return self._hf_video_checkpoint_path
+
+            try:
+                resolved = hf_hub_download(
+                    repo_id=self.repo_id,
+                    filename=filename,
+                    revision=self.revision,
+                    local_files_only=offline,
+                )
+            except Exception as exc:  # pragma: no cover - exercised via focused unit stubs
+                failures.append(f"{filename}: {exc}")
+                continue
+
+            resolved_path = Path(resolved)
+            if resolved_path.is_file():
+                self._hf_video_checkpoint_path = resolved_path
+                return self._hf_video_checkpoint_path
+
+        failure_summary = "; ".join(failures) if failures else "no matching checkpoint candidates found"
+        raise RuntimeError(
+            f"Unable to resolve SAM2 video checkpoint for repo_id={self.repo_id} revision={self.revision}. "
+            f"Tried {', '.join(candidates)}. {failure_summary}"
+        )
+
     def _extract_sam2_predictions(self, output: Any) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
         """Extract masks plus IoU/stability scores from a SAM2 output object.
 
@@ -1174,11 +1242,6 @@ class SAM2Backend:
             RuntimeError: If video tracking fails.
             ImportError: If SAM2 video components missing.
         """
-        if self._hf_model is not None or self._hf_mask_generator is not None:
-            raise NotImplementedError(
-                "Hugging Face repo_id-based SAM2 loading currently supports auto / points / bbox. "
-                "Use the official checkpoint path for video tracking."
-            )
         try:
             from sam2.build_sam import build_sam2_video_predictor
         except ImportError as e:
@@ -1194,10 +1257,19 @@ class SAM2Backend:
         if not hasattr(self, "_video_predictor") or self._video_predictor is None:
             logger.info(f"Loading SAM2 video predictor: {self.model_size} on {self.device}")
             config_name = self.MODEL_CONFIGS[self.model_size]
+            checkpoint_path = (
+                self._resolve_hf_video_checkpoint_path()
+                if self.prefer_hf_pipeline and self.checkpoint_path is None
+                else self.checkpoint_path
+            )
+            if checkpoint_path is None:
+                raise RuntimeError(
+                    "SAM2 video tracking requires either a trusted checkpoint_path or a pinned repo_id/revision"
+                )
 
             self._video_predictor = build_sam2_video_predictor(
                 config_file=config_name,
-                ckpt_path=str(self.checkpoint_path),
+                ckpt_path=str(checkpoint_path),
                 device=self.device,
             )
 

--- a/src/transformation_portal/utils/security.py
+++ b/src/transformation_portal/utils/security.py
@@ -416,7 +416,9 @@ def timeout(seconds: int):
     """
     if not hasattr(signal, "SIGALRM"):
         raise NotImplementedError(
-            "timeout() requires signal.SIGALRM (Unix-only). " "Use multiprocessing or threading-based timeout on Windows."
+            "timeout() requires signal.SIGALRM (Unix-only). "
+            "(TODO_INVENTORY.md §2.4) "
+            "Use multiprocessing or threading-based timeout on Windows."
         )
 
     def timeout_handler(signum, frame):

--- a/tests/spatial_ai/segmentation/test_sam2_backend_contracts.py
+++ b/tests/spatial_ai/segmentation/test_sam2_backend_contracts.py
@@ -162,6 +162,88 @@ def test_hf_loader_reuses_pipeline_components_when_available(
     assert backend._hf_processor is fake_processor
 
 
+def test_video_mode_uses_cached_repo_checkpoint_without_loading_image_pipeline(
+    segmentation_surface: tuple[Any, Any], tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    SAM2Backend, SegmentationInput = segmentation_surface
+    cached_checkpoint = tmp_path / "sam2.1_hiera_large.pt"
+    cached_checkpoint.write_bytes(b"stub-checkpoint")
+    video_dir = tmp_path / "video_frames"
+    video_dir.mkdir()
+    (video_dir / "00000.jpg").write_bytes(b"frame")
+
+    hub_module = ModuleType("huggingface_hub")
+    hub_module.try_to_load_from_cache = lambda *, repo_id=None, filename=None, revision=None: str(cached_checkpoint)
+    hub_module.hf_hub_download = lambda **_kwargs: (_ for _ in ()).throw(
+        AssertionError("hf_hub_download should not run when cached checkpoint exists")
+    )
+    monkeypatch.setitem(sys.modules, "huggingface_hub", hub_module)
+
+    build_calls: list[dict[str, Any]] = []
+
+    class _FakeVideoPredictor:
+        def init_state(self, **kwargs: Any) -> dict[str, Any]:
+            assert kwargs["video_path"] == str(video_dir)
+            return {"num_frames": 1, "video_height": 8, "video_width": 8}
+
+        def add_new_points(self, **kwargs: Any) -> tuple[None, np.ndarray, np.ndarray]:
+            assert kwargs["frame_idx"] == 0
+            assert kwargs["obj_id"] == 1
+            return None, np.array([1], dtype=np.int32), np.ones((1, 8, 8), dtype=np.float32)
+
+        def propagate_in_video(self, inference_state: dict[str, Any]):
+            del inference_state
+            yield 0, np.array([1], dtype=np.int32), np.ones((1, 8, 8), dtype=np.float32)
+
+        def reset_state(self, inference_state: dict[str, Any]) -> None:
+            del inference_state
+
+    sam2_module = ModuleType("sam2")
+    build_module = ModuleType("sam2.build_sam")
+
+    def _build_video_predictor(*, config_file: str, ckpt_path: str, device: str) -> _FakeVideoPredictor:
+        build_calls.append({"config_file": config_file, "ckpt_path": ckpt_path, "device": device})
+        return _FakeVideoPredictor()
+
+    build_module.build_sam2_video_predictor = _build_video_predictor
+    sam2_module.build_sam = build_module
+    monkeypatch.setitem(sys.modules, "sam2", sam2_module)
+    monkeypatch.setitem(sys.modules, "sam2.build_sam", build_module)
+
+    backend = SAM2Backend(
+        model_size="large",
+        device="cpu",
+        repo_id=SAM2_REPO_ID,
+        revision=PINNED_REVISION,
+        prefer_hf_pipeline=True,
+    )
+    monkeypatch.setattr(
+        backend,
+        "_load_model",
+        lambda: (_ for _ in ()).throw(AssertionError("_load_model should be skipped for video mode")),
+    )
+
+    seg_input = SegmentationInput(
+        image=None,
+        gamma=1.0,
+        mode="video",
+        video_path=str(video_dir),
+        prompts={"frame_idx": 0, "object_id": 1, "points": [[2, 3]], "labels": [1]},
+    )
+
+    result = backend.segment(seg_input)
+
+    assert build_calls == [
+        {
+            "config_file": backend.MODEL_CONFIGS["large"],
+            "ckpt_path": str(cached_checkpoint),
+            "device": "cpu",
+        }
+    ]
+    assert result.masks.shape == (1, 8, 8)
+    assert result.temporal_ids.tolist() == [1]
+
+
 def test_clone_for_device_preserves_loading_contract(segmentation_surface: tuple[Any, Any], checkpoint_path: str) -> None:
     SAM2Backend, _ = segmentation_surface
     backend = SAM2Backend(

--- a/tests/spatial_ai/segmentation/test_sam2_backend_contracts.py
+++ b/tests/spatial_ai/segmentation/test_sam2_backend_contracts.py
@@ -352,10 +352,11 @@ def test_hf_prompted_points_keep_sam2_processor_nesting(
         def __init__(self, value: Any) -> None:
             self.value = value
 
-        def to(self, device: Any) -> FakeTensor:
+        def to(self, device: Any) -> Any:
+            del device
             return self
 
-        def cpu(self) -> FakeTensor:
+        def cpu(self) -> Any:
             return self
 
     processor_calls: list[dict[str, Any]] = []
@@ -384,7 +385,11 @@ def test_hf_prompted_points_keep_sam2_processor_nesting(
 
     backend._hf_model = FakeModel()
     backend._hf_processor = FakeProcessor()
-    monkeypatch.setitem(sys.modules, "torch", SimpleNamespace(no_grad=lambda: _NoGrad()))
+
+    def _no_grad() -> _NoGrad:
+        return _NoGrad()
+
+    monkeypatch.setitem(sys.modules, "torch", SimpleNamespace(no_grad=_no_grad))
 
     result = backend._segment_prompted(_points_input(SegmentationInput))
 

--- a/tests/stress/test_stress_large_batch.py
+++ b/tests/stress/test_stress_large_batch.py
@@ -20,6 +20,23 @@ from transformation_portal.lux_depth_v3.pbr_cli import app
 pytestmark = [pytest.mark.stress, pytest.mark.slow]
 
 
+def _measure_best_elapsed(runner: CliRunner, args: list[str], repeats: int = 2) -> tuple[float, object]:
+    """Return the fastest successful CLI run to reduce scheduler noise."""
+    best_elapsed: float | None = None
+    best_result = None
+    for _ in range(repeats):
+        start = time.perf_counter()
+        result = runner.invoke(app, args)
+        elapsed = time.perf_counter() - start
+        assert result.exit_code == 0, result.stdout
+        if best_elapsed is None or elapsed < best_elapsed:
+            best_elapsed = elapsed
+            best_result = result
+    assert best_elapsed is not None
+    assert best_result is not None
+    return best_elapsed, best_result
+
+
 @pytest.fixture
 def large_batch(tmp_path):
     """Create a large batch of synthetic depth files for stress testing."""
@@ -281,9 +298,8 @@ class TestPerformanceBenchmarks:
         runner = CliRunner()
 
         # Measure time for standard preset
-        start = time.time()
-        result = runner.invoke(
-            app,
+        standard_time, _ = _measure_best_elapsed(
+            runner,
             [
                 "generate",
                 "--depth",
@@ -294,15 +310,11 @@ class TestPerformanceBenchmarks:
                 str(output_dir),
             ],
         )
-        standard_time = time.time() - start
-
-        assert result.exit_code == 0
 
         # Measure time for draft preset (should be faster)
         output_dir2 = tmp_path / "output2"
-        start = time.time()
-        result = runner.invoke(
-            app,
+        draft_time, _ = _measure_best_elapsed(
+            runner,
             [
                 "generate",
                 "--depth",
@@ -313,19 +325,13 @@ class TestPerformanceBenchmarks:
                 str(output_dir2),
             ],
         )
-        draft_time = time.time() - start
-
-        assert result.exit_code == 0
 
         print(f"\nPerformance baseline (1024x1024):")
         print(f"  Standard preset: {standard_time:.3f}s")
         print(f"  Draft preset:    {draft_time:.3f}s")
-
-        # NOTE: Currently draft preset is actually slower than standard
-        # This may indicate a performance regression or incorrect preset configuration
-        # For now, we just verify both presets complete successfully
-        # and track timing for regression detection
-        # TODO: Investigate why draft is slower than expected (expected: draft < standard)
+        assert (
+            draft_time <= standard_time * 1.10
+        ), f"Draft preset regressed beyond tolerance: draft={draft_time:.3f}s standard={standard_time:.3f}s"
 
     def test_throughput_by_preset(self, tmp_path):
         """Compare throughput across different presets."""
@@ -344,10 +350,8 @@ class TestPerformanceBenchmarks:
         times = {}
         for preset in presets:
             output_dir = tmp_path / f"output_{preset}"
-
-            start = time.time()
-            result = runner.invoke(
-                app,
+            elapsed, _ = _measure_best_elapsed(
+                runner,
                 [
                     "generate",
                     "--depth-dir",
@@ -358,23 +362,16 @@ class TestPerformanceBenchmarks:
                     str(output_dir),
                 ],
             )
-            elapsed = time.time() - start
-
-            assert result.exit_code == 0
             times[preset] = elapsed
 
         print(f"\nThroughput by preset ({num_files} images):")
         for preset, elapsed in times.items():
             throughput = num_files / elapsed
             print(f"  {preset:8s}: {elapsed:.2f}s ({throughput:.1f} img/s)")
-
-        # NOTE: Current behavior shows premium is fastest, draft is slowest
-        # This is opposite of expected behavior (draft should be fastest for throughput)
-        # For now, we just verify all presets complete and report timings
-        # TODO: Investigate preset performance ordering regression
-        #
-        # Expected: draft < standard < premium (in time)
-        # Actual: premium < standard < draft (in time)
+        assert times["draft"] <= times["standard"] * 1.10, (
+            f"Draft batch throughput regressed beyond tolerance: draft={times['draft']:.3f}s "
+            f"standard={times['standard']:.3f}s"
+        )
 
 
 @pytest.mark.stress

--- a/tests/stress/test_stress_large_batch.py
+++ b/tests/stress/test_stress_large_batch.py
@@ -17,6 +17,8 @@ from typer.testing import CliRunner
 
 from transformation_portal.lux_depth_v3.pbr_cli import app
 
+# pylint: disable=redefined-outer-name
+
 pytestmark = [pytest.mark.stress, pytest.mark.slow]
 
 
@@ -111,7 +113,7 @@ class TestLargeBatchProcessing:
 
         # Calculate throughput
         throughput = num_files / elapsed
-        print(f"\nStress test performance:")
+        print("\nStress test performance:")
         print(f"  Total time: {elapsed:.1f}s")
         print(f"  Throughput: {throughput:.2f} images/sec")
         print(f"  Avg time per image: {elapsed/num_files:.2f}s")
@@ -164,7 +166,7 @@ class TestLargeBatchProcessing:
         # Memory growth should be reasonable
         # Allow up to 2GB growth for 20x 2048x2048 images
         max_growth_mb = 2000
-        print(f"\nMemory usage:")
+        print("\nMemory usage:")
         print(f"  Before: {mem_before:.1f} MB")
         print(f"  After:  {mem_after:.1f} MB")
         print(f"  Delta:  {mem_delta:.1f} MB")
@@ -326,7 +328,7 @@ class TestPerformanceBenchmarks:
             ],
         )
 
-        print(f"\nPerformance baseline (1024x1024):")
+        print("\nPerformance baseline (1024x1024):")
         print(f"  Standard preset: {standard_time:.3f}s")
         print(f"  Draft preset:    {draft_time:.3f}s")
         assert (

--- a/tests/test_pbr_presets.py
+++ b/tests/test_pbr_presets.py
@@ -2,11 +2,6 @@
 
 import pytest
 
-# Pytest markers
-pytestmark = [
-    pytest.mark.unit,
-]
-
 from transformation_portal.lux_depth_v3.config import EnhanceConfig, ModelVariant
 from transformation_portal.lux_depth_v3.pbr_presets import (
     FABRIC_OPTIMIZED,
@@ -20,6 +15,11 @@ from transformation_portal.lux_depth_v3.pbr_presets import (
     get_preset,
     list_presets,
 )
+
+# Pytest markers
+pytestmark = [
+    pytest.mark.unit,
+]
 
 
 class TestPresetConfiguration:

--- a/tests/test_pbr_presets.py
+++ b/tests/test_pbr_presets.py
@@ -197,11 +197,11 @@ class TestFastPreviewPreset:
         """Draft should use base model for speed."""
         assert FAST_PREVIEW.model_variant == ModelVariant.METRIC_BASE
 
-    def test_draft_heavy_smoothing(self):
-        """Draft should use heavy smoothing to hide artifacts."""
-        assert FAST_PREVIEW.pbr_normal_blur_radius >= 2
-        assert FAST_PREVIEW.pbr_roughness_blur_radius >= 5
-        assert FAST_PREVIEW.pbr_ao_blur_radius >= 8
+    def test_draft_blur_budget_stays_below_standard(self):
+        """Draft should keep a lighter blur budget than standard for speed."""
+        assert FAST_PREVIEW.pbr_normal_blur_radius <= STANDARD_QUALITY.pbr_normal_blur_radius
+        assert FAST_PREVIEW.pbr_roughness_blur_radius <= STANDARD_QUALITY.pbr_roughness_blur_radius
+        assert FAST_PREVIEW.pbr_ao_blur_radius < STANDARD_QUALITY.pbr_ao_blur_radius
 
     def test_draft_lower_strength_parameters(self):
         """Draft should have lower strength for speed."""
@@ -319,6 +319,18 @@ class TestPresetConsistency:
 class TestPresetPerformanceCharacteristics:
     """Test performance-related preset characteristics."""
 
+    @staticmethod
+    def _blur_work_score(config: EnhanceConfig) -> int:
+        return sum(
+            (2 * radius) + 1
+            for radius in (
+                config.pbr_normal_blur_radius,
+                config.pbr_roughness_blur_radius,
+                config.pbr_ao_blur_radius,
+            )
+            if radius > 0
+        )
+
     def test_draft_optimized_for_speed(self):
         """Draft should prioritize speed over quality."""
         # Smaller model
@@ -328,6 +340,7 @@ class TestPresetPerformanceCharacteristics:
         # Lower strength (less computation)
         assert FAST_PREVIEW.pbr_normal_strength < 1.0
         assert FAST_PREVIEW.pbr_roughness_strength < 1.0
+        assert self._blur_work_score(FAST_PREVIEW) < self._blur_work_score(STANDARD_QUALITY)
 
     def test_premium_optimized_for_quality(self):
         """Premium should prioritize quality over speed."""

--- a/tests/validation/test_scan_todo_inventory.py
+++ b/tests/validation/test_scan_todo_inventory.py
@@ -17,6 +17,8 @@ from types import ModuleType
 
 import pytest
 
+# pylint: disable=redefined-outer-name,unnecessary-lambda
+
 # Mark all tests in this module as unit tests (ADR-044)
 pytestmark = [
     pytest.mark.unit,

--- a/tests/validation/test_scan_todo_inventory.py
+++ b/tests/validation/test_scan_todo_inventory.py
@@ -153,6 +153,15 @@ class TestTodoDetectionInPythonFiles:
         assert "HACK" in types
 
 
+class TestExcludedPaths:
+    """Tests for generated/ignored path exclusions."""
+
+    def test_next_build_outputs_are_excluded(self, scanner_module: ModuleType) -> None:
+        assert scanner_module._is_excluded_path(Path("web/secure-landing/.next/dev/server/chunks/a.js")) is True
+        assert scanner_module._is_excluded_path(Path("web/secure-landing/.next-build-verify/server/a.js")) is True
+        assert scanner_module._is_excluded_path(Path("web/secure-landing/.next-smoke-123/server/a.js")) is True
+
+
 # ============================================================================
 # TEST: Abstract NotImplementedError Patterns
 # ============================================================================


### PR DESCRIPTION
## Summary
- Draft preset timing had regressed behind standard, repo_id-based SAM2 video mode was still blocked, and generated Next.js output was polluting TODO governance scans.
- This change makes the smallest safe contract updates to restore the draft speed budget, enable pinned repo-backed SAM2 video checkpoint resolution, and keep the TODO inventory focused on tracked source work.

## Changes
- Reduced the draft PBR preset blur budget and replaced observational stress TODOs with enforced draft-vs-standard performance assertions.
- Routed SAM2 video mode before image-pipeline loading and resolved a pinned local checkpoint from Hugging Face cache or download for the official video predictor path.
- Excluded .next build outputs from TODO scans, added focused scanner coverage, and added governance references to the remaining deferred Windows timeout and single-view reconstruction limits.
- Updated preset and SAM2 contract tests; no route, selector, auth, or CLI surface changes beyond enforcing the existing draft performance expectation.

## Validation
Proven green
- ./.venv/bin/pytest -p no:cacheprovider tests/test_pbr_presets.py tests/validation/test_scan_todo_inventory.py tests/spatial_ai/segmentation/test_sam2_backend_contracts.py -q
- ./.venv/bin/pytest -p no:cacheprovider tests/stress/test_stress_large_batch.py -k "baseline_single_image_performance or throughput_by_preset" -q
- ./.venv/bin/python scripts/validation/scan_todo_inventory.py --check-governance
- ./.venv/bin/pytest -p no:cacheprovider tests/utils/test_security.py tests/security/test_security_utils.py tests/spatial_ai/orchestration/test_pipeline.py -k "timeout_raises_on_windows or timeout_raises_not_implemented_on_windows or run_reconstruction_not_implemented" -q

Still failing
- None in the scoped validation set.

Not run
- make test-fast
- make ci

## Risk
- Compatibility risk is bounded to draft preset tuning, SAM2 repo_id video loading, and TODO scanner exclusions for generated frontdoor output.
- The change is revert-safe: it does not alter public routes, auth, selectors, or CLI flags, and deferred platform limits remain fail-closed with governance references.