### PR TITLE
fix(portal-backend): harden routing, dispatch, artifacts, telemetry, and lifespan

### DIFF
--- a/app.py
+++ b/app.py
@@ -610,6 +610,74 @@ def _trusted_allowed_entry(
     return None
 
 
+_UNSAFE_PATH_SEGMENT_RE = re.compile(r"[\x00/\\]")
+
+
+def _trusted_existing_dir(value: str, allowed_roots: List[Path]) -> Optional[Path]:
+    """Return ``value`` as a trusted existing directory inside an allowed root.
+
+    Resolves the user-supplied string against the allowlist and then walks
+    each segment via :func:`_trusted_allowed_entry` (``iterdir`` based). When
+    the full path resolves to an existing directory, the trusted ``Path`` is
+    returned; otherwise ``None``. Callers must not pass any other user-derived
+    string to subsequent filesystem APIs.
+    """
+
+    try:
+        resolved = _resolve_allowed_request_path(value, allowed_roots)
+    except _PortalValidationReasonError:
+        return None
+    trusted = _trusted_allowed_entry(resolved, allowed_roots)
+    if trusted is None:
+        return None
+    try:
+        if not trusted.is_dir():
+            return None
+    except OSError:
+        return None
+    return trusted
+
+
+def _trusted_creatable_dir(value: str, allowed_roots: List[Path]) -> Optional[Path]:
+    """Return ``value`` as a trusted directory path safe to ``mkdir`` later.
+
+    Walks each existing segment via ``Path.iterdir()`` (so pre-existing
+    components are validated against the parent's children rather than
+    by-string) and validates the names of any non-existent trailing segments
+    against :data:`_UNSAFE_PATH_SEGMENT_RE` to defeat traversal injection.
+    """
+
+    try:
+        resolved = _resolve_allowed_request_path(value, allowed_roots)
+    except _PortalValidationReasonError:
+        return None
+    for root in allowed_roots:
+        try:
+            root_real = Path(os.path.realpath(root))
+            relative_parts = resolved.relative_to(root_real).parts
+        except (OSError, RuntimeError, ValueError):
+            continue
+        current = root_real
+        creating = False
+        for part in relative_parts:
+            if part in {"", ".", ".."} or _UNSAFE_PATH_SEGMENT_RE.search(part):
+                return None
+            if creating:
+                current = current / part
+                continue
+            try:
+                next_path = next((child for child in current.iterdir() if child.name == part), None)
+            except (NotADirectoryError, FileNotFoundError, OSError, RuntimeError, ValueError):
+                return None
+            if next_path is None:
+                creating = True
+                current = current / part
+            else:
+                current = next_path
+        return current
+    return None
+
+
 def _ensure_safe_regular_file_path(path_value: Path, allowed_roots: List[Path]) -> Path:
     try:
         candidate_real = _resolve_allowed_request_path(str(path_value), allowed_roots)
@@ -752,9 +820,13 @@ CANCEL_GRACE_SECONDS = _env_float(
 )
 JOB_LIST_LIMIT = _env_int("TP_JOB_LIST_LIMIT", 200, minimum=1)
 MAX_INDEXED_ARTIFACTS = _env_int("TP_MAX_INDEXED_ARTIFACTS", 200, minimum=1)
+# Keep fingerprinting inexpensive by default. Up to MAX_INDEXED_ARTIFACTS files
+# are hashed per job (off the event loop via asyncio.to_thread); deployments
+# that need copy-friendly hashes for larger artifacts can opt in via the env
+# override.
 ARTIFACT_FINGERPRINT_MAX_BYTES = _env_int(
     "TP_ARTIFACT_FINGERPRINT_MAX_BYTES",
-    256 * 1024 * 1024,
+    8 * 1024 * 1024,
     minimum=1024,
 )
 _ARTIFACT_FINGERPRINT_CHUNK_BYTES = 1024 * 1024
@@ -2035,9 +2107,7 @@ def _enforce_dispatch_value_preflight(
                 extra={"pipeline": pipeline},
             )
 
-        device_value = str(
-            _pick(execution_args, "depth_device", "depthDevice", default="") or ""
-        ).strip().lower()
+        device_value = str(_pick(execution_args, "depth_device", "depthDevice", default="") or "").strip().lower()
         if device_value and device_value not in ALLOWED_DEPTH_DEVICES:
             raise JobPreflightError(
                 "invalid_depth_device",
@@ -2047,9 +2117,7 @@ def _enforce_dispatch_value_preflight(
                 extra={"pipeline": pipeline},
             )
 
-        run_card_value = str(
-            _pick(execution_args, "run_card_version", "runCardVersion", default="") or ""
-        ).strip().lower()
+        run_card_value = str(_pick(execution_args, "run_card_version", "runCardVersion", default="") or "").strip().lower()
         if run_card_value and run_card_value not in ALLOWED_RUN_CARD_VERSIONS:
             raise JobPreflightError(
                 "invalid_run_card_version",
@@ -2063,27 +2131,25 @@ def _enforce_dispatch_value_preflight(
 def _enforce_dispatch_filesystem_preflight(
     pipeline: str,
     execution_args: Dict[str, Any],
-) -> None:
-    """Verify that required filesystem inputs exist before dispatching a job.
+) -> Optional[Path]:
+    """Read-only validation of dispatch filesystem inputs.
 
-    Path allowlist validation is already done by ``_argv_from_request``; this
-    extra pass catches the ``passes-preview/fails-in-runner`` gap where a
-    syntactically valid path simply does not exist on disk, or the output
-    directory cannot be written to. Raises :class:`JobPreflightError` with a
-    portal-safe reason on failure.
+    Verifies that ``input_dir`` exists inside an allowed root and returns the
+    trusted ``output_dir`` Path that the caller should ``mkdir`` *after* the
+    job admission gate succeeds (so a 429 reject does not leave behind empty
+    directories under load). Each path component is walked via
+    :func:`_trusted_existing_dir` / :func:`_trusted_creatable_dir`, which
+    iterate ``Path.iterdir()`` rather than passing user-controlled strings to
+    filesystem APIs — this also satisfies the CodeQL ``py/path-injection``
+    detector.
+
+    Raises :class:`JobPreflightError` with a portal-safe reason on failure.
     """
 
-    input_dir_raw = str(
-        _pick(execution_args, "input_dir", "inputDir", default="")
-    ).strip()
+    input_dir_raw = str(_pick(execution_args, "input_dir", "inputDir", default="")).strip()
     if input_dir_raw:
-        try:
-            input_dir_resolved = _resolve_allowed_request_path(
-                input_dir_raw, ALLOWED_INPUT_ROOTS
-            )
-        except _PortalValidationReasonError:
-            input_dir_resolved = None
-        if input_dir_resolved is None or not input_dir_resolved.is_dir():
+        input_dir_trusted = _trusted_existing_dir(input_dir_raw, ALLOWED_INPUT_ROOTS)
+        if input_dir_trusted is None:
             raise JobPreflightError(
                 "input_dir_required",
                 field="input_dir",
@@ -2092,42 +2158,62 @@ def _enforce_dispatch_filesystem_preflight(
                 extra={"pipeline": pipeline},
             )
 
-    output_dir_raw = str(
-        _pick(execution_args, "output_dir", "outputDir", default="")
-    ).strip()
-    if output_dir_raw:
-        try:
-            output_dir_resolved = _resolve_allowed_request_path(
-                output_dir_raw, ALLOWED_OUTPUT_ROOTS
-            )
-        except _PortalValidationReasonError:
-            output_dir_resolved = None
-        if output_dir_resolved is None:
-            raise JobPreflightError(
-                "output_dir_unwritable",
-                field="output_dir",
-                message="The output directory or its parent is not writable.",
-                status_code=400,
-                extra={"pipeline": pipeline},
-            )
-        try:
-            output_dir_resolved.mkdir(parents=True, exist_ok=True)
-        except OSError:
-            raise JobPreflightError(
-                "output_dir_unwritable",
-                field="output_dir",
-                message="The output directory or its parent is not writable.",
-                status_code=400,
-                extra={"pipeline": pipeline},
-            ) from None
-        if not os.access(str(output_dir_resolved), os.W_OK):
-            raise JobPreflightError(
-                "output_dir_unwritable",
-                field="output_dir",
-                message="The output directory or its parent is not writable.",
-                status_code=400,
-                extra={"pipeline": pipeline},
-            )
+    output_dir_raw = str(_pick(execution_args, "output_dir", "outputDir", default="")).strip()
+    if not output_dir_raw:
+        return None
+
+    output_dir_trusted = _trusted_creatable_dir(output_dir_raw, ALLOWED_OUTPUT_ROOTS)
+    if output_dir_trusted is None:
+        raise JobPreflightError(
+            "output_dir_unwritable",
+            field="output_dir",
+            message="The output directory or its parent is not writable.",
+            status_code=400,
+            extra={"pipeline": pipeline},
+        )
+    # Confirm the deepest existing ancestor is writable without creating
+    # anything yet; the actual mkdir happens after admission succeeds.
+    existing_ancestor = output_dir_trusted
+    while not existing_ancestor.exists():
+        parent = existing_ancestor.parent
+        if parent == existing_ancestor:
+            break
+        existing_ancestor = parent
+    if not os.access(str(existing_ancestor), os.W_OK):
+        raise JobPreflightError(
+            "output_dir_unwritable",
+            field="output_dir",
+            message="The output directory or its parent is not writable.",
+            status_code=400,
+            extra={"pipeline": pipeline},
+        )
+    return output_dir_trusted
+
+
+def _materialize_dispatch_output_dir(
+    pipeline: str,
+    output_dir_trusted: Optional[Path],
+) -> None:
+    """Create the trusted output directory after job admission succeeds.
+
+    Splitting mkdir from preflight prevents accumulation of empty directories
+    when dispatch is rejected post-preflight (e.g. by the concurrency gate).
+    The path here was validated component-by-component via iterdir(); only
+    the final ``mkdir`` is necessary to materialise it.
+    """
+
+    if output_dir_trusted is None:
+        return
+    try:
+        output_dir_trusted.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        raise JobPreflightError(
+            "output_dir_unwritable",
+            field="output_dir",
+            message="The output directory or its parent is not writable.",
+            status_code=400,
+            extra={"pipeline": pipeline},
+        ) from None
 
 
 HTTP_STATUS_ERROR_CODES = {
@@ -2620,10 +2706,7 @@ _LOG_REDACT_KV_KEYS = (
 
 _LOG_REDACTION_PATTERNS: Tuple[Tuple[re.Pattern[str], str], ...] = (
     (
-        re.compile(
-            r"(?i)(authorization|proxy-authorization)\s*:\s*"
-            r"(?:bearer|basic|digest|token|apikey)\s+\S+"
-        ),
+        re.compile(r"(?i)(authorization|proxy-authorization)\s*:\s*" r"(?:bearer|basic|digest|token|apikey)\s+\S+"),
         r"\1: <redacted>",
     ),
     (
@@ -2632,9 +2715,7 @@ _LOG_REDACTION_PATTERNS: Tuple[Tuple[re.Pattern[str], str], ...] = (
     ),
     (
         re.compile(
-            r"(?i)(^|[^A-Za-z0-9])("
-            + "|".join(re.escape(key) for key in _LOG_REDACT_KV_KEYS)
-            + r")(\s*[:=]\s*)([^\s,;]+)"
+            r"(?i)(^|[^A-Za-z0-9])(" + "|".join(re.escape(key) for key in _LOG_REDACT_KV_KEYS) + r")(\s*[:=]\s*)([^\s,;]+)"
         ),
         r"\1\2\3<redacted>",
     ),
@@ -3521,9 +3602,7 @@ def _build_lux_config_preview(
     path_errors_by_field = _preview_path_errors_by_field(path_errors)
 
     normalized_args: Dict[str, Any] = {}
-    preset_raw = str(
-        _pick(args, "preset", default=defaults["preset"]) or defaults["preset"]
-    ).strip()
+    preset_raw = str(_pick(args, "preset", default=defaults["preset"]) or defaults["preset"]).strip()
     allowed_preset_names = _allowed_preset_names("lux-depth-v3")
     if allowed_preset_names and preset_raw and preset_raw not in allowed_preset_names:
         errors.append(
@@ -5382,9 +5461,7 @@ def _build_scoped_job_artifacts(
         )
         for relative_path, path in selected_candidates
     ]
-    selected_lookup = {
-        relative_path: path for relative_path, path in selected_candidates
-    }
+    selected_lookup = {relative_path: path for relative_path, path in selected_candidates}
     return items, selected_lookup, truncated
 
 
@@ -7074,9 +7151,16 @@ def _portal_html_response() -> Response:
 
 
 @app.get("/")
-async def serve_ui() -> Response:
+async def serve_ui(request: Request) -> Response:
+    # Preserve the original query string so legacy/deep links such as
+    # ``/?view=review`` continue to land on the correct workspace tab after
+    # the redirect to the canonical ``/portal`` route.
+    query = request.url.query
+    target = "/portal"
+    if query:
+        target = f"{target}?{query}"
     return RedirectResponse(
-        url="/portal",
+        url=target,
         status_code=307,
         headers={"Cache-Control": "no-store"},
     )
@@ -7513,7 +7597,9 @@ async def create_job(payload: Dict[str, Any]) -> JSONResponse:
         )
 
     try:
-        _enforce_dispatch_filesystem_preflight(pipeline, execution_args)
+        # Read-only filesystem preflight: validates paths and returns the
+        # trusted output_dir to materialise *after* admission succeeds.
+        trusted_output_dir = _enforce_dispatch_filesystem_preflight(pipeline, execution_args)
     except JobPreflightError as exc:
         status_code = int(exc.status_code)
         field = str(exc.field or "payload")
@@ -7553,6 +7639,21 @@ async def create_job(payload: Dict[str, Any]) -> JSONResponse:
                     "max_concurrent_jobs": MAX_CONCURRENT_JOBS,
                 },
             )
+        # Materialise output_dir only after admission succeeds so 429-rejected
+        # requests never leave behind directories on disk.
+        try:
+            _materialize_dispatch_output_dir(pipeline, trusted_output_dir)
+        except JobPreflightError as exc:
+            status_code = int(exc.status_code)
+            field = str(exc.field or "payload")
+            reason = _portal_reason_code(exc.reason)
+            del exc
+            return _error_response(
+                status_code,
+                code="INVALID_ARGUMENT",
+                message=_portal_safe_error_message(reason, field=field),
+                details={"field": field, "reason": reason},
+            )
         jid = "job_" + uuid.uuid4().hex[:8]
         effective_request = {"pipeline": pipeline, "args": dict(execution_args)}
         job = Job(id=jid, created_at=_now(), request=payload, effective_request=effective_request)
@@ -7584,9 +7685,7 @@ async def list_jobs(limit: int = JOB_LIST_LIMIT) -> JSONResponse:
         key=lambda item: item.created_at,
         reverse=True,
     )
-    serialized = [
-        _serialize_job(job, include_logs=False) for job in jobs_sorted[:bounded_limit]
-    ]
+    serialized = [_serialize_job(job, include_logs=False) for job in jobs_sorted[:bounded_limit]]
 
     return JSONResponse(
         _api_envelope(
@@ -7663,7 +7762,10 @@ async def get_job_artifact(job_id: str, artifact_path: str) -> Response:
 
     if not job.artifact_lookup:
         if not _hydrate_artifact_lookup_from_items(job):
-            _index_job_artifacts(job)
+            # Fingerprint computation can do bounded synchronous IO; offload
+            # the indexing pass to a worker thread to keep the event loop
+            # responsive for SSE subscribers and concurrent API callers.
+            await asyncio.to_thread(_index_job_artifacts, job)
     resolved_artifact = job.artifact_lookup.get(requested_relative_path)
     if resolved_artifact is None:
         return _error_response(
@@ -7933,8 +8035,10 @@ async def _run_job(job: Job, argv: List[str]) -> None:
         # Index artifacts and publish terminal events BEFORE setting finished_at.
         # This ensures late-connecting SSE clients can deterministically check
         # done_published_at to know if they need to wait for real events or can
-        # safely synthesize a 'done' from job state.
-        indexed_artifacts = _index_job_artifacts(job)
+        # safely synthesize a 'done' from job state. Indexing also computes
+        # bounded SHA-256 fingerprints, so run it in a worker thread to keep
+        # the event loop responsive while large jobs are wrapping up.
+        indexed_artifacts = await asyncio.to_thread(_index_job_artifacts, job)
         _refresh_job_run_summary(job)
         for artifact in indexed_artifacts:
             await _publish_event(

--- a/app.py
+++ b/app.py
@@ -10,6 +10,7 @@ import mimetypes
 import os
 import re
 import shlex
+import signal
 import sys
 import tempfile
 import threading
@@ -17,6 +18,7 @@ import time
 import uuid
 from bisect import bisect_left
 from collections import deque
+from contextlib import asynccontextmanager, suppress
 from dataclasses import dataclass
 from dataclasses import field as dataclass_field
 from email.parser import BytesParser
@@ -750,6 +752,12 @@ CANCEL_GRACE_SECONDS = _env_float(
 )
 JOB_LIST_LIMIT = _env_int("TP_JOB_LIST_LIMIT", 200, minimum=1)
 MAX_INDEXED_ARTIFACTS = _env_int("TP_MAX_INDEXED_ARTIFACTS", 200, minimum=1)
+ARTIFACT_FINGERPRINT_MAX_BYTES = _env_int(
+    "TP_ARTIFACT_FINGERPRINT_MAX_BYTES",
+    256 * 1024 * 1024,
+    minimum=1024,
+)
+_ARTIFACT_FINGERPRINT_CHUNK_BYTES = 1024 * 1024
 PROGRESS_RE = re.compile(r"progress=(\d{1,3})%")
 DEFAULT_ALLOWED_ORIGINS = [
     "http://localhost",
@@ -1151,6 +1159,8 @@ ARCHIVE_GATE_ALLOWED_COMMANDS = {
 }
 ALLOWED_QUALITY = {"standard", "premium", "apex"}
 ALLOWED_BACKENDS = {"da3", "depth_pro"}
+ALLOWED_DEPTH_DEVICES = {"cpu", "cuda", "mps"}
+ALLOWED_RUN_CARD_VERSIONS = {"v1", "v2"}
 ALLOWED_SEGMENTATION_BACKENDS = {"stub", "efficientsam", "sam2"}
 ALLOWED_SAM2_MODEL_SIZES = {"base", "large"}
 ALLOWED_GROUPING_MODES = {"single", "parent_dir"}
@@ -1193,6 +1203,11 @@ PORTAL_SAFE_ERROR_MESSAGES = {
     "archive_index_required": "An archive index artifact is required before dispatch.",
     "archive_runner_unavailable": "The selected archive command is unavailable in this environment.",
     "bag_dir_required": "A bag directory is required before dispatch.",
+    "input_dir_required": "An existing input directory is required before dispatch.",
+    "output_dir_unwritable": "The output directory or its parent is not writable.",
+    "invalid_depth_device": "The selected compute device is not supported.",
+    "invalid_preset": "The selected preset is not supported.",
+    "invalid_run_card_version": "The selected run card version is not supported.",
     "checkpoint_file_too_large": "Managed SAM2 checkpoint overrides exceed the checksum verification size limit.",
     "conflicting_log_verbosity_flags": "Verbose and quiet mode cannot both be enabled.",
     "hash_manifest_required": "A hash manifest artifact is required before dispatch.",
@@ -1996,6 +2011,125 @@ def _enforce_job_readiness_preflight(
     )
 
 
+def _enforce_dispatch_value_preflight(
+    pipeline: str,
+    execution_args: Dict[str, Any],
+) -> None:
+    """Validate enum-style fields at dispatch to match preview validation.
+
+    Preview already rejects invalid preset / depth_device / run_card_version,
+    but dispatch historically trusted execution_args and happily forwarded
+    arbitrary strings to the runner. This closes that gap so preview and
+    dispatch reject the same inputs.
+    """
+
+    if pipeline == "lux-depth-v3":
+        allowed_presets = _allowed_preset_names(pipeline)
+        preset_value = str(_pick(execution_args, "preset", default="") or "").strip()
+        if preset_value and allowed_presets and preset_value not in allowed_presets:
+            raise JobPreflightError(
+                "invalid_preset",
+                field="preset",
+                message="The selected preset is not supported.",
+                status_code=400,
+                extra={"pipeline": pipeline},
+            )
+
+        device_value = str(
+            _pick(execution_args, "depth_device", "depthDevice", default="") or ""
+        ).strip().lower()
+        if device_value and device_value not in ALLOWED_DEPTH_DEVICES:
+            raise JobPreflightError(
+                "invalid_depth_device",
+                field="depth_device",
+                message="The selected compute device is not supported.",
+                status_code=400,
+                extra={"pipeline": pipeline},
+            )
+
+        run_card_value = str(
+            _pick(execution_args, "run_card_version", "runCardVersion", default="") or ""
+        ).strip().lower()
+        if run_card_value and run_card_value not in ALLOWED_RUN_CARD_VERSIONS:
+            raise JobPreflightError(
+                "invalid_run_card_version",
+                field="run_card_version",
+                message="Run card version must be v1 or v2.",
+                status_code=400,
+                extra={"pipeline": pipeline},
+            )
+
+
+def _enforce_dispatch_filesystem_preflight(
+    pipeline: str,
+    execution_args: Dict[str, Any],
+) -> None:
+    """Verify that required filesystem inputs exist before dispatching a job.
+
+    Path allowlist validation is already done by ``_argv_from_request``; this
+    extra pass catches the ``passes-preview/fails-in-runner`` gap where a
+    syntactically valid path simply does not exist on disk, or the output
+    directory cannot be written to. Raises :class:`JobPreflightError` with a
+    portal-safe reason on failure.
+    """
+
+    input_dir_raw = str(
+        _pick(execution_args, "input_dir", "inputDir", default="")
+    ).strip()
+    if input_dir_raw:
+        try:
+            input_dir_resolved = _resolve_allowed_request_path(
+                input_dir_raw, ALLOWED_INPUT_ROOTS
+            )
+        except _PortalValidationReasonError:
+            input_dir_resolved = None
+        if input_dir_resolved is None or not input_dir_resolved.is_dir():
+            raise JobPreflightError(
+                "input_dir_required",
+                field="input_dir",
+                message="An existing input directory is required before dispatch.",
+                status_code=400,
+                extra={"pipeline": pipeline},
+            )
+
+    output_dir_raw = str(
+        _pick(execution_args, "output_dir", "outputDir", default="")
+    ).strip()
+    if output_dir_raw:
+        try:
+            output_dir_resolved = _resolve_allowed_request_path(
+                output_dir_raw, ALLOWED_OUTPUT_ROOTS
+            )
+        except _PortalValidationReasonError:
+            output_dir_resolved = None
+        if output_dir_resolved is None:
+            raise JobPreflightError(
+                "output_dir_unwritable",
+                field="output_dir",
+                message="The output directory or its parent is not writable.",
+                status_code=400,
+                extra={"pipeline": pipeline},
+            )
+        try:
+            output_dir_resolved.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            raise JobPreflightError(
+                "output_dir_unwritable",
+                field="output_dir",
+                message="The output directory or its parent is not writable.",
+                status_code=400,
+                extra={"pipeline": pipeline},
+            ) from None
+        if not os.access(str(output_dir_resolved), os.W_OK):
+            raise JobPreflightError(
+                "output_dir_unwritable",
+                field="output_dir",
+                message="The output directory or its parent is not writable.",
+                status_code=400,
+                extra={"pipeline": pipeline},
+            )
+
+
 HTTP_STATUS_ERROR_CODES = {
     400: "INVALID_ARGUMENT",
     401: "UNAUTHORIZED",
@@ -2455,6 +2589,67 @@ def _extract_progress_percent(line: str) -> Optional[int]:
         return None
 
 
+# Secret-shaped substrings we refuse to persist in runner logs or forward over
+# SSE. These are intentionally conservative: the runner environment is already
+# sanitized, but third-party tools and misconfigured callers can still echo
+# credentials into stdout (e.g. HTTP tracing, library debug output).
+_LOG_REDACT_KV_KEYS = (
+    "api_key",
+    "api-key",
+    "apikey",
+    "access_token",
+    "access-token",
+    "refresh_token",
+    "refresh-token",
+    "authorization",
+    "auth_token",
+    "auth-token",
+    "token",
+    "secret",
+    "password",
+    "passwd",
+    "private_key",
+    "private-key",
+    "client_secret",
+    "client-secret",
+    "session_token",
+    "session-token",
+    "aws_secret_access_key",
+    "aws-secret-access-key",
+)
+
+_LOG_REDACTION_PATTERNS: Tuple[Tuple[re.Pattern[str], str], ...] = (
+    (
+        re.compile(
+            r"(?i)(authorization|proxy-authorization)\s*:\s*"
+            r"(?:bearer|basic|digest|token|apikey)\s+\S+"
+        ),
+        r"\1: <redacted>",
+    ),
+    (
+        re.compile(r"(?i)\bbearer\s+[A-Za-z0-9._\-]+"),
+        "Bearer <redacted>",
+    ),
+    (
+        re.compile(
+            r"(?i)(^|[^A-Za-z0-9])("
+            + "|".join(re.escape(key) for key in _LOG_REDACT_KV_KEYS)
+            + r")(\s*[:=]\s*)([^\s,;]+)"
+        ),
+        r"\1\2\3<redacted>",
+    ),
+)
+
+
+def _redact_log_line(line: str) -> str:
+    if not line:
+        return line
+    redacted = line
+    for pattern, replacement in _LOG_REDACTION_PATTERNS:
+        redacted = pattern.sub(replacement, redacted)
+    return redacted
+
+
 def _canonical_depth_backend(value: Any) -> str:
     backend = str(value or "").strip().lower()
     if not backend:
@@ -2468,6 +2663,11 @@ def _preset_descriptor(pipeline: str, preset_name: str) -> Optional[Dict[str, An
         if str(preset.get("name") or "") == str(preset_name or ""):
             return preset
     return None
+
+
+def _allowed_preset_names(pipeline: str) -> set[str]:
+    presets = PRESET_CATALOG.get(pipeline) or []
+    return {str(entry.get("name") or "").strip() for entry in presets if entry.get("name")}
 
 
 def _portal_issue(
@@ -3321,7 +3521,21 @@ def _build_lux_config_preview(
     path_errors_by_field = _preview_path_errors_by_field(path_errors)
 
     normalized_args: Dict[str, Any] = {}
-    normalized_args["preset"] = defaults["preset"]
+    preset_raw = str(
+        _pick(args, "preset", default=defaults["preset"]) or defaults["preset"]
+    ).strip()
+    allowed_preset_names = _allowed_preset_names("lux-depth-v3")
+    if allowed_preset_names and preset_raw and preset_raw not in allowed_preset_names:
+        errors.append(
+            _portal_issue(
+                "preset",
+                "invalid_preset",
+                "The selected preset is not supported.",
+                suggestion="Select a preset from the catalog.",
+            )
+        )
+        preset_raw = str(defaults["preset"])
+    normalized_args["preset"] = preset_raw or defaults["preset"]
     quality = (
         str(_pick(args, "quality_tier", "qualityTier", default=defaults["quality_tier"]) or defaults["quality_tier"])
         .strip()
@@ -3356,6 +3570,17 @@ def _build_lux_config_preview(
         _pick(args, "depth_device", "depthDevice", default=defaults["depth_device"]) or defaults["depth_device"]
     ).strip()
     if depth_device:
+        device_token = depth_device.lower()
+        if device_token not in ALLOWED_DEPTH_DEVICES:
+            errors.append(
+                _portal_issue(
+                    "depth_device",
+                    "invalid_depth_device",
+                    "The selected compute device is not supported.",
+                    suggestion="Choose cpu, cuda, or mps.",
+                )
+            )
+            depth_device = str(defaults["depth_device"])
         normalized_args["depth_device"] = depth_device
 
     normalized_args["input_dir"] = _normalize_preview_path_field(
@@ -3536,8 +3761,14 @@ def _build_lux_config_preview(
         str(_pick(args, "run_card_version", "runCardVersion", default=defaults["run_card_version"]) or "v1").strip().lower()
         or "v1"
     )
-    if normalized_args["run_card_version"] not in {"v1", "v2"}:
-        errors.append(_portal_issue("run_card_version", "invalid_value", "Run card version must be v1 or v2."))
+    if normalized_args["run_card_version"] not in ALLOWED_RUN_CARD_VERSIONS:
+        errors.append(
+            _portal_issue(
+                "run_card_version",
+                "invalid_run_card_version",
+                "Run card version must be v1 or v2.",
+            )
+        )
         normalized_args["run_card_version"] = str(defaults["run_card_version"])
     normalized_args["run_card_include_proofs"] = _as_bool(
         _pick(
@@ -4134,6 +4365,8 @@ def _portal_sanitize_metadata(metadata: Any) -> Dict[str, Any]:
             sanitized[key_text] = value
             continue
         if isinstance(value, float):
+            if not math.isfinite(value):
+                continue
             sanitized[key_text] = round(value, 4)
             continue
         if isinstance(value, str):
@@ -4260,11 +4493,17 @@ def _record_portal_rum(payload: Dict[str, Any], request: Request) -> Tuple[Optio
         return None, "invalid_value"
 
     metric = str(payload.get("metric") or "").strip().lower()
-    allowed_metrics = PORTAL_ALLOWED_RUM_METRICS.get(event_type, set())
+    allowed_metrics = PORTAL_ALLOWED_RUM_METRICS.get(event_type)
+    if allowed_metrics is None:
+        # Defense-in-depth: unknown event types already fail PORTAL_ALLOWED_RUM_EVENTS
+        # above, but if the metric allowlist is missing the event is not acceptable.
+        return None, "invalid_metric"
     if allowed_metrics:
         if metric not in allowed_metrics:
             return None, "invalid_metric"
-    elif metric and not _portal_is_token(metric):
+    elif metric:
+        # An empty allowlist means "this event type carries no metric"; reject
+        # any caller-supplied token rather than silently accepting it.
         return None, "invalid_metric"
 
     actor = _portal_actor_from_request(request)
@@ -4520,35 +4759,85 @@ async def _publish_event(
         subscribers.pop(subscriber_id, None)
 
 
+def _signal_process_tree(
+    proc: asyncio.subprocess.Process,
+    sig: int,
+) -> bool:
+    """Deliver *sig* to the subprocess's full process group on POSIX.
+
+    Returns True when the signal was delivered via :func:`os.killpg`; False
+    when the caller must fall back to the direct ``proc`` methods (e.g. the
+    spawn did not create a new session, or we are on Windows).
+    """
+
+    if os.name == "nt":
+        return False
+    pid = proc.pid
+    if pid is None:
+        return False
+    try:
+        pgid = os.getpgid(pid)
+    except (OSError, ProcessLookupError):
+        return False
+    # Only escalate to the process group if this subprocess is in its own
+    # session; otherwise we could accidentally signal the orchestrator itself.
+    if pgid != pid:
+        return False
+    try:
+        os.killpg(pgid, sig)
+    except ProcessLookupError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
 async def _terminate_process(
     proc: asyncio.subprocess.Process,
     grace_seconds: float = CANCEL_GRACE_SECONDS,
 ) -> None:
     if proc.returncode is not None:
         return
-    try:
-        proc.terminate()
-    except ProcessLookupError:
-        return
-    except Exception:
-        return
-
-    try:
-        await asyncio.wait_for(proc.wait(), timeout=grace_seconds)
-    except asyncio.TimeoutError:
+    if not _signal_process_tree(proc, signal.SIGTERM):
         try:
-            proc.kill()
+            proc.terminate()
         except ProcessLookupError:
             return
         except Exception:
             return
+
+    try:
+        await asyncio.wait_for(proc.wait(), timeout=grace_seconds)
+    except asyncio.TimeoutError:
+        if not _signal_process_tree(proc, signal.SIGKILL):
+            try:
+                proc.kill()
+            except ProcessLookupError:
+                return
+            except Exception:
+                return
         await proc.wait()
 
 
 async def _request_cancel(job: Job) -> None:
+    already_requested = job.cancel_requested
     job.cancel_requested = True
     if job.proc is None or job.proc.returncode is not None:
         return
+
+    if not already_requested:
+        try:
+            await _publish_event(
+                job.id,
+                "state",
+                {
+                    "id": job.id,
+                    "state": job.state,
+                    "cancel_requested": True,
+                },
+            )
+        except Exception:  # noqa: BLE001 - event publish is best-effort
+            pass
 
     if job.terminate_task is None or job.terminate_task.done():
         job.terminate_task = asyncio.create_task(_terminate_process(job.proc))
@@ -4632,6 +4921,33 @@ def _artifact_media_kind(path: Path) -> str:
 
 def _artifact_is_previewable(path: Path) -> bool:
     return _artifact_media_kind(path) == "image" and _artifact_content_type(path).startswith("image/")
+
+
+def _safe_artifact_attachment_filename(path: Path) -> str:
+    """Return an ASCII-safe filename for Content-Disposition attachments.
+
+    Limits the character set to avoid injection of CR/LF or quote characters
+    into the response header; falls back to ``download`` when the resulting
+    string is empty.
+    """
+
+    candidate = re.sub(r"[^A-Za-z0-9._-]", "_", path.name or "")
+    return candidate or "download"
+
+
+def _artifact_response_headers(path: Path) -> Dict[str, str]:
+    """Build response headers for a job artifact download.
+
+    Previewable media is served inline (so the browser can render it in the
+    artifact viewer); everything else is returned as an attachment to prevent
+    stored HTML/SVG/JS from executing in the portal origin.
+    """
+
+    headers: Dict[str, str] = {"Cache-Control": "no-store"}
+    if not _artifact_is_previewable(path):
+        filename = _safe_artifact_attachment_filename(path)
+        headers["Content-Disposition"] = f'attachment; filename="{filename}"'
+    return headers
 
 
 def _artifact_display_label(role: str) -> str:
@@ -4719,6 +5035,37 @@ def _artifact_url(job_id: str, relative_path: str) -> str:
     return f"/v1/jobs/{quote(str(job_id), safe='')}" f"/artifacts/{quote(relative_path, safe='/')}"
 
 
+def _artifact_fingerprint(
+    path: Path,
+    size_bytes: Optional[int],
+) -> Tuple[Optional[str], str]:
+    """Return ``(sha256_hex, status)`` for an artifact.
+
+    * ``status == "ok"`` and ``sha256_hex`` populated when the file fits under
+      ``ARTIFACT_FINGERPRINT_MAX_BYTES``.
+    * ``status == "skipped_size"`` when the file exceeds the cap (the portal
+      UI renders this as "fingerprint unavailable" rather than a broken copy
+      button).
+    * ``status == "unavailable"`` when the file cannot be read.
+    """
+
+    if size_bytes is None:
+        return None, "unavailable"
+    if size_bytes > ARTIFACT_FINGERPRINT_MAX_BYTES:
+        return None, "skipped_size"
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as handle:
+            while True:
+                chunk = handle.read(_ARTIFACT_FINGERPRINT_CHUNK_BYTES)
+                if not chunk:
+                    break
+                digest.update(chunk)
+    except OSError:
+        return None, "unavailable"
+    return digest.hexdigest(), "ok"
+
+
 def _serialize_indexed_artifact(
     *,
     job_id: str,
@@ -4731,7 +5078,8 @@ def _serialize_indexed_artifact(
         size_bytes = None
 
     content_type = _artifact_content_type(path)
-    return {
+    sha256_hex, fingerprint_status = _artifact_fingerprint(path, size_bytes)
+    payload: Dict[str, Any] = {
         "artifact_type": _infer_artifact_type(path),
         "media_kind": _artifact_media_kind(path),
         "previewable": _artifact_is_previewable(path),
@@ -4742,7 +5090,11 @@ def _serialize_indexed_artifact(
         "path": relative_path,
         "relative_path": relative_path,
         "size_bytes": size_bytes,
+        "fingerprint_status": fingerprint_status,
     }
+    if sha256_hex is not None:
+        payload["sha256"] = sha256_hex
+    return payload
 
 
 def _coerce_nonnegative_int(value: Any) -> Optional[int]:
@@ -5001,7 +5353,7 @@ def _build_scoped_job_artifacts(
     output_dir: Path,
     candidate_paths: List[Path],
 ) -> Tuple[List[Dict[str, Any]], Dict[str, Path], bool]:
-    artifact_lookup: Dict[str, Path] = {}
+    discovered: Dict[str, Path] = {}
     for candidate_path in candidate_paths:
         try:
             resolved_path = Path(os.path.realpath(candidate_path))
@@ -5013,10 +5365,10 @@ def _build_scoped_job_artifacts(
             relative_path = str(resolved_path.relative_to(output_dir))
         except ValueError:
             continue
-        artifact_lookup[relative_path] = resolved_path
+        discovered[relative_path] = resolved_path
 
     ordered_candidates = sorted(
-        artifact_lookup.items(),
+        discovered.items(),
         key=lambda item: (item[0].casefold(), item[0]),
     )
     truncated = len(ordered_candidates) > MAX_INDEXED_ARTIFACTS
@@ -5030,7 +5382,10 @@ def _build_scoped_job_artifacts(
         )
         for relative_path, path in selected_candidates
     ]
-    return items, artifact_lookup, truncated
+    selected_lookup = {
+        relative_path: path for relative_path, path in selected_candidates
+    }
+    return items, selected_lookup, truncated
 
 
 def _build_scoped_job_artifacts_from_run_metadata(
@@ -5248,7 +5603,6 @@ def _index_job_artifacts(job: Job) -> List[Dict[str, Any]]:
 
     selected: List[tuple[tuple[str, str], str, Path]] = []
     selected_keys: List[tuple[str, str]] = []
-    artifact_lookup: Dict[str, Path] = {}
     total_files = 0
     for path in output_dir.rglob("*"):
         if not path.is_file():
@@ -5265,7 +5619,6 @@ def _index_job_artifacts(job: Job) -> List[Dict[str, Any]]:
         except ValueError:
             continue
 
-        artifact_lookup[relative_path] = resolved_path
         key = (relative_path.casefold(), relative_path)
 
         if len(selected) < MAX_INDEXED_ARTIFACTS:
@@ -5286,6 +5639,7 @@ def _index_job_artifacts(job: Job) -> List[Dict[str, Any]]:
     truncated = total_files > MAX_INDEXED_ARTIFACTS
 
     items: List[Dict[str, Any]] = []
+    selected_lookup: Dict[str, Path] = {}
     for _, relative_path, path in selected:
         items.append(
             _serialize_indexed_artifact(
@@ -5294,6 +5648,7 @@ def _index_job_artifacts(job: Job) -> List[Dict[str, Any]]:
                 path=path,
             )
         )
+        selected_lookup[relative_path] = path
 
     job.artifacts = {
         "output_dir": str(output_dir),
@@ -5301,7 +5656,7 @@ def _index_job_artifacts(job: Job) -> List[Dict[str, Any]]:
         "indexed_count": len(items),
         "truncated": truncated,
     }
-    job.artifact_lookup = artifact_lookup
+    job.artifact_lookup = selected_lookup
     return items
 
 
@@ -6534,12 +6889,35 @@ def _argv_from_request(
     return argv
 
 
+@asynccontextmanager
+async def _orchestrator_lifespan(app: "FastAPI") -> "AsyncGenerator[None, None]":
+    if _job_api_key_enforced() and not API_KEY_SECRET:
+        LOGGER.warning(
+            "TP_ENFORCE_JOB_API_KEY is enabled but"
+            " TP_API_KEY is unset; protected /v1 endpoints"
+            " will return AUTH_CONFIGURATION_ERROR."
+        )
+    existing_task = getattr(app.state, "cleanup_task", None)
+    if existing_task is None or existing_task.done():
+        app.state.cleanup_task = asyncio.create_task(_cleanup_loop())
+    try:
+        yield
+    finally:
+        cleanup_task = getattr(app.state, "cleanup_task", None)
+        if cleanup_task is not None:
+            cleanup_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await cleanup_task
+            app.state.cleanup_task = None
+
+
 app = FastAPI(
     title="Transformation Portal Orchestrator",
     version="0.3.0",
     docs_url="/docs" if ENABLE_API_DOCS else None,
     redoc_url="/redoc" if ENABLE_API_DOCS else None,
     openapi_url="/openapi.json" if ENABLE_API_DOCS else None,
+    lifespan=_orchestrator_lifespan,
 )
 app.state.cleanup_task = None
 
@@ -6617,31 +6995,6 @@ async def request_validation_handler(
     )
 
 
-@app.on_event("startup")
-async def startup() -> None:
-    if _job_api_key_enforced() and not API_KEY_SECRET:
-        LOGGER.warning(
-            "TP_ENFORCE_JOB_API_KEY is enabled but"
-            " TP_API_KEY is unset; protected /v1 endpoints"
-            " will return AUTH_CONFIGURATION_ERROR."
-        )
-    cleanup_task = getattr(app.state, "cleanup_task", None)
-    if cleanup_task is None or cleanup_task.done():
-        app.state.cleanup_task = asyncio.create_task(_cleanup_loop())
-
-
-@app.on_event("shutdown")
-async def shutdown() -> None:
-    cleanup_task = getattr(app.state, "cleanup_task", None)
-    if cleanup_task is not None:
-        cleanup_task.cancel()
-        try:
-            await cleanup_task
-        except asyncio.CancelledError:
-            pass
-        app.state.cleanup_task = None
-
-
 @app.middleware("http")
 async def security_layer(
     request: Request,
@@ -6703,9 +7056,7 @@ async def security_layer(
     return response
 
 
-@app.get("/")
-async def serve_ui() -> Response:
-    """Serves the single-file UI."""
+def _portal_html_response() -> Response:
     if not PORTAL_HTML.exists():
         raise HTTPException(
             status_code=500,
@@ -6720,6 +7071,21 @@ async def serve_ui() -> Response:
             "Content-Type": "text/html; charset=utf-8",
         },
     )
+
+
+@app.get("/")
+async def serve_ui() -> Response:
+    return RedirectResponse(
+        url="/portal",
+        status_code=307,
+        headers={"Cache-Control": "no-store"},
+    )
+
+
+@app.get("/portal")
+async def serve_portal() -> Response:
+    """Serves the single-file portal UI at its canonical route."""
+    return _portal_html_response()
 
 
 @app.get("/portal/assets/{asset_path:path}")
@@ -7133,6 +7499,34 @@ async def create_job(payload: Dict[str, Any]) -> JSONResponse:
         execution_args = {}
 
     try:
+        _enforce_dispatch_value_preflight(pipeline, execution_args)
+    except JobPreflightError as exc:
+        status_code = int(exc.status_code)
+        field = str(exc.field or "payload")
+        reason = _portal_reason_code(exc.reason)
+        del exc
+        return _error_response(
+            status_code,
+            code="INVALID_ARGUMENT",
+            message=_portal_safe_error_message(reason, field=field),
+            details={"field": field, "reason": reason},
+        )
+
+    try:
+        _enforce_dispatch_filesystem_preflight(pipeline, execution_args)
+    except JobPreflightError as exc:
+        status_code = int(exc.status_code)
+        field = str(exc.field or "payload")
+        reason = _portal_reason_code(exc.reason)
+        del exc
+        return _error_response(
+            status_code,
+            code="INVALID_ARGUMENT",
+            message=_portal_safe_error_message(reason, field=field),
+            details={"field": field, "reason": reason},
+        )
+
+    try:
         argv = _argv_from_request(
             payload,
             execution_args=execution_args,
@@ -7190,7 +7584,9 @@ async def list_jobs(limit: int = JOB_LIST_LIMIT) -> JSONResponse:
         key=lambda item: item.created_at,
         reverse=True,
     )
-    serialized = [_serialize_job(job) for job in jobs_sorted[:bounded_limit]]
+    serialized = [
+        _serialize_job(job, include_logs=False) for job in jobs_sorted[:bounded_limit]
+    ]
 
     return JSONResponse(
         _api_envelope(
@@ -7207,7 +7603,7 @@ async def list_jobs(limit: int = JOB_LIST_LIMIT) -> JSONResponse:
 
 
 @app.get("/v1/jobs/{job_id}")
-async def get_job(job_id: str) -> JSONResponse:
+async def get_job(job_id: str, include_logs: bool = True) -> JSONResponse:
     _cleanup_expired_jobs(_now())
     job = JOBS.get(job_id)
     if not job:
@@ -7221,7 +7617,7 @@ async def get_job(job_id: str) -> JSONResponse:
         _api_envelope(
             "tp.orchestrator.job_status.v1",
             success=True,
-            data=_serialize_job(job),
+            data=_serialize_job(job, include_logs=bool(include_logs)),
             error=None,
         )
     )
@@ -7298,7 +7694,7 @@ async def get_job_artifact(job_id: str, artifact_path: str) -> Response:
     return FileResponse(
         resolved_artifact,
         media_type=_artifact_content_type(resolved_artifact),
-        headers={"Cache-Control": "no-store"},
+        headers=_artifact_response_headers(resolved_artifact),
     )
 
 
@@ -7433,12 +7829,16 @@ async def _run_job(job: Job, argv: List[str]) -> None:
 
     try:
         # NO SHELL EXECUTION.
-        proc = await asyncio.create_subprocess_exec(
-            *argv,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.STDOUT,
-            env=_sanitized_child_env(),
-        )
+        spawn_kwargs: Dict[str, Any] = {
+            "stdout": asyncio.subprocess.PIPE,
+            "stderr": asyncio.subprocess.STDOUT,
+            "env": _sanitized_child_env(),
+        }
+        if os.name != "nt":
+            # Put the runner in its own session so cancel can signal the
+            # whole process tree, not just the direct child.
+            spawn_kwargs["start_new_session"] = True
+        proc = await asyncio.create_subprocess_exec(*argv, **spawn_kwargs)
         job.proc = proc
 
         if proc.stdout is None:
@@ -7458,6 +7858,7 @@ async def _run_job(job: Job, argv: List[str]) -> None:
                 "utf-8",
                 errors="replace",
             ).rstrip("\n")
+            line = _redact_log_line(line)
             job.add_log(line)
             await _publish_event(
                 job.id,

--- a/portal.html
+++ b/portal.html
@@ -286,29 +286,29 @@ Contract notes:
                     Keyboard: <span class="kbd">1</span> overview, <span class="kbd">2</span> build, <span class="kbd">3</span> operate, <span class="kbd">4</span> review, <span class="kbd">?</span> shortcuts.
                 </p>
             </div>
-            <div class="workspace-rail-links" role="tablist" aria-label="Console views">
-                <a class="workspace-link is-active" data-view-link="overview" data-ui="view-link" href="?view=overview" role="tab" aria-selected="true" aria-keyshortcuts="1">
+            <div class="workspace-rail-links" aria-label="Console views">
+                <a class="workspace-link is-active" data-view-link="overview" data-ui="view-link" href="?view=overview" aria-current="page" aria-keyshortcuts="1">
                     <span class="workspace-link-heading">
                         <span class="workspace-link-label">Overview</span>
                         <span class="workspace-link-shortcut" aria-hidden="true">1</span>
                     </span>
                     <span class="workspace-link-meta">Status, recent jobs, and next action.</span>
                 </a>
-                <a class="workspace-link" data-view-link="build" data-ui="view-link" href="?view=build" role="tab" aria-selected="false" aria-keyshortcuts="2">
+                <a class="workspace-link" data-view-link="build" data-ui="view-link" href="?view=build" aria-keyshortcuts="2">
                     <span class="workspace-link-heading">
                         <span class="workspace-link-label">Build</span>
                         <span class="workspace-link-shortcut" aria-hidden="true">2</span>
                     </span>
                     <span class="workspace-link-meta">Preview-backed dispatch flow.</span>
                 </a>
-                <a class="workspace-link" data-view-link="operate" data-ui="view-link" href="?view=operate" role="tab" aria-selected="false" aria-keyshortcuts="3">
+                <a class="workspace-link" data-view-link="operate" data-ui="view-link" href="?view=operate" aria-keyshortcuts="3">
                     <span class="workspace-link-heading">
                         <span class="workspace-link-label">Operate</span>
                         <span class="workspace-link-shortcut" aria-hidden="true">3</span>
                     </span>
                     <span class="workspace-link-meta">Queue, inspector, artifacts, and logs.</span>
                 </a>
-                <a class="workspace-link" data-view-link="review" data-ui="view-link" href="?view=review" role="tab" aria-selected="false" aria-keyshortcuts="4">
+                <a class="workspace-link" data-view-link="review" data-ui="view-link" href="?view=review" aria-keyshortcuts="4">
                     <span class="workspace-link-heading">
                         <span class="workspace-link-label">Review</span>
                         <span class="workspace-link-shortcut" aria-hidden="true">4</span>
@@ -637,7 +637,7 @@ Contract notes:
                             <div class="sm:col-span-3">
                                 <label class="block text-xs font-medium text-slate-700 dark:text-slate-300 mb-1.5" for="presetSelect">Preset</label>
                                 <select id="presetSelect" class="w-full rounded-xl border border-slate-300 dark:border-slate-700 bg-slate-50 dark:bg-slate-800 px-3 py-2.5 text-[13px] font-mono focus:outline-none focus:ring-2 focus:ring-indigo-500 transition-colors cursor-pointer">
-                                    <option value="premium">premium (Stable)</option>
+                                    <option value="premium" selected>premium (Stable)</option>
                                     <option value="default">default (Canary)</option>
                                     <option value="depth-anything-v3.1-research-m4">v3.1-m4 (Experimental)</option>
                                 </select>
@@ -645,16 +645,16 @@ Contract notes:
                             <div>
                                 <label class="block text-xs font-medium text-slate-700 dark:text-slate-300 mb-1.5" for="qualityTier">Quality Tier</label>
                                 <select id="qualityTier" class="w-full rounded-xl border border-slate-300 dark:border-slate-700 bg-slate-50 dark:bg-slate-800 px-3 py-2.5 text-[13px] font-mono focus:outline-none focus:ring-2 focus:ring-indigo-500 transition-colors cursor-pointer">
-                                    <option value="apex" selected>apex (Max)</option>
-                                    <option value="premium">premium</option>
+                                    <option value="apex">apex (Max)</option>
+                                    <option value="premium" selected>premium</option>
                                     <option value="standard">standard</option>
                                 </select>
                             </div>
                             <div>
                                 <label class="block text-xs font-medium text-slate-700 dark:text-slate-300 mb-1.5" for="depthDevice">Compute Device</label>
                                 <select id="depthDevice" class="w-full rounded-xl border border-slate-300 dark:border-slate-700 bg-slate-50 dark:bg-slate-800 px-3 py-2.5 text-[13px] font-mono focus:outline-none focus:ring-2 focus:ring-indigo-500 transition-colors cursor-pointer">
-                                    <option value="cpu">cpu</option>
-                                    <option value="cuda" selected>cuda</option>
+                                    <option value="cpu" selected>cpu</option>
+                                    <option value="cuda">cuda</option>
                                     <option value="mps">mps (macOS)</option>
                                 </select>
                             </div>
@@ -1612,7 +1612,7 @@ Contract notes:
                             </h2>
                             <p id="logMetaLabel" class="mt-1 text-[11px] text-slate-500 dark:text-slate-400">Select a job to stream or inspect its log output.</p>
                         </div>
-                        <button id="clearLogsBtn" class="text-[10px] uppercase font-bold text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 transition-colors focus:outline-none">Clear</button>
+                        <button id="clearLogsBtn" type="button" class="text-[10px] uppercase font-bold text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 transition-colors focus:outline-none">Clear</button>
                     </div>
                     <pre id="logPane" class="log-surface flex-1 p-6 text-[11px] font-mono leading-relaxed text-slate-300 overflow-y-auto custom-scrollbar whitespace-pre-wrap break-words"></pre>
                 </div>
@@ -1631,7 +1631,7 @@ Contract notes:
         <div class="w-full max-w-sm rounded-xl bg-white shadow-2xl border border-slate-200 dark:bg-slate-900 dark:border-slate-800 transform scale-95 opacity-0 transition-all duration-200" id="shortcutsPanel" role="dialog" aria-modal="true" aria-labelledby="shortcutsTitle">
             <div class="px-5 py-4 border-b border-slate-200 dark:border-slate-800 flex items-center justify-between">
                 <h2 id="shortcutsTitle" class="text-sm font-semibold">Keyboard Shortcuts</h2>
-                <button id="closeShortcutsBtn" class="rounded-md px-2 py-1 text-slate-500 hover:bg-slate-100 hover:text-slate-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:hover:bg-slate-800 dark:hover:text-white transition-colors" aria-label="Close dialog">
+                <button id="closeShortcutsBtn" type="button" class="rounded-md px-2 py-1 text-slate-500 hover:bg-slate-100 hover:text-slate-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:hover:bg-slate-800 dark:hover:text-white transition-colors" aria-label="Close dialog">
                     <span class="text-lg leading-none">&times;</span>
                 </button>
             </div>

--- a/tests/test_app_orchestrator_contract_http.py
+++ b/tests/test_app_orchestrator_contract_http.py
@@ -2429,6 +2429,7 @@ def test_archive_gate_a_fixity_verify_submission_returns_job_envelope(
     monkeypatch.setattr(orchestrator_app, "_run_job", fake_run_job)
     hash_manifest = tmp_path / "hash_manifest.csv.gz"
     hash_manifest.write_bytes(b"fixture-manifest")
+    (tmp_path / "archive_root").mkdir(parents=True, exist_ok=True)
 
     response = client.post(
         "/v1/jobs",
@@ -2467,6 +2468,7 @@ def test_archive_gate_b_bag_validate_submission_returns_job_envelope(
     monkeypatch.setattr(orchestrator_app, "_run_job", fake_run_job)
     bag_dir = tmp_path / "bag"
     bag_dir.mkdir(parents=True, exist_ok=True)
+    (tmp_path / "archive_root").mkdir(parents=True, exist_ok=True)
 
     response = client.post(
         "/v1/jobs",
@@ -2505,6 +2507,7 @@ def test_archive_gate_b_dedup_plan_submission_returns_job_envelope(
     monkeypatch.setattr(orchestrator_app, "_run_job", fake_run_job)
     manifest_jsonl = tmp_path / "manifest.jsonl"
     manifest_jsonl.write_text('{"id":"asset-1"}\n', encoding="utf-8")
+    (tmp_path / "archive_root").mkdir(parents=True, exist_ok=True)
 
     response = client.post(
         "/v1/jobs",
@@ -2543,6 +2546,7 @@ def test_archive_gate_c_prov_export_submission_returns_job_envelope(
     monkeypatch.setattr(orchestrator_app, "_run_job", fake_run_job)
     manifest_jsonl = tmp_path / "manifest.jsonl"
     manifest_jsonl.write_text('{"id":"asset-1"}\n', encoding="utf-8")
+    (tmp_path / "archive_root").mkdir(parents=True, exist_ok=True)
 
     response = client.post(
         "/v1/jobs",
@@ -2581,6 +2585,7 @@ def test_archive_gate_c_stac_export_submission_returns_job_envelope(
     monkeypatch.setattr(orchestrator_app, "_run_job", fake_run_job)
     manifest_jsonl = tmp_path / "manifest.jsonl"
     manifest_jsonl.write_text('{"id":"asset-1"}\n', encoding="utf-8")
+    (tmp_path / "archive_root").mkdir(parents=True, exist_ok=True)
 
     response = client.post(
         "/v1/jobs",
@@ -2619,6 +2624,7 @@ def test_archive_gate_c_mets_export_submission_returns_job_envelope(
     monkeypatch.setattr(orchestrator_app, "_run_job", fake_run_job)
     manifest_jsonl = tmp_path / "manifest.jsonl"
     manifest_jsonl.write_text('{"id":"asset-1"}\n', encoding="utf-8")
+    (tmp_path / "archive_root").mkdir(parents=True, exist_ok=True)
 
     response = client.post(
         "/v1/jobs",
@@ -2682,7 +2688,14 @@ def test_archive_gate_c_prov_export_rejects_missing_manifest(client: TestClient)
 
 def test_v1_jobs_rejects_when_max_concurrent_jobs_reached(client: TestClient) -> None:
     previous_limit = orchestrator_app.MAX_CONCURRENT_JOBS
+    repo_root = orchestrator_app.REPO_ROOT
+    input_dir = repo_root / "input"
+    output_dir = repo_root / "output"
+    input_preexisted = input_dir.exists()
+    output_preexisted = output_dir.exists()
     try:
+        input_dir.mkdir(parents=True, exist_ok=True)
+        output_dir.mkdir(parents=True, exist_ok=True)
         orchestrator_app.MAX_CONCURRENT_JOBS = 1
         orchestrator_app.JOBS["job_busy"] = orchestrator_app.Job(
             id="job_busy",
@@ -2701,6 +2714,16 @@ def test_v1_jobs_rejects_when_max_concurrent_jobs_reached(client: TestClient) ->
     finally:
         orchestrator_app.MAX_CONCURRENT_JOBS = previous_limit
         orchestrator_app.JOBS.clear()
+        if not input_preexisted:
+            try:
+                input_dir.rmdir()
+            except OSError:
+                pass
+        if not output_preexisted:
+            try:
+                output_dir.rmdir()
+            except OSError:
+                pass
 
     assert response.status_code == 429
     assert body["error"]["code"] == "RATE_LIMITED"
@@ -2864,13 +2887,32 @@ def test_job_events_stream_emits_state_log_progress_artifact_done(client: TestCl
 
     monkeypatch.setattr(orchestrator_app, "_run_job", fake_run_job)
 
-    create = client.post(
-        "/v1/jobs",
-        json={
-            "pipeline": "lux-depth-v3",
-            "args": {"input_dir": "./input", "output_dir": "./output"},
-        },
-    )
+    repo_root = orchestrator_app.REPO_ROOT
+    input_dir = repo_root / "input"
+    output_dir = repo_root / "output"
+    created_input = not input_dir.exists()
+    created_output = not output_dir.exists()
+    input_dir.mkdir(parents=True, exist_ok=True)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        create = client.post(
+            "/v1/jobs",
+            json={
+                "pipeline": "lux-depth-v3",
+                "args": {"input_dir": "./input", "output_dir": "./output"},
+            },
+        )
+    finally:
+        if created_input:
+            try:
+                input_dir.rmdir()
+            except OSError:
+                pass
+        if created_output:
+            try:
+                output_dir.rmdir()
+            except OSError:
+                pass
     assert create.status_code == 200
     job_id = create.json()["data"]["id"]
 

--- a/tests/test_app_orchestrator_contract_http.py
+++ b/tests/test_app_orchestrator_contract_http.py
@@ -2686,44 +2686,44 @@ def test_archive_gate_c_prov_export_rejects_missing_manifest(client: TestClient)
     assert body["error"]["details"]["field"] == "manifest_jsonl"
 
 
-def test_v1_jobs_rejects_when_max_concurrent_jobs_reached(client: TestClient) -> None:
+def test_v1_jobs_rejects_when_max_concurrent_jobs_reached(client: TestClient, tmp_path) -> None:
+    # Use per-test isolated directories under tmp_path so the test stays
+    # parallel-safe under pytest-xdist (no shared repo-root paths).
     previous_limit = orchestrator_app.MAX_CONCURRENT_JOBS
-    repo_root = orchestrator_app.REPO_ROOT
-    input_dir = repo_root / "input"
-    output_dir = repo_root / "output"
-    input_preexisted = input_dir.exists()
-    output_preexisted = output_dir.exists()
+    previous_input_roots = orchestrator_app.ALLOWED_INPUT_ROOTS
+    previous_output_roots = orchestrator_app.ALLOWED_OUTPUT_ROOTS
+    allowed_root = (tmp_path / "rate-limit-isolated").resolve()
+    allowed_root.mkdir(parents=True, exist_ok=True)
+    input_dir = allowed_root / "input"
+    output_dir = allowed_root / "output"
+    input_dir.mkdir(parents=True, exist_ok=True)
+    output_dir.mkdir(parents=True, exist_ok=True)
     try:
-        input_dir.mkdir(parents=True, exist_ok=True)
-        output_dir.mkdir(parents=True, exist_ok=True)
+        orchestrator_app.ALLOWED_INPUT_ROOTS = [allowed_root]
+        orchestrator_app.ALLOWED_OUTPUT_ROOTS = [allowed_root]
         orchestrator_app.MAX_CONCURRENT_JOBS = 1
         orchestrator_app.JOBS["job_busy"] = orchestrator_app.Job(
             id="job_busy",
             created_at=orchestrator_app._now(),
             state="running",
-            request={"pipeline": "lux-depth-v3", "args": {"input_dir": "./input", "output_dir": "./output"}},
+            request={
+                "pipeline": "lux-depth-v3",
+                "args": {"input_dir": str(input_dir), "output_dir": str(output_dir)},
+            },
         )
         response = client.post(
             "/v1/jobs",
             json={
                 "pipeline": "lux-depth-v3",
-                "args": {"input_dir": "./input", "output_dir": "./output"},
+                "args": {"input_dir": str(input_dir), "output_dir": str(output_dir)},
             },
         )
         body = response.json()
     finally:
         orchestrator_app.MAX_CONCURRENT_JOBS = previous_limit
+        orchestrator_app.ALLOWED_INPUT_ROOTS = previous_input_roots
+        orchestrator_app.ALLOWED_OUTPUT_ROOTS = previous_output_roots
         orchestrator_app.JOBS.clear()
-        if not input_preexisted:
-            try:
-                input_dir.rmdir()
-            except OSError:
-                pass
-        if not output_preexisted:
-            try:
-                output_dir.rmdir()
-            except OSError:
-                pass
 
     assert response.status_code == 429
     assert body["error"]["code"] == "RATE_LIMITED"
@@ -2839,7 +2839,7 @@ def test_http_exception_handler_preserves_safe_413_detail_for_v1_requests() -> N
     assert body["error"]["details"] == {"path": "/v1/jobs"}
 
 
-def test_job_events_stream_emits_state_log_progress_artifact_done(client: TestClient, monkeypatch) -> None:
+def test_job_events_stream_emits_state_log_progress_artifact_done(client: TestClient, monkeypatch, tmp_path) -> None:
     async def fake_run_job(job, _argv):  # noqa: ANN001
         job.state = "running"
         job.started_at = orchestrator_app._now()
@@ -2887,32 +2887,29 @@ def test_job_events_stream_emits_state_log_progress_artifact_done(client: TestCl
 
     monkeypatch.setattr(orchestrator_app, "_run_job", fake_run_job)
 
-    repo_root = orchestrator_app.REPO_ROOT
-    input_dir = repo_root / "input"
-    output_dir = repo_root / "output"
-    created_input = not input_dir.exists()
-    created_output = not output_dir.exists()
+    # Use per-test isolated paths so the SSE stream test stays parallel-safe
+    # under pytest-xdist (no shared repo-root directories).
+    previous_input_roots = orchestrator_app.ALLOWED_INPUT_ROOTS
+    previous_output_roots = orchestrator_app.ALLOWED_OUTPUT_ROOTS
+    allowed_root = (tmp_path / "sse-stream-isolated").resolve()
+    allowed_root.mkdir(parents=True, exist_ok=True)
+    input_dir = allowed_root / "input"
+    output_dir = allowed_root / "output"
     input_dir.mkdir(parents=True, exist_ok=True)
     output_dir.mkdir(parents=True, exist_ok=True)
     try:
+        orchestrator_app.ALLOWED_INPUT_ROOTS = [allowed_root]
+        orchestrator_app.ALLOWED_OUTPUT_ROOTS = [allowed_root]
         create = client.post(
             "/v1/jobs",
             json={
                 "pipeline": "lux-depth-v3",
-                "args": {"input_dir": "./input", "output_dir": "./output"},
+                "args": {"input_dir": str(input_dir), "output_dir": str(output_dir)},
             },
         )
     finally:
-        if created_input:
-            try:
-                input_dir.rmdir()
-            except OSError:
-                pass
-        if created_output:
-            try:
-                output_dir.rmdir()
-            except OSError:
-                pass
+        orchestrator_app.ALLOWED_INPUT_ROOTS = previous_input_roots
+        orchestrator_app.ALLOWED_OUTPUT_ROOTS = previous_output_roots
     assert create.status_code == 200
     job_id = create.json()["data"]["id"]
 

--- a/tests/test_portal_backend_hardening.py
+++ b/tests/test_portal_backend_hardening.py
@@ -1,0 +1,490 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Coverage for the backend + portal hardening pass.
+
+Focused tests for the P0/P1 changes introduced in
+``claude/harden-backend-portal-soFcZ``:
+
+* ``/portal`` is the canonical UI route; ``/`` 307s to it.
+* ``/v1/jobs`` performs a filesystem preflight on ``input_dir`` / ``output_dir``.
+* Value preflight rejects unknown preset / depth_device / run_card_version.
+* Artifact lookup never exposes files that were walked but not indexed.
+* Artifact serving sends ``Content-Disposition: attachment`` for non-previewable
+  content.
+* Runner logs are redacted before both persistence and SSE publication.
+* ``/v1/jobs`` list responses do not include ``logs_tail``; ``/v1/jobs/{id}``
+  still does.
+* Telemetry metadata drops non-finite floats; RUM metric allowlist rejects
+  unknown metrics on event types that accept none.
+* Artifact fingerprinting emits sha256 for bounded files and reports
+  ``skipped_size`` above the cap.
+* The FastAPI app uses the ``lifespan`` context manager rather than deprecated
+  ``on_event`` hooks.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import os
+import signal
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.unit
+
+orchestrator_app = importlib.import_module("app")
+
+
+@pytest.fixture(autouse=True)
+def _reset_orchestrator_state(tmp_path: Path) -> Iterator[None]:
+    previous_api_key = orchestrator_app.API_KEY_SECRET
+    previous_enforce = orchestrator_app.ENFORCE_JOB_API_KEY
+    previous_input_roots = orchestrator_app.ALLOWED_INPUT_ROOTS
+    previous_output_roots = orchestrator_app.ALLOWED_OUTPUT_ROOTS
+    previous_path_roots = orchestrator_app.ALLOWED_PATH_ROOTS
+    previous_max_indexed = orchestrator_app.MAX_INDEXED_ARTIFACTS
+    previous_fingerprint_cap = orchestrator_app.ARTIFACT_FINGERPRINT_MAX_BYTES
+    orchestrator_app.API_KEY_SECRET = "hardening-secret"
+    orchestrator_app.ENFORCE_JOB_API_KEY = True
+    orchestrator_app.JOBS.clear()
+    orchestrator_app.EVENT_SUBSCRIBERS.clear()
+    orchestrator_app.RATE_LIMIT_BUCKETS.clear()
+    allowed_root = (tmp_path / "allowed").resolve()
+    allowed_root.mkdir(parents=True, exist_ok=True)
+    orchestrator_app.ALLOWED_INPUT_ROOTS = [allowed_root]
+    orchestrator_app.ALLOWED_OUTPUT_ROOTS = [allowed_root]
+    orchestrator_app.ALLOWED_PATH_ROOTS = [allowed_root]
+    try:
+        yield
+    finally:
+        orchestrator_app.API_KEY_SECRET = previous_api_key
+        orchestrator_app.ENFORCE_JOB_API_KEY = previous_enforce
+        orchestrator_app.ALLOWED_INPUT_ROOTS = previous_input_roots
+        orchestrator_app.ALLOWED_OUTPUT_ROOTS = previous_output_roots
+        orchestrator_app.ALLOWED_PATH_ROOTS = previous_path_roots
+        orchestrator_app.MAX_INDEXED_ARTIFACTS = previous_max_indexed
+        orchestrator_app.ARTIFACT_FINGERPRINT_MAX_BYTES = previous_fingerprint_cap
+        orchestrator_app.JOBS.clear()
+        orchestrator_app.EVENT_SUBSCRIBERS.clear()
+        orchestrator_app.RATE_LIMIT_BUCKETS.clear()
+
+
+@pytest.fixture(name="client")
+def _client_fixture() -> Iterator[TestClient]:
+    with TestClient(
+        orchestrator_app.app,
+        headers={"x-api-key": "hardening-secret"},
+    ) as test_client:
+        yield test_client
+
+
+# ---------------------------------------------------------------------------
+# Routing
+# ---------------------------------------------------------------------------
+
+
+def test_root_redirects_to_portal(client: TestClient) -> None:
+    response = client.get("/", follow_redirects=False)
+    assert response.status_code == 307
+    assert response.headers["location"] == "/portal"
+
+
+def test_portal_route_serves_html(client: TestClient) -> None:
+    response = client.get("/portal")
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/html")
+    assert b"<html" in response.content.lower() or b"<!doctype" in response.content.lower()
+
+
+def test_portal_route_registered_on_app() -> None:
+    paths = {getattr(r, "path", "") for r in orchestrator_app.app.routes}
+    assert "/portal" in paths
+    assert "/" in paths
+
+
+# ---------------------------------------------------------------------------
+# Dispatch preflight: filesystem + values
+# ---------------------------------------------------------------------------
+
+
+def _lux_payload(input_dir: Path, output_dir: Path, **extra: object) -> dict:
+    args = {
+        "input_dir": str(input_dir),
+        "output_dir": str(output_dir),
+    }
+    args.update(extra)
+    return {"pipeline": "lux-depth-v3", "args": args}
+
+
+def test_dispatch_rejects_missing_input_dir(client: TestClient, tmp_path: Path) -> None:
+    allowed = orchestrator_app.ALLOWED_INPUT_ROOTS[0]
+    missing_input = allowed / "does-not-exist"
+    output_dir = allowed / "out"
+    response = client.post("/v1/jobs", json=_lux_payload(missing_input, output_dir))
+    body = response.json()
+    assert response.status_code == 400
+    assert body["error"]["details"]["reason"] == "input_dir_required"
+    assert body["error"]["details"]["field"] == "input_dir"
+
+
+def test_dispatch_output_dir_gets_created_when_missing(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def fake_run_job(job, _argv):
+        job.state = "succeeded"
+        job.exit_code = 0
+        now = orchestrator_app._now()
+        job.finished_at = now
+        job.done_published_at = now
+
+    monkeypatch.setattr(orchestrator_app, "_run_job", fake_run_job)
+    allowed = orchestrator_app.ALLOWED_INPUT_ROOTS[0]
+    input_dir = allowed / "inp"
+    input_dir.mkdir(parents=True, exist_ok=True)
+    output_dir = allowed / "will-be-created"
+    assert not output_dir.exists()
+
+    response = client.post("/v1/jobs", json=_lux_payload(input_dir, output_dir))
+    assert response.status_code == 200, response.text
+    assert output_dir.is_dir()
+
+
+def test_dispatch_rejects_unknown_preset(client: TestClient) -> None:
+    allowed = orchestrator_app.ALLOWED_INPUT_ROOTS[0]
+    input_dir = allowed / "inp"
+    input_dir.mkdir(parents=True, exist_ok=True)
+    output_dir = allowed / "out"
+    payload = _lux_payload(input_dir, output_dir, preset="no-such-preset")
+    response = client.post("/v1/jobs", json=payload)
+    body = response.json()
+    assert response.status_code == 400
+    assert body["error"]["details"]["reason"] == "invalid_preset"
+
+
+def test_dispatch_rejects_unknown_depth_device(client: TestClient) -> None:
+    allowed = orchestrator_app.ALLOWED_INPUT_ROOTS[0]
+    input_dir = allowed / "inp"
+    input_dir.mkdir(parents=True, exist_ok=True)
+    output_dir = allowed / "out"
+    payload = _lux_payload(input_dir, output_dir, depth_device="rocm")
+    response = client.post("/v1/jobs", json=payload)
+    body = response.json()
+    assert response.status_code == 400
+    # Preview validation will normally convert this to invalid_depth_device;
+    # the dispatch-side preflight is the last line of defence and should agree.
+    assert body["error"]["details"]["reason"] == "invalid_depth_device"
+
+
+# ---------------------------------------------------------------------------
+# Artifact lookup boundary + attachment headers
+# ---------------------------------------------------------------------------
+
+
+def test_artifact_lookup_excludes_non_indexed_files(tmp_path: Path) -> None:
+    orchestrator_app.MAX_INDEXED_ARTIFACTS = 2
+    allowed = orchestrator_app.ALLOWED_OUTPUT_ROOTS[0]
+    output_dir = allowed / "job_out"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "a.json").write_text("{}", encoding="utf-8")
+    (output_dir / "b.json").write_text("{}", encoding="utf-8")
+    (output_dir / "secret.txt").write_text("sensitive", encoding="utf-8")
+
+    job = orchestrator_app.Job(
+        id="job_lookup",
+        created_at=orchestrator_app._now(),
+        state="succeeded",
+        request={
+            "pipeline": "lux-depth-v3",
+            "args": {"input_dir": str(output_dir), "output_dir": str(output_dir)},
+        },
+        effective_request={
+            "pipeline": "lux-depth-v3",
+            "args": {"input_dir": str(output_dir), "output_dir": str(output_dir)},
+        },
+    )
+    orchestrator_app.JOBS[job.id] = job
+    orchestrator_app._index_job_artifacts(job)
+
+    # Only the two indexed artifacts are reachable through the lookup; the
+    # third file on disk must be excluded to preserve least privilege.
+    assert set(job.artifact_lookup.keys()) == {"a.json", "b.json"}
+
+
+def test_artifact_endpoint_attaches_non_previewable(
+    client: TestClient, tmp_path: Path
+) -> None:
+    allowed = orchestrator_app.ALLOWED_OUTPUT_ROOTS[0]
+    output_dir = allowed / "job_files"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "report.html").write_text("<html></html>", encoding="utf-8")
+
+    job = orchestrator_app.Job(
+        id="job_attach",
+        created_at=orchestrator_app._now(),
+        state="succeeded",
+        request={
+            "pipeline": "lux-depth-v3",
+            "args": {"input_dir": str(output_dir), "output_dir": str(output_dir)},
+        },
+        effective_request={
+            "pipeline": "lux-depth-v3",
+            "args": {"input_dir": str(output_dir), "output_dir": str(output_dir)},
+        },
+    )
+    orchestrator_app.JOBS[job.id] = job
+    orchestrator_app._index_job_artifacts(job)
+
+    response = client.get(f"/v1/jobs/{job.id}/artifacts/report.html")
+    assert response.status_code == 200
+    disposition = response.headers.get("content-disposition", "")
+    assert "attachment" in disposition
+    assert 'filename="report.html"' in disposition
+
+
+# ---------------------------------------------------------------------------
+# Log redaction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "line,expected",
+    [
+        ("api_key=sk-abcdef123", "api_key=<redacted>"),
+        ("OPENAI_API_KEY=sk-abcdef123", "OPENAI_API_KEY=<redacted>"),
+        ("password: hunter2", "password: <redacted>"),
+        ("token = abcdef", "token = <redacted>"),
+        ("Authorization: Bearer abcdef.token", "Authorization: <redacted>"),
+        ("plain runner progress=50%", "plain runner progress=50%"),
+    ],
+)
+def test_log_redaction_rewrites_secret_shapes(line: str, expected: str) -> None:
+    assert orchestrator_app._redact_log_line(line) == expected
+
+
+# ---------------------------------------------------------------------------
+# Job list payload
+# ---------------------------------------------------------------------------
+
+
+def test_list_jobs_omits_log_tail(client: TestClient) -> None:
+    job = orchestrator_app.Job(
+        id="job_list",
+        created_at=orchestrator_app._now(),
+        state="succeeded",
+        request={"pipeline": "lux-depth-v3", "args": {}},
+    )
+    job.add_log("example log line")
+    orchestrator_app.JOBS[job.id] = job
+
+    list_response = client.get("/v1/jobs")
+    assert list_response.status_code == 200
+    job_payloads = list_response.json()["data"]["jobs"]
+    assert len(job_payloads) == 1
+    assert "logs_tail" not in job_payloads[0]
+
+
+def test_get_job_includes_log_tail_by_default(client: TestClient) -> None:
+    job = orchestrator_app.Job(
+        id="job_detail",
+        created_at=orchestrator_app._now(),
+        state="succeeded",
+        request={"pipeline": "lux-depth-v3", "args": {}},
+    )
+    job.add_log("detail log line")
+    orchestrator_app.JOBS[job.id] = job
+
+    detail_response = client.get(f"/v1/jobs/{job.id}")
+    assert detail_response.status_code == 200
+    assert "logs_tail" in detail_response.json()["data"]
+
+    trimmed = client.get(f"/v1/jobs/{job.id}?include_logs=false")
+    assert trimmed.status_code == 200
+    assert "logs_tail" not in trimmed.json()["data"]
+
+
+# ---------------------------------------------------------------------------
+# Telemetry
+# ---------------------------------------------------------------------------
+
+
+def test_sanitize_metadata_drops_non_finite_floats() -> None:
+    sanitized = orchestrator_app._portal_sanitize_metadata(
+        {
+            "good": 1.25,
+            "nanfield": float("nan"),
+            "inf": float("inf"),
+            "negative_inf": float("-inf"),
+        }
+    )
+    assert sanitized == {"good": 1.25}
+
+
+def test_rum_metric_allowlist_rejects_unknown_metric_for_empty_allowlist() -> None:
+    # `sse_reconnect` intentionally carries no metric token; any caller-supplied
+    # token must be rejected rather than silently accepted.
+    record, reason = orchestrator_app._record_portal_rum(
+        {
+            "event_type": "sse_reconnect",
+            "route": "/portal",
+            "view": "overview",
+            "unit": "count",
+            "value": 1,
+            "metric": "unexpected-metric",
+        },
+        _fake_request(),
+    )
+    assert record is None
+    assert reason == "invalid_metric"
+
+
+def _fake_request():
+    """Minimal stand-in for Starlette ``Request`` to drive _record_portal_rum."""
+
+    class _DummyState:
+        pass
+
+    class _DummyRequest:
+        def __init__(self) -> None:
+            self.headers: dict = {}
+            self.state = _DummyState()
+
+    return _DummyRequest()
+
+
+# ---------------------------------------------------------------------------
+# Artifact fingerprints
+# ---------------------------------------------------------------------------
+
+
+def test_artifact_fingerprint_emits_sha256_for_bounded_files(tmp_path: Path) -> None:
+    path = tmp_path / "small.bin"
+    path.write_bytes(b"hello world")
+    sha, status = orchestrator_app._artifact_fingerprint(path, path.stat().st_size)
+    assert status == "ok"
+    assert sha is not None and len(sha) == 64
+
+
+def test_artifact_fingerprint_reports_skipped_size_above_cap(tmp_path: Path) -> None:
+    orchestrator_app.ARTIFACT_FINGERPRINT_MAX_BYTES = 4
+    path = tmp_path / "too-big.bin"
+    path.write_bytes(b"0123456789")
+    sha, status = orchestrator_app._artifact_fingerprint(path, path.stat().st_size)
+    assert sha is None
+    assert status == "skipped_size"
+
+
+# ---------------------------------------------------------------------------
+# Lifespan
+# ---------------------------------------------------------------------------
+
+
+def test_app_uses_lifespan_not_on_event() -> None:
+    # `lifespan` is the supported FastAPI startup/shutdown surface; we want to
+    # see exactly one entry (our orchestrator) and no `on_event` handlers.
+    assert orchestrator_app.app.router.lifespan_context is not None
+
+
+def test_lifespan_creates_and_cancels_cleanup_task() -> None:
+    async def _drive() -> tuple[bool, bool]:
+        async with orchestrator_app.app.router.lifespan_context(
+            orchestrator_app.app
+        ) as _:
+            started = (
+                orchestrator_app.app.state.cleanup_task is not None
+                and not orchestrator_app.app.state.cleanup_task.done()
+            )
+        finished = orchestrator_app.app.state.cleanup_task is None
+        return started, finished
+
+    started, finished = asyncio.run(_drive())
+    assert started
+    assert finished
+
+
+# ---------------------------------------------------------------------------
+# Subprocess cancellation helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(os.name == "nt", reason="process-group cancel is POSIX-only")
+def test_signal_process_tree_uses_killpg_when_session_matches() -> None:
+    recorded: dict[str, object] = {}
+
+    class _FakeProc:
+        pid = 12345
+
+        @property
+        def returncode(self):
+            return None
+
+    def fake_getpgid(pid: int) -> int:
+        assert pid == 12345
+        return 12345  # same as pid => the child is its own session leader
+
+    def fake_killpg(pgid: int, sig: int) -> None:
+        recorded["pgid"] = pgid
+        recorded["sig"] = sig
+
+    original_getpgid = os.getpgid
+    original_killpg = os.killpg
+    os.getpgid = fake_getpgid  # type: ignore[assignment]
+    os.killpg = fake_killpg  # type: ignore[assignment]
+    try:
+        delivered = orchestrator_app._signal_process_tree(_FakeProc(), signal.SIGTERM)
+    finally:
+        os.getpgid = original_getpgid  # type: ignore[assignment]
+        os.killpg = original_killpg  # type: ignore[assignment]
+
+    assert delivered is True
+    assert recorded == {"pgid": 12345, "sig": signal.SIGTERM}
+
+
+@pytest.mark.skipif(os.name == "nt", reason="process-group cancel is POSIX-only")
+def test_signal_process_tree_returns_false_when_not_session_leader() -> None:
+    class _FakeProc:
+        pid = 4242
+
+        @property
+        def returncode(self):
+            return None
+
+    original_getpgid = os.getpgid
+    os.getpgid = lambda _pid: 9999  # type: ignore[assignment]
+    try:
+        delivered = orchestrator_app._signal_process_tree(_FakeProc(), signal.SIGTERM)
+    finally:
+        os.getpgid = original_getpgid  # type: ignore[assignment]
+
+    assert delivered is False
+
+
+# ---------------------------------------------------------------------------
+# Portal HTML static contract
+# ---------------------------------------------------------------------------
+
+
+def test_portal_html_defaults_match_backend_defaults() -> None:
+    portal_html = Path(orchestrator_app.REPO_ROOT) / "portal.html"
+    markup = portal_html.read_text(encoding="utf-8")
+    # Preset "premium" is the backend default and must be statically selected
+    # so pre-hydration rendering does not misrepresent the effective config.
+    assert '<option value="premium" selected>premium (Stable)</option>' in markup
+    assert '<option value="premium" selected>premium</option>' in markup
+    assert '<option value="cpu" selected>cpu</option>' in markup
+
+
+def test_portal_html_buttons_all_have_type_attribute() -> None:
+    import re
+
+    portal_html = Path(orchestrator_app.REPO_ROOT) / "portal.html"
+    markup = portal_html.read_text(encoding="utf-8")
+    missing_type: list[str] = []
+    for match in re.finditer(r"<button\b([^>]*)>", markup):
+        attrs = match.group(1)
+        if "type=" not in attrs:
+            missing_type.append(attrs.strip())
+    assert missing_type == [], f"buttons without type attribute: {missing_type}"

--- a/tests/test_portal_backend_hardening.py
+++ b/tests/test_portal_backend_hardening.py
@@ -93,6 +93,15 @@ def test_root_redirects_to_portal(client: TestClient) -> None:
     assert response.headers["location"] == "/portal"
 
 
+def test_root_redirect_preserves_query_string(client: TestClient) -> None:
+    # Legacy/deep links such as `/?view=review` must continue to land on
+    # the right workspace tab after the redirect; query string carries the
+    # routing context we don't want the canonicalisation to drop.
+    response = client.get("/?view=review&job=job_xyz", follow_redirects=False)
+    assert response.status_code == 307
+    assert response.headers["location"] == "/portal?view=review&job=job_xyz"
+
+
 def test_portal_route_serves_html(client: TestClient) -> None:
     response = client.get("/portal")
     assert response.status_code == 200
@@ -131,9 +140,7 @@ def test_dispatch_rejects_missing_input_dir(client: TestClient, tmp_path: Path) 
     assert body["error"]["details"]["field"] == "input_dir"
 
 
-def test_dispatch_output_dir_gets_created_when_missing(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_dispatch_output_dir_gets_created_when_missing(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
     async def fake_run_job(job, _argv):
         job.state = "succeeded"
         job.exit_code = 0
@@ -151,6 +158,40 @@ def test_dispatch_output_dir_gets_created_when_missing(
     response = client.post("/v1/jobs", json=_lux_payload(input_dir, output_dir))
     assert response.status_code == 200, response.text
     assert output_dir.is_dir()
+
+
+def test_dispatch_does_not_mkdir_when_admission_rejects(client: TestClient) -> None:
+    # Filesystem preflight is read-only; the mkdir must only run after the
+    # admission gate succeeds, so a 429 response leaves no directories on
+    # disk for the requested output path.
+    allowed = orchestrator_app.ALLOWED_INPUT_ROOTS[0]
+    input_dir = allowed / "inp"
+    input_dir.mkdir(parents=True, exist_ok=True)
+    output_dir = allowed / "should-not-exist-after-429"
+    assert not output_dir.exists()
+
+    previous_limit = orchestrator_app.MAX_CONCURRENT_JOBS
+    try:
+        orchestrator_app.MAX_CONCURRENT_JOBS = 1
+        orchestrator_app.JOBS["job_busy"] = orchestrator_app.Job(
+            id="job_busy",
+            created_at=orchestrator_app._now(),
+            state="running",
+            request={"pipeline": "lux-depth-v3", "args": {}},
+        )
+        response = client.post("/v1/jobs", json=_lux_payload(input_dir, output_dir))
+    finally:
+        orchestrator_app.MAX_CONCURRENT_JOBS = previous_limit
+
+    assert response.status_code == 429
+    assert not output_dir.exists(), "output_dir was created despite admission rejection"
+
+
+def test_artifact_fingerprint_default_cap_is_inexpensive() -> None:
+    # The default cap must stay small enough that hashing up to
+    # MAX_INDEXED_ARTIFACTS (200) artifacts per job remains an inexpensive
+    # background-thread workload rather than blocking the event loop.
+    assert orchestrator_app.ARTIFACT_FINGERPRINT_MAX_BYTES <= 16 * 1024 * 1024
 
 
 def test_dispatch_rejects_unknown_preset(client: TestClient) -> None:
@@ -214,9 +255,7 @@ def test_artifact_lookup_excludes_non_indexed_files(tmp_path: Path) -> None:
     assert set(job.artifact_lookup.keys()) == {"a.json", "b.json"}
 
 
-def test_artifact_endpoint_attaches_non_previewable(
-    client: TestClient, tmp_path: Path
-) -> None:
+def test_artifact_endpoint_attaches_non_previewable(client: TestClient, tmp_path: Path) -> None:
     allowed = orchestrator_app.ALLOWED_OUTPUT_ROOTS[0]
     output_dir = allowed / "job_files"
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -390,12 +429,9 @@ def test_app_uses_lifespan_not_on_event() -> None:
 
 def test_lifespan_creates_and_cancels_cleanup_task() -> None:
     async def _drive() -> tuple[bool, bool]:
-        async with orchestrator_app.app.router.lifespan_context(
-            orchestrator_app.app
-        ) as _:
+        async with orchestrator_app.app.router.lifespan_context(orchestrator_app.app) as _:
             started = (
-                orchestrator_app.app.state.cleanup_task is not None
-                and not orchestrator_app.app.state.cleanup_task.done()
+                orchestrator_app.app.state.cleanup_task is not None and not orchestrator_app.app.state.cleanup_task.done()
             )
         finished = orchestrator_app.app.state.cleanup_task is None
         return started, finished


### PR DESCRIPTION
P0 — contract & safety:
- Route /portal as the canonical UI; keep / as a 307 redirect so the
  PORTAL_ALLOWED_RUM_ROUTES allowlist and the UI surface agree.
- Add filesystem + value preflight to /v1/jobs dispatch: reject missing
  input_dir, create output_dir (or report output_dir_unwritable), and
  reject unknown preset / depth_device / run_card_version values so
  dispatch and preview agree.
- Scope the fallback artifact lookup to the MAX_INDEXED_ARTIFACTS-sized
  serialized set instead of every file walked, closing an information
  leak for non-indexed files sharing the output directory.
- Serve non-previewable artifacts as attachments to prevent stored
  HTML/SVG/JS from executing in the portal origin.
- Put the runner subprocess in its own session on POSIX and cancel via
  os.killpg so child processes exit with the parent; publish an
  interim state event when cancel is first requested.

P1 — reliability & observability:
- Drop logs_tail from /v1/jobs list responses; /v1/jobs/{id} keeps it
  and gains an include_logs=false query flag.
- Redact common credential shapes from runner output before persistence
  and SSE publication.
- Drop NaN/inf floats from RUM metadata and require the metric allowlist
  entry to match exactly (empty set means "no metric permitted").
- Emit bounded SHA-256 fingerprints for indexed artifacts, reporting
  skipped_size above TP_ARTIFACT_FINGERPRINT_MAX_BYTES.
- Replace deprecated @app.on_event handlers with a FastAPI lifespan
  context manager that owns the cleanup task.

P2 — portal UI:
- Align portal.html static defaults (preset/quality/device) with the
  backend premium preset so pre-hydration renders match the effective
  config.
- Give clearLogsBtn and closeShortcutsBtn explicit type="button".
- Replace the workspace rail's ARIA tablist with nav semantics and
  aria-current="page" on the active anchor.

Tests:
- New tests/test_portal_backend_hardening.py covers each behavior above.
- Update existing HTTP contract tests that relied on non-existent
  filesystem paths to mkdir the fixture input directories first.