### PR TITLE
test(portal): avoid gitleaks secret-shaped redaction fixtures

### DIFF
--- a/tests/test_portal_backend_hardening.py
+++ b/tests/test_portal_backend_hardening.py
@@ -292,8 +292,10 @@ def test_artifact_endpoint_attaches_non_previewable(client: TestClient, tmp_path
 @pytest.mark.parametrize(
     "line,expected",
     [
-        ("api_key=sk-abcdef123", "api_key=<redacted>"),
-        ("OPENAI_API_KEY=sk-abcdef123", "OPENAI_API_KEY=<redacted>"),
+        # Keep these fixtures non-secret-shaped: CI runs gitleaks on pushed
+        # diffs and on clean checked-out source trees.
+        ("api_key=query-secret", "api_key=<redacted>"),
+        ("OPENAI_API_KEY=query-secret", "OPENAI_API_KEY=<redacted>"),
         ("password: hunter2", "password: <redacted>"),
         ("token = abcdef", "token = <redacted>"),
         ("Authorization: Bearer abcdef.token", "Authorization: <redacted>"),


### PR DESCRIPTION
## Summary
- Root cause: `main` CI gitleaks failures came from secret-shaped redaction test fixtures in `tests/test_portal_backend_hardening.py`.
- Smallest safe change: replace those fixtures with non-secret-shaped placeholders and document why they must stay that way.

## Changes
- Replace `api_key=sk-abcdef123` and `OPENAI_API_KEY=sk-abcdef123` with `query-secret` placeholders in the portal hardening redaction tests.
- Add an inline note that these fixtures must stay non-secret-shaped because CI runs gitleaks against pushed diffs and clean checked-out source trees.
- Leave runtime code, workflow definitions, and `.gitleaks.toml` unchanged.

## Validation
- Proven green
  - `.venv/bin/pytest tests/test_portal_backend_hardening.py -k log_redaction -q`
  - `/opt/homebrew/bin/gitleaks detect --config .gitleaks.toml --source tests/test_portal_backend_hardening.py --no-git --redact --verbose --exit-code 1`
  - `/opt/homebrew/bin/gitleaks detect --config .gitleaks.toml --source tests --no-git --redact --verbose --exit-code 1`
- Still failing
  - None locally.
  - GitHub Actions re-run pending on this PR branch.
- Failure classification
  - The `main` failures were CI security gate failures caused by test fixture content, not product logic.

## Risk
- Low and revert-safe: test-only fixture changes with unchanged assertions and unchanged security policy.
- No compatibility, migration, selector, route, auth, or contract impact.
