### PR TITLE
fix(requirements): normalize host-specific generic lock checks

### DIFF
--- a/requirements/Makefile
+++ b/requirements/Makefile
@@ -309,12 +309,12 @@ check-generic: require-pip-compile
 	$(PIP_COMPILE) security.in -o security.txt >/dev/null; \
 	$(PIP_COMPILE) -c all.txt tools-archive.in -o tools-archive.txt >/dev/null; \
 	normalize_req() { \
-		: "The lock contract separately enforces the Linux-only keyring chain, so host-side diffs ignore those packages and pip-compile provenance comments."; \
+		: "The lock contract separately enforces the Linux-only keyring chain and platform-marked OpenCV runtime pins, so host-side diffs ignore those packages and pip-compile provenance comments."; \
 		file_name="$$(basename "$$1")"; \
 		awk '!/^[[:space:]]*#/ && !/^[[:space:]]*$$/ { print }' "$$1" | \
 		while IFS= read -r line; do \
 			case "$$file_name:$$line" in \
-				all.txt:jeepney==*|all.txt:secretstorage==*|ci.txt:cffi==*|ci.txt:cryptography==*|ci.txt:jeepney==*|ci.txt:pycparser==*|ci.txt:secretstorage==*) \
+				all.txt:jeepney==*|all.txt:secretstorage==*|all.txt:opencv-python==*|all.txt:opencv-python-headless==*|base.txt:opencv-python==*|base.txt:opencv-python-headless==*|ci.txt:cffi==*|ci.txt:cryptography==*|ci.txt:jeepney==*|ci.txt:pycparser==*|ci.txt:secretstorage==*) \
 					continue; \
 					;; \
 			esac; \

--- a/tests/test_requirements_lock_lane_makefile.py
+++ b/tests/test_requirements_lock_lane_makefile.py
@@ -37,12 +37,16 @@ def test_generic_targets_do_not_reference_target_owned_ml_locks() -> None:
         assert "ml-core-linux.txt" not in body
 
 
-def test_check_generic_normalizes_linux_keyring_chain_packages() -> None:
+def test_check_generic_normalizes_host_specific_generic_lock_packages() -> None:
     body = _target_body("check-generic")
 
     for snippet in (
         "all.txt:jeepney==*",
         "all.txt:secretstorage==*",
+        "all.txt:opencv-python==*",
+        "all.txt:opencv-python-headless==*",
+        "base.txt:opencv-python==*",
+        "base.txt:opencv-python-headless==*",
         "ci.txt:cffi==*",
         "ci.txt:cryptography==*",
         "ci.txt:jeepney==*",


### PR DESCRIPTION
## Summary
- Fix the generic lock freshness check on non-Linux hosts.
- Keep `make check-generic` aligned with the lock-contract validator instead of failing on host-specific marker resolution.

## Changes
- Update `requirements/Makefile` normalization for `check-generic` to ignore the platform-marked OpenCV runtime pins in the same way it already ignores the Linux-only keyring chain.
- Extend the focused Makefile unit test to assert those host-specific normalization cases.
- No dependency inputs, compiled lockfiles, ML lockfiles, routes, selectors, API envelopes, or CLI behavior changed.

## Validation
Proven green:
- `.venv/bin/pytest tests/test_requirements_lock_lane_makefile.py`
- `./scripts/validate_dependency_constraints.sh`
- `python3 scripts/validation/check_requirements_lock_contract.py`
- `cd requirements && make check-generic LOCK_PYTHON_VERSION=3.11`

Still failing:
- None in this branch.

## Risk
- Low. The change is limited to local freshness-check normalization and its focused test.
- The separate lock-contract validator still enforces the required platform-marked OpenCV pins, so this is revert-safe and bounded to host portability for `check-generic`.
