### PR TITLE
chore(deps): curate uvicorn 0.45.0 generic lock rotation

### DIFF
--- a/docs/governance/DEPENDABOT_PR_GOVERNANCE.md
+++ b/docs/governance/DEPENDABOT_PR_GOVERNANCE.md
@@ -3,7 +3,7 @@
 **Purpose**: Define triage policy and merge criteria for Dependabot-generated pull requests
 **Owner**: Transformation Portal Architect
 **Created**: 2026-03-26
-**Last Updated**: 2026-04-16
+**Last Updated**: 2026-04-23
 
 ---
 
@@ -60,9 +60,9 @@ The following are the enforced controls that constrain Dependabot PR acceptance:
 The following dependencies are **exact-pinned** in `requirements/base.in` for API/UI parity and security baseline:
 
 ```
-fastapi==0.135.1
+fastapi==0.136.0
 starlette==1.0.0
-uvicorn==0.42.0
+uvicorn==0.45.0
 aiofiles==25.1.0
 ```
 
@@ -203,6 +203,7 @@ Before merging any Dependabot PR:
 | 2026-03-26 | Updated after #1275 closure and curated Starlette merge via #1278 | Architect |
 | 2026-04-16 | Recorded the FastAPI 0.136.0 curated baseline and the "dep pin changed" checklist | Architect |
 | 2026-04-16 | Added ML alert dismissal/remediation governance for supported vs frozen target-owned lanes | Architect |
+| 2026-04-23 | Synced the exact-pinned web stack block with the curated Uvicorn 0.45.0 baseline | Architect |
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     # Exact versions are enforced in requirements/base.in and compiled lockfiles.
     "fastapi>=0.121.0,<0.137",
     "starlette>=0.49.1,<1.1",  # direct runtime import + curated Starlette 1.x validation window
-    "uvicorn>=0.29.0,<0.43",
+    "uvicorn>=0.29.0,<0.46",
     "aiofiles>=23.2.1,<26",
     "tifffile>=2023.7.18,<2027",
     "imagecodecs>=2023.9.18,<2027",

--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -331,7 +331,7 @@ urllib3==2.6.3
     #   id
     #   requests
     #   twine
-uvicorn==0.42.0
+uvicorn==0.45.0
     # via -r base.in
 virtualenv==21.2.1
     # via tox

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -18,7 +18,7 @@ tqdm>=4.66,<5              # progress bar utility
 # Security: keep FastAPI + Starlette on patched baseline for CVE-2025-62727.
 fastapi==0.136.0           # orchestrator API framework (validated against curated Starlette 1.x upgrade)
 starlette==1.0.0           # direct runtime import + curated Starlette 1.x validation target
-uvicorn==0.42.0            # ASGI server runtime pin
+uvicorn==0.45.0            # ASGI server runtime pin
 aiofiles==25.1.0           # async file I/O support for FastAPI file responses
 
 # Schema validation (required for ingest contract)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -165,7 +165,7 @@ typing-inspection==0.4.2
     #   -c all.txt
     #   fastapi
     #   pydantic
-uvicorn==0.42.0
+uvicorn==0.45.0
     # via
     #   -c all.txt
     #   -r base.in


### PR DESCRIPTION
## Summary
- Supersedes #1514.
- Curates the uvicorn bump from 0.42.0 to 0.45.0 across the governed runtime inputs and generic locks.
- Keeps the diff limited to the four intended dependency files; no application code changes.

## Changes
- Bump the uvicorn runtime range in pyproject.toml to <0.46.
- Bump the exact uvicorn pin in requirements/base.in to 0.45.0.
- Regenerate requirements/all.txt and requirements/base.txt for the curated uvicorn rotation only.
- Preserve routes, selectors, API envelopes, CLI behavior, and all ML lockfiles.

## Validation
- Commands run:
  - ./scripts/validate_dependency_constraints.sh
  - python3 scripts/validation/check_requirements_lock_contract.py
  - cd requirements && make check-generic LOCK_PYTHON_VERSION=3.11
  - make test-orchestrator-contract
  - source ~/.nvm/nvm.sh && nvm exec 22 make test-frontdoor-contract
  - source ~/.nvm/nvm.sh && nvm exec 22 make ci
- Proven green:
  - All commands above passed locally on April 22-23, 2026.
- Still failing:
  - None locally.
  - GitHub PR checks were not yet available at PR creation time.
- Failure classification:
  - Earlier failures were environment-only: sandbox tempdir restrictions and a frontdoor dependency tree built under Node 25 instead of the required Node 22 runtime.

## Risk
- Bounded to a single runtime dependency bump and matching generic lock rotation.
- Revert-safe because no application code, route, selector, API, or CLI behavior changes are included.
- Node 22 remains the enforced frontdoor contract.