### PR TITLE
chore(deps): curate pydantic 2.13.3 generic lock refresh

### DIFF
--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -199,11 +199,11 @@ pycodestyle==2.14.0
     #   flake8
 pycparser==3.0
     # via cffi
-pydantic==2.13.1
+pydantic==2.13.3
     # via
     #   -r base.in
     #   fastapi
-pydantic-core==2.46.1
+pydantic-core==2.46.3
     # via pydantic
 pyflakes==3.4.0
     # via flake8

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -89,12 +89,12 @@ pillow==12.2.0
     # via
     #   -c all.txt
     #   -r base.in
-pydantic==2.13.1
+pydantic==2.13.3
     # via
     #   -c all.txt
     #   -r base.in
     #   fastapi
-pydantic-core==2.46.1
+pydantic-core==2.46.3
     # via
     #   -c all.txt
     #   pydantic


### PR DESCRIPTION
## Summary
- Supersedes #1515.
- Curates the pydantic and pydantic-core generic lock refresh on top of the merged uvicorn baseline from #1520.
- Keeps the diff limited to the two governed generic lockfiles; no input file or application code changes.

## Changes
- Update pydantic from 2.13.1 to 2.13.3 in requirements/all.txt.
- Update pydantic-core from 2.46.1 to 2.46.3 in requirements/all.txt.
- Update pydantic from 2.13.1 to 2.13.3 in requirements/base.txt.
- Update pydantic-core from 2.46.1 to 2.46.3 in requirements/base.txt.
- Preserve pyproject.toml, requirements/base.in, all ML lockfiles, route shapes, selectors, API envelopes, and CLI behavior.

## Validation
- Commands run:
  - ./scripts/validate_dependency_constraints.sh
  - python3 scripts/validation/check_requirements_lock_contract.py
  - cd requirements && make check-generic LOCK_PYTHON_VERSION=3.11
  - make test-orchestrator-contract
  - source ~/.nvm/nvm.sh && nvm exec 22 make test-frontdoor-contract
  - source ~/.nvm/nvm.sh && nvm exec 22 make ci
- Proven green:
  - All commands above passed locally on April 22-23, 2026.
  - The branch was then replayed onto current main, and the dependency constraint, lock contract, and generic lock checks were rerun successfully.
- Still failing:
  - None locally.
  - GitHub PR checks were not yet available at PR creation time.
- Failure classification:
  - Earlier failures during preparation were environment-only: sandbox tempdir restrictions and a frontdoor dependency tree built under Node 25 instead of the required Node 22 runtime.

## Risk
- Bounded to a generic lock-only refresh for pydantic and pydantic-core.
- Revert-safe because no application code, route, selector, API, CLI, or dependency input changes are included.
- The required non-Linux opencv marker contract is preserved.