### PR TITLE
fix(ci): isolate mixed schedule workflow concurrency

### DIFF
--- a/.github/workflows/AI_WORKFLOW_PATTERN.md
+++ b/.github/workflows/AI_WORKFLOW_PATTERN.md
@@ -147,6 +147,13 @@ concurrency:
 ```
 
 ```yaml
+# Mixed schedule + push/pull_request workflows
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true       # ← REQUIRED: Prevent cross-event cancellation
+```
+
+```yaml
 # Issue/PR event workflows (issues, issue_comment, pull_request_target)
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}

--- a/.github/workflows/apex_performance.yml
+++ b/.github/workflows/apex_performance.yml
@@ -34,7 +34,7 @@ on:
     - cron: "0 0 * * 0" # Weekly on Sunday 00:00 UTC
 
 concurrency:
-  group: apex-${{ github.event.pull_request.number || github.ref }}
+  group: apex-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 # Workflow-level permissions with least privilege defaults

--- a/.github/workflows/enforcement.yml
+++ b/.github/workflows/enforcement.yml
@@ -12,7 +12,7 @@ on:
 # Concurrency control: Cancel outdated runs on new pushes to the same branch/PR
 # This reduces CI minutes and speeds up feedback on the latest code
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/security-unified.yml
+++ b/.github/workflows/security-unified.yml
@@ -44,7 +44,7 @@ permissions:
   packages: read
 
 concurrency:
-  group: security-unified-${{ github.ref }}
+  group: security-unified-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/Makefile
+++ b/Makefile
@@ -488,6 +488,8 @@ check-stale-docs:
 validate-ci:
 	@echo "Validating GitHub Actions workflows..."
 	@"$(PY)" scripts/validate_ci_config.py
+	@echo "Validating workflow concurrency contract..."
+	@"$(PY)" scripts/validation/check_workflow_concurrency_contract.py
 	@echo "Validating gitleaks workflow contract..."
 	@"$(PY)" scripts/validation/check_gitleaks_workflow_contract.py
 	@echo "Validating dependency-update workflow contract..."

--- a/scripts/validation/check_workflow_concurrency_contract.py
+++ b/scripts/validation/check_workflow_concurrency_contract.py
@@ -48,6 +48,10 @@ def _has_trigger(config: dict[str, Any], trigger_name: str) -> bool:
 def _load_workflow_config(workflow_name: str, text: str) -> dict[str, Any]:
     """Return a normalized workflow mapping.
 
+    Args:
+        workflow_name: Workflow filename used to scope deterministic error messages.
+        text: Raw workflow YAML text to parse and normalize.
+
     Returns:
         dict[str, Any]: The normalized workflow configuration mapping.
 
@@ -64,7 +68,16 @@ def _load_workflow_config(workflow_name: str, text: str) -> dict[str, Any]:
 
 
 def validate_workflow_concurrency_contract_text(workflow_name: str, text: str) -> list[str]:
-    """Return concurrency contract violations for a single workflow file."""
+    """Return concurrency contract violations for a single workflow file.
+
+    Args:
+        workflow_name: Workflow filename used to scope reported violations.
+        text: Raw workflow YAML text to validate.
+
+    Returns:
+        list[str]: File-scoped contract violations, including YAML loader/import
+        errors and mixed-trigger concurrency violations.
+    """
     try:
         config = _load_workflow_config(workflow_name, text)
     except ValueError as exc:

--- a/scripts/validation/check_workflow_concurrency_contract.py
+++ b/scripts/validation/check_workflow_concurrency_contract.py
@@ -46,7 +46,11 @@ def _has_trigger(config: dict[str, Any], trigger_name: str) -> bool:
 
 
 def _load_workflow_config(workflow_name: str, text: str) -> dict[str, Any]:
-    """Return a normalized workflow mapping or raise a deterministic contract error."""
+    """Return a normalized workflow mapping.
+
+    Raises:
+        ValueError: When PyYAML is unavailable or the workflow text is invalid YAML.
+    """
     if yaml is None:
         raise ValueError(f"{workflow_name}: PyYAML not installed (pip install PyYAML)")
     try:

--- a/scripts/validation/check_workflow_concurrency_contract.py
+++ b/scripts/validation/check_workflow_concurrency_contract.py
@@ -48,6 +48,9 @@ def _has_trigger(config: dict[str, Any], trigger_name: str) -> bool:
 def _load_workflow_config(workflow_name: str, text: str) -> dict[str, Any]:
     """Return a normalized workflow mapping.
 
+    Returns:
+        dict[str, Any]: The normalized workflow configuration mapping.
+
     Raises:
         ValueError: When PyYAML is unavailable or the workflow text is invalid YAML.
     """

--- a/scripts/validation/check_workflow_concurrency_contract.py
+++ b/scripts/validation/check_workflow_concurrency_contract.py
@@ -7,6 +7,7 @@ workflows on the same branch when cancel-in-progress is enabled.
 
 from __future__ import annotations
 
+import re
 import sys
 from pathlib import Path
 from typing import Any
@@ -16,7 +17,7 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
 
-EVENT_NAME_SNIPPET = "github.event_name"
+EVENT_NAME_EXPRESSION = re.compile(r"\$\{\{\s*github\.event_name\s*\}\}")
 
 
 def _normalize_workflow_config(config: dict[str, Any] | None) -> dict[str, Any]:
@@ -68,10 +69,11 @@ def validate_workflow_concurrency_contract_text(workflow_name: str, text: str) -
         )
         return errors
 
-    if EVENT_NAME_SNIPPET not in group:
+    if EVENT_NAME_EXPRESSION.search(group) is None:
         errors.append(
-            f"{workflow_name}: mixed schedule/push workflow must include {EVENT_NAME_SNIPPET!r} in "
-            f"concurrency.group when cancel-in-progress is true (current: {group!r})"
+            f"{workflow_name}: mixed schedule/push workflow must include an interpolated "
+            f"'${{{{ github.event_name }}}}' token in concurrency.group when cancel-in-progress "
+            f"is true (current: {group!r})"
         )
 
     return errors
@@ -82,7 +84,9 @@ def validate_repo_workflow_concurrency_contract(workflows_dir: Path = WORKFLOWS_
     errors: list[str] = []
 
     for workflow_path in sorted(workflows_dir.glob("*.yml")) + sorted(workflows_dir.glob("*.yaml")):
-        errors.extend(validate_workflow_concurrency_contract_text(workflow_path.name, workflow_path.read_text()))
+        errors.extend(
+            validate_workflow_concurrency_contract_text(workflow_path.name, workflow_path.read_text(encoding="utf-8"))
+        )
 
     return errors
 

--- a/scripts/validation/check_workflow_concurrency_contract.py
+++ b/scripts/validation/check_workflow_concurrency_contract.py
@@ -12,7 +12,10 @@ import sys
 from pathlib import Path
 from typing import Any
 
-import yaml
+try:
+    import yaml
+except ImportError:
+    yaml = None
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
@@ -42,9 +45,23 @@ def _has_trigger(config: dict[str, Any], trigger_name: str) -> bool:
     return False
 
 
+def _load_workflow_config(workflow_name: str, text: str) -> dict[str, Any]:
+    """Return a normalized workflow mapping or raise a deterministic contract error."""
+    if yaml is None:
+        raise ValueError(f"{workflow_name}: PyYAML not installed (pip install PyYAML)")
+    try:
+        loaded = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise ValueError(f"{workflow_name}: invalid YAML: {exc}") from exc
+    return _normalize_workflow_config(loaded)
+
+
 def validate_workflow_concurrency_contract_text(workflow_name: str, text: str) -> list[str]:
     """Return concurrency contract violations for a single workflow file."""
-    config = _normalize_workflow_config(yaml.safe_load(text))
+    try:
+        config = _load_workflow_config(workflow_name, text)
+    except ValueError as exc:
+        return [str(exc)]
     errors: list[str] = []
 
     has_schedule = _has_trigger(config, "schedule")

--- a/scripts/validation/check_workflow_concurrency_contract.py
+++ b/scripts/validation/check_workflow_concurrency_contract.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Validate workflow concurrency isolation for mixed schedule/event workflows.
+
+This guard prevents scheduled workflows from cancelling push or pull_request
+workflows on the same branch when cancel-in-progress is enabled.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
+
+EVENT_NAME_SNIPPET = "github.event_name"
+
+
+def _normalize_workflow_config(config: dict[str, Any] | None) -> dict[str, Any]:
+    """Return a workflow mapping with YAML 1.1 boolean keys normalized."""
+    if not isinstance(config, dict):
+        return {}
+    if True in config and "on" not in config:
+        config = dict(config)
+        config["on"] = config.pop(True)
+    return config
+
+
+def _has_trigger(config: dict[str, Any], trigger_name: str) -> bool:
+    """Return True when the workflow declares the given trigger."""
+    triggers = config.get("on")
+    if isinstance(triggers, dict):
+        return trigger_name in triggers
+    if isinstance(triggers, list):
+        return trigger_name in triggers
+    if isinstance(triggers, str):
+        return triggers == trigger_name
+    return False
+
+
+def validate_workflow_concurrency_contract_text(workflow_name: str, text: str) -> list[str]:
+    """Return concurrency contract violations for a single workflow file."""
+    config = _normalize_workflow_config(yaml.safe_load(text))
+    errors: list[str] = []
+
+    has_schedule = _has_trigger(config, "schedule")
+    has_push = _has_trigger(config, "push")
+    has_pull_request = _has_trigger(config, "pull_request")
+
+    if not has_schedule or not (has_push or has_pull_request):
+        return errors
+
+    concurrency = config.get("concurrency")
+    if not isinstance(concurrency, dict):
+        return errors
+
+    if concurrency.get("cancel-in-progress") is not True:
+        return errors
+
+    group = concurrency.get("group")
+    if not isinstance(group, str):
+        errors.append(
+            f"{workflow_name}: mixed schedule/push workflow must define a string concurrency.group when "
+            "cancel-in-progress is true"
+        )
+        return errors
+
+    if EVENT_NAME_SNIPPET not in group:
+        errors.append(
+            f"{workflow_name}: mixed schedule/push workflow must include {EVENT_NAME_SNIPPET!r} in "
+            f"concurrency.group when cancel-in-progress is true (current: {group!r})"
+        )
+
+    return errors
+
+
+def validate_repo_workflow_concurrency_contract(workflows_dir: Path = WORKFLOWS_DIR) -> list[str]:
+    """Validate all workflow files in the repository."""
+    errors: list[str] = []
+
+    for workflow_path in sorted(workflows_dir.glob("*.yml")) + sorted(workflows_dir.glob("*.yaml")):
+        errors.extend(validate_workflow_concurrency_contract_text(workflow_path.name, workflow_path.read_text()))
+
+    return errors
+
+
+def main() -> int:
+    errors = validate_repo_workflow_concurrency_contract()
+
+    if errors:
+        print("ERROR: workflow concurrency contract validation failed:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+
+    print("workflow concurrency contract passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_check_workflow_concurrency_contract.py
+++ b/tests/test_check_workflow_concurrency_contract.py
@@ -32,8 +32,8 @@ jobs:
 """
     errors = workflow_contract.validate_workflow_concurrency_contract_text("broken.yml", text)
     assert errors == [
-        "broken.yml: mixed schedule/push workflow must include 'github.event_name' in concurrency.group when "
-        "cancel-in-progress is true (current: '${{ github.workflow }}-${{ github.ref }}')"
+        "broken.yml: mixed schedule/push workflow must include an interpolated '${{ github.event_name }}' token "
+        "in concurrency.group when cancel-in-progress is true (current: '${{ github.workflow }}-${{ github.ref }}')"
     ]
 
 
@@ -57,6 +57,30 @@ jobs:
       - run: echo ok
 """
     assert workflow_contract.validate_workflow_concurrency_contract_text("safe.yml", text) == []
+
+
+def test_literal_event_name_text_without_expression_fails() -> None:
+    text = """
+name: Fake Event Namespace
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 1 * * *'
+concurrency:
+  group: mywf-github.event_name-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+"""
+    errors = workflow_contract.validate_workflow_concurrency_contract_text("fake.yml", text)
+    assert errors == [
+        "fake.yml: mixed schedule/push workflow must include an interpolated '${{ github.event_name }}' token "
+        "in concurrency.group when cancel-in-progress is true (current: 'mywf-github.event_name-${{ github.ref }}')"
+    ]
 
 
 def test_schedule_only_workflow_is_exempt() -> None:

--- a/tests/test_check_workflow_concurrency_contract.py
+++ b/tests/test_check_workflow_concurrency_contract.py
@@ -119,3 +119,15 @@ jobs:
       - run: echo ok
 """
     assert workflow_contract.validate_workflow_concurrency_contract_text("no-cancel.yml", text) == []
+
+
+def test_invalid_yaml_is_reported_as_file_scoped_contract_violation() -> None:
+    errors = workflow_contract.validate_workflow_concurrency_contract_text("broken.yml", "on: [")
+    assert len(errors) == 1
+    assert errors[0].startswith("broken.yml: invalid YAML:")
+
+
+def test_missing_pyyaml_is_reported_as_file_scoped_contract_violation(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(workflow_contract, "yaml", None)
+    errors = workflow_contract.validate_workflow_concurrency_contract_text("broken.yml", "on: push")
+    assert errors == ["broken.yml: PyYAML not installed (pip install PyYAML)"]

--- a/tests/test_check_workflow_concurrency_contract.py
+++ b/tests/test_check_workflow_concurrency_contract.py
@@ -1,0 +1,97 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+TOOL_PATH = PROJECT_ROOT / "scripts" / "validation" / "check_workflow_concurrency_contract.py"
+SPEC = importlib.util.spec_from_file_location("check_workflow_concurrency_contract", TOOL_PATH)
+assert SPEC is not None and SPEC.loader is not None
+workflow_contract = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(workflow_contract)
+
+
+def test_branch_only_group_fails_for_mixed_schedule_push_workflow() -> None:
+    text = """
+name: Broken Workflow
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 1 * * *'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+"""
+    errors = workflow_contract.validate_workflow_concurrency_contract_text("broken.yml", text)
+    assert errors == [
+        "broken.yml: mixed schedule/push workflow must include 'github.event_name' in concurrency.group when "
+        "cancel-in-progress is true (current: '${{ github.workflow }}-${{ github.ref }}')"
+    ]
+
+
+def test_event_namespaced_group_passes_for_mixed_schedule_push_workflow() -> None:
+    text = """
+name: Safe Workflow
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 1 * * *'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+"""
+    assert workflow_contract.validate_workflow_concurrency_contract_text("safe.yml", text) == []
+
+
+def test_schedule_only_workflow_is_exempt() -> None:
+    text = """
+name: Schedule Only
+on:
+  schedule:
+    - cron: '0 1 * * *'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+"""
+    assert workflow_contract.validate_workflow_concurrency_contract_text("schedule-only.yml", text) == []
+
+
+def test_mixed_schedule_push_workflow_with_cancel_disabled_is_exempt() -> None:
+    text = """
+name: Non Cancelling Workflow
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 1 * * *'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+"""
+    assert workflow_contract.validate_workflow_concurrency_contract_text("no-cancel.yml", text) == []


### PR DESCRIPTION
## Summary
- Fix a CI governance bug where mixed schedule + push workflows on the same branch shared one concurrency group and scheduled runs could cancel in-flight push runs on `main`.
- Scope the affected workflow concurrency groups by `github.event_name` and add a validator so the same regression cannot re-enter through future workflow edits.

## Changes
- Update `.github/workflows/enforcement.yml`, `.github/workflows/security-unified.yml`, and `.github/workflows/apex_performance.yml` to include `github.event_name` in their concurrency groups.
- Add `scripts/validation/check_workflow_concurrency_contract.py` and focused coverage in `tests/test_check_workflow_concurrency_contract.py`.
- Wire the new contract into `make validate-ci`.
- Extend `.github/workflows/AI_WORKFLOW_PATTERN.md` with the mixed schedule/push concurrency pattern.

## Validation
Proven green:
- `/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin/python -m pytest tests/test_check_workflow_concurrency_contract.py`
- `make PY=/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin/python validate-ci`

Still failing:
- None in the executed scope.

Environment notes:
- The clean worktree does not have its own `.venv`, so local validation used the canonical repo-managed Python 3.11 interpreter from `/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin/python`.

## Risk
- Bounded to GitHub Actions workflow concurrency semantics and CI governance validation only; no product code, routes, selectors, API envelopes, CLI flags, or dependency contracts change.
- Revert-safe because the functional change is limited to workflow concurrency keys and a matching validator/test guard.