### PR TITLE
fix(lux-depth): unify depth contracts and run-card semantics

### DIFF
--- a/src/transformation_portal/lux_depth_v3/bootstrap/sky_seed.py
+++ b/src/transformation_portal/lux_depth_v3/bootstrap/sky_seed.py
@@ -24,6 +24,22 @@ from typing import Any, Dict, List, Tuple
 import numpy as np
 
 
+def _clamp_finite_float(
+    value: Any,
+    *,
+    name: str,
+    minimum: float,
+    maximum: float,
+) -> float:
+    try:
+        resolved = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a finite number") from exc
+    if not np.isfinite(resolved):
+        raise ValueError(f"{name} must be finite")
+    return float(np.clip(resolved, minimum, maximum))
+
+
 def detect_sky_seed(image: np.ndarray, config: Any) -> Dict[str, Any]:
     """Detect sky region using heuristics.
 
@@ -66,13 +82,24 @@ def detect_sky_seed(image: np.ndarray, config: Any) -> Dict[str, Any]:
 
     H, W = img.shape[:2]
 
-    # Get configuration parameters with safe defaults
-    top_region_fraction = getattr(config, "sky_top_region_fraction", 0.5)
-    gradient_threshold = getattr(config, "sky_gradient_threshold", 0.05)
-    brightness_threshold = getattr(config, "sky_brightness_threshold", 0.4)
-
-    # Input validation: clamp top_region_fraction to [0, 1]
-    top_region_fraction = np.clip(top_region_fraction, 0.0, 1.0)
+    top_region_fraction = _clamp_finite_float(
+        getattr(config, "sky_top_region_fraction", 0.5),
+        name="sky_top_region_fraction",
+        minimum=0.0,
+        maximum=1.0,
+    )
+    gradient_threshold = _clamp_finite_float(
+        getattr(config, "sky_gradient_threshold", 0.05),
+        name="sky_gradient_threshold",
+        minimum=0.0,
+        maximum=float(np.sqrt(2.0)),
+    )
+    brightness_threshold = _clamp_finite_float(
+        getattr(config, "sky_brightness_threshold", 0.4),
+        name="sky_brightness_threshold",
+        minimum=0.0,
+        maximum=1.0,
+    )
 
     # 1. Top-of-frame prior
     # Sky is typically in the upper portion of the image
@@ -125,7 +152,7 @@ def detect_sky_seed(image: np.ndarray, config: Any) -> Dict[str, Any]:
 
     # Generate prompt points for SAM2 refinement
     points_positive = _sample_points_inside(coarse_mask, num_points=5)
-    points_negative = _sample_points_outside(coarse_mask, H, W, num_points=5)
+    points_negative = _sample_points_outside(coarse_mask, num_points=5)
 
     return {
         "coarse_mask": coarse_mask,
@@ -174,13 +201,11 @@ def _sample_points_inside(mask: np.ndarray, num_points: int = 5) -> List[Tuple[i
     return [(int(xs[i]), int(ys[i])) for i in indices]
 
 
-def _sample_points_outside(mask: np.ndarray, H: int, W: int, num_points: int = 5) -> List[Tuple[int, int]]:
+def _sample_points_outside(mask: np.ndarray, num_points: int = 5) -> List[Tuple[int, int]]:
     """Sample deterministic points outside the mask using stratified sampling.
 
     Args:
         mask: Binary mask (H, W) with values in {0, 1}
-        H: Image height
-        W: Image width
         num_points: Number of points to sample
 
     Returns:

--- a/src/transformation_portal/lux_depth_v3/contracts/depth_artifact.py
+++ b/src/transformation_portal/lux_depth_v3/contracts/depth_artifact.py
@@ -4,8 +4,7 @@ This module defines the core contract for depth artifacts across all pipeline
 stages. The DepthArtifact is designed to be self-describing, auditable, and
 interoperable.
 
-Contract Version: 1.0.0
-Schema Compatibility: v2.0.0 Golden Path
+The artifact schema version is exposed as ``DEPTH_ARTIFACT_SCHEMA_VERSION``.
 
 Example:
     >>> from transformation_portal.lux_depth_v3.contracts import DepthArtifact
@@ -105,6 +104,13 @@ class CameraIntrinsics:
             Estimated CameraIntrinsics
         """
         import math
+
+        if width <= 0:
+            raise ValueError("width must be positive")
+        if height <= 0:
+            raise ValueError("height must be positive")
+        if not 0 < fov_degrees < 180:
+            raise ValueError("fov_degrees must be greater than 0 and less than 180")
 
         fov_rad = math.radians(fov_degrees)
         fx = width / (2 * math.tan(fov_rad / 2))
@@ -258,6 +264,16 @@ class DepthArtifact:
                     "must match depth_map "
                     f"shape {self.depth_map.shape}"
                 )
+            if self.metric_map_m.dtype != np.float32:
+                logger.warning(
+                    "metric_map_m dtype is %s, converting to float32",
+                    self.metric_map_m.dtype,
+                )
+                object.__setattr__(
+                    self,
+                    "metric_map_m",
+                    self.metric_map_m.astype(np.float32),
+                )
 
         if self.confidence is not None:
             if not isinstance(self.confidence, np.ndarray):
@@ -265,6 +281,16 @@ class DepthArtifact:
             if self.confidence.shape != self.depth_map.shape:
                 raise ValueError(
                     f"confidence shape " f"{self.confidence.shape} " "must match depth_map " f"shape {self.depth_map.shape}"
+                )
+            if self.confidence.dtype != np.float32:
+                logger.warning(
+                    "confidence dtype is %s, converting to float32",
+                    self.confidence.dtype,
+                )
+                object.__setattr__(
+                    self,
+                    "confidence",
+                    self.confidence.astype(np.float32),
                 )
 
         # Provenance validation
@@ -346,7 +372,10 @@ class DepthArtifact:
         }
 
     def compute_content_hash(self) -> str:
-        """Compute content-addressable hash of depth data.
+        """Compute the depth-raster content hash.
+
+        The compatibility contract intentionally hashes only ``depth_map`` bytes;
+        optional arrays, intrinsics, metadata, and provenance are not included.
 
         Returns:
             SHA-256 hash (first 16 chars) of depth_map bytes
@@ -433,6 +462,7 @@ class DepthArtifactWriter:
         # Save JSON sidecar
         if self.save_sidecar:
             sidecar_path = self.output_dir / f"{stem}_depth.json"
+            paths["sidecar"] = sidecar_path
             sidecar_data = artifact.to_sidecar_dict()
             # Add output paths to sidecar
             sidecar_data["outputs"] = {k: str(v) for k, v in paths.items()}
@@ -446,8 +476,6 @@ class DepthArtifactWriter:
                     ensure_ascii=False,
                     allow_nan=False,
                 )
-            paths["sidecar"] = sidecar_path
-
         logger.info("Wrote DepthArtifact: %s", stem)
         return paths
 
@@ -455,15 +483,18 @@ class DepthArtifactWriter:
         """Write 16-bit PNG preview of depth map."""
         from PIL import Image
 
-        # Normalize to [0, 1]
-        d_min, d_max = depth.min(), depth.max()
-        if d_max - d_min > 1e-8:
-            normalized = (depth - d_min) / (d_max - d_min)
+        finite_mask = np.isfinite(depth)
+        normalized = np.zeros(depth.shape, dtype=np.float32)
+        if finite_mask.any():
+            finite_depth = depth[finite_mask].astype(np.float32)
+            d_min, d_max = float(finite_depth.min()), float(finite_depth.max())
+            if d_max - d_min > 1e-8:
+                normalized[finite_mask] = (finite_depth - d_min) / (d_max - d_min)
         else:
-            normalized = np.zeros_like(depth)
+            logger.warning("Depth preview input contains no finite values; writing zero preview")
 
         # Convert to 16-bit
-        depth_u16 = (normalized * 65535).astype(np.uint16)
+        depth_u16 = (np.clip(normalized, 0.0, 1.0) * 65535).astype(np.uint16)
 
         # Save as 16-bit PNG
         img = Image.fromarray(depth_u16, mode="I;16")

--- a/src/transformation_portal/lux_depth_v3/protocols/depth_model.py
+++ b/src/transformation_portal/lux_depth_v3/protocols/depth_model.py
@@ -455,14 +455,31 @@ class DepthModelRegistry:
                 raise KeyError(f"No backend found for " f"role={role.name}, " f"commercial_only={commercial_only}")
 
             # Return first matching (priority order determined by registration)
+            failures = []
+            last_error: Optional[Exception] = None
             for info in candidates:
                 for reg_name, registered_info in self._backend_info.items():
                     if registered_info.model_id == info.model_id:
-                        return self.get_backend(
-                            name=reg_name,
-                            commercial_only=commercial_only,
-                            use_cache=use_cache,
-                        )
+                        try:
+                            return self.get_backend(
+                                name=reg_name,
+                                commercial_only=commercial_only,
+                                use_cache=use_cache,
+                            )
+                        except Exception as exc:
+                            last_error = exc
+                            failures.append(f"{reg_name}: {exc}")
+                            logger.warning(
+                                "Skipping depth backend '%s' during role lookup: %s",
+                                reg_name,
+                                exc,
+                            )
+
+            if failures:
+                raise RuntimeError(
+                    f"No constructable backend found for role={role.name}, "
+                    f"commercial_only={commercial_only}; failures: {'; '.join(failures)}"
+                ) from last_error
 
         raise KeyError("Must specify either 'name' or 'role'")
 

--- a/src/transformation_portal/lux_depth_v3/protocols/depth_model.py
+++ b/src/transformation_portal/lux_depth_v3/protocols/depth_model.py
@@ -8,9 +8,7 @@ must implement. This enables:
 - Consistent provenance tracking
 - Circuit breaker patterns for fallback
 
-Protocol Version: 1.0.0
-
-Compatible with: v2.0.0 Golden Path
+The protocol version is exposed as ``DEPTH_MODEL_PROTOCOL_VERSION``.
 
 Example
 -------
@@ -269,19 +267,59 @@ class DepthModelRegistry:
     def __init__(self) -> None:
         """Initialize empty registry."""
         self._backends: Dict[str, Type[DepthModel]] = {}
+        self._backend_info: Dict[str, BackendInfo] = {}
         self._instances: Dict[str, DepthModel] = {}
         self._fallback_chains: Dict[BackendRole, List[str]] = {}
+
+    @staticmethod
+    def _resolve_backend_info(backend_class: Type[DepthModel]) -> BackendInfo:
+        """Resolve class-available backend metadata without construction."""
+        backend_info = getattr(backend_class, "backend_info", None)
+        if isinstance(backend_info, BackendInfo):
+            return backend_info
+        if callable(backend_info):
+            resolved = backend_info()
+            if isinstance(resolved, BackendInfo):
+                return resolved
+
+        get_backend_info = getattr(backend_class, "get_backend_info", None)
+        if callable(get_backend_info):
+            resolved = get_backend_info()
+            if isinstance(resolved, BackendInfo):
+                return resolved
+
+        info_attr = getattr(backend_class, "info", None)
+        if isinstance(info_attr, BackendInfo):
+            return info_attr
+
+        raise TypeError(
+            f"{backend_class.__name__} must expose BackendInfo via a class-level "
+            "'backend_info' attribute/callable or get_backend_info() method"
+        )
+
+    @staticmethod
+    def _validate_backend_class_surface(backend_class: Type[DepthModel]) -> None:
+        required_attrs = ("load", "predict")
+        missing_or_invalid = [attr for attr in required_attrs if not callable(getattr(backend_class, attr, None))]
+        if missing_or_invalid:
+            raise TypeError(
+                f"{backend_class.__name__} does not implement DepthModel protocol "
+                "(missing or non-callable: "
+                f"{', '.join(missing_or_invalid)})"
+            )
 
     def register(
         self,
         backend_class: Type[DepthModel],
         name: Optional[str] = None,
+        info: Optional[BackendInfo] = None,
     ) -> None:
         """Register a depth model backend.
 
         Args:
             backend_class: Class implementing DepthModel protocol
             name: Optional registration name (defaults to class name)
+            info: Optional class-available backend metadata override
 
         Raises:
             TypeError: If backend_class doesn't implement DepthModel
@@ -289,27 +327,15 @@ class DepthModelRegistry:
         if not isinstance(backend_class, type):
             raise TypeError("backend_class must be a class")
 
-        # Validate protocol compliance
-        # Require core DepthModel surface: info, load, predict
-        instance = backend_class()
-        required_attrs = ("load", "predict")
-        missing_or_invalid = [
-            attr for attr in required_attrs if not hasattr(instance, attr) or not callable(getattr(instance, attr, None))
-        ]
-        # Check for info property separately (can be property or method)
-        if not hasattr(instance, "info"):
-            missing_or_invalid.append("info")
-
-        if missing_or_invalid:
-            raise TypeError(
-                f"{backend_class.__name__} does not "
-                "implement DepthModel protocol "
-                "(missing or non-callable: "
-                f"{', '.join(missing_or_invalid)})"
-            )
+        self._validate_backend_class_surface(backend_class)
+        resolved_info = info or self._resolve_backend_info(backend_class)
+        if not isinstance(resolved_info, BackendInfo):
+            raise TypeError("backend metadata must be a BackendInfo instance")
 
         reg_name = name or backend_class.__name__
         self._backends[reg_name] = backend_class
+        self._backend_info[reg_name] = resolved_info
+        self._instances.pop(reg_name, None)
         logger.info("Registered depth backend: %s", reg_name)
 
     def list_backends(
@@ -328,10 +354,7 @@ class DepthModelRegistry:
             List of BackendInfo for matching backends
         """
         results = []
-        for name, cls in self._backends.items():
-            instance = cls()
-            info = instance.info
-
+        for info in self._backend_info.values():
             if role is not None and info.role != role:
                 continue
 
@@ -372,15 +395,14 @@ class DepthModelRegistry:
             if name not in self._backends:
                 raise KeyError(f"Backend '{name}' not registered")
 
+            info = self._backend_info[name]
+            if commercial_only and not info.is_commercial_safe():
+                raise ValueError(f"Backend '{name}' requires " "non-commercial license " f"(tier: {info.license_tier.value})")
+
             if use_cache and name in self._instances:
                 return self._instances[name]
 
             instance = self._backends[name]()
-
-            if commercial_only and not instance.info.is_commercial_safe():
-                raise ValueError(
-                    f"Backend '{name}' requires " "non-commercial license " f"(tier: {instance.info.license_tier.value})"
-                )
 
             if use_cache:
                 self._instances[name] = instance
@@ -397,8 +419,8 @@ class DepthModelRegistry:
 
             # Return first matching (priority order determined by registration)
             for info in candidates:
-                for reg_name, cls in self._backends.items():
-                    if cls().info.model_id == info.model_id:
+                for reg_name, registered_info in self._backend_info.items():
+                    if registered_info.model_id == info.model_id:
                         return self.get_backend(
                             name=reg_name,
                             commercial_only=commercial_only,
@@ -465,6 +487,7 @@ def get_registry() -> DepthModelRegistry:
 
 def register_backend(
     name: Optional[str] = None,
+    info: Optional[BackendInfo] = None,
 ) -> Callable[[Type[DepthModel]], Type[DepthModel]]:
     """Decorator to register a depth model backend.
 
@@ -475,7 +498,7 @@ def register_backend(
     """
 
     def decorator(cls: Type[DepthModel]) -> Type[DepthModel]:
-        get_registry().register(cls, name)
+        get_registry().register(cls, name, info=info)
         return cls
 
     return decorator

--- a/src/transformation_portal/lux_depth_v3/protocols/depth_model.py
+++ b/src/transformation_portal/lux_depth_v3/protocols/depth_model.py
@@ -29,6 +29,7 @@ Example
 
 from __future__ import annotations
 
+import inspect
 import logging
 from dataclasses import dataclass, field
 from enum import Enum, auto
@@ -299,14 +300,47 @@ class DepthModelRegistry:
 
     @staticmethod
     def _validate_backend_class_surface(backend_class: Type[DepthModel]) -> None:
-        required_attrs = ("load", "predict")
-        missing_or_invalid = [attr for attr in required_attrs if not callable(getattr(backend_class, attr, None))]
+        required_methods = ("load", "predict")
+        missing_or_invalid = [attr for attr in required_methods if not callable(getattr(backend_class, attr, None))]
+        try:
+            info_member = inspect.getattr_static(backend_class, "info")
+        except AttributeError:
+            info_member = None
+        if not isinstance(info_member, (BackendInfo, property)):
+            missing_or_invalid.append("info")
+
         if missing_or_invalid:
             raise TypeError(
                 f"{backend_class.__name__} does not implement DepthModel protocol "
-                "(missing or non-callable: "
+                "(missing or invalid: "
                 f"{', '.join(missing_or_invalid)})"
             )
+
+    @staticmethod
+    def _validate_runtime_backend_info(
+        name: str,
+        registered_info: BackendInfo,
+        instance: DepthModel,
+        commercial_only: bool,
+    ) -> None:
+        """Validate runtime metadata before returning a constructed backend."""
+        runtime_info = getattr(instance, "info", None)
+        if not isinstance(runtime_info, BackendInfo):
+            raise TypeError(f"Backend '{name}' instance.info must be a BackendInfo instance")
+
+        if registered_info.model_id != runtime_info.model_id or registered_info.license_tier != runtime_info.license_tier:
+            logger.warning(
+                "Registered backend info for '%s' differs from instance.info "
+                "(registered model_id=%s, tier=%s; runtime model_id=%s, tier=%s)",
+                name,
+                registered_info.model_id,
+                registered_info.license_tier.value,
+                runtime_info.model_id,
+                runtime_info.license_tier.value,
+            )
+
+        if commercial_only and not runtime_info.is_commercial_safe():
+            raise ValueError(f"Backend '{name}' requires non-commercial license " f"(tier: {runtime_info.license_tier.value})")
 
     def register(
         self,
@@ -400,9 +434,12 @@ class DepthModelRegistry:
                 raise ValueError(f"Backend '{name}' requires " "non-commercial license " f"(tier: {info.license_tier.value})")
 
             if use_cache and name in self._instances:
-                return self._instances[name]
+                instance = self._instances[name]
+                self._validate_runtime_backend_info(name, info, instance, commercial_only)
+                return instance
 
             instance = self._backends[name]()
+            self._validate_runtime_backend_info(name, info, instance, commercial_only)
 
             if use_cache:
                 self._instances[name] = instance

--- a/src/transformation_portal/lux_depth_v3/validators/run_card_backend_semantics.py
+++ b/src/transformation_portal/lux_depth_v3/validators/run_card_backend_semantics.py
@@ -1,0 +1,89 @@
+"""Shared backend semantic validation for Lux run cards."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def collect_run_card_backend_semantic_errors(payload: dict[str, Any]) -> list[str]:
+    """Return backend-selection semantic errors for a run-card payload.
+
+    This helper is intentionally artifact-agnostic. Integrity verification may
+    enrich these errors with artifact-derived diagnostics, but the pass/fail
+    semantics live here.
+    """
+    backend_selection = payload.get("backend_selection")
+    backend_summary = payload.get("backend_summary")
+    if not isinstance(backend_selection, dict) or not isinstance(backend_summary, dict):
+        return []
+
+    errors: list[str] = []
+    final_backends_used = backend_summary.get("final_backends_used")
+    if not isinstance(final_backends_used, list):
+        return ["backend_summary.final_backends_used must be an array"]
+
+    success_count = payload.get("success_count")
+    if not isinstance(success_count, int):
+        success_count = 0
+
+    if not final_backends_used:
+        if success_count > 0:
+            errors.append("backend_summary.final_backends_used must be non-empty when success_count > 0")
+        return errors
+
+    primary_backend = final_backends_used[0]
+    if not isinstance(primary_backend, str) or not primary_backend:
+        errors.append("backend_summary.final_backends_used[0] must be a non-empty string")
+        return errors
+
+    summary_primary = backend_summary.get("primary_backend")
+    if summary_primary != primary_backend:
+        errors.append("backend_summary.primary_backend must equal backend_summary.final_backends_used[0]")
+
+    resolved = backend_selection.get("resolved")
+    if not isinstance(resolved, str) or not resolved:
+        errors.append("backend_selection.resolved must be a non-empty string")
+        return errors
+    if resolved != primary_backend:
+        errors.append("backend_selection.resolved must match backend_summary.final_backends_used[0]")
+
+    requested_backend = backend_selection.get("requested") or backend_summary.get("requested_backend")
+    fallback_images = backend_summary.get("fallback_images")
+    total_images = payload.get("total_images")
+    error_count = payload.get("error_count")
+    run_failed = (
+        isinstance(error_count, int) and error_count > 0 or isinstance(total_images, int) and success_count < total_images
+    )
+    if (
+        requested_backend == "depth_pro"
+        and isinstance(fallback_images, int)
+        and success_count > 0
+        and fallback_images == success_count
+        and primary_backend != requested_backend
+        and not run_failed
+    ):
+        errors.append(
+            "requested backend 'depth_pro' was not honored: "
+            f"all successful images ({success_count}/{success_count}) used fallback backend '{primary_backend}'"
+        )
+
+    logical_backend = backend_selection.get("logical_backend")
+    resolved_engine = backend_selection.get("resolved_engine")
+    wrapper_declared = logical_backend is not None or resolved_engine is not None
+    if not wrapper_declared:
+        return errors
+
+    if not isinstance(logical_backend, str) or not logical_backend:
+        errors.append("backend_selection.logical_backend must be a non-empty string when wrapper semantics are declared")
+    if not isinstance(resolved_engine, str) or not resolved_engine:
+        errors.append("backend_selection.resolved_engine must be a non-empty string when wrapper semantics are declared")
+    if isinstance(logical_backend, str) and isinstance(resolved_engine, str):
+        if logical_backend == resolved_engine:
+            errors.append("backend_selection.logical_backend and backend_selection.resolved_engine must differ")
+        if resolved_engine != primary_backend:
+            errors.append("backend_selection.resolved_engine must match backend_summary.final_backends_used[0]")
+
+    if isinstance(fallback_images, int) and fallback_images != 0:
+        errors.append("wrapper semantics are only valid when backend_summary.fallback_images == 0")
+
+    return errors

--- a/src/transformation_portal/lux_depth_v3/validators/run_card_integrity.py
+++ b/src/transformation_portal/lux_depth_v3/validators/run_card_integrity.py
@@ -18,17 +18,9 @@ from transformation_portal.lux_depth_v3.run_card_contract import (
     normalize_run_card_relative_path,
     with_inferred_run_card_version,
 )
-from transformation_portal.schemas.run_card import load_run_card_schema
 
-from .jsonschema_formats import build_jsonschema_format_checker
-from .run_card_validator import _default_schema_path
-
-try:
-    from jsonschema import Draft202012Validator, FormatChecker
-except ImportError:  # pragma: no cover - runtime guard for environments missing optional deps
-    Draft202012Validator = None  # type: ignore[assignment]
-    FormatChecker = None  # type: ignore[assignment]
-
+from .run_card_backend_semantics import collect_run_card_backend_semantic_errors
+from .run_card_validator import _default_schema_path, _load_validator
 
 SHA256_HEX_RE = re.compile(r"^[a-f0-9]{64}$")
 DEFAULT_SCHEMA_V1_PATH = _default_schema_path("v1")
@@ -47,6 +39,17 @@ def _load_json(path: Path) -> tuple[Any | None, str | None]:
         return None, f"Invalid JSON in {path}: {exc.msg} (line {exc.lineno}, column {exc.colno})"
     except OSError as exc:
         return None, f"Failed to read JSON file {path}: {exc}"
+
+
+def _read_text(path: Path) -> tuple[str | None, str | None]:
+    try:
+        return path.read_text(encoding="utf-8"), None
+    except FileNotFoundError:
+        return None, f"Text file not found: {path}"
+    except PermissionError:
+        return None, f"Permission denied reading text file: {path}"
+    except OSError as exc:
+        return None, f"Failed to read text file {path}: {exc}"
 
 
 def canonical_json_text(payload: Any) -> str:
@@ -79,61 +82,22 @@ def resolve_artifact_path(
     return artifact_path, None
 
 
-def _verify_backend_semantics(run_card_payload: dict[str, Any], errors: list[str]) -> None:
-    backend_selection = run_card_payload.get("backend_selection")
-    backend_summary = run_card_payload.get("backend_summary")
-    if not isinstance(backend_selection, dict) or not isinstance(backend_summary, dict):
-        return
-
-    final_backends_used = backend_summary.get("final_backends_used")
-    if not isinstance(final_backends_used, list):
-        errors.append("backend_summary.final_backends_used must be an array")
-        return
-
-    success_count = run_card_payload.get("success_count")
-    if not isinstance(success_count, int):
-        success_count = 0
-
-    if not final_backends_used:
-        if success_count > 0:
-            errors.append("backend_summary.final_backends_used must be non-empty when success_count > 0")
-        return
-
-    primary_backend = final_backends_used[0]
-    if not isinstance(primary_backend, str) or not primary_backend:
-        errors.append("backend_summary.final_backends_used[0] must be a non-empty string")
-        return
-
-    summary_primary = backend_summary.get("primary_backend")
-    if summary_primary != primary_backend:
-        errors.append("backend_summary.primary_backend must equal backend_summary.final_backends_used[0]")
-
-    resolved = backend_selection.get("resolved")
-    if not isinstance(resolved, str) or not resolved:
-        errors.append("backend_selection.resolved must be a non-empty string")
-        return
-    if resolved != primary_backend:
-        errors.append("backend_selection.resolved must match backend_summary.final_backends_used[0]")
-
-    logical_backend = backend_selection.get("logical_backend")
-    resolved_engine = backend_selection.get("resolved_engine")
-    wrapper_declared = logical_backend is not None or resolved_engine is not None
-    if not wrapper_declared:
-        return
-
-    if not isinstance(logical_backend, str) or not logical_backend:
-        errors.append("backend_selection.logical_backend must be a non-empty string when wrapper semantics are declared")
-    if not isinstance(resolved_engine, str) or not resolved_engine:
-        errors.append("backend_selection.resolved_engine must be a non-empty string when wrapper semantics are declared")
-    if isinstance(logical_backend, str) and isinstance(resolved_engine, str):
-        if logical_backend == resolved_engine:
-            errors.append("backend_selection.logical_backend and backend_selection.resolved_engine must differ")
-        if resolved_engine != primary_backend:
-            errors.append("backend_selection.resolved_engine must match backend_summary.final_backends_used[0]")
-
-    fallback_images = backend_summary.get("fallback_images")
-    if isinstance(fallback_images, int) and fallback_images != 0:
-        errors.append("wrapper semantics are only valid when backend_summary.fallback_images == 0")
+def _verify_backend_semantics(
+    run_card_payload: dict[str, Any],
+    *,
+    run_card_root: Path,
+    errors: list[str],
+) -> None:
+    for error in collect_run_card_backend_semantic_errors(run_card_payload):
+        if error.startswith("requested backend 'depth_pro' was not honored"):
+            fallback_reason = _first_combined_manifest_fallback_reason(
+                run_card_payload,
+                run_card_root=run_card_root,
+                errors=errors,
+            )
+            if fallback_reason:
+                error = f"{error}. First fallback reason: {fallback_reason}"
+        errors.append(error)
 
 
 def _first_combined_manifest_fallback_reason(
@@ -180,56 +144,6 @@ def _first_combined_manifest_fallback_reason(
             if isinstance(error_message, str) and error_message.strip():
                 return f"{relative_path}: {error_message.strip()}"
     return None
-
-
-def _verify_requested_depth_pro_fulfillment(
-    run_card_payload: dict[str, Any],
-    *,
-    run_card_root: Path,
-    errors: list[str],
-) -> None:
-    backend_selection = run_card_payload.get("backend_selection")
-    backend_summary = run_card_payload.get("backend_summary")
-    if not isinstance(backend_selection, dict) or not isinstance(backend_summary, dict):
-        return
-
-    requested_backend = backend_selection.get("requested") or backend_summary.get("requested_backend")
-    if requested_backend != "depth_pro":
-        return
-
-    success_count = run_card_payload.get("success_count")
-    fallback_images = backend_summary.get("fallback_images")
-    primary_backend = backend_summary.get("primary_backend")
-    total_images = run_card_payload.get("total_images")
-    error_count = run_card_payload.get("error_count")
-    has_error_failures = isinstance(error_count, int) and error_count > 0
-    has_incomplete_successes = (
-        isinstance(success_count, int) and isinstance(total_images, int) and success_count < total_images
-    )
-    run_failed = has_error_failures or has_incomplete_successes
-    if (
-        not isinstance(success_count, int)
-        or success_count <= 0
-        or not isinstance(fallback_images, int)
-        or fallback_images != success_count
-        or not isinstance(primary_backend, str)
-        or primary_backend == requested_backend
-        or run_failed
-    ):
-        return
-
-    error = (
-        "requested backend 'depth_pro' was not honored: "
-        f"all successful images ({success_count}/{success_count}) used fallback backend '{primary_backend}'"
-    )
-    fallback_reason = _first_combined_manifest_fallback_reason(
-        run_card_payload,
-        run_card_root=run_card_root,
-        errors=errors,
-    )
-    if fallback_reason:
-        error = f"{error}. First fallback reason: {fallback_reason}"
-    errors.append(error)
 
 
 def _verify_config_fingerprint(run_card_payload: dict[str, Any], errors: list[str]) -> None:
@@ -413,8 +327,6 @@ def verify_run_card_integrity(
     """Return list of integrity errors for a run card."""
     if not run_card_path.exists():
         return [f"Run card not found: {run_card_path}"]
-    if Draft202012Validator is None or FormatChecker is None:
-        return ["jsonschema dependency is required (install jsonschema>=4.21.0,<5)"]
 
     raw_run_card_payload, run_card_load_error = _load_json(run_card_path)
     if run_card_load_error:
@@ -427,14 +339,20 @@ def verify_run_card_integrity(
     if schema_path is not None:
         if not effective_schema_path.exists():
             return [f"Run card schema not found: {effective_schema_path}"]
-        schema_payload, schema_load_error = _load_json(effective_schema_path)
-        if schema_load_error:
-            return [schema_load_error]
-    else:
-        schema_payload = load_run_card_schema(infer_run_card_version(run_card_payload))
 
     errors: list[str] = []
-    validator = Draft202012Validator(schema_payload, format_checker=build_jsonschema_format_checker())
+    try:
+        validator = _load_validator(
+            str(effective_schema_path) if schema_path is not None else None,
+            infer_run_card_version(run_card_payload),
+        )
+    except RuntimeError as exc:
+        errors.append(str(exc))
+        return errors
+    except (JSONDecodeError, OSError) as exc:
+        errors.append(f"Failed to load run card schema {effective_schema_path}: {exc}")
+        return errors
+
     schema_errors = sorted(validator.iter_errors(run_card_payload), key=lambda item: list(item.path))
     for item in schema_errors:
         errors.append(f"Schema validation failed at {format_error_path(item.path)}: {item.message}")
@@ -515,8 +433,7 @@ def verify_run_card_integrity(
         errors=errors,
     )
 
-    _verify_backend_semantics(run_card_payload, errors)
-    _verify_requested_depth_pro_fulfillment(
+    _verify_backend_semantics(
         run_card_payload,
         run_card_root=run_card_path.parent,
         errors=errors,
@@ -524,9 +441,12 @@ def verify_run_card_integrity(
     _verify_config_fingerprint(run_card_payload, errors)
 
     if check_canonical_json:
-        raw_text = run_card_path.read_text(encoding="utf-8")
-        canonical = canonical_json_text(raw_run_card_payload)
-        if raw_text not in (canonical, canonical + "\n"):
-            errors.append("JSON canonical serialization drift detected (expected sort_keys=True, indent=2)")
+        raw_text, raw_text_error = _read_text(run_card_path)
+        if raw_text_error:
+            errors.append(raw_text_error)
+        else:
+            canonical = canonical_json_text(raw_run_card_payload)
+            if raw_text not in (canonical, canonical + "\n"):
+                errors.append("JSON canonical serialization drift detected (expected sort_keys=True, indent=2)")
 
     return errors

--- a/src/transformation_portal/lux_depth_v3/validators/run_card_validator.py
+++ b/src/transformation_portal/lux_depth_v3/validators/run_card_validator.py
@@ -44,6 +44,7 @@ from transformation_portal.lux_depth_v3.run_card_contract import (
 from transformation_portal.schemas.run_card import load_run_card_schema
 
 from .jsonschema_formats import build_jsonschema_format_checker
+from .run_card_backend_semantics import collect_run_card_backend_semantic_errors
 
 
 class RunCardValidationError(RuntimeError):
@@ -177,116 +178,9 @@ def validate_run_card_backend_semantics(payload: Dict[str, Any]) -> None:
     Raises:
         RuntimeError: If backend semantics are inconsistent
     """
-    backend_selection = payload.get("backend_selection")
-    backend_summary = payload.get("backend_summary")
-    if not isinstance(backend_selection, dict) or not isinstance(backend_summary, dict):
-        return
-
-    final_backends_used = backend_summary.get("final_backends_used")
-    if not isinstance(final_backends_used, list):
-        return
-
-    success_count = payload.get("success_count")
-    if not isinstance(success_count, int):
-        success_count = 0
-
-    if not final_backends_used:
-        if success_count > 0:
-            raise RuntimeError(
-                "Run card backend semantics validation failed: "
-                "backend_summary.final_backends_used must be "
-                "non-empty when success_count > 0."
-            )
-        return
-
-    primary_backend = final_backends_used[0]
-    if not isinstance(primary_backend, str) or not primary_backend:
-        raise RuntimeError(
-            "Run card backend semantics validation failed: "
-            "backend_summary.final_backends_used[0] must be a non-empty string."
-        )
-
-    summary_primary = backend_summary.get("primary_backend")
-    if summary_primary != primary_backend:
-        raise RuntimeError(
-            "Run card backend semantics validation failed: "
-            "backend_summary.primary_backend must equal "
-            "backend_summary.final_backends_used[0]."
-        )
-
-    resolved = backend_selection.get("resolved")
-    if not isinstance(resolved, str) or not resolved:
-        raise RuntimeError(
-            "Run card backend semantics validation failed: " "backend_selection.resolved must be a non-empty string."
-        )
-
-    if resolved != primary_backend:
-        raise RuntimeError(
-            "Run card backend semantics validation failed: "
-            "backend_selection.resolved must match "
-            "backend_summary.final_backends_used[0]."
-        )
-
-    requested_backend = backend_selection.get("requested") or backend_summary.get("requested_backend")
-    fallback_images = backend_summary.get("fallback_images")
-    total_images = payload.get("total_images")
-    error_count = payload.get("error_count")
-    run_failed = (
-        isinstance(error_count, int) and error_count > 0 or isinstance(total_images, int) and success_count < total_images
-    )
-    if (
-        requested_backend == "depth_pro"
-        and isinstance(fallback_images, int)
-        and success_count > 0
-        and fallback_images == success_count
-        and primary_backend != requested_backend
-    ):
-        if run_failed:
-            return
-        raise RuntimeError(
-            "Run card backend request fulfillment validation failed: "
-            "requested backend 'depth_pro' was not honored; "
-            f"all successful images used fallback backend '{primary_backend}'."
-        )
-
-    # Wrapper semantics validation
-    logical_backend = backend_selection.get("logical_backend")
-    resolved_engine = backend_selection.get("resolved_engine")
-    wrapper_declared = logical_backend is not None or resolved_engine is not None
-    if not wrapper_declared:
-        return
-
-    if not isinstance(logical_backend, str) or not logical_backend:
-        raise RuntimeError(
-            "Run card backend semantics validation failed: "
-            "backend_selection.logical_backend must be a non-empty string "
-            "when wrapper semantics are declared."
-        )
-    if not isinstance(resolved_engine, str) or not resolved_engine:
-        raise RuntimeError(
-            "Run card backend semantics validation failed: "
-            "backend_selection.resolved_engine must be a non-empty string "
-            "when wrapper semantics are declared."
-        )
-    if logical_backend == resolved_engine:
-        raise RuntimeError(
-            "Run card backend semantics validation failed: "
-            "backend_selection.logical_backend and "
-            "backend_selection.resolved_engine must differ."
-        )
-    if resolved_engine != primary_backend:
-        raise RuntimeError(
-            "Run card backend semantics validation failed: "
-            "backend_selection.resolved_engine must match "
-            "backend_summary.final_backends_used[0]."
-        )
-
-    if isinstance(fallback_images, int) and fallback_images != 0:
-        raise RuntimeError(
-            "Run card backend semantics validation failed: "
-            "wrapper semantics are only valid when "
-            "backend_summary.fallback_images == 0."
-        )
+    errors = collect_run_card_backend_semantic_errors(payload)
+    if errors:
+        raise RuntimeError("Run card backend semantics validation failed: " + "; ".join(errors))
 
 
 class RunCardValidator:

--- a/src/transformation_portal/lux_depth_v3/validators/run_card_validator.py
+++ b/src/transformation_portal/lux_depth_v3/validators/run_card_validator.py
@@ -46,6 +46,13 @@ from transformation_portal.schemas.run_card import load_run_card_schema
 from .jsonschema_formats import build_jsonschema_format_checker
 from .run_card_backend_semantics import collect_run_card_backend_semantic_errors
 
+JSONSCHEMA_REQUIREMENT = "jsonschema>=4.21.0,<5"
+JSONSCHEMA_INSTALL_HINT = (
+    "jsonschema dependency is required for run card schema validation "
+    f"({JSONSCHEMA_REQUIREMENT}); install the core runtime with "
+    "`make install-core` or install dependencies from requirements/base.in"
+)
+
 
 class RunCardValidationError(RuntimeError):
     """Raised when run card validation fails.
@@ -93,7 +100,7 @@ def _build_validator(schema: Dict[str, Any]) -> Any:
         import jsonschema
     except ImportError as exc:  # pragma: no cover
         raise RuntimeError(
-            "jsonschema dependency is required for run card schema validation",
+            JSONSCHEMA_INSTALL_HINT,
         ) from exc
 
     try:

--- a/tests/lux_depth_v3/validators/test_run_card_validator.py
+++ b/tests/lux_depth_v3/validators/test_run_card_validator.py
@@ -235,6 +235,24 @@ class TestBackendSemanticsValidation:
         ):
             validate_run_card_backend_semantics(payload)
 
+    def test_non_list_final_backends_raises(self):
+        """Backend semantics reject malformed final_backends_used consistently."""
+        from transformation_portal.lux_depth_v3.validators import (
+            validate_run_card_backend_semantics,
+        )
+
+        payload = {
+            "backend_selection": {"resolved": "da3"},
+            "backend_summary": {
+                "final_backends_used": "da3",
+                "primary_backend": "da3",
+            },
+            "success_count": 1,
+        }
+
+        with pytest.raises(RuntimeError, match="final_backends_used must be an array"):
+            validate_run_card_backend_semantics(payload)
+
     def test_primary_backend_mismatch_raises(self):
         """Test that primary_backend not matching final_backends_used[0] raises."""
         from transformation_portal.lux_depth_v3.validators import (
@@ -300,6 +318,31 @@ class TestBackendSemanticsValidation:
         }
 
         validate_run_card_backend_semantics(payload)
+
+    def test_requested_depth_pro_full_success_fallback_raises(self):
+        """Requested Depth Pro full fallback fails when the run otherwise succeeded."""
+        from transformation_portal.lux_depth_v3.validators import (
+            validate_run_card_backend_semantics,
+        )
+
+        payload = {
+            "backend_selection": {
+                "requested": "depth_pro",
+                "resolved": "da3",
+            },
+            "backend_summary": {
+                "requested_backend": "depth_pro",
+                "final_backends_used": ["da3"],
+                "primary_backend": "da3",
+                "fallback_images": 2,
+            },
+            "total_images": 2,
+            "success_count": 2,
+            "error_count": 0,
+        }
+
+        with pytest.raises(RuntimeError, match="requested backend 'depth_pro' was not honored"):
+            validate_run_card_backend_semantics(payload)
 
 
 class TestWrapperSemanticsValidation:

--- a/tests/materials/test_materials_v3_phase_b_sky.py
+++ b/tests/materials/test_materials_v3_phase_b_sky.py
@@ -158,6 +158,32 @@ def test_sky_seed_generates_prompts():
         assert len(result["points_positive"]) > 0 or len(result["points_negative"]) > 0
 
 
+def test_sky_seed_clamps_threshold_knobs():
+    """Out-of-range finite thresholds are clamped predictably."""
+    H, W = 32, 32
+    image = np.ones((H, W, 3), dtype=np.uint8) * 255
+    config = PhaseBTestConfig(
+        sky_top_region_fraction=2.0,
+        sky_gradient_threshold=-1.0,
+        sky_brightness_threshold=2.0,
+    )
+
+    result = detect_sky_seed(image, config)
+
+    assert result["coarse_mask"].shape == (H, W)
+    assert 0.0 <= result["confidence"] <= 1.0
+
+
+def test_sky_seed_rejects_non_finite_thresholds():
+    """Non-finite thresholds fail closed instead of reaching arithmetic paths."""
+    H, W = 32, 32
+    image = np.ones((H, W, 3), dtype=np.uint8) * 255
+    config = PhaseBTestConfig(sky_top_region_fraction=float("nan"))
+
+    with pytest.raises(ValueError, match="sky_top_region_fraction must be finite"):
+        detect_sky_seed(image, config)
+
+
 # =============================================================================
 # B3: Sky Pixel Operations Tests
 # =============================================================================

--- a/tests/test_verify_run_card_integrity.py
+++ b/tests/test_verify_run_card_integrity.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import builtins
 import hashlib
 import importlib.util
 import json
@@ -196,6 +197,34 @@ def test_verify_run_card_integrity_rejects_schema_violation(tmp_path: Path):
 
     errors = module.verify_run_card_integrity(run_card_path)
     assert any("Schema validation failed" in error for error in errors)
+
+
+def test_verify_run_card_integrity_reports_jsonschema_install_hint(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Missing jsonschema is reported with the governed version/install hint."""
+    from transformation_portal.lux_depth_v3.validators import run_card_validator
+
+    module = _load_script_module("verify_run_card_integrity_missing_jsonschema", "scripts/verify_run_card_integrity.py")
+    run_card_path = tmp_path / "run_card_valid.json"
+    payload = _valid_run_card_payload(module)
+    _write_json(run_card_path, payload)
+
+    original_import = builtins.__import__
+
+    def block_jsonschema_import(name, globals=None, locals=None, fromlist=(), level=0):  # noqa: A002
+        if name == "jsonschema" or name.startswith("jsonschema."):
+            raise ImportError("simulated missing jsonschema")
+        return original_import(name, globals, locals, fromlist, level)
+
+    run_card_validator._load_validator.cache_clear()
+    monkeypatch.setattr(builtins, "__import__", block_jsonschema_import)
+    errors = module.verify_run_card_integrity(run_card_path)
+    run_card_validator._load_validator.cache_clear()
+
+    assert errors == [
+        "jsonschema dependency is required for run card schema validation "
+        "(jsonschema>=4.21.0,<5); install the core runtime with "
+        "`make install-core` or install dependencies from requirements/base.in"
+    ]
 
 
 def test_verify_run_card_integrity_rejects_missing_sha256(tmp_path: Path):

--- a/tests/test_verify_run_card_integrity.py
+++ b/tests/test_verify_run_card_integrity.py
@@ -263,6 +263,21 @@ def test_verify_run_card_integrity_detects_canonical_json_drift(tmp_path: Path):
     assert any("canonical serialization drift" in error for error in errors)
 
 
+def test_verify_run_card_integrity_collects_canonical_read_failure(tmp_path: Path, monkeypatch):
+    module = _load_script_module("verify_run_card_integrity_script_canonical_read", "scripts/verify_run_card_integrity.py")
+    run_card_path = tmp_path / "run_card.json"
+    payload = _valid_run_card_payload(module)
+    _write_json(run_card_path, payload)
+
+    def fail_read_text(path: Path):
+        return None, f"Failed to read text file {path}: simulated failure"
+
+    monkeypatch.setitem(module.verify_run_card_integrity.__globals__, "_read_text", fail_read_text)
+
+    errors = module.verify_run_card_integrity(run_card_path, check_canonical_json=True)
+    assert any("simulated failure" in error for error in errors)
+
+
 def test_verify_run_card_integrity_rejects_backend_semantic_mismatch(tmp_path: Path):
     module = _load_script_module("verify_run_card_integrity_script_backend", "scripts/verify_run_card_integrity.py")
     run_card_path = tmp_path / "run_card_backend_mismatch.json"
@@ -272,6 +287,21 @@ def test_verify_run_card_integrity_rejects_backend_semantic_mismatch(tmp_path: P
 
     errors = module.verify_run_card_integrity(run_card_path)
     assert any("backend_selection.resolved must match backend_summary.final_backends_used[0]" in error for error in errors)
+
+
+def test_verify_run_card_integrity_and_validator_share_final_backend_type_semantics(tmp_path: Path):
+    module = _load_script_module("verify_run_card_integrity_script_backend_type", "scripts/verify_run_card_integrity.py")
+    from transformation_portal.lux_depth_v3.validators import validate_run_card_backend_semantics
+
+    run_card_path = tmp_path / "run_card_backend_type.json"
+    payload = _valid_run_card_payload(module)
+    payload["backend_summary"]["final_backends_used"] = "da3"
+    _write_json(run_card_path, payload)
+
+    errors = module.verify_run_card_integrity(run_card_path)
+    assert any("backend_summary.final_backends_used must be an array" in error for error in errors)
+    with pytest.raises(RuntimeError, match="backend_summary.final_backends_used must be an array"):
+        validate_run_card_backend_semantics(payload)
 
 
 def test_verify_run_card_integrity_accepts_wrapper_semantics(tmp_path: Path):
@@ -305,6 +335,29 @@ def test_verify_run_card_integrity_rejects_requested_depth_pro_full_fallback(tmp
     assert any("requested backend 'depth_pro' was not honored" in error for error in errors)
 
 
+def test_verify_run_card_integrity_and_validator_share_depth_pro_fallback_semantics(tmp_path: Path):
+    module = _load_script_module("verify_run_card_integrity_script_depth_pro_shared", "scripts/verify_run_card_integrity.py")
+    from transformation_portal.lux_depth_v3.validators import validate_run_card_backend_semantics
+
+    run_card_path = tmp_path / "run_card_depth_pro_fallback.json"
+    payload = _valid_run_card_payload(module)
+    payload["backend_selection"]["requested"] = "depth_pro"
+    payload["backend_selection"]["resolved"] = "da3"
+    payload["backend_summary"]["requested_backend"] = "depth_pro"
+    payload["backend_summary"]["primary_backend"] = "da3"
+    payload["backend_summary"]["final_backends_used"] = ["da3"]
+    payload["backend_summary"]["fallback_images"] = 1
+    payload["total_images"] = 1
+    payload["success_count"] = 1
+    payload["error_count"] = 0
+    _write_json(run_card_path, payload)
+
+    errors = module.verify_run_card_integrity(run_card_path)
+    assert any("requested backend 'depth_pro' was not honored" in error for error in errors)
+    with pytest.raises(RuntimeError, match="requested backend 'depth_pro' was not honored"):
+        validate_run_card_backend_semantics(payload)
+
+
 def test_verify_run_card_integrity_handles_non_integer_success_count_without_crashing(tmp_path: Path):
     module = _load_script_module(
         "verify_run_card_integrity_script_depth_pro_type_guard", "scripts/verify_run_card_integrity.py"
@@ -326,6 +379,18 @@ def test_verify_run_card_integrity_handles_non_integer_success_count_without_cra
 
     assert errors
     assert any("success_count" in error for error in errors)
+
+
+def test_verify_run_card_integrity_reports_malformed_override_schema(tmp_path: Path):
+    module = _load_script_module("verify_run_card_integrity_script_bad_schema", "scripts/verify_run_card_integrity.py")
+    run_card_path = tmp_path / "run_card.json"
+    bad_schema_path = tmp_path / "bad_schema.json"
+    payload = _valid_run_card_payload(module)
+    _write_json(run_card_path, payload)
+    bad_schema_path.write_text(json.dumps({"type": 123}), encoding="utf-8")
+
+    errors = module.verify_run_card_integrity(run_card_path, schema_path=bad_schema_path)
+    assert any("Run card schema is invalid" in error for error in errors)
 
 
 def test_verify_run_card_integrity_rejects_combined_manifest_path_escape(tmp_path: Path):

--- a/tests/unit/depth/test_depth_artifact.py
+++ b/tests/unit/depth/test_depth_artifact.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+from PIL import Image
 
 pytestmark = [pytest.mark.unit]
 
@@ -106,6 +107,20 @@ class TestCameraIntrinsics:
         # fx = width / (2 * tan(30°)) ≈ 1663 for 1920px width
         assert intrinsics.fx > 1000  # Focal length should be reasonable for typical FOV
 
+    @pytest.mark.parametrize(
+        ("width", "height", "fov_degrees", "match"),
+        [
+            (0, 100, 60.0, "width must be positive"),
+            (100, 0, 60.0, "height must be positive"),
+            (100, 100, 0.0, "fov_degrees"),
+            (100, 100, 180.0, "fov_degrees"),
+        ],
+    )
+    def test_estimate_from_image_rejects_invalid_inputs(self, width, height, fov_degrees, match):
+        """Test intrinsics estimation guardrails."""
+        with pytest.raises(ValueError, match=match):
+            CameraIntrinsics.estimate_from_image(width=width, height=height, fov_degrees=fov_degrees)
+
 
 class TestDepthProvenance:
     """Test DepthProvenance dataclass."""
@@ -199,6 +214,23 @@ class TestDepthArtifact:
         )
         assert artifact.has_metric_depth
         assert artifact.metric_map_m is not None
+
+    def test_optional_arrays_normalize_to_float32(self, sample_provenance):
+        """Metric and confidence arrays follow the same float32 dtype contract as depth_map."""
+        depth_map = np.ones((4, 4), dtype=np.float64)
+        metric_map = np.arange(16, dtype=np.float64).reshape(4, 4)
+        confidence = np.ones((4, 4), dtype=np.uint8)
+        artifact = DepthArtifact(
+            depth_map=depth_map,
+            provenance=sample_provenance,
+            metric_map_m=metric_map,
+            confidence=confidence,
+        )
+        assert artifact.depth_map.dtype == np.float32
+        assert artifact.metric_map_m is not None
+        assert artifact.metric_map_m.dtype == np.float32
+        assert artifact.confidence is not None
+        assert artifact.confidence.dtype == np.float32
 
     def test_artifact_with_confidence(self, sample_depth_map, sample_provenance):
         """Test artifact with confidence map."""
@@ -297,6 +329,28 @@ class TestDepthArtifact:
         hash3 = artifact3.compute_content_hash()
         assert hash1 != hash3
 
+    def test_artifact_content_hash_is_depth_raster_only(self, sample_provenance):
+        """Optional arrays and provenance do not alter the compatibility hash."""
+        depth_map = np.ones((4, 4), dtype=np.float32)
+        other_provenance = DepthProvenance(
+            model_id="other-model",
+            license_tier=LicenseTier.NON_COMMERCIAL,
+        )
+        artifact1 = DepthArtifact(
+            depth_map=depth_map,
+            provenance=sample_provenance,
+            metric_map_m=np.zeros((4, 4), dtype=np.float32),
+            confidence=np.zeros((4, 4), dtype=np.float32),
+        )
+        artifact2 = DepthArtifact(
+            depth_map=depth_map.copy(),
+            provenance=other_provenance,
+            metric_map_m=np.ones((4, 4), dtype=np.float32),
+            confidence=np.ones((4, 4), dtype=np.float32),
+            metadata={"different": True},
+        )
+        assert artifact1.compute_content_hash() == artifact2.compute_content_hash()
+
     def test_artifact_validation_non_2d(self, sample_provenance):
         """Test validation rejects non-2D depth maps."""
         with pytest.raises(ValueError, match="must be 2D"):
@@ -353,6 +407,7 @@ class TestDepthArtifactWriter:
             with open(paths["sidecar"]) as f:
                 sidecar = json.load(f)
             assert sidecar["schema_version"] == "1.0.0"
+            assert sidecar["outputs"]["sidecar"] == str(paths["sidecar"])
 
     def test_write_artifact_with_metric(self):
         """Test writing artifact with metric depth."""
@@ -377,6 +432,56 @@ class TestDepthArtifactWriter:
 
             loaded_metric = np.load(paths["depth_metric"])
             np.testing.assert_array_equal(loaded_metric, metric_map)
+
+    def test_write_artifact_persists_optional_arrays_as_float32(self):
+        """Persisted optional arrays use the normalized artifact dtype."""
+        depth_map = np.random.rand(4, 4).astype(np.float32)
+        metric_map = np.random.rand(4, 4).astype(np.float64)
+        confidence = np.ones((4, 4), dtype=np.uint8)
+        provenance = DepthProvenance(
+            model_id="metric-model",
+            license_tier=LicenseTier.EXPERIMENTAL,
+        )
+        artifact = DepthArtifact(
+            depth_map=depth_map,
+            provenance=provenance,
+            metric_map_m=metric_map,
+            confidence=confidence,
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            writer = DepthArtifactWriter(output_dir=Path(tmpdir))
+            paths = writer.write(artifact, stem="metric_test")
+
+            assert np.load(paths["depth_metric"]).dtype == np.float32
+            assert np.load(paths["confidence"]).dtype == np.float32
+
+    def test_write_preview_handles_nan_inf_deterministically(self):
+        """Preview normalization ignores non-finite values."""
+        depth = np.array([[np.nan, 0.0], [np.inf, 1.0]], dtype=np.float32)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "preview.png"
+            writer = DepthArtifactWriter(output_dir=Path(tmpdir), save_float=False)
+            writer._write_preview(depth, path)
+
+            preview = np.array(Image.open(path))
+            assert preview[0, 0] == 0
+            assert preview[1, 0] == 0
+            assert preview[0, 1] == 0
+            assert preview[1, 1] == 65535
+
+    def test_write_preview_all_invalid_writes_zero_preview(self):
+        """All-invalid preview input has a deterministic zero fallback."""
+        depth = np.array([[np.nan, np.inf], [-np.inf, np.nan]], dtype=np.float32)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "preview.png"
+            writer = DepthArtifactWriter(output_dir=Path(tmpdir), save_float=False)
+            writer._write_preview(depth, path)
+
+            preview = np.array(Image.open(path))
+            assert np.all(preview == 0)
 
     def test_write_artifact_selective(self):
         """Test writing with selective outputs."""

--- a/tests/unit/depth/test_depth_protocol.py
+++ b/tests/unit/depth/test_depth_protocol.py
@@ -273,6 +273,10 @@ class TestDepthModelRegistry:
             def __init__(self, required_arg):
                 self.required_arg = required_arg
 
+            @property
+            def info(self) -> BackendInfo:
+                return self.backend_info
+
             def load(self, device: str = "auto", weights_path: Optional[Path] = None, strict_license: bool = True) -> None:
                 pass
 
@@ -287,6 +291,15 @@ class TestDepthModelRegistry:
         """Backends must expose metadata without instance construction."""
 
         class MissingMetadataBackend:
+            @property
+            def info(self) -> BackendInfo:
+                return BackendInfo(
+                    name="Missing Metadata Runtime Info",
+                    model_id="mock/missing-metadata-runtime-info",
+                    role=BackendRole.PRODUCTION,
+                    license_tier=LicenseTier.COMMERCIAL,
+                )
+
             def load(self, device: str = "auto", weights_path: Optional[Path] = None, strict_license: bool = True) -> None:
                 pass
 
@@ -295,6 +308,26 @@ class TestDepthModelRegistry:
 
         with pytest.raises(TypeError, match="must expose BackendInfo"):
             registry.register(MissingMetadataBackend)
+
+    def test_register_requires_protocol_info_member(self, registry):
+        """Class validation requires the runtime protocol info member."""
+
+        class MissingInfoBackend:
+            backend_info = BackendInfo(
+                name="Missing Info",
+                model_id="mock/missing-info",
+                role=BackendRole.PRODUCTION,
+                license_tier=LicenseTier.COMMERCIAL,
+            )
+
+            def load(self, device: str = "auto", weights_path: Optional[Path] = None, strict_license: bool = True) -> None:
+                pass
+
+            def predict(self, image: np.ndarray) -> DepthArtifact:
+                raise NotImplementedError
+
+        with pytest.raises(TypeError, match="info"):
+            registry.register(MissingInfoBackend)
 
     def test_list_backends_by_role(self, registry):
         """Test listing backends filtered by role."""
@@ -404,6 +437,48 @@ class TestDepthModelRegistry:
         registry.get_backend(name="MockResearchBackend", commercial_only=False)
         with pytest.raises(ValueError, match="non-commercial license"):
             registry.get_backend(name="MockResearchBackend", commercial_only=True)
+
+    def test_get_backend_rechecks_runtime_info_for_commercial_only(self, registry):
+        """Registration metadata overrides cannot mask non-commercial runtime info."""
+        commercial_override = BackendInfo(
+            name="Runtime Override",
+            model_id="mock/runtime-override",
+            role=BackendRole.PRODUCTION,
+            license_tier=LicenseTier.COMMERCIAL,
+        )
+
+        class RuntimeResearchBackend:
+            constructor_calls = 0
+            backend_info = BackendInfo(
+                name="Runtime Research",
+                model_id="mock/runtime-research",
+                role=BackendRole.PRODUCTION,
+                license_tier=LicenseTier.NON_COMMERCIAL,
+            )
+
+            def __init__(self):
+                type(self).constructor_calls += 1
+
+            @property
+            def info(self) -> BackendInfo:
+                return self.backend_info
+
+            def load(self, device: str = "auto", weights_path: Optional[Path] = None, strict_license: bool = True) -> None:
+                pass
+
+            def predict(self, image: np.ndarray) -> DepthArtifact:
+                raise NotImplementedError
+
+        registry.register(
+            RuntimeResearchBackend,
+            name="runtime_research",
+            info=commercial_override,
+        )
+        registry.get_backend(name="runtime_research", commercial_only=False)
+
+        with pytest.raises(ValueError, match="non-commercial license"):
+            registry.get_backend(name="runtime_research", commercial_only=True)
+        assert RuntimeResearchBackend.constructor_calls == 1
 
     def test_get_backend_not_found(self, registry):
         """Test error when backend not found."""

--- a/tests/unit/depth/test_depth_protocol.py
+++ b/tests/unit/depth/test_depth_protocol.py
@@ -425,6 +425,62 @@ class TestDepthModelRegistry:
         assert CountingProductionBackend.constructor_calls == 1
         assert CountingAuditBackend.constructor_calls == 0
 
+    def test_role_lookup_skips_unconstructable_candidate(self, registry):
+        """Role lookup can fall through when a registered backend needs constructor args."""
+
+        class ConstructorRequiredProductionBackend:
+            backend_info = BackendInfo(
+                name="Constructor Required Production",
+                model_id="mock/constructor-required-production",
+                role=BackendRole.PRODUCTION,
+                license_tier=LicenseTier.COMMERCIAL,
+            )
+
+            def __init__(self, required_arg):
+                self.required_arg = required_arg
+
+            @property
+            def info(self) -> BackendInfo:
+                return self.backend_info
+
+            def load(self, device: str = "auto", weights_path: Optional[Path] = None, strict_license: bool = True) -> None:
+                pass
+
+            def predict(self, image: np.ndarray) -> DepthArtifact:
+                raise NotImplementedError
+
+        class FallbackProductionBackend:
+            constructor_calls = 0
+            backend_info = BackendInfo(
+                name="Fallback Production",
+                model_id="mock/fallback-production",
+                role=BackendRole.PRODUCTION,
+                license_tier=LicenseTier.COMMERCIAL,
+            )
+
+            def __init__(self):
+                type(self).constructor_calls += 1
+
+            @property
+            def info(self) -> BackendInfo:
+                return self.backend_info
+
+            def load(self, device: str = "auto", weights_path: Optional[Path] = None, strict_license: bool = True) -> None:
+                pass
+
+            def predict(self, image: np.ndarray) -> DepthArtifact:
+                raise NotImplementedError
+
+        registry.register(ConstructorRequiredProductionBackend, name="constructor_required")
+        registry.register(FallbackProductionBackend, name="fallback")
+
+        with pytest.raises(TypeError):
+            registry.get_backend(name="constructor_required")
+        backend = registry.get_backend(role=BackendRole.PRODUCTION, use_cache=False)
+
+        assert isinstance(backend, FallbackProductionBackend)
+        assert FallbackProductionBackend.constructor_calls == 1
+
     def test_get_backend_commercial_only_rejects_research(self, registry):
         """Test that commercial_only rejects non-commercial backends."""
         registry.register(MockResearchBackend)

--- a/tests/unit/depth/test_depth_protocol.py
+++ b/tests/unit/depth/test_depth_protocol.py
@@ -25,24 +25,26 @@ from transformation_portal.lux_depth_v3.protocols import (
 class MockCommercialBackend:
     """Mock commercial depth backend for testing."""
 
+    backend_info = BackendInfo(
+        name="Mock Commercial Backend",
+        model_id="mock/commercial-v1",
+        role=BackendRole.PRODUCTION,
+        license_tier=LicenseTier.COMMERCIAL,
+        capabilities=frozenset(
+            {
+                BackendCapability.RELATIVE_DEPTH,
+                BackendCapability.BATCH_INFERENCE,
+            }
+        ),
+        description="Test backend for commercial use",
+    )
+
     def __init__(self):
         self._loaded = False
 
     @property
     def info(self) -> BackendInfo:
-        return BackendInfo(
-            name="Mock Commercial Backend",
-            model_id="mock/commercial-v1",
-            role=BackendRole.PRODUCTION,
-            license_tier=LicenseTier.COMMERCIAL,
-            capabilities=frozenset(
-                {
-                    BackendCapability.RELATIVE_DEPTH,
-                    BackendCapability.BATCH_INFERENCE,
-                }
-            ),
-            description="Test backend for commercial use",
-        )
+        return self.backend_info
 
     def load(
         self,
@@ -71,22 +73,24 @@ class MockCommercialBackend:
 class MockResearchBackend:
     """Mock research backend (non-commercial) for testing."""
 
+    backend_info = BackendInfo(
+        name="Mock Research Backend",
+        model_id="mock/research-v1",
+        role=BackendRole.AUDIT,
+        license_tier=LicenseTier.NON_COMMERCIAL,
+        capabilities=frozenset(
+            {
+                BackendCapability.RELATIVE_DEPTH,
+                BackendCapability.METRIC_DEPTH,
+                BackendCapability.CONFIDENCE_MAP,
+            }
+        ),
+        description="Test backend for research (non-commercial)",
+    )
+
     @property
     def info(self) -> BackendInfo:
-        return BackendInfo(
-            name="Mock Research Backend",
-            model_id="mock/research-v1",
-            role=BackendRole.AUDIT,
-            license_tier=LicenseTier.NON_COMMERCIAL,
-            capabilities=frozenset(
-                {
-                    BackendCapability.RELATIVE_DEPTH,
-                    BackendCapability.METRIC_DEPTH,
-                    BackendCapability.CONFIDENCE_MAP,
-                }
-            ),
-            description="Test backend for research (non-commercial)",
-        )
+        return self.backend_info
 
     def load(
         self,
@@ -116,21 +120,23 @@ class MockResearchBackend:
 class MockVideoBackend:
     """Mock video-capable backend for testing."""
 
+    backend_info = BackendInfo(
+        name="Mock Video Backend",
+        model_id="mock/video-v1",
+        role=BackendRole.VIDEO,
+        license_tier=LicenseTier.COMMERCIAL,
+        capabilities=frozenset(
+            {
+                BackendCapability.RELATIVE_DEPTH,
+                BackendCapability.VIDEO_STREAMING,
+            }
+        ),
+        description="Test backend for video processing",
+    )
+
     @property
     def info(self) -> BackendInfo:
-        return BackendInfo(
-            name="Mock Video Backend",
-            model_id="mock/video-v1",
-            role=BackendRole.VIDEO,
-            license_tier=LicenseTier.COMMERCIAL,
-            capabilities=frozenset(
-                {
-                    BackendCapability.RELATIVE_DEPTH,
-                    BackendCapability.VIDEO_STREAMING,
-                }
-            ),
-            description="Test backend for video processing",
-        )
+        return self.backend_info
 
     def load(
         self,
@@ -253,6 +259,43 @@ class TestDepthModelRegistry:
         backend = registry.get_backend(name="custom_name")
         assert backend.info.model_id == "mock/commercial-v1"
 
+    def test_register_backend_does_not_require_constructor(self, registry):
+        """Registration and listing use class metadata without construction."""
+
+        class ConstructorRequiredBackend:
+            backend_info = BackendInfo(
+                name="Constructor Required",
+                model_id="mock/constructor-required",
+                role=BackendRole.PRODUCTION,
+                license_tier=LicenseTier.COMMERCIAL,
+            )
+
+            def __init__(self, required_arg):
+                self.required_arg = required_arg
+
+            def load(self, device: str = "auto", weights_path: Optional[Path] = None, strict_license: bool = True) -> None:
+                pass
+
+            def predict(self, image: np.ndarray) -> DepthArtifact:
+                raise NotImplementedError
+
+        registry.register(ConstructorRequiredBackend, name="constructor_required")
+        backends = registry.list_backends(role=BackendRole.PRODUCTION)
+        assert [info.model_id for info in backends] == ["mock/constructor-required"]
+
+    def test_register_requires_class_available_backend_info(self, registry):
+        """Backends must expose metadata without instance construction."""
+
+        class MissingMetadataBackend:
+            def load(self, device: str = "auto", weights_path: Optional[Path] = None, strict_license: bool = True) -> None:
+                pass
+
+            def predict(self, image: np.ndarray) -> DepthArtifact:
+                raise NotImplementedError
+
+        with pytest.raises(TypeError, match="must expose BackendInfo"):
+            registry.register(MissingMetadataBackend)
+
     def test_list_backends_by_role(self, registry):
         """Test listing backends filtered by role."""
         registry.register(MockCommercialBackend)
@@ -289,9 +332,76 @@ class TestDepthModelRegistry:
         backend = registry.get_backend(role=BackendRole.PRODUCTION)
         assert backend.info.role == BackendRole.PRODUCTION
 
+    def test_list_and_role_lookup_do_not_instantiate_all_backends(self, registry):
+        """Metadata discovery stays constructor-free; acquisition builds only the selected backend."""
+
+        class CountingProductionBackend:
+            constructor_calls = 0
+            backend_info = BackendInfo(
+                name="Counting Production",
+                model_id="mock/counting-production",
+                role=BackendRole.PRODUCTION,
+                license_tier=LicenseTier.COMMERCIAL,
+            )
+
+            def __init__(self):
+                type(self).constructor_calls += 1
+
+            @property
+            def info(self) -> BackendInfo:
+                return self.backend_info
+
+            def load(self, device: str = "auto", weights_path: Optional[Path] = None, strict_license: bool = True) -> None:
+                pass
+
+            def predict(self, image: np.ndarray) -> DepthArtifact:
+                raise NotImplementedError
+
+        class CountingAuditBackend:
+            constructor_calls = 0
+            backend_info = BackendInfo(
+                name="Counting Audit",
+                model_id="mock/counting-audit",
+                role=BackendRole.AUDIT,
+                license_tier=LicenseTier.NON_COMMERCIAL,
+            )
+
+            def __init__(self):
+                type(self).constructor_calls += 1
+
+            @property
+            def info(self) -> BackendInfo:
+                return self.backend_info
+
+            def load(self, device: str = "auto", weights_path: Optional[Path] = None, strict_license: bool = True) -> None:
+                pass
+
+            def predict(self, image: np.ndarray) -> DepthArtifact:
+                raise NotImplementedError
+
+        registry.register(CountingProductionBackend, name="production")
+        registry.register(CountingAuditBackend, name="audit")
+
+        listed = registry.list_backends()
+        assert len(listed) == 2
+        assert CountingProductionBackend.constructor_calls == 0
+        assert CountingAuditBackend.constructor_calls == 0
+
+        backend = registry.get_backend(role=BackendRole.PRODUCTION, use_cache=False)
+        assert isinstance(backend, CountingProductionBackend)
+        assert CountingProductionBackend.constructor_calls == 1
+        assert CountingAuditBackend.constructor_calls == 0
+
     def test_get_backend_commercial_only_rejects_research(self, registry):
         """Test that commercial_only rejects non-commercial backends."""
         registry.register(MockResearchBackend)
+        with pytest.raises(ValueError, match="non-commercial license"):
+            registry.get_backend(name="MockResearchBackend", commercial_only=True)
+
+    def test_get_backend_commercial_only_rejects_cached_research(self, registry):
+        """Commercial filtering is enforced before returning cached instances."""
+        registry.register(MockResearchBackend)
+        registry.get_backend(name="MockResearchBackend", commercial_only=False)
         with pytest.raises(ValueError, match="non-commercial license"):
             registry.get_backend(name="MockResearchBackend", commercial_only=True)
 


### PR DESCRIPTION
## Summary
- Remove constructor-dependent metadata discovery from the `lux_depth_v3` protocol registry.
- Consolidate run-card backend semantics and tighten depth artifact preview/dtype contracts.

## Changes
- Cache class-level `BackendInfo` in `DepthModelRegistry`; registration, listing, and role lookup no longer construct backend instances.
- Add a shared run-card backend-semantic validator reused by validator and integrity entrypoints, with integrity-only fallback diagnostics kept additive.
- Normalize optional `DepthArtifact` arrays to `float32`, clarify `compute_content_hash()` as a depth-raster compatibility hash, and make preview normalization finite-safe with an all-invalid zero fallback.
- Include the sidecar path in sidecar `outputs`, reuse schema-validator construction in integrity checks, collect canonical-read failures, add intrinsics guardrails, and clamp/validate `sky_seed` threshold knobs.
- Add focused regression coverage for the registry, run-card semantics, artifact dtype/hash/preview behavior, sidecar outputs, canonical-read handling, intrinsics guardrails, and sky thresholds.

## Validation
Proven green:
- `.venv/bin/pytest tests/unit/depth/test_depth_protocol.py tests/unit/depth/test_depth_artifact.py tests/lux_depth_v3/validators/test_run_card_validator.py tests/test_verify_run_card_integrity.py tests/materials/test_materials_v3_phase_b_sky.py` -> 118 passed
- `make test-fast` -> 73 passed
- `.venv/bin/black --check src/transformation_portal/lux_depth_v3/bootstrap/sky_seed.py src/transformation_portal/lux_depth_v3/contracts/depth_artifact.py src/transformation_portal/lux_depth_v3/protocols/depth_model.py src/transformation_portal/lux_depth_v3/validators/run_card_backend_semantics.py src/transformation_portal/lux_depth_v3/validators/run_card_integrity.py src/transformation_portal/lux_depth_v3/validators/run_card_validator.py tests/lux_depth_v3/validators/test_run_card_validator.py tests/materials/test_materials_v3_phase_b_sky.py tests/test_verify_run_card_integrity.py tests/unit/depth/test_depth_artifact.py tests/unit/depth/test_depth_protocol.py` -> passed
- `.venv/bin/isort --check-only src/transformation_portal/lux_depth_v3/bootstrap/sky_seed.py src/transformation_portal/lux_depth_v3/contracts/depth_artifact.py src/transformation_portal/lux_depth_v3/protocols/depth_model.py src/transformation_portal/lux_depth_v3/validators/run_card_backend_semantics.py src/transformation_portal/lux_depth_v3/validators/run_card_integrity.py src/transformation_portal/lux_depth_v3/validators/run_card_validator.py tests/lux_depth_v3/validators/test_run_card_validator.py tests/materials/test_materials_v3_phase_b_sky.py tests/test_verify_run_card_integrity.py tests/unit/depth/test_depth_artifact.py tests/unit/depth/test_depth_protocol.py` -> passed
- `git diff --check` -> passed

Still failing:
- Normal commit hooks / `make pre-commit` are blocked by local environment and generated-artifact state, not product logic in this patch: `auto-format-staged` and `check-test-markers` cannot find a bare `python` executable, and `gitleaks` scans existing generated `output/` and `web/secure-landing/.next/` artifacts.

## Risk
- Compatibility: `DepthModelRegistry` registration now requires class-available `BackendInfo` or explicit registration metadata; this is scoped to the protocol registry and covered by tests.
- Contract: optional depth artifact arrays now persist as `float32`, matching the required depth raster policy.
- Operational: run-card semantic pass/fail logic is centralized while integrity-only diagnostics remain additive.
- Revert-safe: changes are bounded to `lux_depth_v3` contracts/protocols/validators/bootstrap logic and focused tests; no route, selector, API envelope, or auth behavior changes.
