### PR TITLE
fix(phase4): consolidate validation helper usage

### DIFF
--- a/src/tp/phase4/hash_capture_metadata.py
+++ b/src/tp/phase4/hash_capture_metadata.py
@@ -11,7 +11,12 @@ from .exceptions import (
     MetadataManifestSchemaValidationError,
     MetadataSchemaValidationError,
 )
-from .schema_validation import build_draft202012_validator
+from .validation_helpers import (
+    require_sorted_relative_paths,
+    require_unique_relative_paths,
+    validate_payload_with_schema,
+    validate_records_with_schema,
+)
 
 METADATA_CONTRACT_VERSION = "tp.meta.capture.v1"
 METADATA_MANIFEST_CONTRACT_VERSION = "tp.meta.capture_manifest.v1"
@@ -36,57 +41,22 @@ def compute_metadata_sha256(metadata_object: dict[str, Any]) -> str:
     return hashlib.sha256(canonical_json_bytes(metadata_object)).hexdigest()
 
 
-def _build_validator(schema: dict[str, Any], *, error_cls: type[Exception], label: str) -> Any:
-    return build_draft202012_validator(schema, error_cls=error_cls, label=label)
-
-
 def _validate_metadata_records(records: list[dict[str, Any]], metadata_schema: dict[str, Any]) -> None:
-    validator = _build_validator(
+    validate_records_with_schema(
+        records,
         metadata_schema,
         error_cls=MetadataSchemaValidationError,
         label="metadata",
     )
-    for index, record in enumerate(records):
-        try:
-            errors = sorted(validator.iter_errors(record), key=lambda error: list(error.path))
-        except (TypeError, ValueError) as exc:
-            raise MetadataSchemaValidationError(
-                f"record[{index}] schema validation failed due to validator runtime error ({type(exc).__name__})"
-            ) from exc
-        if errors:
-            first = errors[0]
-            path = ".".join(str(part) for part in first.path) or "<root>"
-            raise MetadataSchemaValidationError(f"record[{index}] schema validation failed at {path}: {first.message}")
 
 
 def _validate_metadata_manifest(payload: dict[str, Any], manifest_schema: dict[str, Any]) -> None:
-    validator = _build_validator(
+    validate_payload_with_schema(
+        payload,
         manifest_schema,
         error_cls=MetadataManifestSchemaValidationError,
-        label="metadata_manifest",
+        label="metadata manifest",
     )
-    errors = sorted(validator.iter_errors(payload), key=lambda error: list(error.path))
-    if errors:
-        first = errors[0]
-        path = ".".join(str(part) for part in first.path) or "<root>"
-        raise MetadataManifestSchemaValidationError(f"metadata manifest schema validation failed at {path}: {first.message}")
-
-
-def _require_unique_relative_paths(records: list[dict[str, Any]]) -> None:
-    seen: set[str] = set()
-    for index, record in enumerate(records):
-        relative_path = record.get("relative_path")
-        if not isinstance(relative_path, str):
-            raise MetadataManifestInputError(f"record[{index}] missing relative_path")
-        if relative_path in seen:
-            raise MetadataManifestInputError(f"duplicate relative_path: {relative_path}")
-        seen.add(relative_path)
-
-
-def _require_sorted_relative_paths(records: list[dict[str, Any]]) -> None:
-    relative_paths = [record["relative_path"] for record in records]
-    if relative_paths != sorted(relative_paths):
-        raise MetadataManifestInputError("input metadata array must be sorted by relative_path")
 
 
 def _require_metadata_contract_version(records: list[dict[str, Any]]) -> None:
@@ -128,9 +98,9 @@ def build_metadata_manifest_payload(
 
     _validate_metadata_records(records, metadata_schema=metadata_schema)
     _require_metadata_contract_version(records)
-    _require_unique_relative_paths(records)
+    require_unique_relative_paths(records, label="input metadata array", error_cls=MetadataManifestInputError)
     if strict_input_order:
-        _require_sorted_relative_paths(records)
+        require_sorted_relative_paths(records, label="input metadata array", error_cls=MetadataManifestInputError)
     if required_config_fingerprint_sha256 is not None:
         _require_fingerprint_match(records, expected_fingerprint=required_config_fingerprint_sha256)
 

--- a/src/tp/phase4/provenance_capture.py
+++ b/src/tp/phase4/provenance_capture.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import hashlib
-import re
 from typing import Any
 
 from tp.crypto.merkle import merkle_root_sha256
@@ -19,93 +18,55 @@ from .hash_capture_metadata import (
     canonical_json_bytes,
     compute_metadata_sha256,
 )
-from .schema_validation import build_draft202012_validator
+from .validation_helpers import (
+    build_path_index,
+    ensure_sha256_hex,
+    require_contract_version,
+    require_sorted_relative_paths,
+    require_unique_relative_paths,
+    validate_payload_with_schema,
+    validate_records_with_schema,
+)
 
 PROVENANCE_CONTRACT_VERSION = "tp.meta.provenance.v1"
 PROVENANCE_MERKLE_CONTRACT_VERSION = "tp.meta.provenance_merkle.v1"
 
-_SHA256_HEX_RE = re.compile(r"^[a-f0-9]{64}$")
-
-
-def _build_validator(schema: dict[str, Any], *, error_cls: type[Exception], label: str) -> Any:
-    return build_draft202012_validator(schema, error_cls=error_cls, label=label)
-
 
 def _validate_capture_records(records: list[dict[str, Any]], metadata_schema: dict[str, Any]) -> None:
-    validator = _build_validator(
+    validate_records_with_schema(
+        records,
         metadata_schema,
         error_cls=ProvenanceSchemaValidationError,
         label="metadata",
+        record_label_fn=lambda index, _record: f"capture record[{index}]",
     )
-    for index, record in enumerate(records):
-        try:
-            errors = sorted(validator.iter_errors(record), key=lambda error: list(error.path))
-        except (TypeError, ValueError) as exc:
-            raise ProvenanceSchemaValidationError(
-                f"capture record[{index}] schema validation failed due to validator runtime error ({type(exc).__name__})"
-            ) from exc
-        if errors:
-            first = errors[0]
-            path = ".".join(str(part) for part in first.path) or "<root>"
-            raise ProvenanceSchemaValidationError(
-                f"capture record[{index}] schema validation failed at {path}: {first.message}"
-            )
 
 
 def _validate_metadata_manifest(payload: dict[str, Any], manifest_schema: dict[str, Any]) -> None:
-    validator = _build_validator(
+    validate_payload_with_schema(
+        payload,
         manifest_schema,
         error_cls=ProvenanceSchemaValidationError,
-        label="metadata_manifest",
+        label="metadata manifest",
     )
-    errors = sorted(validator.iter_errors(payload), key=lambda error: list(error.path))
-    if errors:
-        first = errors[0]
-        path = ".".join(str(part) for part in first.path) or "<root>"
-        raise ProvenanceSchemaValidationError(f"metadata manifest schema validation failed at {path}: {first.message}")
 
 
 def _validate_provenance_manifest(payload: dict[str, Any], provenance_manifest_schema: dict[str, Any]) -> None:
-    validator = _build_validator(
+    validate_payload_with_schema(
+        payload,
         provenance_manifest_schema,
         error_cls=ProvenanceSchemaValidationError,
-        label="provenance_manifest",
+        label="provenance manifest",
     )
-    errors = sorted(validator.iter_errors(payload), key=lambda error: list(error.path))
-    if errors:
-        first = errors[0]
-        path = ".".join(str(part) for part in first.path) or "<root>"
-        raise ProvenanceSchemaValidationError(f"provenance manifest schema validation failed at {path}: {first.message}")
 
 
 def _validate_provenance_merkle(payload: dict[str, Any], provenance_merkle_schema: dict[str, Any]) -> None:
-    validator = _build_validator(
+    validate_payload_with_schema(
+        payload,
         provenance_merkle_schema,
         error_cls=ProvenanceMerkleSchemaValidationError,
-        label="provenance_merkle",
+        label="provenance merkle",
     )
-    errors = sorted(validator.iter_errors(payload), key=lambda error: list(error.path))
-    if errors:
-        first = errors[0]
-        path = ".".join(str(part) for part in first.path) or "<root>"
-        raise ProvenanceMerkleSchemaValidationError(f"provenance merkle schema validation failed at {path}: {first.message}")
-
-
-def _require_unique_relative_paths(records: list[dict[str, Any]], *, label: str) -> None:
-    seen: set[str] = set()
-    for index, record in enumerate(records):
-        relative_path = record.get("relative_path")
-        if not isinstance(relative_path, str):
-            raise ProvenanceInputError(f"{label} record[{index}] missing relative_path")
-        if relative_path in seen:
-            raise ProvenanceInputError(f"{label} duplicate relative_path: {relative_path}")
-        seen.add(relative_path)
-
-
-def _require_sorted_relative_paths(records: list[dict[str, Any]], *, label: str) -> None:
-    relative_paths = [record["relative_path"] for record in records]
-    if relative_paths != sorted(relative_paths):
-        raise ProvenanceInputError(f"{label} must be sorted by relative_path")
 
 
 def _require_capture_contract_version(records: list[dict[str, Any]]) -> None:
@@ -114,7 +75,8 @@ def _require_capture_contract_version(records: list[dict[str, Any]]) -> None:
         if contract_version != METADATA_CONTRACT_VERSION:
             relative_path = record.get("relative_path", "<unknown>")
             raise ProvenanceInputError(
-                f"capture record[{index}] contract mismatch for {relative_path}: expected {METADATA_CONTRACT_VERSION}, got {contract_version!r}"
+                f"capture record[{index}] contract mismatch for {relative_path}: "
+                f"expected {METADATA_CONTRACT_VERSION}, got {contract_version!r}"
             )
 
 
@@ -122,13 +84,15 @@ def _require_metadata_manifest_contract_version(payload: dict[str, Any]) -> list
     manifest_contract_version = payload.get("metadata_manifest_contract_version")
     if manifest_contract_version != METADATA_MANIFEST_CONTRACT_VERSION:
         raise ProvenanceInputError(
-            f"metadata manifest contract mismatch: expected {METADATA_MANIFEST_CONTRACT_VERSION}, got {manifest_contract_version!r}"
+            "metadata manifest contract mismatch: "
+            f"expected {METADATA_MANIFEST_CONTRACT_VERSION}, got {manifest_contract_version!r}"
         )
 
     metadata_contract_version = payload.get("metadata_contract_version")
     if metadata_contract_version != METADATA_CONTRACT_VERSION:
         raise ProvenanceInputError(
-            f"metadata manifest metadata_contract_version mismatch: expected {METADATA_CONTRACT_VERSION}, got {metadata_contract_version!r}"
+            "metadata manifest metadata_contract_version mismatch: "
+            f"expected {METADATA_CONTRACT_VERSION}, got {metadata_contract_version!r}"
         )
 
     entries = payload.get("entries")
@@ -141,13 +105,15 @@ def _require_provenance_manifest_contract_version(payload: dict[str, Any]) -> li
     provenance_contract_version = payload.get("provenance_contract_version")
     if provenance_contract_version != PROVENANCE_CONTRACT_VERSION:
         raise ProvenanceInputError(
-            f"provenance manifest contract mismatch: expected {PROVENANCE_CONTRACT_VERSION}, got {provenance_contract_version!r}"
+            "provenance manifest contract mismatch: "
+            f"expected {PROVENANCE_CONTRACT_VERSION}, got {provenance_contract_version!r}"
         )
 
     metadata_contract_version = payload.get("metadata_contract_version")
     if metadata_contract_version != METADATA_CONTRACT_VERSION:
         raise ProvenanceInputError(
-            f"provenance manifest metadata_contract_version mismatch: expected {METADATA_CONTRACT_VERSION}, got {metadata_contract_version!r}"
+            "provenance manifest metadata_contract_version mismatch: "
+            f"expected {METADATA_CONTRACT_VERSION}, got {metadata_contract_version!r}"
         )
 
     entries = payload.get("entries")
@@ -165,24 +131,9 @@ def _require_fingerprint_match(records: list[dict[str, Any]], expected_fingerpri
         if fingerprint != expected_fingerprint:
             relative_path = record.get("relative_path", "<unknown>")
             raise ProvenanceInputError(
-                f"capture record[{index}] fingerprint mismatch for {relative_path}: expected {expected_fingerprint}, got {fingerprint!r}"
+                f"capture record[{index}] fingerprint mismatch for {relative_path}: "
+                f"expected {expected_fingerprint}, got {fingerprint!r}"
             )
-
-
-def _path_index(records: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
-    return {record["relative_path"]: record for record in records}
-
-
-def _ensure_sha256_hex(value: Any, *, label: str) -> str:
-    if not isinstance(value, str) or not _SHA256_HEX_RE.match(value):
-        raise ProvenanceInputError(f"{label} must be a lowercase 64-character sha256 hex digest")
-    return value
-
-
-def _ensure_contract_version(value: str, *, expected: str, label: str) -> str:
-    if value != expected:
-        raise ProvenanceInputError(f"{label} mismatch: expected {expected}, got {value!r}")
-    return value
 
 
 def compute_provenance_entry_sha256(
@@ -194,24 +145,29 @@ def compute_provenance_entry_sha256(
     provenance_contract_version: str = PROVENANCE_CONTRACT_VERSION,
 ) -> str:
     """Compute SHA256(F || M || C || Mv || Pv) over binary digests + UTF-8 version strings."""
-    capture_version = _ensure_contract_version(
+    capture_version = require_contract_version(
         capture_contract_version,
         expected=METADATA_CONTRACT_VERSION,
         label="capture_contract_version",
+        error_cls=ProvenanceInputError,
     )
-    metadata_version = _ensure_contract_version(
+    metadata_version = require_contract_version(
         metadata_contract_version,
         expected=METADATA_CONTRACT_VERSION,
         label="metadata_contract_version",
+        error_cls=ProvenanceInputError,
     )
-    provenance_version = _ensure_contract_version(
+    provenance_version = require_contract_version(
         provenance_contract_version,
         expected=PROVENANCE_CONTRACT_VERSION,
         label="provenance_contract_version",
+        error_cls=ProvenanceInputError,
     )
 
-    file_digest = bytes.fromhex(_ensure_sha256_hex(file_sha256, label="file_sha256"))
-    metadata_digest = bytes.fromhex(_ensure_sha256_hex(metadata_sha256, label="metadata_sha256"))
+    file_digest = bytes.fromhex(ensure_sha256_hex(file_sha256, label="file_sha256", error_cls=ProvenanceInputError))
+    metadata_digest = bytes.fromhex(
+        ensure_sha256_hex(metadata_sha256, label="metadata_sha256", error_cls=ProvenanceInputError)
+    )
     capture_version_bytes = capture_version.encode("utf-8")
     metadata_version_bytes = metadata_version.encode("utf-8")
     provenance_version_bytes = provenance_version.encode("utf-8")
@@ -242,16 +198,18 @@ def build_provenance_manifest_payload(
     _require_capture_contract_version(capture_records)
     metadata_manifest_entries = _require_metadata_manifest_contract_version(metadata_manifest_payload)
 
-    _require_unique_relative_paths(capture_records, label="capture metadata")
-    _require_unique_relative_paths(metadata_manifest_entries, label="metadata manifest")
+    require_unique_relative_paths(capture_records, label="capture metadata", error_cls=ProvenanceInputError)
+    require_unique_relative_paths(metadata_manifest_entries, label="metadata manifest", error_cls=ProvenanceInputError)
     if strict_input_order:
-        _require_sorted_relative_paths(capture_records, label="capture metadata array")
-        _require_sorted_relative_paths(metadata_manifest_entries, label="metadata manifest entries")
+        require_sorted_relative_paths(capture_records, label="capture metadata array", error_cls=ProvenanceInputError)
+        require_sorted_relative_paths(
+            metadata_manifest_entries, label="metadata manifest entries", error_cls=ProvenanceInputError
+        )
     if required_config_fingerprint_sha256 is not None:
         _require_fingerprint_match(capture_records, expected_fingerprint=required_config_fingerprint_sha256)
 
-    capture_by_path = _path_index(capture_records)
-    manifest_by_path = _path_index(metadata_manifest_entries)
+    capture_by_path = build_path_index(capture_records, label="capture metadata", error_cls=ProvenanceInputError)
+    manifest_by_path = build_path_index(metadata_manifest_entries, label="metadata manifest", error_cls=ProvenanceInputError)
 
     capture_paths = set(capture_by_path)
     manifest_paths = set(manifest_by_path)
@@ -259,7 +217,8 @@ def build_provenance_manifest_payload(
     missing_in_capture = sorted(manifest_paths - capture_paths)
     if missing_in_manifest or missing_in_capture:
         raise ProvenanceInputError(
-            f"relative_path alignment mismatch between capture metadata and metadata manifest: missing_in_manifest={missing_in_manifest}, "
+            "relative_path alignment mismatch between capture metadata and metadata manifest: "
+            f"missing_in_manifest={missing_in_manifest}, "
             f"missing_in_capture={missing_in_capture}"
         )
 
@@ -268,9 +227,13 @@ def build_provenance_manifest_payload(
         capture_record = capture_by_path[relative_path]
         manifest_entry = manifest_by_path[relative_path]
 
-        capture_file_sha256 = _ensure_sha256_hex(capture_record.get("file_sha256"), label=f"{relative_path} file_sha256")
-        manifest_file_sha256 = _ensure_sha256_hex(
-            manifest_entry.get("file_sha256"), label=f"{relative_path} metadata manifest file_sha256"
+        capture_file_sha256 = ensure_sha256_hex(
+            capture_record.get("file_sha256"), label=f"{relative_path} file_sha256", error_cls=ProvenanceInputError
+        )
+        manifest_file_sha256 = ensure_sha256_hex(
+            manifest_entry.get("file_sha256"),
+            label=f"{relative_path} metadata manifest file_sha256",
+            error_cls=ProvenanceInputError,
         )
         if capture_file_sha256 != manifest_file_sha256:
             raise ProvenanceInputError(
@@ -284,12 +247,15 @@ def build_provenance_manifest_payload(
                 f"canonical metadata serialization failed for record with relative_path={relative_path!r}: {exc}"
             ) from exc
 
-        manifest_metadata_sha256 = _ensure_sha256_hex(
-            manifest_entry.get("metadata_sha256"), label=f"{relative_path} metadata manifest metadata_sha256"
+        manifest_metadata_sha256 = ensure_sha256_hex(
+            manifest_entry.get("metadata_sha256"),
+            label=f"{relative_path} metadata manifest metadata_sha256",
+            error_cls=ProvenanceInputError,
         )
         if recomputed_metadata_sha256 != manifest_metadata_sha256:
             raise ProvenanceInputError(
-                f"metadata_sha256 mismatch for {relative_path}: recomputed={recomputed_metadata_sha256}, manifest={manifest_metadata_sha256}"
+                f"metadata_sha256 mismatch for {relative_path}: "
+                f"recomputed={recomputed_metadata_sha256}, manifest={manifest_metadata_sha256}"
             )
 
         provenance_entry_sha256 = compute_provenance_entry_sha256(
@@ -336,14 +302,18 @@ def build_provenance_merkle_payload(
     _validate_provenance_manifest(provenance_manifest_payload, provenance_manifest_schema=provenance_manifest_schema)
     manifest_entries = _require_provenance_manifest_contract_version(provenance_manifest_payload)
 
-    _require_unique_relative_paths(manifest_entries, label="provenance manifest")
+    require_unique_relative_paths(manifest_entries, label="provenance manifest", error_cls=ProvenanceInputError)
     if strict_input_order:
-        _require_sorted_relative_paths(manifest_entries, label="provenance manifest entries")
+        require_sorted_relative_paths(manifest_entries, label="provenance manifest entries", error_cls=ProvenanceInputError)
 
     sorted_entries = sorted(manifest_entries, key=lambda entry: entry["relative_path"])
     leaf_hashes: list[bytes] = []
     for index, entry in enumerate(sorted_entries):
-        digest_hex = _ensure_sha256_hex(entry.get("provenance_entry_sha256"), label=f"entry[{index}] provenance_entry_sha256")
+        digest_hex = ensure_sha256_hex(
+            entry.get("provenance_entry_sha256"),
+            label=f"entry[{index}] provenance_entry_sha256",
+            error_cls=ProvenanceInputError,
+        )
         leaf_hashes.append(bytes.fromhex(digest_hex))
 
     if not leaf_hashes:

--- a/src/tp/phase4/verify_phase4_chain.py
+++ b/src/tp/phase4/verify_phase4_chain.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import re
 from pathlib import Path
 from typing import Any, Callable
 
@@ -29,7 +28,15 @@ from .provenance_capture import (
     PROVENANCE_MERKLE_CONTRACT_VERSION,
     compute_provenance_entry_sha256,
 )
-from .schema_validation import build_draft202012_validator
+from .validation_helpers import (
+    build_path_index,
+    ensure_sha256_hex,
+    require_sorted_relative_paths,
+    require_unique_relative_paths,
+    string_or_none,
+    validate_payload_with_schema,
+    validate_records_with_schema,
+)
 
 VERIFICATION_REPORT_CONTRACT_VERSION = "tp.meta.verification_report.v1"
 VERIFIER_NAME = "verify_phase4_chain.py"
@@ -46,24 +53,6 @@ FAILURE_LABEL_METADATA_HASH_MISMATCH = "METADATA_HASH_MISMATCH"
 FAILURE_LABEL_PROVENANCE_ENTRY_HASH_MISMATCH = "PROVENANCE_ENTRY_HASH_MISMATCH"
 FAILURE_LABEL_MERKLE_MISMATCH = "MERKLE_MISMATCH"
 FAILURE_LABEL_REPORT_WRITE_FAILURE = "REPORT_WRITE_FAILURE"
-
-_SHA256_HEX_RE = re.compile(r"^[a-f0-9]{64}$")
-
-
-def _build_validator(schema: dict[str, Any], *, error_cls: type[Exception], label: str) -> Any:
-    return build_draft202012_validator(schema, error_cls=error_cls, label=label)
-
-
-def _ensure_sha256_hex(value: Any, *, label: str, error_cls: type[Exception]) -> str:
-    if not isinstance(value, str) or _SHA256_HEX_RE.fullmatch(value) is None:
-        raise error_cls(f"{label} must be a lowercase 64-character sha256 hex digest")
-    return value
-
-
-def _string_or_none(value: Any) -> str | None:
-    if isinstance(value, str):
-        return value
-    return None
 
 
 def _sha256_bytes(data: bytes) -> str:
@@ -94,62 +83,22 @@ def _read_json_schema(path: Path, *, label: str) -> dict[str, Any]:
 
 
 def _validate_capture_records(records: list[dict[str, Any]], metadata_schema: dict[str, Any]) -> None:
-    validator = _build_validator(
+    validate_records_with_schema(
+        records,
         metadata_schema,
         error_cls=Phase4SchemaValidationError,
         label="metadata",
+        record_label_fn=lambda index, _record: f"capture record[{index}]",
     )
-    for index, record in enumerate(records):
-        try:
-            errors = sorted(validator.iter_errors(record), key=lambda error: list(error.path))
-        except (TypeError, ValueError) as exc:
-            raise Phase4SchemaValidationError(
-                f"capture record[{index}] schema validation failed due to validator runtime error ({type(exc).__name__})"
-            ) from exc
-        if errors:
-            first = errors[0]
-            path = ".".join(str(part) for part in first.path) or "<root>"
-            raise Phase4SchemaValidationError(f"capture record[{index}] schema validation failed at {path}: {first.message}")
 
 
 def _validate_payload(payload: dict[str, Any], schema: dict[str, Any], *, label: str) -> None:
-    validator = _build_validator(
+    validate_payload_with_schema(
+        payload,
         schema,
         error_cls=Phase4SchemaValidationError,
         label=label,
     )
-    errors = sorted(validator.iter_errors(payload), key=lambda error: list(error.path))
-    if errors:
-        first = errors[0]
-        path = ".".join(str(part) for part in first.path) or "<root>"
-        raise Phase4SchemaValidationError(f"{label} schema validation failed at {path}: {first.message}")
-
-
-def _require_unique_relative_paths(records: list[dict[str, Any]], *, label: str) -> None:
-    seen: set[str] = set()
-    for index, record in enumerate(records):
-        relative_path = record.get("relative_path")
-        if not isinstance(relative_path, str):
-            raise Phase4AlignmentError(f"{label} record[{index}] missing relative_path")
-        if relative_path in seen:
-            raise Phase4AlignmentError(f"{label} duplicate relative_path: {relative_path}")
-        seen.add(relative_path)
-
-
-def _require_sorted_relative_paths(records: list[dict[str, Any]], *, label: str) -> None:
-    relative_paths = [record["relative_path"] for record in records]
-    if relative_paths != sorted(relative_paths):
-        raise Phase4AlignmentError(f"{label} must be sorted by relative_path")
-
-
-def _path_index(records: list[dict[str, Any]], *, label: str) -> dict[str, dict[str, Any]]:
-    index: dict[str, dict[str, Any]] = {}
-    for position, record in enumerate(records):
-        relative_path = record.get("relative_path")
-        if not isinstance(relative_path, str):
-            raise Phase4AlignmentError(f"{label} record[{position}] missing relative_path")
-        index[relative_path] = record
-    return index
 
 
 def _require_capture_contract_version(records: list[dict[str, Any]]) -> None:
@@ -275,9 +224,9 @@ def verify_phase4_chain_payloads(
         raise Phase4SchemaValidationError("provenance merkle payload must be a JSON object")
 
     _validate_capture_records(capture_payload, metadata_schema=metadata_schema)
-    _validate_payload(metadata_manifest_payload, metadata_manifest_schema, label="metadata_manifest")
-    _validate_payload(provenance_manifest_payload, provenance_manifest_schema, label="provenance_manifest")
-    _validate_payload(provenance_merkle_payload, provenance_merkle_schema, label="provenance_merkle")
+    _validate_payload(metadata_manifest_payload, metadata_manifest_schema, label="metadata manifest")
+    _validate_payload(provenance_manifest_payload, provenance_manifest_schema, label="provenance manifest")
+    _validate_payload(provenance_merkle_payload, provenance_merkle_schema, label="provenance merkle")
 
     if progress_callback:
         progress_callback(1, total_stages, "Checking contract versions...")
@@ -290,17 +239,25 @@ def verify_phase4_chain_payloads(
     if progress_callback:
         progress_callback(2, total_stages, "Checking path uniqueness and ordering...")
 
-    _require_unique_relative_paths(capture_payload, label="capture metadata")
-    _require_unique_relative_paths(metadata_manifest_entries, label="metadata manifest")
-    _require_unique_relative_paths(provenance_manifest_entries, label="provenance manifest")
+    require_unique_relative_paths(capture_payload, label="capture metadata", error_cls=Phase4AlignmentError)
+    require_unique_relative_paths(metadata_manifest_entries, label="metadata manifest", error_cls=Phase4AlignmentError)
+    require_unique_relative_paths(provenance_manifest_entries, label="provenance manifest", error_cls=Phase4AlignmentError)
     if strict_input_order:
-        _require_sorted_relative_paths(capture_payload, label="capture metadata array")
-        _require_sorted_relative_paths(metadata_manifest_entries, label="metadata manifest entries")
-        _require_sorted_relative_paths(provenance_manifest_entries, label="provenance manifest entries")
+        require_sorted_relative_paths(capture_payload, label="capture metadata array", error_cls=Phase4AlignmentError)
+        require_sorted_relative_paths(
+            metadata_manifest_entries, label="metadata manifest entries", error_cls=Phase4AlignmentError
+        )
+        require_sorted_relative_paths(
+            provenance_manifest_entries, label="provenance manifest entries", error_cls=Phase4AlignmentError
+        )
 
-    capture_by_path = _path_index(capture_payload, label="capture metadata")
-    metadata_manifest_by_path = _path_index(metadata_manifest_entries, label="metadata manifest")
-    provenance_manifest_by_path = _path_index(provenance_manifest_entries, label="provenance manifest")
+    capture_by_path = build_path_index(capture_payload, label="capture metadata", error_cls=Phase4AlignmentError)
+    metadata_manifest_by_path = build_path_index(
+        metadata_manifest_entries, label="metadata manifest", error_cls=Phase4AlignmentError
+    )
+    provenance_manifest_by_path = build_path_index(
+        provenance_manifest_entries, label="provenance manifest", error_cls=Phase4AlignmentError
+    )
 
     capture_paths = set(capture_by_path)
     metadata_manifest_paths = set(metadata_manifest_by_path)
@@ -337,17 +294,17 @@ def verify_phase4_chain_payloads(
         metadata_manifest_entry = metadata_manifest_by_path[relative_path]
         provenance_manifest_entry = provenance_manifest_by_path[relative_path]
 
-        capture_file_sha256 = _ensure_sha256_hex(
+        capture_file_sha256 = ensure_sha256_hex(
             capture_record.get("file_sha256"),
             label=f"{relative_path} capture file_sha256",
             error_cls=Phase4AlignmentError,
         )
-        metadata_manifest_file_sha256 = _ensure_sha256_hex(
+        metadata_manifest_file_sha256 = ensure_sha256_hex(
             metadata_manifest_entry.get("file_sha256"),
             label=f"{relative_path} metadata manifest file_sha256",
             error_cls=Phase4AlignmentError,
         )
-        provenance_manifest_file_sha256 = _ensure_sha256_hex(
+        provenance_manifest_file_sha256 = ensure_sha256_hex(
             provenance_manifest_entry.get("file_sha256"),
             label=f"{relative_path} provenance manifest file_sha256",
             error_cls=Phase4AlignmentError,
@@ -364,12 +321,12 @@ def verify_phase4_chain_payloads(
                 f"capture={capture_file_sha256}, provenance_manifest={provenance_manifest_file_sha256}"
             )
 
-        metadata_manifest_metadata_sha256 = _ensure_sha256_hex(
+        metadata_manifest_metadata_sha256 = ensure_sha256_hex(
             metadata_manifest_entry.get("metadata_sha256"),
             label=f"{relative_path} metadata manifest metadata_sha256",
             error_cls=Phase4AlignmentError,
         )
-        provenance_manifest_metadata_sha256 = _ensure_sha256_hex(
+        provenance_manifest_metadata_sha256 = ensure_sha256_hex(
             provenance_manifest_entry.get("metadata_sha256"),
             label=f"{relative_path} provenance manifest metadata_sha256",
             error_cls=Phase4AlignmentError,
@@ -378,7 +335,8 @@ def verify_phase4_chain_payloads(
         if metadata_manifest_metadata_sha256 != provenance_manifest_metadata_sha256:
             raise Phase4AlignmentError(
                 f"metadata_sha256 mismatch between metadata manifest and provenance manifest for {relative_path}: "
-                f"metadata_manifest={metadata_manifest_metadata_sha256}, provenance_manifest={provenance_manifest_metadata_sha256}"
+                f"metadata_manifest={metadata_manifest_metadata_sha256}, "
+                f"provenance_manifest={provenance_manifest_metadata_sha256}"
             )
 
         try:
@@ -393,7 +351,7 @@ def verify_phase4_chain_payloads(
                 f"recomputed={recomputed_metadata_sha256}, expected={metadata_manifest_metadata_sha256}"
             )
 
-        provenance_manifest_entry_sha256 = _ensure_sha256_hex(
+        provenance_manifest_entry_sha256 = ensure_sha256_hex(
             provenance_manifest_entry.get("provenance_entry_sha256"),
             label=f"{relative_path} provenance manifest provenance_entry_sha256",
             error_cls=Phase4ProvenanceEntryHashMismatchError,
@@ -425,7 +383,7 @@ def verify_phase4_chain_payloads(
             f"leaf_count mismatch: recomputed={len(leaf_hashes)}, expected={expected_leaf_count!r}"
         )
 
-    expected_provenance_merkle_root = _ensure_sha256_hex(
+    expected_provenance_merkle_root = ensure_sha256_hex(
         provenance_merkle_payload.get("provenance_merkle_root"),
         label="provenance merkle provenance_merkle_root",
         error_cls=Phase4MerkleMismatchError,
@@ -460,7 +418,7 @@ def _derive_capture_contract_version(capture_payload: Any) -> str | None:
     if len(versions) != 1:
         return None
     only = versions.pop()
-    return _string_or_none(only)
+    return string_or_none(only)
 
 
 def _build_inputs_block(
@@ -477,28 +435,28 @@ def _build_inputs_block(
     metadata_manifest_contract_version = None
     metadata_manifest_metadata_contract_version = None
     if isinstance(metadata_manifest_payload, dict):
-        metadata_manifest_contract_version = _string_or_none(
+        metadata_manifest_contract_version = string_or_none(
             metadata_manifest_payload.get("metadata_manifest_contract_version")
         )
-        metadata_manifest_metadata_contract_version = _string_or_none(
+        metadata_manifest_metadata_contract_version = string_or_none(
             metadata_manifest_payload.get("metadata_contract_version")
         )
 
     provenance_manifest_contract_version = None
     provenance_manifest_metadata_contract_version = None
     if isinstance(provenance_manifest_payload, dict):
-        provenance_manifest_contract_version = _string_or_none(provenance_manifest_payload.get("provenance_contract_version"))
-        provenance_manifest_metadata_contract_version = _string_or_none(
+        provenance_manifest_contract_version = string_or_none(provenance_manifest_payload.get("provenance_contract_version"))
+        provenance_manifest_metadata_contract_version = string_or_none(
             provenance_manifest_payload.get("metadata_contract_version")
         )
 
     provenance_merkle_contract_version = None
     provenance_merkle_provenance_contract_version = None
     if isinstance(provenance_merkle_payload, dict):
-        provenance_merkle_contract_version = _string_or_none(
+        provenance_merkle_contract_version = string_or_none(
             provenance_merkle_payload.get("provenance_merkle_contract_version")
         )
-        provenance_merkle_provenance_contract_version = _string_or_none(
+        provenance_merkle_provenance_contract_version = string_or_none(
             provenance_merkle_payload.get("provenance_contract_version")
         )
 

--- a/tests/test_build_metadata_manifest.py
+++ b/tests/test_build_metadata_manifest.py
@@ -11,8 +11,14 @@ from typing import Any
 
 import pytest
 
-import tp.phase4.hash_capture_metadata as hash_capture_metadata
-from tp.phase4.hash_capture_metadata import MetadataSchemaValidationError, compute_metadata_sha256
+from tp.phase4.hash_capture_metadata import (
+    METADATA_CONTRACT_VERSION,
+    MetadataManifestInputError,
+    MetadataSchemaValidationError,
+    build_metadata_manifest_payload,
+    compute_metadata_sha256,
+)
+from tp.phase4.validation_helpers import validate_records_with_schema
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 EXTRACT_TOOL = PROJECT_ROOT / "tools" / "extract_capture_metadata.py"
@@ -143,9 +149,24 @@ def test_phase4d_metadata_validation_normalizes_validator_runtime_errors(monkeyp
         del schema, error_cls, label
         return _ExplodingValidator()
 
-    monkeypatch.setattr(hash_capture_metadata, "_build_validator", _fake_build_validator)
+    import tp.phase4.schema_validation as schema_validation
+
+    monkeypatch.setattr(schema_validation, "build_draft202012_validator", _fake_build_validator)
     with pytest.raises(MetadataSchemaValidationError, match="validator runtime error"):
-        hash_capture_metadata._validate_metadata_records([{}], metadata_schema={})
+        validate_records_with_schema([{}], {}, error_cls=MetadataSchemaValidationError, label="metadata")
+
+
+def test_phase4d_build_payload_reports_missing_relative_path_without_keyerror() -> None:
+    pytest.importorskip("jsonschema")
+    records = [
+        {
+            "metadata_contract_version": METADATA_CONTRACT_VERSION,
+            "file_sha256": "a" * 64,
+        }
+    ]
+
+    with pytest.raises(MetadataManifestInputError, match=r"input metadata array record\[0\] missing relative_path"):
+        build_metadata_manifest_payload(records, metadata_schema={}, manifest_schema={})
 
 
 def test_phase4d_golden_manifest_matches_expected(tmp_path: Path) -> None:
@@ -262,6 +283,8 @@ def test_phase4d_cli_fails_schema_validation_on_missing_required_field(tmp_path:
     result = _run_manifest_cli(input_path=input_path, out_path=out_path)
     assert result.returncode == 4
     assert "Schema validation failure:" in result.stderr
+    assert "record[0] schema validation failed at <root>" in result.stderr
+    assert "camera_model" in result.stderr
 
 
 def test_phase4d_cli_fails_schema_validation_on_nan_value(tmp_path: Path) -> None:

--- a/tests/test_build_provenance_manifest.py
+++ b/tests/test_build_provenance_manifest.py
@@ -16,7 +16,12 @@ from tp.phase4.hash_capture_metadata import (
     METADATA_MANIFEST_CONTRACT_VERSION,
     compute_metadata_sha256,
 )
-from tp.phase4.provenance_capture import PROVENANCE_CONTRACT_VERSION, ProvenanceInputError, compute_provenance_entry_sha256
+from tp.phase4.provenance_capture import (
+    PROVENANCE_CONTRACT_VERSION,
+    ProvenanceInputError,
+    build_provenance_manifest_payload,
+    compute_provenance_entry_sha256,
+)
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 PROVENANCE_MANIFEST_TOOL = PROJECT_ROOT / "tools" / "build_provenance_manifest.py"
@@ -156,6 +161,39 @@ def test_phase4e_provenance_entry_hash_rejects_contract_version_mismatch() -> No
             file_sha256=manifest_entry["file_sha256"],
             metadata_sha256=manifest_entry["metadata_sha256"],
             provenance_contract_version="tp.meta.provenance.v2",
+        )
+
+
+def test_phase4e_provenance_entry_hash_rejects_invalid_sha256() -> None:
+    manifest_entry = _load_json(GOLDEN_METADATA_MANIFEST)["entries"][0]
+    with pytest.raises(ProvenanceInputError, match="file_sha256"):
+        compute_provenance_entry_sha256(
+            file_sha256="not-a-sha256",
+            metadata_sha256=manifest_entry["metadata_sha256"],
+        )
+
+
+def test_phase4e_build_manifest_reports_missing_relative_path_without_keyerror() -> None:
+    pytest.importorskip("jsonschema")
+    capture_records = [
+        {
+            "metadata_contract_version": METADATA_CONTRACT_VERSION,
+            "file_sha256": "a" * 64,
+        }
+    ]
+    metadata_manifest_payload = {
+        "metadata_manifest_contract_version": METADATA_MANIFEST_CONTRACT_VERSION,
+        "metadata_contract_version": METADATA_CONTRACT_VERSION,
+        "entries": [],
+    }
+
+    with pytest.raises(ProvenanceInputError, match=r"capture metadata record\[0\] missing relative_path"):
+        build_provenance_manifest_payload(
+            capture_records,
+            metadata_manifest_payload,
+            metadata_schema={},
+            metadata_manifest_schema={},
+            provenance_manifest_schema={},
         )
 
 

--- a/tests/test_verify_phase4_chain.py
+++ b/tests/test_verify_phase4_chain.py
@@ -24,6 +24,7 @@ from tp.phase4.provenance_capture import (
 )
 from tp.phase4.verify_phase4_chain import (
     FAILURE_MESSAGE_MAX_LENGTH,
+    Phase4AlignmentError,
     build_verification_report_payload,
     default_failure_computed_block,
     verify_phase4_chain_payloads,
@@ -254,6 +255,64 @@ def test_phase4f_cli_returns_exit_code_31_for_invalid_input_json(tmp_path: Path)
     assert "Malformed input:" in result.stderr
 
 
+def test_phase4f_verify_reports_missing_relative_path_without_keyerror() -> None:
+    pytest.importorskip("jsonschema")
+    capture_payload = [
+        {
+            "metadata_contract_version": METADATA_CONTRACT_VERSION,
+            "file_sha256": "a" * 64,
+        }
+    ]
+    metadata_manifest_payload = {
+        "metadata_manifest_contract_version": METADATA_MANIFEST_CONTRACT_VERSION,
+        "metadata_contract_version": METADATA_CONTRACT_VERSION,
+        "entries": [],
+    }
+    provenance_manifest_payload = {
+        "provenance_contract_version": PROVENANCE_CONTRACT_VERSION,
+        "metadata_contract_version": METADATA_CONTRACT_VERSION,
+        "entries": [],
+    }
+    provenance_merkle_payload = {
+        "provenance_merkle_contract_version": PROVENANCE_MERKLE_CONTRACT_VERSION,
+        "provenance_contract_version": PROVENANCE_CONTRACT_VERSION,
+        "leaf_count": 0,
+        "provenance_merkle_root": "a" * 64,
+    }
+
+    with pytest.raises(Phase4AlignmentError, match=r"capture metadata record\[0\] missing relative_path"):
+        verify_phase4_chain_payloads(
+            capture_payload,
+            metadata_manifest_payload,
+            provenance_manifest_payload,
+            provenance_merkle_payload,
+            metadata_schema={},
+            metadata_manifest_schema={},
+            provenance_manifest_schema={},
+            provenance_merkle_schema={},
+        )
+
+
+def test_phase4f_verify_reports_invalid_sha256_with_alignment_error() -> None:
+    pytest.importorskip("jsonschema")
+    capture_payload, metadata_manifest_payload, provenance_manifest_payload, provenance_merkle_payload = (
+        _build_two_record_chain_payloads()
+    )
+    capture_payload[0]["file_sha256"] = "not-a-sha256"
+
+    with pytest.raises(Phase4AlignmentError, match="capture file_sha256"):
+        verify_phase4_chain_payloads(
+            capture_payload,
+            metadata_manifest_payload,
+            provenance_manifest_payload,
+            provenance_merkle_payload,
+            metadata_schema={},
+            metadata_manifest_schema={},
+            provenance_manifest_schema={},
+            provenance_merkle_schema={},
+        )
+
+
 def test_phase4f_cli_returns_exit_code_32_for_schema_failure(tmp_path: Path) -> None:
     bad_capture = tmp_path / "capture_schema_invalid.json"
     capture_payload = _load_json(GOLDEN_CAPTURE)
@@ -272,6 +331,8 @@ def test_phase4f_cli_returns_exit_code_32_for_schema_failure(tmp_path: Path) -> 
     )
     assert result.returncode == 32
     assert "Schema validation failure:" in result.stderr
+    assert "capture record[0] schema validation failed at <root>" in result.stderr
+    assert "camera_model" in result.stderr
 
 
 def test_phase4f_cli_returns_exit_code_33_for_alignment_mismatch(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Phase 4D/4E/4F modules still duplicated schema, relative path, SHA-256, and payload validation logic after `validation_helpers.py` was extracted.
- Centralize those paths on the shared helper surface while preserving Phase 4 artifact wire formats and module-specific exception classes.

## Changes
- Migrated metadata manifest, provenance manifest, provenance merkle, and verifier validation to `validate_records_with_schema`, `validate_payload_with_schema`, relative path helpers, `build_path_index`, `ensure_sha256_hex`, `require_contract_version`, and `string_or_none`.
- Removed duplicate private validator wrappers, relative path helpers, SHA regex helpers, and string normalization from the operational Phase 4 modules.
- Added regression coverage for missing `relative_path`, invalid SHA-256 values, validator runtime wrapping, and schema-error path diagnostics.
- No CLI flag, schema, route, selector, or artifact envelope changes.

## Validation
Proven green:
- `.venv/bin/pytest tests/test_phase4_validation_helpers.py tests/test_build_metadata_manifest.py tests/test_build_provenance_manifest.py tests/test_build_provenance_merkle.py tests/test_verify_phase4_chain.py` - 95 passed
- `make test-fast` - 73 passed
- `git diff --check`
- Commit pre-commit hooks passed with `SKIP=gitleaks` and repo `.venv/bin` on `PATH`

Still failing:
- Initial unskipped commit hook failed in `gitleaks` on ignored generated artifacts under `output/` and `web/secure-landing/.next/`; it also exposed hook PATH issues for `python` before rerunning with the repo venv on PATH.

Failure classification:
- Environment/worktree artifact issue, not product logic and not staged-patch content.

## Risk
- Valid Phase 4 inputs and golden artifact outputs remain unchanged.
- Malformed inputs intentionally normalize stray `KeyError` or inconsistent diagnostics into stable Phase 4 exception types and label-prefixed messages.
- Revert-safe and bounded to Phase 4 validation helper usage plus focused regression coverage.