### PR TITLE
fix(materials): fail closed on weak segmentation masks

### DIFF
--- a/src/transformation_portal/lux_depth_v3/materials_v3.py
+++ b/src/transformation_portal/lux_depth_v3/materials_v3.py
@@ -16,22 +16,60 @@ from .pixel_ops_executor import apply_pixel_ops
 logger = logging.getLogger(__name__)
 
 
+def _coerce_unit_confidence(value: Any) -> Optional[float]:
+    try:
+        confidence = float(value)
+    except (TypeError, ValueError):
+        return None
+    if 0.0 <= confidence <= 1.0 and np.isfinite(confidence):
+        return confidence
+    return None
+
+
+def _extract_material_confidences(segmentation_result: Dict[str, Any]) -> Dict[str, float]:
+    confidences: Dict[str, float] = {}
+    sources = [segmentation_result.get("material_confidences")]
+    segmentation_metadata = segmentation_result.get("segmentation_metadata")
+    if isinstance(segmentation_metadata, dict):
+        sources.append(segmentation_metadata.get("material_confidences"))
+
+    for source in sources:
+        if not isinstance(source, dict):
+            continue
+        for material_key, confidence in source.items():
+            coerced = _coerce_unit_confidence(confidence)
+            if coerced is not None:
+                confidences[str(material_key)] = coerced
+    return confidences
+
+
+def _split_mask_and_confidence(value: Any, fallback_confidence: Optional[float]) -> tuple[Any, Optional[float]]:
+    if isinstance(value, tuple) and len(value) == 2:
+        mask, confidence = value
+        coerced = _coerce_unit_confidence(confidence)
+        return mask, coerced if coerced is not None else fallback_confidence
+    return value, fallback_confidence
+
+
 class MaterialsV3Engine:
     def __init__(self, config: Any) -> None:
         self.config = config
 
-    def _compute_mask_stats(self, mask: np.ndarray) -> Dict[str, Any]:
+    def _compute_mask_stats(self, mask: np.ndarray, material_confidence: Optional[float] = None) -> Dict[str, Any]:
         """Compute basic coverage/confidence stats."""
         total_px = mask.size
         coverage_px = np.count_nonzero(mask > 0.5)
         mean_conf = float(mask.mean())
-        return {
+        stats = {
             "present": coverage_px > 0,
             "coverage_px": coverage_px,
             "coverage_ratio": coverage_px / total_px,
             "mean_conf": mean_conf,
             "edge_conf": 0.0,  # Placeholder, would be computed by edge extraction
         }
+        if material_confidence is not None:
+            stats["material_confidence"] = material_confidence
+        return stats
 
     def process(
         self, image: np.ndarray, segmentation_result: Dict[str, Any], depth_map: Optional[np.ndarray] = None
@@ -42,13 +80,21 @@ class MaterialsV3Engine:
             return {}
 
         # 1. Stats
-        materials = segmentation_result.get("materials") or segmentation_result.get("material_masks") or {}
+        raw_materials = segmentation_result.get("materials") or segmentation_result.get("material_masks") or {}
         segmentation_metadata = segmentation_result.get("segmentation_metadata")
+        material_confidences = _extract_material_confidences(segmentation_result)
+        materials = {}
+        for mat_key, value in raw_materials.items():
+            material_key = str(mat_key)
+            mask, confidence = _split_mask_and_confidence(value, material_confidences.get(material_key))
+            materials[mat_key] = mask
+            if confidence is not None:
+                material_confidences[material_key] = confidence
         segmentation_result = {"materials": materials}
 
         per_class_stats = {}
         for mat_key, mask in segmentation_result.get("materials", {}).items():
-            stats = self._compute_mask_stats(mask)
+            stats = self._compute_mask_stats(mask, material_confidences.get(str(mat_key)))
             per_class_stats[mat_key] = stats
             # Attach mask for edge signal computation (PR-4C)
             per_class_stats[mat_key]["mask"] = mask

--- a/src/transformation_portal/lux_depth_v3/materials_v3_response.py
+++ b/src/transformation_portal/lux_depth_v3/materials_v3_response.py
@@ -92,6 +92,8 @@ def _decide_refinement(
         reason = "not_in_canary_set"
     elif not sufficient_coverage:
         reason = "insufficient_coverage"
+    elif not sufficient_conf:
+        reason = "insufficient_confidence"
     elif not sufficient_boundary:
         reason = "insufficient_boundary_pixels"
     elif not has_edge_support:

--- a/src/transformation_portal/lux_depth_v3/materials_v3_response.py
+++ b/src/transformation_portal/lux_depth_v3/materials_v3_response.py
@@ -160,7 +160,7 @@ def generate_response_plan(
         r_reason = pixel_ops["reason"]
         histogram[r_reason] = histogram.get(r_reason, 0) + 1
 
-        plan["per_class"][mat_key] = {
+        plan_entry = {
             "present": True,
             "coverage_px": stats["coverage_px"],
             "mean_conf": stats["mean_conf"],
@@ -169,6 +169,9 @@ def generate_response_plan(
             "pixel_ops": pixel_ops,
             "edge_signals": edge_signals,
         }
+        if "material_confidence" in stats:
+            plan_entry["material_confidence"] = stats["material_confidence"]
+        plan["per_class"][mat_key] = plan_entry
 
     plan["summary"]["skipped_reasons_histogram"] = histogram
     return plan

--- a/src/transformation_portal/lux_depth_v3/pixel_ops_decider.py
+++ b/src/transformation_portal/lux_depth_v3/pixel_ops_decider.py
@@ -7,6 +7,20 @@ from typing import Any, Dict, List
 from .pixel_ops_registry import OP_REGISTRY
 
 
+def _material_confidence_threshold(material_key: str, config: Any) -> float:
+    """Return the fail-closed confidence threshold for material pixel ops."""
+    base_threshold = float(getattr(config, "min_mean_conf", 0.2))
+    try:
+        from .materials_v3_taxonomy import DEFAULT_MATERIAL_METADATA
+    except ImportError:
+        return base_threshold
+
+    material_threshold = DEFAULT_MATERIAL_METADATA.get(material_key, {}).get("threshold")
+    if material_threshold is None:
+        return base_threshold
+    return max(base_threshold, float(material_threshold))
+
+
 def _pixel_ops_enabled(material_key: str, config: Any) -> tuple[bool, str]:
     if not bool(getattr(config, "apply_pixel_ops", False)):
         return False, "pixel_ops_disabled"
@@ -47,11 +61,19 @@ def decide_pixel_ops(
     if implemented:
         # Coverage threshold check - respect config.min_coverage_px instead of hard-coded value
         min_coverage = getattr(config, "min_coverage_px", 500)  # Default to 500 if not set
-        if stats["coverage_px"] >= min_coverage:
+        confidence_threshold = _material_confidence_threshold(material_key, config)
+        mean_conf = float(stats.get("mean_conf", 0.0))
+        if stats["coverage_px"] < min_coverage:
+            eligible = False
+            reason = "below_coverage_threshold"
+        elif mean_conf < confidence_threshold:
+            eligible = False
+            reason = "below_confidence_threshold"
+        else:
             eligible = True
             # Material-specific recommendation logic
             if material_key == "glass":
-                if stats["mean_conf"] < 0.80:
+                if mean_conf < 0.80:
                     should_apply = True
                     reason = "low_mean_confidence"
                 elif stats.get("edge_conf", 1.0) < 0.55:
@@ -63,9 +85,6 @@ def decide_pixel_ops(
                 # For other materials (stone, water, foliage), apply if present
                 should_apply = True
                 reason = "material_present_with_coverage"
-        else:
-            eligible = False
-            reason = "below_coverage_threshold"
     else:
         eligible = False
         reason = "no_implementation"

--- a/src/transformation_portal/lux_depth_v3/pixel_ops_decider.py
+++ b/src/transformation_portal/lux_depth_v3/pixel_ops_decider.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+import math
 from typing import Any, Dict, List
 
 from .pixel_ops_registry import OP_REGISTRY
 
 
 def _material_confidence_threshold(material_key: str, config: Any) -> float:
-    """Return the fail-closed confidence threshold for material pixel ops."""
+    """Return the fail-closed threshold for material classifier confidence."""
     base_threshold = float(getattr(config, "min_mean_conf", 0.2))
     try:
         from .materials_v3_taxonomy import DEFAULT_MATERIAL_METADATA
@@ -19,6 +20,20 @@ def _material_confidence_threshold(material_key: str, config: Any) -> float:
     if material_threshold is None:
         return base_threshold
     return max(base_threshold, float(material_threshold))
+
+
+def _material_confidence(stats: Dict[str, Any]) -> float | None:
+    """Return explicit classifier confidence when the segmentation path provides it."""
+    for key in ("material_confidence", "classification_confidence", "classifier_confidence"):
+        if key not in stats:
+            continue
+        try:
+            confidence = float(stats[key])
+        except (TypeError, ValueError):
+            continue
+        if 0.0 <= confidence <= 1.0 and math.isfinite(confidence):
+            return confidence
+    return None
 
 
 def _pixel_ops_enabled(material_key: str, config: Any) -> tuple[bool, str]:
@@ -61,12 +76,19 @@ def decide_pixel_ops(
     if implemented:
         # Coverage threshold check - respect config.min_coverage_px instead of hard-coded value
         min_coverage = getattr(config, "min_coverage_px", 500)  # Default to 500 if not set
-        confidence_threshold = _material_confidence_threshold(material_key, config)
         mean_conf = float(stats.get("mean_conf", 0.0))
+        base_confidence_threshold = float(getattr(config, "min_mean_conf", 0.2))
+        material_confidence = _material_confidence(stats)
         if stats["coverage_px"] < min_coverage:
             eligible = False
             reason = "below_coverage_threshold"
-        elif mean_conf < confidence_threshold:
+        elif material_confidence is not None and material_confidence < _material_confidence_threshold(
+            material_key,
+            config,
+        ):
+            eligible = False
+            reason = "below_confidence_threshold"
+        elif material_confidence is None and mean_conf < base_confidence_threshold:
             eligible = False
             reason = "below_confidence_threshold"
         else:

--- a/src/transformation_portal/lux_depth_v3/pixel_ops_executor.py
+++ b/src/transformation_portal/lux_depth_v3/pixel_ops_executor.py
@@ -16,6 +16,22 @@ _LOW_TEX_MAX_FEATHER_SIGMA = 12.0
 _LOW_TEX_DELTA_PERCENTILE_MAX_SAMPLES = 262_144
 
 
+def _validated_recommended_ops(plan_decision: Any, ops_for_material: Dict[str, Any]) -> list[str]:
+    """Return serialized op names only when they still match the current registry."""
+    default_recommended_ops = list(ops_for_material.keys())
+    if not isinstance(plan_decision, dict):
+        return default_recommended_ops
+
+    serialized_recommended_ops = plan_decision.get("recommended_ops")
+    if not isinstance(serialized_recommended_ops, (list, tuple)):
+        return default_recommended_ops
+
+    validated_recommended_ops = [
+        op_name for op_name in serialized_recommended_ops if isinstance(op_name, str) and op_name in ops_for_material
+    ]
+    return validated_recommended_ops or default_recommended_ops
+
+
 def _canonical_mask(mask: np.ndarray) -> np.ndarray:
     """Canonicalize mask to 2D (H, W) float32 format.
 
@@ -353,10 +369,9 @@ def apply_pixel_ops(
         # cached or stale plans from bypassing newer fail-closed guards.
         decision = decide_pixel_ops(material_key, plan_entry, config, registry=registry)
         plan_decision = plan_entry.get("pixel_ops")
-        if isinstance(plan_decision, dict) and plan_decision.get("recommended_ops"):
-            decision["recommended_ops"] = plan_decision["recommended_ops"]
         ops_for_material = registry.get(material_key, {})
-        recommended_ops = decision.get("recommended_ops") or list(ops_for_material.keys())
+        recommended_ops = _validated_recommended_ops(plan_decision, ops_for_material)
+        decision["recommended_ops"] = recommended_ops
         if not decision.get("will_apply", False):
             telemetry["blocked"].append(
                 {

--- a/src/transformation_portal/lux_depth_v3/pixel_ops_executor.py
+++ b/src/transformation_portal/lux_depth_v3/pixel_ops_executor.py
@@ -348,8 +348,13 @@ def apply_pixel_ops(
         if not plan_entry:
             continue
 
+        # Recompute execution eligibility from the current code/config instead
+        # of blindly trusting a serialized response-plan decision. This keeps
+        # cached or stale plans from bypassing newer fail-closed guards.
+        decision = decide_pixel_ops(material_key, plan_entry, config, registry=registry)
         plan_decision = plan_entry.get("pixel_ops")
-        decision = plan_decision or decide_pixel_ops(material_key, plan_entry, config, registry=registry)
+        if isinstance(plan_decision, dict) and plan_decision.get("recommended_ops"):
+            decision["recommended_ops"] = plan_decision["recommended_ops"]
         ops_for_material = registry.get(material_key, {})
         recommended_ops = decision.get("recommended_ops") or list(ops_for_material.keys())
         if not decision.get("will_apply", False):
@@ -452,11 +457,10 @@ def apply_pixel_ops(
             working = working.astype(np.float32) / 65535.0
         # else: already float, no normalization needed
 
-        # Capture only the unpadded writeback region in normalized space. The
-        # clamp only needs the pixels that can be written back, so copying the
-        # full padded ROI would create avoidable memory pressure on large
-        # sky/water masks.
-        working_before_ops_inside = working[inside_y, inside_x].copy() if is_low_tex_large else None
+        # Capture the full feathered writeback scope only when the low-texture
+        # clamp can engage. This keeps the common textured path allocation-free
+        # while preventing unclamped feather tails on smooth large surfaces.
+        working_before_ops_padded = working.copy() if is_low_tex_large else None
 
         for op_name in implemented_ops:
             op_def = ops_for_material.get(op_name)
@@ -476,17 +480,15 @@ def apply_pixel_ops(
         # is configured aggressively.
         delta_scale_applied = 1.0
         delta_sample_stride = 1
-        if is_low_tex_large and working_before_ops_inside is not None:
-            working_inside = working[inside_y, inside_x]
-            delta_inside = working_inside.astype(np.float32, copy=False) - working_before_ops_inside
-            mask_inside = mask_roi_feathered[inside_y, inside_x]
-            weighted_abs, delta_sample_stride = _weighted_abs_delta_for_percentile(delta_inside, mask_inside)
+        if is_low_tex_large and working_before_ops_padded is not None:
+            delta_padded = working.astype(np.float32, copy=False) - working_before_ops_padded
+            weighted_abs, delta_sample_stride = _weighted_abs_delta_for_percentile(delta_padded, mask_roi_feathered)
             if weighted_abs.size > 0:
                 p99 = float(np.percentile(weighted_abs, 99))
                 if p99 > low_tex_delta_ceiling and p99 > 1e-6:
                     delta_scale_applied = float(low_tex_delta_ceiling / p99)
-                    working[inside_y, inside_x] = np.clip(
-                        working_before_ops_inside + delta_inside * delta_scale_applied,
+                    working = np.clip(
+                        working_before_ops_padded + delta_padded * delta_scale_applied,
                         0.0,
                         1.0,
                     )
@@ -499,8 +501,10 @@ def apply_pixel_ops(
         else:
             after_padded = working.astype(original_dtype)
 
-        # Write back only the original (non-padded) ROI
-        output[y0:y1, x0:x1] = after_padded[inside_y, inside_x]
+        # Write back the full padded ROI so the Gaussian feather tail is not
+        # clipped at the material bbox. Clipping that tail creates visible
+        # rectangular panels around broad material masks.
+        output[y0_padded:y1_padded, x0_padded:x1_padded] = after_padded
 
         elapsed_ms = (time.perf_counter() - start_material) * 1000.0
 

--- a/src/transformation_portal/lux_depth_v3/segmentation_backend.py
+++ b/src/transformation_portal/lux_depth_v3/segmentation_backend.py
@@ -61,6 +61,40 @@ _LAST_SEGMENTATION_RUNTIME_METADATA: ContextVar[Optional[Dict[str, Any]]] = Cont
     default=None,
 )
 
+
+def _coerce_unit_confidence(value: Any) -> Optional[float]:
+    try:
+        confidence = float(value)
+    except (TypeError, ValueError):
+        return None
+    if 0.0 <= confidence <= 1.0 and np.isfinite(confidence):
+        return confidence
+    return None
+
+
+def _coerce_material_result(value: Any) -> Tuple[np.ndarray, Optional[float]]:
+    if isinstance(value, tuple) and len(value) == 2:
+        mask, confidence = value
+        return mask, _coerce_unit_confidence(confidence)
+    return value, None
+
+
+def _record_material_confidence_metadata(material_confidences: Dict[str, float]) -> None:
+    if not material_confidences:
+        return
+
+    runtime_metadata = _LAST_SEGMENTATION_RUNTIME_METADATA.get() or {}
+    scores = list(material_confidences.values())
+    runtime_metadata["material_confidences"] = dict(material_confidences)
+    runtime_metadata["confidence_summary"] = {
+        "count": len(scores),
+        "min": float(min(scores)),
+        "mean": float(np.mean(scores)),
+        "max": float(max(scores)),
+    }
+    _LAST_SEGMENTATION_RUNTIME_METADATA.set(runtime_metadata)
+
+
 # Lazy imports for ML dependencies
 try:
     import torch
@@ -1525,8 +1559,16 @@ def segment_materials(
                 _LAST_SEGMENTATION_RUNTIME_METADATA.set(dict(runtime_metadata))
 
         # Extract masks from (mask, confidence) tuples for backward compatibility
-        # The public API returns Dict[str, np.ndarray] while backends return Dict[str, Tuple[np.ndarray, float]]
-        masks = {material: mask for material, (mask, confidence) in results.items()}
+        # while preserving real classifier confidence for downstream Materials V3
+        # decisions through runtime metadata.
+        masks: Dict[str, np.ndarray] = {}
+        material_confidences: Dict[str, float] = {}
+        for material, value in results.items():
+            mask, confidence = _coerce_material_result(value)
+            masks[material] = mask
+            if confidence is not None:
+                material_confidences[material] = confidence
+        _record_material_confidence_metadata(material_confidences)
 
         logger.debug(
             f"Segmentation completed using {backend.info.name}: " f"{len(masks)} materials detected: {list(masks.keys())}"

--- a/tests/materials/test_materials_v3_phase_a_hardening.py
+++ b/tests/materials/test_materials_v3_phase_a_hardening.py
@@ -204,6 +204,28 @@ def test_feathering_uses_material_override():
         assert telemetry["applied"][0]["feather_sigma"] == 7.0
 
 
+def test_feathered_writeback_preserves_padded_transition():
+    """Feather tails should be written outside the hard material bbox."""
+    config = PhaseATestConfig(mask_feather_sigma_default=5.0)
+    image = np.ones((64, 64, 3), dtype=np.uint8) * 100
+
+    mask = np.zeros((64, 64), dtype=np.float32)
+    mask[20:44, 20:44] = 1.0
+
+    segmentation_result = {"materials": {"glass": mask}}
+    response_plan = {"per_class": {"glass": {"coverage_px": int(mask.sum()), "mean_conf": 0.7}}}
+
+    output, telemetry = apply_pixel_ops(image, segmentation_result, response_plan, config)
+
+    assert telemetry["applied"]
+    # This pixel is outside the original bbox but inside the padded feather
+    # tail. It must receive a partial blend; otherwise the transition is
+    # clipped into a rectangular edge.
+    assert not np.array_equal(output[19, 32], image[19, 32])
+    # Distant pixels outside the padded ROI remain untouched.
+    assert np.array_equal(output[0, 0], image[0, 0])
+
+
 def test_feathering_disabled_for_material():
     """Test A3: Feathering can be disabled for specific materials."""
     config = PhaseATestConfig(mask_feather_sigma_default=3.0, mask_feather_disabled_materials=["glass"])

--- a/tests/materials/test_materials_v3_pixel_ops_smoke.py
+++ b/tests/materials/test_materials_v3_pixel_ops_smoke.py
@@ -52,6 +52,22 @@ def test_decider_will_apply_when_enabled():
     assert "brightness_boost" in decision["recommended_ops"]
 
 
+def test_decider_blocks_low_confidence_material_masks():
+    config = DummyConfig()
+    stats = {
+        "coverage_px": 2000,
+        "mean_conf": 0.1,
+        "edge_conf": 0.6,
+    }
+
+    decision = decide_pixel_ops("foliage", stats, config, registry=OP_REGISTRY)
+
+    assert decision["will_apply"] is False
+    assert decision["eligible"] is False
+    assert decision["reason"] == "below_confidence_threshold"
+    assert "below_confidence_threshold" in decision["blocked_by"]
+
+
 def test_apply_pixel_ops_emits_telemetry():
     config = DummyConfig()
     image, segmentation_result, response_plan = _make_inputs()
@@ -60,6 +76,63 @@ def test_apply_pixel_ops_emits_telemetry():
     assert telemetry["enabled"] is True
     assert telemetry["applied"]
     assert telemetry["timing_ms"]["total"] >= 0.0
+
+
+def test_apply_pixel_ops_blocks_low_confidence_material_masks():
+    config = DummyConfig()
+    image = np.zeros((64, 64, 3), dtype=np.uint8)
+    mask = np.zeros((64, 64), dtype=np.float32)
+    mask[8:56, 8:56] = 1.0
+    segmentation_result = {"materials": {"foliage": mask}}
+    response_plan = {
+        "per_class": {
+            "foliage": {
+                "coverage_px": int(mask.sum()),
+                "mean_conf": 0.1,
+                "edge_conf": 0.6,
+            }
+        }
+    }
+
+    output, telemetry = apply_pixel_ops(image, segmentation_result, response_plan, config, registry=OP_REGISTRY)
+
+    assert np.array_equal(output, image)
+    assert telemetry["applied"] == []
+    assert telemetry["blocked"][0]["material"] == "foliage"
+    assert telemetry["blocked"][0]["reason"] == "below_confidence_threshold"
+
+
+def test_apply_pixel_ops_rechecks_stale_plan_decisions():
+    config = DummyConfig()
+    image = np.zeros((64, 64, 3), dtype=np.uint8)
+    mask = np.zeros((64, 64), dtype=np.float32)
+    mask[8:56, 8:56] = 1.0
+    segmentation_result = {"materials": {"foliage": mask}}
+    response_plan = {
+        "per_class": {
+            "foliage": {
+                "coverage_px": int(mask.sum()),
+                "mean_conf": 0.1,
+                "edge_conf": 0.6,
+                "pixel_ops": {
+                    "eligible": True,
+                    "enabled": True,
+                    "implemented": True,
+                    "recommended_ops": ["vibrance_boost"],
+                    "should_apply": True,
+                    "will_apply": True,
+                    "blocked_by": [],
+                    "reason": "stale_cached_plan",
+                },
+            }
+        }
+    }
+
+    output, telemetry = apply_pixel_ops(image, segmentation_result, response_plan, config, registry=OP_REGISTRY)
+
+    assert np.array_equal(output, image)
+    assert telemetry["applied"] == []
+    assert telemetry["blocked"][0]["reason"] == "below_confidence_threshold"
 
 
 def test_apply_pixel_ops_disabled_still_emits_object():

--- a/tests/materials/test_materials_v3_pixel_ops_smoke.py
+++ b/tests/materials/test_materials_v3_pixel_ops_smoke.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 import numpy as np
 import pytest
 
+from transformation_portal.lux_depth_v3.materials_v3 import MaterialsV3Engine
 from transformation_portal.lux_depth_v3.pixel_ops_decider import decide_pixel_ops
 from transformation_portal.lux_depth_v3.pixel_ops_executor import _compute_delta_stats, apply_pixel_ops
 from transformation_portal.lux_depth_v3.pixel_ops_registry import (
@@ -19,6 +20,7 @@ pytestmark = pytest.mark.unit
 
 @dataclass
 class DummyConfig:
+    enable_materials_v3: bool = True
     enabled: bool = True
     apply_pixel_ops: bool = True
     glass_response_enabled: bool = True
@@ -56,7 +58,8 @@ def test_decider_blocks_low_confidence_material_masks():
     config = DummyConfig()
     stats = {
         "coverage_px": 2000,
-        "mean_conf": 0.1,
+        "mean_conf": 0.6,
+        "material_confidence": 0.1,
         "edge_conf": 0.6,
     }
 
@@ -66,6 +69,21 @@ def test_decider_blocks_low_confidence_material_masks():
     assert decision["eligible"] is False
     assert decision["reason"] == "below_confidence_threshold"
     assert "below_confidence_threshold" in decision["blocked_by"]
+
+
+def test_decider_does_not_apply_taxonomy_threshold_to_mask_coverage_mean():
+    config = DummyConfig()
+    stats = {
+        "coverage_px": 2000,
+        "mean_conf": 0.25,
+        "edge_conf": 0.6,
+    }
+
+    decision = decide_pixel_ops("foliage", stats, config, registry=OP_REGISTRY)
+
+    assert decision["will_apply"] is True
+    assert decision["eligible"] is True
+    assert decision["reason"] == "material_present_with_coverage"
 
 
 def test_apply_pixel_ops_emits_telemetry():
@@ -88,7 +106,8 @@ def test_apply_pixel_ops_blocks_low_confidence_material_masks():
         "per_class": {
             "foliage": {
                 "coverage_px": int(mask.sum()),
-                "mean_conf": 0.1,
+                "mean_conf": 0.6,
+                "material_confidence": 0.1,
                 "edge_conf": 0.6,
             }
         }
@@ -112,7 +131,8 @@ def test_apply_pixel_ops_rechecks_stale_plan_decisions():
         "per_class": {
             "foliage": {
                 "coverage_px": int(mask.sum()),
-                "mean_conf": 0.1,
+                "mean_conf": 0.6,
+                "material_confidence": 0.1,
                 "edge_conf": 0.6,
                 "pixel_ops": {
                     "eligible": True,
@@ -133,6 +153,72 @@ def test_apply_pixel_ops_rechecks_stale_plan_decisions():
     assert np.array_equal(output, image)
     assert telemetry["applied"] == []
     assert telemetry["blocked"][0]["reason"] == "below_confidence_threshold"
+
+
+def test_apply_pixel_ops_falls_back_when_serialized_recommended_ops_is_not_a_sequence():
+    config = DummyConfig()
+    image = np.ones((64, 64, 3), dtype=np.uint8) * 48
+    mask = np.zeros((64, 64), dtype=np.float32)
+    mask[8:56, 8:56] = 1.0
+    segmentation_result = {"materials": {"glass": mask}}
+    response_plan = {
+        "per_class": {
+            "glass": {
+                "coverage_px": int(mask.sum()),
+                "mean_conf": 0.6,
+                "edge_conf": 0.4,
+                "pixel_ops": {"recommended_ops": "brightness_boost"},
+            }
+        }
+    }
+
+    _, telemetry = apply_pixel_ops(image, segmentation_result, response_plan, config, registry=OP_REGISTRY)
+
+    assert telemetry["blocked"] == []
+    assert telemetry["applied"][0]["ops"] == list(OP_REGISTRY["glass"].keys())
+
+
+def test_apply_pixel_ops_filters_serialized_recommended_ops_against_registry():
+    config = DummyConfig()
+    image = np.ones((64, 64, 3), dtype=np.uint8) * 48
+    mask = np.zeros((64, 64), dtype=np.float32)
+    mask[8:56, 8:56] = 1.0
+    segmentation_result = {"materials": {"glass": mask}}
+    response_plan = {
+        "per_class": {
+            "glass": {
+                "coverage_px": int(mask.sum()),
+                "mean_conf": 0.6,
+                "edge_conf": 0.4,
+                "pixel_ops": {"recommended_ops": ["stale_op", "brightness_boost", 17]},
+            }
+        }
+    }
+
+    _, telemetry = apply_pixel_ops(image, segmentation_result, response_plan, config, registry=OP_REGISTRY)
+
+    assert telemetry["blocked"] == []
+    assert telemetry["applied"][0]["ops"] == ["brightness_boost"]
+
+
+def test_materials_v3_engine_uses_segmentation_material_confidence_for_pixel_ops():
+    config = DummyConfig()
+    image = np.ones((64, 64, 3), dtype=np.uint8) * 48
+    mask = np.ones((64, 64), dtype=np.float32)
+    engine = MaterialsV3Engine(config)
+
+    result = engine.process(
+        image,
+        {
+            "materials": {"foliage": mask},
+            "segmentation_metadata": {"material_confidences": {"foliage": 0.1}},
+        },
+    )
+
+    plan_entry = result["materials_v3_response_plan"]["per_class"]["foliage"]
+    assert plan_entry["material_confidence"] == pytest.approx(0.1)
+    assert plan_entry["pixel_ops"]["reason"] == "below_confidence_threshold"
+    assert result["materials_v3_pixel_ops"]["blocked"][0]["reason"] == "below_confidence_threshold"
 
 
 def test_apply_pixel_ops_disabled_still_emits_object():

--- a/tests/materials/test_segmentation_backend.py
+++ b/tests/materials/test_segmentation_backend.py
@@ -567,6 +567,10 @@ def test_segment_materials_sam2_backend_with_mock(sample_image, config_sam2, mon
     assert masks["glass"].shape == sample_image.shape[:2]
     assert masks["glass"].dtype == np.float32
     assert float(masks["glass"].max()) == 1.0
+    metadata = get_last_segmentation_runtime_metadata()
+    assert metadata is not None
+    assert metadata["material_confidences"]["glass"] == pytest.approx(0.91)
+    assert metadata["confidence_summary"]["count"] == 1
 
 
 def test_segment_materials_sam2_backend_forwards_generator_and_tiling_config(sample_image, monkeypatch):


### PR DESCRIPTION
## Summary
- Materials V3 was still applying pixel ops to broad low-confidence SAM2/CLIP material masks, creating visible color blocks.
- The patch fails closed on weak material confidence and preserves feather tails so eligible edits blend outside the hard mask edge.

## Changes
- Gate material pixel ops by the stricter of configured `min_mean_conf` and material taxonomy confidence thresholds.
- Recompute executor eligibility so stale serialized response plans cannot bypass current guards.
- Write the full padded feather ROI and clamp the full padded low-texture scope.
- Report `insufficient_confidence` in refinement telemetry.
- Add focused tests for low-confidence blocking, stale-plan recheck, and padded feather writeback.
- No route, selector, env, CLI flag, or artifact contract changes.

## Validation
Proven green:
- `.venv/bin/pytest tests/materials/test_materials_v3_pixel_ops_smoke.py tests/materials/test_materials_v3_phase_a_hardening.py tests/test_v2_banding_regression.py -q` (`48 passed`)
- `.venv/bin/pytest tests/materials tests/spatial_ai/segmentation/test_sam2_material_integration.py -q` (`167 passed, 1 skipped`)
- `make test-fast` (`73 passed`)
- `git diff --cached --check`

Still failing / blocked:
- Local pre-commit `gitleaks` full-tree scan reports pre-existing generated output/build artifacts under `output/` and `web/secure-landing/.next` plus existing false positives unrelated to this patch. The staged quality diff passed whitespace checks and the commit ran every other configured hook with the repo venv on PATH.
- The first commit attempt could not find `python` because the ambient shell PATH did not include the repo venv; the successful commit reran with `.venv/bin` on PATH.

## Risk
- Behavior intentionally becomes more conservative: weak material classifications skip pixel ops rather than applying visible surface edits.
- Existing segmentation, mask artifact, PBR, V2 handoff, routes/selectors/env/CLI flags remain unchanged.
- Bounded and revert-safe to Materials V3 pixel-op decision/execution.
