### PR TITLE
perf(materials): reduce segmentation latency

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -5,6 +5,10 @@ useDefault = true
 
 # Keep this compatible with the manual firewall scan, which currently runs
 # gitleaks v8.21.x and does not support global allowlist targetRules.
+[allowlist]
+description = "Ignore generated local artifact directories already excluded from version control"
+paths = ['''(^|/)(output|output_[^/]*|test_output|test_artifacts|processed_images|processed_output|extracted_context|docs/api/_build|__pycache__|\.pytest_cache|\.mypy_cache|\.ruff_cache|\.pyre|web/secure-landing/(?:\.next|\.next-build-verify|\.next-smoke-[^/]*|\.next-codex-[^/]*))(/|$)''']
+
 [[rules]]
 id = "generic-api-key"
 
@@ -14,3 +18,14 @@ condition = "AND"
 regexTarget = "line"
 regexes = ['''return normalizedReason==="auth_failure"\|\|normalizedReason==="auth"\|\|normalizedStatus===401\|\|normalizedStatus===403\?\{reason:"auth_failure"''']
 paths = ['''(^|/)public/portal-assets/portal\.js$''']
+
+[[rules.allowlists]]
+description = "Ignore the SAM2 tiling UI flag false positive"
+condition = "AND"
+regexTarget = "line"
+regexes = ['''sam2TilingEnabled''']
+paths = [
+  '''(^|/)public/portal-assets/portal\.js$''',
+  '''(^|/)tests/test_app_orchestrator_runtime\.py$''',
+  '''(^|/)web/secure-landing/portal-src/portal\.template\.js$''',
+]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
     hooks:
       - id: auto-format-staged
         name: Auto-format staged Python files
-        entry: python scripts/dev/auto_format_changed.py
+        entry: scripts/setup/run_repo_python.sh scripts/dev/auto_format_changed.py
         language: system
         pass_filenames: false
         stages: [pre-commit]
@@ -85,7 +85,7 @@ repos:
 
       - id: check-test-markers
         name: Check Test Markers (ADR-044)
-        entry: python scripts/validation/check_test_markers.py
+        entry: scripts/setup/run_repo_python.sh scripts/validation/check_test_markers.py
         language: system
         files: ^tests/.*\.py$
         types: [python]

--- a/app.py
+++ b/app.py
@@ -1234,6 +1234,7 @@ ALLOWED_BACKENDS = {"da3", "depth_pro"}
 ALLOWED_DEPTH_DEVICES = {"cpu", "cuda", "mps"}
 ALLOWED_RUN_CARD_VERSIONS = {"v1", "v2"}
 ALLOWED_SEGMENTATION_BACKENDS = {"stub", "efficientsam", "sam2"}
+ALLOWED_SEGMENTATION_CACHE_POLICIES = {"off", "read_write"}
 ALLOWED_SAM2_MODEL_SIZES = {"base", "large"}
 ALLOWED_GROUPING_MODES = {"single", "parent_dir"}
 ALLOWED_RECONSTRUCTION_TIERS = {
@@ -1374,6 +1375,7 @@ PORTAL_ALLOWED_EVENT_FIELDS = {
     "run_card_include_proofs",
     "run_card_version",
     "segmentation_backend",
+    "segmentation_cache",
     "strict_segmentation",
 }
 PORTAL_ALLOWED_RUM_EVENT_TYPES = {
@@ -1430,6 +1432,7 @@ LUX_PORTAL_DEFAULT_ARGS: Dict[str, Any] = {
     "depth_device": "cpu",
     "enable_segmentation": False,
     "segmentation_backend": "stub",
+    "segmentation_cache": "read_write",
     "sam2_model_size": "base",
     "sam2_tiling_enabled": False,
     "sam2_tile_size_px": 1536,
@@ -3706,6 +3709,31 @@ def _build_lux_config_preview(
         )
         segmentation_backend = str(defaults["segmentation_backend"])
     normalized_args["segmentation_backend"] = segmentation_backend
+
+    segmentation_cache = (
+        str(
+            _pick(
+                args,
+                "segmentation_cache",
+                "segmentationCache",
+                default=defaults["segmentation_cache"],
+            )
+            or defaults["segmentation_cache"]
+        )
+        .strip()
+        .lower()
+    )
+    if segmentation_cache not in ALLOWED_SEGMENTATION_CACHE_POLICIES:
+        errors.append(
+            _portal_issue(
+                "segmentation_cache",
+                "invalid_segmentation_cache",
+                "Segmentation cache policy is not supported.",
+                suggestion="Choose off or read_write.",
+            )
+        )
+        segmentation_cache = str(defaults["segmentation_cache"])
+    normalized_args["segmentation_cache"] = segmentation_cache
 
     sam2_model_size = (
         str(
@@ -6488,6 +6516,19 @@ def _argv_from_request(
             "strictSegmentation",
             default=False,
         )
+        segmentation_cache = (
+            str(
+                _pick(
+                    args,
+                    "segmentation_cache",
+                    "segmentationCache",
+                    default="read_write",
+                )
+                or "read_write"
+            )
+            .strip()
+            .lower()
+        )
         enable_reconstruction = _pick(
             args,
             "enable_reconstruction",
@@ -6546,6 +6587,8 @@ def _argv_from_request(
             )
         if segmentation_backend == "sam2" and sam2_model_size not in ALLOWED_SAM2_MODEL_SIZES:
             raise _PortalValidationReasonError("Invalid sam2_model_size", reason="invalid_sam2_model_size")
+        if segmentation_cache not in ALLOWED_SEGMENTATION_CACHE_POLICIES:
+            raise _PortalValidationReasonError("Invalid segmentation_cache", reason="invalid_segmentation_cache")
         if grouping_mode not in ALLOWED_GROUPING_MODES:
             raise _PortalValidationReasonError("Invalid grouping_mode")
 
@@ -6689,6 +6732,8 @@ def _argv_from_request(
                 onoff(enable_segmentation),
                 "--segmentation-backend",
                 segmentation_backend,
+                "--segmentation-cache",
+                segmentation_cache,
                 "--materials-v3",
                 onoff(
                     _pick(

--- a/scripts/setup/run_repo_python.sh
+++ b/scripts/setup/run_repo_python.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# Run a repository Python script through the same interpreter resolver used by
+# Makefile targets. This keeps pre-commit system hooks independent of a bare
+# `python` binary on PATH while still failing closed on unsupported runtimes.
+
+set -euo pipefail
+
+if (($# < 1)); then
+    echo "Usage: $0 <script.py> [args...]" >&2
+    exit 64
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+PYTHON_BIN="$("${SCRIPT_DIR}/resolve_python_311.sh")"
+
+cd "${REPO_ROOT}"
+exec "${PYTHON_BIN}" "$@"

--- a/scripts/validation/check_gitleaks_workflow_contract.py
+++ b/scripts/validation/check_gitleaks_workflow_contract.py
@@ -14,8 +14,19 @@ FIREWALL_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "ci-quality-firew
 
 EXPECTED_RULE_ID = "generic-api-key"
 EXPECTED_PATH_REGEX = r"(^|/)public/portal-assets/portal\.js$"
+EXPECTED_ARTIFACT_PATH_REGEX = (
+    r"(^|/)(output|output_[^/]*|test_output|test_artifacts|processed_images|processed_output|"
+    r"extracted_context|docs/api/_build|__pycache__|\.pytest_cache|\.mypy_cache|\.ruff_cache|\.pyre|"
+    r"web/secure-landing/(?:\.next|\.next-build-verify|\.next-smoke-[^/]*|\.next-codex-[^/]*))(/|$)"
+)
 EXPECTED_REGEX_TARGET = "line"
 EXPECTED_MATCH_REGEX = r'return normalizedReason==="auth_failure"\|\|normalizedReason==="auth"\|\|normalizedStatus===401\|\|normalizedStatus===403\?\{reason:"auth_failure"'
+EXPECTED_SAM2_TILING_MATCH_REGEX = r"sam2TilingEnabled"
+EXPECTED_SAM2_TILING_PATH_REGEXES = [
+    r"(^|/)public/portal-assets/portal\.js$",
+    r"(^|/)tests/test_app_orchestrator_runtime\.py$",
+    r"(^|/)web/secure-landing/portal-src/portal\.template\.js$",
+]
 EXPECTED_CI_SNIPPET = "GITLEAKS_CONFIG: .gitleaks.toml"
 EXPECTED_FIREWALL_SNIPPET = "detect --config .gitleaks.toml --source . --verbose --no-git --exit-code 1"
 
@@ -55,14 +66,27 @@ def _validate_config(config: dict[str, object]) -> list[str]:
     if EXPECTED_RULE_ID in disabled_rules:
         errors.append("gitleaks config must not disable the generic-api-key rule")
 
-    global_allowlists = config.get("allowlists", [])
-    if isinstance(global_allowlists, list):
-        for allowlist in global_allowlists:
+    legacy_global_allowlists = config.get("allowlists", [])
+    if isinstance(legacy_global_allowlists, list):
+        for allowlist in legacy_global_allowlists:
             if not isinstance(allowlist, dict):
                 continue
             for path_regex in allowlist.get("paths", []):
                 if "public/portal-assets" in str(path_regex):
                     errors.append("gitleaks config must not define a global allowlist for portal assets")
+        if legacy_global_allowlists:
+            errors.append("gitleaks global allowlist must use singular [allowlist] syntax for v8.21.x")
+
+    global_allowlist = config.get("allowlist")
+    if not isinstance(global_allowlist, dict):
+        errors.append("gitleaks config must define exactly one ignored generated artifact directory allowlist")
+    else:
+        path_patterns = [str(path_regex) for path_regex in global_allowlist.get("paths", [])]
+        for path_regex in path_patterns:
+            if "public/portal-assets" in str(path_regex):
+                errors.append("gitleaks config must not define a global allowlist for portal assets")
+        if path_patterns != [EXPECTED_ARTIFACT_PATH_REGEX]:
+            errors.append("gitleaks global allowlist must be scoped only to ignored generated artifact directories")
 
     matching_rules = [
         rule for rule in config.get("rules", []) if isinstance(rule, dict) and rule.get("id") == EXPECTED_RULE_ID
@@ -71,26 +95,34 @@ def _validate_config(config: dict[str, object]) -> list[str]:
         return errors + ["gitleaks config must define exactly one generic-api-key rule extension"]
 
     allowlists = matching_rules[0].get("allowlists", [])
-    if not isinstance(allowlists, list) or len(allowlists) != 1:
-        return errors + ["generic-api-key rule extension must define exactly one allowlist"]
+    if not isinstance(allowlists, list) or len(allowlists) != 2:
+        return errors + ["generic-api-key rule extension must define exactly two narrow allowlists"]
 
-    allowlist = allowlists[0]
-    if not isinstance(allowlist, dict):
-        return errors + ["generic-api-key allowlist must be a TOML table"]
+    auth_allowlist_found = False
+    sam2_allowlist_found = False
+    for allowlist in allowlists:
+        if not isinstance(allowlist, dict):
+            return errors + ["generic-api-key allowlists must be TOML tables"]
 
-    if allowlist.get("condition") != "AND":
-        errors.append("generic-api-key allowlist must require AND semantics")
+        if allowlist.get("condition") != "AND":
+            errors.append("generic-api-key allowlists must require AND semantics")
 
-    if allowlist.get("regexTarget") != EXPECTED_REGEX_TARGET:
-        errors.append("generic-api-key allowlist must target the portal source line")
+        if allowlist.get("regexTarget") != EXPECTED_REGEX_TARGET:
+            errors.append("generic-api-key allowlists must target source lines")
 
-    path_patterns = allowlist.get("paths", [])
-    if path_patterns != [EXPECTED_PATH_REGEX]:
-        errors.append("generic-api-key allowlist must be scoped only to public/portal-assets/portal.js")
+        path_patterns = allowlist.get("paths", [])
+        match_patterns = allowlist.get("regexes", [])
+        if path_patterns == [EXPECTED_PATH_REGEX] and match_patterns == [EXPECTED_MATCH_REGEX]:
+            auth_allowlist_found = True
+        elif path_patterns == EXPECTED_SAM2_TILING_PATH_REGEXES and match_patterns == [EXPECTED_SAM2_TILING_MATCH_REGEX]:
+            sam2_allowlist_found = True
+        else:
+            errors.append("generic-api-key allowlists must be scoped only to approved false-positive patterns")
 
-    match_patterns = allowlist.get("regexes", [])
-    if match_patterns != [EXPECTED_MATCH_REGEX]:
+    if not auth_allowlist_found:
         errors.append("generic-api-key allowlist must match only the generated auth failure false-positive branch")
+    if not sam2_allowlist_found:
+        errors.append("generic-api-key allowlist must match only the SAM2 tiling flag false positive")
 
     return errors
 

--- a/src/transformation_portal/lux_depth_v3/__main__.py
+++ b/src/transformation_portal/lux_depth_v3/__main__.py
@@ -463,6 +463,11 @@ def main(
         "--strict-segmentation",
         help=("Fail on segmentation backend errors instead of " + "falling back to stub"),
     ),
+    segmentation_cache: str = typer.Option(
+        "read_write",
+        "--segmentation-cache",
+        help="Segmentation cache policy: off or read_write.",
+    ),
     # Caching
     cache_depth: str = typer.Option(
         "off",
@@ -815,6 +820,13 @@ def main(
         print(error_msg, file=sys.stdout)
         raise typer.Exit(code=1)
 
+    normalized_segmentation_cache = str(segmentation_cache or "read_write").strip().lower()
+    if normalized_segmentation_cache not in {"off", "read_write"}:
+        error_msg = "Invalid --segmentation-cache. Must be one of: off, read_write"
+        logger.error(error_msg)
+        print(error_msg, file=sys.stdout)
+        raise typer.Exit(code=1)
+
     # APEX strict gate: do not allow Materials V3 no-op configurations
     if quality_tier.lower() == "apex" and enable_materials_v3:
         if not enable_material_segmentation:
@@ -959,6 +971,7 @@ def main(
         sam2_stability_score_thresh=sam2_stability_score_thresh,
         sam2_crop_n_layers=sam2_crop_n_layers,
         strict_backend=strict_segmentation,
+        material_segmentation_cache_policy=normalized_segmentation_cache,
         emit_master16=enable_emit_master16,
         emit_upscaled16=enable_emit_upscaled16,
         emit_marketing=enable_emit_marketing,

--- a/src/transformation_portal/lux_depth_v3/config.py
+++ b/src/transformation_portal/lux_depth_v3/config.py
@@ -403,6 +403,10 @@ class EnhanceConfig:
     # If True, raise on backend errors
     # instead of falling back to stub
     strict_backend: bool = False
+    # Exact-result segmentation cache policy for real segmentation runs.
+    # "off" disables cache lookup/write; "read_write" reuses validated masks
+    # and records cache provenance in Materials V3 metadata.
+    material_segmentation_cache_policy: str = "read_write"
     # SAM2 variant when backend="sam2":
     # base or large
     sam2_model_size: str = "base"

--- a/src/transformation_portal/lux_depth_v3/execution_engine.py
+++ b/src/transformation_portal/lux_depth_v3/execution_engine.py
@@ -171,6 +171,7 @@ class PBRStageResult:
     roughness_path: Optional[str] = None
     ao_path: Optional[str] = None
     runtime_s: float = 0.0
+    timing_ms: Optional[Dict[str, float]] = None
     config: Optional[Dict[str, Any]] = None
     error: Optional[str] = None
 
@@ -188,6 +189,7 @@ class PBRStageResult:
             "roughness_path": self.roughness_path,
             "ao_path": self.ao_path,
             "runtime_seconds": self.runtime_s,
+            "timing_ms": dict(self.timing_ms or {}),
             "config": self.config or {},
         }
 
@@ -293,14 +295,18 @@ def generate_pbr_stage(
     try:
         logger.info("Generating PBR maps...")
         pbr_t0 = time.time()
+        pbr_perf_t0 = time.perf_counter()
 
         # Use to_pbr_config() for consistent parameter conversion
         pbr_config = config.to_pbr_config()
 
         # Generate maps from depth
+        pbr_generate_t0 = time.perf_counter()
         normal_map, roughness_map, ao_map = generate_pbr_maps(depth, config=pbr_config)
+        pbr_generate_ms = round((time.perf_counter() - pbr_generate_t0) * 1000.0, 3)
 
         # Write PBR maps
+        pbr_write_t0 = time.perf_counter()
         pbr_dir = output_root / "pbr"
         pbr_dir.mkdir(parents=True, exist_ok=True)
 
@@ -314,8 +320,10 @@ def generate_pbr_stage(
             output_dir=pbr_dir,
             base_name=sanitized_stem,
         )
+        pbr_write_ms = round((time.perf_counter() - pbr_write_t0) * 1000.0, 3)
 
         pbr_runtime = time.time() - pbr_t0
+        pbr_total_ms = round((time.perf_counter() - pbr_perf_t0) * 1000.0, 3)
         logger.info(
             "PBR maps generated in %.2fs: %s",
             pbr_runtime,
@@ -328,6 +336,11 @@ def generate_pbr_stage(
             roughness_path=str(pbr_paths["roughness"]),
             ao_path=str(pbr_paths["ao"]),
             runtime_s=pbr_runtime,
+            timing_ms={
+                "generate_maps": pbr_generate_ms,
+                "write_maps": pbr_write_ms,
+                "total": pbr_total_ms,
+            },
             config={
                 "normal_strength": pbr_config.normal_strength,
                 "normal_blur_radius": pbr_config.normal_blur_radius,

--- a/src/transformation_portal/lux_depth_v3/materials_v3.py
+++ b/src/transformation_portal/lux_depth_v3/materials_v3.py
@@ -6,6 +6,7 @@ Handles material segmentation, refinement planning, and pixel operations.
 from __future__ import annotations
 
 import logging
+import time
 from typing import Any, Dict, Optional
 
 import numpy as np
@@ -57,15 +58,27 @@ class MaterialsV3Engine:
 
     def _compute_mask_stats(self, mask: np.ndarray, material_confidence: Optional[float] = None) -> Dict[str, Any]:
         """Compute basic coverage/confidence stats."""
-        total_px = mask.size
-        coverage_px = np.count_nonzero(mask > 0.5)
-        mean_conf = float(mask.mean())
+        mask_2d = np.asarray(mask, dtype=np.float32)
+        if mask_2d.ndim == 3 and mask_2d.shape[-1] == 1:
+            mask_2d = mask_2d.squeeze(axis=-1)
+        elif mask_2d.ndim == 3 and mask_2d.shape[0] == 1:
+            mask_2d = mask_2d.squeeze(axis=0)
+        total_px = mask_2d.size
+        active = mask_2d > 0.5
+        coverage_px = int(np.count_nonzero(active))
+        mean_conf = float(mask_2d.mean())
+        bbox = None
+        if coverage_px > 0:
+            ys, xs = np.where(active)
+            bbox = (int(xs.min()), int(ys.min()), int(xs.max()) + 1, int(ys.max()) + 1)
         stats = {
             "present": coverage_px > 0,
             "coverage_px": coverage_px,
-            "coverage_ratio": coverage_px / total_px,
+            "coverage_ratio": coverage_px / total_px if total_px else 0.0,
             "mean_conf": mean_conf,
             "edge_conf": 0.0,  # Placeholder, would be computed by edge extraction
+            "bbox": bbox,
+            "mask": mask_2d,
         }
         if material_confidence is not None:
             stats["material_confidence"] = material_confidence
@@ -79,7 +92,10 @@ class MaterialsV3Engine:
         if not getattr(self.config, "enable_materials_v3", False):
             return {}
 
+        timing_ms: Dict[str, float] = {}
+
         # 1. Stats
+        t_stats = time.perf_counter()
         raw_materials = segmentation_result.get("materials") or segmentation_result.get("material_masks") or {}
         segmentation_metadata = segmentation_result.get("segmentation_metadata")
         material_confidences = _extract_material_confidences(segmentation_result)
@@ -96,11 +112,12 @@ class MaterialsV3Engine:
         for mat_key, mask in segmentation_result.get("materials", {}).items():
             stats = self._compute_mask_stats(mask, material_confidences.get(str(mat_key)))
             per_class_stats[mat_key] = stats
-            # Attach mask for edge signal computation (PR-4C)
-            per_class_stats[mat_key]["mask"] = mask
+        timing_ms["stats"] = round((time.perf_counter() - t_stats) * 1000.0, 3)
 
         # 2. Plan (Schema v3.1)
+        t_plan = time.perf_counter()
         response_plan = generate_response_plan(per_class_stats, image, self.config)
+        timing_ms["planning"] = round((time.perf_counter() - t_plan) * 1000.0, 3)
 
         # Clean up
         for mat_key in per_class_stats:
@@ -108,7 +125,13 @@ class MaterialsV3Engine:
                 del per_class_stats[mat_key]["mask"]
 
         # 3. Execution (Pixel Ops)
+        t_pixel_ops = time.perf_counter()
         enhanced_image, pixel_ops = apply_pixel_ops(image, segmentation_result, response_plan, self.config)
+        timing_ms["pixel_ops"] = round((time.perf_counter() - t_pixel_ops) * 1000.0, 3)
+        if isinstance(pixel_ops, dict):
+            existing_timings = pixel_ops.get("timing_ms")
+            if isinstance(existing_timings, dict):
+                timing_ms["pixel_ops_executor_total"] = existing_timings.get("total", timing_ms["pixel_ops"])
 
         return {
             "enhanced_image": enhanced_image,  # Modified image with pixel ops applied
@@ -117,6 +140,7 @@ class MaterialsV3Engine:
             "materials_v3_metadata": {
                 "version": "3.1",
                 "segmentation_metadata": segmentation_metadata if isinstance(segmentation_metadata, dict) else None,
+                "timing_ms": timing_ms,
             },
             "material_masks": segmentation_result.get("materials", {}),
         }

--- a/src/transformation_portal/lux_depth_v3/materials_v3_response.py
+++ b/src/transformation_portal/lux_depth_v3/materials_v3_response.py
@@ -16,6 +16,7 @@ from .pixel_ops_registry import OP_REGISTRY
 def compute_edge_signals(
     mask_np: np.ndarray,
     rgb_np: np.ndarray,
+    grad_mag: np.ndarray | None = None,
 ) -> Dict[str, float]:
     """Computes objective boundary metrics using image gradients."""
     if mask_np is None or mask_np.sum() == 0:
@@ -40,7 +41,21 @@ def compute_edge_signals(
     if boundary_pixels_count == 0:
         return {"boundary_pixels": 0, "edge_alignment": 0.0}
 
-    # 2. Compute Image Gradients (Sobel)
+    # 2. Use precomputed image gradients when available; otherwise compute
+    # them for backward-compatible direct helper calls.
+    if grad_mag is None:
+        grad_mag = _normalized_gradient_magnitude(rgb_np)
+
+    # 3. Compute Alignment (Mean gradient magnitude at boundary)
+    alignment_score = float(np.mean(grad_mag[boundary_mask]))
+
+    return {
+        "boundary_pixels": boundary_pixels_count,
+        "edge_alignment": round(alignment_score, 4),
+    }
+
+
+def _normalized_gradient_magnitude(rgb_np: np.ndarray) -> np.ndarray:
     if rgb_np.ndim == 3 and rgb_np.shape[2] == 3:
         gray = np.dot(rgb_np[..., :3], [0.2989, 0.5870, 0.1140])
     else:
@@ -53,14 +68,7 @@ def compute_edge_signals(
     max_grad = np.max(grad_mag)
     if max_grad > 0:
         grad_mag /= max_grad
-
-    # 3. Compute Alignment (Mean gradient magnitude at boundary)
-    alignment_score = float(np.mean(grad_mag[boundary_mask]))
-
-    return {
-        "boundary_pixels": boundary_pixels_count,
-        "edge_alignment": round(alignment_score, 4),
-    }
+    return grad_mag
 
 
 def _decide_refinement(
@@ -140,6 +148,7 @@ def generate_response_plan(
     }
 
     histogram: Dict[str, int] = {}
+    shared_grad_mag = _normalized_gradient_magnitude(rgb_image) if per_class_stats else None
     for mat_key, stats in per_class_stats.items():
         if not stats.get("present", False):
             continue
@@ -147,7 +156,7 @@ def generate_response_plan(
 
         edge_signals = {"boundary_pixels": 0, "edge_alignment": 0.0}
         if "mask" in stats:
-            edge_signals = compute_edge_signals(stats["mask"], rgb_image)
+            edge_signals = compute_edge_signals(stats["mask"], rgb_image, shared_grad_mag)
 
         refinement = _decide_refinement(mat_key, stats, edge_signals, config)
         pixel_ops = _decide_pixel_ops(mat_key, stats, config)
@@ -165,6 +174,7 @@ def generate_response_plan(
             "coverage_px": stats["coverage_px"],
             "mean_conf": stats["mean_conf"],
             "edge_conf": stats.get("edge_conf", 0.0),
+            "bbox": stats.get("bbox"),
             "refinement": refinement,
             "pixel_ops": pixel_ops,
             "edge_signals": edge_signals,

--- a/src/transformation_portal/lux_depth_v3/orchestrator.py
+++ b/src/transformation_portal/lux_depth_v3/orchestrator.py
@@ -2519,14 +2519,18 @@ class EnhanceOrchestrator:
         try:
             logger.info("Generating PBR maps...")
             pbr_t0 = time.time()
+            pbr_perf_t0 = time.perf_counter()
 
             # Use to_pbr_config() for consistent parameter conversion
             pbr_config = self.config.to_pbr_config()
 
             # Generate maps from depth
+            pbr_generate_t0 = time.perf_counter()
             normal_map, roughness_map, ao_map = generate_pbr_maps(depth, config=pbr_config)
+            pbr_generate_ms = round((time.perf_counter() - pbr_generate_t0) * 1000.0, 3)
 
             # Write PBR maps
+            pbr_write_t0 = time.perf_counter()
             pbr_dir = self.output_root / "pbr"
             pbr_dir.mkdir(parents=True, exist_ok=True)
 
@@ -2540,8 +2544,10 @@ class EnhanceOrchestrator:
                 output_dir=pbr_dir,
                 base_name=sanitized_stem,
             )
+            pbr_write_ms = round((time.perf_counter() - pbr_write_t0) * 1000.0, 3)
 
             pbr_runtime = time.time() - pbr_t0
+            pbr_total_ms = round((time.perf_counter() - pbr_perf_t0) * 1000.0, 3)
             logger.info(
                 "PBR maps generated in" " %.2fs: %s",
                 pbr_runtime,
@@ -2554,6 +2560,11 @@ class EnhanceOrchestrator:
                 "roughness_path": str(pbr_paths["roughness"]),
                 "ao_path": str(pbr_paths["ao"]),
                 "runtime_seconds": pbr_runtime,
+                "timing_ms": {
+                    "generate_maps": pbr_generate_ms,
+                    "write_maps": pbr_write_ms,
+                    "total": pbr_total_ms,
+                },
                 "config": {
                     "normal_strength": pbr_config.normal_strength,
                     "normal_blur_radius": pbr_config.normal_blur_radius,
@@ -2794,6 +2805,7 @@ class EnhanceOrchestrator:
                 "materials": segment_materials(
                     preprocessed_uint8_for_seg,
                     self.config,
+                    cache_dir=self.output_root / ".cache" / "material_segmentation",
                 ),
             }
             segmentation_runtime = get_last_segmentation_runtime_metadata()
@@ -2829,10 +2841,12 @@ class EnhanceOrchestrator:
 
                 material_masks = materials_v3_result.get("material_masks")
                 if isinstance(material_masks, dict) and material_masks:
+                    t_mask_serialize = time.perf_counter()
                     mask_artifact_path = self._persist_material_masks_artifact(
                         material_masks,
                         output_key,
                     )
+                    mask_serialization_ms = round((time.perf_counter() - t_mask_serialize) * 1000.0, 3)
                     if mask_artifact_path:
                         materials_v3_metadata = materials_v3_result.setdefault(
                             "materials_v3_metadata",
@@ -2858,6 +2872,10 @@ class EnhanceOrchestrator:
                         segmentation_metadata["mask_artifact_shape"] = list(
                             np.asarray(next(iter(material_masks.values()))).shape[:2]
                         )
+                        timing_metadata = segmentation_metadata.get("timing_ms")
+                        timing_metadata = dict(timing_metadata) if isinstance(timing_metadata, dict) else {}
+                        timing_metadata["mask_serialization"] = mask_serialization_ms
+                        segmentation_metadata["timing_ms"] = timing_metadata
                         materials_v3_metadata["segmentation_metadata"] = segmentation_metadata
 
                 enhanced_image = materials_v3_result.get("enhanced_image")

--- a/src/transformation_portal/lux_depth_v3/pixel_ops_executor.py
+++ b/src/transformation_portal/lux_depth_v3/pixel_ops_executor.py
@@ -82,6 +82,25 @@ def _bounding_box(mask: np.ndarray) -> tuple[int, int, int, int] | None:
     return int(xs.min()), int(ys.min()), int(xs.max()) + 1, int(ys.max()) + 1
 
 
+def _validated_plan_bbox(
+    bbox: Any,
+    mask: np.ndarray,
+    image_shape: Tuple[int, int],
+) -> tuple[int, int, int, int] | None:
+    if not isinstance(bbox, (list, tuple)) or len(bbox) != 4:
+        return None
+    img_h, img_w = image_shape
+    try:
+        x0, y0, x1, y1 = [int(value) for value in bbox]
+    except (TypeError, ValueError):
+        return None
+    if x0 < 0 or y0 < 0 or x1 > img_w or y1 > img_h or x1 <= x0 or y1 <= y0:
+        return None
+    if not np.any(mask[y0:y1, x0:x1] > 0.5):
+        return None
+    return x0, y0, x1, y1
+
+
 def _roi_mean_gradient_energy(roi_normalized: np.ndarray) -> float:
     """Mean gradient magnitude of a normalized [0, 1] float32 ROI.
 
@@ -397,7 +416,9 @@ def apply_pixel_ops(
             )
             continue
 
-        bbox = _bounding_box(mask_2d)
+        bbox = _validated_plan_bbox(plan_entry.get("bbox"), mask_2d, image.shape[:2])
+        if bbox is None:
+            bbox = _bounding_box(mask_2d)
         if bbox is None:
             telemetry["blocked"].append(
                 {

--- a/src/transformation_portal/lux_depth_v3/segmentation_backend.py
+++ b/src/transformation_portal/lux_depth_v3/segmentation_backend.py
@@ -41,15 +41,19 @@ For usage examples, see docs/reference/materials_v3_quick_reference_old.md
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
 import os
+import time
 from contextvars import ContextVar
 from functools import lru_cache
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, Dict, List, Literal, Optional, Tuple, cast
+from typing import Any, Dict, List, Literal, Mapping, Optional, Tuple, cast
 
 import numpy as np
+
+from transformation_portal.ingest.canonical_json import canonicalize_json, dump_json
 
 from .config import EnhanceConfig
 from .protocols.segmentation_backend import SegmentationBackend, SegmentationBackendInfo
@@ -79,20 +83,31 @@ def _coerce_material_result(value: Any) -> Tuple[np.ndarray, Optional[float]]:
     return value, None
 
 
-def _record_material_confidence_metadata(material_confidences: Dict[str, float]) -> None:
-    if not material_confidences:
-        return
+def _split_material_results(results: Mapping[str, Any]) -> Tuple[Dict[str, np.ndarray], Dict[str, float]]:
+    masks: Dict[str, np.ndarray] = {}
+    material_confidences: Dict[str, float] = {}
+    for material, value in results.items():
+        mask, confidence = _coerce_material_result(value)
+        masks[material] = mask
+        if confidence is not None:
+            material_confidences[material] = confidence
+    return masks, material_confidences
 
-    runtime_metadata = _LAST_SEGMENTATION_RUNTIME_METADATA.get() or {}
+
+def _material_confidence_metadata(material_confidences: Dict[str, float]) -> Dict[str, Any]:
+    if not material_confidences:
+        return {}
+
     scores = list(material_confidences.values())
-    runtime_metadata["material_confidences"] = dict(material_confidences)
-    runtime_metadata["confidence_summary"] = {
-        "count": len(scores),
-        "min": float(min(scores)),
-        "mean": float(np.mean(scores)),
-        "max": float(max(scores)),
+    return {
+        "material_confidences": dict(material_confidences),
+        "confidence_summary": {
+            "count": len(scores),
+            "min": float(min(scores)),
+            "mean": float(np.mean(scores)),
+            "max": float(max(scores)),
+        },
     }
-    _LAST_SEGMENTATION_RUNTIME_METADATA.set(runtime_metadata)
 
 
 # Lazy imports for ML dependencies
@@ -149,6 +164,8 @@ except ImportError:
 
 SAM2_AUTO_TILING_MAX_AREA_PX = 8_000_000
 SAM2_AUTO_TILING_MAX_DIM_PX = 4096
+SEGMENTATION_CACHE_SCHEMA_VERSION = "materials-segmentation-cache.v1"
+_CACHE_MASK_CHECKSUM_CHUNK_SIZE = 1024 * 1024
 
 
 def _build_sam2_generator_kwargs(
@@ -201,6 +218,219 @@ def _serialize_sam2_tiling_config(tiling: Any) -> Optional[Dict[str, Any]]:
         },
         "max_concurrency": getattr(tiling, "max_concurrency", None),
     }
+
+
+def _stable_array_hash(array: np.ndarray) -> str:
+    arr = array if array.flags.c_contiguous else np.ascontiguousarray(array)
+    digest = hashlib.sha256()
+    digest.update(str(arr.shape).encode("utf-8"))
+    digest.update(str(arr.dtype).encode("utf-8"))
+    view = memoryview(cast(Any, arr.view(np.uint8).reshape(-1)))
+    digest.update(cast(Any, view))
+    return digest.hexdigest()
+
+
+def _mask_checksum(mask: np.ndarray) -> str:
+    arr = mask if mask.flags.c_contiguous else np.ascontiguousarray(mask)
+    digest = hashlib.sha256()
+    digest.update(str(arr.shape).encode("utf-8"))
+    digest.update(str(arr.dtype).encode("utf-8"))
+    view = memoryview(cast(Any, arr.view(np.uint8).reshape(-1)))
+    for offset in range(0, len(view), _CACHE_MASK_CHECKSUM_CHUNK_SIZE):
+        digest.update(cast(Any, view[offset : offset + _CACHE_MASK_CHECKSUM_CHUNK_SIZE]))
+    return digest.hexdigest()
+
+
+@lru_cache(maxsize=8)
+def _cached_file_sha256(path: str, size: int, mtime_ns: int) -> str:
+    del size, mtime_ns
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as handle:
+        for chunk in iter(lambda: handle.read(_CACHE_MASK_CHECKSUM_CHUNK_SIZE), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _file_identity(path_value: Optional[str]) -> Optional[Dict[str, Any]]:
+    if not path_value:
+        return None
+    path = Path(path_value)
+    if not path.is_file():
+        return {"path": str(path), "exists": False, "sha256": None, "size": None, "mtime_ns": None}
+    try:
+        stat = path.stat()
+        return {
+            "path": str(path),
+            "exists": True,
+            "sha256": _cached_file_sha256(str(path), int(stat.st_size), int(stat.st_mtime_ns)),
+            "size": int(stat.st_size),
+            "mtime_ns": int(stat.st_mtime_ns),
+        }
+    except OSError:
+        return {"path": str(path), "exists": False, "sha256": None, "size": None, "mtime_ns": None}
+
+
+def _normalise_cache_policy(value: Any) -> str:
+    policy = str(value or "read_write").strip().lower()
+    return policy if policy in {"off", "read_write"} else "off"
+
+
+def _segmentation_cache_paths(cache_dir: Path, cache_key: str) -> tuple[Path, Path]:
+    shard = cache_key[:2]
+    root = cache_dir / shard
+    return root / f"{cache_key}.npz", root / f"{cache_key}.json"
+
+
+def _build_segmentation_cache_key(
+    *,
+    image: np.ndarray,
+    backend_name: str,
+    device: str,
+    strict_backend: bool,
+    sam2_model_size: str,
+    sam2_checkpoint_path: Optional[str],
+    sam2_tiling_enabled: bool,
+    sam2_tile_size_px: int,
+    sam2_overlap_px: int,
+    sam2_global_pass_longest_side: int,
+    sam2_max_concurrency: int,
+    sam2_points_per_side: int,
+    sam2_points_per_batch: int,
+    sam2_pred_iou_thresh: float,
+    sam2_stability_score_thresh: float,
+    sam2_crop_n_layers: int,
+    sky_top_region_fraction: float,
+    sky_gradient_threshold: float,
+    sky_brightness_threshold: float,
+) -> tuple[str, Dict[str, Any]]:
+    payload: Dict[str, Any] = {
+        "schema_version": SEGMENTATION_CACHE_SCHEMA_VERSION,
+        "image_hash": _stable_array_hash(image),
+        "image_shape": list(image.shape),
+        "image_dtype": str(image.dtype),
+        "backend": backend_name,
+        "device": device,
+        "strict_backend": bool(strict_backend),
+        "sam2_model_size": sam2_model_size,
+        "sam2_checkpoint": _file_identity(sam2_checkpoint_path),
+        "sam2_generator": {
+            "points_per_side": int(sam2_points_per_side),
+            "points_per_batch": int(sam2_points_per_batch),
+            "pred_iou_thresh": float(sam2_pred_iou_thresh),
+            "stability_score_thresh": float(sam2_stability_score_thresh),
+            "crop_n_layers": int(sam2_crop_n_layers),
+        },
+        "sam2_tiling": {
+            "enabled": bool(sam2_tiling_enabled),
+            "tile_size_px": int(sam2_tile_size_px),
+            "overlap_px": int(sam2_overlap_px),
+            "global_pass_longest_side": int(sam2_global_pass_longest_side),
+            "max_concurrency": int(sam2_max_concurrency),
+        },
+        "sky_bootstrap": {
+            "top_region_fraction": float(sky_top_region_fraction),
+            "gradient_threshold": float(sky_gradient_threshold),
+            "brightness_threshold": float(sky_brightness_threshold),
+        },
+    }
+    cache_key = hashlib.sha256(canonicalize_json(payload)).hexdigest()
+    return cache_key, payload
+
+
+def _read_cached_material_masks(
+    *,
+    cache_dir: Path,
+    cache_key: str,
+    expected_payload: Dict[str, Any],
+) -> Optional[tuple[Dict[str, Tuple[np.ndarray, float]], Dict[str, Any]]]:
+    masks_path, metadata_path = _segmentation_cache_paths(cache_dir, cache_key)
+    if not masks_path.is_file() or not metadata_path.is_file():
+        return None
+
+    try:
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        if metadata.get("schema_version") != SEGMENTATION_CACHE_SCHEMA_VERSION:
+            return None
+        if metadata.get("cache_key") != cache_key:
+            return None
+        if metadata.get("key_payload") != expected_payload:
+            return None
+        mask_entries = metadata.get("masks")
+        if not isinstance(mask_entries, dict):
+            return None
+
+        results: Dict[str, Tuple[np.ndarray, float]] = {}
+        with np.load(masks_path, allow_pickle=False) as data:
+            for material, entry in mask_entries.items():
+                if not isinstance(entry, dict) or material not in data.files:
+                    return None
+                mask = np.asarray(data[material])
+                if list(mask.shape) != list(entry.get("shape") or []):
+                    return None
+                if str(mask.dtype) != str(entry.get("dtype")):
+                    return None
+                if _mask_checksum(mask) != entry.get("sha256"):
+                    return None
+                confidence = _coerce_unit_confidence(entry.get("confidence"))
+                if confidence is None:
+                    return None
+                results[str(material)] = (mask.astype(np.float32, copy=False), confidence)
+        return results, metadata
+    except Exception as exc:
+        logger.debug("Ignoring invalid material segmentation cache entry %s: %s", cache_key, exc)
+        return None
+
+
+def _write_cached_material_masks(
+    *,
+    cache_dir: Path,
+    cache_key: str,
+    key_payload: Dict[str, Any],
+    results: Dict[str, Tuple[np.ndarray, float]],
+    runtime_metadata: Optional[Dict[str, Any]],
+) -> None:
+    if not results:
+        return
+
+    masks_path, metadata_path = _segmentation_cache_paths(cache_dir, cache_key)
+    masks_path.parent.mkdir(parents=True, exist_ok=True)
+
+    arrays: Dict[str, np.ndarray] = {}
+    mask_entries: Dict[str, Dict[str, Any]] = {}
+    for material, (mask, confidence) in sorted(results.items()):
+        arr = np.asarray(mask, dtype=np.float32)
+        arrays[material] = arr
+        mask_entries[material] = {
+            "shape": list(arr.shape),
+            "dtype": str(arr.dtype),
+            "sha256": _mask_checksum(arr),
+            "confidence": float(confidence),
+        }
+
+    temp_npz = masks_path.with_suffix(".npz.tmp")
+    temp_json = metadata_path.with_suffix(".json.tmp")
+    try:
+        with temp_npz.open("wb") as handle:
+            np.savez_compressed(handle, **cast(Any, arrays))
+        metadata = {
+            "schema_version": SEGMENTATION_CACHE_SCHEMA_VERSION,
+            "cache_key": cache_key,
+            "key_payload": key_payload,
+            "masks": mask_entries,
+            "runtime_metadata": runtime_metadata or {},
+        }
+        with temp_json.open("w", encoding="utf-8") as handle:
+            dump_json(metadata, handle, sort_keys=True, indent=2, ensure_ascii=False, allow_nan=False)
+            handle.write("\n")
+        temp_npz.replace(masks_path)
+        temp_json.replace(metadata_path)
+    finally:
+        for temp_path in (temp_npz, temp_json):
+            if temp_path.exists():
+                try:
+                    temp_path.unlink()
+                except OSError:
+                    logger.debug("Failed to remove temporary segmentation cache file: %s", temp_path)
 
 
 # =============================================================================
@@ -281,6 +511,9 @@ class EfficientSAMBackend:
         self._clip_preprocess: Any = None
         self._clip_tokenizer: Any = None
         self._clip_runtime_metadata: Optional[Dict[str, Any]] = None
+        self._clip_text_features: Any = None
+        self._clip_text_prompt_signature: Optional[Tuple[str, ...]] = None
+        self._clip_classification_timing_ms: Dict[str, float] = {}
         self._sky_top_region_fraction = float(sky_top_region_fraction)
         self._sky_gradient_threshold = float(sky_gradient_threshold)
         self._sky_brightness_threshold = float(sky_brightness_threshold)
@@ -365,9 +598,14 @@ class EfficientSAMBackend:
 
     def get_runtime_metadata(self) -> Optional[Dict[str, Any]]:
         """Expose runtime metadata for governance/attestation reports."""
-        if self._clip_runtime_metadata is None:
+        metadata: Dict[str, Any] = {}
+        if self._clip_runtime_metadata is not None:
+            metadata["clip_runtime"] = dict(self._clip_runtime_metadata)
+        if self._clip_classification_timing_ms:
+            metadata["clip_classification"] = {"timing_ms": dict(self._clip_classification_timing_ms)}
+        if not metadata:
             return None
-        return {"clip_runtime": dict(self._clip_runtime_metadata)}
+        return metadata
 
     def _load_clip_runtime(self) -> Tuple[Any, Any, Any]:
         """Load CLIP model/tokenizer with cache-first offline-safe resolution."""
@@ -723,10 +961,18 @@ class EfficientSAMBackend:
             we first generate heuristic segments and then classify them with CLIP.
             This provides better material detection than pure heuristics alone.
         """
+        self._clip_classification_timing_ms = {}
+        t_total = time.perf_counter()
+
         # If no SAM segments, generate heuristic segments first
         if not segments:
+            t_heuristic = time.perf_counter()
             logger.debug("No SAM segments provided, generating heuristic segments for CLIP classification")
             heuristic_results = self._heuristic_segmentation(image)
+            self._clip_classification_timing_ms["heuristic_segments"] = round(
+                (time.perf_counter() - t_heuristic) * 1000.0,
+                3,
+            )
 
             # Convert heuristic masks to segment format for CLIP
             # Note: heuristic_results is Dict[str, Tuple[np.ndarray, float]]
@@ -789,13 +1035,19 @@ class EfficientSAMBackend:
                 "stone": "a photo of stone, concrete, and gray surfaces",
             }
 
-            # Tokenize text prompts
-            text_tokens = tokenizer(list(material_prompts.values())).to(self._device)
-
             with torch.no_grad():
-                # Encode text prompts
-                text_features = model.encode_text(text_tokens)
-                text_features = text_features / text_features.norm(dim=-1, keepdim=True)
+                prompt_signature = tuple(material_prompts.values())
+                if self._clip_text_features is None or self._clip_text_prompt_signature != prompt_signature:
+                    t_text = time.perf_counter()
+                    text_tokens = tokenizer(list(material_prompts.values())).to(self._device)
+                    text_features = model.encode_text(text_tokens)
+                    self._clip_text_features = text_features / text_features.norm(dim=-1, keepdim=True)
+                    self._clip_text_prompt_signature = prompt_signature
+                    self._clip_classification_timing_ms["text_encode"] = round(
+                        (time.perf_counter() - t_text) * 1000.0,
+                        3,
+                    )
+                text_features = self._clip_text_features
 
                 # Initialize material masks with tracking for confidence scores
                 h, w = image.shape[:2]
@@ -806,7 +1058,9 @@ class EfficientSAMBackend:
                 # Convert image to PIL for preprocessing
                 pil_image = Image.fromarray(image)
 
-                # Classify each segment
+                t_crop = time.perf_counter()
+                region_tensors = []
+                region_segments: list[tuple[int, Dict[str, Any]]] = []
                 for seg_idx, segment in enumerate(segments):
                     mask = segment["segmentation"]
                     bbox = segment["bbox"]  # [x, y, w, h]
@@ -821,15 +1075,31 @@ class EfficientSAMBackend:
                     # Crop and preprocess region
                     region = pil_image.crop((x1, y1, x2, y2))
                     region_tensor = preprocess(region).unsqueeze(0).to(self._device)
+                    region_tensors.append(region_tensor)
+                    region_segments.append((seg_idx, segment))
+                self._clip_classification_timing_ms["crop_preprocess"] = round(
+                    (time.perf_counter() - t_crop) * 1000.0,
+                    3,
+                )
 
-                    # Encode image region
-                    image_features = model.encode_image(region_tensor)
-                    image_features = image_features / image_features.norm(dim=-1, keepdim=True)
+                if not region_tensors:
+                    return self._heuristic_segmentation(image)
 
-                    # Compute similarity scores
-                    similarities = (image_features @ text_features.T).squeeze(0)
+                t_image = time.perf_counter()
+                image_batch = torch.cat(region_tensors, dim=0)
+                image_features = model.encode_image(image_batch)
+                image_features = image_features / image_features.norm(dim=-1, keepdim=True)
+                similarity_batch = image_features @ text_features.T
+                self._clip_classification_timing_ms["image_encode"] = round(
+                    (time.perf_counter() - t_image) * 1000.0,
+                    3,
+                )
+                self._clip_classification_timing_ms["batch_size"] = float(len(region_tensors))
 
-                    # Assign to best matching material
+                # Classify each segment in stable input order
+                for row_idx, (seg_idx, segment) in enumerate(region_segments):
+                    mask = segment["segmentation"]
+                    similarities = similarity_batch[row_idx]
                     best_idx = similarities.argmax().item()
                     best_material = list(material_prompts.keys())[best_idx]
                     best_score = similarities[best_idx].item()
@@ -874,9 +1144,11 @@ class EfficientSAMBackend:
                     f"CLIP classified {len(segments)} segments into {len(material_masks)} materials: "
                     f"{', '.join(f'{m} ({c:.0%})' for m, (_, c) in material_masks.items())}"
                 )
+                self._clip_classification_timing_ms["total"] = round((time.perf_counter() - t_total) * 1000.0, 3)
                 return material_masks
 
         except Exception as e:
+            self._clip_classification_timing_ms["total"] = round((time.perf_counter() - t_total) * 1000.0, 3)
             logger.warning(f"CLIP classification failed: {e}, falling back to heuristics")
             import traceback
 
@@ -1465,6 +1737,7 @@ def _get_backend_instance(
 def segment_materials(
     image: np.ndarray,
     config: EnhanceConfig,
+    cache_dir: Optional[Path] = None,
 ) -> Dict[str, np.ndarray]:
     """Segment image into material masks.
 
@@ -1494,6 +1767,8 @@ def segment_materials(
         ValueError: If image format is invalid
     """
     _LAST_SEGMENTATION_RUNTIME_METADATA.set(None)
+    t_total = time.perf_counter()
+    timing_ms: Dict[str, float] = {}
 
     # Check if segmentation is enabled
     enable_segmentation = getattr(config, "enable_material_segmentation", False)
@@ -1520,12 +1795,73 @@ def segment_materials(
     sky_top_region_fraction = float(getattr(config, "sky_top_region_fraction", 0.5))
     sky_gradient_threshold = float(getattr(config, "sky_gradient_threshold", 0.05))
     sky_brightness_threshold = float(getattr(config, "sky_brightness_threshold", 0.4))
+    cache_policy = _normalise_cache_policy(getattr(config, "material_segmentation_cache_policy", "read_write"))
 
     # Get device for backend (if applicable)
     device = getattr(config, "depth_device", "cpu")  # Reuse depth_device setting
+    cache_key: Optional[str] = None
+    cache_payload: Optional[Dict[str, Any]] = None
+    cache_enabled = bool(cache_dir) and cache_policy == "read_write" and backend_name != "stub"
+
+    if cache_enabled and cache_dir is not None:
+        t_cache = time.perf_counter()
+        try:
+            cache_key, cache_payload = _build_segmentation_cache_key(
+                image=image,
+                backend_name=backend_name,
+                device=device,
+                strict_backend=strict_backend,
+                sam2_model_size=sam2_model_size,
+                sam2_checkpoint_path=sam2_checkpoint_path,
+                sam2_tiling_enabled=sam2_tiling_enabled,
+                sam2_tile_size_px=sam2_tile_size_px,
+                sam2_overlap_px=sam2_overlap_px,
+                sam2_global_pass_longest_side=sam2_global_pass_longest_side,
+                sam2_max_concurrency=sam2_max_concurrency,
+                sam2_points_per_side=sam2_points_per_side,
+                sam2_points_per_batch=sam2_points_per_batch,
+                sam2_pred_iou_thresh=sam2_pred_iou_thresh,
+                sam2_stability_score_thresh=sam2_stability_score_thresh,
+                sam2_crop_n_layers=sam2_crop_n_layers,
+                sky_top_region_fraction=sky_top_region_fraction,
+                sky_gradient_threshold=sky_gradient_threshold,
+                sky_brightness_threshold=sky_brightness_threshold,
+            )
+            cached = _read_cached_material_masks(
+                cache_dir=cache_dir,
+                cache_key=cache_key,
+                expected_payload=cache_payload,
+            )
+            timing_ms["cache_lookup"] = round((time.perf_counter() - t_cache) * 1000.0, 3)
+            if cached is not None:
+                cached_results, cached_metadata = cached
+                masks, material_confidences = _split_material_results(cached_results)
+                confidence_metadata = _material_confidence_metadata(material_confidences)
+                timing_ms["total"] = round((time.perf_counter() - t_total) * 1000.0, 3)
+                metadata: Dict[str, Any] = {
+                    "cache_hit": True,
+                    "cache_key": cache_key,
+                    "cache_policy": cache_policy,
+                    "timing_ms": timing_ms,
+                    "mask_count": len(masks),
+                    "backend": backend_name,
+                    "device": device,
+                    "model_size": sam2_model_size if backend_name == "sam2" else None,
+                }
+                cached_runtime = cached_metadata.get("runtime_metadata")
+                if isinstance(cached_runtime, dict):
+                    metadata.update(cached_runtime)
+                metadata.update(confidence_metadata)
+                _LAST_SEGMENTATION_RUNTIME_METADATA.set(metadata)
+                logger.debug("Material segmentation cache hit: %s", cache_key)
+                return masks
+        except Exception as exc:
+            timing_ms["cache_lookup"] = round((time.perf_counter() - t_cache) * 1000.0, 3)
+            logger.debug("Material segmentation cache lookup skipped after error: %s", exc)
 
     try:
         # Get or create backend instance (cached)
+        t_backend = time.perf_counter()
         backend = _get_backend_instance(
             backend_name,
             device=device,
@@ -1546,29 +1882,58 @@ def segment_materials(
             sky_gradient_threshold=sky_gradient_threshold,
             sky_brightness_threshold=sky_brightness_threshold,
         )
+        timing_ms["backend_load"] = round((time.perf_counter() - t_backend) * 1000.0, 3)
 
         # Run segmentation
+        t_segment = time.perf_counter()
         results = backend.segment(image)
+        timing_ms["backend_segment"] = round((time.perf_counter() - t_segment) * 1000.0, 3)
+        runtime_metadata: Optional[Dict[str, Any]] = None
         if hasattr(backend, "get_runtime_metadata"):
             try:
                 runtime_metadata = backend.get_runtime_metadata()
             except Exception as exc:
                 logger.debug("Failed to query segmentation runtime metadata: %s", exc)
                 runtime_metadata = None
-            if isinstance(runtime_metadata, dict):
-                _LAST_SEGMENTATION_RUNTIME_METADATA.set(dict(runtime_metadata))
 
         # Extract masks from (mask, confidence) tuples for backward compatibility
         # while preserving real classifier confidence for downstream Materials V3
         # decisions through runtime metadata.
-        masks: Dict[str, np.ndarray] = {}
-        material_confidences: Dict[str, float] = {}
-        for material, value in results.items():
-            mask, confidence = _coerce_material_result(value)
-            masks[material] = mask
-            if confidence is not None:
-                material_confidences[material] = confidence
-        _record_material_confidence_metadata(material_confidences)
+        masks, material_confidences = _split_material_results(results)
+        confidence_metadata = _material_confidence_metadata(material_confidences)
+        runtime_metadata_for_cache = dict(runtime_metadata) if isinstance(runtime_metadata, dict) else {}
+        runtime_metadata_for_cache.update(confidence_metadata)
+
+        if cache_enabled and cache_dir is not None and cache_key and cache_payload and results:
+            t_cache_write = time.perf_counter()
+            try:
+                _write_cached_material_masks(
+                    cache_dir=cache_dir,
+                    cache_key=cache_key,
+                    key_payload=cache_payload,
+                    results=results,
+                    runtime_metadata=runtime_metadata_for_cache,
+                )
+            except Exception as exc:
+                logger.debug("Material segmentation cache write failed: %s", exc)
+            timing_ms["cache_write"] = round((time.perf_counter() - t_cache_write) * 1000.0, 3)
+
+        timing_ms["total"] = round((time.perf_counter() - t_total) * 1000.0, 3)
+        metadata = {
+            "cache_hit": False,
+            "cache_key": cache_key,
+            "cache_policy": cache_policy,
+            "timing_ms": timing_ms,
+            "mask_count": len(masks),
+            "backend": backend_name,
+            "executed_backend": getattr(getattr(backend, "info", None), "model_id", None),
+            "device": getattr(backend, "_device", device),
+            "model_size": sam2_model_size if backend_name == "sam2" else None,
+        }
+        if isinstance(runtime_metadata, dict):
+            metadata.update(runtime_metadata)
+        metadata.update(confidence_metadata)
+        _LAST_SEGMENTATION_RUNTIME_METADATA.set(metadata)
 
         logger.debug(
             f"Segmentation completed using {backend.info.name}: " f"{len(masks)} materials detected: {list(masks.keys())}"

--- a/src/transformation_portal/reporting/contracts.py
+++ b/src/transformation_portal/reporting/contracts.py
@@ -299,14 +299,19 @@ def build_stage_report(
     status: str,
     capability: Optional[Mapping[str, Any]] = None,
     quality_gate: Optional[Mapping[str, Any]] = None,
+    metadata: Optional[Mapping[str, Any]] = None,
 ) -> dict[str, Any]:
     """Build a normalized stage-report payload."""
-    return {
+    report = {
         "stage": stage,
         "status": status,
         "capability": _copy_mapping(capability),
         "quality_gate": _copy_mapping(quality_gate),
     }
+    metadata_copy = _copy_mapping(metadata)
+    if metadata_copy is not None:
+        report["metadata"] = metadata_copy
+    return report
 
 
 def derive_stage_report_map(stage_reports: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:

--- a/src/transformation_portal/spatial_ai/materials/contracts.py
+++ b/src/transformation_portal/spatial_ai/materials/contracts.py
@@ -191,6 +191,7 @@ class PBRGenerationMetadata:
     material_hint: Optional[str] = None
     depth_used: bool = False
     backend_decision: Optional[BackendDecision] = None
+    timing_ms: Optional[dict] = None
 
     def to_dict(self) -> dict:
         """Convert metadata to dictionary for serialization."""
@@ -202,6 +203,7 @@ class PBRGenerationMetadata:
             "material_hint": self.material_hint,
             "depth_used": self.depth_used,
             "backend_decision": (self.backend_decision.to_dict() if self.backend_decision is not None else None),
+            "timing_ms": dict(self.timing_ms or {}),
         }
 
 

--- a/src/transformation_portal/spatial_ai/materials/material_backend.py
+++ b/src/transformation_portal/spatial_ai/materials/material_backend.py
@@ -25,6 +25,7 @@ Performance:
 
 import inspect
 import os
+import time
 from typing import Any, Dict, Literal, Optional, cast
 
 import numpy as np
@@ -315,6 +316,7 @@ class MaterialBackend:
             self._warn_backend_resolution(decision)
 
         # Route to appropriate backend (returns metadata tuple now)
+        start_total = time.perf_counter()
         result = None
         if decision.executed_backend == "pbr_fusion":
             result = self._generate_pbr_fusion(rgb, mask, depth, material_hint, config, decision)
@@ -347,6 +349,10 @@ class MaterialBackend:
             )
 
         # Wrap into PBRTextures contract
+        if metadata is not None:
+            timing_ms = dict(getattr(metadata, "timing_ms", {}) or {})
+            timing_ms.setdefault("total", round((time.perf_counter() - start_total) * 1000.0, 3))
+            metadata.timing_ms = timing_ms
         return PBRTextures(
             albedo=albedo,
             normal=normal,

--- a/src/transformation_portal/spatial_ai/materials/pbr_generator.py
+++ b/src/transformation_portal/spatial_ai/materials/pbr_generator.py
@@ -128,6 +128,20 @@ class PBRGenerator:
         Returns:
             List of N PBRTextures objects, one per segment.
         """
+        config = config or self.backend_engine._build_generation_config()
+        decision = self.backend_engine.resolve_backend_decision(config.backend)
+        if decision.executed_backend == "heuristic" and not (
+            config.strict_backend and decision.requested_backend != decision.executed_backend
+        ):
+            return self._generate_batch_heuristic_shared(
+                image=image,
+                gamma=gamma,
+                masks=masks,
+                depth=depth,
+                material_hints=material_hints,
+                config=config,
+            )
+
         results = []
 
         # Process each segment
@@ -146,6 +160,77 @@ class PBRGenerator:
             )
 
             results.append(pbr)
+
+        return results
+
+    def _generate_batch_heuristic_shared(
+        self,
+        *,
+        image: np.ndarray,
+        gamma: float,
+        masks: List[np.ndarray],
+        depth: Optional[np.ndarray],
+        material_hints: Optional[List[str]],
+        config: MaterialGenerationConfig,
+    ) -> List[PBRTextures]:
+        """Generate heuristic PBR textures by sharing full-image intermediates.
+
+        The heuristic backend computes full-image albedo/normal/roughness/AO
+        before applying each mask, so one unmasked generation per material hint
+        is equivalent to repeated per-mask generation and avoids duplicate
+        bilateral/Sobel/variance passes.
+        """
+        MaterialInput(image=image, gamma=gamma, depth=depth)
+        base_by_hint: dict[Optional[str], PBRTextures] = {}
+        results: List[PBRTextures] = []
+
+        for idx, mask in enumerate(masks):
+            hint = material_hints[idx] if material_hints else None
+            MaterialInput(image=image, gamma=gamma, mask=mask, depth=depth, material_hint=hint)
+            if hint not in base_by_hint:
+                base_by_hint[hint] = self.backend_engine.generate_pbr_textures(
+                    rgb=image,
+                    mask=None,
+                    depth=depth,
+                    material_hint=hint,
+                    config=config,
+                )
+            base = base_by_hint[hint]
+            mask_bool = np.asarray(mask, dtype=bool)
+
+            albedo = base.albedo.copy()
+            normal = base.normal.copy()
+            roughness = base.roughness.copy()
+            metallic = base.metallic.copy()
+            ao = base.ambient_occlusion.copy()
+            height = base.height.copy() if base.height is not None else None
+
+            albedo[~mask_bool] = 0.0
+            normal[~mask_bool] = [0.0, 0.0, 1.0]
+            roughness[~mask_bool] = 0.5
+            metallic[~mask_bool] = 0.0
+            ao[~mask_bool] = 1.0
+            if height is not None:
+                height[~mask_bool] = 0.5
+
+            properties = MaterialProperties(
+                roughness_mean=float(np.mean(roughness[mask_bool])),
+                metallic_mean=float(np.mean(metallic[mask_bool])),
+                ao_strength=float(np.mean(1.0 - ao[mask_bool])),
+                normal_strength=config.normal_strength,
+            )
+            results.append(
+                PBRTextures(
+                    albedo=albedo,
+                    normal=normal,
+                    roughness=roughness,
+                    metallic=metallic,
+                    ambient_occlusion=ao,
+                    height=height,
+                    properties=properties,
+                    metadata=base.metadata,
+                )
+            )
 
         return results
 

--- a/src/transformation_portal/spatial_ai/orchestration/pipeline.py
+++ b/src/transformation_portal/spatial_ai/orchestration/pipeline.py
@@ -38,9 +38,11 @@ import logging
 import math
 import os
 import tempfile
+import time
 from dataclasses import asdict, dataclass, field, is_dataclass
+from functools import lru_cache
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Mapping, Optional, Union, cast
 
 import numpy as np
 
@@ -49,7 +51,7 @@ from transformation_portal.compliance import (
     validate_materials_preset,
     validate_non_commercial_preset,
 )
-from transformation_portal.ingest.canonical_json import dump_json
+from transformation_portal.ingest.canonical_json import canonicalize_json, dump_json
 from transformation_portal.reporting.contracts import build_stage_report, derive_stage_report_map
 from transformation_portal.spatial_ai.ingest.linear_decoder import LinearDecoder, LinearIngestResult
 from transformation_portal.spatial_ai.materials.contracts import MaterialInput, PBRTextures
@@ -96,7 +98,206 @@ def _is_reload_safe_pipeline_config(candidate: object) -> bool:
 def _sha256_array(array: np.ndarray) -> str:
     """Return a deterministic SHA-256 for a numpy array payload."""
     contiguous = array if array.flags["C_CONTIGUOUS"] else np.ascontiguousarray(array)
-    return hashlib.sha256(memoryview(contiguous.view(np.uint8))).hexdigest()
+    return hashlib.sha256(memoryview(contiguous.view(np.uint8).ravel())).hexdigest()
+
+
+_SEGMENTATION_CACHE_SCHEMA_VERSION = "spatial-ai-segmentation-cache.v1"
+
+
+def _normalise_segmentation_cache_policy(value: Any) -> str:
+    policy = str(value or "read_write").strip().lower()
+    return policy if policy in {"off", "read_write"} else "off"
+
+
+def _segmentation_cache_paths(cache_dir: Path, cache_key: str) -> tuple[Path, Path]:
+    root = cache_dir / cache_key[:2]
+    return root / f"{cache_key}.npz", root / f"{cache_key}.json"
+
+
+def _file_identity(path_value: Any) -> Optional[dict[str, Any]]:
+    if not path_value:
+        return None
+    path = Path(str(path_value))
+    if not path.is_file():
+        return {
+            "path": str(path),
+            "exists": False,
+            "sha256": None,
+            "size": None,
+            "mtime_ns": None,
+        }
+    try:
+        stat = path.stat()
+        return {
+            "path": str(path),
+            "exists": True,
+            "sha256": _sha256_file_cached(str(path), int(stat.st_size), int(stat.st_mtime_ns)),
+            "size": int(stat.st_size),
+            "mtime_ns": int(stat.st_mtime_ns),
+        }
+    except OSError:
+        return {
+            "path": str(path),
+            "exists": False,
+            "sha256": None,
+            "size": None,
+            "mtime_ns": None,
+        }
+
+
+@lru_cache(maxsize=8)
+def _sha256_file_cached(path: str, size: int, mtime_ns: int) -> str:
+    del size, mtime_ns
+    return _sha256_file(Path(path))
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _metadata_to_cache_dict(metadata: MaskMetadata) -> dict[str, Any]:
+    return {
+        "area": int(metadata.area),
+        "bbox": list(metadata.bbox),
+        "stability_score": float(metadata.stability_score),
+        "material_label": metadata.material_label,
+        "material_confidence": metadata.material_confidence,
+        "is_empty": bool(metadata.is_empty),
+    }
+
+
+def _metadata_from_cache_dict(data: Mapping[str, Any]) -> MaskMetadata:
+    return MaskMetadata(
+        area=int(data["area"]),
+        bbox=tuple(int(value) for value in data["bbox"]),
+        stability_score=float(data["stability_score"]),
+        material_label=data.get("material_label"),
+        material_confidence=(float(data["material_confidence"]) if data.get("material_confidence") is not None else None),
+        is_empty=bool(data.get("is_empty", False)),
+    )
+
+
+def _segmentation_result_checksum(result: SegmentationResult) -> str:
+    digest = hashlib.sha256()
+    for array in (result.masks, result.scores):
+        contiguous = array if array.flags["C_CONTIGUOUS"] else np.ascontiguousarray(array)
+        digest.update(str(contiguous.shape).encode("utf-8"))
+        digest.update(str(contiguous.dtype).encode("utf-8"))
+        digest.update(memoryview(contiguous.view(np.uint8).ravel()))
+    digest.update(canonicalize_json([_metadata_to_cache_dict(item) for item in result.metadata]))
+    return digest.hexdigest()
+
+
+def _segmentation_mask_count(result: Any) -> int:
+    masks = getattr(result, "masks", None)
+    if masks is None:
+        return 0
+    shape = getattr(masks, "shape", None)
+    if shape:
+        return int(shape[0])
+    try:
+        return len(masks)
+    except TypeError:
+        return 0
+
+
+def _build_segmentation_cache_key(
+    *,
+    image: np.ndarray,
+    segmentation_cfg: Mapping[str, Any],
+    device: str,
+) -> tuple[str, dict[str, Any]]:
+    model_cfg = segmentation_cfg.get("model", {}) if isinstance(segmentation_cfg.get("model"), Mapping) else {}
+    sanitized_model_cfg = dict(model_cfg)
+    checkpoint_path = sanitized_model_cfg.get("checkpoint_path")
+    sanitized_model_cfg["checkpoint"] = _file_identity(checkpoint_path)
+    sanitized_model_cfg.pop("checkpoint_path", None)
+    payload = {
+        "schema_version": _SEGMENTATION_CACHE_SCHEMA_VERSION,
+        "image_hash": _sha256_array(image),
+        "image_shape": list(image.shape),
+        "image_dtype": str(image.dtype),
+        "backend": segmentation_cfg.get("backend", "sam2"),
+        "device": device,
+        "model": _sanitize_json_value(sanitized_model_cfg),
+        "generator": dict(segmentation_cfg.get("generator", {}) or {}),
+        "material_classification": bool(segmentation_cfg.get("material_classification", False)),
+        "material_confidence_threshold": float(segmentation_cfg.get("material_confidence_threshold", 0.3)),
+        "tiling": _sanitize_json_value(segmentation_cfg.get("tiling", {}) or {}),
+    }
+    cache_key = hashlib.sha256(canonicalize_json(payload)).hexdigest()
+    return cache_key, payload
+
+
+def _read_segmentation_cache(
+    *,
+    cache_dir: Path,
+    cache_key: str,
+    key_payload: Mapping[str, Any],
+) -> Optional[SegmentationResult]:
+    masks_path, metadata_path = _segmentation_cache_paths(cache_dir, cache_key)
+    if not masks_path.is_file() or not metadata_path.is_file():
+        return None
+    try:
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        if metadata.get("schema_version") != _SEGMENTATION_CACHE_SCHEMA_VERSION:
+            return None
+        if metadata.get("cache_key") != cache_key or metadata.get("key_payload") != dict(key_payload):
+            return None
+        with np.load(masks_path, allow_pickle=False) as data:
+            masks = np.asarray(data["masks"])
+            scores = np.asarray(data["scores"])
+        mask_metadata = [_metadata_from_cache_dict(item) for item in metadata.get("metadata", [])]
+        result = SegmentationResult(
+            masks=masks.astype(bool, copy=False), scores=scores.astype(np.float32), metadata=mask_metadata
+        )
+        if _segmentation_result_checksum(result) != metadata.get("result_sha256"):
+            return None
+        return result
+    except Exception as exc:
+        logger.debug("Ignoring invalid spatial segmentation cache entry %s: %s", cache_key, exc)
+        return None
+
+
+def _write_segmentation_cache(
+    *,
+    cache_dir: Path,
+    cache_key: str,
+    key_payload: Mapping[str, Any],
+    result: SegmentationResult,
+) -> None:
+    if _segmentation_mask_count(result) == 0:
+        return
+    if not isinstance(result.masks, np.ndarray) or not isinstance(result.scores, np.ndarray):
+        return
+    masks_path, metadata_path = _segmentation_cache_paths(cache_dir, cache_key)
+    masks_path.parent.mkdir(parents=True, exist_ok=True)
+    temp_npz = masks_path.with_suffix(".npz.tmp")
+    temp_json = metadata_path.with_suffix(".json.tmp")
+    try:
+        with temp_npz.open("wb") as handle:
+            np.savez_compressed(handle, masks=result.masks, scores=result.scores)
+        metadata = {
+            "schema_version": _SEGMENTATION_CACHE_SCHEMA_VERSION,
+            "cache_key": cache_key,
+            "key_payload": dict(key_payload),
+            "metadata": [_metadata_to_cache_dict(item) for item in result.metadata],
+            "result_sha256": _segmentation_result_checksum(result),
+        }
+        with temp_json.open("w", encoding="utf-8") as handle:
+            dump_json(metadata, handle, indent=2, sort_keys=True, ensure_ascii=False, allow_nan=False)
+            handle.write("\n")
+        temp_npz.replace(masks_path)
+        temp_json.replace(metadata_path)
+    finally:
+        for temp_path in (temp_npz, temp_json):
+            if temp_path.exists():
+                with contextlib.suppress(OSError):
+                    temp_path.unlink()
 
 
 def _sanitize_json_value(value: Any) -> Any:
@@ -226,6 +427,17 @@ class PipelineConfig:
         for stage in self.stages:
             if stage not in VALID_STAGES:
                 raise ValueError(f"Invalid stage '{stage}'. Valid: {VALID_STAGES}")
+
+        raw_segmentation_cfg = self.segmentation or {}
+        raw_cache_policy = raw_segmentation_cfg.get("cache_policy") if isinstance(raw_segmentation_cfg, dict) else None
+        if raw_cache_policy is not None and str(raw_cache_policy).strip().lower() not in {"off", "read_write"}:
+            raise ValueError("segmentation.cache_policy must be one of: off, read_write")
+
+        segmentation_cfg = dict(raw_segmentation_cfg)
+        segmentation_cfg["cache_policy"] = _normalise_segmentation_cache_policy(
+            segmentation_cfg.get("cache_policy", "read_write")
+        )
+        self.segmentation = segmentation_cfg
 
         # Tier validation
         VALID_TIERS = ["standard", "apex_research", "apex_research_ultra", "experimental"]
@@ -474,6 +686,8 @@ class SpatialAIPipeline:
 
         # Track stateful backends for sequence lifecycle reset (ADR-026 §2.3)
         self._stateful_backends: Dict[str, Any] = {}
+        self._last_segmentation_stage_metadata: Dict[str, Any] = {}
+        self._last_materials_stage_metadata: Dict[str, Any] = {}
 
         logger.info(f"Initialized pipeline: tier={self.config.tier}, stages={self.config.stages}")
 
@@ -616,7 +830,13 @@ class SpatialAIPipeline:
 
                     result.segmentation = self._run_segmentation(result.linear_image, output_dir, save_intermediates)
                     result.stages_completed.append("segmentation")
-                    result.stage_reports.append(build_stage_report(stage="segmentation", status="completed"))
+                    result.stage_reports.append(
+                        build_stage_report(
+                            stage="segmentation",
+                            status="completed",
+                            metadata=self._last_segmentation_stage_metadata,
+                        )
+                    )
 
                 # Phase 2.2: Materials
                 if "materials" in self.config.stages:
@@ -627,7 +847,13 @@ class SpatialAIPipeline:
                         result.linear_image, result.segmentation, output_dir, save_intermediates
                     )
                     result.stages_completed.append("materials")
-                    result.stage_reports.append(build_stage_report(stage="materials", status="completed"))
+                    result.stage_reports.append(
+                        build_stage_report(
+                            stage="materials",
+                            status="completed",
+                            metadata=self._last_materials_stage_metadata,
+                        )
+                    )
 
                 # Phase 2.3: Reconstruction
                 if "reconstruction" in self.config.stages:
@@ -1029,6 +1255,9 @@ class SpatialAIPipeline:
             SegmentationResult.
         """
         self.progress_tracker.start_stage("segment", "Segmentation")
+        self._last_segmentation_stage_metadata = {}
+        timing_ms: dict[str, float] = {}
+        t_stage = time.perf_counter()
 
         try:
             # Parse config
@@ -1046,6 +1275,7 @@ class SpatialAIPipeline:
             enable_material = bool(self.config.segmentation.get("material_classification", False))
             material_threshold = float(self.config.segmentation.get("material_confidence_threshold", 0.3))
             tiling_cfg = SegmentationTilingConfig.from_dict(self.config.segmentation.get("tiling"))
+            cache_policy = _normalise_segmentation_cache_policy(self.config.segmentation.get("cache_policy", "read_write"))
 
             active_device: Dict[str, Literal["cuda", "mps", "cpu"]] = {
                 "value": cast(Literal["cuda", "mps", "cpu"], self.resource_manager.select_device())
@@ -1084,14 +1314,47 @@ class SpatialAIPipeline:
                 self.resource_manager.register_model("sam2", backend)
                 return backend
 
-            _build_backend(active_device["value"])
-
             # Create input contract
             seg_input = SegmentationInput(
                 image=ingest_result.linear_rgb,
                 gamma=ingest_result.gamma,
                 mode="auto",
             )
+
+            cache_key: Optional[str] = None
+            cache_payload: Dict[str, Any] = {}
+            cache_key_device: Optional[Literal["cuda", "mps", "cpu"]] = None
+            if cache_policy == "read_write":
+                t_cache = time.perf_counter()
+                cache_key_device = active_device["value"]
+                cache_key, cache_payload = _build_segmentation_cache_key(
+                    image=ingest_result.linear_rgb,
+                    segmentation_cfg=self.config.segmentation,
+                    device=cache_key_device,
+                )
+                cached_result = _read_segmentation_cache(
+                    cache_dir=output_dir / ".cache" / "spatial_ai" / "segmentation",
+                    cache_key=cache_key,
+                    key_payload=cache_payload,
+                )
+                timing_ms["cache_lookup"] = round((time.perf_counter() - t_cache) * 1000.0, 3)
+                if cached_result is not None:
+                    self.progress_tracker.complete_stage("segment", success=True)
+                    timing_ms["total"] = round((time.perf_counter() - t_stage) * 1000.0, 3)
+                    self._last_segmentation_stage_metadata = {
+                        "cache_hit": True,
+                        "cache_key": cache_key,
+                        "cache_policy": cache_policy,
+                        "timing_ms": timing_ms,
+                        "mask_count": _segmentation_mask_count(cached_result),
+                        "backend": backend_cfg,
+                        "device": active_device["value"],
+                        "model_size": model_size,
+                    }
+                    logger.info("Segmentation cache hit: %s", cache_key)
+                    return cached_result
+
+            _build_backend(active_device["value"])
 
             # Execute
             def _segment() -> SegmentationResult:
@@ -1115,6 +1378,7 @@ class SpatialAIPipeline:
                 else self.config.error_strategy
             )
 
+            t_segment = time.perf_counter()
             result = self.error_handler.execute_with_retry(
                 func=_segment,
                 stage="segment",
@@ -1122,6 +1386,42 @@ class SpatialAIPipeline:
                 device=active_device["value"],
                 on_device_change=_on_device_change,
             )
+            timing_ms["backend_segment"] = round((time.perf_counter() - t_segment) * 1000.0, 3)
+            classifier = getattr(backend_holder["backend"], "_material_classifier", None)
+            classifier_timing = getattr(classifier, "_last_timing_ms", None)
+            if isinstance(classifier_timing, dict) and classifier_timing:
+                clip_timing = {
+                    str(key): float(value) for key, value in classifier_timing.items() if isinstance(value, (int, float))
+                }
+                timing_ms["clip_classification"] = round(
+                    sum(value for key, value in clip_timing.items() if key != "batch_size"),
+                    3,
+                )
+            else:
+                clip_timing = {}
+
+            if cache_policy == "read_write" and cache_key:
+                if cache_key_device != active_device["value"]:
+                    t_cache_rekey = time.perf_counter()
+                    cache_key, cache_payload = _build_segmentation_cache_key(
+                        image=ingest_result.linear_rgb,
+                        segmentation_cfg=self.config.segmentation,
+                        device=active_device["value"],
+                    )
+                    cache_key_device = active_device["value"]
+                    timing_ms["cache_rekey"] = round((time.perf_counter() - t_cache_rekey) * 1000.0, 3)
+
+                t_cache_write = time.perf_counter()
+                try:
+                    _write_segmentation_cache(
+                        cache_dir=output_dir / ".cache" / "spatial_ai" / "segmentation",
+                        cache_key=cache_key,
+                        key_payload=cache_payload,
+                        result=result,
+                    )
+                except Exception as exc:
+                    logger.debug("Spatial segmentation cache write failed: %s", exc)
+                timing_ms["cache_write"] = round((time.perf_counter() - t_cache_write) * 1000.0, 3)
 
             # Save masks if requested
             if save_intermediates:
@@ -1134,11 +1434,25 @@ class SpatialAIPipeline:
                 logger.debug(f"Saved segmentation masks: {masks_path}")
 
             self.progress_tracker.complete_stage("segment", success=True)
-            if result.scores.size:
-                score_summary = f"[{result.scores.min():.3f}, {result.scores.max():.3f}]"
+            timing_ms["total"] = round((time.perf_counter() - t_stage) * 1000.0, 3)
+            self._last_segmentation_stage_metadata = {
+                "cache_hit": False,
+                "cache_key": cache_key,
+                "cache_policy": cache_policy,
+                "timing_ms": timing_ms,
+                "mask_count": _segmentation_mask_count(result),
+                "backend": backend_cfg,
+                "device": active_device["value"],
+                "model_size": model_size,
+            }
+            if clip_timing:
+                self._last_segmentation_stage_metadata["clip_classification"] = {"timing_ms": clip_timing}
+            scores = np.asarray(getattr(result, "scores", []), dtype=np.float32)
+            if scores.size:
+                score_summary = f"[{scores.min():.3f}, {scores.max():.3f}]"
             else:
                 score_summary = "empty"
-            logger.info(f"Segmentation completed: {len(result.masks)} masks, " f"scores={score_summary}")
+            logger.info(f"Segmentation completed: {_segmentation_mask_count(result)} masks, " f"scores={score_summary}")
 
             # Unload model to free memory
             self.resource_manager.unload_model("sam2")
@@ -1168,6 +1482,9 @@ class SpatialAIPipeline:
             Dict mapping segment IDs to PBR textures.
         """
         self.progress_tracker.start_stage("materials", "PBR Materials")
+        self._last_materials_stage_metadata = {}
+        timing_ms: dict[str, float] = {}
+        t_stage = time.perf_counter()
 
         try:
             # Parse config
@@ -1280,6 +1597,7 @@ class SpatialAIPipeline:
                     _build_backend(rebuilt_device, replace_tracking=True)
 
                 try:
+                    t_generate = time.perf_counter()
                     pbr_textures = self.error_handler.execute_with_retry(
                         func=_generate,
                         stage="materials",
@@ -1287,6 +1605,7 @@ class SpatialAIPipeline:
                         device=active_device["value"],
                         on_device_change=_on_device_change,
                     )
+                    timing_ms[f"segment_{i}"] = round((time.perf_counter() - t_generate) * 1000.0, 3)
                 except PipelineError:
                     if per_segment_strategy == ErrorRecoveryStrategy.FAIL_FAST:
                         raise
@@ -1333,6 +1652,13 @@ class SpatialAIPipeline:
                 logger.debug(f"Saved PBR textures: {textures_dir}")
 
             self.progress_tracker.complete_stage("materials", success=True)
+            timing_ms["total"] = round((time.perf_counter() - t_stage) * 1000.0, 3)
+            self._last_materials_stage_metadata = {
+                "timing_ms": timing_ms,
+                "segment_count": len(materials),
+                "backend": backend_cfg,
+                "device": active_device["value"],
+            }
             logger.info(f"Materials completed: {len(materials)} segments")
 
             # Unload model to free memory (C3: match segmentation lifecycle)

--- a/src/transformation_portal/spatial_ai/segmentation/material_classifier.py
+++ b/src/transformation_portal/spatial_ai/segmentation/material_classifier.py
@@ -28,6 +28,7 @@ Example:
 from __future__ import annotations
 
 import logging
+import time
 from typing import List, Optional, Tuple
 
 import numpy as np
@@ -114,6 +115,7 @@ class MaterialClassifier:
         self._model = None
         self._processor = None
         self._available = None  # Lazy check
+        self._last_timing_ms = {}
 
         logger.info(
             f"MaterialClassifier initialized: "
@@ -202,6 +204,7 @@ class MaterialClassifier:
             List of (label, confidence) tuples (N items).
             Label is None if confidence below threshold.
         """
+        self._last_timing_ms = {}
         if not self.is_available():
             if self.strict:
                 raise RuntimeError(
@@ -224,51 +227,55 @@ class MaterialClassifier:
             logger.warning("CLIP material classification unavailable; returning unlabeled masks: %s", exc)
             return [(None, None) for _ in range(len(masks))]
 
-        results = []
+        results: List[Tuple[Optional[str], Optional[float]]] = [(None, None) for _ in range(len(masks))]
+        extracted_regions = []
+        extracted_indices = []
 
-        for mask in masks:
+        t_extract = time.perf_counter()
+        for idx, mask in enumerate(masks):
             # Extract masked region
             masked_image = self._extract_masked_region(image, mask)
 
             if masked_image is None:
                 # Empty mask or extraction failed
-                results.append((None, None))
                 continue
 
-            try:
-                # Prepare inputs for CLIP
-                inputs = self._processor(
-                    text=self.material_classes,
-                    images=masked_image,
-                    return_tensors="pt",
-                    padding=True,
-                )
-                inputs = {k: v.to(self._model.device) for k, v in inputs.items()}
+            extracted_regions.append(masked_image)
+            extracted_indices.append(idx)
+        self._last_timing_ms["extract_regions"] = round((time.perf_counter() - t_extract) * 1000.0, 3)
 
-                # Run CLIP
-                with torch.no_grad():
-                    outputs = self._model(**inputs)
+        if not extracted_regions:
+            return results
 
-                # Compute similarities (logits)
-                logits_per_image = outputs.logits_per_image  # (1, N_classes)
-                probs = logits_per_image.softmax(dim=1)[0]  # (N_classes,)
+        try:
+            t_clip = time.perf_counter()
+            # Prepare all crops in one processor call. This keeps text/material
+            # ordering stable while avoiding per-mask tokenizer/model overhead.
+            inputs = self._processor(
+                text=self.material_classes,
+                images=extracted_regions,
+                return_tensors="pt",
+                padding=True,
+            )
+            inputs = {k: v.to(self._model.device) for k, v in inputs.items()}
 
-                # Get top prediction
+            # Run CLIP for the whole mask batch
+            with torch.no_grad():
+                outputs = self._model(**inputs)
+
+            probs_by_image = outputs.logits_per_image.softmax(dim=1)
+            for row_idx, mask_idx in enumerate(extracted_indices):
+                probs = probs_by_image[row_idx]
                 best_idx = probs.argmax().item()
                 best_prob = probs[best_idx].item()
-            except Exception as exc:
-                if self.strict:
-                    raise
-                logger.warning("CLIP material classification failed for one mask; leaving it unlabeled: %s", exc)
-                results.append((None, None))
-                continue
-
-            # Check confidence threshold
-            if best_prob >= self.confidence_threshold:
-                label = self.material_classes[best_idx]
-                results.append((label, best_prob))
-            else:
-                results.append((None, None))
+                if best_prob >= self.confidence_threshold:
+                    results[mask_idx] = (self.material_classes[best_idx], best_prob)
+            self._last_timing_ms["clip_batch"] = round((time.perf_counter() - t_clip) * 1000.0, 3)
+            self._last_timing_ms["batch_size"] = len(extracted_regions)
+        except Exception as exc:
+            if self.strict:
+                raise
+            logger.warning("CLIP material classification failed for mask batch; leaving masks unlabeled: %s", exc)
 
         return results
 

--- a/tests/materials/test_segmentation_backend.py
+++ b/tests/materials/test_segmentation_backend.py
@@ -16,9 +16,11 @@ Note: Tests marked with @pytest.mark.ml require torch/torchvision.
 
 from __future__ import annotations
 
+import json
 import socket
 import sys
 import types
+from contextlib import contextmanager
 from types import SimpleNamespace
 
 import numpy as np
@@ -739,6 +741,264 @@ def test_segment_materials_sam2_backend_auto_enables_tiling_for_large_images(mon
     assert metadata["sam2_runtime"]["tiling"]["decision"] == "auto_large_image"
     assert metadata["sam2_runtime"]["tiling"]["effective"]["enabled"] is True
     assert metadata["sam2_runtime"]["tiling"]["image_shape"] == [4097, 2, 3]
+
+
+def test_segment_materials_cache_hit_skips_backend(sample_image, tmp_path, monkeypatch):
+    """Validated exact-match cache entries should skip backend execution."""
+    import transformation_portal.lux_depth_v3.segmentation_backend as seg_module
+
+    calls = {"segment": 0}
+    glass_mask = np.zeros(sample_image.shape[:2], dtype=np.float32)
+    glass_mask[5:20, 5:20] = 1.0
+
+    class FakeBackend:
+        info = SegmentationBackendInfo(
+            name="Fake EfficientSAM",
+            model_id="fake-efficientsam",
+            requires_gpu=False,
+            requires_weights=False,
+            approximate_memory_mb=1,
+            description="test",
+        )
+        _device = "cpu"
+
+        def segment(self, image):
+            calls["segment"] += 1
+            assert image.shape == sample_image.shape
+            return {"glass": (glass_mask, 0.91)}
+
+        def get_runtime_metadata(self):
+            return {"clip_runtime": {"weights_source": "test"}}
+
+    monkeypatch.setattr(seg_module, "_get_backend_instance", lambda *args, **kwargs: FakeBackend())
+    config = EnhanceConfig(
+        enable_material_segmentation=True,
+        material_segmentation_backend="efficientsam",
+        material_segmentation_cache_policy="read_write",
+        depth_device="cpu",
+    )
+
+    first = segment_materials(sample_image, config, cache_dir=tmp_path)
+    first_metadata = get_last_segmentation_runtime_metadata()
+    second = segment_materials(sample_image, config, cache_dir=tmp_path)
+    second_metadata = get_last_segmentation_runtime_metadata()
+
+    assert calls["segment"] == 1
+    assert np.array_equal(first["glass"], second["glass"])
+    assert first_metadata["cache_hit"] is False
+    assert second_metadata["cache_hit"] is True
+    assert second_metadata["mask_count"] == 1
+    assert second_metadata["backend"] == "efficientsam"
+    assert first_metadata["material_confidences"]["glass"] == pytest.approx(0.91)
+    assert second_metadata["material_confidences"]["glass"] == pytest.approx(0.91)
+    assert second_metadata["confidence_summary"]["count"] == 1
+
+
+def test_efficientsam_clip_classification_batches_segments(sample_image, monkeypatch):
+    """EfficientSAM CLIP classification should encode all segment crops in one batch."""
+    import transformation_portal.lux_depth_v3.segmentation_backend as seg_module
+
+    class FakeScalar:
+        def __init__(self, value):
+            self.value = value
+
+        def item(self):
+            return self.value
+
+    class FakeTensor:
+        def __init__(self, values):
+            self.values = np.asarray(values, dtype=np.float32)
+
+        def to(self, _device):
+            return self
+
+        def unsqueeze(self, axis):
+            return FakeTensor(np.expand_dims(self.values, axis))
+
+        def norm(self, dim=-1, keepdim=True):
+            return FakeTensor(np.linalg.norm(self.values, axis=dim, keepdims=keepdim))
+
+        def __truediv__(self, other):
+            other_values = other.values if isinstance(other, FakeTensor) else other
+            return FakeTensor(self.values / np.maximum(other_values, 1e-6))
+
+        @property
+        def T(self):
+            return FakeTensor(self.values.T)
+
+        def __matmul__(self, other):
+            return FakeTensor(self.values @ other.values)
+
+        def __getitem__(self, key):
+            return FakeTensor(self.values[key])
+
+        def argmax(self):
+            return FakeScalar(int(np.argmax(self.values)))
+
+        def item(self):
+            return float(np.asarray(self.values).item())
+
+    @contextmanager
+    def fake_no_grad():
+        yield
+
+    class FakeTorch:
+        @staticmethod
+        def no_grad():
+            return fake_no_grad()
+
+        @staticmethod
+        def cat(tensors, dim=0):
+            return FakeTensor(np.concatenate([tensor.values for tensor in tensors], axis=dim))
+
+    monkeypatch.setitem(sys.modules, "torch", FakeTorch)
+    monkeypatch.setattr(seg_module, "OPEN_CLIP_AVAILABLE", True)
+
+    model_calls = {"encode_text": 0, "encode_image": 0}
+    preprocess_vectors = [
+        [1.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 1.0],
+    ]
+
+    class FakeModel:
+        def encode_text(self, tokens):
+            model_calls["encode_text"] += 1
+            return tokens
+
+        def encode_image(self, image_batch):
+            model_calls["encode_image"] += 1
+            return image_batch
+
+    def fake_tokenizer(_prompts):
+        return FakeTensor(np.eye(4, dtype=np.float32))
+
+    def fake_preprocess(_region):
+        return FakeTensor(preprocess_vectors.pop(0))
+
+    backend = EfficientSAMBackend()
+    backend._device = "cpu"
+    backend._load_clip_runtime = lambda: (FakeModel(), fake_preprocess, fake_tokenizer)
+
+    mask_a = np.zeros(sample_image.shape[:2], dtype=bool)
+    mask_a[2:30, 2:30] = True
+    mask_b = np.zeros(sample_image.shape[:2], dtype=bool)
+    mask_b[25:55, 25:55] = True
+    segments = [
+        {"segmentation": mask_a, "bbox": [2, 2, 28, 28], "area": int(mask_a.sum())},
+        {"segmentation": mask_b, "bbox": [25, 25, 30, 30], "area": int(mask_b.sum())},
+    ]
+
+    result = backend._classify_segments_with_clip(sample_image, segments)
+
+    assert model_calls == {"encode_text": 1, "encode_image": 1}
+    assert set(result) == {"glass", "stone"}
+    assert result["glass"][1] == pytest.approx(1.0)
+    assert result["stone"][1] == pytest.approx(1.0)
+    metadata = backend.get_runtime_metadata()
+    assert metadata["clip_classification"]["timing_ms"]["batch_size"] == 2.0
+
+
+def test_segment_materials_cache_key_invalidates_on_config_change(sample_image, tmp_path, monkeypatch):
+    """Cache keys should include segmentation-affecting configuration."""
+    import transformation_portal.lux_depth_v3.segmentation_backend as seg_module
+
+    calls = {"segment": 0}
+
+    class FakeBackend:
+        info = SegmentationBackendInfo("Fake", "fake", False, False, 1, "test")
+        _device = "cpu"
+
+        def segment(self, image):
+            calls["segment"] += 1
+            mask = np.zeros(image.shape[:2], dtype=np.float32)
+            mask[calls["segment"] : calls["segment"] + 4, 0:4] = 1.0
+            return {"glass": (mask, 0.9)}
+
+    monkeypatch.setattr(seg_module, "_get_backend_instance", lambda *args, **kwargs: FakeBackend())
+    config = EnhanceConfig(
+        enable_material_segmentation=True,
+        material_segmentation_backend="efficientsam",
+        material_segmentation_cache_policy="read_write",
+        sky_gradient_threshold=0.05,
+    )
+    changed_config = EnhanceConfig(
+        enable_material_segmentation=True,
+        material_segmentation_backend="efficientsam",
+        material_segmentation_cache_policy="read_write",
+        sky_gradient_threshold=0.06,
+    )
+
+    segment_materials(sample_image, config, cache_dir=tmp_path)
+    segment_materials(sample_image, changed_config, cache_dir=tmp_path)
+
+    assert calls["segment"] == 2
+
+
+def test_segment_materials_corrupt_cache_recomputes(sample_image, tmp_path, monkeypatch):
+    """Invalid cache metadata should be rejected and recomputed."""
+    import transformation_portal.lux_depth_v3.segmentation_backend as seg_module
+
+    calls = {"segment": 0}
+
+    class FakeBackend:
+        info = SegmentationBackendInfo("Fake", "fake", False, False, 1, "test")
+        _device = "cpu"
+
+        def segment(self, image):
+            calls["segment"] += 1
+            mask = np.zeros(image.shape[:2], dtype=np.float32)
+            mask[1:8, 1:8] = 1.0
+            return {"glass": (mask, 0.9)}
+
+    monkeypatch.setattr(seg_module, "_get_backend_instance", lambda *args, **kwargs: FakeBackend())
+    config = EnhanceConfig(
+        enable_material_segmentation=True,
+        material_segmentation_backend="efficientsam",
+        material_segmentation_cache_policy="read_write",
+    )
+
+    segment_materials(sample_image, config, cache_dir=tmp_path)
+    metadata_files = list(tmp_path.glob("*/*.json"))
+    assert metadata_files
+    metadata_files[0].write_text('{"schema_version":"bad"}', encoding="utf-8")
+    segment_materials(sample_image, config, cache_dir=tmp_path)
+
+    assert calls["segment"] == 2
+
+
+def test_segment_materials_cache_rejects_missing_confidence(sample_image, tmp_path, monkeypatch):
+    """Exact-result cache entries must not synthesize missing confidence values."""
+    import transformation_portal.lux_depth_v3.segmentation_backend as seg_module
+
+    calls = {"segment": 0}
+
+    class FakeBackend:
+        info = SegmentationBackendInfo("Fake", "fake", False, False, 1, "test")
+        _device = "cpu"
+
+        def segment(self, image):
+            calls["segment"] += 1
+            mask = np.zeros(image.shape[:2], dtype=np.float32)
+            mask[calls["segment"] : calls["segment"] + 4, 1:5] = 1.0
+            return {"glass": (mask, 0.9)}
+
+    monkeypatch.setattr(seg_module, "_get_backend_instance", lambda *args, **kwargs: FakeBackend())
+    config = EnhanceConfig(
+        enable_material_segmentation=True,
+        material_segmentation_backend="efficientsam",
+        material_segmentation_cache_policy="read_write",
+    )
+
+    segment_materials(sample_image, config, cache_dir=tmp_path)
+    metadata_files = list(tmp_path.glob("*/*.json"))
+    assert metadata_files
+    metadata = json.loads(metadata_files[0].read_text(encoding="utf-8"))
+    metadata["masks"]["glass"].pop("confidence")
+    metadata_files[0].write_text(json.dumps(metadata), encoding="utf-8")
+
+    segment_materials(sample_image, config, cache_dir=tmp_path)
+
+    assert calls["segment"] == 2
 
 
 def test_segment_materials_sam2_strict_mode_missing_backend(sample_image, monkeypatch):

--- a/tests/spatial_ai/materials/test_pbr_generator.py
+++ b/tests/spatial_ai/materials/test_pbr_generator.py
@@ -168,6 +168,61 @@ class TestPBRGenerator:
 
         assert len(results) == len(sample_masks)
 
+    def test_batch_heuristic_shared_matches_per_segment_outputs(self, generator):
+        """Shared heuristic intermediates should be equivalent to per-mask generation."""
+        rng = np.random.default_rng(1234)
+        image = rng.random((32, 32, 3), dtype=np.float32)
+        depth = rng.random((32, 32), dtype=np.float32)
+        masks = []
+        mask_a = np.zeros((32, 32), dtype=bool)
+        mask_a[2:20, 3:18] = True
+        masks.append(mask_a)
+        mask_b = np.zeros((32, 32), dtype=bool)
+        mask_b[10:30, 12:31] = True
+        masks.append(mask_b)
+        hints = ["metal", "wood"]
+        config = MaterialGenerationConfig(
+            backend="heuristic",
+            device="cpu",
+            normal_strength=1.3,
+            ao_intensity=0.6,
+        )
+
+        expected = [
+            generator.generate(
+                image=image,
+                gamma=1.0,
+                mask=mask,
+                depth=depth,
+                material_hint=hint,
+                config=config,
+            )
+            for mask, hint in zip(masks, hints)
+        ]
+        actual = generator.generate_batch(
+            image=image,
+            gamma=1.0,
+            masks=masks,
+            depth=depth,
+            material_hints=hints,
+            config=config,
+        )
+
+        for expected_pbr, actual_pbr in zip(expected, actual):
+            np.testing.assert_allclose(actual_pbr.albedo, expected_pbr.albedo, atol=1e-6)
+            np.testing.assert_allclose(actual_pbr.normal, expected_pbr.normal, atol=1e-6)
+            np.testing.assert_allclose(actual_pbr.roughness, expected_pbr.roughness, atol=1e-6)
+            np.testing.assert_allclose(actual_pbr.metallic, expected_pbr.metallic, atol=1e-6)
+            np.testing.assert_allclose(
+                actual_pbr.ambient_occlusion,
+                expected_pbr.ambient_occlusion,
+                atol=1e-6,
+            )
+            np.testing.assert_allclose(actual_pbr.height, expected_pbr.height, atol=1e-6)
+            assert actual_pbr.properties.roughness_mean == pytest.approx(expected_pbr.properties.roughness_mean)
+            assert actual_pbr.properties.metallic_mean == pytest.approx(expected_pbr.properties.metallic_mean)
+            assert actual_pbr.properties.ao_strength == pytest.approx(expected_pbr.properties.ao_strength)
+
     def test_contract_validation(self, generator):
         """Test input contract validation."""
         # Invalid image dtype

--- a/tests/spatial_ai/orchestration/test_forward_port_contracts.py
+++ b/tests/spatial_ai/orchestration/test_forward_port_contracts.py
@@ -244,6 +244,213 @@ def test_pipeline_rebuilds_segmentation_backend_on_cpu_fallback(monkeypatch: pyt
     assert float(result.scores[0]) == pytest.approx(0.95)
 
 
+def test_pipeline_rekeys_segmentation_cache_after_cpu_fallback(monkeypatch: pytest.MonkeyPatch, tmp_path: Any) -> None:
+    pipeline_mod = _import_pipeline_module(monkeypatch)
+    monkeypatch.setattr(pipeline_mod, "SegmentationTilingConfig", _FakeTilingConfig)
+
+    builds: list[Any] = []
+
+    class FakeSAM2Backend:
+        def __init__(
+            self,
+            *,
+            model_size: Any,
+            device: Any,
+            checkpoint_path: Any = None,
+            repo_id: Any = None,
+            revision: Any = None,
+            prefer_hf_pipeline: Any = None,
+            generator_kwargs: Any = None,
+            enable_material_classification: bool = False,
+            material_confidence_threshold: float = 0.3,
+            tiling: Any = None,
+        ) -> None:
+            del checkpoint_path, repo_id, revision, prefer_hf_pipeline, generator_kwargs
+            del enable_material_classification, material_confidence_threshold, tiling
+            self.model_size = model_size
+            self.device = device
+            builds.append(self)
+
+        def segment(self, seg_input: Any) -> Any:
+            del seg_input
+            if self.device == "cuda":
+                raise RuntimeError("CUDA out of memory")
+            mask = np.zeros((1, 2, 2), dtype=bool)
+            mask[0, 0, 0] = True
+            return pipeline_mod.SegmentationResult(
+                masks=mask,
+                scores=np.array([0.95], dtype=np.float32),
+                metadata=[
+                    pipeline_mod.MaskMetadata(
+                        area=1,
+                        bbox=(0, 0, 1, 1),
+                        stability_score=0.9,
+                    )
+                ],
+            )
+
+    monkeypatch.setattr(pipeline_mod, "SAM2Backend", FakeSAM2Backend)
+
+    pipeline = _make_pipeline(
+        {
+            "tier": "standard",
+            "pipeline": {
+                "segmentation": {
+                    "backend": "sam2",
+                    "cache_policy": "read_write",
+                    "model": {
+                        "size": "large",
+                        "repo_id": SAM2_REPO_ID,
+                        "revision": PINNED_REVISION,
+                        "prefer_hf_pipeline": True,
+                    },
+                }
+            },
+            "error_strategy": "retry_cpu_fallback",
+        },
+        pipeline_mod,
+        monkeypatch,
+    )
+
+    ingest_result = _make_ingest_result()
+    result = pipeline._run_segmentation(
+        ingest_result=ingest_result,
+        output_dir=tmp_path,
+        save_intermediates=False,
+    )
+    metadata = dict(pipeline._last_segmentation_stage_metadata)
+    cache_dir = tmp_path / ".cache" / "spatial_ai" / "segmentation"
+
+    cuda_key, cuda_payload = pipeline_mod._build_segmentation_cache_key(
+        image=ingest_result.linear_rgb,
+        segmentation_cfg=pipeline.config.segmentation,
+        device="cuda",
+    )
+    cpu_key, cpu_payload = pipeline_mod._build_segmentation_cache_key(
+        image=ingest_result.linear_rgb,
+        segmentation_cfg=pipeline.config.segmentation,
+        device="cpu",
+    )
+
+    assert [backend.device for backend in builds] == ["cuda", "cpu"]
+    assert metadata["device"] == "cpu"
+    assert metadata["cache_key"] == cpu_key
+    assert metadata["cache_key"] != cuda_key
+    assert "cache_rekey" in metadata["timing_ms"]
+    assert (
+        pipeline_mod._read_segmentation_cache(
+            cache_dir=cache_dir,
+            cache_key=cuda_key,
+            key_payload=cuda_payload,
+        )
+        is None
+    )
+    cached_cpu = pipeline_mod._read_segmentation_cache(
+        cache_dir=cache_dir,
+        cache_key=cpu_key,
+        key_payload=cpu_payload,
+    )
+    assert cached_cpu is not None
+    assert np.array_equal(cached_cpu.masks, result.masks)
+
+
+def test_pipeline_segmentation_cache_hit_skips_backend(monkeypatch: pytest.MonkeyPatch, tmp_path: Any) -> None:
+    pipeline_mod = _import_pipeline_module(monkeypatch)
+    monkeypatch.setattr(pipeline_mod, "SegmentationTilingConfig", _FakeTilingConfig)
+
+    builds: list[Any] = []
+    calls = {"segment": 0}
+
+    class FakeSAM2Backend:
+        def __init__(
+            self,
+            *,
+            model_size: Any,
+            device: Any,
+            checkpoint_path: Any = None,
+            repo_id: Any = None,
+            revision: Any = None,
+            prefer_hf_pipeline: Any = None,
+            generator_kwargs: Any = None,
+            enable_material_classification: bool = False,
+            material_confidence_threshold: float = 0.3,
+            tiling: Any = None,
+        ) -> None:
+            self.model_size = model_size
+            self.device = device
+            self.checkpoint_path = checkpoint_path
+            self.repo_id = repo_id
+            self.revision = revision
+            self.prefer_hf_pipeline = prefer_hf_pipeline
+            self.generator_kwargs = dict(generator_kwargs or {})
+            self.enable_material_classification = enable_material_classification
+            self.material_confidence_threshold = material_confidence_threshold
+            self.tiling = tiling
+            builds.append(self)
+
+        def segment(self, seg_input: Any) -> Any:
+            calls["segment"] += 1
+            del seg_input
+            mask = np.zeros((1, 2, 2), dtype=bool)
+            mask[0, 0, 0] = True
+            return pipeline_mod.SegmentationResult(
+                masks=mask,
+                scores=np.array([0.91], dtype=np.float32),
+                metadata=[
+                    pipeline_mod.MaskMetadata(
+                        area=1,
+                        bbox=(0, 0, 1, 1),
+                        stability_score=0.93,
+                        material_label="glass",
+                        material_confidence=0.88,
+                    )
+                ],
+            )
+
+    monkeypatch.setattr(pipeline_mod, "SAM2Backend", FakeSAM2Backend)
+
+    pipeline = _make_pipeline(
+        {
+            "tier": "standard",
+            "pipeline": {
+                "segmentation": {
+                    "backend": "sam2",
+                    "cache_policy": "read_write",
+                    "model": {
+                        "size": "large",
+                        "repo_id": SAM2_REPO_ID,
+                        "revision": PINNED_REVISION,
+                        "prefer_hf_pipeline": True,
+                    },
+                }
+            },
+        },
+        pipeline_mod,
+        monkeypatch,
+    )
+
+    first = pipeline._run_segmentation(
+        ingest_result=_make_ingest_result(),
+        output_dir=tmp_path,
+        save_intermediates=False,
+    )
+    first_metadata = dict(pipeline._last_segmentation_stage_metadata)
+    second = pipeline._run_segmentation(
+        ingest_result=_make_ingest_result(),
+        output_dir=tmp_path,
+        save_intermediates=False,
+    )
+    second_metadata = dict(pipeline._last_segmentation_stage_metadata)
+
+    assert len(builds) == 1
+    assert calls["segment"] == 1
+    assert np.array_equal(first.masks, second.masks)
+    assert first_metadata["cache_hit"] is False
+    assert second_metadata["cache_hit"] is True
+    assert second_metadata["mask_count"] == 1
+    assert second_metadata["cache_key"] == first_metadata["cache_key"]
+
+
 def test_pipeline_rebuilds_material_backend_on_cpu_fallback(monkeypatch: pytest.MonkeyPatch, tmp_path: Any) -> None:
     pipeline_mod = _import_pipeline_module(monkeypatch)
     builds: list[Any] = []

--- a/tests/spatial_ai/orchestration/test_pipeline.py
+++ b/tests/spatial_ai/orchestration/test_pipeline.py
@@ -46,7 +46,7 @@ class TestPipelineConfig:
         assert config.tier == "standard"
         assert config.stages == ["ingest"]
         assert config.ingest == {}
-        assert config.segmentation == {}
+        assert config.segmentation == {"cache_policy": "read_write"}
         assert config.materials == {}
         assert config.reconstruction == {}
         assert config.resource_limits is None
@@ -70,6 +70,26 @@ class TestPipelineConfig:
         assert config.ingest["strict_ingest"] is True
         assert config.resource_limits is limits
         assert config.error_strategy == ErrorRecoveryStrategy.RETRY_WITH_CPU_FALLBACK
+        assert config.segmentation["cache_policy"] == "read_write"
+
+    def test_segmentation_cache_policy_normalized(self):
+        """Segmentation cache policy is additive and defaults to read/write."""
+        default_config = PipelineConfig(tier="standard", stages=["ingest"])
+        assert default_config.segmentation["cache_policy"] == "read_write"
+
+        disabled_config = PipelineConfig(
+            tier="standard",
+            stages=["ingest", "segment"],
+            segmentation={"backend": "sam2", "cache_policy": "off"},
+        )
+        assert disabled_config.segmentation["cache_policy"] == "off"
+
+        with pytest.raises(ValueError, match="segmentation.cache_policy"):
+            PipelineConfig(
+                tier="standard",
+                stages=["ingest", "segment"],
+                segmentation={"backend": "sam2", "cache_policy": "invalid"},
+            )
 
     def test_invalid_stage_rejected(self):
         """Test invalid stage name is rejected."""
@@ -499,7 +519,7 @@ class TestSpatialAIPipelinePresetLoading:
         assert config.tier == "apex_research"
         assert set(config.stages) == {"ingest", "segmentation", "materials"}
         assert config.ingest == {"strict_ingest": True, "emit_exr": True}
-        assert config.segmentation == {"backend": "sam2"}
+        assert config.segmentation == {"backend": "sam2", "cache_policy": "read_write"}
 
 
 class TestSpatialAIPipelineIngestStage:

--- a/tests/spatial_ai/segmentation/test_material_classifier.py
+++ b/tests/spatial_ai/segmentation/test_material_classifier.py
@@ -1,5 +1,6 @@
 """Unit tests for material classifier (Phase 2.1)."""
 
+import sys
 from unittest.mock import MagicMock, Mock, patch
 
 import numpy as np
@@ -225,6 +226,112 @@ class TestMaterialClassifierClassifyMasks:
 
         # Empty mask should return (None, None)
         assert results[0] == (None, None)
+
+    def test_classify_masks_batches_clip_and_preserves_order(self, monkeypatch):
+        """Batched CLIP classification should preserve mask ordering."""
+
+        class FakeScalar:
+            def __init__(self, value):
+                self.value = value
+
+            def item(self):
+                return self.value
+
+        class FakeTensor:
+            def __init__(self, values):
+                self.values = np.asarray(values, dtype=np.float32)
+
+            def to(self, _device):
+                return self
+
+            def softmax(self, dim):
+                shifted = self.values - np.max(self.values, axis=dim, keepdims=True)
+                exp = np.exp(shifted)
+                return FakeTensor(exp / np.sum(exp, axis=dim, keepdims=True))
+
+            def __getitem__(self, key):
+                return FakeTensor(self.values[key])
+
+            def argmax(self):
+                return FakeScalar(int(np.argmax(self.values)))
+
+            def item(self):
+                return float(np.asarray(self.values).item())
+
+        class FakeNoGrad:
+            def __enter__(self):
+                return None
+
+            def __exit__(self, *_exc):
+                return False
+
+        fake_torch = type("FakeTorch", (), {"no_grad": staticmethod(lambda: FakeNoGrad())})
+        monkeypatch.setitem(sys.modules, "torch", fake_torch)
+
+        processor_calls = []
+        model_calls = []
+
+        class FakeProcessor:
+            def __call__(self, *, text, images, return_tensors, padding):
+                processor_calls.append(
+                    {
+                        "text": list(text),
+                        "image_count": len(images),
+                        "return_tensors": return_tensors,
+                        "padding": padding,
+                    }
+                )
+                return {"pixel_values": FakeTensor([[0.0]]), "input_ids": FakeTensor([[0.0]])}
+
+        class FakeModel:
+            device = "cpu"
+
+            def __call__(self, **_inputs):
+                model_calls.append("batch")
+                return type(
+                    "FakeOutputs",
+                    (),
+                    {
+                        # Two non-empty masks: first should classify as glass,
+                        # third should classify as wood. The middle mask is empty.
+                        "logits_per_image": FakeTensor(
+                            [
+                                [0.1, 3.0],
+                                [4.0, 0.1],
+                            ]
+                        )
+                    },
+                )()
+
+        classifier = MaterialClassifier(
+            device="cpu",
+            confidence_threshold=0.5,
+            material_classes=["wood", "glass"],
+        )
+        classifier._available = True
+        classifier._processor = FakeProcessor()
+        classifier._model = FakeModel()
+
+        image = np.ones((32, 32, 3), dtype=np.uint8) * 127
+        masks = np.zeros((3, 32, 32), dtype=bool)
+        masks[0, 2:14, 2:14] = True
+        masks[2, 16:30, 16:30] = True
+
+        results = classifier.classify_masks(image, masks)
+
+        assert results[0][0] == "glass"
+        assert results[1] == (None, None)
+        assert results[2][0] == "wood"
+        assert processor_calls == [
+            {
+                "text": ["wood", "glass"],
+                "image_count": 2,
+                "return_tensors": "pt",
+                "padding": True,
+            }
+        ]
+        assert model_calls == ["batch"]
+        assert classifier._last_timing_ms["batch_size"] == 2
 
 
 class TestMaterialClassifierModelLoading:

--- a/tests/structural/test_pre_commit_runtime_contract.py
+++ b/tests/structural/test_pre_commit_runtime_contract.py
@@ -1,0 +1,44 @@
+"""Keep local pre-commit hooks independent of a bare `python` executable."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.unit
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PRE_COMMIT_CONFIG = REPO_ROOT / ".pre-commit-config.yaml"
+REPO_PYTHON_RUNNER = "scripts/setup/run_repo_python.sh"
+PYTHON_HOOK_IDS = {"auto-format-staged", "check-test-markers"}
+
+
+def _load_pre_commit_config() -> dict:
+    assert PRE_COMMIT_CONFIG.exists(), f"missing pre-commit config at {PRE_COMMIT_CONFIG}"
+    return yaml.safe_load(PRE_COMMIT_CONFIG.read_text(encoding="utf-8"))
+
+
+def test_python_pre_commit_hooks_use_repo_python_runner() -> None:
+    config = _load_pre_commit_config()
+    hooks = {
+        str(hook.get("id")): hook
+        for repo in config.get("repos", [])
+        for hook in repo.get("hooks", [])
+        if hook.get("id") in PYTHON_HOOK_IDS
+    }
+
+    assert set(hooks) == PYTHON_HOOK_IDS
+    for hook_id, hook in hooks.items():
+        entry = str(hook.get("entry", ""))
+        assert entry.startswith(f"{REPO_PYTHON_RUNNER} "), f"{hook_id} must resolve Python through the repo runner"
+        assert not entry.startswith("python "), f"{hook_id} must not depend on a bare python executable"
+
+
+def test_repo_python_runner_is_executable() -> None:
+    runner = REPO_ROOT / REPO_PYTHON_RUNNER
+    assert runner.exists(), f"missing repo Python runner at {runner}"
+    assert os.access(runner, os.X_OK), f"{runner} must be executable for pre-commit system hooks"

--- a/tests/test_check_gitleaks_workflow_contract.py
+++ b/tests/test_check_gitleaks_workflow_contract.py
@@ -20,6 +20,10 @@ title = "Transformation Portal gitleaks config"
 [extend]
 useDefault = true
 
+[allowlist]
+description = "Ignore generated local artifact directories already excluded from version control"
+paths = ['''{gitleaks_contract.EXPECTED_ARTIFACT_PATH_REGEX}''']
+
 [[rules]]
 id = "{gitleaks_contract.EXPECTED_RULE_ID}"
 
@@ -29,6 +33,17 @@ condition = "AND"
 regexTarget = "{gitleaks_contract.EXPECTED_REGEX_TARGET}"
 regexes = ['''{gitleaks_contract.EXPECTED_MATCH_REGEX}''']
 paths = ['''{gitleaks_contract.EXPECTED_PATH_REGEX}''']
+
+[[rules.allowlists]]
+description = "Ignore the SAM2 tiling UI flag false positive"
+condition = "AND"
+regexTarget = "{gitleaks_contract.EXPECTED_REGEX_TARGET}"
+regexes = ['''{gitleaks_contract.EXPECTED_SAM2_TILING_MATCH_REGEX}''']
+paths = [
+  '''{gitleaks_contract.EXPECTED_SAM2_TILING_PATH_REGEXES[0]}''',
+  '''{gitleaks_contract.EXPECTED_SAM2_TILING_PATH_REGEXES[1]}''',
+  '''{gitleaks_contract.EXPECTED_SAM2_TILING_PATH_REGEXES[2]}''',
+]
 """
 
 
@@ -92,6 +107,39 @@ paths = ['''^public/portal-assets/''']
         firewall_workflow_text=valid_firewall_workflow_text(),
     )
     assert "gitleaks config must not define a global allowlist for portal assets" in errors
+    assert "gitleaks global allowlist must use singular [allowlist] syntax for v8.21.x" in errors
+
+
+def test_missing_generated_artifact_allowlist_is_reported() -> None:
+    config_text = valid_config_text().replace(
+        f"""
+[allowlist]
+description = "Ignore generated local artifact directories already excluded from version control"
+paths = ['''{gitleaks_contract.EXPECTED_ARTIFACT_PATH_REGEX}''']
+""",
+        "",
+        1,
+    )
+    errors = gitleaks_contract.validate_gitleaks_contract(
+        config_text=config_text,
+        ci_workflow_text=valid_ci_workflow_text(),
+        firewall_workflow_text=valid_firewall_workflow_text(),
+    )
+    assert "gitleaks config must define exactly one ignored generated artifact directory allowlist" in errors
+
+
+def test_broad_generated_artifact_allowlist_is_reported() -> None:
+    config_text = valid_config_text().replace(
+        f"paths = ['''{gitleaks_contract.EXPECTED_ARTIFACT_PATH_REGEX}''']",
+        "paths = ['''.*''']",
+        1,
+    )
+    errors = gitleaks_contract.validate_gitleaks_contract(
+        config_text=config_text,
+        ci_workflow_text=valid_ci_workflow_text(),
+        firewall_workflow_text=valid_firewall_workflow_text(),
+    )
+    assert "gitleaks global allowlist must be scoped only to ignored generated artifact directories" in errors
 
 
 def test_broad_rule_path_allowlist_is_reported() -> None:
@@ -105,7 +153,8 @@ def test_broad_rule_path_allowlist_is_reported() -> None:
         ci_workflow_text=valid_ci_workflow_text(),
         firewall_workflow_text=valid_firewall_workflow_text(),
     )
-    assert "generic-api-key allowlist must be scoped only to public/portal-assets/portal.js" in errors
+    assert "generic-api-key allowlists must be scoped only to approved false-positive patterns" in errors
+    assert "generic-api-key allowlist must match only the generated auth failure false-positive branch" in errors
 
 
 def test_wrong_regex_target_is_reported() -> None:
@@ -119,7 +168,7 @@ def test_wrong_regex_target_is_reported() -> None:
         ci_workflow_text=valid_ci_workflow_text(),
         firewall_workflow_text=valid_firewall_workflow_text(),
     )
-    assert "generic-api-key allowlist must target the portal source line" in errors
+    assert "generic-api-key allowlists must target source lines" in errors
 
 
 def test_wrong_match_regex_is_reported() -> None:

--- a/tests/test_pipeline_corrections.py
+++ b/tests/test_pipeline_corrections.py
@@ -37,7 +37,11 @@ class TestStageAliasNormalization:
 
         assert "segmentation" in config.stages
         assert "segment" not in config.stages
-        assert config.segmentation == {"backend": "sam2", "model": {"size": "large"}}
+        assert config.segmentation == {
+            "backend": "sam2",
+            "cache_policy": "read_write",
+            "model": {"size": "large"},
+        }
 
     def test_segmentation_key_still_works(self):
         """Config dict with 'segmentation' key should still work as before."""
@@ -51,7 +55,7 @@ class TestStageAliasNormalization:
         config = SpatialAIPipeline._dict_to_config(data)
 
         assert "segmentation" in config.stages
-        assert config.segmentation == {"backend": "sam2"}
+        assert config.segmentation == {"backend": "sam2", "cache_policy": "read_write"}
 
     def test_segment_alias_preferred_over_empty_segmentation(self):
         """When only 'segment' is present, its data is used for segmentation."""


### PR DESCRIPTION
## Summary
- Objective: reduce materials segmentation and associated pathway latency without changing max-fidelity SAM2 behavior, APEX fail-closed semantics, response envelopes, routes, or selectors.
- Smallest safe change: add exact-result caches, model/text reuse, batched CLIP work, shared material/PBR intermediates, and additive timing metadata/configuration.

## Changes
- Added `--segmentation-cache {off,read_write}`, `EnhanceConfig.material_segmentation_cache_policy`, and `PipelineConfig.segmentation.cache_policy` with default `read_write` only for real segmentation runs.
- Added Lux Materials V3 and `spatial_ai` exact-match segmentation caches keyed by image identity, backend/model/checkpoint identity, generator kwargs, tiling, material classifier config, and schema version; cache reads validate checksum, shape, dtype, mask metadata, and schema before reuse.
- Batched CLIP material classification in Lux EfficientSAM classification and `spatial_ai.segmentation.material_classifier`, preserving stable output ordering and text/model reuse.
- Added timing metadata for segmentation, CLIP, Materials V3 planning/stats/pixel ops, mask serialization, materials backend generation, and PBR map generation.
- Reduced duplicate Materials V3 work by reusing canonical masks, bbox/coverage stats, and image gradients across planning and pixel operations.
- Optimized spatial PBR batch generation by sharing full-image heuristic intermediates per material hint while preserving per-mask outputs within existing tolerances.
- Hardened local validation by routing Python pre-commit hooks through the repo Python resolver and scoping gitleaks allowlists to ignored generated artifacts plus narrow existing false positives.
- Portal/CLI forwarding is additive only; selector, route, response envelope, and contract shapes remain stable.

## Validation
Proven green:
- `.venv/bin/pytest tests/materials/test_segmentation_backend.py::test_segment_materials_cache_hit_skips_backend tests/materials/test_segmentation_backend.py::test_efficientsam_clip_classification_batches_segments tests/materials/test_segmentation_backend.py::test_segment_materials_cache_key_invalidates_on_config_change tests/materials/test_segmentation_backend.py::test_segment_materials_corrupt_cache_recomputes tests/spatial_ai/segmentation/test_material_classifier.py::TestMaterialClassifierClassifyMasks::test_classify_masks_batches_clip_and_preserves_order tests/spatial_ai/materials/test_pbr_generator.py::TestPBRGenerator::test_batch_heuristic_shared_matches_per_segment_outputs tests/spatial_ai/orchestration/test_pipeline.py::TestPipelineConfig::test_segmentation_cache_policy_normalized tests/spatial_ai/orchestration/test_forward_port_contracts.py::test_pipeline_segmentation_cache_hit_skips_backend -v` -> 8 passed
- `.venv/bin/pytest tests/materials tests/spatial_ai/segmentation tests/spatial_ai/materials -m "not slow and not benchmark" -v` -> 390 passed, 10 skipped, 24 deselected
- `.venv/bin/pytest tests/spatial_ai/orchestration/test_pipeline.py tests/spatial_ai/orchestration/test_forward_port_contracts.py tests/test_pipeline_corrections.py -m "not slow and not benchmark" -v` -> 85 passed
- `.venv/bin/pytest tests/test_check_gitleaks_workflow_contract.py tests/structural/test_gitleaks_hook_registered.py tests/structural/test_pre_commit_runtime_contract.py -v` -> 15 passed
- `.venv/bin/python scripts/validation/check_gitleaks_workflow_contract.py` -> passed
- `.venv/bin/pre-commit run gitleaks --all-files -v` -> passed
- `.venv/bin/black --check --target-version py311 <touched Python files>` -> passed
- `make test-fast` -> 73 passed
- `make test-orchestrator-contract` -> 360 passed after sandbox escalation for local temp/cache access
- `make test-portal-contract` -> 254 passed
- `make validate-ci` -> passed
- `make pre-commit` -> passed
- `git diff --check` -> passed

Still failing:
- None observed in the required local validation path.

Not run:
- Manual SAM2 ML benchmark: `.venv/bin/pytest tests/spatial_ai/segmentation/test_sam2_backend_performance.py -m "benchmark and ml and slow" -v -s`; this requires the SAM2 checkpoint/runtime and remains outside PR gating.

## Risk
- Compatibility risk is bounded by additive config and metadata only; existing defaults keep segmentation disabled unless explicitly enabled by existing controls.
- Cache correctness risk is bounded by strict key construction and validation of schema, config, checksum, dtype, shape, and metadata before reuse; corrupt or mismatched entries recompute.
- Max-fidelity risk is bounded: SAM2 large/full-quality behavior and tiling defaults are preserved; no final segmentation downsampling or heuristic demotion was introduced.
- Operational risk is bounded to ignored generated artifacts and narrow known false-positive gitleaks allowlists; source/portal allowlist drift is covered by contract tests.
- Revert-safe: the change is localized to segmentation/materials/PBR paths plus validation hook policy, with additive interfaces and focused regression coverage.