### PR TITLE
fix(frontdoor): pin patched postcss

### DIFF
--- a/web/secure-landing/package-lock.json
+++ b/web/secure-landing/package-lock.json
@@ -1577,9 +1577,9 @@
       "license": "ISC"
     },
     "node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -1596,9 +1596,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"

--- a/web/secure-landing/package.json
+++ b/web/secure-landing/package.json
@@ -23,6 +23,9 @@
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
   },
+  "overrides": {
+    "postcss": "8.5.10"
+  },
   "devDependencies": {
     "esbuild": "^0.28.0"
   }


### PR DESCRIPTION
## Summary
- Resolves Dependabot alert #170 by forcing the frontdoor transitive PostCSS resolution into patched version 8.5.10.
- Keeps the change scoped to the secure landing npm manifest and lockfile.

## Changes
- Added an npm override for postcss 8.5.10 in web/secure-landing/package.json.
- Regenerated web/secure-landing/package-lock.json so Next resolves postcss 8.5.10 instead of 8.4.31.
- No route, selector, auth, API, or browser contract changes.

## Validation
Proven green:
- npm ls postcss --all
- npm audit --json
- make test-frontdoor-contract
- git diff --cached --check

Still failing:
- None observed.

Failure classification:
- No product, stale-test, or environment/tooling failures remain.

## Risk
- Compatibility risk is bounded to the npm override for a transitive CSS parser dependency used by the managed frontdoor build path.
- Revert-safe: removing the override and restoring the prior lock entry returns the previous dependency graph.
- Dependabot alert closure depends on this patch landing on main and GitHub rescanning web/secure-landing/package-lock.json.