### PR TITLE
feat(apex): add quality evaluation foundation

### DIFF
--- a/docs/depth_pipeline/DEPTH_BACKEND_BENCHMARK_PROTOCOL.md
+++ b/docs/depth_pipeline/DEPTH_BACKEND_BENCHMARK_PROTOCOL.md
@@ -1,0 +1,47 @@
+# Depth Backend Benchmark Protocol
+
+This benchmark governs the Depth Pro and DA3 comparison used by APEX quality work.
+
+## Roles
+
+- `da3_metric`: commercial-safe baseline.
+- `depth_pro`: research-quality reference, gated by the existing non-commercial and Apple Depth Pro research-license acknowledgements.
+
+Depth Pro is a quality yardstick, not a deployable default.
+
+## Command
+
+```bash
+.venv/bin/python tools/benchmark_depth_backends.py \
+  --evalset evalsets/picacho_apex \
+  --backends da3-metric,depth_pro \
+  --quality-tier apex \
+  --output-dir output/depth_backend_benchmark \
+  --emit-comparison-report on
+```
+
+Depth Pro remains `license_blocked` unless the operator explicitly passes:
+
+```bash
+--non-commercial-ok true \
+--accept-apple-depth-pro-research-license true
+```
+
+## Report
+
+The tool emits `depth_backend_comparison_report.json` with:
+
+- backend id
+- license tier
+- per-asset status
+- depth edge score
+- boundary halo risk
+- architectural plausibility
+- runtime
+- provenance, skip, and error fields
+
+The default command is offline-safe and records assets as `not_executed` until a live execution runner is wired in. Unit tests must not download models.
+
+## Promotion Rule
+
+Depth stack changes should show a report-backed improvement on the same evalset before becoming APEX defaults. A backend can be faster or easier to operate, but APEX promotion requires quality evidence against this benchmark.

--- a/docs/validation/APEX_VISUAL_QUALITY_PROTOCOL.md
+++ b/docs/validation/APEX_VISUAL_QUALITY_PROTOCOL.md
@@ -1,0 +1,48 @@
+# APEX Visual Quality Protocol
+
+This protocol makes APEX quality changes evidence-led before adding new visual effects.
+
+## Corpus
+
+The seed corpus lives in `evalsets/picacho_apex/evalset.json`. It stores referenced assets only:
+
+- `asset_ref`: source image path, relative to the repository root unless absolute
+- `sha256`: exact source image digest
+- `scene_type`: architectural scene category
+- `expected_materials`: materials expected to be present
+- `risk_zones`: boundaries or surfaces likely to show artifacts
+- `reject_if`: visual defects that disqualify a candidate
+- `manual_quality_score`: nullable human APEX score placeholder
+
+Large source images are not committed as eval artifacts. The runner reports missing assets as `missing_asset` and checksum drift as `checksum_mismatch`.
+
+## Report
+
+Run:
+
+```bash
+.venv/bin/python tools/run_apex_eval.py \
+  --evalset evalsets/picacho_apex \
+  --output-dir output/apex_eval \
+  --emit-report on
+```
+
+The output is `apex_eval_report.json`. It records corpus readiness and, when candidate outputs are supplied, visible-delta metrics:
+
+```bash
+.venv/bin/python tools/run_apex_eval.py \
+  --evalset evalsets/picacho_apex \
+  --output-dir output/apex_eval \
+  --candidate-output depth_pro_materials:picacho_pool_750_v2_enhanced=output/candidate_pool.tif
+```
+
+## Quality Trajectory
+
+APEX promotion requires a report-backed improvement path:
+
+- Depth Pro is the research-quality yardstick.
+- DA3 metric is the commercial-safe baseline.
+- Materials V3 pixel operations require calibrated material confidence.
+- APEX runs fail closed when masks exist, implemented operations exist, and zero Materials V3 pixel operations apply.
+
+The long-term APEX score should combine depth edge fidelity, material precision, pixel-op false positive risk, visible delta metrics, and manual APEX score. A missed enhancement is acceptable; a wrong material edit is not.

--- a/docs/validation/APEX_VISUAL_QUALITY_PROTOCOL.md
+++ b/docs/validation/APEX_VISUAL_QUALITY_PROTOCOL.md
@@ -4,17 +4,47 @@ This protocol makes APEX quality changes evidence-led before adding new visual e
 
 ## Corpus
 
-The seed corpus lives in `evalsets/picacho_apex/evalset.json`. It stores referenced assets only:
+The seed corpus lives in `evalsets/picacho_apex/evalset.json`. It stores referenced assets only. The current
+Picacho corpus is a smoke/readiness corpus, not canonical APEX quality evidence, because it does not include
+validated 16-bit source references.
 
 - `asset_ref`: source image path, relative to the repository root unless absolute
 - `sha256`: exact source image digest
+- `dataset_tier`: corpus class, such as `canonical_apex`, `smoke_or_readiness`, `synthetic_smoke`, or
+  `delivery_preview`
+- `asset_role`: asset class, such as `canonical_apex_reference`, `delivery_preview`, `synthetic_smoke`, or
+  `compatibility_fixture`
+- `reference_path`: canonical reference path when available; defaults to `asset_ref`
+- `delivery_path`: optional delivery derivative path
+- `canonical_bit_depth`: canonical reference bit depth when known
+- `canonical_format`: canonical reference format when known
+- `canonical_color_space`: documented source profile or color space
+- `evaluate_at_native_resolution`: whether final scoring must run at native reference resolution
+- `allow_downsampled_model_inference`: whether model-specific tensor inputs may be downsampled or normalized
+- `preserve_16bit_intermediates`: whether pixel operations must preserve 16-bit working data
+- `canonical_scoring_eligible`: explicit manifest assertion; the report still verifies the fields fail closed
+- `canonical_scoring_blocked_reason`: reason a ready asset is not canonical scoring evidence
 - `scene_type`: architectural scene category
 - `expected_materials`: materials expected to be present
 - `risk_zones`: boundaries or surfaces likely to show artifacts
 - `reject_if`: visual defects that disqualify a candidate
 - `manual_quality_score`: nullable human APEX score placeholder
 
-Large source images are not committed as eval artifacts. The runner reports missing assets as `missing_asset` and checksum drift as `checksum_mismatch`.
+Large source images are not committed as eval artifacts. The runner reports missing assets as `missing_asset` and
+checksum drift as `checksum_mismatch`.
+
+Canonical APEX scoring requires all of the following:
+
+- `dataset_tier=canonical_apex`
+- `asset_role=canonical_apex_reference`
+- `canonical_bit_depth >= 16`
+- `canonical_format` is `tif` or `tiff`
+- `evaluate_at_native_resolution=true`
+- `preserve_16bit_intermediates=true`
+
+8-bit JPEGs, delivery derivatives, renderings, and synthetic fixtures may be ready and useful for smoke coverage,
+UI/report checks, compatibility checks, or edge-case tests. They must not count as canonical APEX quality-scoring
+references.
 
 ## Report
 
@@ -27,7 +57,8 @@ Run:
   --emit-report on
 ```
 
-The output is `apex_eval_report.json`. It records corpus readiness and, when candidate outputs are supplied, visible-delta metrics:
+The output is `apex_eval_report.json`. It records corpus readiness and, when candidate outputs are supplied,
+visible-delta metrics:
 
 ```bash
 .venv/bin/python tools/run_apex_eval.py \
@@ -35,6 +66,46 @@ The output is `apex_eval_report.json`. It records corpus readiness and, when can
   --output-dir output/apex_eval \
   --candidate-output depth_pro_materials:picacho_pool_750_v2_enhanced=output/candidate_pool.tif
 ```
+
+Readiness and canonical scoring eligibility are separate report concepts. A ready asset can still be noncanonical:
+
+- `ready_asset_count`: assets with valid checksums
+- `canonical_scoring_eligible_count`: ready assets that pass the canonical 16-bit contract
+- `missing_asset_count`: unresolved referenced assets
+- `noncanonical_asset_count`: ready assets blocked from canonical APEX scoring
+- `canonical_scoring_blocked_reason_counts`: blocked reasons for ready noncanonical assets
+
+Each asset report records `asset_role`, `reference_bit_depth`, `reference_format`, `reference_color_space`,
+`canonical_scoring_eligible`, and `canonical_scoring_blocked_reason`.
+
+Depth benchmark reports also separate model input derivation from the evaluation target. Depth Pro, DA3, and other
+depth backends may consume normalized 8-bit or downsampled tensors, but benchmark cases must still record the
+16-bit source path as `evaluation_target` when one exists.
+
+## 16-Bit Working Path
+
+Canonical APEX scoring follows this path:
+
+```text
+16-bit source
+  -> model-specific normalized inference copy
+  -> masks / depth / material decisions
+  -> Materials V3 pixel operations against the 16-bit working image
+  -> final 16-bit QC metrics
+  -> 8-bit delivery derivative
+```
+
+Model inference resolution is not the same thing as evaluation or output resolution. A backend may run on a normalized
+copy, but Materials V3 edits and APEX quality metrics should operate on the 16-bit working image when a canonical
+reference exists.
+
+Expected artifacts for canonical APEX runs:
+
+- `*_materials_v3_master16.tif`
+- `*_v2_master16.tif`
+- `*_delivery_srgb8.jpg`
+- `*_diff_heatmap.png`
+- `*_mask_overlay.png`
 
 ## Quality Trajectory
 
@@ -45,4 +116,5 @@ APEX promotion requires a report-backed improvement path:
 - Materials V3 pixel operations require calibrated material confidence.
 - APEX runs fail closed when masks exist, implemented operations exist, and zero Materials V3 pixel operations apply.
 
-The long-term APEX score should combine depth edge fidelity, material precision, pixel-op false positive risk, visible delta metrics, and manual APEX score. A missed enhancement is acceptable; a wrong material edit is not.
+The long-term APEX score should combine depth edge fidelity, material precision, pixel-op false positive risk,
+visible delta metrics, and manual APEX score. A missed enhancement is acceptable; a wrong material edit is not.

--- a/evalsets/picacho_apex/evalset.json
+++ b/evalsets/picacho_apex/evalset.json
@@ -1,0 +1,67 @@
+{
+  "assets": [
+    {
+      "asset_id": "picacho_kitchen_750_v2_en",
+      "asset_ref": "input_images/750Picacho_Kitchen_jpg_ed31bfc4_v2_en.tiff",
+      "expected_materials": [
+        "glass",
+        "stone",
+        "wood"
+      ],
+      "manual_quality_score": null,
+      "notes": "Interior kitchen source for glass, stone, and wood finishing risk.",
+      "reject_if": [
+        "glass over-brightening",
+        "stone crunchiness",
+        "depth edge tearing"
+      ],
+      "risk_zones": [
+        "interior_glass_stone_wood",
+        "specular_reflection"
+      ],
+      "scene_type": "picacho_kitchen",
+      "sha256": "048410f39d34f676ee6f7a670f568dcbf3940bceb59f8b5c0071b2b1c205ff8a"
+    },
+    {
+      "asset_id": "picacho_pool_750_v2_enhanced",
+      "asset_ref": "input_images/750Picacho_Pool_jpg_58014ff8_v2_enhanced.tiff",
+      "expected_materials": [
+        "water",
+        "stone",
+        "foliage",
+        "glass",
+        "sky"
+      ],
+      "manual_quality_score": null,
+      "notes": "Exterior pool source for water, sky, foliage, glass, and stone boundary risk.",
+      "reject_if": [
+        "haloing",
+        "water plasticity",
+        "foliage oversaturation",
+        "glass over-brightening",
+        "depth edge tearing"
+      ],
+      "risk_zones": [
+        "sky_pool_boundary",
+        "water_glass_boundary",
+        "exterior_foliage_stone_glass"
+      ],
+      "scene_type": "picacho_pool",
+      "sha256": "4b641138578e1bea4bb3cf93e9f3d91853e7c631de48f20133362596773accb9"
+    }
+  ],
+  "description": "Referenced Picacho APEX visual-quality seed corpus for maximum-quality Depth Pro/DA3 and Materials V3 evaluation.",
+  "evalset_id": "picacho_apex",
+  "metadata": {
+    "asset_policy": "referenced_assets_only",
+    "quality_trajectory": [
+      "depth_edge_fidelity",
+      "material_precision",
+      "pixel_op_false_positive_risk",
+      "visible_delta_metrics",
+      "manual_apex_score"
+    ]
+  },
+  "schema_version": "apex_evalset.v1",
+  "version": "v1"
+}

--- a/evalsets/picacho_apex/evalset.json
+++ b/evalsets/picacho_apex/evalset.json
@@ -3,6 +3,15 @@
     {
       "asset_id": "picacho_kitchen_750_v2_en",
       "asset_ref": "input_images/750Picacho_Kitchen_jpg_ed31bfc4_v2_en.tiff",
+      "asset_role": "delivery_preview",
+      "allow_downsampled_model_inference": true,
+      "canonical_bit_depth": null,
+      "canonical_color_space": "derived_from_jpeg_source",
+      "canonical_format": "tiff",
+      "canonical_scoring_blocked_reason": "missing_16bit_reference",
+      "canonical_scoring_eligible": false,
+      "delivery_path": "input_images/750Picacho_Kitchen_jpg_ed31bfc4_v2_en.tiff",
+      "evaluate_at_native_resolution": false,
       "expected_materials": [
         "glass",
         "stone",
@@ -19,12 +28,23 @@
         "interior_glass_stone_wood",
         "specular_reflection"
       ],
+      "preserve_16bit_intermediates": false,
+      "reference_path": "input_images/750Picacho_Kitchen_jpg_ed31bfc4_v2_en.tiff",
       "scene_type": "picacho_kitchen",
       "sha256": "048410f39d34f676ee6f7a670f568dcbf3940bceb59f8b5c0071b2b1c205ff8a"
     },
     {
       "asset_id": "picacho_pool_750_v2_enhanced",
       "asset_ref": "input_images/750Picacho_Pool_jpg_58014ff8_v2_enhanced.tiff",
+      "asset_role": "delivery_preview",
+      "allow_downsampled_model_inference": true,
+      "canonical_bit_depth": null,
+      "canonical_color_space": "derived_from_jpeg_source",
+      "canonical_format": "tiff",
+      "canonical_scoring_blocked_reason": "missing_16bit_reference",
+      "canonical_scoring_eligible": false,
+      "delivery_path": "input_images/750Picacho_Pool_jpg_58014ff8_v2_enhanced.tiff",
+      "evaluate_at_native_resolution": false,
       "expected_materials": [
         "water",
         "stone",
@@ -46,14 +66,21 @@
         "water_glass_boundary",
         "exterior_foliage_stone_glass"
       ],
+      "preserve_16bit_intermediates": false,
+      "reference_path": "input_images/750Picacho_Pool_jpg_58014ff8_v2_enhanced.tiff",
       "scene_type": "picacho_pool",
       "sha256": "4b641138578e1bea4bb3cf93e9f3d91853e7c631de48f20133362596773accb9"
     }
   ],
+  "canonical_bit_depth": null,
+  "canonical_color_space": null,
+  "canonical_format": null,
   "description": "Referenced Picacho APEX visual-quality seed corpus for maximum-quality Depth Pro/DA3 and Materials V3 evaluation.",
+  "dataset_tier": "smoke_or_readiness",
   "evalset_id": "picacho_apex",
   "metadata": {
     "asset_policy": "referenced_assets_only",
+    "canonical_scoring_blocked_reason": "missing_16bit_reference",
     "quality_trajectory": [
       "depth_edge_fidelity",
       "material_precision",

--- a/src/transformation_portal/evals/__init__.py
+++ b/src/transformation_portal/evals/__init__.py
@@ -28,6 +28,14 @@ from transformation_portal.evals.apex_llava_integration import (
     create_production_harness,
     create_quality_max_harness,
 )
+from transformation_portal.evals.apex_visual import (
+    ApexEvalAsset,
+    ApexEvalSet,
+    DepthBackendRunResult,
+    build_apex_eval_report,
+    build_depth_backend_benchmark_report,
+    load_apex_evalset,
+)
 from transformation_portal.evals.benchmark_suite import (
     BenchmarkResult,
     BenchmarkSuite,
@@ -63,6 +71,13 @@ __all__ = [
     "create_llava_backend",
     "create_production_harness",
     "create_quality_max_harness",
+    # APEX visual eval corpus
+    "ApexEvalAsset",
+    "ApexEvalSet",
+    "DepthBackendRunResult",
+    "build_apex_eval_report",
+    "build_depth_backend_benchmark_report",
+    "load_apex_evalset",
     # Benchmark suite
     "BenchmarkResult",
     "BenchmarkSuite",

--- a/src/transformation_portal/evals/apex_visual.py
+++ b/src/transformation_portal/evals/apex_visual.py
@@ -93,15 +93,24 @@ def _bool_with_default(value: Any, default: bool) -> bool:
     return bool(value)
 
 
-def _normalized_format(asset: "ApexEvalAsset") -> str | None:
-    explicit = _normalize_optional_str(asset.canonical_format)
-    if explicit:
-        return explicit.lower().lstrip(".")
-    path_hint = asset.reference_path or asset.asset_ref
-    suffix = Path(path_hint).suffix.lower().lstrip(".")
-    if suffix in {"jpg", "jpeg"}:
+def _normalize_image_format(value: Any) -> str | None:
+    normalized = _normalize_optional_str(value)
+    if normalized is None:
+        return None
+    normalized = normalized.lower().lstrip(".")
+    if normalized == "jpg":
         return "jpeg"
-    return suffix or None
+    if normalized == "tif":
+        return "tiff"
+    return normalized
+
+
+def _normalized_format(asset: "ApexEvalAsset") -> str | None:
+    explicit = _normalize_image_format(asset.canonical_format)
+    if explicit:
+        return explicit
+    path_hint = asset.reference_path or asset.asset_ref
+    return _normalize_image_format(Path(path_hint).suffix)
 
 
 def _reference_bit_depth(asset: "ApexEvalAsset") -> int | None:
@@ -110,6 +119,85 @@ def _reference_bit_depth(asset: "ApexEvalAsset") -> int | None:
     if _normalized_format(asset) == "jpeg":
         return 8
     return None
+
+
+def _bit_depth_from_dtype(dtype: Any) -> int | None:
+    try:
+        np_dtype = np.dtype(dtype)
+    except TypeError:
+        return None
+    if np_dtype.kind == "b":
+        return 1
+    if np_dtype.kind in {"u", "i", "f"}:
+        return int(np_dtype.itemsize * 8)
+    return None
+
+
+def _bit_depth_from_pil_mode(mode: str | None) -> int | None:
+    if mode in {"1"}:
+        return 1
+    if mode in {"L", "LA", "P", "RGB", "RGBA", "CMYK", "YCbCr"}:
+        return 8
+    if mode in {"I;16", "I;16B", "I;16L"}:
+        return 16
+    if mode in {"I", "F"}:
+        return 32
+    return None
+
+
+def _tiff_bit_depth(path: Path) -> int | None:
+    try:
+        tifffile = importlib.import_module("tifffile")
+        with tifffile.TiffFile(path) as tiff:
+            if not tiff.pages:
+                return None
+            page = tiff.pages[0]
+            dtype_bits = _bit_depth_from_dtype(getattr(page, "dtype", None))
+            if dtype_bits is not None:
+                return dtype_bits
+            bits_per_sample = getattr(page, "bitspersample", None)
+            if isinstance(bits_per_sample, (tuple, list)):
+                return int(max(bits_per_sample)) if bits_per_sample else None
+            if bits_per_sample is not None:
+                return int(bits_per_sample)
+    except (ImportError, OSError, ValueError, TypeError, AttributeError, IndexError):
+        return None
+    return None
+
+
+def _reference_image_metadata(path: Path) -> dict[str, Any]:
+    metadata: dict[str, Any] = {
+        "detected_reference_format": None,
+        "detected_reference_bit_depth": None,
+        "observable_reference_metadata_status": "missing_reference_asset",
+        "observable_reference_metadata_error": None,
+    }
+    if not path.is_file():
+        return metadata
+
+    from PIL import Image, UnidentifiedImageError
+
+    try:
+        with Image.open(path) as image:
+            detected_format = _normalize_image_format(image.format or path.suffix)
+            detected_bit_depth = _bit_depth_from_pil_mode(image.mode)
+    except (OSError, ValueError, UnidentifiedImageError) as exc:
+        metadata["observable_reference_metadata_status"] = "unreadable_reference_image"
+        metadata["observable_reference_metadata_error"] = str(exc)
+        return metadata
+
+    if detected_format == "tiff":
+        tiff_bit_depth = _tiff_bit_depth(path)
+        detected_bit_depth = tiff_bit_depth if tiff_bit_depth is not None else detected_bit_depth
+    if detected_format == "jpeg" and detected_bit_depth is None:
+        detected_bit_depth = 8
+
+    metadata["detected_reference_format"] = detected_format
+    metadata["detected_reference_bit_depth"] = detected_bit_depth
+    metadata["observable_reference_metadata_status"] = (
+        "ok" if detected_format is not None and detected_bit_depth is not None else "missing_observable_reference_metadata"
+    )
+    return metadata
 
 
 @dataclass(frozen=True)
@@ -311,9 +399,17 @@ def _canonical_scoring_status(
     asset: ApexEvalAsset,
     *,
     asset_ready: bool,
+    reference_metadata: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
-    reference_format = _normalized_format(asset)
-    reference_bit_depth = _reference_bit_depth(asset)
+    reference_metadata = reference_metadata or {}
+    declared_format = _normalized_format(asset)
+    declared_bit_depth = _reference_bit_depth(asset)
+    detected_format = _normalize_image_format(reference_metadata.get("detected_reference_format"))
+    detected_bit_depth = _optional_int(reference_metadata.get("detected_reference_bit_depth"))
+    metadata_status = str(reference_metadata.get("observable_reference_metadata_status") or "not_checked")
+    metadata_error = _normalize_optional_str(reference_metadata.get("observable_reference_metadata_error"))
+    reference_format = detected_format or declared_format
+    reference_bit_depth = detected_bit_depth if detected_bit_depth is not None else declared_bit_depth
     eligible = True
     blocked_reason: str | None = None
 
@@ -326,12 +422,21 @@ def _canonical_scoring_status(
     elif asset.asset_role != CANONICAL_APEX_ASSET_ROLE:
         eligible = False
         blocked_reason = "asset_role_not_canonical"
+    elif metadata_status == "missing_reference_asset":
+        eligible = False
+        blocked_reason = "missing_reference_asset"
+    elif metadata_status != "ok":
+        eligible = False
+        blocked_reason = "missing_observable_reference_metadata"
+    elif declared_format is not None and reference_format != declared_format:
+        eligible = False
+        blocked_reason = "reference_format_mismatch"
     elif reference_bit_depth is None:
         eligible = False
         blocked_reason = "missing_16bit_reference"
     elif reference_bit_depth < 16:
         eligible = False
-        blocked_reason = "non_16bit_reference"
+        blocked_reason = "reference_bit_depth_below_16"
     elif reference_format not in CANONICAL_REFERENCE_FORMATS:
         eligible = False
         blocked_reason = "non_tiff_reference"
@@ -354,6 +459,12 @@ def _canonical_scoring_status(
         "delivery_path": asset.delivery_path,
         "reference_bit_depth": reference_bit_depth,
         "reference_format": reference_format,
+        "declared_reference_bit_depth": declared_bit_depth,
+        "declared_reference_format": declared_format,
+        "detected_reference_bit_depth": detected_bit_depth,
+        "detected_reference_format": detected_format,
+        "observable_reference_metadata_status": metadata_status,
+        "observable_reference_metadata_error": metadata_error,
         "reference_color_space": asset.canonical_color_space,
         "evaluate_at_native_resolution": asset.evaluate_at_native_resolution,
         "allow_downsampled_model_inference": asset.allow_downsampled_model_inference,
@@ -366,7 +477,13 @@ def _canonical_scoring_status(
 def canonical_scoring_status(evalset: ApexEvalSet, asset: ApexEvalAsset) -> dict[str, Any]:
     """Return canonical APEX quality scoring eligibility for an eval asset."""
     path = evalset.resolve_asset_path(asset)
-    return _canonical_scoring_status(evalset, asset, asset_ready=path.is_file() and sha256_file(path) == asset.sha256)
+    reference_metadata = _reference_image_metadata(evalset.resolve_reference_path(asset)) if path.is_file() else None
+    return _canonical_scoring_status(
+        evalset,
+        asset,
+        asset_ready=path.is_file() and sha256_file(path) == asset.sha256,
+        reference_metadata=reference_metadata,
+    )
 
 
 def asset_status(evalset: ApexEvalSet, asset: ApexEvalAsset) -> dict[str, Any]:
@@ -384,6 +501,7 @@ def asset_status(evalset: ApexEvalSet, asset: ApexEvalAsset) -> dict[str, Any]:
 
     actual_sha = sha256_file(path)
     status = "ready" if actual_sha == asset.sha256 else "checksum_mismatch"
+    reference_metadata = _reference_image_metadata(evalset.resolve_reference_path(asset))
     return {
         "asset_id": asset.asset_id,
         "status": status,
@@ -392,7 +510,12 @@ def asset_status(evalset: ApexEvalSet, asset: ApexEvalAsset) -> dict[str, Any]:
         "expected_sha256": asset.sha256,
         "actual_sha256": actual_sha,
         "size_bytes": int(path.stat().st_size),
-        **_canonical_scoring_status(evalset, asset, asset_ready=status == "ready"),
+        **_canonical_scoring_status(
+            evalset,
+            asset,
+            asset_ready=status == "ready",
+            reference_metadata=reference_metadata,
+        ),
     }
 
 
@@ -500,6 +623,12 @@ def build_apex_eval_report(
             "delivery_path": status["delivery_path"],
             "reference_bit_depth": status["reference_bit_depth"],
             "reference_format": status["reference_format"],
+            "declared_reference_bit_depth": status["declared_reference_bit_depth"],
+            "declared_reference_format": status["declared_reference_format"],
+            "detected_reference_bit_depth": status["detected_reference_bit_depth"],
+            "detected_reference_format": status["detected_reference_format"],
+            "observable_reference_metadata_status": status["observable_reference_metadata_status"],
+            "observable_reference_metadata_error": status["observable_reference_metadata_error"],
             "reference_color_space": status["reference_color_space"],
             "evaluate_at_native_resolution": status["evaluate_at_native_resolution"],
             "allow_downsampled_model_inference": status["allow_downsampled_model_inference"],
@@ -651,11 +780,21 @@ def _architectural_plausibility(depth_map: np.ndarray | None) -> float | None:
     return float(np.clip(spread * (1.0 - saturation), 0.0, 1.0))
 
 
-def _depth_case_io_metadata(evalset: ApexEvalSet, asset: ApexEvalAsset) -> tuple[dict[str, Any], dict[str, Any]]:
+def _depth_case_io_metadata(
+    evalset: ApexEvalSet,
+    asset: ApexEvalAsset,
+    source_status: Mapping[str, Any] | None = None,
+) -> tuple[dict[str, Any], dict[str, Any]]:
     reference_path = asset.reference_path or asset.asset_ref
     resolved_reference = str(evalset.resolve_reference_path(asset))
-    reference_bit_depth = _reference_bit_depth(asset)
-    reference_format = _normalized_format(asset)
+    reference_bit_depth = (
+        _optional_int(source_status.get("reference_bit_depth")) if source_status is not None else _reference_bit_depth(asset)
+    )
+    reference_format = (
+        _normalize_image_format(source_status.get("reference_format"))
+        if source_status is not None
+        else _normalized_format(asset)
+    )
     downsampled = bool(asset.allow_downsampled_model_inference)
     model_input = {
         "derived_from": reference_path,
@@ -724,7 +863,7 @@ def build_depth_backend_benchmark_report(
         runtimes: list[float] = []
         for asset in evalset.assets:
             source_status = asset_status(evalset, asset)
-            model_input, evaluation_target = _depth_case_io_metadata(evalset, asset)
+            model_input, evaluation_target = _depth_case_io_metadata(evalset, asset, source_status)
             if source_status["status"] != "ready":
                 backend_report["assets"].append(
                     {

--- a/src/transformation_portal/evals/apex_visual.py
+++ b/src/transformation_portal/evals/apex_visual.py
@@ -1,0 +1,504 @@
+"""APEX visual quality evalset and benchmark helpers.
+
+The helpers in this module are intentionally offline-safe. They validate the
+quality corpus, emit deterministic readiness reports, and provide a seam for
+benchmark execution without forcing model downloads in unit tests.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Iterable, Mapping, Sequence
+
+import numpy as np
+
+from transformation_portal.evals.metrics import lpips_score, ssim
+from transformation_portal.ingest.canonical_json import dump_json
+from transformation_portal.lux_depth_v3.model_registry import MODEL_REGISTRY, UsageClass
+
+APEX_EVALSET_SCHEMA_VERSION = "apex_evalset.v1"
+APEX_EVAL_REPORT_VERSION = "apex_eval_report.v1"
+DEPTH_BACKEND_BENCHMARK_REPORT_VERSION = "depth_backend_benchmark_report.v1"
+DEPTH_PRO_BACKENDS = {"depth_pro"}
+
+
+@dataclass(frozen=True)
+class ApexEvalAsset:
+    """Single source image entry in an APEX visual evalset."""
+
+    asset_id: str
+    asset_ref: str
+    sha256: str
+    scene_type: str
+    expected_materials: tuple[str, ...]
+    risk_zones: tuple[str, ...]
+    reject_if: tuple[str, ...]
+    manual_quality_score: float | None = None
+    notes: str | None = None
+
+    @classmethod
+    def from_mapping(cls, payload: Mapping[str, Any]) -> "ApexEvalAsset":
+        required = ("asset_id", "asset_ref", "sha256", "scene_type")
+        missing = [key for key in required if not str(payload.get(key, "")).strip()]
+        if missing:
+            raise ValueError(f"APEX eval asset missing required fields: {', '.join(missing)}")
+
+        manual_score = payload.get("manual_quality_score")
+        if manual_score is not None:
+            manual_score = float(manual_score)
+            if not 0.0 <= manual_score <= 1.0:
+                raise ValueError("manual_quality_score must be null or in [0, 1]")
+
+        return cls(
+            asset_id=str(payload["asset_id"]),
+            asset_ref=str(payload["asset_ref"]),
+            sha256=str(payload["sha256"]).lower(),
+            scene_type=str(payload["scene_type"]),
+            expected_materials=tuple(str(item) for item in payload.get("expected_materials", [])),
+            risk_zones=tuple(str(item) for item in payload.get("risk_zones", [])),
+            reject_if=tuple(str(item) for item in payload.get("reject_if", [])),
+            manual_quality_score=manual_score,
+            notes=(str(payload["notes"]) if payload.get("notes") is not None else None),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "asset_id": self.asset_id,
+            "asset_ref": self.asset_ref,
+            "sha256": self.sha256,
+            "scene_type": self.scene_type,
+            "expected_materials": list(self.expected_materials),
+            "risk_zones": list(self.risk_zones),
+            "reject_if": list(self.reject_if),
+            "manual_quality_score": self.manual_quality_score,
+            "notes": self.notes,
+        }
+
+
+@dataclass(frozen=True)
+class ApexEvalSet:
+    """Loaded APEX visual evalset."""
+
+    evalset_id: str
+    version: str
+    description: str
+    assets: tuple[ApexEvalAsset, ...]
+    source_path: Path
+    repo_root: Path
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def resolve_asset_path(self, asset: ApexEvalAsset) -> Path:
+        path = Path(asset.asset_ref)
+        if path.is_absolute():
+            return path
+        return self.repo_root / path
+
+
+@dataclass(frozen=True)
+class DepthBackendRunResult:
+    """One backend execution result consumed by benchmark reporting."""
+
+    backend: str
+    asset_id: str
+    status: str
+    runtime_ms: float | None = None
+    depth_map: np.ndarray | None = None
+    depth_path: str | None = None
+    provenance: dict[str, Any] = field(default_factory=dict)
+    error: str | None = None
+
+
+DepthBackendRunner = Callable[[str, ApexEvalAsset, Path, str], DepthBackendRunResult]
+
+
+def repository_root(start: Path | None = None) -> Path:
+    """Resolve the repository root from this package location or a caller path."""
+    current = (start or Path(__file__)).resolve()
+    for candidate in (current, *current.parents):
+        if (candidate / "pyproject.toml").is_file() and (candidate / "src").is_dir():
+            return candidate
+    return Path.cwd().resolve()
+
+
+def load_apex_evalset(evalset_path: Path | str, *, repo_root: Path | None = None) -> ApexEvalSet:
+    """Load an APEX evalset JSON file or directory containing ``evalset.json``."""
+    root = (repo_root or repository_root()).resolve()
+    path = Path(evalset_path)
+    if not path.is_absolute():
+        path = root / path
+    if path.is_dir():
+        path = path / "evalset.json"
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if payload.get("schema_version") != APEX_EVALSET_SCHEMA_VERSION:
+        raise ValueError(
+            f"Unsupported APEX evalset schema: {payload.get('schema_version')!r}; " f"expected {APEX_EVALSET_SCHEMA_VERSION!r}"
+        )
+    assets_raw = payload.get("assets")
+    if not isinstance(assets_raw, list) or not assets_raw:
+        raise ValueError("APEX evalset must contain a non-empty assets list")
+    assets = tuple(ApexEvalAsset.from_mapping(item) for item in assets_raw)
+    return ApexEvalSet(
+        evalset_id=str(payload.get("evalset_id") or path.parent.name),
+        version=str(payload.get("version") or "v1"),
+        description=str(payload.get("description") or ""),
+        assets=assets,
+        source_path=path,
+        repo_root=root,
+        metadata=dict(payload.get("metadata") or {}),
+    )
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def asset_status(evalset: ApexEvalSet, asset: ApexEvalAsset) -> dict[str, Any]:
+    path = evalset.resolve_asset_path(asset)
+    if not path.is_file():
+        return {
+            "asset_id": asset.asset_id,
+            "status": "missing_asset",
+            "asset_ref": asset.asset_ref,
+            "resolved_path": str(path),
+            "expected_sha256": asset.sha256,
+            "actual_sha256": None,
+        }
+
+    actual_sha = sha256_file(path)
+    status = "ready" if actual_sha == asset.sha256 else "checksum_mismatch"
+    return {
+        "asset_id": asset.asset_id,
+        "status": status,
+        "asset_ref": asset.asset_ref,
+        "resolved_path": str(path),
+        "expected_sha256": asset.sha256,
+        "actual_sha256": actual_sha,
+        "size_bytes": int(path.stat().st_size),
+    }
+
+
+def visible_delta_metrics(reference: Path, candidate: Path) -> dict[str, Any]:
+    """Compute deterministic visible-delta metrics for two rendered images."""
+    from PIL import Image
+
+    ref = np.asarray(Image.open(reference).convert("RGB"), dtype=np.float32) / 255.0
+    cand = np.asarray(Image.open(candidate).convert("RGB"), dtype=np.float32) / 255.0
+    if ref.shape != cand.shape:
+        return {
+            "status": "shape_mismatch",
+            "reference_shape": list(ref.shape),
+            "candidate_shape": list(cand.shape),
+            "ssim": None,
+            "lpips": None,
+            "delta_e_proxy_mean_abs": None,
+            "delta_e_proxy_max_abs": None,
+        }
+
+    abs_delta = np.abs(cand - ref)
+    try:
+        ssim_value: float | None = float(ssim(cand, ref))
+    except Exception:
+        ssim_value = None
+    try:
+        lpips_value = float(lpips_score(cand, ref))
+        if not math.isfinite(lpips_value):
+            lpips_value = None
+    except Exception:
+        lpips_value = None
+    return {
+        "status": "ok",
+        "ssim": ssim_value,
+        "lpips": lpips_value,
+        "delta_e_proxy_mean_abs": float(abs_delta.mean()),
+        "delta_e_proxy_max_abs": float(abs_delta.max()),
+    }
+
+
+def build_apex_eval_report(
+    evalset_path: Path | str,
+    *,
+    output_dir: Path | str,
+    candidate_outputs: Mapping[str, Mapping[str, Path | str]] | None = None,
+    repo_root: Path | None = None,
+) -> dict[str, Any]:
+    """Build and persist an APEX eval report.
+
+    ``candidate_outputs`` maps candidate name to ``asset_id -> output path``.
+    When no candidate output is provided, the report still validates corpus
+    readiness and leaves visual-delta metrics unset.
+    """
+    evalset = load_apex_evalset(evalset_path, repo_root=repo_root)
+    output_root = Path(output_dir)
+    if not output_root.is_absolute():
+        output_root = evalset.repo_root / output_root
+    output_root.mkdir(parents=True, exist_ok=True)
+
+    candidate_outputs = candidate_outputs or {}
+    assets_report = []
+    for asset in evalset.assets:
+        status = asset_status(evalset, asset)
+        candidates = []
+        for candidate_name, outputs in sorted(candidate_outputs.items()):
+            output_value = outputs.get(asset.asset_id)
+            if output_value is None:
+                candidates.append(
+                    {
+                        "candidate": candidate_name,
+                        "status": "missing_candidate_output",
+                        "metrics": {},
+                    }
+                )
+                continue
+            candidate_path = Path(output_value)
+            if not candidate_path.is_absolute():
+                candidate_path = evalset.repo_root / candidate_path
+            if status["status"] != "ready":
+                candidates.append(
+                    {
+                        "candidate": candidate_name,
+                        "status": "source_not_ready",
+                        "metrics": {},
+                    }
+                )
+                continue
+            if not candidate_path.is_file():
+                candidates.append(
+                    {
+                        "candidate": candidate_name,
+                        "status": "missing_candidate_output",
+                        "output_path": str(candidate_path),
+                        "metrics": {},
+                    }
+                )
+                continue
+            metrics = visible_delta_metrics(Path(status["resolved_path"]), candidate_path)
+            candidates.append(
+                {
+                    "candidate": candidate_name,
+                    "status": metrics.pop("status"),
+                    "output_path": str(candidate_path),
+                    "metrics": {
+                        "depth_edge_fidelity": None,
+                        "material_precision": None,
+                        "pixel_op_false_positive_risk": None,
+                        **metrics,
+                    },
+                }
+            )
+
+        assets_report.append(
+            {
+                **asset.to_dict(),
+                "asset_status": status,
+                "candidates": candidates,
+            }
+        )
+
+    ready_count = sum(1 for item in assets_report if item["asset_status"]["status"] == "ready")
+    report = {
+        "schema_version": APEX_EVAL_REPORT_VERSION,
+        "evalset": {
+            "evalset_id": evalset.evalset_id,
+            "version": evalset.version,
+            "description": evalset.description,
+            "source_path": str(evalset.source_path),
+            "asset_count": len(evalset.assets),
+            "ready_asset_count": ready_count,
+        },
+        "quality_trajectory": {
+            "depth_pro_role": "research_quality_yardstick",
+            "da3_metric_role": "commercial_safe_baseline",
+            "pixel_op_authority": "calibrated_material_confidence_required",
+            "apex_noop_policy": "fail_closed_when_masks_and_implemented_ops_apply_zero_operations",
+        },
+        "assets": assets_report,
+    }
+    report_path = output_root / "apex_eval_report.json"
+    with report_path.open("w", encoding="utf-8") as handle:
+        dump_json(report, handle, sort_keys=True, indent=2, ensure_ascii=False, allow_nan=False)
+        handle.write("\n")
+    return report
+
+
+def _backend_license_tier(backend: str) -> str:
+    normalized = backend.strip().lower().replace("-", "_")
+    if normalized in DEPTH_PRO_BACKENDS:
+        return "research_only"
+    spec = MODEL_REGISTRY.get(normalized)
+    if spec and spec.usage_class == UsageClass.COMMERCIAL_OK:
+        return "commercial_ok"
+    if spec and spec.usage_class == UsageClass.NON_COMMERCIAL_ONLY:
+        return "research_only"
+    return "unknown"
+
+
+def _depth_edge_score(depth_map: np.ndarray | None) -> float | None:
+    if depth_map is None:
+        return None
+    arr = np.asarray(depth_map, dtype=np.float32)
+    if arr.ndim != 2 or arr.size == 0:
+        return None
+    finite = np.isfinite(arr)
+    if not finite.any():
+        return 0.0
+    arr = np.nan_to_num(arr, nan=0.0, posinf=0.0, neginf=0.0)
+    gy, gx = np.gradient(arr)
+    grad = np.sqrt(gx * gx + gy * gy)
+    p95 = float(np.percentile(grad, 95))
+    return float(np.clip(p95, 0.0, 1.0))
+
+
+def _architectural_plausibility(depth_map: np.ndarray | None) -> float | None:
+    if depth_map is None:
+        return None
+    arr = np.asarray(depth_map, dtype=np.float32)
+    finite = arr[np.isfinite(arr)]
+    if finite.size == 0:
+        return 0.0
+    spread = float(np.percentile(finite, 95) - np.percentile(finite, 5))
+    saturation = float(np.mean((finite <= 1e-4) | (finite >= 1.0 - 1e-4)))
+    return float(np.clip(spread * (1.0 - saturation), 0.0, 1.0))
+
+
+def build_depth_backend_benchmark_report(
+    evalset_path: Path | str,
+    *,
+    backends: Sequence[str],
+    quality_tier: str,
+    output_dir: Path | str,
+    non_commercial_ok: bool = False,
+    accept_depth_pro_license: bool = False,
+    runner: DepthBackendRunner | None = None,
+    repo_root: Path | None = None,
+) -> dict[str, Any]:
+    """Build a governed depth backend comparison report."""
+    evalset = load_apex_evalset(evalset_path, repo_root=repo_root)
+    output_root = Path(output_dir)
+    if not output_root.is_absolute():
+        output_root = evalset.repo_root / output_root
+    output_root.mkdir(parents=True, exist_ok=True)
+
+    backend_reports: list[dict[str, Any]] = []
+    for backend in backends:
+        normalized_backend = backend.strip().lower().replace("-", "_")
+        license_tier = _backend_license_tier(normalized_backend)
+        backend_report = {
+            "backend": normalized_backend,
+            "license_tier": license_tier,
+            "quality_tier": quality_tier,
+            "status": "ready",
+            "assets": [],
+        }
+        if normalized_backend in DEPTH_PRO_BACKENDS and not (non_commercial_ok and accept_depth_pro_license):
+            backend_report["status"] = "license_blocked"
+            backend_report["license_requirements"] = {
+                "non_commercial_ok": bool(non_commercial_ok),
+                "accept_apple_depth_pro_research_license": bool(accept_depth_pro_license),
+            }
+            backend_reports.append(backend_report)
+            continue
+
+        asset_scores: list[float] = []
+        runtimes: list[float] = []
+        for asset in evalset.assets:
+            source_status = asset_status(evalset, asset)
+            if source_status["status"] != "ready":
+                backend_report["assets"].append(
+                    {
+                        "asset_id": asset.asset_id,
+                        "status": source_status["status"],
+                        "source": source_status,
+                    }
+                )
+                continue
+            if runner is None:
+                backend_report["assets"].append(
+                    {
+                        "asset_id": asset.asset_id,
+                        "status": "not_executed",
+                        "source": source_status,
+                        "metrics": {
+                            "depth_edge_score": None,
+                            "boundary_halo_risk": None,
+                            "architectural_plausibility": None,
+                            "runtime_ms": None,
+                        },
+                    }
+                )
+                continue
+            started = time.perf_counter()
+            run_result = runner(normalized_backend, asset, output_root, quality_tier)
+            runtime_ms = (
+                float(run_result.runtime_ms)
+                if run_result.runtime_ms is not None
+                else round((time.perf_counter() - started) * 1000.0, 3)
+            )
+            edge_score = _depth_edge_score(run_result.depth_map)
+            plausibility = _architectural_plausibility(run_result.depth_map)
+            if edge_score is not None:
+                asset_scores.append(edge_score)
+            runtimes.append(runtime_ms)
+            backend_report["assets"].append(
+                {
+                    "asset_id": asset.asset_id,
+                    "status": run_result.status,
+                    "source": source_status,
+                    "depth_path": run_result.depth_path,
+                    "provenance": run_result.provenance,
+                    "error": run_result.error,
+                    "metrics": {
+                        "depth_edge_score": edge_score,
+                        "boundary_halo_risk": None if edge_score is None else float(np.clip(1.0 - edge_score, 0.0, 1.0)),
+                        "architectural_plausibility": plausibility,
+                        "runtime_ms": runtime_ms,
+                    },
+                }
+            )
+        if asset_scores:
+            backend_report["depth_edge_score"] = float(np.mean(asset_scores))
+            backend_report["boundary_halo_risk"] = float(np.clip(1.0 - backend_report["depth_edge_score"], 0.0, 1.0))
+        else:
+            backend_report["depth_edge_score"] = None
+            backend_report["boundary_halo_risk"] = None
+        backend_report["runtime_ms"] = float(np.mean(runtimes)) if runtimes else None
+        backend_reports.append(backend_report)
+
+    report = {
+        "schema_version": DEPTH_BACKEND_BENCHMARK_REPORT_VERSION,
+        "evalset": {
+            "evalset_id": evalset.evalset_id,
+            "version": evalset.version,
+            "asset_count": len(evalset.assets),
+            "source_path": str(evalset.source_path),
+        },
+        "quality_tier": quality_tier,
+        "backends": backend_reports,
+    }
+    report_path = output_root / "depth_backend_comparison_report.json"
+    with report_path.open("w", encoding="utf-8") as handle:
+        dump_json(report, handle, sort_keys=True, indent=2, ensure_ascii=False, allow_nan=False)
+        handle.write("\n")
+    return report
+
+
+def parse_candidate_outputs(values: Iterable[str]) -> dict[str, dict[str, Path]]:
+    """Parse ``candidate:asset_id=path`` CLI values."""
+    parsed: dict[str, dict[str, Path]] = {}
+    for value in values:
+        candidate_part, sep, output_path = value.partition("=")
+        if sep != "=":
+            raise ValueError(f"Invalid candidate output {value!r}; expected candidate:asset_id=path")
+        candidate, sep, asset_id = candidate_part.partition(":")
+        if sep != ":" or not candidate or not asset_id:
+            raise ValueError(f"Invalid candidate output {value!r}; expected candidate:asset_id=path")
+        parsed.setdefault(candidate, {})[asset_id] = Path(output_path)
+    return parsed

--- a/src/transformation_portal/evals/apex_visual.py
+++ b/src/transformation_portal/evals/apex_visual.py
@@ -26,6 +26,28 @@ APEX_EVALSET_SCHEMA_VERSION = "apex_evalset.v1"
 APEX_EVAL_REPORT_VERSION = "apex_eval_report.v1"
 DEPTH_BACKEND_BENCHMARK_REPORT_VERSION = "depth_backend_benchmark_report.v1"
 DEPTH_PRO_BACKENDS = {"depth_pro"}
+CANONICAL_APEX_DATASET_TIER = "canonical_apex"
+DEFAULT_DATASET_TIER = "smoke_or_readiness"
+CANONICAL_APEX_ASSET_ROLE = "canonical_apex_reference"
+DEFAULT_ASSET_ROLE = "compatibility_fixture"
+DATASET_TIERS = frozenset(
+    {
+        CANONICAL_APEX_DATASET_TIER,
+        DEFAULT_DATASET_TIER,
+        "delivery_preview",
+        "synthetic_smoke",
+        "compatibility_fixture",
+    }
+)
+ASSET_ROLES = frozenset(
+    {
+        CANONICAL_APEX_ASSET_ROLE,
+        "delivery_preview",
+        "synthetic_smoke",
+        "compatibility_fixture",
+    }
+)
+CANONICAL_REFERENCE_FORMATS = frozenset({"tif", "tiff"})
 
 
 def _lpips_available() -> bool:
@@ -36,6 +58,58 @@ def _lpips_available() -> bool:
     except ImportError:
         return False
     return True
+
+
+def _normalize_optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    normalized = str(value).strip()
+    return normalized or None
+
+
+def _optional_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    return int(value)
+
+
+def _optional_bool(value: Any) -> bool | None:
+    if value is None:
+        return None
+    return _bool_with_default(value, False)
+
+
+def _bool_with_default(value: Any, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+    return bool(value)
+
+
+def _normalized_format(asset: "ApexEvalAsset") -> str | None:
+    explicit = _normalize_optional_str(asset.canonical_format)
+    if explicit:
+        return explicit.lower().lstrip(".")
+    path_hint = asset.reference_path or asset.asset_ref
+    suffix = Path(path_hint).suffix.lower().lstrip(".")
+    if suffix in {"jpg", "jpeg"}:
+        return "jpeg"
+    return suffix or None
+
+
+def _reference_bit_depth(asset: "ApexEvalAsset") -> int | None:
+    if asset.canonical_bit_depth is not None:
+        return int(asset.canonical_bit_depth)
+    if _normalized_format(asset) == "jpeg":
+        return 8
+    return None
 
 
 @dataclass(frozen=True)
@@ -49,6 +123,17 @@ class ApexEvalAsset:
     expected_materials: tuple[str, ...]
     risk_zones: tuple[str, ...]
     reject_if: tuple[str, ...]
+    asset_role: str = DEFAULT_ASSET_ROLE
+    reference_path: str | None = None
+    delivery_path: str | None = None
+    canonical_bit_depth: int | None = None
+    canonical_format: str | None = None
+    canonical_color_space: str | None = None
+    evaluate_at_native_resolution: bool = False
+    allow_downsampled_model_inference: bool = True
+    preserve_16bit_intermediates: bool = False
+    canonical_scoring_eligible: bool | None = None
+    canonical_scoring_blocked_reason: str | None = None
     manual_quality_score: float | None = None
     notes: str | None = None
 
@@ -65,6 +150,16 @@ class ApexEvalAsset:
             if not 0.0 <= manual_score <= 1.0:
                 raise ValueError("manual_quality_score must be null or in [0, 1]")
 
+        asset_role = str(payload.get("asset_role") or DEFAULT_ASSET_ROLE)
+        if asset_role not in ASSET_ROLES:
+            raise ValueError(f"Unsupported APEX asset_role {asset_role!r}")
+
+        canonical_bit_depth = _optional_int(payload.get("canonical_bit_depth"))
+        canonical_format = _normalize_optional_str(payload.get("canonical_format"))
+        reference_path = _normalize_optional_str(payload.get("reference_path")) or str(payload["asset_ref"])
+        delivery_path = _normalize_optional_str(payload.get("delivery_path"))
+        canonical_eligible = _optional_bool(payload.get("canonical_scoring_eligible"))
+
         return cls(
             asset_id=str(payload["asset_id"]),
             asset_ref=str(payload["asset_ref"]),
@@ -73,6 +168,17 @@ class ApexEvalAsset:
             expected_materials=tuple(str(item) for item in payload.get("expected_materials", [])),
             risk_zones=tuple(str(item) for item in payload.get("risk_zones", [])),
             reject_if=tuple(str(item) for item in payload.get("reject_if", [])),
+            asset_role=asset_role,
+            reference_path=reference_path,
+            delivery_path=delivery_path,
+            canonical_bit_depth=canonical_bit_depth,
+            canonical_format=canonical_format,
+            canonical_color_space=_normalize_optional_str(payload.get("canonical_color_space")),
+            evaluate_at_native_resolution=_bool_with_default(payload.get("evaluate_at_native_resolution"), False),
+            allow_downsampled_model_inference=_bool_with_default(payload.get("allow_downsampled_model_inference"), True),
+            preserve_16bit_intermediates=_bool_with_default(payload.get("preserve_16bit_intermediates"), False),
+            canonical_scoring_eligible=canonical_eligible,
+            canonical_scoring_blocked_reason=_normalize_optional_str(payload.get("canonical_scoring_blocked_reason")),
             manual_quality_score=manual_score,
             notes=(str(payload["notes"]) if payload.get("notes") is not None else None),
         )
@@ -86,6 +192,17 @@ class ApexEvalAsset:
             "expected_materials": list(self.expected_materials),
             "risk_zones": list(self.risk_zones),
             "reject_if": list(self.reject_if),
+            "asset_role": self.asset_role,
+            "reference_path": self.reference_path,
+            "delivery_path": self.delivery_path,
+            "canonical_bit_depth": self.canonical_bit_depth,
+            "canonical_format": self.canonical_format,
+            "canonical_color_space": self.canonical_color_space,
+            "evaluate_at_native_resolution": self.evaluate_at_native_resolution,
+            "allow_downsampled_model_inference": self.allow_downsampled_model_inference,
+            "preserve_16bit_intermediates": self.preserve_16bit_intermediates,
+            "canonical_scoring_eligible": self.canonical_scoring_eligible,
+            "canonical_scoring_blocked_reason": self.canonical_scoring_blocked_reason,
             "manual_quality_score": self.manual_quality_score,
             "notes": self.notes,
         }
@@ -101,10 +218,20 @@ class ApexEvalSet:
     assets: tuple[ApexEvalAsset, ...]
     source_path: Path
     repo_root: Path
+    dataset_tier: str = DEFAULT_DATASET_TIER
+    canonical_bit_depth: int | None = None
+    canonical_format: str | None = None
+    canonical_color_space: str | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
 
     def resolve_asset_path(self, asset: ApexEvalAsset) -> Path:
         path = Path(asset.asset_ref)
+        if path.is_absolute():
+            return path
+        return self.repo_root / path
+
+    def resolve_reference_path(self, asset: ApexEvalAsset) -> Path:
+        path = Path(asset.reference_path or asset.asset_ref)
         if path.is_absolute():
             return path
         return self.repo_root / path
@@ -153,6 +280,9 @@ def load_apex_evalset(evalset_path: Path | str, *, repo_root: Path | None = None
     if not isinstance(assets_raw, list) or not assets_raw:
         raise ValueError("APEX evalset must contain a non-empty assets list")
     assets = tuple(ApexEvalAsset.from_mapping(item) for item in assets_raw)
+    dataset_tier = str(payload.get("dataset_tier") or DEFAULT_DATASET_TIER)
+    if dataset_tier not in DATASET_TIERS:
+        raise ValueError(f"Unsupported APEX dataset_tier {dataset_tier!r}")
     return ApexEvalSet(
         evalset_id=str(payload.get("evalset_id") or path.parent.name),
         version=str(payload.get("version") or "v1"),
@@ -160,6 +290,10 @@ def load_apex_evalset(evalset_path: Path | str, *, repo_root: Path | None = None
         assets=assets,
         source_path=path,
         repo_root=root,
+        dataset_tier=dataset_tier,
+        canonical_bit_depth=_optional_int(payload.get("canonical_bit_depth")),
+        canonical_format=_normalize_optional_str(payload.get("canonical_format")),
+        canonical_color_space=_normalize_optional_str(payload.get("canonical_color_space")),
         metadata=dict(payload.get("metadata") or {}),
     )
 
@@ -172,6 +306,69 @@ def sha256_file(path: Path) -> str:
     return digest.hexdigest()
 
 
+def _canonical_scoring_status(
+    evalset: ApexEvalSet,
+    asset: ApexEvalAsset,
+    *,
+    asset_ready: bool,
+) -> dict[str, Any]:
+    reference_format = _normalized_format(asset)
+    reference_bit_depth = _reference_bit_depth(asset)
+    eligible = True
+    blocked_reason: str | None = None
+
+    if not asset_ready:
+        eligible = False
+        blocked_reason = "asset_not_ready"
+    elif evalset.dataset_tier != CANONICAL_APEX_DATASET_TIER:
+        eligible = False
+        blocked_reason = "noncanonical_dataset_tier"
+    elif asset.asset_role != CANONICAL_APEX_ASSET_ROLE:
+        eligible = False
+        blocked_reason = "asset_role_not_canonical"
+    elif reference_bit_depth is None:
+        eligible = False
+        blocked_reason = "missing_16bit_reference"
+    elif reference_bit_depth < 16:
+        eligible = False
+        blocked_reason = "non_16bit_reference"
+    elif reference_format not in CANONICAL_REFERENCE_FORMATS:
+        eligible = False
+        blocked_reason = "non_tiff_reference"
+    elif not asset.evaluate_at_native_resolution:
+        eligible = False
+        blocked_reason = "native_resolution_evaluation_required"
+    elif not asset.preserve_16bit_intermediates:
+        eligible = False
+        blocked_reason = "preserve_16bit_intermediates_required"
+    elif asset.canonical_scoring_eligible is False:
+        eligible = False
+        blocked_reason = asset.canonical_scoring_blocked_reason or "canonical_scoring_disabled"
+
+    if not eligible and asset.canonical_scoring_blocked_reason:
+        blocked_reason = asset.canonical_scoring_blocked_reason
+
+    return {
+        "asset_role": asset.asset_role,
+        "reference_path": asset.reference_path or asset.asset_ref,
+        "delivery_path": asset.delivery_path,
+        "reference_bit_depth": reference_bit_depth,
+        "reference_format": reference_format,
+        "reference_color_space": asset.canonical_color_space,
+        "evaluate_at_native_resolution": asset.evaluate_at_native_resolution,
+        "allow_downsampled_model_inference": asset.allow_downsampled_model_inference,
+        "preserve_16bit_intermediates": asset.preserve_16bit_intermediates,
+        "canonical_scoring_eligible": eligible,
+        "canonical_scoring_blocked_reason": None if eligible else blocked_reason,
+    }
+
+
+def canonical_scoring_status(evalset: ApexEvalSet, asset: ApexEvalAsset) -> dict[str, Any]:
+    """Return canonical APEX quality scoring eligibility for an eval asset."""
+    path = evalset.resolve_asset_path(asset)
+    return _canonical_scoring_status(evalset, asset, asset_ready=path.is_file() and sha256_file(path) == asset.sha256)
+
+
 def asset_status(evalset: ApexEvalSet, asset: ApexEvalAsset) -> dict[str, Any]:
     path = evalset.resolve_asset_path(asset)
     if not path.is_file():
@@ -182,6 +379,7 @@ def asset_status(evalset: ApexEvalSet, asset: ApexEvalAsset) -> dict[str, Any]:
             "resolved_path": str(path),
             "expected_sha256": asset.sha256,
             "actual_sha256": None,
+            **_canonical_scoring_status(evalset, asset, asset_ready=False),
         }
 
     actual_sha = sha256_file(path)
@@ -194,6 +392,7 @@ def asset_status(evalset: ApexEvalSet, asset: ApexEvalAsset) -> dict[str, Any]:
         "expected_sha256": asset.sha256,
         "actual_sha256": actual_sha,
         "size_bytes": int(path.stat().st_size),
+        **_canonical_scoring_status(evalset, asset, asset_ready=status == "ready"),
     }
 
 
@@ -295,6 +494,19 @@ def build_apex_eval_report(
     assets_report = []
     for asset in evalset.assets:
         status = asset_status(evalset, asset)
+        canonical_fields = {
+            "asset_role": status["asset_role"],
+            "reference_path": status["reference_path"],
+            "delivery_path": status["delivery_path"],
+            "reference_bit_depth": status["reference_bit_depth"],
+            "reference_format": status["reference_format"],
+            "reference_color_space": status["reference_color_space"],
+            "evaluate_at_native_resolution": status["evaluate_at_native_resolution"],
+            "allow_downsampled_model_inference": status["allow_downsampled_model_inference"],
+            "preserve_16bit_intermediates": status["preserve_16bit_intermediates"],
+            "canonical_scoring_eligible": status["canonical_scoring_eligible"],
+            "canonical_scoring_blocked_reason": status["canonical_scoring_blocked_reason"],
+        }
         candidates = []
         for candidate_name, outputs in sorted(candidate_outputs.items()):
             output_value = outputs.get(asset.asset_id)
@@ -347,12 +559,25 @@ def build_apex_eval_report(
         assets_report.append(
             {
                 **asset.to_dict(),
+                **canonical_fields,
                 "asset_status": status,
                 "candidates": candidates,
             }
         )
 
     ready_count = sum(1 for item in assets_report if item["asset_status"]["status"] == "ready")
+    canonical_count = sum(
+        1 for item in assets_report if item["asset_status"]["status"] == "ready" and item["canonical_scoring_eligible"]
+    )
+    missing_count = sum(1 for item in assets_report if item["asset_status"]["status"] == "missing_asset")
+    noncanonical_count = sum(
+        1 for item in assets_report if item["asset_status"]["status"] == "ready" and not item["canonical_scoring_eligible"]
+    )
+    blocked_reason_counts: dict[str, int] = {}
+    for item in assets_report:
+        reason = item["canonical_scoring_blocked_reason"]
+        if item["asset_status"]["status"] == "ready" and reason:
+            blocked_reason_counts[reason] = blocked_reason_counts.get(reason, 0) + 1
     report = {
         "schema_version": APEX_EVAL_REPORT_VERSION,
         "evalset": {
@@ -360,8 +585,16 @@ def build_apex_eval_report(
             "version": evalset.version,
             "description": evalset.description,
             "source_path": str(evalset.source_path),
+            "dataset_tier": evalset.dataset_tier,
+            "canonical_bit_depth": evalset.canonical_bit_depth,
+            "canonical_format": evalset.canonical_format,
+            "canonical_color_space": evalset.canonical_color_space,
             "asset_count": len(evalset.assets),
             "ready_asset_count": ready_count,
+            "canonical_scoring_eligible_count": canonical_count,
+            "missing_asset_count": missing_count,
+            "noncanonical_asset_count": noncanonical_count,
+            "canonical_scoring_blocked_reason_counts": blocked_reason_counts,
         },
         "quality_trajectory": {
             "depth_pro_role": "research_quality_yardstick",
@@ -418,6 +651,37 @@ def _architectural_plausibility(depth_map: np.ndarray | None) -> float | None:
     return float(np.clip(spread * (1.0 - saturation), 0.0, 1.0))
 
 
+def _depth_case_io_metadata(evalset: ApexEvalSet, asset: ApexEvalAsset) -> tuple[dict[str, Any], dict[str, Any]]:
+    reference_path = asset.reference_path or asset.asset_ref
+    resolved_reference = str(evalset.resolve_reference_path(asset))
+    reference_bit_depth = _reference_bit_depth(asset)
+    reference_format = _normalized_format(asset)
+    downsampled = bool(asset.allow_downsampled_model_inference)
+    model_input = {
+        "derived_from": reference_path,
+        "resolved_derived_from": resolved_reference,
+        "input_bit_depth": 8 if downsampled else reference_bit_depth,
+        "input_color_space": "srgb" if downsampled else asset.canonical_color_space,
+        "input_resolution": None,
+        "downsampled_for_inference": downsampled,
+    }
+    evaluation_target = {
+        "path": reference_path,
+        "resolved_path": resolved_reference,
+        "bit_depth": reference_bit_depth,
+        "format": reference_format,
+        "color_space": asset.canonical_color_space,
+        "evaluate_at_native_resolution": asset.evaluate_at_native_resolution,
+    }
+    return model_input, evaluation_target
+
+
+def _merge_mapping(base: dict[str, Any], override: Any) -> dict[str, Any]:
+    if isinstance(override, Mapping):
+        return {**base, **dict(override)}
+    return base
+
+
 def build_depth_backend_benchmark_report(
     evalset_path: Path | str,
     *,
@@ -460,12 +724,15 @@ def build_depth_backend_benchmark_report(
         runtimes: list[float] = []
         for asset in evalset.assets:
             source_status = asset_status(evalset, asset)
+            model_input, evaluation_target = _depth_case_io_metadata(evalset, asset)
             if source_status["status"] != "ready":
                 backend_report["assets"].append(
                     {
                         "asset_id": asset.asset_id,
                         "status": source_status["status"],
                         "source": source_status,
+                        "model_input": model_input,
+                        "evaluation_target": evaluation_target,
                     }
                 )
                 continue
@@ -475,6 +742,8 @@ def build_depth_backend_benchmark_report(
                         "asset_id": asset.asset_id,
                         "status": "not_executed",
                         "source": source_status,
+                        "model_input": model_input,
+                        "evaluation_target": evaluation_target,
                         "metrics": {
                             "depth_edge_score": None,
                             "boundary_halo_risk": None,
@@ -496,13 +765,16 @@ def build_depth_backend_benchmark_report(
             if edge_score is not None:
                 asset_scores.append(edge_score)
             runtimes.append(runtime_ms)
+            provenance = dict(run_result.provenance)
             backend_report["assets"].append(
                 {
                     "asset_id": asset.asset_id,
                     "status": run_result.status,
                     "source": source_status,
                     "depth_path": run_result.depth_path,
-                    "provenance": run_result.provenance,
+                    "model_input": _merge_mapping(model_input, provenance.get("model_input")),
+                    "evaluation_target": _merge_mapping(evaluation_target, provenance.get("evaluation_target")),
+                    "provenance": provenance,
                     "error": run_result.error,
                     "metrics": {
                         "depth_edge_score": edge_score,

--- a/src/transformation_portal/evals/apex_visual.py
+++ b/src/transformation_portal/evals/apex_visual.py
@@ -197,23 +197,51 @@ def asset_status(evalset: ApexEvalSet, asset: ApexEvalAsset) -> dict[str, Any]:
     }
 
 
+def _visible_delta_unavailable(status: str, **extra: Any) -> dict[str, Any]:
+    return {
+        "status": status,
+        "ssim": None,
+        "lpips": None,
+        "delta_e_proxy_mean_abs": None,
+        "delta_e_proxy_max_abs": None,
+        "metric_warnings": [],
+        **extra,
+    }
+
+
+def _load_rgb_image(path: Path, *, role: str) -> tuple[np.ndarray | None, dict[str, Any] | None]:
+    from PIL import Image, UnidentifiedImageError
+
+    try:
+        with Image.open(path) as image:
+            rgb = image.convert("RGB")
+            return np.asarray(rgb, dtype=np.float32) / 255.0, None
+    except (OSError, ValueError, UnidentifiedImageError) as exc:
+        return None, _visible_delta_unavailable(
+            "unreadable_image",
+            unreadable_role=role,
+            unreadable_path=str(path),
+            error=str(exc),
+        )
+
+
 def visible_delta_metrics(reference: Path, candidate: Path) -> dict[str, Any]:
     """Compute deterministic visible-delta metrics for two rendered images."""
-    from PIL import Image
+    ref, ref_error = _load_rgb_image(reference, role="reference")
+    if ref_error is not None:
+        return ref_error
+    cand, cand_error = _load_rgb_image(candidate, role="candidate")
+    if cand_error is not None:
+        return cand_error
 
-    ref = np.asarray(Image.open(reference).convert("RGB"), dtype=np.float32) / 255.0
-    cand = np.asarray(Image.open(candidate).convert("RGB"), dtype=np.float32) / 255.0
+    assert ref is not None
+    assert cand is not None
     if ref.shape != cand.shape:
-        return {
-            "status": "shape_mismatch",
-            "reference_shape": list(ref.shape),
-            "candidate_shape": list(cand.shape),
-            "ssim": None,
-            "lpips": None,
-            "delta_e_proxy_mean_abs": None,
-            "delta_e_proxy_max_abs": None,
-            "metric_warnings": [],
-        }
+        return _visible_delta_unavailable(
+            "shape_mismatch",
+            reference_shape=list(ref.shape),
+            candidate_shape=list(cand.shape),
+        )
 
     abs_delta = np.abs(cand - ref)
     metric_warnings: list[str] = []

--- a/src/transformation_portal/evals/apex_visual.py
+++ b/src/transformation_portal/evals/apex_visual.py
@@ -8,6 +8,7 @@ benchmark execution without forcing model downloads in unit tests.
 from __future__ import annotations
 
 import hashlib
+import importlib
 import json
 import math
 import time
@@ -25,6 +26,16 @@ APEX_EVALSET_SCHEMA_VERSION = "apex_evalset.v1"
 APEX_EVAL_REPORT_VERSION = "apex_eval_report.v1"
 DEPTH_BACKEND_BENCHMARK_REPORT_VERSION = "depth_backend_benchmark_report.v1"
 DEPTH_PRO_BACKENDS = {"depth_pro"}
+
+
+def _lpips_available() -> bool:
+    """Return whether LPIPS can produce authoritative visible-delta evidence."""
+    try:
+        importlib.import_module("lpips")
+        importlib.import_module("torch")
+    except ImportError:
+        return False
+    return True
 
 
 @dataclass(frozen=True)
@@ -201,25 +212,35 @@ def visible_delta_metrics(reference: Path, candidate: Path) -> dict[str, Any]:
             "lpips": None,
             "delta_e_proxy_mean_abs": None,
             "delta_e_proxy_max_abs": None,
+            "metric_warnings": [],
         }
 
     abs_delta = np.abs(cand - ref)
+    metric_warnings: list[str] = []
     try:
         ssim_value: float | None = float(ssim(cand, ref))
     except Exception:
         ssim_value = None
-    try:
-        lpips_value = float(lpips_score(cand, ref))
-        if not math.isfinite(lpips_value):
+        metric_warnings.append("ssim_unavailable")
+    if _lpips_available():
+        try:
+            lpips_value = float(lpips_score(cand, ref))
+            if not math.isfinite(lpips_value):
+                lpips_value = None
+                metric_warnings.append("lpips_nonfinite")
+        except Exception:
             lpips_value = None
-    except Exception:
+            metric_warnings.append("lpips_unavailable")
+    else:
         lpips_value = None
+        metric_warnings.append("lpips_unavailable")
     return {
-        "status": "ok",
+        "status": "partial_metrics" if metric_warnings else "ok",
         "ssim": ssim_value,
         "lpips": lpips_value,
         "delta_e_proxy_mean_abs": float(abs_delta.mean()),
         "delta_e_proxy_max_abs": float(abs_delta.max()),
+        "metric_warnings": metric_warnings,
     }
 
 

--- a/src/transformation_portal/evals/apex_visual.py
+++ b/src/transformation_portal/evals/apex_visual.py
@@ -707,8 +707,10 @@ def build_apex_eval_report(
         reason = item["canonical_scoring_blocked_reason"]
         if item["asset_status"]["status"] == "ready" and reason:
             blocked_reason_counts[reason] = blocked_reason_counts.get(reason, 0) + 1
+    report_path = output_root / "apex_eval_report.json"
     report = {
         "schema_version": APEX_EVAL_REPORT_VERSION,
+        "report_path": str(report_path),
         "evalset": {
             "evalset_id": evalset.evalset_id,
             "version": evalset.version,
@@ -733,7 +735,6 @@ def build_apex_eval_report(
         },
         "assets": assets_report,
     }
-    report_path = output_root / "apex_eval_report.json"
     with report_path.open("w", encoding="utf-8") as handle:
         dump_json(report, handle, sort_keys=True, indent=2, ensure_ascii=False, allow_nan=False)
         handle.write("\n")
@@ -932,8 +933,10 @@ def build_depth_backend_benchmark_report(
         backend_report["runtime_ms"] = float(np.mean(runtimes)) if runtimes else None
         backend_reports.append(backend_report)
 
+    report_path = output_root / "depth_backend_comparison_report.json"
     report = {
         "schema_version": DEPTH_BACKEND_BENCHMARK_REPORT_VERSION,
+        "report_path": str(report_path),
         "evalset": {
             "evalset_id": evalset.evalset_id,
             "version": evalset.version,
@@ -943,7 +946,6 @@ def build_depth_backend_benchmark_report(
         "quality_tier": quality_tier,
         "backends": backend_reports,
     }
-    report_path = output_root / "depth_backend_comparison_report.json"
     with report_path.open("w", encoding="utf-8") as handle:
         dump_json(report, handle, sort_keys=True, indent=2, ensure_ascii=False, allow_nan=False)
         handle.write("\n")

--- a/src/transformation_portal/lux_depth_v3/material_confidence_contract.py
+++ b/src/transformation_portal/lux_depth_v3/material_confidence_contract.py
@@ -1,0 +1,35 @@
+"""Shared Materials V3 confidence score-type contract."""
+
+from __future__ import annotations
+
+CLIP_SOFTMAX_MARGIN_SCORE_TYPE = "clip_softmax_margin_v1"
+HEURISTIC_MATERIAL_SCORE_TYPE = "heuristic_material_confidence_v1"
+MATERIAL_CLASSIFIER_SCORE_TYPE = "material_classifier_probability_v1"
+RAW_CLIP_SIMILARITY_SCORE_TYPE = "raw_clip_similarity"
+MISSING_CLIP_SCORE_FALLBACK_TYPE = "missing_clip_score_fallback"
+MATERIALS_V3_CALIBRATION_VERSION = "materials_v3_calibration_v1"
+
+APEX_PIXEL_OP_AUTHORITY_SCORE_TYPES = frozenset(
+    {
+        CLIP_SOFTMAX_MARGIN_SCORE_TYPE,
+        MATERIAL_CLASSIFIER_SCORE_TYPE,
+    }
+)
+RAW_OR_UNSUPPORTED_SCORE_TYPES = frozenset(
+    {
+        RAW_CLIP_SIMILARITY_SCORE_TYPE,
+        HEURISTIC_MATERIAL_SCORE_TYPE,
+        MISSING_CLIP_SCORE_FALLBACK_TYPE,
+    }
+)
+
+__all__ = [
+    "APEX_PIXEL_OP_AUTHORITY_SCORE_TYPES",
+    "CLIP_SOFTMAX_MARGIN_SCORE_TYPE",
+    "HEURISTIC_MATERIAL_SCORE_TYPE",
+    "MATERIAL_CLASSIFIER_SCORE_TYPE",
+    "MATERIALS_V3_CALIBRATION_VERSION",
+    "MISSING_CLIP_SCORE_FALLBACK_TYPE",
+    "RAW_CLIP_SIMILARITY_SCORE_TYPE",
+    "RAW_OR_UNSUPPORTED_SCORE_TYPES",
+]

--- a/src/transformation_portal/lux_depth_v3/materials_v3.py
+++ b/src/transformation_portal/lux_depth_v3/materials_v3.py
@@ -44,6 +44,22 @@ def _extract_material_confidences(segmentation_result: Dict[str, Any]) -> Dict[s
     return confidences
 
 
+def _extract_material_confidence_evidence(segmentation_result: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    evidence: Dict[str, Dict[str, Any]] = {}
+    sources = [segmentation_result.get("material_confidence_evidence")]
+    segmentation_metadata = segmentation_result.get("segmentation_metadata")
+    if isinstance(segmentation_metadata, dict):
+        sources.append(segmentation_metadata.get("material_confidence_evidence"))
+
+    for source in sources:
+        if not isinstance(source, dict):
+            continue
+        for material_key, value in source.items():
+            if isinstance(value, dict):
+                evidence[str(material_key)] = dict(value)
+    return evidence
+
+
 def _split_mask_and_confidence(value: Any, fallback_confidence: Optional[float]) -> tuple[Any, Optional[float]]:
     if isinstance(value, tuple) and len(value) == 2:
         mask, confidence = value
@@ -56,7 +72,12 @@ class MaterialsV3Engine:
     def __init__(self, config: Any) -> None:
         self.config = config
 
-    def _compute_mask_stats(self, mask: np.ndarray, material_confidence: Optional[float] = None) -> Dict[str, Any]:
+    def _compute_mask_stats(
+        self,
+        mask: np.ndarray,
+        material_confidence: Optional[float] = None,
+        confidence_evidence: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
         """Compute basic coverage/confidence stats."""
         mask_2d = np.asarray(mask, dtype=np.float32)
         if mask_2d.ndim == 3 and mask_2d.shape[-1] == 1:
@@ -82,6 +103,20 @@ class MaterialsV3Engine:
         }
         if material_confidence is not None:
             stats["material_confidence"] = material_confidence
+        if isinstance(confidence_evidence, dict):
+            for key in (
+                "confidence_score_type",
+                "raw_clip_similarity",
+                "clip_softmax_probability",
+                "clip_top2_margin",
+                "calibration_version",
+            ):
+                if key in confidence_evidence:
+                    stats[key] = confidence_evidence[key]
+            if "material_confidence" in confidence_evidence:
+                evidence_conf = _coerce_unit_confidence(confidence_evidence.get("material_confidence"))
+                if evidence_conf is not None:
+                    stats["material_confidence"] = evidence_conf
         return stats
 
     def process(
@@ -99,6 +134,7 @@ class MaterialsV3Engine:
         raw_materials = segmentation_result.get("materials") or segmentation_result.get("material_masks") or {}
         segmentation_metadata = segmentation_result.get("segmentation_metadata")
         material_confidences = _extract_material_confidences(segmentation_result)
+        material_confidence_evidence = _extract_material_confidence_evidence(segmentation_result)
         materials = {}
         for mat_key, value in raw_materials.items():
             material_key = str(mat_key)
@@ -110,7 +146,12 @@ class MaterialsV3Engine:
 
         per_class_stats = {}
         for mat_key, mask in segmentation_result.get("materials", {}).items():
-            stats = self._compute_mask_stats(mask, material_confidences.get(str(mat_key)))
+            material_key = str(mat_key)
+            stats = self._compute_mask_stats(
+                mask,
+                material_confidences.get(material_key),
+                material_confidence_evidence.get(material_key),
+            )
             per_class_stats[mat_key] = stats
         timing_ms["stats"] = round((time.perf_counter() - t_stats) * 1000.0, 3)
 

--- a/src/transformation_portal/lux_depth_v3/materials_v3_response.py
+++ b/src/transformation_portal/lux_depth_v3/materials_v3_response.py
@@ -179,8 +179,16 @@ def generate_response_plan(
             "pixel_ops": pixel_ops,
             "edge_signals": edge_signals,
         }
-        if "material_confidence" in stats:
-            plan_entry["material_confidence"] = stats["material_confidence"]
+        for confidence_key in (
+            "material_confidence",
+            "confidence_score_type",
+            "raw_clip_similarity",
+            "clip_softmax_probability",
+            "clip_top2_margin",
+            "calibration_version",
+        ):
+            if confidence_key in stats:
+                plan_entry[confidence_key] = stats[confidence_key]
         plan["per_class"][mat_key] = plan_entry
 
     plan["summary"]["skipped_reasons_histogram"] = histogram

--- a/src/transformation_portal/lux_depth_v3/orchestrator.py
+++ b/src/transformation_portal/lux_depth_v3/orchestrator.py
@@ -35,7 +35,7 @@ from enum import Enum
 from functools import lru_cache
 from multiprocessing import cpu_count
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, cast
+from typing import Any, Callable, Dict, List, Mapping, Optional, cast
 
 import numpy as np
 
@@ -2838,6 +2838,7 @@ class EnhanceOrchestrator:
                         artifact_shape=artifact_shape,
                         processing_shape=_shape_2d(preprocessed_array),
                     )
+                self._enforce_apex_materials_pixel_ops_gate(materials_v3_result)
 
                 material_masks = materials_v3_result.get("material_masks")
                 if isinstance(material_masks, dict) and material_masks:
@@ -4721,6 +4722,67 @@ class EnhanceOrchestrator:
                 " with 0 Materials V3"
                 " operations.",
             )
+
+    @staticmethod
+    def _pixel_ops_blocked_reasons(pixel_ops: Mapping[str, Any]) -> Dict[str, int]:
+        histogram: Dict[str, int] = {}
+        blocked = pixel_ops.get("blocked")
+        if not isinstance(blocked, list):
+            return histogram
+        for entry in blocked:
+            if not isinstance(entry, dict):
+                continue
+            reasons = entry.get("blocked_by")
+            if isinstance(reasons, list) and reasons:
+                for reason in reasons:
+                    reason_key = str(reason)
+                    histogram[reason_key] = histogram.get(reason_key, 0) + 1
+            else:
+                reason_key = str(entry.get("reason") or "unknown")
+                histogram[reason_key] = histogram.get(reason_key, 0) + 1
+        return histogram
+
+    def _enforce_apex_materials_pixel_ops_gate(self, materials_v3_result: Optional[Dict[str, Any]]) -> None:
+        """Fail closed when APEX Materials V3 silently produces no pixel ops."""
+        if not self._is_apex_materials_gate_enabled():
+            return
+        if not bool(getattr(self.config, "apply_pixel_ops", False)):
+            return
+        if not isinstance(materials_v3_result, dict):
+            return
+
+        material_masks = materials_v3_result.get("material_masks")
+        if not isinstance(material_masks, dict) or not material_masks:
+            return
+
+        from .pixel_ops_registry import OP_REGISTRY
+
+        implemented_materials = [
+            material
+            for material in material_masks
+            if any(op.implemented for op in OP_REGISTRY.get(str(material), {}).values())
+        ]
+        if not implemented_materials:
+            return
+
+        pixel_ops = materials_v3_result.get("materials_v3_pixel_ops")
+        if not isinstance(pixel_ops, dict):
+            return
+        applied_ops = pixel_ops.get("applied")
+        if isinstance(applied_ops, list) and applied_ops:
+            return
+
+        blocked_reasons = self._pixel_ops_blocked_reasons(pixel_ops)
+        raise ApexStrictGateError(
+            "APEX_MATERIALS_PIXEL_OPS_EMPTY",
+            "Material masks were detected, but every implemented Materials V3 pixel operation was blocked.",
+            details={
+                "material_count": len(material_masks),
+                "implemented_materials": [str(material) for material in implemented_materials],
+                "applied_ops_count": 0,
+                "blocked_reasons": blocked_reasons,
+            },
+        )
 
     def _load_cached_depth(
         self,

--- a/src/transformation_portal/lux_depth_v3/pixel_ops_decider.py
+++ b/src/transformation_portal/lux_depth_v3/pixel_ops_decider.py
@@ -7,6 +7,20 @@ from typing import Any, Dict, List
 
 from .pixel_ops_registry import OP_REGISTRY
 
+APEX_PIXEL_OP_AUTHORITY_SCORE_TYPES = frozenset(
+    {
+        "clip_softmax_margin_v1",
+        "material_classifier_probability_v1",
+    }
+)
+RAW_OR_UNSUPPORTED_SCORE_TYPES = frozenset(
+    {
+        "raw_clip_similarity",
+        "heuristic_material_confidence_v1",
+        "missing_clip_score_fallback",
+    }
+)
+
 
 def _material_confidence_threshold(material_key: str, config: Any) -> float:
     """Return the fail-closed threshold for material classifier confidence."""
@@ -33,6 +47,34 @@ def _material_confidence(stats: Dict[str, Any]) -> float | None:
             continue
         if 0.0 <= confidence <= 1.0 and math.isfinite(confidence):
             return confidence
+    return None
+
+
+def _is_apex_tier(config: Any) -> bool:
+    return str(getattr(config, "quality_tier", "")).strip().lower() == "apex"
+
+
+def _confidence_score_type(stats: Dict[str, Any]) -> str | None:
+    value = stats.get("confidence_score_type")
+    if value is None:
+        return None
+    normalized = str(value).strip()
+    return normalized or None
+
+
+def _apex_confidence_authority_blocker(stats: Dict[str, Any], config: Any) -> str | None:
+    """Return the fail-closed reason when APEX lacks calibrated confidence."""
+    if not _is_apex_tier(config):
+        return None
+    if _material_confidence(stats) is None:
+        return "missing_material_confidence"
+    score_type = _confidence_score_type(stats)
+    if score_type is None:
+        return "missing_confidence_score_type"
+    if score_type in RAW_OR_UNSUPPORTED_SCORE_TYPES:
+        return "unsupported_confidence_score_type"
+    if score_type not in APEX_PIXEL_OP_AUTHORITY_SCORE_TYPES:
+        return "unsupported_confidence_score_type"
     return None
 
 
@@ -79,9 +121,13 @@ def decide_pixel_ops(
         mean_conf = float(stats.get("mean_conf", 0.0))
         base_confidence_threshold = float(getattr(config, "min_mean_conf", 0.2))
         material_confidence = _material_confidence(stats)
+        apex_confidence_blocker = _apex_confidence_authority_blocker(stats, config)
         if stats["coverage_px"] < min_coverage:
             eligible = False
             reason = "below_coverage_threshold"
+        elif apex_confidence_blocker is not None:
+            eligible = False
+            reason = apex_confidence_blocker
         elif material_confidence is not None and material_confidence < _material_confidence_threshold(
             material_key,
             config,
@@ -134,4 +180,10 @@ def decide_pixel_ops(
         "will_apply": will_apply,
         "blocked_by": blocked_by,
         "reason": reason,
+        "material_confidence": material_confidence,
+        "confidence_score_type": _confidence_score_type(stats),
+        "authority_score_type_accepted": (
+            not _is_apex_tier(config)
+            or (_confidence_score_type(stats) in APEX_PIXEL_OP_AUTHORITY_SCORE_TYPES and material_confidence is not None)
+        ),
     }

--- a/src/transformation_portal/lux_depth_v3/pixel_ops_decider.py
+++ b/src/transformation_portal/lux_depth_v3/pixel_ops_decider.py
@@ -5,21 +5,11 @@ from __future__ import annotations
 import math
 from typing import Any, Dict, List
 
+from .material_confidence_contract import (
+    APEX_PIXEL_OP_AUTHORITY_SCORE_TYPES,
+    RAW_OR_UNSUPPORTED_SCORE_TYPES,
+)
 from .pixel_ops_registry import OP_REGISTRY
-
-APEX_PIXEL_OP_AUTHORITY_SCORE_TYPES = frozenset(
-    {
-        "clip_softmax_margin_v1",
-        "material_classifier_probability_v1",
-    }
-)
-RAW_OR_UNSUPPORTED_SCORE_TYPES = frozenset(
-    {
-        "raw_clip_similarity",
-        "heuristic_material_confidence_v1",
-        "missing_clip_score_fallback",
-    }
-)
 
 
 def _material_confidence_threshold(material_key: str, config: Any) -> float:

--- a/src/transformation_portal/lux_depth_v3/pixel_ops_executor.py
+++ b/src/transformation_portal/lux_depth_v3/pixel_ops_executor.py
@@ -398,6 +398,8 @@ def apply_pixel_ops(
                     "reason": decision.get("reason", "not_recommended"),
                     "blocked_by": decision.get("blocked_by", []),
                     "recommended_ops": recommended_ops,
+                    "material_confidence": decision.get("material_confidence"),
+                    "confidence_score_type": decision.get("confidence_score_type"),
                 }
             )
             continue
@@ -558,6 +560,8 @@ def apply_pixel_ops(
                 "timing_ms": round(elapsed_ms, 3),
                 "delta_stats": delta_stats,
                 "feather_sigma": feather_sigma,
+                "material_confidence": decision.get("material_confidence"),
+                "confidence_score_type": decision.get("confidence_score_type"),
                 "bbox_padding": pad,
                 "low_tex_guard": {
                     "applied": bool(is_low_tex_large),

--- a/src/transformation_portal/lux_depth_v3/segmentation_backend.py
+++ b/src/transformation_portal/lux_depth_v3/segmentation_backend.py
@@ -56,14 +56,16 @@ import numpy as np
 from transformation_portal.ingest.canonical_json import canonicalize_json, dump_json
 
 from .config import EnhanceConfig
+from .material_confidence_contract import (
+    CLIP_SOFTMAX_MARGIN_SCORE_TYPE,
+    HEURISTIC_MATERIAL_SCORE_TYPE,
+    MATERIAL_CLASSIFIER_SCORE_TYPE,
+    MATERIALS_V3_CALIBRATION_VERSION,
+    MISSING_CLIP_SCORE_FALLBACK_TYPE,
+)
 from .protocols.segmentation_backend import SegmentationBackend, SegmentationBackendInfo
 
 logger = logging.getLogger(__name__)
-
-CLIP_SOFTMAX_MARGIN_SCORE_TYPE = "clip_softmax_margin_v1"
-HEURISTIC_MATERIAL_SCORE_TYPE = "heuristic_material_confidence_v1"
-MATERIAL_CLASSIFIER_SCORE_TYPE = "material_classifier_probability_v1"
-MATERIALS_V3_CALIBRATION_VERSION = "materials_v3_calibration_v1"
 
 _LAST_SEGMENTATION_RUNTIME_METADATA: ContextVar[Optional[Dict[str, Any]]] = ContextVar(
     "_LAST_SEGMENTATION_RUNTIME_METADATA",
@@ -904,7 +906,7 @@ class EfficientSAMBackend:
         Returns:
             Dict[material_name, (mask, confidence)] where:
             - mask: (H, W) float32 [0.0-1.0]
-            - confidence: CLIP similarity or heuristic score [0.0-1.0]
+            - confidence: calibrated CLIP probability or heuristic score [0.0-1.0]
         """
         # Step 1: Run EfficientSAM to generate segment proposals
         segments = self._run_sam_inference(image)
@@ -1002,12 +1004,13 @@ class EfficientSAMBackend:
         Returns:
             Dict mapping material names to (mask, confidence) tuples:
             - mask: Aggregated binary mask (H, W) float32 [0.0-1.0]
-            - confidence: Average CLIP similarity score [0.0-1.0]
+            - confidence: area-weighted calibrated CLIP softmax probability [0.0-1.0]
 
         Note:
             If segments list is empty (which happens when SAM doesn't run),
             we first generate heuristic segments and then classify them with CLIP.
-            This provides better material detection than pure heuristics alone.
+            Raw CLIP similarity is retained as evidence metadata, not as
+            authoritative Materials V3 confidence.
         """
         self._clip_classification_timing_ms = {}
         self._material_confidence_evidence = {}
@@ -1167,7 +1170,9 @@ class EfficientSAMBackend:
                     softmax_probability = float(probabilities[best_idx]) if probabilities.size else 0.0
                     if probabilities.size >= 2:
                         top2 = np.partition(probabilities, -2)[-2:]
-                        top2_margin = float(top2[-1] - top2[-2])
+                        top1 = float(max(top2[0], top2[1]))
+                        top2_second = float(min(top2[0], top2[1]))
+                        top2_margin = top1 - top2_second
                     else:
                         top2_margin = float(softmax_probability)
 
@@ -1194,7 +1199,7 @@ class EfficientSAMBackend:
                             f"top2_margin={top2_margin:.3f}, area={segment['area']}px"
                         )
 
-                # Compute aggregate confidence per material (area-weighted average)
+                # Compute aggregate calibrated confidence per material (area-weighted average).
                 material_masks: Dict[str, Tuple[np.ndarray, float]] = {}
                 material_evidence: Dict[str, Dict[str, Any]] = {}
                 for name, data in material_data.items():
@@ -1205,7 +1210,7 @@ class EfficientSAMBackend:
                     # Only include materials with sufficient coverage
                     if mask.sum() > 500:
                         if scores:
-                            # Area-weighted average of CLIP scores for this material
+                            # Area-weighted average of calibrated CLIP probabilities for this material.
                             total_area = sum(areas)
                             weighted_conf = sum(s * a for s, a in zip(scores, areas)) / total_area
                             raw_scores = data["raw_similarities"]
@@ -1228,7 +1233,7 @@ class EfficientSAMBackend:
                             material_masks[name] = (mask, 0.5)
                             material_evidence[name] = {
                                 "material_confidence": 0.5,
-                                "confidence_score_type": "missing_clip_score_fallback",
+                                "confidence_score_type": MISSING_CLIP_SCORE_FALLBACK_TYPE,
                                 "raw_clip_similarity": None,
                                 "clip_softmax_probability": None,
                                 "clip_top2_margin": None,

--- a/src/transformation_portal/lux_depth_v3/segmentation_backend.py
+++ b/src/transformation_portal/lux_depth_v3/segmentation_backend.py
@@ -142,7 +142,7 @@ def _tensor_values_1d(value: Any) -> np.ndarray:
                         raise
             if hasattr(value, "tolist"):
                 return np.asarray(value.tolist(), dtype=np.float32).reshape(-1)
-        except (AttributeError, RuntimeError, TypeError, ValueError):
+        except (AttributeError, TypeError, ValueError):
             logger.debug("Tensor-like value conversion failed; falling back to array coercion", exc_info=True)
     values = getattr(value, "values", None)
     if values is not None and not callable(values):

--- a/src/transformation_portal/lux_depth_v3/segmentation_backend.py
+++ b/src/transformation_portal/lux_depth_v3/segmentation_backend.py
@@ -60,6 +60,11 @@ from .protocols.segmentation_backend import SegmentationBackend, SegmentationBac
 
 logger = logging.getLogger(__name__)
 
+CLIP_SOFTMAX_MARGIN_SCORE_TYPE = "clip_softmax_margin_v1"
+HEURISTIC_MATERIAL_SCORE_TYPE = "heuristic_material_confidence_v1"
+MATERIAL_CLASSIFIER_SCORE_TYPE = "material_classifier_probability_v1"
+MATERIALS_V3_CALIBRATION_VERSION = "materials_v3_calibration_v1"
+
 _LAST_SEGMENTATION_RUNTIME_METADATA: ContextVar[Optional[Dict[str, Any]]] = ContextVar(
     "_LAST_SEGMENTATION_RUNTIME_METADATA",
     default=None,
@@ -94,12 +99,15 @@ def _split_material_results(results: Mapping[str, Any]) -> Tuple[Dict[str, np.nd
     return masks, material_confidences
 
 
-def _material_confidence_metadata(material_confidences: Dict[str, float]) -> Dict[str, Any]:
+def _material_confidence_metadata(
+    material_confidences: Dict[str, float],
+    evidence: Optional[Dict[str, Dict[str, Any]]] = None,
+) -> Dict[str, Any]:
     if not material_confidences:
         return {}
 
     scores = list(material_confidences.values())
-    return {
+    metadata: Dict[str, Any] = {
         "material_confidences": dict(material_confidences),
         "confidence_summary": {
             "count": len(scores),
@@ -108,6 +116,41 @@ def _material_confidence_metadata(material_confidences: Dict[str, float]) -> Dic
             "max": float(max(scores)),
         },
     }
+    if evidence:
+        metadata["material_confidence_evidence"] = {
+            str(material): dict(values)
+            for material, values in evidence.items()
+            if material in material_confidences and isinstance(values, dict)
+        }
+    return metadata
+
+
+def _tensor_values_1d(value: Any) -> np.ndarray:
+    """Convert torch/fake tensor rows into a 1D float32 array."""
+    if hasattr(value, "detach") and hasattr(value, "cpu"):
+        try:
+            value = value.detach().cpu()
+            if hasattr(value, "float"):
+                value = value.float()
+            if hasattr(value, "numpy"):
+                return np.asarray(value.numpy(), dtype=np.float32).reshape(-1)
+        except Exception:
+            pass
+    if hasattr(value, "values"):
+        return np.asarray(value.values, dtype=np.float32).reshape(-1)
+    return np.asarray(value, dtype=np.float32).reshape(-1)
+
+
+def _softmax_probabilities(values: np.ndarray, logit_scale: float = 20.0) -> np.ndarray:
+    if values.size == 0:
+        return values.astype(np.float32)
+    logits = values.astype(np.float32) * float(logit_scale)
+    shifted = logits - float(np.max(logits))
+    exp_values = np.exp(shifted)
+    total = float(exp_values.sum())
+    if total <= 0.0 or not np.isfinite(total):
+        return np.zeros_like(values, dtype=np.float32)
+    return (exp_values / total).astype(np.float32)
 
 
 # Lazy imports for ML dependencies
@@ -514,6 +557,7 @@ class EfficientSAMBackend:
         self._clip_text_features: Any = None
         self._clip_text_prompt_signature: Optional[Tuple[str, ...]] = None
         self._clip_classification_timing_ms: Dict[str, float] = {}
+        self._material_confidence_evidence: Dict[str, Dict[str, Any]] = {}
         self._sky_top_region_fraction = float(sky_top_region_fraction)
         self._sky_gradient_threshold = float(sky_gradient_threshold)
         self._sky_brightness_threshold = float(sky_brightness_threshold)
@@ -603,6 +647,10 @@ class EfficientSAMBackend:
             metadata["clip_runtime"] = dict(self._clip_runtime_metadata)
         if self._clip_classification_timing_ms:
             metadata["clip_classification"] = {"timing_ms": dict(self._clip_classification_timing_ms)}
+        if self._material_confidence_evidence:
+            metadata["material_confidence_evidence"] = {
+                str(material): dict(values) for material, values in self._material_confidence_evidence.items()
+            }
         if not metadata:
             return None
         return metadata
@@ -962,6 +1010,7 @@ class EfficientSAMBackend:
             This provides better material detection than pure heuristics alone.
         """
         self._clip_classification_timing_ms = {}
+        self._material_confidence_evidence = {}
         t_total = time.perf_counter()
 
         # If no SAM segments, generate heuristic segments first
@@ -1052,7 +1101,15 @@ class EfficientSAMBackend:
                 # Initialize material masks with tracking for confidence scores
                 h, w = image.shape[:2]
                 material_data: Dict[str, Dict[str, Any]] = {
-                    name: {"mask": np.zeros((h, w), dtype=np.float32), "scores": [], "areas": []} for name in material_prompts
+                    name: {
+                        "mask": np.zeros((h, w), dtype=np.float32),
+                        "scores": [],
+                        "raw_similarities": [],
+                        "softmax_probabilities": [],
+                        "top2_margins": [],
+                        "areas": [],
+                    }
+                    for name in material_prompts
                 }
 
                 # Convert image to PIL for preprocessing
@@ -1100,14 +1157,27 @@ class EfficientSAMBackend:
                 for row_idx, (seg_idx, segment) in enumerate(region_segments):
                     mask = segment["segmentation"]
                     similarities = similarity_batch[row_idx]
-                    best_idx = similarities.argmax().item()
+                    similarity_values = _tensor_values_1d(similarities)
+                    probabilities = _softmax_probabilities(similarity_values)
+                    if similarity_values.size == 0:
+                        continue
+                    best_idx = int(np.argmax(similarity_values))
                     best_material = list(material_prompts.keys())[best_idx]
-                    best_score = similarities[best_idx].item()
+                    raw_similarity = float(similarity_values[best_idx])
+                    softmax_probability = float(probabilities[best_idx]) if probabilities.size else 0.0
+                    if probabilities.size >= 2:
+                        top2 = np.partition(probabilities, -2)[-2:]
+                        top2_margin = float(top2[-1] - top2[-2])
+                    else:
+                        top2_margin = float(softmax_probability)
 
-                    # Only add if confidence is reasonable (> 0.2)
-                    if best_score > 0.2:
-                        # Track confidence score and segment area for weighted averaging
-                        material_data[best_material]["scores"].append(best_score)
+                    # Only add if calibrated probability is reasonable (> 0.2)
+                    if softmax_probability > 0.2:
+                        # Track calibrated confidence, raw evidence, and segment area for weighted averaging.
+                        material_data[best_material]["scores"].append(softmax_probability)
+                        material_data[best_material]["raw_similarities"].append(raw_similarity)
+                        material_data[best_material]["softmax_probabilities"].append(softmax_probability)
+                        material_data[best_material]["top2_margins"].append(top2_margin)
                         material_data[best_material]["areas"].append(segment["area"])
 
                         # Add segment mask to material (using max to handle overlaps)
@@ -1119,11 +1189,14 @@ class EfficientSAMBackend:
                         match_str = "✓" if heuristic_label == best_material else f"({heuristic_label}→{best_material})"
                         logger.debug(
                             f"Segment {seg_idx}: {best_material} {match_str} "
-                            f"score={best_score:.3f}, area={segment['area']}px"
+                            f"raw_similarity={raw_similarity:.3f}, "
+                            f"softmax_probability={softmax_probability:.3f}, "
+                            f"top2_margin={top2_margin:.3f}, area={segment['area']}px"
                         )
 
                 # Compute aggregate confidence per material (area-weighted average)
                 material_masks: Dict[str, Tuple[np.ndarray, float]] = {}
+                material_evidence: Dict[str, Dict[str, Any]] = {}
                 for name, data in material_data.items():
                     mask = data["mask"]
                     scores = data["scores"]
@@ -1135,15 +1208,38 @@ class EfficientSAMBackend:
                             # Area-weighted average of CLIP scores for this material
                             total_area = sum(areas)
                             weighted_conf = sum(s * a for s, a in zip(scores, areas)) / total_area
+                            raw_scores = data["raw_similarities"]
+                            probs = data["softmax_probabilities"]
+                            margins = data["top2_margins"]
+                            weighted_raw = sum(s * a for s, a in zip(raw_scores, areas)) / total_area
+                            weighted_prob = sum(s * a for s, a in zip(probs, areas)) / total_area
+                            weighted_margin = sum(s * a for s, a in zip(margins, areas)) / total_area
                             material_masks[name] = (mask, float(weighted_conf))
+                            material_evidence[name] = {
+                                "material_confidence": float(weighted_conf),
+                                "confidence_score_type": CLIP_SOFTMAX_MARGIN_SCORE_TYPE,
+                                "raw_clip_similarity": float(weighted_raw),
+                                "clip_softmax_probability": float(weighted_prob),
+                                "clip_top2_margin": float(weighted_margin),
+                                "calibration_version": MATERIALS_V3_CALIBRATION_VERSION,
+                            }
                         else:
                             # No scores (shouldn't happen, but handle gracefully)
                             material_masks[name] = (mask, 0.5)
+                            material_evidence[name] = {
+                                "material_confidence": 0.5,
+                                "confidence_score_type": "missing_clip_score_fallback",
+                                "raw_clip_similarity": None,
+                                "clip_softmax_probability": None,
+                                "clip_top2_margin": None,
+                                "calibration_version": None,
+                            }
 
                 logger.info(
                     f"CLIP classified {len(segments)} segments into {len(material_masks)} materials: "
                     f"{', '.join(f'{m} ({c:.0%})' for m, (_, c) in material_masks.items())}"
                 )
+                self._material_confidence_evidence = material_evidence
                 self._clip_classification_timing_ms["total"] = round((time.perf_counter() - t_total) * 1000.0, 3)
                 return material_masks
 
@@ -1259,6 +1355,17 @@ class EfficientSAMBackend:
         if stone_mask.sum() > 500:
             masks["stone"] = (stone_mask.astype(np.float32), 0.5)
 
+        self._material_confidence_evidence = {
+            material: {
+                "material_confidence": float(confidence),
+                "confidence_score_type": HEURISTIC_MATERIAL_SCORE_TYPE,
+                "raw_clip_similarity": None,
+                "clip_softmax_probability": None,
+                "clip_top2_margin": None,
+                "calibration_version": None,
+            }
+            for material, (_, confidence) in masks.items()
+        }
         return masks
 
     def _bootstrap_sky(self, image: np.ndarray, config: Any) -> Dict[str, Any]:
@@ -1617,6 +1724,17 @@ class SAM2SegmentationBackend(EfficientSAMBackend):
                 len(segments),
                 list(material_buckets.keys()),
             )
+            self._material_confidence_evidence = {
+                material: {
+                    "material_confidence": float(bucket[1]),
+                    "confidence_score_type": MATERIAL_CLASSIFIER_SCORE_TYPE,
+                    "raw_clip_similarity": None,
+                    "clip_softmax_probability": None,
+                    "clip_top2_margin": None,
+                    "calibration_version": MATERIALS_V3_CALIBRATION_VERSION,
+                }
+                for material, bucket in material_buckets.items()
+            }
             return {k: (v[0], float(v[1])) for k, v in material_buckets.items()}
 
         # No explicit labels: reuse existing CLIP/heuristic material labeling.

--- a/src/transformation_portal/lux_depth_v3/segmentation_backend.py
+++ b/src/transformation_portal/lux_depth_v3/segmentation_backend.py
@@ -135,11 +135,18 @@ def _tensor_values_1d(value: Any) -> np.ndarray:
             if hasattr(value, "float"):
                 value = value.float()
             if hasattr(value, "numpy"):
-                return np.asarray(value.numpy(), dtype=np.float32).reshape(-1)
+                try:
+                    return np.asarray(value.numpy(), dtype=np.float32).reshape(-1)
+                except RuntimeError as exc:
+                    if "Numpy is not available" not in str(exc):
+                        raise
+            if hasattr(value, "tolist"):
+                return np.asarray(value.tolist(), dtype=np.float32).reshape(-1)
         except Exception:
             pass
-    if hasattr(value, "values"):
-        return np.asarray(value.values, dtype=np.float32).reshape(-1)
+    values = getattr(value, "values", None)
+    if values is not None and not callable(values):
+        return np.asarray(values, dtype=np.float32).reshape(-1)
     return np.asarray(value, dtype=np.float32).reshape(-1)
 
 

--- a/src/transformation_portal/lux_depth_v3/segmentation_backend.py
+++ b/src/transformation_portal/lux_depth_v3/segmentation_backend.py
@@ -127,6 +127,17 @@ def _material_confidence_metadata(
     return metadata
 
 
+def _material_confidence_evidence_from_metadata(
+    metadata: Optional[Dict[str, Any]],
+) -> Optional[Dict[str, Dict[str, Any]]]:
+    if not isinstance(metadata, dict):
+        return None
+    evidence = metadata.get("material_confidence_evidence")
+    if not isinstance(evidence, dict):
+        return None
+    return {str(material): dict(values) for material, values in evidence.items() if isinstance(values, dict)}
+
+
 def _tensor_values_1d(value: Any) -> np.ndarray:
     """Convert torch/fake tensor rows into a 1D float32 array."""
     if hasattr(value, "detach") and hasattr(value, "cpu"):
@@ -1966,7 +1977,11 @@ def segment_materials(
             if cached is not None:
                 cached_results, cached_metadata = cached
                 masks, material_confidences = _split_material_results(cached_results)
-                confidence_metadata = _material_confidence_metadata(material_confidences)
+                cached_runtime = cached_metadata.get("runtime_metadata")
+                confidence_metadata = _material_confidence_metadata(
+                    material_confidences,
+                    evidence=_material_confidence_evidence_from_metadata(cached_runtime),
+                )
                 timing_ms["total"] = round((time.perf_counter() - t_total) * 1000.0, 3)
                 metadata: Dict[str, Any] = {
                     "cache_hit": True,
@@ -1978,7 +1993,6 @@ def segment_materials(
                     "device": device,
                     "model_size": sam2_model_size if backend_name == "sam2" else None,
                 }
-                cached_runtime = cached_metadata.get("runtime_metadata")
                 if isinstance(cached_runtime, dict):
                     metadata.update(cached_runtime)
                 metadata.update(confidence_metadata)
@@ -2030,7 +2044,10 @@ def segment_materials(
         # while preserving real classifier confidence for downstream Materials V3
         # decisions through runtime metadata.
         masks, material_confidences = _split_material_results(results)
-        confidence_metadata = _material_confidence_metadata(material_confidences)
+        confidence_metadata = _material_confidence_metadata(
+            material_confidences,
+            evidence=_material_confidence_evidence_from_metadata(runtime_metadata),
+        )
         runtime_metadata_for_cache = dict(runtime_metadata) if isinstance(runtime_metadata, dict) else {}
         runtime_metadata_for_cache.update(confidence_metadata)
 

--- a/src/transformation_portal/lux_depth_v3/segmentation_backend.py
+++ b/src/transformation_portal/lux_depth_v3/segmentation_backend.py
@@ -142,8 +142,8 @@ def _tensor_values_1d(value: Any) -> np.ndarray:
                         raise
             if hasattr(value, "tolist"):
                 return np.asarray(value.tolist(), dtype=np.float32).reshape(-1)
-        except Exception:
-            pass
+        except (AttributeError, RuntimeError, TypeError, ValueError):
+            logger.debug("Tensor-like value conversion failed; falling back to array coercion", exc_info=True)
     values = getattr(value, "values", None)
     if values is not None and not callable(values):
         return np.asarray(values, dtype=np.float32).reshape(-1)

--- a/tests/evals/test_apex_visual.py
+++ b/tests/evals/test_apex_visual.py
@@ -1,0 +1,148 @@
+"""Tests for APEX visual quality evalset and depth benchmark helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from transformation_portal.evals.apex_visual import (
+    APEX_EVALSET_SCHEMA_VERSION,
+    DepthBackendRunResult,
+    build_apex_eval_report,
+    build_depth_backend_benchmark_report,
+    load_apex_evalset,
+    sha256_file,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _write_evalset(root: Path, asset_path: Path, *, sha256: str | None = None) -> Path:
+    evalset_dir = root / "evalsets" / "apex"
+    evalset_dir.mkdir(parents=True)
+    payload = {
+        "schema_version": APEX_EVALSET_SCHEMA_VERSION,
+        "evalset_id": "unit_apex",
+        "version": "v1",
+        "description": "unit",
+        "assets": [
+            {
+                "asset_id": "unit_image",
+                "asset_ref": str(asset_path.relative_to(root)),
+                "sha256": sha256 or sha256_file(asset_path),
+                "scene_type": "pool_exterior",
+                "expected_materials": ["water", "stone"],
+                "risk_zones": ["water_glass_boundary"],
+                "reject_if": ["haloing"],
+                "manual_quality_score": None,
+            }
+        ],
+    }
+    path = evalset_dir / "evalset.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_apex_eval_report_tracks_ready_assets_and_candidate_metrics(tmp_path):
+    image_path = tmp_path / "input.png"
+    candidate_path = tmp_path / "candidate.png"
+    image = np.zeros((16, 16, 3), dtype=np.uint8)
+    image[4:12, 4:12] = 120
+    Image.fromarray(image).save(image_path)
+    Image.fromarray(image.copy()).save(candidate_path)
+    evalset_path = _write_evalset(tmp_path, image_path)
+
+    report = build_apex_eval_report(
+        evalset_path,
+        output_dir=tmp_path / "report",
+        candidate_outputs={"identity": {"unit_image": candidate_path}},
+        repo_root=tmp_path,
+    )
+
+    assert report["evalset"]["ready_asset_count"] == 1
+    asset = report["assets"][0]
+    assert asset["asset_status"]["status"] == "ready"
+    assert asset["candidates"][0]["status"] == "ok"
+    assert asset["candidates"][0]["metrics"]["ssim"] == pytest.approx(1.0)
+    assert (tmp_path / "report" / "apex_eval_report.json").is_file()
+
+
+def test_apex_eval_report_marks_missing_assets(tmp_path):
+    image_path = tmp_path / "input.png"
+    Image.fromarray(np.zeros((8, 8, 3), dtype=np.uint8)).save(image_path)
+    evalset_path = _write_evalset(tmp_path, image_path)
+    image_path.unlink()
+
+    report = build_apex_eval_report(evalset_path, output_dir=tmp_path / "report", repo_root=tmp_path)
+
+    assert report["evalset"]["ready_asset_count"] == 0
+    assert report["assets"][0]["asset_status"]["status"] == "missing_asset"
+
+
+def test_load_apex_evalset_rejects_checksum_drift_in_report(tmp_path):
+    image_path = tmp_path / "input.png"
+    Image.fromarray(np.zeros((8, 8, 3), dtype=np.uint8)).save(image_path)
+    evalset_path = _write_evalset(tmp_path, image_path, sha256="0" * 64)
+
+    evalset = load_apex_evalset(evalset_path, repo_root=tmp_path)
+    report = build_apex_eval_report(evalset.source_path, output_dir=tmp_path / "report", repo_root=tmp_path)
+
+    assert report["assets"][0]["asset_status"]["status"] == "checksum_mismatch"
+
+
+def test_depth_backend_benchmark_blocks_depth_pro_without_license(tmp_path):
+    image_path = tmp_path / "input.png"
+    Image.fromarray(np.zeros((8, 8, 3), dtype=np.uint8)).save(image_path)
+    evalset_path = _write_evalset(tmp_path, image_path)
+
+    report = build_depth_backend_benchmark_report(
+        evalset_path,
+        backends=["depth_pro"],
+        quality_tier="apex",
+        output_dir=tmp_path / "benchmark",
+        repo_root=tmp_path,
+    )
+
+    backend = report["backends"][0]
+    assert backend["backend"] == "depth_pro"
+    assert backend["status"] == "license_blocked"
+
+
+def test_depth_backend_benchmark_uses_mocked_runner(tmp_path):
+    image_path = tmp_path / "input.png"
+    Image.fromarray(np.zeros((8, 8, 3), dtype=np.uint8)).save(image_path)
+    evalset_path = _write_evalset(tmp_path, image_path)
+
+    def runner(backend, asset, output_dir, quality_tier):
+        assert backend == "da3_metric"
+        assert asset.asset_id == "unit_image"
+        assert output_dir == tmp_path / "benchmark"
+        assert quality_tier == "apex"
+        depth = np.tile(np.linspace(0.0, 1.0, 8, dtype=np.float32), (8, 1))
+        return DepthBackendRunResult(
+            backend=backend,
+            asset_id=asset.asset_id,
+            status="success",
+            runtime_ms=12.5,
+            depth_map=depth,
+            provenance={"model": "mock"},
+        )
+
+    report = build_depth_backend_benchmark_report(
+        evalset_path,
+        backends=["da3-metric"],
+        quality_tier="apex",
+        output_dir=tmp_path / "benchmark",
+        runner=runner,
+        repo_root=tmp_path,
+    )
+
+    backend = report["backends"][0]
+    assert backend["status"] == "ready"
+    assert backend["assets"][0]["status"] == "success"
+    assert backend["assets"][0]["metrics"]["runtime_ms"] == pytest.approx(12.5)
+    assert backend["depth_edge_score"] is not None

--- a/tests/evals/test_apex_visual.py
+++ b/tests/evals/test_apex_visual.py
@@ -153,7 +153,40 @@ def test_jpeg_cannot_be_promoted_to_canonical_apex_reference(tmp_path):
     assert report["evalset"]["canonical_scoring_eligible_count"] == 0
     asset = report["assets"][0]
     assert asset["canonical_scoring_eligible"] is False
-    assert asset["canonical_scoring_blocked_reason"] == "non_16bit_reference"
+    assert asset["canonical_scoring_blocked_reason"] == "reference_bit_depth_below_16"
+
+
+def test_misdeclared_8bit_tiff_is_not_canonical_scoring_eligible(tmp_path):
+    image_path = tmp_path / "misdeclared_reference.tif"
+    Image.fromarray(np.zeros((8, 8, 3), dtype=np.uint8)).save(image_path, format="TIFF")
+    evalset_path = _write_evalset(
+        tmp_path,
+        image_path,
+        dataset_tier="canonical_apex",
+        asset_overrides={
+            "asset_role": "canonical_apex_reference",
+            "canonical_bit_depth": 16,
+            "canonical_format": "tiff",
+            "canonical_color_space": "documented_source_profile",
+            "canonical_scoring_eligible": True,
+            "evaluate_at_native_resolution": True,
+            "preserve_16bit_intermediates": True,
+        },
+    )
+
+    report = build_apex_eval_report(evalset_path, output_dir=tmp_path / "report", repo_root=tmp_path)
+
+    assert report["evalset"]["ready_asset_count"] == 1
+    assert report["evalset"]["canonical_scoring_eligible_count"] == 0
+    assert report["evalset"]["noncanonical_asset_count"] == 1
+    asset = report["assets"][0]
+    assert asset["asset_status"]["status"] == "ready"
+    assert asset["declared_reference_bit_depth"] == 16
+    assert asset["detected_reference_bit_depth"] == 8
+    assert asset["reference_bit_depth"] == 8
+    assert asset["reference_format"] == "tiff"
+    assert asset["canonical_scoring_eligible"] is False
+    assert asset["canonical_scoring_blocked_reason"] == "reference_bit_depth_below_16"
 
 
 def test_rendering_asset_is_smoke_only_even_with_canonical_like_fields(tmp_path):

--- a/tests/evals/test_apex_visual.py
+++ b/tests/evals/test_apex_visual.py
@@ -24,27 +24,39 @@ from transformation_portal.evals.apex_visual import (
 pytestmark = pytest.mark.unit
 
 
-def _write_evalset(root: Path, asset_path: Path, *, sha256: str | None = None) -> Path:
+def _write_evalset(
+    root: Path,
+    asset_path: Path,
+    *,
+    sha256: str | None = None,
+    dataset_tier: str = "smoke_or_readiness",
+    evalset_overrides: dict | None = None,
+    asset_overrides: dict | None = None,
+) -> Path:
     evalset_dir = root / "evalsets" / "apex"
-    evalset_dir.mkdir(parents=True)
+    evalset_dir.mkdir(parents=True, exist_ok=True)
+    asset_payload = {
+        "asset_id": "unit_image",
+        "asset_ref": str(asset_path.relative_to(root)),
+        "sha256": sha256 or sha256_file(asset_path),
+        "scene_type": "pool_exterior",
+        "expected_materials": ["water", "stone"],
+        "risk_zones": ["water_glass_boundary"],
+        "reject_if": ["haloing"],
+        "manual_quality_score": None,
+    }
+    if asset_overrides:
+        asset_payload.update(asset_overrides)
     payload = {
         "schema_version": APEX_EVALSET_SCHEMA_VERSION,
         "evalset_id": "unit_apex",
         "version": "v1",
         "description": "unit",
-        "assets": [
-            {
-                "asset_id": "unit_image",
-                "asset_ref": str(asset_path.relative_to(root)),
-                "sha256": sha256 or sha256_file(asset_path),
-                "scene_type": "pool_exterior",
-                "expected_materials": ["water", "stone"],
-                "risk_zones": ["water_glass_boundary"],
-                "reject_if": ["haloing"],
-                "manual_quality_score": None,
-            }
-        ],
+        "dataset_tier": dataset_tier,
+        "assets": [asset_payload],
     }
+    if evalset_overrides:
+        payload.update(evalset_overrides)
     path = evalset_dir / "evalset.json"
     path.write_text(json.dumps(payload), encoding="utf-8")
     return path
@@ -88,6 +100,127 @@ def test_apex_eval_report_tracks_ready_assets_and_candidate_metrics(tmp_path):
     assert (tmp_path / "report" / "apex_eval_report.json").is_file()
 
 
+def test_jpeg_delivery_asset_is_ready_but_not_canonical_scoring_eligible(tmp_path):
+    image_path = tmp_path / "delivery.jpg"
+    Image.fromarray(np.zeros((8, 8, 3), dtype=np.uint8)).save(image_path, format="JPEG")
+    evalset_path = _write_evalset(
+        tmp_path,
+        image_path,
+        asset_overrides={
+            "asset_role": "delivery_preview",
+            "canonical_bit_depth": 8,
+            "canonical_format": "jpeg",
+            "canonical_color_space": "srgb",
+            "canonical_scoring_eligible": True,
+        },
+    )
+
+    report = build_apex_eval_report(evalset_path, output_dir=tmp_path / "report", repo_root=tmp_path)
+
+    assert report["evalset"]["ready_asset_count"] == 1
+    assert report["evalset"]["canonical_scoring_eligible_count"] == 0
+    assert report["evalset"]["noncanonical_asset_count"] == 1
+    asset = report["assets"][0]
+    assert asset["asset_status"]["status"] == "ready"
+    assert asset["asset_role"] == "delivery_preview"
+    assert asset["reference_bit_depth"] == 8
+    assert asset["reference_format"] == "jpeg"
+    assert asset["canonical_scoring_eligible"] is False
+    assert asset["canonical_scoring_blocked_reason"] == "noncanonical_dataset_tier"
+
+
+def test_jpeg_cannot_be_promoted_to_canonical_apex_reference(tmp_path):
+    image_path = tmp_path / "misdeclared_reference.jpg"
+    Image.fromarray(np.zeros((8, 8, 3), dtype=np.uint8)).save(image_path, format="JPEG")
+    evalset_path = _write_evalset(
+        tmp_path,
+        image_path,
+        dataset_tier="canonical_apex",
+        asset_overrides={
+            "asset_role": "canonical_apex_reference",
+            "canonical_bit_depth": 8,
+            "canonical_format": "jpeg",
+            "canonical_color_space": "srgb",
+            "canonical_scoring_eligible": True,
+            "evaluate_at_native_resolution": True,
+            "preserve_16bit_intermediates": True,
+        },
+    )
+
+    report = build_apex_eval_report(evalset_path, output_dir=tmp_path / "report", repo_root=tmp_path)
+
+    assert report["evalset"]["ready_asset_count"] == 1
+    assert report["evalset"]["canonical_scoring_eligible_count"] == 0
+    asset = report["assets"][0]
+    assert asset["canonical_scoring_eligible"] is False
+    assert asset["canonical_scoring_blocked_reason"] == "non_16bit_reference"
+
+
+def test_rendering_asset_is_smoke_only_even_with_canonical_like_fields(tmp_path):
+    image_path = tmp_path / "rendering.png"
+    Image.fromarray(np.zeros((8, 8, 3), dtype=np.uint8)).save(image_path)
+    evalset_path = _write_evalset(
+        tmp_path,
+        image_path,
+        dataset_tier="synthetic_smoke",
+        asset_overrides={
+            "asset_role": "synthetic_smoke",
+            "canonical_bit_depth": 16,
+            "canonical_format": "tiff",
+            "canonical_color_space": "documented_source_profile",
+            "canonical_scoring_eligible": True,
+            "evaluate_at_native_resolution": True,
+            "preserve_16bit_intermediates": True,
+        },
+    )
+
+    report = build_apex_eval_report(evalset_path, output_dir=tmp_path / "report", repo_root=tmp_path)
+
+    assert report["evalset"]["dataset_tier"] == "synthetic_smoke"
+    assert report["evalset"]["canonical_scoring_eligible_count"] == 0
+    assert report["evalset"]["noncanonical_asset_count"] == 1
+    asset = report["assets"][0]
+    assert asset["asset_role"] == "synthetic_smoke"
+    assert asset["canonical_scoring_eligible"] is False
+    assert asset["canonical_scoring_blocked_reason"] == "noncanonical_dataset_tier"
+
+
+def test_16bit_tiff_reference_is_canonical_scoring_eligible(tmp_path):
+    image_path = tmp_path / "reference16.tif"
+    Image.fromarray(np.zeros((8, 8), dtype=np.uint16), mode="I;16").save(image_path)
+    evalset_path = _write_evalset(
+        tmp_path,
+        image_path,
+        dataset_tier="canonical_apex",
+        evalset_overrides={
+            "canonical_bit_depth": 16,
+            "canonical_format": "tiff",
+            "canonical_color_space": "documented_source_profile",
+        },
+        asset_overrides={
+            "asset_role": "canonical_apex_reference",
+            "canonical_bit_depth": 16,
+            "canonical_format": "tiff",
+            "canonical_color_space": "documented_source_profile",
+            "canonical_scoring_eligible": True,
+            "evaluate_at_native_resolution": True,
+            "preserve_16bit_intermediates": True,
+        },
+    )
+
+    report = build_apex_eval_report(evalset_path, output_dir=tmp_path / "report", repo_root=tmp_path)
+
+    assert report["evalset"]["ready_asset_count"] == 1
+    assert report["evalset"]["canonical_scoring_eligible_count"] == 1
+    assert report["evalset"]["noncanonical_asset_count"] == 0
+    asset = report["assets"][0]
+    assert asset["asset_role"] == "canonical_apex_reference"
+    assert asset["reference_bit_depth"] == 16
+    assert asset["reference_format"] == "tiff"
+    assert asset["canonical_scoring_eligible"] is True
+    assert asset["canonical_scoring_blocked_reason"] is None
+
+
 def test_apex_eval_report_marks_missing_assets(tmp_path):
     image_path = tmp_path / "input.png"
     Image.fromarray(np.zeros((8, 8, 3), dtype=np.uint8)).save(image_path)
@@ -97,6 +230,8 @@ def test_apex_eval_report_marks_missing_assets(tmp_path):
     report = build_apex_eval_report(evalset_path, output_dir=tmp_path / "report", repo_root=tmp_path)
 
     assert report["evalset"]["ready_asset_count"] == 0
+    assert report["evalset"]["canonical_scoring_eligible_count"] == 0
+    assert report["evalset"]["missing_asset_count"] == 1
     assert report["assets"][0]["asset_status"]["status"] == "missing_asset"
 
 
@@ -235,9 +370,23 @@ def test_depth_backend_benchmark_blocks_depth_pro_without_license(tmp_path):
 
 
 def test_depth_backend_benchmark_uses_mocked_runner(tmp_path):
-    image_path = tmp_path / "input.png"
-    Image.fromarray(np.zeros((8, 8, 3), dtype=np.uint8)).save(image_path)
-    evalset_path = _write_evalset(tmp_path, image_path)
+    image_path = tmp_path / "reference16.tif"
+    Image.fromarray(np.zeros((8, 8), dtype=np.uint16), mode="I;16").save(image_path)
+    evalset_path = _write_evalset(
+        tmp_path,
+        image_path,
+        dataset_tier="canonical_apex",
+        asset_overrides={
+            "asset_role": "canonical_apex_reference",
+            "canonical_bit_depth": 16,
+            "canonical_format": "tiff",
+            "canonical_color_space": "documented_source_profile",
+            "canonical_scoring_eligible": True,
+            "evaluate_at_native_resolution": True,
+            "allow_downsampled_model_inference": True,
+            "preserve_16bit_intermediates": True,
+        },
+    )
 
     def runner(backend, asset, output_dir, quality_tier):
         assert backend == "da3_metric"
@@ -251,7 +400,7 @@ def test_depth_backend_benchmark_uses_mocked_runner(tmp_path):
             status="success",
             runtime_ms=12.5,
             depth_map=depth,
-            provenance={"model": "mock"},
+            provenance={"model": "mock", "model_input": {"input_resolution": [1024, 768]}},
         )
 
     report = build_depth_backend_benchmark_report(
@@ -265,6 +414,14 @@ def test_depth_backend_benchmark_uses_mocked_runner(tmp_path):
 
     backend = report["backends"][0]
     assert backend["status"] == "ready"
-    assert backend["assets"][0]["status"] == "success"
-    assert backend["assets"][0]["metrics"]["runtime_ms"] == pytest.approx(12.5)
+    asset = backend["assets"][0]
+    assert asset["status"] == "success"
+    assert asset["metrics"]["runtime_ms"] == pytest.approx(12.5)
+    assert asset["model_input"]["derived_from"] == str(image_path.relative_to(tmp_path))
+    assert asset["model_input"]["input_bit_depth"] == 8
+    assert asset["model_input"]["input_resolution"] == [1024, 768]
+    assert asset["model_input"]["downsampled_for_inference"] is True
+    assert asset["evaluation_target"]["path"] == str(image_path.relative_to(tmp_path))
+    assert asset["evaluation_target"]["bit_depth"] == 16
+    assert asset["evaluation_target"]["evaluate_at_native_resolution"] is True
     assert backend["depth_edge_score"] is not None

--- a/tests/evals/test_apex_visual.py
+++ b/tests/evals/test_apex_visual.py
@@ -50,6 +50,16 @@ def _write_evalset(root: Path, asset_path: Path, *, sha256: str | None = None) -
     return path
 
 
+def _load_tool_module(script_name: str, module_name: str):
+    script_path = Path(__file__).resolve().parents[2] / "tools" / script_name
+    spec = importlib.util.spec_from_file_location(module_name, script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
 def test_apex_eval_report_tracks_ready_assets_and_candidate_metrics(tmp_path):
     image_path = tmp_path / "input.png"
     candidate_path = tmp_path / "candidate.png"
@@ -97,12 +107,7 @@ def test_run_apex_eval_returns_nonzero_for_non_ready_assets(tmp_path, monkeypatc
     image_path.unlink()
     output_dir = tmp_path / "report"
 
-    script_path = Path(__file__).resolve().parents[2] / "tools" / "run_apex_eval.py"
-    spec = importlib.util.spec_from_file_location("run_apex_eval_unit", script_path)
-    assert spec is not None
-    assert spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
+    module = _load_tool_module("run_apex_eval.py", "run_apex_eval_unit")
 
     monkeypatch.setattr(
         sys,
@@ -123,6 +128,52 @@ def test_run_apex_eval_returns_nonzero_for_non_ready_assets(tmp_path, monkeypatc
     assert "non-ready assets: unit_image" in capsys.readouterr().out
 
 
+def test_run_apex_eval_returns_stable_input_error_for_bad_candidate_output(tmp_path, monkeypatch, capsys):
+    module = _load_tool_module("run_apex_eval.py", "run_apex_eval_bad_candidate_unit")
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_apex_eval.py",
+            "--evalset",
+            str(tmp_path / "missing_evalset"),
+            "--output-dir",
+            str(tmp_path / "report"),
+            "--candidate-output",
+            "not-valid",
+        ],
+    )
+
+    assert module.main() == 2
+    captured = capsys.readouterr()
+    assert "APEX eval error:" in captured.err
+    assert "expected candidate:asset_id=path" in captured.err
+
+
+def test_benchmark_depth_backends_returns_stable_input_error_for_missing_evalset(tmp_path, monkeypatch, capsys):
+    module = _load_tool_module("benchmark_depth_backends.py", "benchmark_depth_backends_missing_evalset_unit")
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "benchmark_depth_backends.py",
+            "--evalset",
+            str(tmp_path / "missing_evalset"),
+            "--backends",
+            "da3-metric",
+            "--output-dir",
+            str(tmp_path / "benchmark"),
+        ],
+    )
+
+    assert module.main() == 2
+    captured = capsys.readouterr()
+    assert "Depth backend benchmark error:" in captured.err
+    assert "missing_evalset" in captured.err
+
+
 def test_visible_delta_metrics_marks_lpips_unavailable_as_partial(tmp_path, monkeypatch):
     reference_path = tmp_path / "reference.png"
     candidate_path = tmp_path / "candidate.png"
@@ -137,6 +188,21 @@ def test_visible_delta_metrics_marks_lpips_unavailable_as_partial(tmp_path, monk
     assert metrics["lpips"] is None
     assert "lpips_unavailable" in metrics["metric_warnings"]
     assert metrics["ssim"] == pytest.approx(1.0)
+
+
+def test_visible_delta_metrics_reports_unreadable_candidate(tmp_path):
+    reference_path = tmp_path / "reference.png"
+    candidate_path = tmp_path / "candidate.txt"
+    Image.fromarray(np.zeros((8, 8, 3), dtype=np.uint8)).save(reference_path)
+    candidate_path.write_text("not an image", encoding="utf-8")
+
+    metrics = visible_delta_metrics(reference_path, candidate_path)
+
+    assert metrics["status"] == "unreadable_image"
+    assert metrics["unreadable_role"] == "candidate"
+    assert metrics["unreadable_path"] == str(candidate_path)
+    assert metrics["ssim"] is None
+    assert metrics["lpips"] is None
 
 
 def test_load_apex_evalset_rejects_checksum_drift_in_report(tmp_path):

--- a/tests/evals/test_apex_visual.py
+++ b/tests/evals/test_apex_visual.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import importlib.util
 import json
+import sys
 from pathlib import Path
 
 import numpy as np
@@ -16,6 +18,7 @@ from transformation_portal.evals.apex_visual import (
     build_depth_backend_benchmark_report,
     load_apex_evalset,
     sha256_file,
+    visible_delta_metrics,
 )
 
 pytestmark = pytest.mark.unit
@@ -66,8 +69,12 @@ def test_apex_eval_report_tracks_ready_assets_and_candidate_metrics(tmp_path):
     assert report["evalset"]["ready_asset_count"] == 1
     asset = report["assets"][0]
     assert asset["asset_status"]["status"] == "ready"
-    assert asset["candidates"][0]["status"] == "ok"
-    assert asset["candidates"][0]["metrics"]["ssim"] == pytest.approx(1.0)
+    candidate = asset["candidates"][0]
+    assert candidate["status"] in {"ok", "partial_metrics"}
+    assert candidate["metrics"]["ssim"] == pytest.approx(1.0)
+    if candidate["status"] == "partial_metrics":
+        assert "lpips_unavailable" in candidate["metrics"]["metric_warnings"]
+        assert candidate["metrics"]["lpips"] is None
     assert (tmp_path / "report" / "apex_eval_report.json").is_file()
 
 
@@ -81,6 +88,55 @@ def test_apex_eval_report_marks_missing_assets(tmp_path):
 
     assert report["evalset"]["ready_asset_count"] == 0
     assert report["assets"][0]["asset_status"]["status"] == "missing_asset"
+
+
+def test_run_apex_eval_returns_nonzero_for_non_ready_assets(tmp_path, monkeypatch, capsys):
+    image_path = tmp_path / "input.png"
+    Image.fromarray(np.zeros((8, 8, 3), dtype=np.uint8)).save(image_path)
+    evalset_path = _write_evalset(tmp_path, image_path)
+    image_path.unlink()
+    output_dir = tmp_path / "report"
+
+    script_path = Path(__file__).resolve().parents[2] / "tools" / "run_apex_eval.py"
+    spec = importlib.util.spec_from_file_location("run_apex_eval_unit", script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_apex_eval.py",
+            "--evalset",
+            str(evalset_path),
+            "--output-dir",
+            str(output_dir),
+            "--emit-report",
+            "off",
+        ],
+    )
+
+    assert module.main() == 1
+    assert (output_dir / "apex_eval_report.json").is_file()
+    assert "non-ready assets: unit_image" in capsys.readouterr().out
+
+
+def test_visible_delta_metrics_marks_lpips_unavailable_as_partial(tmp_path, monkeypatch):
+    reference_path = tmp_path / "reference.png"
+    candidate_path = tmp_path / "candidate.png"
+    image = np.zeros((8, 8, 3), dtype=np.uint8)
+    Image.fromarray(image).save(reference_path)
+    Image.fromarray(image.copy()).save(candidate_path)
+    monkeypatch.setattr("transformation_portal.evals.apex_visual._lpips_available", lambda: False)
+
+    metrics = visible_delta_metrics(reference_path, candidate_path)
+
+    assert metrics["status"] == "partial_metrics"
+    assert metrics["lpips"] is None
+    assert "lpips_unavailable" in metrics["metric_warnings"]
+    assert metrics["ssim"] == pytest.approx(1.0)
 
 
 def test_load_apex_evalset_rejects_checksum_drift_in_report(tmp_path):

--- a/tests/evals/test_apex_visual.py
+++ b/tests/evals/test_apex_visual.py
@@ -319,6 +319,30 @@ def test_run_apex_eval_returns_stable_input_error_for_bad_candidate_output(tmp_p
     assert "expected candidate:asset_id=path" in captured.err
 
 
+def test_run_apex_eval_prints_resolved_report_path(tmp_path, monkeypatch, capsys):
+    module = _load_tool_module("run_apex_eval.py", "run_apex_eval_resolved_path_unit")
+    resolved_report = tmp_path / "resolved" / "apex_eval_report.json"
+
+    def fake_build_report(*args, **kwargs):
+        return {"report_path": str(resolved_report), "assets": []}
+
+    monkeypatch.setattr(module, "build_apex_eval_report", fake_build_report)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_apex_eval.py",
+            "--evalset",
+            "evalsets/picacho_apex",
+            "--output-dir",
+            "relative-output",
+        ],
+    )
+
+    assert module.main() == 0
+    assert capsys.readouterr().out.strip() == str(resolved_report)
+
+
 def test_benchmark_depth_backends_returns_stable_input_error_for_missing_evalset(tmp_path, monkeypatch, capsys):
     module = _load_tool_module("benchmark_depth_backends.py", "benchmark_depth_backends_missing_evalset_unit")
 
@@ -340,6 +364,32 @@ def test_benchmark_depth_backends_returns_stable_input_error_for_missing_evalset
     captured = capsys.readouterr()
     assert "Depth backend benchmark error:" in captured.err
     assert "missing_evalset" in captured.err
+
+
+def test_benchmark_depth_backends_prints_resolved_report_path(tmp_path, monkeypatch, capsys):
+    module = _load_tool_module("benchmark_depth_backends.py", "benchmark_depth_backends_resolved_path_unit")
+    resolved_report = tmp_path / "resolved" / "depth_backend_comparison_report.json"
+
+    def fake_build_report(*args, **kwargs):
+        return {"report_path": str(resolved_report), "backends": []}
+
+    monkeypatch.setattr(module, "build_depth_backend_benchmark_report", fake_build_report)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "benchmark_depth_backends.py",
+            "--evalset",
+            "evalsets/picacho_apex",
+            "--backends",
+            "da3-metric",
+            "--output-dir",
+            "relative-output",
+        ],
+    )
+
+    assert module.main() == 0
+    assert capsys.readouterr().out.strip() == str(resolved_report)
 
 
 def test_visible_delta_metrics_marks_lpips_unavailable_as_partial(tmp_path, monkeypatch):

--- a/tests/evals/test_apex_visual.py
+++ b/tests/evals/test_apex_visual.py
@@ -366,6 +366,33 @@ def test_benchmark_depth_backends_returns_stable_input_error_for_missing_evalset
     assert "missing_evalset" in captured.err
 
 
+def test_benchmark_depth_backends_rejects_empty_backend_list(tmp_path, monkeypatch, capsys):
+    module = _load_tool_module("benchmark_depth_backends.py", "benchmark_depth_backends_empty_backends_unit")
+
+    def fail_build_report(*args, **kwargs):
+        raise AssertionError("empty backend list must fail before report generation")
+
+    monkeypatch.setattr(module, "build_depth_backend_benchmark_report", fail_build_report)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "benchmark_depth_backends.py",
+            "--evalset",
+            "evalsets/picacho_apex",
+            "--backends",
+            ",,,",
+            "--output-dir",
+            str(tmp_path),
+        ],
+    )
+
+    assert module.main() == 2
+    captured = capsys.readouterr()
+    assert "--backends must include at least one backend id" in captured.err
+    assert not captured.out
+
+
 def test_benchmark_depth_backends_prints_resolved_report_path(tmp_path, monkeypatch, capsys):
     module = _load_tool_module("benchmark_depth_backends.py", "benchmark_depth_backends_resolved_path_unit")
     resolved_report = tmp_path / "resolved" / "depth_backend_comparison_report.json"

--- a/tests/materials/test_materials_v3_orchestrator_integration.py
+++ b/tests/materials/test_materials_v3_orchestrator_integration.py
@@ -372,6 +372,98 @@ def test_apex_strict_gate_requires_non_empty_material_masks(tmp_path, mock_depth
         orchestrator._enforce_apex_materials_gate({"materials": {}})
 
 
+def test_apex_strict_gate_fails_when_material_masks_apply_zero_pixel_ops(
+    tmp_path,
+    mock_depth_backend,
+    mock_da3_available,
+):
+    """APEX + Materials V3 should not silently succeed when all implemented ops are blocked."""
+    config = EnhanceConfig(
+        quality_tier="apex",
+        enable_materials_v3=True,
+        enable_material_segmentation=True,
+        material_segmentation_backend="sam2",
+        strict_backend=True,
+        apply_pixel_ops=True,
+        depth_device="cpu",
+        enable_v2=False,
+    )
+    orchestrator = EnhanceOrchestrator(config, tmp_path)
+    mask = np.ones((8, 8), dtype=np.float32)
+    materials_result = {
+        "material_masks": {"water": mask},
+        "materials_v3_pixel_ops": {
+            "enabled": True,
+            "applied": [],
+            "blocked": [
+                {
+                    "material": "water",
+                    "reason": "below_confidence_threshold",
+                    "blocked_by": ["below_confidence_threshold"],
+                }
+            ],
+        },
+    }
+
+    with pytest.raises(ApexStrictGateError, match="APEX_MATERIALS_PIXEL_OPS_EMPTY") as exc_info:
+        orchestrator._enforce_apex_materials_pixel_ops_gate(materials_result)
+
+    assert exc_info.value.code == "APEX_MATERIALS_PIXEL_OPS_EMPTY"
+    assert exc_info.value.details["blocked_reasons"] == {"below_confidence_threshold": 1}
+    assert exc_info.value.details["implemented_materials"] == ["water"]
+
+
+def test_apex_materials_stage_invokes_zero_pixel_ops_gate(
+    tmp_path,
+    mock_depth_backend,
+    mock_da3_available,
+):
+    """The live Materials V3 stage should fail before persisting a silent no-op handoff."""
+    config = EnhanceConfig(
+        quality_tier="apex",
+        enable_materials_v3=True,
+        enable_material_segmentation=True,
+        material_segmentation_backend="sam2",
+        strict_backend=True,
+        apply_pixel_ops=True,
+        depth_device="cpu",
+        enable_v2=False,
+        emit_master16=False,
+        emit_upscaled16=False,
+    )
+    orchestrator = EnhanceOrchestrator(config, tmp_path)
+    mask = np.ones((32, 32), dtype=np.float32)
+    segmentation_metadata = {
+        "material_confidences": {"water": 0.9},
+        "material_confidence_evidence": {
+            "water": {
+                "material_confidence": 0.9,
+                "confidence_score_type": "raw_clip_similarity",
+                "raw_clip_similarity": 0.9,
+                "clip_softmax_probability": None,
+                "clip_top2_margin": None,
+                "calibration_version": None,
+            }
+        },
+    }
+
+    with (
+        patch("transformation_portal.lux_depth_v3.segmentation_backend.segment_materials", return_value={"water": mask}),
+        patch(
+            "transformation_portal.lux_depth_v3.segmentation_backend.get_last_segmentation_runtime_metadata",
+            return_value=segmentation_metadata,
+        ),
+        pytest.raises(ApexStrictGateError, match="APEX_MATERIALS_PIXEL_OPS_EMPTY") as exc_info,
+    ):
+        orchestrator._run_materials_v3_stage(
+            preprocessed_array=np.ones((32, 32, 3), dtype=np.float32) * 0.5,
+            depth_map=np.ones((32, 32), dtype=np.float32),
+            output_key=Path("apex/noop"),
+        )
+
+    assert exc_info.value.details["blocked_reasons"] == {"unsupported_confidence_score_type": 1}
+
+
 def test_apex_strict_gate_not_applied_outside_apex(tmp_path, mock_depth_backend, mock_da3_available):
     """Standard tier should not enforce apex-only gate constraints."""
     config = EnhanceConfig(

--- a/tests/materials/test_materials_v3_pixel_ops_smoke.py
+++ b/tests/materials/test_materials_v3_pixel_ops_smoke.py
@@ -27,6 +27,7 @@ class DummyConfig:
     min_coverage_px: int = 500
     min_mean_conf: float = 0.2
     refinement_strategy: str = "canary"
+    quality_tier: str = "standard"
 
 
 def _make_inputs():
@@ -69,6 +70,43 @@ def test_decider_blocks_low_confidence_material_masks():
     assert decision["eligible"] is False
     assert decision["reason"] == "below_confidence_threshold"
     assert "below_confidence_threshold" in decision["blocked_by"]
+
+
+def test_apex_decider_rejects_raw_clip_similarity_as_pixel_op_authority():
+    config = DummyConfig(quality_tier="apex")
+    stats = {
+        "coverage_px": 2000,
+        "mean_conf": 0.6,
+        "material_confidence": 0.9,
+        "confidence_score_type": "raw_clip_similarity",
+        "edge_conf": 0.6,
+    }
+
+    decision = decide_pixel_ops("water", stats, config, registry=OP_REGISTRY)
+
+    assert decision["will_apply"] is False
+    assert decision["reason"] == "unsupported_confidence_score_type"
+    assert "unsupported_confidence_score_type" in decision["blocked_by"]
+
+
+def test_apex_decider_accepts_calibrated_clip_softmax_margin_confidence():
+    config = DummyConfig(quality_tier="apex")
+    stats = {
+        "coverage_px": 2000,
+        "mean_conf": 0.6,
+        "material_confidence": 0.82,
+        "confidence_score_type": "clip_softmax_margin_v1",
+        "clip_softmax_probability": 0.82,
+        "clip_top2_margin": 0.24,
+        "calibration_version": "materials_v3_calibration_v1",
+        "edge_conf": 0.6,
+    }
+
+    decision = decide_pixel_ops("water", stats, config, registry=OP_REGISTRY)
+
+    assert decision["will_apply"] is True
+    assert decision["authority_score_type_accepted"] is True
+    assert decision["confidence_score_type"] == "clip_softmax_margin_v1"
 
 
 def test_decider_does_not_apply_taxonomy_threshold_to_mask_coverage_mean():
@@ -219,6 +257,39 @@ def test_materials_v3_engine_uses_segmentation_material_confidence_for_pixel_ops
     assert plan_entry["material_confidence"] == pytest.approx(0.1)
     assert plan_entry["pixel_ops"]["reason"] == "below_confidence_threshold"
     assert result["materials_v3_pixel_ops"]["blocked"][0]["reason"] == "below_confidence_threshold"
+
+
+def test_materials_v3_engine_propagates_confidence_contract_fields():
+    config = DummyConfig(quality_tier="apex")
+    image = np.ones((64, 64, 3), dtype=np.uint8) * 48
+    mask = np.ones((64, 64), dtype=np.float32)
+    engine = MaterialsV3Engine(config)
+
+    result = engine.process(
+        image,
+        {
+            "materials": {"water": mask},
+            "segmentation_metadata": {
+                "material_confidences": {"water": 0.78},
+                "material_confidence_evidence": {
+                    "water": {
+                        "material_confidence": 0.78,
+                        "confidence_score_type": "clip_softmax_margin_v1",
+                        "raw_clip_similarity": 0.24,
+                        "clip_softmax_probability": 0.78,
+                        "clip_top2_margin": 0.11,
+                        "calibration_version": "materials_v3_calibration_v1",
+                    }
+                },
+            },
+        },
+    )
+
+    plan_entry = result["materials_v3_response_plan"]["per_class"]["water"]
+    assert plan_entry["material_confidence"] == pytest.approx(0.78)
+    assert plan_entry["confidence_score_type"] == "clip_softmax_margin_v1"
+    assert plan_entry["raw_clip_similarity"] == pytest.approx(0.24)
+    assert result["materials_v3_pixel_ops"]["applied"][0]["confidence_score_type"] == "clip_softmax_margin_v1"
 
 
 def test_apply_pixel_ops_disabled_still_emits_object():

--- a/tests/materials/test_segmentation_backend.py
+++ b/tests/materials/test_segmentation_backend.py
@@ -572,6 +572,7 @@ def test_segment_materials_sam2_backend_with_mock(sample_image, config_sam2, mon
     metadata = get_last_segmentation_runtime_metadata()
     assert metadata is not None
     assert metadata["material_confidences"]["glass"] == pytest.approx(0.91)
+    assert metadata["material_confidence_evidence"]["glass"]["confidence_score_type"] == "material_classifier_probability_v1"
     assert metadata["confidence_summary"]["count"] == 1
 
 
@@ -896,6 +897,8 @@ def test_efficientsam_clip_classification_batches_segments(sample_image, monkeyp
     assert result["stone"][1] == pytest.approx(1.0)
     metadata = backend.get_runtime_metadata()
     assert metadata["clip_classification"]["timing_ms"]["batch_size"] == 2.0
+    assert metadata["material_confidence_evidence"]["glass"]["confidence_score_type"] == "clip_softmax_margin_v1"
+    assert metadata["material_confidence_evidence"]["glass"]["raw_clip_similarity"] == pytest.approx(1.0)
 
 
 def test_segment_materials_cache_key_invalidates_on_config_change(sample_image, tmp_path, monkeypatch):

--- a/tests/materials/test_segmentation_backend.py
+++ b/tests/materials/test_segmentation_backend.py
@@ -35,6 +35,7 @@ from transformation_portal.lux_depth_v3.segmentation_backend import (
     SAM2SegmentationBackend,
     StubBackend,
     _get_backend_instance,
+    _tensor_values_1d,
     get_last_segmentation_runtime_metadata,
     segment_materials,
 )
@@ -899,6 +900,33 @@ def test_efficientsam_clip_classification_batches_segments(sample_image, monkeyp
     assert metadata["clip_classification"]["timing_ms"]["batch_size"] == 2.0
     assert metadata["material_confidence_evidence"]["glass"]["confidence_score_type"] == "clip_softmax_margin_v1"
     assert metadata["material_confidence_evidence"]["glass"]["raw_clip_similarity"] == pytest.approx(1.0)
+
+
+def test_tensor_values_1d_falls_back_to_tolist_when_numpy_bridge_unavailable():
+    """Torch tensors can lose ``.numpy()`` support when NumPy ABI versions drift."""
+
+    class TensorLike:
+        def detach(self):
+            return self
+
+        def cpu(self):
+            return self
+
+        def float(self):
+            return self
+
+        def numpy(self):
+            raise RuntimeError("Numpy is not available")
+
+        def tolist(self):
+            return [0.1, 0.9, 0.2]
+
+        def values(self):
+            raise AssertionError("callable values method must not be treated as tensor data")
+
+    values = _tensor_values_1d(TensorLike())
+
+    assert values.tolist() == pytest.approx([0.1, 0.9, 0.2])
 
 
 def test_segment_materials_cache_key_invalidates_on_config_change(sample_image, tmp_path, monkeypatch):

--- a/tests/materials/test_segmentation_backend.py
+++ b/tests/materials/test_segmentation_backend.py
@@ -949,6 +949,29 @@ def test_tensor_values_1d_does_not_swallow_unexpected_tensor_errors():
         _tensor_values_1d(TensorLike())
 
 
+def test_tensor_values_1d_does_not_swallow_unexpected_runtime_errors():
+    """Only the known torch/NumPy ABI bridge failure may fall back to ``tolist``."""
+
+    class TensorLike:
+        def detach(self):
+            return self
+
+        def cpu(self):
+            return self
+
+        def float(self):
+            return self
+
+        def numpy(self):
+            raise RuntimeError("unexpected torch conversion failure")
+
+        def tolist(self):
+            raise AssertionError("unexpected RuntimeError must not fall back to tolist")
+
+    with pytest.raises(RuntimeError, match="unexpected torch conversion failure"):
+        _tensor_values_1d(TensorLike())
+
+
 def test_segment_materials_cache_key_invalidates_on_config_change(sample_image, tmp_path, monkeypatch):
     """Cache keys should include segmentation-affecting configuration."""
     import transformation_portal.lux_depth_v3.segmentation_backend as seg_module

--- a/tests/materials/test_segmentation_backend.py
+++ b/tests/materials/test_segmentation_backend.py
@@ -929,6 +929,26 @@ def test_tensor_values_1d_falls_back_to_tolist_when_numpy_bridge_unavailable():
     assert values.tolist() == pytest.approx([0.1, 0.9, 0.2])
 
 
+def test_tensor_values_1d_does_not_swallow_unexpected_tensor_errors():
+    """Unexpected tensor conversion failures should remain visible to callers."""
+
+    class TensorLike:
+        def detach(self):
+            return self
+
+        def cpu(self):
+            return self
+
+        def float(self):
+            return self
+
+        def numpy(self):
+            raise AssertionError("unexpected tensor conversion failure")
+
+    with pytest.raises(AssertionError, match="unexpected tensor conversion failure"):
+        _tensor_values_1d(TensorLike())
+
+
 def test_segment_materials_cache_key_invalidates_on_config_change(sample_image, tmp_path, monkeypatch):
     """Cache keys should include segmentation-affecting configuration."""
     import transformation_portal.lux_depth_v3.segmentation_backend as seg_module

--- a/tests/materials/test_segmentation_backend.py
+++ b/tests/materials/test_segmentation_backend.py
@@ -349,7 +349,19 @@ def test_segment_materials_exposes_runtime_metadata(monkeypatch, sample_image):
             return {"glass": (np.ones((2, 2), dtype=np.float32), 0.9)}
 
         def get_runtime_metadata(self):
-            return {"clip_runtime": {"offline_mode": True, "weights_source": "cache_path"}}
+            return {
+                "clip_runtime": {"offline_mode": True, "weights_source": "cache_path"},
+                "material_confidence_evidence": {
+                    "glass": {
+                        "material_confidence": 0.9,
+                        "confidence_score_type": "material_classifier_probability_v1",
+                    },
+                    "stone": {
+                        "material_confidence": 0.2,
+                        "confidence_score_type": "material_classifier_probability_v1",
+                    },
+                },
+            }
 
     monkeypatch.setattr(seg_module, "_get_backend_instance", lambda *_args, **_kwargs: _FakeBackend())
 
@@ -360,6 +372,9 @@ def test_segment_materials_exposes_runtime_metadata(monkeypatch, sample_image):
     metadata = get_last_segmentation_runtime_metadata()
     assert metadata is not None
     assert metadata["clip_runtime"]["weights_source"] == "cache_path"
+    assert set(metadata["material_confidence_evidence"]) == {"glass"}
+    score_type = metadata["material_confidence_evidence"]["glass"]["confidence_score_type"]
+    assert score_type == "material_classifier_probability_v1"
 
 
 @pytest.mark.ml
@@ -770,7 +785,19 @@ def test_segment_materials_cache_hit_skips_backend(sample_image, tmp_path, monke
             return {"glass": (glass_mask, 0.91)}
 
         def get_runtime_metadata(self):
-            return {"clip_runtime": {"weights_source": "test"}}
+            return {
+                "clip_runtime": {"weights_source": "test"},
+                "material_confidence_evidence": {
+                    "glass": {
+                        "material_confidence": 0.91,
+                        "confidence_score_type": "material_classifier_probability_v1",
+                    },
+                    "stone": {
+                        "material_confidence": 0.2,
+                        "confidence_score_type": "material_classifier_probability_v1",
+                    },
+                },
+            }
 
     monkeypatch.setattr(seg_module, "_get_backend_instance", lambda *args, **kwargs: FakeBackend())
     config = EnhanceConfig(
@@ -793,6 +820,8 @@ def test_segment_materials_cache_hit_skips_backend(sample_image, tmp_path, monke
     assert second_metadata["backend"] == "efficientsam"
     assert first_metadata["material_confidences"]["glass"] == pytest.approx(0.91)
     assert second_metadata["material_confidences"]["glass"] == pytest.approx(0.91)
+    assert set(first_metadata["material_confidence_evidence"]) == {"glass"}
+    assert set(second_metadata["material_confidence_evidence"]) == {"glass"}
     assert second_metadata["confidence_summary"]["count"] == 1
 
 

--- a/tools/benchmark_depth_backends.py
+++ b/tools/benchmark_depth_backends.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Emit a governed Depth Pro / DA3 backend benchmark report.
+
+The default mode is offline-safe: it validates the evalset and writes a
+comparison report with assets marked ``not_executed``. The Python API accepts
+a runner callable for tests and for future live-execution wiring.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from transformation_portal.evals.apex_visual import build_depth_backend_benchmark_report
+
+
+def _bool_flag(value: str) -> bool:
+    normalized = value.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    raise argparse.ArgumentTypeError(f"Expected boolean-like value, got {value!r}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Emit a governed depth backend comparison report.")
+    parser.add_argument("--evalset", required=True, help="Evalset directory or evalset.json path.")
+    parser.add_argument("--backends", required=True, help="Comma-separated backend ids, e.g. da3-metric,depth_pro.")
+    parser.add_argument("--quality-tier", default="apex", help="Quality tier recorded in the report.")
+    parser.add_argument("--output-dir", required=True, help="Directory for depth_backend_comparison_report.json.")
+    parser.add_argument(
+        "--emit-comparison-report",
+        choices=("on", "off"),
+        default="on",
+        help="Compatibility flag; reports are always persisted for deterministic audit evidence.",
+    )
+    parser.add_argument("--non-commercial-ok", type=_bool_flag, default=False)
+    parser.add_argument("--accept-apple-depth-pro-research-license", type=_bool_flag, default=False)
+    args = parser.parse_args()
+
+    backends = [item.strip() for item in args.backends.split(",") if item.strip()]
+    report = build_depth_backend_benchmark_report(
+        Path(args.evalset),
+        backends=backends,
+        quality_tier=args.quality_tier,
+        output_dir=Path(args.output_dir),
+        non_commercial_ok=args.non_commercial_ok,
+        accept_depth_pro_license=args.accept_apple_depth_pro_research_license,
+    )
+    if args.emit_comparison_report == "on":
+        print(Path(args.output_dir) / "depth_backend_comparison_report.json")
+    blocked = [item["backend"] for item in report["backends"] if item["status"] == "license_blocked"]
+    if blocked:
+        print("License-blocked backend(s): " + ", ".join(blocked))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/benchmark_depth_backends.py
+++ b/tools/benchmark_depth_backends.py
@@ -9,6 +9,7 @@ a runner callable for tests and for future live-execution wiring.
 from __future__ import annotations
 
 import argparse
+import sys
 from pathlib import Path
 
 from transformation_portal.evals.apex_visual import build_depth_backend_benchmark_report
@@ -40,14 +41,18 @@ def main() -> int:
     args = parser.parse_args()
 
     backends = [item.strip() for item in args.backends.split(",") if item.strip()]
-    report = build_depth_backend_benchmark_report(
-        Path(args.evalset),
-        backends=backends,
-        quality_tier=args.quality_tier,
-        output_dir=Path(args.output_dir),
-        non_commercial_ok=args.non_commercial_ok,
-        accept_depth_pro_license=args.accept_apple_depth_pro_research_license,
-    )
+    try:
+        report = build_depth_backend_benchmark_report(
+            Path(args.evalset),
+            backends=backends,
+            quality_tier=args.quality_tier,
+            output_dir=Path(args.output_dir),
+            non_commercial_ok=args.non_commercial_ok,
+            accept_depth_pro_license=args.accept_apple_depth_pro_research_license,
+        )
+    except (OSError, ValueError) as exc:
+        print(f"Depth backend benchmark error: {exc}", file=sys.stderr)
+        return 2
     if args.emit_comparison_report == "on":
         print(Path(args.output_dir) / "depth_backend_comparison_report.json")
     blocked = [item["backend"] for item in report["backends"] if item["status"] == "license_blocked"]

--- a/tools/benchmark_depth_backends.py
+++ b/tools/benchmark_depth_backends.py
@@ -54,7 +54,7 @@ def main() -> int:
         print(f"Depth backend benchmark error: {exc}", file=sys.stderr)
         return 2
     if args.emit_comparison_report == "on":
-        print(Path(args.output_dir) / "depth_backend_comparison_report.json")
+        print(report["report_path"])
     blocked = [item["backend"] for item in report["backends"] if item["status"] == "license_blocked"]
     if blocked:
         print("License-blocked backend(s): " + ", ".join(blocked))

--- a/tools/benchmark_depth_backends.py
+++ b/tools/benchmark_depth_backends.py
@@ -41,6 +41,12 @@ def main() -> int:
     args = parser.parse_args()
 
     backends = [item.strip() for item in args.backends.split(",") if item.strip()]
+    if not backends:
+        print(
+            "Depth backend benchmark error: --backends must include at least one backend id.",
+            file=sys.stderr,
+        )
+        return 2
     try:
         report = build_depth_backend_benchmark_report(
             Path(args.evalset),

--- a/tools/run_apex_eval.py
+++ b/tools/run_apex_eval.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Run offline-safe APEX visual evalset validation/reporting."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from transformation_portal.evals.apex_visual import build_apex_eval_report, parse_candidate_outputs
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Emit an APEX visual quality eval report.")
+    parser.add_argument("--evalset", required=True, help="Evalset directory or evalset.json path.")
+    parser.add_argument("--output-dir", required=True, help="Directory for apex_eval_report.json.")
+    parser.add_argument(
+        "--candidate-output",
+        action="append",
+        default=[],
+        metavar="CANDIDATE:ASSET_ID=PATH",
+        help="Optional candidate output image for visible-delta metrics. May be repeated.",
+    )
+    parser.add_argument(
+        "--emit-report",
+        choices=("on", "off"),
+        default="on",
+        help="Compatibility flag; off validates inputs but does not suppress process exit status.",
+    )
+    args = parser.parse_args()
+
+    candidate_outputs = parse_candidate_outputs(args.candidate_output)
+    report = build_apex_eval_report(
+        Path(args.evalset),
+        output_dir=Path(args.output_dir),
+        candidate_outputs=candidate_outputs,
+    )
+    if args.emit_report == "on":
+        print(Path(args.output_dir) / "apex_eval_report.json")
+    missing = [item["asset_id"] for item in report["assets"] if item["asset_status"]["status"] not in {"ready"}]
+    if missing:
+        print("APEX eval report emitted with non-ready assets: " + ", ".join(missing))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/run_apex_eval.py
+++ b/tools/run_apex_eval.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import sys
 from pathlib import Path
 
 from transformation_portal.evals.apex_visual import build_apex_eval_report, parse_candidate_outputs
@@ -28,12 +29,16 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    candidate_outputs = parse_candidate_outputs(args.candidate_output)
-    report = build_apex_eval_report(
-        Path(args.evalset),
-        output_dir=Path(args.output_dir),
-        candidate_outputs=candidate_outputs,
-    )
+    try:
+        candidate_outputs = parse_candidate_outputs(args.candidate_output)
+        report = build_apex_eval_report(
+            Path(args.evalset),
+            output_dir=Path(args.output_dir),
+            candidate_outputs=candidate_outputs,
+        )
+    except (OSError, ValueError) as exc:
+        print(f"APEX eval error: {exc}", file=sys.stderr)
+        return 2
     if args.emit_report == "on":
         print(Path(args.output_dir) / "apex_eval_report.json")
     missing = [item["asset_id"] for item in report["assets"] if item["asset_status"]["status"] not in {"ready"}]

--- a/tools/run_apex_eval.py
+++ b/tools/run_apex_eval.py
@@ -39,6 +39,7 @@ def main() -> int:
     missing = [item["asset_id"] for item in report["assets"] if item["asset_status"]["status"] not in {"ready"}]
     if missing:
         print("APEX eval report emitted with non-ready assets: " + ", ".join(missing))
+        return 1
     return 0
 
 

--- a/tools/run_apex_eval.py
+++ b/tools/run_apex_eval.py
@@ -40,7 +40,7 @@ def main() -> int:
         print(f"APEX eval error: {exc}", file=sys.stderr)
         return 2
     if args.emit_report == "on":
-        print(Path(args.output_dir) / "apex_eval_report.json")
+        print(report["report_path"])
     missing = [item["asset_id"] for item in report["assets"] if item["asset_status"]["status"] not in {"ready"}]
     if missing:
         print("APEX eval report emitted with non-ready assets: " + ", ".join(missing))


### PR DESCRIPTION
## Summary
- Establishes the APEX quality-control foundation: referenced eval corpus, offline-safe visual eval reporting, governed depth backend benchmark reporting, calibrated Materials V3 confidence, and strict zero-op failure behavior.
- Fixes the observed false-success posture where APEX Materials V3 could detect masks and classify materials while applying zero implemented pixel operations.

## Changes
- Added referenced Picacho eval metadata under evalsets/picacho_apex and docs for the APEX visual quality protocol.
- Added tools/run_apex_eval.py and transformation_portal.evals.apex_visual for corpus readiness and candidate visible-delta reports.
- Added tools/benchmark_depth_backends.py and the depth benchmark protocol, treating DA3 metric as the commercial-safe baseline and Depth Pro as a research-only yardstick.
- Added Materials V3 confidence evidence fields: confidence_score_type, raw_clip_similarity, clip_softmax_probability, clip_top2_margin, and calibration_version.
- Changed CLIP fallback to use calibrated softmax/margin confidence for pixel-op authority while retaining raw similarity only as evidence.
- Added strict APEX_MATERIALS_PIXEL_OPS_EMPTY when APEX Materials V3 has masks and implemented ops but applies none.
- Updated unit coverage for eval reporting, benchmark governance, confidence authority, segmentation evidence, and the strict APEX no-op gate.

## Validation
Proven green:
- PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -c "...compile touched files..." -> syntax ok
- .venv/bin/pytest tests/evals -q -> 251 passed, 1 skipped
- .venv/bin/pytest tests/materials/test_materials_v3_pixel_ops_smoke.py -q -> 20 passed
- .venv/bin/pytest tests/materials/test_segmentation_backend.py -q -> 42 passed, 1 skipped
- .venv/bin/pytest tests/materials/test_materials_v3_orchestrator_integration.py -q -> 38 passed
- make test-portal-contract -> 262 passed
- .venv/bin/black --check <touched Python files> -> passed
- .venv/bin/python tools/run_apex_eval.py --evalset evalsets/picacho_apex --output-dir output/apex_eval --emit-report on -> emitted ignored report with both referenced assets ready
- .venv/bin/python tools/benchmark_depth_backends.py --evalset evalsets/picacho_apex --backends da3-metric,depth_pro --quality-tier apex --output-dir output/depth_backend_benchmark --emit-comparison-report on -> emitted ignored report; depth_pro license_blocked as expected without research acknowledgements
- git diff --check --cached -> clean
- pre-commit hooks during git commit -> passed

Still failing:
- None observed.

Failure classification:
- Depth Pro license_blocked in the benchmark report is expected governance behavior, not a product failure.

## Risk
- Behavior change is intentionally strict only for APEX + Materials V3 + apply_pixel_ops when implemented material ops exist and all are blocked; lower tiers retain existing reporting behavior.
- Eval and benchmark tooling is additive and offline-safe by default, so it does not force model downloads in CI.
- The confidence contract is backward-compatible outside APEX but fail-closed for APEX pixel-op authority, making the change bounded and revert-safe.