### PR TITLE
feat(apex): add canonical provenance metadata

### DIFF
--- a/docs/validation/APEX_VISUAL_QUALITY_PROTOCOL.md
+++ b/docs/validation/APEX_VISUAL_QUALITY_PROTOCOL.md
@@ -19,6 +19,15 @@ validated 16-bit source references.
 - `canonical_bit_depth`: canonical reference bit depth when known
 - `canonical_format`: canonical reference format when known
 - `canonical_color_space`: documented source profile or color space
+- `source_raw_path`: optional camera-original RAW provenance path; metadata only
+- `source_raw_format`: optional RAW provenance format, such as `dng`, `cr2`, `cr3`, `nef`, `arw`, `raf`, `orf`, or `rw2`
+- `source_raw_sha256`: optional camera-original RAW SHA-256 provenance digest
+- `raw_development_profile`: optional metadata label or settings reference for the RAW development profile
+- `raw_development_settings_sha256`: optional SHA-256 digest for pinned RAW development settings
+- `canonical_icc_profile_name`: optional embedded or declared canonical ICC/profile name
+- `canonical_icc_profile_sha256`: optional ICC/profile SHA-256 provenance digest
+- `working_color_space`: optional color space used for scoring/editing intermediates
+- `working_transfer_function`: optional transfer function used for scoring/editing intermediates
 - `evaluate_at_native_resolution`: whether final scoring must run at native reference resolution
 - `allow_downsampled_model_inference`: whether model-specific tensor inputs may be downsampled or normalized
 - `preserve_16bit_intermediates`: whether pixel operations must preserve 16-bit working data
@@ -28,10 +37,19 @@ validated 16-bit source references.
 - `expected_materials`: materials expected to be present
 - `risk_zones`: boundaries or surfaces likely to show artifacts
 - `reject_if`: visual defects that disqualify a candidate
-- `manual_quality_score`: nullable human APEX score placeholder
+- `manual_quality_score`: nullable normalized human APEX score in `[0.0, 1.0]`, where `1.0` indicates no
+  visible regression and APEX-quality improvement
 
 Large source images are not committed as eval artifacts. The runner reports missing assets as `missing_asset` and
 checksum drift as `checksum_mismatch`.
+
+Camera-original RAW files such as DNG, CR2/CR3, NEF, ARW, RAF, ORF, and RW2 may be recorded as provenance assets.
+They are not canonical scoring targets. `source_raw_path`, `raw_development_profile`, ICC/profile fields, and
+working-color fields are metadata-only in the v1 provenance contract; they are not resolved, loaded, or
+existence-checked, and they do not affect asset readiness or canonical scoring eligibility.
+
+Canonical APEX scoring is performed against a deterministic developed 16-bit RGB reference, preferably
+`*_master16.tif`, with pinned color-management and development settings.
 
 Canonical APEX scoring requires all of the following:
 
@@ -76,11 +94,13 @@ Readiness and canonical scoring eligibility are separate report concepts. A read
 - `canonical_scoring_blocked_reason_counts`: blocked reasons for ready noncanonical assets
 
 Each asset report records `asset_role`, `reference_bit_depth`, `reference_format`, `reference_color_space`,
-`canonical_scoring_eligible`, and `canonical_scoring_blocked_reason`.
+`canonical_scoring_eligible`, and `canonical_scoring_blocked_reason`. Optional RAW, ICC/profile, and working-color
+provenance fields are emitted only when present.
 
 Depth benchmark reports also separate model input derivation from the evaluation target. Depth Pro, DA3, and other
 depth backends may consume normalized 8-bit or downsampled tensors, but benchmark cases must still record the
-16-bit source path as `evaluation_target` when one exists.
+16-bit source path as `evaluation_target` when one exists. RAW and working-color provenance belongs under
+`evaluation_target`, not `model_input`.
 
 ## 16-Bit Working Path
 
@@ -115,6 +135,9 @@ APEX promotion requires a report-backed improvement path:
 - DA3 metric is the commercial-safe baseline.
 - Materials V3 pixel operations require calibrated material confidence.
 - APEX runs fail closed when masks exist, implemented operations exist, and zero Materials V3 pixel operations apply.
+  The strict APEX Materials V3 no-op failure code is `APEX_MATERIALS_PIXEL_OPS_EMPTY`.
+- Synthetic APEX performance reports are plumbing and regression evidence only. They are not real APEX image-quality
+  evidence.
 
 The long-term APEX score should combine depth edge fidelity, material precision, pixel-op false positive risk,
 visible delta metrics, and manual APEX score. A missed enhancement is acceptable; a wrong material edit is not.

--- a/src/transformation_portal/evals/apex_visual.py
+++ b/src/transformation_portal/evals/apex_visual.py
@@ -11,6 +11,7 @@ import hashlib
 import importlib
 import json
 import math
+import re
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -48,6 +49,7 @@ ASSET_ROLES = frozenset(
     }
 )
 CANONICAL_REFERENCE_FORMATS = frozenset({"tif", "tiff"})
+PROVENANCE_SHA_RE = re.compile(r"^[0-9a-f]{64}$")
 
 
 def _lpips_available() -> bool:
@@ -102,6 +104,22 @@ def _normalize_image_format(value: Any) -> str | None:
         return "jpeg"
     if normalized == "tif":
         return "tiff"
+    return normalized
+
+
+def _normalize_source_raw_format(value: Any) -> str | None:
+    normalized = _normalize_optional_str(value)
+    if normalized is None:
+        return None
+    return normalized.lower().lstrip(".")
+
+
+def _optional_provenance_sha(value: Any, *, field_name: str) -> str | None:
+    normalized = _normalize_optional_str(value)
+    if normalized is None:
+        return None
+    if not PROVENANCE_SHA_RE.fullmatch(normalized):
+        raise ValueError(f"{field_name} must be a lowercase 64-character hexadecimal SHA-256 digest")
     return normalized
 
 
@@ -223,6 +241,15 @@ class ApexEvalAsset:
     canonical_scoring_eligible: bool | None = None
     canonical_scoring_blocked_reason: str | None = None
     manual_quality_score: float | None = None
+    source_raw_path: str | None = None
+    source_raw_format: str | None = None
+    source_raw_sha256: str | None = None
+    raw_development_profile: str | None = None
+    raw_development_settings_sha256: str | None = None
+    canonical_icc_profile_name: str | None = None
+    canonical_icc_profile_sha256: str | None = None
+    working_color_space: str | None = None
+    working_transfer_function: str | None = None
     notes: str | None = None
 
     @classmethod
@@ -268,11 +295,43 @@ class ApexEvalAsset:
             canonical_scoring_eligible=canonical_eligible,
             canonical_scoring_blocked_reason=_normalize_optional_str(payload.get("canonical_scoring_blocked_reason")),
             manual_quality_score=manual_score,
+            source_raw_path=_normalize_optional_str(payload.get("source_raw_path")),
+            source_raw_format=_normalize_source_raw_format(payload.get("source_raw_format")),
+            source_raw_sha256=_optional_provenance_sha(
+                payload.get("source_raw_sha256"),
+                field_name="source_raw_sha256",
+            ),
+            raw_development_profile=_normalize_optional_str(payload.get("raw_development_profile")),
+            raw_development_settings_sha256=_optional_provenance_sha(
+                payload.get("raw_development_settings_sha256"),
+                field_name="raw_development_settings_sha256",
+            ),
+            canonical_icc_profile_name=_normalize_optional_str(payload.get("canonical_icc_profile_name")),
+            canonical_icc_profile_sha256=_optional_provenance_sha(
+                payload.get("canonical_icc_profile_sha256"),
+                field_name="canonical_icc_profile_sha256",
+            ),
+            working_color_space=_normalize_optional_str(payload.get("working_color_space")),
+            working_transfer_function=_normalize_optional_str(payload.get("working_transfer_function")),
             notes=(str(payload["notes"]) if payload.get("notes") is not None else None),
         )
 
+    def provenance_dict(self) -> dict[str, Any]:
+        values = {
+            "source_raw_path": self.source_raw_path,
+            "source_raw_format": self.source_raw_format,
+            "source_raw_sha256": self.source_raw_sha256,
+            "raw_development_profile": self.raw_development_profile,
+            "raw_development_settings_sha256": self.raw_development_settings_sha256,
+            "canonical_icc_profile_name": self.canonical_icc_profile_name,
+            "canonical_icc_profile_sha256": self.canonical_icc_profile_sha256,
+            "working_color_space": self.working_color_space,
+            "working_transfer_function": self.working_transfer_function,
+        }
+        return {key: value for key, value in values.items() if value is not None}
+
     def to_dict(self) -> dict[str, Any]:
-        return {
+        payload = {
             "asset_id": self.asset_id,
             "asset_ref": self.asset_ref,
             "sha256": self.sha256,
@@ -294,6 +353,8 @@ class ApexEvalAsset:
             "manual_quality_score": self.manual_quality_score,
             "notes": self.notes,
         }
+        payload.update(self.provenance_dict())
+        return payload
 
 
 @dataclass(frozen=True)
@@ -813,6 +874,7 @@ def _depth_case_io_metadata(
         "color_space": asset.canonical_color_space,
         "evaluate_at_native_resolution": asset.evaluate_at_native_resolution,
     }
+    evaluation_target.update(asset.provenance_dict())
     return model_input, evaluation_target
 
 

--- a/tests/evals/test_apex_visual.py
+++ b/tests/evals/test_apex_visual.py
@@ -23,6 +23,10 @@ from transformation_portal.evals.apex_visual import (
 
 pytestmark = pytest.mark.unit
 
+VALID_SOURCE_RAW_SHA = "a" * 64
+VALID_RAW_SETTINGS_SHA = "b" * 64
+VALID_ICC_SHA = "c" * 64
+
 
 def _write_evalset(
     root: Path,
@@ -60,6 +64,72 @@ def _write_evalset(
     path = evalset_dir / "evalset.json"
     path.write_text(json.dumps(payload), encoding="utf-8")
     return path
+
+
+def test_apex_eval_asset_omits_absent_provenance_fields(tmp_path):
+    image_path = tmp_path / "input.png"
+    Image.fromarray(np.zeros((8, 8, 3), dtype=np.uint8)).save(image_path)
+    evalset_path = _write_evalset(tmp_path, image_path)
+
+    evalset = load_apex_evalset(evalset_path, repo_root=tmp_path)
+    asset_payload = evalset.assets[0].to_dict()
+    report = build_apex_eval_report(evalset_path, output_dir=tmp_path / "report", repo_root=tmp_path)
+    report_asset = report["assets"][0]
+
+    for key in (
+        "source_raw_path",
+        "source_raw_format",
+        "source_raw_sha256",
+        "raw_development_profile",
+        "raw_development_settings_sha256",
+        "canonical_icc_profile_name",
+        "canonical_icc_profile_sha256",
+        "working_color_space",
+        "working_transfer_function",
+    ):
+        assert key not in asset_payload
+        assert key not in report_asset
+
+
+def test_apex_eval_asset_round_trips_provenance_fields(tmp_path):
+    image_path = tmp_path / "input.png"
+    Image.fromarray(np.zeros((8, 8, 3), dtype=np.uint8)).save(image_path)
+    evalset_path = _write_evalset(
+        tmp_path,
+        image_path,
+        asset_overrides={
+            "source_raw_path": "source_raw/example.dng",
+            "source_raw_format": ".DNG",
+            "source_raw_sha256": VALID_SOURCE_RAW_SHA,
+            "raw_development_profile": "Capture One Picacho APEX v1",
+            "raw_development_settings_sha256": VALID_RAW_SETTINGS_SHA,
+            "canonical_icc_profile_name": "ProPhoto RGB",
+            "canonical_icc_profile_sha256": VALID_ICC_SHA,
+            "working_color_space": "ProPhoto RGB",
+            "working_transfer_function": "linear",
+        },
+    )
+
+    evalset = load_apex_evalset(evalset_path, repo_root=tmp_path)
+    asset_payload = evalset.assets[0].to_dict()
+    report = build_apex_eval_report(evalset_path, output_dir=tmp_path / "report", repo_root=tmp_path)
+    report_asset = report["assets"][0]
+
+    expected = {
+        "source_raw_path": "source_raw/example.dng",
+        "source_raw_format": "dng",
+        "source_raw_sha256": VALID_SOURCE_RAW_SHA,
+        "raw_development_profile": "Capture One Picacho APEX v1",
+        "raw_development_settings_sha256": VALID_RAW_SETTINGS_SHA,
+        "canonical_icc_profile_name": "ProPhoto RGB",
+        "canonical_icc_profile_sha256": VALID_ICC_SHA,
+        "working_color_space": "ProPhoto RGB",
+        "working_transfer_function": "linear",
+    }
+    for key, value in expected.items():
+        assert asset_payload[key] == value
+        assert report_asset[key] == value
+    assert report_asset["asset_status"]["status"] == "ready"
 
 
 def _load_tool_module(script_name: str, module_name: str):
@@ -189,6 +259,59 @@ def test_misdeclared_8bit_tiff_is_not_canonical_scoring_eligible(tmp_path):
     assert asset["canonical_scoring_blocked_reason"] == "reference_bit_depth_below_16"
 
 
+def test_missing_raw_source_path_does_not_affect_asset_status(tmp_path):
+    image_path = tmp_path / "input.png"
+    Image.fromarray(np.zeros((8, 8, 3), dtype=np.uint8)).save(image_path)
+    evalset_path = _write_evalset(
+        tmp_path,
+        image_path,
+        asset_overrides={
+            "source_raw_path": "source_raw/missing_capture.dng",
+            "source_raw_format": "dng",
+            "source_raw_sha256": VALID_SOURCE_RAW_SHA,
+        },
+    )
+
+    report = build_apex_eval_report(evalset_path, output_dir=tmp_path / "report", repo_root=tmp_path)
+
+    assert report["evalset"]["ready_asset_count"] == 1
+    assert report["evalset"]["missing_asset_count"] == 0
+    asset = report["assets"][0]
+    assert asset["asset_status"]["status"] == "ready"
+    assert asset["source_raw_path"] == "source_raw/missing_capture.dng"
+    assert asset["canonical_scoring_eligible"] is False
+
+
+def test_raw_source_provenance_does_not_make_asset_canonical_scoring_eligible(tmp_path):
+    image_path = tmp_path / "reference8.tif"
+    Image.fromarray(np.zeros((8, 8, 3), dtype=np.uint8)).save(image_path, format="TIFF")
+    evalset_path = _write_evalset(
+        tmp_path,
+        image_path,
+        dataset_tier="canonical_apex",
+        asset_overrides={
+            "asset_role": "canonical_apex_reference",
+            "canonical_bit_depth": 8,
+            "canonical_format": "tiff",
+            "canonical_scoring_eligible": True,
+            "evaluate_at_native_resolution": True,
+            "preserve_16bit_intermediates": True,
+            "source_raw_path": "source_raw/example.dng",
+            "source_raw_format": "dng",
+            "source_raw_sha256": VALID_SOURCE_RAW_SHA,
+        },
+    )
+
+    report = build_apex_eval_report(evalset_path, output_dir=tmp_path / "report", repo_root=tmp_path)
+
+    asset = report["assets"][0]
+    assert asset["asset_status"]["status"] == "ready"
+    assert asset["source_raw_path"] == "source_raw/example.dng"
+    assert asset["source_raw_format"] == "dng"
+    assert asset["canonical_scoring_eligible"] is False
+    assert asset["canonical_scoring_blocked_reason"] == "reference_bit_depth_below_16"
+
+
 def test_rendering_asset_is_smoke_only_even_with_canonical_like_fields(tmp_path):
     image_path = tmp_path / "rendering.png"
     Image.fromarray(np.zeros((8, 8, 3), dtype=np.uint8)).save(image_path)
@@ -266,6 +389,79 @@ def test_apex_eval_report_marks_missing_assets(tmp_path):
     assert report["evalset"]["canonical_scoring_eligible_count"] == 0
     assert report["evalset"]["missing_asset_count"] == 1
     assert report["assets"][0]["asset_status"]["status"] == "missing_asset"
+
+
+@pytest.mark.parametrize("manual_score", [None, 0.0, 1.0])
+def test_manual_quality_score_accepts_normalized_values(tmp_path, manual_score):
+    image_path = tmp_path / "input.png"
+    Image.fromarray(np.zeros((8, 8, 3), dtype=np.uint8)).save(image_path)
+    evalset_path = _write_evalset(
+        tmp_path,
+        image_path,
+        asset_overrides={"manual_quality_score": manual_score},
+    )
+
+    asset = load_apex_evalset(evalset_path, repo_root=tmp_path).assets[0]
+
+    assert asset.manual_quality_score == manual_score
+
+
+@pytest.mark.parametrize("manual_score", [-0.01, 1.01])
+def test_manual_quality_score_rejects_out_of_range_values(tmp_path, manual_score):
+    image_path = tmp_path / "input.png"
+    Image.fromarray(np.zeros((8, 8, 3), dtype=np.uint8)).save(image_path)
+    evalset_path = _write_evalset(
+        tmp_path,
+        image_path,
+        asset_overrides={"manual_quality_score": manual_score},
+    )
+
+    with pytest.raises(ValueError, match="manual_quality_score"):
+        load_apex_evalset(evalset_path, repo_root=tmp_path)
+
+
+@pytest.mark.parametrize(
+    ("field_name", "invalid_value"),
+    [
+        ("source_raw_sha256", "a" * 63),
+        ("source_raw_sha256", "a" * 65),
+        ("source_raw_sha256", "A" * 64),
+        ("source_raw_sha256", ("a" * 63) + "g"),
+        ("raw_development_settings_sha256", "b" * 63),
+        ("canonical_icc_profile_sha256", "c" * 65),
+    ],
+)
+def test_provenance_sha_fields_require_lowercase_64_hex(tmp_path, field_name, invalid_value):
+    image_path = tmp_path / "input.png"
+    Image.fromarray(np.zeros((8, 8, 3), dtype=np.uint8)).save(image_path)
+    evalset_path = _write_evalset(
+        tmp_path,
+        image_path,
+        asset_overrides={field_name: invalid_value},
+    )
+
+    with pytest.raises(ValueError, match=field_name):
+        load_apex_evalset(evalset_path, repo_root=tmp_path)
+
+
+def test_empty_provenance_sha_fields_normalize_to_absent(tmp_path):
+    image_path = tmp_path / "input.png"
+    Image.fromarray(np.zeros((8, 8, 3), dtype=np.uint8)).save(image_path)
+    evalset_path = _write_evalset(
+        tmp_path,
+        image_path,
+        asset_overrides={
+            "source_raw_sha256": "",
+            "raw_development_settings_sha256": " ",
+            "canonical_icc_profile_sha256": None,
+        },
+    )
+
+    payload = load_apex_evalset(evalset_path, repo_root=tmp_path).assets[0].to_dict()
+
+    assert "source_raw_sha256" not in payload
+    assert "raw_development_settings_sha256" not in payload
+    assert "canonical_icc_profile_sha256" not in payload
 
 
 def test_run_apex_eval_returns_nonzero_for_non_ready_assets(tmp_path, monkeypatch, capsys):
@@ -495,6 +691,15 @@ def test_depth_backend_benchmark_uses_mocked_runner(tmp_path):
             "evaluate_at_native_resolution": True,
             "allow_downsampled_model_inference": True,
             "preserve_16bit_intermediates": True,
+            "source_raw_path": "source_raw/reference.dng",
+            "source_raw_format": ".DNG",
+            "source_raw_sha256": VALID_SOURCE_RAW_SHA,
+            "raw_development_profile": "Capture One Picacho APEX v1",
+            "raw_development_settings_sha256": VALID_RAW_SETTINGS_SHA,
+            "canonical_icc_profile_name": "ProPhoto RGB",
+            "canonical_icc_profile_sha256": VALID_ICC_SHA,
+            "working_color_space": "ProPhoto RGB",
+            "working_transfer_function": "linear",
         },
     )
 
@@ -531,7 +736,18 @@ def test_depth_backend_benchmark_uses_mocked_runner(tmp_path):
     assert asset["model_input"]["input_bit_depth"] == 8
     assert asset["model_input"]["input_resolution"] == [1024, 768]
     assert asset["model_input"]["downsampled_for_inference"] is True
+    assert "source_raw_path" not in asset["model_input"]
+    assert "working_color_space" not in asset["model_input"]
     assert asset["evaluation_target"]["path"] == str(image_path.relative_to(tmp_path))
     assert asset["evaluation_target"]["bit_depth"] == 16
     assert asset["evaluation_target"]["evaluate_at_native_resolution"] is True
+    assert asset["evaluation_target"]["source_raw_path"] == "source_raw/reference.dng"
+    assert asset["evaluation_target"]["source_raw_format"] == "dng"
+    assert asset["evaluation_target"]["source_raw_sha256"] == VALID_SOURCE_RAW_SHA
+    assert asset["evaluation_target"]["raw_development_profile"] == "Capture One Picacho APEX v1"
+    assert asset["evaluation_target"]["raw_development_settings_sha256"] == VALID_RAW_SETTINGS_SHA
+    assert asset["evaluation_target"]["canonical_icc_profile_name"] == "ProPhoto RGB"
+    assert asset["evaluation_target"]["canonical_icc_profile_sha256"] == VALID_ICC_SHA
+    assert asset["evaluation_target"]["working_color_space"] == "ProPhoto RGB"
+    assert asset["evaluation_target"]["working_transfer_function"] == "linear"
     assert backend["depth_edge_score"] is not None


### PR DESCRIPTION
## Summary
- Add optional APEX eval asset provenance fields for RAW source, RAW development, ICC/profile, and working color metadata.
- Preserve #1542 canonical scoring eligibility: provenance paths are metadata-only and do not affect readiness or canonical scoring.
- Document RAW provenance semantics, manual score scale, synthetic-report limitations, and the APEX zero-op failure code.

## Changes
- Extend APEX eval asset parsing/serialization with optional provenance fields emitted only when present.
- Validate provenance SHA fields with strict lowercase 64-character hex.
- Carry present RAW and working-color provenance into depth benchmark evaluation_target, not model_input.
- Add tests for round-trip behavior, missing RAW path non-blocking behavior, RAW non-authority, SHA validation, source_raw_format normalization, depth propagation, and manual score bounds.

## Validation
- .venv/bin/pytest tests/evals/test_apex_visual.py -q
- .venv/bin/pytest tests/evals -q
- git diff --check
- make pre-commit

## Risk
- Additive and backward compatible: apex_evalset.v1 is unchanged, existing evalsets without provenance fields retain their current report shape, and canonical scoring gates are unchanged.