### PR TITLE
fix(apex): score candidates with v1 metrics

### DIFF
--- a/docs/validation/APEX_VISUAL_QUALITY_PROTOCOL.md
+++ b/docs/validation/APEX_VISUAL_QUALITY_PROTOCOL.md
@@ -92,7 +92,7 @@ APEX_EVAL_ASSET_ROOT=/Volumes/apex_eval_assets \
 ```
 
 The output is `apex_eval_report.json`. It records corpus readiness and, when candidate outputs are supplied,
-visible-delta metrics:
+authoritative `apex_metrics.v1` candidate metrics:
 
 ```bash
 .venv/bin/python tools/run_apex_eval.py \
@@ -112,6 +112,12 @@ Readiness and canonical scoring eligibility are separate report concepts. A read
 Each asset report records `asset_role`, `reference_bit_depth`, `reference_format`, `reference_color_space`,
 `canonical_scoring_eligible`, and `canonical_scoring_blocked_reason`. Optional RAW, ICC/profile, and working-color
 provenance fields are emitted only when present.
+
+Candidate-output scoring compares against `reference_path`, not `asset_ref`. For canonical assets, the reference and
+candidate output must be readable 16-bit TIFF/TIF images with matching dimensions; mismatches fail closed and are not
+resized. Candidate entries use `metric_contract=apex_metrics.v1` and `metrics_authoritative=true` only when
+`compute_apex_metrics` produced valid metric-status evidence. Legacy visible-delta-only metrics are compatibility
+evidence and are not promotion-authoritative.
 
 Depth benchmark reports also separate model input derivation from the evaluation target. Depth Pro, DA3, and other
 depth backends may consume normalized 8-bit or downsampled tensors, but benchmark cases must still record the

--- a/src/transformation_portal/evals/apex_evidence_bundle.py
+++ b/src/transformation_portal/evals/apex_evidence_bundle.py
@@ -9,6 +9,7 @@ from typing import Any, Iterable, Mapping
 from transformation_portal.ingest.canonical_json import dump_json
 
 APEX_EVIDENCE_BUNDLE_VERSION = "apex_evidence_bundle.v1"
+APEX_METRIC_CONTRACT_VERSION = "apex_metrics.v1"
 APEX_MATERIALS_PIXEL_OPS_EMPTY = "APEX_MATERIALS_PIXEL_OPS_EMPTY"
 
 
@@ -74,17 +75,35 @@ def _metrics_valid(candidate: Mapping[str, Any]) -> bool:
     status = candidate.get("status")
     if status in {
         "missing_candidate_output",
+        "missing_candidate",
+        "missing_reference",
         "source_not_ready",
         "shape_mismatch",
+        "dimension_mismatch",
         "invalid_candidate_dimensions",
         "unreadable_image",
+        "unreadable_reference",
+        "unreadable_candidate",
+        "unsupported_reference_bit_depth",
+        "unsupported_candidate_bit_depth",
+        "metrics_not_computed",
     }:
+        return False
+    if status != "ok":
+        return False
+    if candidate.get("metric_contract") != APEX_METRIC_CONTRACT_VERSION:
+        return False
+    if candidate.get("metrics_authoritative") is not True:
         return False
     metrics = candidate.get("metrics")
     if not isinstance(metrics, Mapping):
         return False
     for value in metrics.values():
-        if isinstance(value, Mapping) and value.get("status") in {"invalid_input", "dimension_mismatch"}:
+        if isinstance(value, Mapping) and value.get("status") in {
+            "invalid_input",
+            "dimension_mismatch",
+            "unsupported_bit_depth",
+        }:
             return False
     return True
 
@@ -158,7 +177,14 @@ def build_apex_evidence_bundle(
             evidence_path = candidate_evidence.get(candidate_id, {}).get(str(asset.get("asset_id")))
             evidence_payload = _load_evidence(evidence_path, repo_root=repo) if evidence_path is not None else None
             materials = _materials_status(candidate_id, evidence_payload)
-            candidate_output_status = "present" if candidate.get("output_path") else "missing"
+            candidate_output = candidate.get("candidate_output")
+            candidate_output_path = None
+            if isinstance(candidate_output, Mapping):
+                candidate_output_path = candidate_output.get("path")
+            candidate_output_path = candidate_output_path or candidate.get("output_path")
+            candidate_output_status = (
+                "present" if candidate_output_path and candidate.get("status") != "missing_candidate" else "missing"
+            )
             metrics_valid = _metrics_valid(candidate)
             case_verdict = (
                 "pass"
@@ -179,13 +205,14 @@ def build_apex_evidence_bundle(
                         "allow_downsampled_model_inference": asset.get("allow_downsampled_model_inference"),
                     },
                     "evaluation_target": {
-                        "path": asset.get("reference_path"),
+                        "path": candidate.get("evaluation_target_path") or asset.get("reference_path"),
                         "evaluate_at_native_resolution": asset.get("evaluate_at_native_resolution"),
                         "preserve_16bit_intermediates": asset.get("preserve_16bit_intermediates"),
+                        "reference_resolution": candidate.get("reference_resolution"),
                     },
                     "candidate_output": {
                         "status": candidate_output_status,
-                        "path": candidate.get("output_path"),
+                        "path": candidate_output_path,
                     },
                     "materials_v3": materials,
                     "depth": {},

--- a/src/transformation_portal/evals/apex_evidence_bundle.py
+++ b/src/transformation_portal/evals/apex_evidence_bundle.py
@@ -182,8 +182,11 @@ def build_apex_evidence_bundle(
             if isinstance(candidate_output, Mapping):
                 candidate_output_path = candidate_output.get("path")
             candidate_output_path = candidate_output_path or candidate.get("output_path")
+            candidate_status = candidate.get("status")
             candidate_output_status = (
-                "present" if candidate_output_path and candidate.get("status") != "missing_candidate" else "missing"
+                "present"
+                if candidate_output_path and candidate_status not in {"missing_candidate", "missing_candidate_output"}
+                else "missing"
             )
             metrics_valid = _metrics_valid(candidate)
             case_verdict = (

--- a/src/transformation_portal/evals/apex_visual.py
+++ b/src/transformation_portal/evals/apex_visual.py
@@ -19,7 +19,9 @@ from typing import Any, Callable, Iterable, Mapping, Sequence
 
 import numpy as np
 
+from transformation_portal.evals.apex_metrics import compute_apex_metrics
 from transformation_portal.evals.asset_resolver import ResolvedAsset, resolve_manifest_path
+from transformation_portal.evals.image_io import load_16bit_tiff
 from transformation_portal.evals.image_metadata import inspect_reference_image, normalize_image_format
 from transformation_portal.evals.metrics import lpips_score, ssim
 from transformation_portal.ingest.canonical_json import dump_json
@@ -27,6 +29,7 @@ from transformation_portal.lux_depth_v3.model_registry import MODEL_REGISTRY, Us
 
 APEX_EVALSET_SCHEMA_VERSION = "apex_evalset.v1"
 APEX_EVAL_REPORT_VERSION = "apex_eval_report.v1"
+APEX_METRIC_CONTRACT_VERSION = "apex_metrics.v1"
 DEPTH_BACKEND_BENCHMARK_REPORT_VERSION = "depth_backend_benchmark_report.v1"
 DEPTH_PRO_BACKENDS = {"depth_pro"}
 CANONICAL_APEX_DATASET_TIER = "canonical_apex"
@@ -688,6 +691,171 @@ def visible_delta_metrics(reference: Path, candidate: Path) -> dict[str, Any]:
     }
 
 
+def _candidate_report_base(
+    *,
+    candidate_name: str,
+    status: str,
+    candidate_path: Path | None,
+    reference_resolution: ResolvedAsset,
+    metrics: Mapping[str, Any] | None = None,
+    metrics_authoritative: bool = False,
+    reason: str | None = None,
+    extra: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "candidate": candidate_name,
+        "status": status,
+        "metric_contract": APEX_METRIC_CONTRACT_VERSION,
+        "metrics_authoritative": bool(metrics_authoritative),
+        "evaluation_target_path": reference_resolution.reported_path,
+        "reference_resolution": reference_resolution.to_report_dict(),
+        "candidate_output": {
+            "path": str(candidate_path) if candidate_path is not None else None,
+        },
+        "metrics": dict(metrics or {}),
+    }
+    if candidate_path is not None:
+        payload["output_path"] = str(candidate_path)
+    if reason:
+        payload["reason"] = reason
+    if extra:
+        payload.update(dict(extra))
+    return payload
+
+
+def _read_image_array(path: Path, *, require_16bit_tiff: bool, role: str) -> tuple[np.ndarray | None, str | None, str | None]:
+    if require_16bit_tiff:
+        array, metadata = load_16bit_tiff(path)
+        if array is not None:
+            return array, None, None
+        reason = str(metadata.get("reason") or metadata.get("observable_reference_metadata_status") or "invalid_input")
+        if reason in {"non_tiff_reference", "reference_bit_depth_below_16", "loaded_bit_depth_below_16"}:
+            return None, f"unsupported_{role}_bit_depth", reason
+        return None, f"unreadable_{role}", reason
+
+    from PIL import Image, UnidentifiedImageError
+
+    try:
+        if _normalize_image_format(path.suffix) == "tiff":
+            tifffile = importlib.import_module("tifffile")
+            return np.asarray(tifffile.imread(path)), None, None
+        with Image.open(path) as image:
+            return np.asarray(image.convert("RGB")), None, None
+    except (ImportError, OSError, ValueError, TypeError, UnidentifiedImageError) as exc:
+        return None, f"unreadable_{role}", str(exc)
+
+
+def _candidate_metrics_report(
+    *,
+    evalset: ApexEvalSet,
+    asset: ApexEvalAsset,
+    asset_report_status: Mapping[str, Any],
+    candidate_name: str,
+    output_value: Path | str | None,
+) -> dict[str, Any]:
+    reference_resolution = evalset.resolve_reference(asset)
+    candidate_path = Path(output_value) if output_value is not None else None
+    if candidate_path is not None and not candidate_path.is_absolute():
+        candidate_path = evalset.repo_root / candidate_path
+
+    if candidate_path is None or not candidate_path.is_file():
+        return _candidate_report_base(
+            candidate_name=candidate_name,
+            status="missing_candidate",
+            candidate_path=candidate_path,
+            reference_resolution=reference_resolution,
+            reason="candidate_output_missing",
+        )
+
+    if asset_report_status.get("status") != "ready":
+        return _candidate_report_base(
+            candidate_name=candidate_name,
+            status="metrics_not_computed",
+            candidate_path=candidate_path,
+            reference_resolution=reference_resolution,
+            reason=f"asset_status_{asset_report_status.get('status')}",
+        )
+
+    reference_path = reference_resolution.resolved_path
+    if reference_path is None or reference_resolution.escaped_asset_root or not reference_path.is_file():
+        return _candidate_report_base(
+            candidate_name=candidate_name,
+            status="missing_reference",
+            candidate_path=candidate_path,
+            reference_resolution=reference_resolution,
+            reason="reference_path_missing_or_unresolved",
+        )
+
+    canonical_comparison = (
+        bool(asset_report_status.get("canonical_scoring_eligible"))
+        or evalset.dataset_tier == CANONICAL_APEX_DATASET_TIER
+        or asset.asset_role == CANONICAL_APEX_ASSET_ROLE
+    )
+    reference, reference_status, reference_reason = _read_image_array(
+        reference_path,
+        require_16bit_tiff=canonical_comparison,
+        role="reference",
+    )
+    if reference_status:
+        return _candidate_report_base(
+            candidate_name=candidate_name,
+            status=reference_status,
+            candidate_path=candidate_path,
+            reference_resolution=reference_resolution,
+            reason=reference_reason,
+        )
+
+    candidate, candidate_status, candidate_reason = _read_image_array(
+        candidate_path,
+        require_16bit_tiff=canonical_comparison,
+        role="candidate",
+    )
+    if candidate_status:
+        return _candidate_report_base(
+            candidate_name=candidate_name,
+            status=candidate_status,
+            candidate_path=candidate_path,
+            reference_resolution=reference_resolution,
+            reason=candidate_reason,
+        )
+
+    assert reference is not None
+    assert candidate is not None
+    metrics = compute_apex_metrics(
+        reference,
+        candidate,
+        working_color_space=asset.working_color_space,
+        working_transfer_function=asset.working_transfer_function,
+    )
+    visible_status = str(metrics.get("visible_delta", {}).get("status") or "")
+    if visible_status == "dimension_mismatch":
+        return _candidate_report_base(
+            candidate_name=candidate_name,
+            status="dimension_mismatch",
+            candidate_path=candidate_path,
+            reference_resolution=reference_resolution,
+            metrics=metrics,
+            reason="dimension_mismatch",
+        )
+    if visible_status != "ok":
+        return _candidate_report_base(
+            candidate_name=candidate_name,
+            status="metrics_not_computed",
+            candidate_path=candidate_path,
+            reference_resolution=reference_resolution,
+            metrics=metrics,
+            reason=visible_status or "metrics_not_computed",
+        )
+    return _candidate_report_base(
+        candidate_name=candidate_name,
+        status="ok",
+        candidate_path=candidate_path,
+        reference_resolution=reference_resolution,
+        metrics=metrics,
+        metrics_authoritative=True,
+    )
+
+
 def build_apex_eval_report(
     evalset_path: Path | str,
     *,
@@ -700,7 +868,7 @@ def build_apex_eval_report(
 
     ``candidate_outputs`` maps candidate name to ``asset_id -> output path``.
     When no candidate output is provided, the report still validates corpus
-    readiness and leaves visual-delta metrics unset.
+    readiness and leaves candidate metrics unset.
     """
     evalset = load_apex_evalset(evalset_path, repo_root=repo_root, asset_root=asset_root)
     output_root = Path(output_dir)
@@ -741,61 +909,14 @@ def build_apex_eval_report(
         }
         candidates = []
         for candidate_name, outputs in sorted(candidate_outputs.items()):
-            output_value = outputs.get(asset.asset_id)
-            if output_value is None:
-                candidates.append(
-                    {
-                        "candidate": candidate_name,
-                        "status": "missing_candidate_output",
-                        "metrics": {},
-                    }
-                )
-                continue
-            candidate_path = Path(output_value)
-            if not candidate_path.is_absolute():
-                candidate_path = evalset.repo_root / candidate_path
-            if status["status"] != "ready":
-                candidates.append(
-                    {
-                        "candidate": candidate_name,
-                        "status": "source_not_ready",
-                        "metrics": {},
-                    }
-                )
-                continue
-            if not candidate_path.is_file():
-                candidates.append(
-                    {
-                        "candidate": candidate_name,
-                        "status": "missing_candidate_output",
-                        "output_path": str(candidate_path),
-                        "metrics": {},
-                    }
-                )
-                continue
-            source_path = evalset.resolve_asset(asset).resolved_path
-            if source_path is None:
-                candidates.append(
-                    {
-                        "candidate": candidate_name,
-                        "status": "source_not_ready",
-                        "metrics": {},
-                    }
-                )
-                continue
-            metrics = visible_delta_metrics(source_path, candidate_path)
             candidates.append(
-                {
-                    "candidate": candidate_name,
-                    "status": metrics.pop("status"),
-                    "output_path": str(candidate_path),
-                    "metrics": {
-                        "depth_edge_fidelity": None,
-                        "material_precision": None,
-                        "pixel_op_false_positive_risk": None,
-                        **metrics,
-                    },
-                }
+                _candidate_metrics_report(
+                    evalset=evalset,
+                    asset=asset,
+                    asset_report_status=status,
+                    candidate_name=candidate_name,
+                    output_value=outputs.get(asset.asset_id),
+                )
             )
 
         assets_report.append(

--- a/tests/evals/test_apex_candidate_evidence.py
+++ b/tests/evals/test_apex_candidate_evidence.py
@@ -138,6 +138,31 @@ def test_legacy_visible_delta_metrics_do_not_authorize_promotion(tmp_path):
     assert bundle["cases"][0]["metrics_status"] == "invalid"
 
 
+def test_legacy_missing_candidate_output_stays_missing_in_evidence_bundle(tmp_path):
+    report = _apex_report(tmp_path)
+    report["assets"][0]["candidates"][0] = {
+        "candidate": "materials_v3",
+        "status": "missing_candidate_output",
+        "output_path": str(tmp_path / "missing_candidate16.tif"),
+        "metrics": {},
+    }
+    evidence = _materials_evidence(tmp_path / "materials.json")
+
+    bundle = build_apex_evidence_bundle(
+        report,
+        output_dir=tmp_path / "bundle",
+        candidate_evidence={"materials_v3": {"unit_image": evidence}},
+        repo_root=tmp_path,
+    )
+
+    assert bundle["promotion_verdict"] == "blocked"
+    assert "missing_candidate_output" in bundle["promotion_blocked_reasons"]
+    case = bundle["cases"][0]
+    assert case["candidate_output"]["status"] == "missing"
+    assert case["candidate_output"]["path"] == str(tmp_path / "missing_candidate16.tif")
+    assert case["metrics_status"] == "invalid"
+
+
 def test_evidence_bundle_relative_output_uses_report_context(tmp_path):
     report = _apex_report(tmp_path)
     evidence = _materials_evidence(tmp_path / "materials.json")

--- a/tests/evals/test_apex_candidate_evidence.py
+++ b/tests/evals/test_apex_candidate_evidence.py
@@ -111,6 +111,33 @@ def test_candidate_output_and_materials_telemetry_attach_to_bundle(tmp_path):
     assert (tmp_path / "bundle" / "evidence_bundle.json").is_file()
 
 
+def test_legacy_visible_delta_metrics_do_not_authorize_promotion(tmp_path):
+    report = _apex_report(tmp_path)
+    report["assets"][0]["candidates"][0] = {
+        "candidate": "materials_v3",
+        "status": "ok",
+        "output_path": str(tmp_path / "candidate16.tif"),
+        "metrics": {
+            "ssim": 1.0,
+            "lpips": None,
+            "delta_e_proxy_mean_abs": 0.0,
+            "delta_e_proxy_max_abs": 0.0,
+        },
+    }
+    evidence = _materials_evidence(tmp_path / "materials.json")
+
+    bundle = build_apex_evidence_bundle(
+        report,
+        output_dir=tmp_path / "bundle",
+        candidate_evidence={"materials_v3": {"unit_image": evidence}},
+        repo_root=tmp_path,
+    )
+
+    assert bundle["promotion_verdict"] == "blocked"
+    assert "invalid_metrics" in bundle["promotion_blocked_reasons"]
+    assert bundle["cases"][0]["metrics_status"] == "invalid"
+
+
 def test_evidence_bundle_relative_output_uses_report_context(tmp_path):
     report = _apex_report(tmp_path)
     evidence = _materials_evidence(tmp_path / "materials.json")

--- a/tests/evals/test_apex_visual.py
+++ b/tests/evals/test_apex_visual.py
@@ -162,12 +162,217 @@ def test_apex_eval_report_tracks_ready_assets_and_candidate_metrics(tmp_path):
     asset = report["assets"][0]
     assert asset["asset_status"]["status"] == "ready"
     candidate = asset["candidates"][0]
-    assert candidate["status"] in {"ok", "partial_metrics"}
-    assert candidate["metrics"]["ssim"] == pytest.approx(1.0)
-    if candidate["status"] == "partial_metrics":
-        assert "lpips_unavailable" in candidate["metrics"]["metric_warnings"]
-        assert candidate["metrics"]["lpips"] is None
+    assert candidate["status"] == "ok"
+    assert candidate["metric_contract"] == "apex_metrics.v1"
+    assert candidate["metrics_authoritative"] is True
+    assert candidate["evaluation_target_path"] == str(image_path.relative_to(tmp_path))
+    assert candidate["metrics"]["visible_delta"]["status"] == "ok"
+    assert candidate["metrics"]["visible_delta"]["value"] == pytest.approx(0.0)
     assert (tmp_path / "report" / "apex_eval_report.json").is_file()
+
+
+def test_candidate_metrics_compare_against_reference_path_not_asset_ref(tmp_path):
+    delivery_path = tmp_path / "delivery_8bit" / "example_delivery.jpg"
+    reference_path = tmp_path / "reference_16bit" / "example_master16.tif"
+    candidate_path = tmp_path / "output" / "example_candidate_master16.tif"
+    delivery_path.parent.mkdir(parents=True)
+    reference_path.parent.mkdir(parents=True)
+    candidate_path.parent.mkdir(parents=True)
+    Image.fromarray(np.full((8, 8, 3), 255, dtype=np.uint8)).save(delivery_path, format="JPEG")
+    reference = np.zeros((8, 8), dtype=np.uint16)
+    reference[2:6, 2:6] = 32768
+    Image.fromarray(reference, mode="I;16").save(reference_path)
+    Image.fromarray(reference.copy(), mode="I;16").save(candidate_path)
+    evalset_path = _write_evalset(
+        tmp_path,
+        delivery_path,
+        dataset_tier="canonical_apex",
+        asset_overrides={
+            "asset_role": "canonical_apex_reference",
+            "reference_path": str(reference_path.relative_to(tmp_path)),
+            "canonical_bit_depth": 16,
+            "canonical_format": "tiff",
+            "canonical_color_space": "documented_source_profile",
+            "canonical_scoring_eligible": True,
+            "evaluate_at_native_resolution": True,
+            "preserve_16bit_intermediates": True,
+        },
+    )
+
+    report = build_apex_eval_report(
+        evalset_path,
+        output_dir=tmp_path / "report",
+        candidate_outputs={"materials_v3": {"unit_image": candidate_path}},
+        repo_root=tmp_path,
+    )
+
+    candidate = report["assets"][0]["candidates"][0]
+    assert report["evalset"]["canonical_scoring_eligible_count"] == 1
+    assert candidate["status"] == "ok"
+    assert candidate["evaluation_target_path"] == str(reference_path.relative_to(tmp_path))
+    assert candidate["reference_resolution"]["reported_path"] == str(reference_path.relative_to(tmp_path))
+    assert candidate["metrics"]["visible_delta"]["value"] == pytest.approx(0.0)
+
+
+def test_candidate_dimension_mismatch_fails_closed_without_resizing(tmp_path):
+    reference_path = tmp_path / "reference16.tif"
+    candidate_path = tmp_path / "candidate16.tif"
+    Image.fromarray(np.zeros((8, 8), dtype=np.uint16), mode="I;16").save(reference_path)
+    Image.fromarray(np.zeros((4, 4), dtype=np.uint16), mode="I;16").save(candidate_path)
+    evalset_path = _write_evalset(
+        tmp_path,
+        reference_path,
+        dataset_tier="canonical_apex",
+        asset_overrides={
+            "asset_role": "canonical_apex_reference",
+            "canonical_bit_depth": 16,
+            "canonical_format": "tiff",
+            "canonical_scoring_eligible": True,
+            "evaluate_at_native_resolution": True,
+            "preserve_16bit_intermediates": True,
+        },
+    )
+
+    report = build_apex_eval_report(
+        evalset_path,
+        output_dir=tmp_path / "report",
+        candidate_outputs={"materials_v3": {"unit_image": candidate_path}},
+        repo_root=tmp_path,
+    )
+
+    candidate = report["assets"][0]["candidates"][0]
+    assert candidate["status"] == "dimension_mismatch"
+    assert candidate["metrics_authoritative"] is False
+    assert candidate["metrics"]["visible_delta"]["status"] == "dimension_mismatch"
+
+
+def test_canonical_candidate_metrics_reject_unsupported_reference_bit_depth(tmp_path):
+    reference_path = tmp_path / "reference8.tif"
+    candidate_path = tmp_path / "candidate16.tif"
+    Image.fromarray(np.zeros((8, 8, 3), dtype=np.uint8)).save(reference_path, format="TIFF")
+    Image.fromarray(np.zeros((8, 8), dtype=np.uint16), mode="I;16").save(candidate_path)
+    evalset_path = _write_evalset(
+        tmp_path,
+        reference_path,
+        dataset_tier="canonical_apex",
+        asset_overrides={
+            "asset_role": "canonical_apex_reference",
+            "canonical_bit_depth": 16,
+            "canonical_format": "tiff",
+            "canonical_scoring_eligible": True,
+            "evaluate_at_native_resolution": True,
+            "preserve_16bit_intermediates": True,
+        },
+    )
+
+    report = build_apex_eval_report(
+        evalset_path,
+        output_dir=tmp_path / "report",
+        candidate_outputs={"materials_v3": {"unit_image": candidate_path}},
+        repo_root=tmp_path,
+    )
+
+    candidate = report["assets"][0]["candidates"][0]
+    assert candidate["status"] == "unsupported_reference_bit_depth"
+    assert candidate["metrics_authoritative"] is False
+
+
+def test_canonical_candidate_metrics_reject_unsupported_candidate_bit_depth(tmp_path):
+    reference_path = tmp_path / "reference16.tif"
+    candidate_path = tmp_path / "candidate8.tif"
+    Image.fromarray(np.zeros((8, 8), dtype=np.uint16), mode="I;16").save(reference_path)
+    Image.fromarray(np.zeros((8, 8, 3), dtype=np.uint8)).save(candidate_path, format="TIFF")
+    evalset_path = _write_evalset(
+        tmp_path,
+        reference_path,
+        dataset_tier="canonical_apex",
+        asset_overrides={
+            "asset_role": "canonical_apex_reference",
+            "canonical_bit_depth": 16,
+            "canonical_format": "tiff",
+            "canonical_scoring_eligible": True,
+            "evaluate_at_native_resolution": True,
+            "preserve_16bit_intermediates": True,
+        },
+    )
+
+    report = build_apex_eval_report(
+        evalset_path,
+        output_dir=tmp_path / "report",
+        candidate_outputs={"materials_v3": {"unit_image": candidate_path}},
+        repo_root=tmp_path,
+    )
+
+    candidate = report["assets"][0]["candidates"][0]
+    assert candidate["status"] == "unsupported_candidate_bit_depth"
+    assert candidate["metrics_authoritative"] is False
+
+
+def test_missing_and_unreadable_candidate_outputs_return_fail_closed_statuses(tmp_path):
+    reference_path = tmp_path / "reference16.tif"
+    unreadable_path = tmp_path / "candidate16.tif"
+    Image.fromarray(np.zeros((8, 8), dtype=np.uint16), mode="I;16").save(reference_path)
+    unreadable_path.write_text("not a tiff", encoding="utf-8")
+    evalset_path = _write_evalset(
+        tmp_path,
+        reference_path,
+        dataset_tier="canonical_apex",
+        asset_overrides={
+            "asset_role": "canonical_apex_reference",
+            "canonical_bit_depth": 16,
+            "canonical_format": "tiff",
+            "canonical_scoring_eligible": True,
+            "evaluate_at_native_resolution": True,
+            "preserve_16bit_intermediates": True,
+        },
+    )
+
+    report = build_apex_eval_report(
+        evalset_path,
+        output_dir=tmp_path / "report",
+        candidate_outputs={
+            "missing": {"unit_image": tmp_path / "missing_candidate.tif"},
+            "unreadable": {"unit_image": unreadable_path},
+        },
+        repo_root=tmp_path,
+    )
+
+    candidates = {candidate["candidate"]: candidate for candidate in report["assets"][0]["candidates"]}
+    assert candidates["missing"]["status"] == "missing_candidate"
+    assert candidates["missing"]["metrics_authoritative"] is False
+    assert candidates["unreadable"]["status"] == "unreadable_candidate"
+    assert candidates["unreadable"]["metrics_authoritative"] is False
+
+
+def test_unreadable_reference_output_returns_fail_closed_status(tmp_path):
+    reference_path = tmp_path / "reference16.tif"
+    candidate_path = tmp_path / "candidate16.tif"
+    reference_path.write_text("not a tiff", encoding="utf-8")
+    Image.fromarray(np.zeros((8, 8), dtype=np.uint16), mode="I;16").save(candidate_path)
+    evalset_path = _write_evalset(
+        tmp_path,
+        reference_path,
+        dataset_tier="canonical_apex",
+        asset_overrides={
+            "asset_role": "canonical_apex_reference",
+            "canonical_bit_depth": 16,
+            "canonical_format": "tiff",
+            "canonical_scoring_eligible": True,
+            "evaluate_at_native_resolution": True,
+            "preserve_16bit_intermediates": True,
+        },
+    )
+
+    report = build_apex_eval_report(
+        evalset_path,
+        output_dir=tmp_path / "report",
+        candidate_outputs={"materials_v3": {"unit_image": candidate_path}},
+        repo_root=tmp_path,
+    )
+
+    candidate = report["assets"][0]["candidates"][0]
+    assert candidate["status"] == "unreadable_reference"
+    assert candidate["metrics_authoritative"] is False
 
 
 def test_jpeg_delivery_asset_is_ready_but_not_canonical_scoring_eligible(tmp_path):


### PR DESCRIPTION
## Summary
- Candidate-output reporting still compared outputs against `asset_ref` and could feed legacy visible-delta metrics into promotion evidence.
- This change scores candidates against the canonical `reference_path`, emits authoritative `apex_metrics.v1` status-bearing metrics, and keeps legacy/non-authoritative metrics from satisfying promotion validity.

## Changes
- Adds a candidate comparison path in `apex_visual.py` that resolves `reference_path`, loads canonical comparisons through the 16-bit TIFF helper, calls `compute_apex_metrics`, and fails closed for missing/unreadable references, missing/unreadable candidates, unsupported bit depth, or dimension mismatch.
- Preserves `asset_ref` readiness/checksum behavior while changing only the candidate scoring target to the canonical reference target.
- Tightens evidence-bundle metric validation so promotion requires `metric_contract="apex_metrics.v1"` and `metrics_authoritative=true`.
- Updates APEX visual-quality protocol docs to describe reference-target scoring and promotion-authoritative metric requirements.
- Adds regression coverage for reference-path scoring, legacy metrics rejection, fail-closed candidate/reference statuses, unsupported bit depth, and no-resize dimension mismatch.

## Validation
Proven green:
- `.venv/bin/pytest tests/evals/test_apex_asset_resolver.py tests/evals/test_apex_image_io.py tests/evals/test_apex_metrics.py tests/evals/test_apex_candidate_evidence.py tests/evals/test_apex_visual.py -q` (`79 passed`)
- `make test-fast` (`73 passed`)
- `make pre-commit`
- `make ci-quick`

Still failing:
- None. `make ci-quick` emits the existing non-blocking advisory pylint note in `tests/test_depth_tools.py` and the existing TODO/FIXME count warning, but the target exits successfully.

## Risk
- Candidate report shape is additive for `metric_contract`, `metrics_authoritative`, `evaluation_target_path`, `reference_resolution`, and `candidate_output`; legacy `output_path` remains present for compatibility.
- Canonical candidate scoring is stricter by design: non-16-bit references/candidates and dimension mismatches no longer produce promotion-authoritative evidence.
- No route, selector, CLI flag, auth, or runtime dependency changes.
- Revert-safe because the patch is scoped to APEX eval reporting, evidence validation, tests, and protocol docs.