### PR TITLE
test(apex): harden evidence promotion contract

### DIFF
--- a/docs/validation/APEX_VISUAL_QUALITY_PROTOCOL.md
+++ b/docs/validation/APEX_VISUAL_QUALITY_PROTOCOL.md
@@ -133,8 +133,15 @@ APEX evidence bundles may attach existing candidate outputs and explicit Materia
   --output-dir output/apex_eval \
   --candidate-output materials_v3:pool_water_stone_001=output/pool_materials_v3_master16.tif \
   --candidate-evidence materials_v3:pool_water_stone_001=output/pool_materials_v3_evidence.json \
-  --emit-evidence-bundle on
+  --run-scope-asset-id pool_water_stone_001 \
+  --emit-evidence-bundle on \
+  --synthetic-data off
 ```
+
+When a run scope is provided, every scoped canonical asset must have candidate output evidence before promotion can be
+eligible. When run scope is omitted, candidate outputs and required candidate telemetry must cover every canonical asset
+in the manifest. Missing Materials V3 telemetry, invalid `apex_metrics.v1` statuses, unsupported bit depth, dimension
+mismatch, `APEX_MATERIALS_PIXEL_OPS_EMPTY`, raw CLIP pixel-op authority, or `synthetic_data=true` blocks promotion.
 
 ## 16-Bit Working Path
 

--- a/src/transformation_portal/evals/apex_evidence_bundle.py
+++ b/src/transformation_portal/evals/apex_evidence_bundle.py
@@ -6,11 +6,24 @@ import json
 from pathlib import Path
 from typing import Any, Iterable, Mapping
 
+from transformation_portal.evals.apex_metrics import (
+    METRIC_STATUS_DIMENSION_MISMATCH,
+    METRIC_STATUS_INVALID_INPUT,
+    METRIC_STATUS_UNSUPPORTED_BIT_DEPTH,
+    METRIC_STATUSES,
+)
 from transformation_portal.ingest.canonical_json import dump_json
 
 APEX_EVIDENCE_BUNDLE_VERSION = "apex_evidence_bundle.v1"
 APEX_METRIC_CONTRACT_VERSION = "apex_metrics.v1"
 APEX_MATERIALS_PIXEL_OPS_EMPTY = "APEX_MATERIALS_PIXEL_OPS_EMPTY"
+_PROMOTION_BLOCKING_METRIC_STATUSES = frozenset(
+    {
+        METRIC_STATUS_INVALID_INPUT,
+        METRIC_STATUS_UNSUPPORTED_BIT_DEPTH,
+        METRIC_STATUS_DIMENSION_MISMATCH,
+    }
+)
 
 
 def parse_candidate_evidence(values: Iterable[str]) -> dict[str, dict[str, Path]]:
@@ -98,12 +111,15 @@ def _metrics_valid(candidate: Mapping[str, Any]) -> bool:
     metrics = candidate.get("metrics")
     if not isinstance(metrics, Mapping):
         return False
+    if not metrics:
+        return False
     for value in metrics.values():
-        if isinstance(value, Mapping) and value.get("status") in {
-            "invalid_input",
-            "dimension_mismatch",
-            "unsupported_bit_depth",
-        }:
+        if not isinstance(value, Mapping):
+            return False
+        metric_status = value.get("status")
+        if metric_status not in METRIC_STATUSES:
+            return False
+        if metric_status in _PROMOTION_BLOCKING_METRIC_STATUSES:
             return False
     return True
 

--- a/tests/evals/test_apex_candidate_evidence.py
+++ b/tests/evals/test_apex_candidate_evidence.py
@@ -57,6 +57,40 @@ def _write_evalset(root: Path, asset_path: Path, *, asset_id: str = "unit_image"
     return path
 
 
+def _write_multi_asset_evalset(root: Path, asset_paths: dict[str, Path]) -> Path:
+    payload = {
+        "schema_version": APEX_EVALSET_SCHEMA_VERSION,
+        "evalset_id": "unit_canonical_multi",
+        "version": "v1",
+        "description": "unit multi",
+        "dataset_tier": "canonical_apex",
+        "assets": [
+            {
+                "asset_id": asset_id,
+                "asset_ref": str(asset_path.relative_to(root)),
+                "sha256": sha256_file(asset_path),
+                "asset_role": "canonical_apex_reference",
+                "reference_path": str(asset_path.relative_to(root)),
+                "canonical_bit_depth": 16,
+                "canonical_format": "tiff",
+                "canonical_scoring_eligible": True,
+                "evaluate_at_native_resolution": True,
+                "preserve_16bit_intermediates": True,
+                "scene_type": "pool_exterior",
+                "expected_materials": ["water", "stone"],
+                "risk_zones": ["pool_edge"],
+                "reject_if": ["halo"],
+            }
+            for asset_id, asset_path in asset_paths.items()
+        ],
+    }
+    evalset_dir = root / "evalsets" / "apex_multi"
+    evalset_dir.mkdir(parents=True, exist_ok=True)
+    path = evalset_dir / "evalset.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
 def _materials_evidence(path: Path, *, applied_ops_count: int = 4, raw_authorized: bool = False) -> Path:
     payload = {
         "materials_v3_enabled": True,
@@ -82,6 +116,27 @@ def _apex_report(tmp_path: Path, *, candidate: bool = True):
     _write_16bit(candidate_path)
     evalset_path = _write_evalset(tmp_path, image_path)
     outputs = {"materials_v3": {"unit_image": candidate_path}} if candidate else {}
+    return build_apex_eval_report(
+        evalset_path,
+        output_dir=tmp_path / "report",
+        candidate_outputs=outputs,
+        repo_root=tmp_path,
+    )
+
+
+def _multi_apex_report(tmp_path: Path, *, candidate_asset_ids: set[str]):
+    asset_paths = {
+        "pool_image": tmp_path / "reference_pool16.tif",
+        "kitchen_image": tmp_path / "reference_kitchen16.tif",
+    }
+    for asset_path in asset_paths.values():
+        _write_16bit(asset_path)
+    evalset_path = _write_multi_asset_evalset(tmp_path, asset_paths)
+    outputs: dict[str, dict[str, Path]] = {"materials_v3": {}}
+    for asset_id in candidate_asset_ids:
+        candidate_path = tmp_path / f"{asset_id}_candidate16.tif"
+        _write_16bit(candidate_path)
+        outputs["materials_v3"][asset_id] = candidate_path
     return build_apex_eval_report(
         evalset_path,
         output_dir=tmp_path / "report",
@@ -188,6 +243,77 @@ def test_missing_materials_telemetry_blocks_materials_v3_promotion(tmp_path):
     assert bundle["cases"][0]["materials_v3"]["status"] == "missing_evidence"
 
 
+def test_unscoped_multi_asset_promotion_requires_all_canonical_candidate_outputs(tmp_path):
+    report = _multi_apex_report(tmp_path, candidate_asset_ids={"pool_image"})
+    evidence = _materials_evidence(tmp_path / "pool_materials.json")
+
+    bundle = build_apex_evidence_bundle(
+        report,
+        output_dir=tmp_path / "bundle",
+        candidate_evidence={"materials_v3": {"pool_image": evidence}},
+        repo_root=tmp_path,
+    )
+
+    cases_by_asset = {case["asset_id"]: case for case in bundle["cases"]}
+    assert bundle["promotion_verdict"] == "blocked"
+    assert "missing_candidate_output" in bundle["promotion_blocked_reasons"]
+    assert "invalid_metrics" in bundle["promotion_blocked_reasons"]
+    assert cases_by_asset["pool_image"]["candidate_output"]["status"] == "present"
+    assert cases_by_asset["kitchen_image"]["candidate_output"]["status"] == "missing"
+    assert cases_by_asset["kitchen_image"]["metrics_status"] == "invalid"
+
+
+def test_run_scope_requires_candidate_for_every_scoped_canonical_asset(tmp_path):
+    report = _multi_apex_report(tmp_path, candidate_asset_ids={"pool_image"})
+    evidence = _materials_evidence(tmp_path / "pool_materials.json")
+
+    bundle = build_apex_evidence_bundle(
+        report,
+        output_dir=tmp_path / "bundle",
+        candidate_evidence={"materials_v3": {"pool_image": evidence}},
+        run_scope_asset_ids=["pool_image", "kitchen_image"],
+        repo_root=tmp_path,
+    )
+
+    assert bundle["promotion_verdict"] == "blocked"
+    assert "missing_candidate_output" in bundle["promotion_blocked_reasons"]
+    assert "invalid_metrics" in bundle["promotion_blocked_reasons"]
+
+
+def test_run_scope_can_promote_complete_subset_without_unscoped_assets(tmp_path):
+    report = _multi_apex_report(tmp_path, candidate_asset_ids={"pool_image"})
+    evidence = _materials_evidence(tmp_path / "pool_materials.json")
+
+    bundle = build_apex_evidence_bundle(
+        report,
+        output_dir=tmp_path / "bundle",
+        candidate_evidence={"materials_v3": {"pool_image": evidence}},
+        run_scope_asset_ids=["pool_image"],
+        repo_root=tmp_path,
+    )
+
+    assert bundle["promotion_verdict"] == "eligible"
+    assert bundle["promotion_blocked_reasons"] == []
+
+
+def test_materials_v3_telemetry_required_for_every_scoped_candidate(tmp_path):
+    report = _multi_apex_report(tmp_path, candidate_asset_ids={"pool_image", "kitchen_image"})
+    evidence = _materials_evidence(tmp_path / "pool_materials.json")
+
+    bundle = build_apex_evidence_bundle(
+        report,
+        output_dir=tmp_path / "bundle",
+        candidate_evidence={"materials_v3": {"pool_image": evidence}},
+        run_scope_asset_ids=["pool_image", "kitchen_image"],
+        repo_root=tmp_path,
+    )
+
+    cases_by_asset = {case["asset_id"]: case for case in bundle["cases"]}
+    assert bundle["promotion_verdict"] == "blocked"
+    assert "missing_materials_v3_evidence" in bundle["promotion_blocked_reasons"]
+    assert cases_by_asset["kitchen_image"]["materials_v3"]["status"] == "missing_evidence"
+
+
 def test_run_scope_asset_ids_limit_promotion_scope(tmp_path):
     report = _apex_report(tmp_path)
     evidence = _materials_evidence(tmp_path / "materials.json")
@@ -218,6 +344,47 @@ def test_synthetic_data_blocks_promotion(tmp_path):
 
     assert bundle["promotion_verdict"] == "blocked"
     assert "synthetic_data" in bundle["promotion_blocked_reasons"]
+
+
+@pytest.mark.parametrize(
+    "metric_status",
+    [
+        "invalid_input",
+        "unsupported_bit_depth",
+        "dimension_mismatch",
+    ],
+)
+def test_invalid_metric_status_blocks_promotion(tmp_path, metric_status):
+    report = _apex_report(tmp_path)
+    report["assets"][0]["candidates"][0]["metrics"]["visible_delta"]["status"] = metric_status
+    evidence = _materials_evidence(tmp_path / "materials.json")
+
+    bundle = build_apex_evidence_bundle(
+        report,
+        output_dir=tmp_path / "bundle",
+        candidate_evidence={"materials_v3": {"unit_image": evidence}},
+        repo_root=tmp_path,
+    )
+
+    assert bundle["promotion_verdict"] == "blocked"
+    assert "invalid_metrics" in bundle["promotion_blocked_reasons"]
+    assert bundle["cases"][0]["metrics_status"] == "invalid"
+
+
+def test_metric_without_explicit_v1_status_blocks_promotion(tmp_path):
+    report = _apex_report(tmp_path)
+    report["assets"][0]["candidates"][0]["metrics"]["visible_delta"] = {"value": 0.0}
+    evidence = _materials_evidence(tmp_path / "materials.json")
+
+    bundle = build_apex_evidence_bundle(
+        report,
+        output_dir=tmp_path / "bundle",
+        candidate_evidence={"materials_v3": {"unit_image": evidence}},
+        repo_root=tmp_path,
+    )
+
+    assert bundle["promotion_verdict"] == "blocked"
+    assert "invalid_metrics" in bundle["promotion_blocked_reasons"]
 
 
 def test_zero_eligible_canonical_assets_blocks_promotion(tmp_path):

--- a/tests/evals/test_apex_docs_commands.py
+++ b/tests/evals/test_apex_docs_commands.py
@@ -1,0 +1,79 @@
+"""Tests for APEX validation documentation command examples."""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import shlex
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+APEX_CLI_MODULES = {
+    "tools/audit_apex_assets.py": "audit_apex_assets_docs_unit",
+    "tools/run_apex_eval.py": "run_apex_eval_docs_unit",
+}
+
+
+def _load_tool_module(script_path: str, module_name: str):
+    path = REPO_ROOT / script_path
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _parser_options(script_path: str) -> set[str]:
+    module = _load_tool_module(script_path, APEX_CLI_MODULES[script_path])
+    parser = module.build_parser()
+    return {option for action in parser._actions for option in action.option_strings}
+
+
+def _documented_apex_commands() -> list[tuple[Path, str, set[str]]]:
+    commands: list[tuple[Path, str, set[str]]] = []
+    for doc_path in sorted((REPO_ROOT / "docs" / "validation").glob("*.md")):
+        text = doc_path.read_text(encoding="utf-8")
+        for block in re.findall(r"```bash\n(.*?)\n```", text, flags=re.DOTALL):
+            logical_lines = block.replace("\\\n", " ").splitlines()
+            for raw_line in logical_lines:
+                line = raw_line.strip()
+                if not line:
+                    continue
+                tokens = shlex.split(line)
+                for script_path in APEX_CLI_MODULES:
+                    if script_path not in tokens:
+                        continue
+                    script_index = tokens.index(script_path)
+                    options = {token.split("=", 1)[0] for token in tokens[script_index + 1 :] if token.startswith("--")}
+                    commands.append((doc_path, script_path, options))
+    return commands
+
+
+def test_validation_docs_apex_commands_use_current_cli_options():
+    known_options = {script_path: _parser_options(script_path) for script_path in APEX_CLI_MODULES}
+    failures = []
+
+    for doc_path, script_path, documented_options in _documented_apex_commands():
+        unknown_options = sorted(documented_options - known_options[script_path])
+        if unknown_options:
+            failures.append(f"{doc_path.relative_to(REPO_ROOT)} {script_path}: {', '.join(unknown_options)}")
+
+    assert failures == []
+
+
+def test_evidence_bundle_command_example_documents_run_scope_and_synthetic_mode():
+    commands = [
+        options
+        for doc_path, script_path, options in _documented_apex_commands()
+        if doc_path.name == "APEX_VISUAL_QUALITY_PROTOCOL.md"
+        and script_path == "tools/run_apex_eval.py"
+        and "--emit-evidence-bundle" in options
+    ]
+
+    assert commands
+    assert any({"--run-scope-asset-id", "--synthetic-data"}.issubset(options) for options in commands)

--- a/tools/audit_apex_assets.py
+++ b/tools/audit_apex_assets.py
@@ -20,7 +20,7 @@ def _bool_flag(value: str) -> bool:
     raise argparse.ArgumentTypeError(f"Expected boolean-like value, got {value!r}")
 
 
-def main() -> int:
+def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Audit APEX evalset assets.")
     parser.add_argument("--evalset", required=True, help="Evalset directory or evalset.json path.")
     parser.add_argument("--asset-root", default=None, help="Optional external asset root for evalset asset paths.")
@@ -36,6 +36,11 @@ def main() -> int:
         default=False,
         help="Fail when no canonical assets are eligible or canonical assets are missing/invalid.",
     )
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
     args = parser.parse_args()
 
     try:

--- a/tools/run_apex_eval.py
+++ b/tools/run_apex_eval.py
@@ -11,7 +11,7 @@ from transformation_portal.evals.apex_visual import build_apex_eval_report, pars
 from transformation_portal.evals.apex_evidence_bundle import build_apex_evidence_bundle, parse_candidate_evidence
 
 
-def main() -> int:
+def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Emit an APEX visual quality eval report.")
     parser.add_argument("--evalset", required=True, help="Evalset directory or evalset.json path.")
     parser.add_argument("--output-dir", required=True, help="Directory for apex_eval_report.json.")
@@ -21,7 +21,7 @@ def main() -> int:
         action="append",
         default=[],
         metavar="CANDIDATE:ASSET_ID=PATH",
-        help="Optional candidate output image for visible-delta metrics. May be repeated.",
+        help="Optional candidate output image for APEX metric evaluation. May be repeated.",
     )
     parser.add_argument(
         "--emit-report",
@@ -54,6 +54,11 @@ def main() -> int:
         default="off",
         help="Emit evidence_bundle.json alongside the APEX eval report.",
     )
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
     args = parser.parse_args()
 
     try:


### PR DESCRIPTION
## Summary
- Hardens the post-#1545 APEX evidence promotion contract so partial scope, malformed metric evidence, and stale docs examples cannot look promotion-ready.
- Keeps the change bounded to evidence validation, focused tests, and command documentation. No new CLI flags, dependencies, runner integration, manifest binaries, or promotion policy surfaces were added.

## Changes
- Require candidate metrics to use valid `apex_metrics.v1` status-bearing entries before promotion can treat them as authoritative.
- Add multi-asset promotion tests for unscoped runs, scoped runs, subset scope, missing candidate outputs, missing Materials V3 telemetry, invalid metric statuses, and malformed metric entries.
- Add validation-doc command tests that compare documented APEX CLI options against parser definitions and require the evidence-bundle example to document `--run-scope-asset-id` and `--synthetic-data`.
- Expose additive `build_parser()` helpers in `tools/run_apex_eval.py` and `tools/audit_apex_assets.py` for deterministic command-example validation.
- Update `docs/validation/APEX_VISUAL_QUALITY_PROTOCOL.md` with run-scope coverage and fail-closed promotion blockers.

## Validation
Proven green:
- `.venv/bin/pytest tests/evals/test_apex_candidate_evidence.py tests/evals/test_apex_docs_commands.py -q` -> 21 passed
- `.venv/bin/pytest tests/evals -q` -> 336 passed, 1 skipped
- `make test-fast` -> 73 passed
- `make pre-commit` -> passed
- `make ci-quick` -> passed

Still failing:
- None in the requested validation path.

Notes:
- `make ci-quick` reports the existing advisory pylint note in `tests/test_depth_tools.py` (`wrong-import-position`), but the local CI gate completed successfully. This is tooling/advisory output, not a product regression from this PR.

## Risk
- Compatibility risk is low: schema versions and CLI flags are unchanged; parser builders are additive.
- The main behavior change is deliberately fail-closed: malformed or non-status-bearing metric entries no longer satisfy promotion eligibility.
- The change is revert-safe and bounded to APEX evidence promotion validation and docs command coverage.