### PR TITLE
feat(apex): add real canonical manifest v0

### DIFF
--- a/evalsets/apex_real_estate_v1/README.md
+++ b/evalsets/apex_real_estate_v1/README.md
@@ -1,0 +1,90 @@
+# APEX Real Estate v1
+
+This evalset is the initial real canonical APEX real-estate corpus.
+
+The repository commits metadata only. Canonical 16-bit TIFF/TIF references, RAW files, ICC/profile assets, delivery derivatives, candidate outputs, and generated evidence bundles must remain outside git.
+
+## External asset root
+
+Expected local layout:
+
+```text
+$APEX_EVAL_ASSET_ROOT/
+  apex_real_estate_v1/
+    reference_16bit/
+      pool_water_stone_001_master16.tif
+      kitchen_glass_metal_001_master16.tif
+      exterior_foliage_sky_001_master16.tif
+    delivery_8bit/
+    source_raw/
+    annotations/
+    baselines/
+```
+
+Recommended local root:
+
+```bash
+export APEX_EVAL_ASSET_ROOT="$HOME/apex_eval_assets"
+```
+
+## Canonical evidence rule
+
+Canonical APEX quality evidence requires externally resolved, deterministic developed 16-bit TIFF/TIF references.
+
+RAW files, ICC/profile fields, and working-color fields are provenance only.
+
+8-bit delivery derivatives, renderings, and synthetic fixtures are NOT canonical APEX quality evidence.
+
+For this first manifest, `asset_ref` and `reference_path` intentionally point to the same canonical 16-bit TIFF/TIF master.
+
+## Local audit
+
+```bash
+APEX_EVAL_ASSET_ROOT="$HOME/apex_eval_assets" \
+.venv/bin/python tools/audit_apex_assets.py \
+  --evalset evalsets/apex_real_estate_v1/evalset.json \
+  --require-canonical on \
+  --output-dir output/apex_asset_audit
+```
+
+Expected:
+
+```text
+exit 0
+canonical_scoring_eligible_count >= 3
+no checksum_mismatch
+no missing canonical references
+```
+
+## Non-binary policy
+
+Do NOT commit:
+
+```text
+*.tif
+*.tiff
+*.dng
+*.cr2
+*.cr3
+*.nef
+*.arw
+*.raf
+*.orf
+*.rw2
+large *.jpg
+output/
+```
+
+## Next step
+
+After this manifest lands, the next PR documents the first real evidence run using:
+
+```text
+--candidate-output
+--candidate-evidence
+--emit-evidence-bundle on
+--synthetic-data off
+--run-scope-asset-id
+```
+
+Generated outputs must remain uncommitted.

--- a/evalsets/apex_real_estate_v1/README.md
+++ b/evalsets/apex_real_estate_v1/README.md
@@ -4,6 +4,8 @@ This evalset is the initial real canonical APEX real-estate corpus.
 
 The repository commits metadata only. Canonical 16-bit TIFF/TIF references, RAW files, ICC/profile assets, delivery derivatives, candidate outputs, and generated evidence bundles must remain outside git.
 
+`evalset_id` and top-level `version` identify the `apex_real_estate_v1` corpus family. `metadata.manifest_revision` tracks the initial metadata-only real manifest revision.
+
 ## External asset root
 
 Expected local layout:
@@ -71,9 +73,10 @@ Do NOT commit:
 *.raf
 *.orf
 *.rw2
-large *.jpg
 output/
 ```
+
+Large delivery JPEGs, including files under `delivery_8bit/`, must stay under the external asset root.
 
 ## Next step
 

--- a/evalsets/apex_real_estate_v1/evalset.json
+++ b/evalsets/apex_real_estate_v1/evalset.json
@@ -1,0 +1,124 @@
+{
+  "schema_version": "apex_evalset.v1",
+  "evalset_id": "apex_real_estate_v1",
+  "version": "v0",
+  "dataset_tier": "canonical_apex",
+  "canonical_bit_depth": 16,
+  "canonical_color_space": "ProPhoto RGB",
+  "canonical_format": "tiff",
+  "description": "Initial metadata-only real canonical APEX real-estate corpus. Canonical 16-bit TIFF/TIF references live outside git under an operator-provided asset root.",
+  "metadata": {
+    "asset_policy": "external_assets_only",
+    "initial_assets": 3,
+    "target_assets": "8-12"
+  },
+  "assets": [
+    {
+      "asset_id": "pool_water_stone_001",
+      "asset_ref": "apex_real_estate_v1/reference_16bit/pool_water_stone_001_master16.tif",
+      "sha256": "797349d48aa30b695a39e6f8f506b130231595c2d0b4cf8b86a32f1c37a43231",
+      "asset_role": "canonical_apex_reference",
+      "reference_path": "apex_real_estate_v1/reference_16bit/pool_water_stone_001_master16.tif",
+      "canonical_bit_depth": 16,
+      "canonical_format": "tiff",
+      "canonical_color_space": "ProPhoto RGB",
+      "working_color_space": "ProPhoto RGB",
+      "working_transfer_function": "linear",
+      "evaluate_at_native_resolution": true,
+      "allow_downsampled_model_inference": true,
+      "preserve_16bit_intermediates": true,
+      "canonical_scoring_eligible": true,
+      "scene_type": "pool_exterior",
+      "expected_materials": [
+        "water",
+        "stone",
+        "foliage",
+        "sky"
+      ],
+      "risk_zones": [
+        "pool_edge",
+        "sky_pool_boundary"
+      ],
+      "reject_if": [
+        "halo",
+        "material_bleed",
+        "water_overclarity",
+        "sky_color_drift",
+        "stone_texture_clipping"
+      ],
+      "manual_quality_score": null
+    },
+    {
+      "asset_id": "kitchen_glass_metal_001",
+      "asset_ref": "apex_real_estate_v1/reference_16bit/kitchen_glass_metal_001_master16.tif",
+      "sha256": "ccf48d8d44fd838dd432dc5b63498f0ada24abc81efb7a6ba8bf640a6a37c0d3",
+      "asset_role": "canonical_apex_reference",
+      "reference_path": "apex_real_estate_v1/reference_16bit/kitchen_glass_metal_001_master16.tif",
+      "canonical_bit_depth": 16,
+      "canonical_format": "tiff",
+      "canonical_color_space": "ProPhoto RGB",
+      "working_color_space": "ProPhoto RGB",
+      "working_transfer_function": "linear",
+      "evaluate_at_native_resolution": true,
+      "allow_downsampled_model_inference": true,
+      "preserve_16bit_intermediates": true,
+      "canonical_scoring_eligible": true,
+      "scene_type": "kitchen_interior",
+      "expected_materials": [
+        "stone",
+        "glass",
+        "metal",
+        "wood",
+        "painted_surface"
+      ],
+      "risk_zones": [
+        "countertop_edge",
+        "appliance_reflections"
+      ],
+      "reject_if": [
+        "halo",
+        "material_bleed",
+        "stone_texture_clipping",
+        "metal_reflection_artifacts",
+        "color_temperature_drift"
+      ],
+      "manual_quality_score": null
+    },
+    {
+      "asset_id": "exterior_foliage_sky_001",
+      "asset_ref": "apex_real_estate_v1/reference_16bit/exterior_foliage_sky_001_master16.tif",
+      "sha256": "d0ef2e5aac06ef8011396b9e3be2d9d891e7417ccb59dce548dc5415aeccea81",
+      "asset_role": "canonical_apex_reference",
+      "reference_path": "apex_real_estate_v1/reference_16bit/exterior_foliage_sky_001_master16.tif",
+      "canonical_bit_depth": 16,
+      "canonical_format": "tiff",
+      "canonical_color_space": "ProPhoto RGB",
+      "working_color_space": "ProPhoto RGB",
+      "working_transfer_function": "linear",
+      "evaluate_at_native_resolution": true,
+      "allow_downsampled_model_inference": true,
+      "preserve_16bit_intermediates": true,
+      "canonical_scoring_eligible": true,
+      "scene_type": "exterior_foliage_sky",
+      "expected_materials": [
+        "foliage",
+        "sky",
+        "stucco",
+        "glass",
+        "stone"
+      ],
+      "risk_zones": [
+        "tree_sky_boundary",
+        "facade_glass_boundary"
+      ],
+      "reject_if": [
+        "halo",
+        "foliage_oversaturation",
+        "sky_color_drift",
+        "material_bleed",
+        "facade_texture_clipping"
+      ],
+      "manual_quality_score": null
+    }
+  ]
+}

--- a/evalsets/apex_real_estate_v1/evalset.json
+++ b/evalsets/apex_real_estate_v1/evalset.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "apex_evalset.v1",
   "evalset_id": "apex_real_estate_v1",
-  "version": "v0",
+  "version": "v1",
   "dataset_tier": "canonical_apex",
   "canonical_bit_depth": 16,
   "canonical_color_space": "ProPhoto RGB",
@@ -9,7 +9,8 @@
   "description": "Initial metadata-only real canonical APEX real-estate corpus. Canonical 16-bit TIFF/TIF references live outside git under an operator-provided asset root.",
   "metadata": {
     "asset_policy": "external_assets_only",
-    "initial_assets": 3,
+    "manifest_revision": "v0",
+    "minimum_initial_assets": 3,
     "target_assets": "8-12"
   },
   "assets": [


### PR DESCRIPTION
## Summary
Adds the first metadata-only real canonical APEX real-estate manifest.

The manifest references three externally stored deterministic developed 16-bit TIFF/TIF masters:
- pool / water / stone
- kitchen / glass / metal
- exterior / foliage / sky

No image, RAW, ICC, delivery, candidate, or generated evidence binaries are committed.

## Changes
- Adds `evalsets/apex_real_estate_v1/evalset.json`.
- Adds `evalsets/apex_real_estate_v1/README.md`.
- Keeps `asset_ref == reference_path` for the first manifest to avoid scoring-target ambiguity.
- Adds top-level canonical manifest fields used by the loader:
  - `evalset_id`
  - `version`
  - `dataset_tier`
  - `canonical_bit_depth`
  - `canonical_color_space`
  - `canonical_format`
- Preserves Picacho as smoke/readiness only.
- Preserves the canonical scoring gate and `apex_evalset.v1`.

## Local Asset Validation
External asset root:

```bash
export APEX_EVAL_ASSET_ROOT="$HOME/apex_eval_assets"
```

Confirmed local references:
- TIFF / RGB / uint16 / 16 bits per sample / 3 samples per pixel.
- SHA-256 checksums recorded in manifest.

Audit result:

```text
canonical_scoring_eligible_count: 3
ready_asset_count: 3
missing_asset_count: 0
noncanonical_asset_count: 0
blocked reasons: {}
```

Detected canonical assets:

```text
pool_water_stone_001 ready True tiff 16
kitchen_glass_metal_001 ready True tiff 16
exterior_foliage_sky_001 ready True tiff 16
```

## Validation
Proven green:
- `.venv/bin/python -m json.tool evalsets/apex_real_estate_v1/evalset.json >/tmp/apex_evalset_check.json`
- `APEX_EVAL_ASSET_ROOT="$HOME/apex_eval_assets" .venv/bin/python tools/audit_apex_assets.py --evalset evalsets/apex_real_estate_v1/evalset.json --require-canonical on --output-dir output/apex_asset_audit` -> exit 0
- `.venv/bin/pytest tests/evals/test_apex_asset_resolver.py tests/evals/test_apex_visual.py -q` -> 53 passed
- `git diff --check`
- `.venv/bin/pytest tests/evals -q` -> 336 passed, 1 skipped
- `make test-fast` -> 73 passed
- `make pre-commit` -> passed
- `make ci-quick` -> passed

Still failing:
- None in the requested validation path.

Notes:
- Bare `python -m json.tool ...` was not available in this shell (`python` not found), so JSON validation used the repo venv interpreter.
- `make ci-quick` reports the existing advisory pylint note in `tests/test_depth_tools.py` (`wrong-import-position`), but the quick CI gate completed successfully. This is tooling/advisory output, not a product regression from this PR.

## Risk
Low. This is a metadata-only manifest PR with no binaries committed. CI without external assets must not treat missing external canonical references as real quality evidence.