### PR TITLE
docs(apex): add real canonical evidence runbook

### DIFF
--- a/docs/validation/APEX_REAL_CANONICAL_EVIDENCE_RUNBOOK.md
+++ b/docs/validation/APEX_REAL_CANONICAL_EVIDENCE_RUNBOOK.md
@@ -112,9 +112,10 @@ export APEX_EVAL_ASSET_ROOT="$HOME/apex_eval_assets"
   --synthetic-data off
 ```
 
-## Expected Fail-Closed Reasons
+## Evidence Statuses And Promotion Reasons
 
-Promotion can be blocked by:
+Asset audit and candidate comparison entries can report per-asset or
+per-candidate statuses such as:
 
 - `missing_asset`
 - `path_escapes_asset_root`
@@ -126,6 +127,16 @@ Promotion can be blocked by:
 - `unsupported_candidate_bit_depth`
 - `dimension_mismatch`
 - `metrics_not_computed`
+
+These statuses are useful for troubleshooting the underlying asset or candidate
+failure. They are not all emitted directly as run-level
+`promotion_blocked_reasons`.
+
+Evidence bundle `promotion_blocked_reasons` currently include:
+
+- `zero_canonical_eligible_assets`
+- `missing_candidate_output`
+- `invalid_metrics`
 - `missing_materials_v3_evidence`
 - `synthetic_data`
 - `APEX_MATERIALS_PIXEL_OPS_EMPTY`

--- a/docs/validation/APEX_REAL_CANONICAL_EVIDENCE_RUNBOOK.md
+++ b/docs/validation/APEX_REAL_CANONICAL_EVIDENCE_RUNBOOK.md
@@ -1,0 +1,136 @@
+# APEX Real Canonical Evidence Runbook
+
+This runbook describes the first non-synthetic APEX evidence workflow for the
+metadata-only `apex_real_estate_v1` canonical manifest.
+
+The expected outcome is an evidence bundle with real canonical inputs and
+fail-closed verdicts. A failed promotion verdict is a valid real evidence result
+when candidate outputs, telemetry, dimensions, bit depth, metrics, or Materials
+V3 gates fail closed.
+
+## Prerequisites
+
+- External canonical assets are mounted outside git.
+- `evalsets/apex_real_estate_v1/evalset.json` is present.
+- Candidate outputs are externally stored 16-bit TIFF/TIF files.
+- Candidate output dimensions match each asset's `reference_path`.
+- Materials V3 telemetry JSON files are stored outside git.
+- Generated `output/` reports remain uncommitted.
+
+Set the local asset root:
+
+```bash
+export APEX_EVAL_ASSET_ROOT="$HOME/apex_eval_assets"
+```
+
+## Canonical Asset Audit
+
+Run the audit before producing evidence:
+
+```bash
+export APEX_EVAL_ASSET_ROOT="$HOME/apex_eval_assets"
+.venv/bin/python tools/audit_apex_assets.py \
+  --evalset evalsets/apex_real_estate_v1/evalset.json \
+  --require-canonical on \
+  --output-dir output/apex_asset_audit
+```
+
+The audit should exit `0` when all mounted canonical references are present,
+checksum-valid, TIFF/TIF, and at least 16-bit.
+
+## Materials V3 Telemetry
+
+Each `materials_v3` candidate needs telemetry evidence. Minimal telemetry shape:
+
+```json
+{
+  "materials_v3_enabled": true,
+  "pixel_ops_enabled": true,
+  "masks_exist": true,
+  "implemented_ops_exist": true,
+  "applied_ops_count": 1,
+  "blocked_reason_counts": {
+    "below_confidence_threshold": 0
+  },
+  "confidence_authority": {
+    "raw_clip_similarity_authorized_pixel_ops": false,
+    "calibrated_score_type": "clip_softmax_margin_v1"
+  }
+}
+```
+
+For APEX promotion, `raw_clip_similarity_authorized_pixel_ops` must be `false`.
+Raw CLIP similarity may appear as evidence, but it must not authorize pixel
+operations.
+
+## Scoped Evidence Run
+
+Use an explicit run scope for a one-asset real evidence run:
+
+```bash
+export APEX_EVAL_ASSET_ROOT="$HOME/apex_eval_assets"
+.venv/bin/python tools/run_apex_eval.py \
+  --evalset evalsets/apex_real_estate_v1/evalset.json \
+  --asset-root "$APEX_EVAL_ASSET_ROOT" \
+  --output-dir output/apex_eval_real \
+  --candidate-output materials_v3:pool_water_stone_001="$APEX_EVAL_ASSET_ROOT/apex_real_estate_v1/baselines/materials_v3/pool_water_stone_001_materials_v3_master16.tif" \
+  --candidate-evidence materials_v3:pool_water_stone_001="$APEX_EVAL_ASSET_ROOT/apex_real_estate_v1/baselines/materials_v3/pool_water_stone_001_materials_v3_evidence.json" \
+  --run-scope-asset-id pool_water_stone_001 \
+  --emit-evidence-bundle on \
+  --synthetic-data off
+```
+
+Candidate-output scoring compares the candidate against `reference_path`, not
+`asset_ref`. For canonical assets, the reference and candidate must be readable
+16-bit TIFF/TIF files with matching dimensions. Scoring does not resize.
+
+Portable report fields must not expose full local resolved reference paths.
+
+## Full Manifest Evidence Run
+
+If `--run-scope-asset-id` is omitted, promotion eligibility is evaluated across
+all canonical-eligible assets in the manifest. A single candidate output against
+the three-asset manifest is not promotion-eligible unless the run is explicitly
+scoped to that asset.
+
+Full-manifest promotion requires candidate output and Materials V3 telemetry for
+all current canonical assets:
+
+```bash
+export APEX_EVAL_ASSET_ROOT="$HOME/apex_eval_assets"
+.venv/bin/python tools/run_apex_eval.py \
+  --evalset evalsets/apex_real_estate_v1/evalset.json \
+  --asset-root "$APEX_EVAL_ASSET_ROOT" \
+  --output-dir output/apex_eval_real \
+  --candidate-output materials_v3:pool_water_stone_001="$APEX_EVAL_ASSET_ROOT/apex_real_estate_v1/baselines/materials_v3/pool_water_stone_001_materials_v3_master16.tif" \
+  --candidate-evidence materials_v3:pool_water_stone_001="$APEX_EVAL_ASSET_ROOT/apex_real_estate_v1/baselines/materials_v3/pool_water_stone_001_materials_v3_evidence.json" \
+  --candidate-output materials_v3:kitchen_glass_metal_001="$APEX_EVAL_ASSET_ROOT/apex_real_estate_v1/baselines/materials_v3/kitchen_glass_metal_001_materials_v3_master16.tif" \
+  --candidate-evidence materials_v3:kitchen_glass_metal_001="$APEX_EVAL_ASSET_ROOT/apex_real_estate_v1/baselines/materials_v3/kitchen_glass_metal_001_materials_v3_evidence.json" \
+  --candidate-output materials_v3:exterior_foliage_sky_001="$APEX_EVAL_ASSET_ROOT/apex_real_estate_v1/baselines/materials_v3/exterior_foliage_sky_001_materials_v3_master16.tif" \
+  --candidate-evidence materials_v3:exterior_foliage_sky_001="$APEX_EVAL_ASSET_ROOT/apex_real_estate_v1/baselines/materials_v3/exterior_foliage_sky_001_materials_v3_evidence.json" \
+  --emit-evidence-bundle on \
+  --synthetic-data off
+```
+
+## Expected Fail-Closed Reasons
+
+Promotion can be blocked by:
+
+- `missing_asset`
+- `path_escapes_asset_root`
+- `missing_reference`
+- `missing_candidate`
+- `unreadable_reference`
+- `unreadable_candidate`
+- `unsupported_reference_bit_depth`
+- `unsupported_candidate_bit_depth`
+- `dimension_mismatch`
+- `metrics_not_computed`
+- `missing_materials_v3_evidence`
+- `synthetic_data`
+- `APEX_MATERIALS_PIXEL_OPS_EMPTY`
+- `raw_clip_similarity_authorized_pixel_ops`
+
+Generated reports and evidence bundles under `output/` are local validation
+artifacts. Do not commit them unless a later redacted-fixture policy explicitly
+allows that.

--- a/evalsets/apex_real_estate_v1/README.md
+++ b/evalsets/apex_real_estate_v1/README.md
@@ -78,16 +78,10 @@ output/
 
 Large delivery JPEGs, including files under `delivery_8bit/`, must stay under the external asset root.
 
-## Next step
+## Real evidence runbook
 
-After this manifest lands, the next PR documents the first real evidence run using:
+The first non-synthetic APEX evidence workflow is documented in:
 
-```text
---candidate-output
---candidate-evidence
---emit-evidence-bundle on
---synthetic-data off
---run-scope-asset-id
-```
+`docs/validation/APEX_REAL_CANONICAL_EVIDENCE_RUNBOOK.md`
 
-Generated outputs must remain uncommitted.
+Generated evidence outputs must remain uncommitted unless a later redacted-fixture policy explicitly allows them.

--- a/tests/evals/test_apex_docs_commands.py
+++ b/tests/evals/test_apex_docs_commands.py
@@ -77,7 +77,7 @@ def test_validation_docs_apex_commands_use_current_cli_options():
         if unknown_options:
             failures.append(f"{doc_path.relative_to(REPO_ROOT)} {script_path}: {', '.join(unknown_options)}")
 
-    assert failures == []
+    assert not failures
 
 
 def test_real_canonical_runbook_audit_command_uses_current_cli_options():
@@ -99,8 +99,8 @@ def test_real_canonical_runbook_evidence_command_uses_current_cli_options():
     assert all(options <= known_options for options in commands)
 
 
-def test_real_canonical_runbook_evidence_command_documents_required_flags():
-    required = {
+def test_real_canonical_runbook_scoped_evidence_example_documents_scope_flags():
+    scoped_example_flags = {
         "--asset-root",
         "--candidate-output",
         "--candidate-evidence",
@@ -110,7 +110,7 @@ def test_real_canonical_runbook_evidence_command_documents_required_flags():
     }
     commands = _commands_for_doc(REAL_CANONICAL_RUNBOOK, "tools/run_apex_eval.py")
 
-    assert any(required.issubset(options) for options in commands)
+    assert any(scoped_example_flags.issubset(options) for options in commands)
 
 
 def test_real_canonical_runbook_full_manifest_command_mentions_all_three_asset_ids():

--- a/tests/evals/test_apex_docs_commands.py
+++ b/tests/evals/test_apex_docs_commands.py
@@ -16,6 +16,12 @@ APEX_CLI_MODULES = {
     "tools/audit_apex_assets.py": "audit_apex_assets_docs_unit",
     "tools/run_apex_eval.py": "run_apex_eval_docs_unit",
 }
+REAL_CANONICAL_RUNBOOK = "APEX_REAL_CANONICAL_EVIDENCE_RUNBOOK.md"
+REAL_CANONICAL_ASSET_IDS = {
+    "pool_water_stone_001",
+    "kitchen_glass_metal_001",
+    "exterior_foliage_sky_001",
+}
 
 
 def _load_tool_module(script_path: str, module_name: str):
@@ -54,6 +60,14 @@ def _documented_apex_commands() -> list[tuple[Path, str, set[str]]]:
     return commands
 
 
+def _commands_for_doc(doc_name: str, script_path: str) -> list[set[str]]:
+    return [
+        options
+        for doc_path, documented_script_path, options in _documented_apex_commands()
+        if doc_path.name == doc_name and documented_script_path == script_path
+    ]
+
+
 def test_validation_docs_apex_commands_use_current_cli_options():
     known_options = {script_path: _parser_options(script_path) for script_path in APEX_CLI_MODULES}
     failures = []
@@ -64,6 +78,45 @@ def test_validation_docs_apex_commands_use_current_cli_options():
             failures.append(f"{doc_path.relative_to(REPO_ROOT)} {script_path}: {', '.join(unknown_options)}")
 
     assert failures == []
+
+
+def test_real_canonical_runbook_audit_command_uses_current_cli_options():
+    script_path = "tools/audit_apex_assets.py"
+    known_options = _parser_options(script_path)
+    commands = _commands_for_doc(REAL_CANONICAL_RUNBOOK, script_path)
+
+    assert commands
+    assert all(options <= known_options for options in commands)
+    assert any("--require-canonical" in options for options in commands)
+
+
+def test_real_canonical_runbook_evidence_command_uses_current_cli_options():
+    script_path = "tools/run_apex_eval.py"
+    known_options = _parser_options(script_path)
+    commands = _commands_for_doc(REAL_CANONICAL_RUNBOOK, script_path)
+
+    assert commands
+    assert all(options <= known_options for options in commands)
+
+
+def test_real_canonical_runbook_evidence_command_documents_required_flags():
+    required = {
+        "--asset-root",
+        "--candidate-output",
+        "--candidate-evidence",
+        "--run-scope-asset-id",
+        "--emit-evidence-bundle",
+        "--synthetic-data",
+    }
+    commands = _commands_for_doc(REAL_CANONICAL_RUNBOOK, "tools/run_apex_eval.py")
+
+    assert any(required.issubset(options) for options in commands)
+
+
+def test_real_canonical_runbook_full_manifest_command_mentions_all_three_asset_ids():
+    text = (REPO_ROOT / "docs" / "validation" / REAL_CANONICAL_RUNBOOK).read_text(encoding="utf-8")
+
+    assert REAL_CANONICAL_ASSET_IDS <= set(re.findall(r"\b[a-z]+(?:_[a-z0-9]+)+\b", text))
 
 
 def test_evidence_bundle_command_example_documents_run_scope_and_synthetic_mode():


### PR DESCRIPTION
## Summary
- Adds the first non-synthetic APEX canonical evidence runbook under docs/validation.
- Keeps the change to docs plus parser-backed command tests; no CLI, schema, runner, Materials V3 tuning, generated artifact, or image binary changes.

## Changes
- Documents canonical asset audit and real evidence commands for the apex_real_estate_v1 manifest.
- Includes scoped and full-manifest evidence examples using current run_apex_eval.py flags.
- Adds minimal Materials V3 telemetry JSON guidance and fail-closed operator expectations.
- Replaces the evalset README placeholder with a link to the new runbook.
- Extends APEX docs-command tests to guard runbook audit/evidence commands and current asset IDs.

## Validation
- `.venv/bin/pytest tests/evals/test_apex_docs_commands.py -q` -> 6 passed
- `.venv/bin/pytest tests/evals/test_apex_asset_resolver.py tests/evals/test_apex_visual.py tests/evals/test_apex_candidate_evidence.py -q` -> 72 passed
- `.venv/bin/pytest tests/evals -q` -> 340 passed, 1 skipped
- `make test-fast` -> 73 passed
- `make pre-commit` -> passed
- `make ci-quick` -> passed; existing advisory pylint note remains non-blocking in tests/test_depth_tools.py
- `APEX_EVAL_ASSET_ROOT="$HOME/apex_eval_assets" .venv/bin/python tools/audit_apex_assets.py --evalset evalsets/apex_real_estate_v1/evalset.json --require-canonical on --output-dir output/apex_asset_audit` -> exit 0

## Risk
- Low. Documentation and tests only.
- Revert-safe: removes no CLI behavior and commits no generated outputs or binaries.