### PR TITLE
docs(apex): add redacted evidence fixture policy

### DIFF
--- a/docs/validation/APEX_REAL_CANONICAL_EVIDENCE_RUNBOOK.md
+++ b/docs/validation/APEX_REAL_CANONICAL_EVIDENCE_RUNBOOK.md
@@ -143,5 +143,6 @@ Evidence bundle `promotion_blocked_reasons` currently include:
 - `raw_clip_similarity_authorized_pixel_ops`
 
 Generated reports and evidence bundles under `output/` are local validation
-artifacts. Do not commit them unless a later redacted-fixture policy explicitly
-allows that.
+artifacts. Do not commit them unless they satisfy the redacted fixture policy:
+
+`docs/validation/APEX_REDACTED_EVIDENCE_FIXTURE_POLICY.md`

--- a/docs/validation/APEX_REDACTED_EVIDENCE_FIXTURE_POLICY.md
+++ b/docs/validation/APEX_REDACTED_EVIDENCE_FIXTURE_POLICY.md
@@ -1,0 +1,87 @@
+# APEX Redacted Evidence Fixture Policy
+
+## Purpose
+
+This policy defines the narrow conditions under which APEX evidence fixtures may
+be committed for schema regression, parser stability, or renderer stability
+tests.
+
+Committed APEX evidence fixtures are allowed only for schema regression and
+parser/renderer stability. They are never real APEX quality evidence and must
+never satisfy promotion eligibility.
+
+## Default Rule
+
+Real generated APEX evidence, canonical references, RAW files, TIFF/TIF masters,
+ICC/profile binaries, Materials V3 candidate outputs, private image assets,
+delivery images, and generated `output/` bundles must remain outside git.
+
+Real canonical evidence remains external-asset-only and requires non-synthetic
+runs against mounted canonical references.
+
+## Allowed Fixtures
+
+Committed fixtures may be used only when all of these are true:
+
+- The fixture is tiny enough for repository policy.
+- The fixture is synthetic or fully redacted.
+- The fixture exists only for schema regression, parser stability, or renderer
+  stability.
+- The fixture is labeled non-promotional.
+- The fixture cannot satisfy APEX promotion eligibility.
+
+## Prohibited Fixtures
+
+Do not commit:
+
+- real canonical 16-bit TIFF/TIF references
+- RAW/DNG/CR2/CR3/NEF/ARW/RAF/ORF/RW2 files
+- ICC/profile binaries
+- real Materials V3 candidate outputs
+- real generated evidence bundles
+- private property imagery
+- large JPEG/PNG delivery images
+- delivery images that could reconstruct the underlying property asset
+- generated `output/` artifacts from real APEX runs
+
+## Non-Promotional Requirement
+
+Any committed fixture must use `synthetic_data=true` or equivalent
+non-promotional labeling.
+
+For evidence-shaped fixtures, promotion must remain blocked. Prefer
+`promotion_verdict: blocked` and a `promotion_blocked_reasons` value such as
+`synthetic_data` or an equivalent `fixture_non_promotional` reason when the
+fixture shape supports those fields.
+
+```json
+{
+  "run": {
+    "synthetic_data": true
+  },
+  "promotion_verdict": "blocked",
+  "promotion_blocked_reasons": [
+    "synthetic_data"
+  ]
+}
+```
+
+Raw CLIP similarity, synthetic metrics, redacted images, or fixture-only
+telemetry must never authorize Materials V3 pixel operations or real APEX
+promotion.
+
+## Future Fixture PR Checklist
+
+Any future PR adding a committed APEX fixture must document:
+
+- fixture purpose
+- fixture size
+- fixture provenance
+- synthetic or redaction method
+- why docs-only coverage is insufficient
+- why the fixture cannot expose private real-estate imagery
+- confirmation that it cannot satisfy promotion eligibility
+- confirmation that promotion eligibility remains blocked
+
+If any checklist item cannot be satisfied, keep the artifact outside git and use
+the external asset-root workflow instead.

--- a/evalsets/apex_real_estate_v1/README.md
+++ b/evalsets/apex_real_estate_v1/README.md
@@ -84,4 +84,6 @@ The first non-synthetic APEX evidence workflow is documented in:
 
 `docs/validation/APEX_REAL_CANONICAL_EVIDENCE_RUNBOOK.md`
 
-Generated evidence outputs must remain uncommitted unless a later redacted-fixture policy explicitly allows them.
+Generated evidence outputs must remain uncommitted unless they satisfy the redacted fixture policy:
+
+`docs/validation/APEX_REDACTED_EVIDENCE_FIXTURE_POLICY.md`

--- a/tests/evals/test_apex_fixture_policy_docs.py
+++ b/tests/evals/test_apex_fixture_policy_docs.py
@@ -1,0 +1,74 @@
+"""Tests for APEX redacted evidence fixture policy documentation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+POLICY_PATH = REPO_ROOT / "docs" / "validation" / "APEX_REDACTED_EVIDENCE_FIXTURE_POLICY.md"
+RUNBOOK_PATH = REPO_ROOT / "docs" / "validation" / "APEX_REAL_CANONICAL_EVIDENCE_RUNBOOK.md"
+REAL_ESTATE_README_PATH = REPO_ROOT / "evalsets" / "apex_real_estate_v1" / "README.md"
+POLICY_LINK = "docs/validation/APEX_REDACTED_EVIDENCE_FIXTURE_POLICY.md"
+
+
+def _policy_text() -> str:
+    return POLICY_PATH.read_text(encoding="utf-8")
+
+
+def test_apex_redacted_evidence_fixture_policy_exists():
+    assert POLICY_PATH.exists()
+
+
+def test_apex_redacted_evidence_fixture_policy_locks_non_promotional_contract():
+    text = _policy_text()
+    normalized = text.lower()
+    collapsed = " ".join(normalized.split())
+
+    assert "synthetic_data=true" in text
+    assert "schema regression" in normalized
+    assert "non-promotional" in normalized
+    assert "never real apex quality evidence" in normalized
+    assert "must never satisfy promotion eligibility" in collapsed
+
+
+def test_apex_redacted_evidence_fixture_policy_prohibits_real_artifacts():
+    text = _policy_text()
+    prohibited_terms = {
+        "TIFF/TIF",
+        "RAW/DNG/CR2/CR3/NEF/ARW/RAF/ORF/RW2",
+        "ICC/profile binaries",
+        "candidate outputs",
+        "generated `output/` artifacts",
+        "private property imagery",
+    }
+
+    for term in prohibited_terms:
+        assert term in text
+
+
+def test_apex_redacted_evidence_fixture_policy_has_future_fixture_pr_checklist():
+    normalized = _policy_text().lower()
+
+    for phrase in (
+        "fixture purpose",
+        "fixture size",
+        "fixture provenance",
+        "synthetic or redaction method",
+        "why docs-only coverage is insufficient",
+        "cannot expose private real-estate imagery",
+        "cannot satisfy promotion eligibility",
+        "promotion eligibility remains blocked",
+    ):
+        assert phrase in normalized
+
+
+def test_real_canonical_docs_link_to_redacted_fixture_policy():
+    runbook = RUNBOOK_PATH.read_text(encoding="utf-8")
+    readme = REAL_ESTATE_README_PATH.read_text(encoding="utf-8")
+
+    assert POLICY_LINK in runbook
+    assert POLICY_LINK in readme


### PR DESCRIPTION
## Summary
- Adds the APEX redacted evidence fixture policy for future schema-regression fixtures.
- Keeps real canonical evidence external-only and non-synthetic.
- Updates the real evidence runbook and real-estate README to link to the concrete policy.

## Changes
- Adds docs/validation/APEX_REDACTED_EVIDENCE_FIXTURE_POLICY.md.
- Documents allowed tiny synthetic/redacted fixtures, prohibited real artifacts, non-promotional labeling, and future fixture PR checklist requirements.
- Adds focused docs tests for policy existence, required governance language, prohibited artifacts, checklist coverage, and policy links.

## Validation
- .venv/bin/pytest tests/evals/test_apex_docs_commands.py -q -> 6 passed
- .venv/bin/pytest tests/evals/test_apex_fixture_policy_docs.py -q -> 5 passed
- make pre-commit -> passed
- make ci-quick -> passed; existing non-blocking pylint advisory remains in tests/test_depth_tools.py

## Risk
- Low. Docs/test-only governance change.
- No fixtures, generated outputs, binaries, CLI flags, schemas, runner integration, or Materials V3 behavior changes.