### PR TITLE
docs(apex): clarify real evidence candidate extraction workflow

### DIFF
--- a/docs/validation/APEX_REAL_CANONICAL_EVIDENCE_RUNBOOK.md
+++ b/docs/validation/APEX_REAL_CANONICAL_EVIDENCE_RUNBOOK.md
@@ -76,13 +76,15 @@ steps:
 
 For manual Lux Depth V3 -> Materials V3 candidate extraction, the generation
 command must include `--keep-intermediates`. Without it, the pipeline may remove
-`temp/*_materials_v3_enhanced.tif` before the operator can copy the 16-bit
-Materials V3 candidate to the stable external baseline path.
+`<output-dir>/temp/*_materials_v3_enhanced.*` before the operator can copy the
+16-bit Materials V3 candidate to the stable external baseline path.
 
 Use the same governed APEX settings that will be scored later:
 
 ```bash
 python -m transformation_portal.lux_depth_v3 \
+  --input-dir "$APEX_EVAL_ASSET_ROOT/apex_real_estate_v1/reference_16bit" \
+  --output-dir output/apex_candidate_generation \
   --quality-tier apex \
   --materials-v3 on \
   --enable-segmentation on \
@@ -99,13 +101,6 @@ Copy extracted artifacts to stable external baseline paths under
 ```text
 $APEX_EVAL_ASSET_ROOT/apex_real_estate_v1/baselines/materials_v3/<asset_id>_materials_v3_master16.tif
 $APEX_EVAL_ASSET_ROOT/apex_real_estate_v1/baselines/materials_v3/<asset_id>_materials_v3_evidence.json
-```
-
-When mask-aware metrics are being scored, also copy Materials V3 mask bundles to
-stable external paths and pass them with `--candidate-mask`:
-
-```text
-$APEX_EVAL_ASSET_ROOT/apex_real_estate_v1/baselines/materials_v3/<asset_id>_materials_v3_masks.npz
 ```
 
 ## Scoped Evidence Run

--- a/docs/validation/APEX_REAL_CANONICAL_EVIDENCE_RUNBOOK.md
+++ b/docs/validation/APEX_REAL_CANONICAL_EVIDENCE_RUNBOOK.md
@@ -63,6 +63,51 @@ For APEX promotion, `raw_clip_similarity_authorized_pixel_ops` must be `false`.
 Raw CLIP similarity may appear as evidence, but it must not authorize pixel
 operations.
 
+## Candidate Generation / Extraction
+
+Candidate generation, candidate extraction, and candidate scoring are separate
+steps:
+
+- Candidate generation runs Lux Depth V3 with Materials V3 enabled.
+- Candidate extraction copies the generated 16-bit Materials V3 candidate and
+  telemetry into stable external baseline paths.
+- Candidate scoring runs `tools/run_apex_eval.py` against those extracted
+  external files.
+
+For manual Lux Depth V3 -> Materials V3 candidate extraction, the generation
+command must include `--keep-intermediates`. Without it, the pipeline may remove
+`temp/*_materials_v3_enhanced.tif` before the operator can copy the 16-bit
+Materials V3 candidate to the stable external baseline path.
+
+Use the same governed APEX settings that will be scored later:
+
+```bash
+python -m transformation_portal.lux_depth_v3 \
+  --quality-tier apex \
+  --materials-v3 on \
+  --enable-segmentation on \
+  --strict-segmentation \
+  --emit-master16 on \
+  --emit-run-card on \
+  --keep-intermediates \
+  --overwrite
+```
+
+Copy extracted artifacts to stable external baseline paths under
+`baselines/materials_v3`:
+
+```text
+$APEX_EVAL_ASSET_ROOT/apex_real_estate_v1/baselines/materials_v3/<asset_id>_materials_v3_master16.tif
+$APEX_EVAL_ASSET_ROOT/apex_real_estate_v1/baselines/materials_v3/<asset_id>_materials_v3_evidence.json
+```
+
+When mask-aware metrics are being scored, also copy Materials V3 mask bundles to
+stable external paths and pass them with `--candidate-mask`:
+
+```text
+$APEX_EVAL_ASSET_ROOT/apex_real_estate_v1/baselines/materials_v3/<asset_id>_materials_v3_masks.npz
+```
+
 ## Scoped Evidence Run
 
 Use an explicit run scope for a one-asset real evidence run:

--- a/tests/evals/test_apex_docs_commands.py
+++ b/tests/evals/test_apex_docs_commands.py
@@ -119,6 +119,20 @@ def test_real_canonical_runbook_full_manifest_command_mentions_all_three_asset_i
     assert REAL_CANONICAL_ASSET_IDS <= set(re.findall(r"\b[a-z]+(?:_[a-z0-9]+)+\b", text))
 
 
+def test_real_canonical_runbook_documents_candidate_extraction_workflow():
+    text = (REPO_ROOT / "docs" / "validation" / REAL_CANONICAL_RUNBOOK).read_text(encoding="utf-8")
+
+    for required in (
+        "--keep-intermediates",
+        "temp/*_materials_v3_enhanced.tif",
+        "baselines/materials_v3",
+        "--candidate-output",
+        "--candidate-evidence",
+        "--synthetic-data off",
+    ):
+        assert required in text
+
+
 def test_evidence_bundle_command_example_documents_run_scope_and_synthetic_mode():
     commands = [
         options

--- a/tests/evals/test_apex_docs_commands.py
+++ b/tests/evals/test_apex_docs_commands.py
@@ -124,8 +124,10 @@ def test_real_canonical_runbook_documents_candidate_extraction_workflow():
 
     for required in (
         "--keep-intermediates",
-        "temp/*_materials_v3_enhanced.tif",
+        "<output-dir>/temp/*_materials_v3_enhanced.*",
         "baselines/materials_v3",
+        "--input-dir",
+        "--output-dir",
         "--candidate-output",
         "--candidate-evidence",
         "--synthetic-data off",


### PR DESCRIPTION
## Summary
- Clarifies the real APEX candidate generation, extraction, and scoring workflow after the full-manifest evidence run.
- Documents the smallest safe operator guidance for preserving Materials V3 intermediates and copying extracted artifacts to stable external baseline paths.

## Changes
- Adds a Candidate Generation / Extraction section to the real canonical evidence runbook.
- Documents required Lux Depth V3 flags including --keep-intermediates and --overwrite.
- Locks the external baselines/materials_v3 destination convention for master16, evidence JSON, and mask NPZ artifacts.
- Adds focused docs-test assertions for the candidate extraction workflow.

## Validation
Proven green:
- /Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin/pytest -q tests/evals/test_apex_docs_commands.py tests/evals/test_apex_fixture_policy_docs.py

Still failing:
- None observed.

Failure classification:
- Not applicable.

## Risk
- Documentation/test-only change; no runtime, schema, CLI, route, selector, or artifact contract changes.
- Revert-safe because it only updates operator guidance and docs coverage.
