### PR TITLE
feat(apex): attach Materials V3 masks to mask-aware APEX metrics

### DIFF
--- a/src/transformation_portal/evals/apex_evidence_bundle.py
+++ b/src/transformation_portal/evals/apex_evidence_bundle.py
@@ -234,6 +234,7 @@ def build_apex_evidence_bundle(
                         "path": candidate_output_path,
                     },
                     "materials_v3": materials,
+                    "mask_evidence": candidate.get("mask_evidence") or {"status": "not_supplied"},
                     "depth": {},
                     "metrics": candidate.get("metrics") or {},
                     "metrics_status": "valid" if metrics_valid else "invalid",

--- a/src/transformation_portal/evals/apex_visual.py
+++ b/src/transformation_portal/evals/apex_visual.py
@@ -775,7 +775,18 @@ def _load_candidate_mask_union(
         return None, _invalid_mask_evidence("candidate_mask_missing", reported_path)
 
     try:
-        with np.load(mask_path, allow_pickle=False) as payload:
+        loaded_payload = np.load(mask_path, allow_pickle=False)
+    except (OSError, ValueError, TypeError, EOFError, zipfile.BadZipFile):
+        return None, _invalid_mask_evidence("candidate_mask_invalid_npz", reported_path)
+
+    if not hasattr(loaded_payload, "files"):
+        close_payload = getattr(loaded_payload, "close", None)
+        if callable(close_payload):
+            close_payload()
+        return None, _invalid_mask_evidence("candidate_mask_invalid_npz", reported_path)
+
+    try:
+        with loaded_payload as payload:
             keys = sorted(payload.files)
             if not keys:
                 return None, _invalid_mask_evidence("candidate_mask_empty", reported_path)
@@ -790,7 +801,7 @@ def _load_candidate_mask_union(
                     return None, _invalid_mask_evidence("candidate_mask_dimension_mismatch", reported_path)
                 union |= array.astype(bool)
                 valid_mask_count += 1
-    except (OSError, ValueError, TypeError, EOFError, zipfile.BadZipFile):
+    except (AttributeError, OSError, ValueError, TypeError, EOFError, zipfile.BadZipFile):
         return None, _invalid_mask_evidence("candidate_mask_invalid_npz", reported_path)
 
     if valid_mask_count == 0:

--- a/src/transformation_portal/evals/apex_visual.py
+++ b/src/transformation_portal/evals/apex_visual.py
@@ -13,6 +13,7 @@ import json
 import math
 import re
 import time
+import zipfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Iterable, Mapping, Sequence
@@ -723,6 +724,84 @@ def _candidate_report_base(
     return payload
 
 
+def _invalid_mask_metric(reason: str, comparison: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "status": "invalid_input",
+        "reason": reason,
+        "value": None,
+        "comparison": dict(comparison),
+    }
+
+
+def _mask_evidence_not_supplied() -> dict[str, Any]:
+    return {"status": "not_supplied"}
+
+
+def _invalid_mask_evidence(reason: str, reported_path: str) -> dict[str, Any]:
+    return {
+        "status": "invalid",
+        "reason": reason,
+        "reported_path": reported_path,
+    }
+
+
+def _candidate_mask_path(mask_value: Path | str, *, repo_root: Path) -> tuple[Path, str]:
+    mask_path = Path(mask_value)
+    reported_path = str(mask_value)
+    if not mask_path.is_absolute():
+        mask_path = repo_root / mask_path
+    return mask_path, reported_path
+
+
+def _load_candidate_mask_union(
+    mask_value: Path | str | None,
+    *,
+    repo_root: Path,
+    expected_shape: tuple[int, int],
+) -> tuple[np.ndarray | None, dict[str, Any]]:
+    if mask_value is None:
+        return None, _mask_evidence_not_supplied()
+
+    mask_path, reported_path = _candidate_mask_path(mask_value, repo_root=repo_root)
+    if not mask_path.is_file():
+        return None, _invalid_mask_evidence("candidate_mask_missing", reported_path)
+
+    try:
+        with np.load(mask_path, allow_pickle=False) as payload:
+            keys = sorted(payload.files)
+            if not keys:
+                return None, _invalid_mask_evidence("candidate_mask_empty", reported_path)
+
+            union = np.zeros(expected_shape, dtype=bool)
+            valid_mask_count = 0
+            for key in keys:
+                array = np.asarray(payload[key])
+                if array.ndim != 2:
+                    continue
+                if array.shape != expected_shape:
+                    return None, _invalid_mask_evidence("candidate_mask_dimension_mismatch", reported_path)
+                union |= array.astype(bool)
+                valid_mask_count += 1
+    except (OSError, ValueError, TypeError, EOFError, zipfile.BadZipFile):
+        return None, _invalid_mask_evidence("candidate_mask_invalid_npz", reported_path)
+
+    if valid_mask_count == 0:
+        return None, _invalid_mask_evidence("candidate_mask_no_2d_arrays", reported_path)
+    union_nonzero_pixels = int(np.count_nonzero(union))
+    if union_nonzero_pixels == 0:
+        return None, _invalid_mask_evidence("candidate_mask_empty", reported_path)
+
+    return union, {
+        "status": "ok",
+        "reported_path": reported_path,
+        "format": "npz",
+        "mask_count": valid_mask_count,
+        "union_shape": [int(expected_shape[0]), int(expected_shape[1])],
+        "union_nonzero_pixels": union_nonzero_pixels,
+        "source": "candidate_mask",
+    }
+
+
 def _read_image_array(path: Path, *, require_16bit_tiff: bool, role: str) -> tuple[np.ndarray | None, str | None, str | None]:
     if require_16bit_tiff:
         array, metadata = load_16bit_tiff(path)
@@ -752,11 +831,13 @@ def _candidate_metrics_report(
     asset_report_status: Mapping[str, Any],
     candidate_name: str,
     output_value: Path | str | None,
+    mask_value: Path | str | None = None,
 ) -> dict[str, Any]:
     reference_resolution = evalset.resolve_reference(asset)
     candidate_path = Path(output_value) if output_value is not None else None
     if candidate_path is not None and not candidate_path.is_absolute():
         candidate_path = evalset.repo_root / candidate_path
+    mask_evidence = _mask_evidence_not_supplied() if mask_value is None else None
 
     if candidate_path is None or not candidate_path.is_file():
         return _candidate_report_base(
@@ -765,6 +846,7 @@ def _candidate_metrics_report(
             candidate_path=candidate_path,
             reference_resolution=reference_resolution,
             reason="candidate_output_missing",
+            extra={"mask_evidence": mask_evidence or _mask_evidence_not_supplied()},
         )
 
     if asset_report_status.get("status") != "ready":
@@ -774,6 +856,7 @@ def _candidate_metrics_report(
             candidate_path=candidate_path,
             reference_resolution=reference_resolution,
             reason=f"asset_status_{asset_report_status.get('status')}",
+            extra={"mask_evidence": mask_evidence or _mask_evidence_not_supplied()},
         )
 
     reference_path = reference_resolution.resolved_path
@@ -784,6 +867,7 @@ def _candidate_metrics_report(
             candidate_path=candidate_path,
             reference_resolution=reference_resolution,
             reason="reference_path_missing_or_unresolved",
+            extra={"mask_evidence": mask_evidence or _mask_evidence_not_supplied()},
         )
 
     canonical_comparison = (
@@ -803,6 +887,7 @@ def _candidate_metrics_report(
             candidate_path=candidate_path,
             reference_resolution=reference_resolution,
             reason=reference_reason,
+            extra={"mask_evidence": mask_evidence or _mask_evidence_not_supplied()},
         )
 
     candidate, candidate_status, candidate_reason = _read_image_array(
@@ -817,13 +902,20 @@ def _candidate_metrics_report(
             candidate_path=candidate_path,
             reference_resolution=reference_resolution,
             reason=candidate_reason,
+            extra={"mask_evidence": mask_evidence or _mask_evidence_not_supplied()},
         )
 
     assert reference is not None
     assert candidate is not None
+    mask, mask_evidence = _load_candidate_mask_union(
+        mask_value,
+        repo_root=evalset.repo_root,
+        expected_shape=(int(reference.shape[0]), int(reference.shape[1])),
+    )
     metrics = compute_apex_metrics(
         reference,
         candidate,
+        mask=mask,
         working_color_space=asset.working_color_space,
         working_transfer_function=asset.working_transfer_function,
     )
@@ -836,6 +928,7 @@ def _candidate_metrics_report(
             reference_resolution=reference_resolution,
             metrics=metrics,
             reason="dimension_mismatch",
+            extra={"mask_evidence": mask_evidence},
         )
     if visible_status != "ok":
         return _candidate_report_base(
@@ -845,6 +938,21 @@ def _candidate_metrics_report(
             reference_resolution=reference_resolution,
             metrics=metrics,
             reason=visible_status or "metrics_not_computed",
+            extra={"mask_evidence": mask_evidence},
+        )
+    if mask_evidence.get("status") == "invalid":
+        reason = str(mask_evidence.get("reason") or "candidate_mask_invalid")
+        comparison = metrics.get("visible_delta", {}).get("comparison") or {}
+        metrics["outside_mask_delta"] = _invalid_mask_metric(reason, comparison)
+        metrics["seam_halo_score"] = _invalid_mask_metric(reason, comparison)
+        return _candidate_report_base(
+            candidate_name=candidate_name,
+            status="metrics_not_computed",
+            candidate_path=candidate_path,
+            reference_resolution=reference_resolution,
+            metrics=metrics,
+            reason=reason,
+            extra={"mask_evidence": mask_evidence},
         )
     return _candidate_report_base(
         candidate_name=candidate_name,
@@ -853,6 +961,7 @@ def _candidate_metrics_report(
         reference_resolution=reference_resolution,
         metrics=metrics,
         metrics_authoritative=True,
+        extra={"mask_evidence": mask_evidence},
     )
 
 
@@ -861,6 +970,7 @@ def build_apex_eval_report(
     *,
     output_dir: Path | str,
     candidate_outputs: Mapping[str, Mapping[str, Path | str]] | None = None,
+    candidate_masks: Mapping[str, Mapping[str, Path | str]] | None = None,
     repo_root: Path | None = None,
     asset_root: Path | str | None = None,
 ) -> dict[str, Any]:
@@ -877,6 +987,7 @@ def build_apex_eval_report(
     output_root.mkdir(parents=True, exist_ok=True)
 
     candidate_outputs = candidate_outputs or {}
+    candidate_masks = candidate_masks or {}
     assets_report = []
     for asset in evalset.assets:
         status = asset_status(evalset, asset)
@@ -908,7 +1019,10 @@ def build_apex_eval_report(
             "reference_resolution": status["reference_resolution"],
         }
         candidates = []
-        for candidate_name, outputs in sorted(candidate_outputs.items()):
+        candidate_names = sorted(set(candidate_outputs) | set(candidate_masks))
+        for candidate_name in candidate_names:
+            outputs = candidate_outputs.get(candidate_name, {})
+            masks = candidate_masks.get(candidate_name, {})
             candidates.append(
                 _candidate_metrics_report(
                     evalset=evalset,
@@ -916,6 +1030,7 @@ def build_apex_eval_report(
                     asset_report_status=status,
                     candidate_name=candidate_name,
                     output_value=outputs.get(asset.asset_id),
+                    mask_value=masks.get(asset.asset_id),
                 )
             )
 
@@ -1192,15 +1307,25 @@ def build_depth_backend_benchmark_report(
     return report
 
 
-def parse_candidate_outputs(values: Iterable[str]) -> dict[str, dict[str, Path]]:
-    """Parse ``candidate:asset_id=path`` CLI values."""
+def _parse_candidate_path_map(values: Iterable[str], *, label: str) -> dict[str, dict[str, Path]]:
+    """Parse ``candidate:asset_id=path`` CLI path mappings."""
     parsed: dict[str, dict[str, Path]] = {}
     for value in values:
         candidate_part, sep, output_path = value.partition("=")
         if sep != "=":
-            raise ValueError(f"Invalid candidate output {value!r}; expected candidate:asset_id=path")
+            raise ValueError(f"Invalid {label} {value!r}; expected candidate:asset_id=path")
         candidate, sep, asset_id = candidate_part.partition(":")
         if sep != ":" or not candidate or not asset_id:
-            raise ValueError(f"Invalid candidate output {value!r}; expected candidate:asset_id=path")
+            raise ValueError(f"Invalid {label} {value!r}; expected candidate:asset_id=path")
         parsed.setdefault(candidate, {})[asset_id] = Path(output_path)
     return parsed
+
+
+def parse_candidate_outputs(values: Iterable[str]) -> dict[str, dict[str, Path]]:
+    """Parse ``candidate:asset_id=path`` candidate output CLI values."""
+    return _parse_candidate_path_map(values, label="candidate output")
+
+
+def parse_candidate_masks(values: Iterable[str]) -> dict[str, dict[str, Path]]:
+    """Parse ``candidate:asset_id=path`` candidate mask CLI values."""
+    return _parse_candidate_path_map(values, label="candidate mask")

--- a/src/transformation_portal/evals/apex_visual.py
+++ b/src/transformation_portal/evals/apex_visual.py
@@ -737,6 +737,14 @@ def _mask_evidence_not_supplied() -> dict[str, Any]:
     return {"status": "not_supplied"}
 
 
+def _mask_evidence_not_evaluated(mask_value: Path | str, *, reason: str) -> dict[str, Any]:
+    return {
+        "status": "not_evaluated",
+        "reason": reason,
+        "reported_path": str(mask_value),
+    }
+
+
 def _invalid_mask_evidence(reason: str, reported_path: str) -> dict[str, Any]:
     return {
         "status": "invalid",
@@ -796,7 +804,7 @@ def _load_candidate_mask_union(
         "reported_path": reported_path,
         "format": "npz",
         "mask_count": valid_mask_count,
-        "union_shape": [int(expected_shape[0]), int(expected_shape[1])],
+        "union_shape": [int(expected_shape[1]), int(expected_shape[0])],
         "union_nonzero_pixels": union_nonzero_pixels,
         "source": "candidate_mask",
     }
@@ -839,6 +847,11 @@ def _candidate_metrics_report(
         candidate_path = evalset.repo_root / candidate_path
     mask_evidence = _mask_evidence_not_supplied() if mask_value is None else None
 
+    def mask_evidence_for_skip(reason: str) -> dict[str, Any]:
+        if mask_value is None:
+            return _mask_evidence_not_supplied()
+        return _mask_evidence_not_evaluated(mask_value, reason=reason)
+
     if candidate_path is None or not candidate_path.is_file():
         return _candidate_report_base(
             candidate_name=candidate_name,
@@ -846,17 +859,18 @@ def _candidate_metrics_report(
             candidate_path=candidate_path,
             reference_resolution=reference_resolution,
             reason="candidate_output_missing",
-            extra={"mask_evidence": mask_evidence or _mask_evidence_not_supplied()},
+            extra={"mask_evidence": mask_evidence_for_skip("candidate_output_missing")},
         )
 
     if asset_report_status.get("status") != "ready":
+        asset_status_reason = f"asset_status_{asset_report_status.get('status')}"
         return _candidate_report_base(
             candidate_name=candidate_name,
             status="metrics_not_computed",
             candidate_path=candidate_path,
             reference_resolution=reference_resolution,
-            reason=f"asset_status_{asset_report_status.get('status')}",
-            extra={"mask_evidence": mask_evidence or _mask_evidence_not_supplied()},
+            reason=asset_status_reason,
+            extra={"mask_evidence": mask_evidence_for_skip(asset_status_reason)},
         )
 
     reference_path = reference_resolution.resolved_path
@@ -867,7 +881,11 @@ def _candidate_metrics_report(
             candidate_path=candidate_path,
             reference_resolution=reference_resolution,
             reason="reference_path_missing_or_unresolved",
-            extra={"mask_evidence": mask_evidence or _mask_evidence_not_supplied()},
+            extra={
+                "mask_evidence": mask_evidence_for_skip(
+                    "reference_path_missing_or_unresolved",
+                ),
+            },
         )
 
     canonical_comparison = (
@@ -887,7 +905,11 @@ def _candidate_metrics_report(
             candidate_path=candidate_path,
             reference_resolution=reference_resolution,
             reason=reference_reason,
-            extra={"mask_evidence": mask_evidence or _mask_evidence_not_supplied()},
+            extra={
+                "mask_evidence": mask_evidence_for_skip(
+                    str(reference_reason or reference_status),
+                ),
+            },
         )
 
     candidate, candidate_status, candidate_reason = _read_image_array(
@@ -902,7 +924,11 @@ def _candidate_metrics_report(
             candidate_path=candidate_path,
             reference_resolution=reference_resolution,
             reason=candidate_reason,
-            extra={"mask_evidence": mask_evidence or _mask_evidence_not_supplied()},
+            extra={
+                "mask_evidence": mask_evidence_for_skip(
+                    str(candidate_reason or candidate_status),
+                ),
+            },
         )
 
     assert reference is not None
@@ -977,8 +1003,11 @@ def build_apex_eval_report(
     """Build and persist an APEX eval report.
 
     ``candidate_outputs`` maps candidate name to ``asset_id -> output path``.
-    When no candidate output is provided, the report still validates corpus
-    readiness and leaves candidate metrics unset.
+    ``candidate_masks`` maps candidate name to ``asset_id -> Materials V3 mask
+    NPZ path``. Candidate entries are emitted for the union of candidate names
+    present in either map, so mask-only candidate names still produce explicit
+    missing-output reports. When no candidate output is provided, the report
+    still validates corpus readiness and leaves candidate metrics unset.
     """
     evalset = load_apex_evalset(evalset_path, repo_root=repo_root, asset_root=asset_root)
     output_root = Path(output_dir)

--- a/tests/evals/test_apex_candidate_evidence.py
+++ b/tests/evals/test_apex_candidate_evidence.py
@@ -147,6 +147,15 @@ def _multi_apex_report(tmp_path: Path, *, candidate_asset_ids: set[str]):
 
 def test_candidate_output_and_materials_telemetry_attach_to_bundle(tmp_path):
     report = _apex_report(tmp_path)
+    report["assets"][0]["candidates"][0]["mask_evidence"] = {
+        "status": "ok",
+        "reported_path": "external/materials_v3_masks.npz",
+        "format": "npz",
+        "mask_count": 1,
+        "union_shape": [8, 8],
+        "union_nonzero_pixels": 16,
+        "source": "candidate_mask",
+    }
     evidence = _materials_evidence(tmp_path / "materials.json")
 
     bundle = build_apex_evidence_bundle(
@@ -163,7 +172,55 @@ def test_candidate_output_and_materials_telemetry_attach_to_bundle(tmp_path):
     assert case["materials_v3"]["status"] == "ok"
     assert case["materials_v3"]["applied_ops_count"] == 4
     assert case["materials_v3"]["confidence_authority"]["raw_clip_similarity_authorized_pixel_ops"] is False
+    assert case["mask_evidence"] == {
+        "status": "ok",
+        "reported_path": "external/materials_v3_masks.npz",
+        "format": "npz",
+        "mask_count": 1,
+        "union_shape": [8, 8],
+        "union_nonzero_pixels": 16,
+        "source": "candidate_mask",
+    }
     assert (tmp_path / "bundle" / "evidence_bundle.json").is_file()
+
+
+def test_invalid_explicit_mask_evidence_blocks_promotion_via_invalid_metrics(tmp_path):
+    report = _apex_report(tmp_path)
+    candidate = report["assets"][0]["candidates"][0]
+    candidate["status"] = "metrics_not_computed"
+    candidate["metrics_authoritative"] = False
+    candidate["mask_evidence"] = {
+        "status": "invalid",
+        "reason": "candidate_mask_dimension_mismatch",
+        "reported_path": "external/materials_v3_masks.npz",
+    }
+    candidate["metrics"]["outside_mask_delta"] = {
+        "status": "invalid_input",
+        "reason": "candidate_mask_dimension_mismatch",
+        "value": None,
+        "comparison": {},
+    }
+    candidate["metrics"]["seam_halo_score"] = {
+        "status": "invalid_input",
+        "reason": "candidate_mask_dimension_mismatch",
+        "value": None,
+        "comparison": {},
+    }
+    evidence = _materials_evidence(tmp_path / "materials.json")
+
+    bundle = build_apex_evidence_bundle(
+        report,
+        output_dir=tmp_path / "bundle",
+        candidate_evidence={"materials_v3": {"unit_image": evidence}},
+        repo_root=tmp_path,
+    )
+
+    case = bundle["cases"][0]
+    assert bundle["promotion_verdict"] == "blocked"
+    assert "invalid_metrics" in bundle["promotion_blocked_reasons"]
+    assert case["metrics_status"] == "invalid"
+    assert case["mask_evidence"]["status"] == "invalid"
+    assert case["metrics"]["outside_mask_delta"]["status"] != "mask_missing"
 
 
 def test_legacy_visible_delta_metrics_do_not_authorize_promotion(tmp_path):

--- a/tests/evals/test_apex_visual.py
+++ b/tests/evals/test_apex_visual.py
@@ -17,6 +17,7 @@ from transformation_portal.evals.apex_visual import (
     build_apex_eval_report,
     build_depth_backend_benchmark_report,
     load_apex_evalset,
+    parse_candidate_masks,
     sha256_file,
     visible_delta_metrics,
 )
@@ -212,6 +213,156 @@ def test_candidate_metrics_compare_against_reference_path_not_asset_ref(tmp_path
     assert candidate["evaluation_target_path"] == str(reference_path.relative_to(tmp_path))
     assert candidate["reference_resolution"]["reported_path"] == str(reference_path.relative_to(tmp_path))
     assert candidate["metrics"]["visible_delta"]["value"] == pytest.approx(0.0)
+
+
+def test_parse_candidate_masks_uses_candidate_asset_mapping():
+    parsed = parse_candidate_masks(["materials_v3:asset_1=output/masks.npz"])
+
+    assert parsed == {"materials_v3": {"asset_1": Path("output/masks.npz")}}
+
+
+def test_candidate_mask_npz_enables_mask_aware_metrics(tmp_path):
+    reference_path = tmp_path / "reference16.tif"
+    candidate_path = tmp_path / "candidate16.tif"
+    mask_path = tmp_path / "materials_v3_masks.npz"
+    reference = np.zeros((8, 8), dtype=np.uint16)
+    candidate = reference.copy()
+    candidate[1:7, 1:7] = 50000
+    mask = np.zeros((8, 8), dtype=np.float32)
+    mask[2:6, 2:6] = 1.0
+    Image.fromarray(reference, mode="I;16").save(reference_path)
+    Image.fromarray(candidate, mode="I;16").save(candidate_path)
+    np.savez(mask_path, z_mask=mask, a_mask=np.zeros((8, 8), dtype=np.float32))
+    evalset_path = _write_evalset(
+        tmp_path,
+        reference_path,
+        dataset_tier="canonical_apex",
+        asset_overrides={
+            "asset_role": "canonical_apex_reference",
+            "canonical_bit_depth": 16,
+            "canonical_format": "tiff",
+            "canonical_scoring_eligible": True,
+            "evaluate_at_native_resolution": True,
+            "preserve_16bit_intermediates": True,
+        },
+    )
+
+    report = build_apex_eval_report(
+        evalset_path,
+        output_dir=tmp_path / "report",
+        candidate_outputs={"materials_v3": {"unit_image": candidate_path}},
+        candidate_masks={"materials_v3": {"unit_image": mask_path}},
+        repo_root=tmp_path,
+    )
+
+    candidate_report = report["assets"][0]["candidates"][0]
+    assert candidate_report["status"] == "ok"
+    assert candidate_report["metrics_authoritative"] is True
+    assert candidate_report["metrics"]["outside_mask_delta"]["status"] == "ok"
+    assert candidate_report["metrics"]["outside_mask_delta"]["value"] > 0.0
+    assert candidate_report["metrics"]["seam_halo_score"]["status"] == "ok"
+    assert candidate_report["metrics"]["seam_halo_score"]["value"] > 0.0
+    assert candidate_report["mask_evidence"] == {
+        "status": "ok",
+        "reported_path": str(mask_path),
+        "format": "npz",
+        "mask_count": 2,
+        "union_shape": [8, 8],
+        "union_nonzero_pixels": 16,
+        "source": "candidate_mask",
+    }
+
+
+def test_absent_candidate_mask_preserves_mask_missing_metric_status(tmp_path):
+    reference_path = tmp_path / "reference16.tif"
+    candidate_path = tmp_path / "candidate16.tif"
+    Image.fromarray(np.zeros((8, 8), dtype=np.uint16), mode="I;16").save(reference_path)
+    Image.fromarray(np.zeros((8, 8), dtype=np.uint16), mode="I;16").save(candidate_path)
+    evalset_path = _write_evalset(
+        tmp_path,
+        reference_path,
+        dataset_tier="canonical_apex",
+        asset_overrides={
+            "asset_role": "canonical_apex_reference",
+            "canonical_bit_depth": 16,
+            "canonical_format": "tiff",
+            "canonical_scoring_eligible": True,
+            "evaluate_at_native_resolution": True,
+            "preserve_16bit_intermediates": True,
+        },
+    )
+
+    report = build_apex_eval_report(
+        evalset_path,
+        output_dir=tmp_path / "report",
+        candidate_outputs={"materials_v3": {"unit_image": candidate_path}},
+        repo_root=tmp_path,
+    )
+
+    candidate_report = report["assets"][0]["candidates"][0]
+    assert candidate_report["mask_evidence"] == {"status": "not_supplied"}
+    assert candidate_report["metrics"]["outside_mask_delta"]["status"] == "mask_missing"
+    assert candidate_report["metrics"]["seam_halo_score"]["status"] == "not_applicable"
+    assert candidate_report["metrics"]["seam_halo_score"]["reason"] == "mask_missing"
+
+
+@pytest.mark.parametrize(
+    ("mask_builder", "expected_reason"),
+    [
+        (lambda path: None, "candidate_mask_missing"),
+        (lambda path: path.write_text("not an npz", encoding="utf-8"), "candidate_mask_invalid_npz"),
+        (lambda path: np.savez(path), "candidate_mask_empty"),
+        (lambda path: np.savez(path, glass=np.zeros((8, 8), dtype=np.float32)), "candidate_mask_empty"),
+        (lambda path: np.savez(path, overlay=np.ones((8, 8, 3), dtype=np.float32)), "candidate_mask_no_2d_arrays"),
+        (lambda path: np.savez(path, glass=np.ones((4, 4), dtype=np.float32)), "candidate_mask_dimension_mismatch"),
+    ],
+)
+def test_invalid_explicit_candidate_mask_blocks_without_mask_missing_fallback(
+    tmp_path,
+    mask_builder,
+    expected_reason,
+):
+    reference_path = tmp_path / "reference16.tif"
+    candidate_path = tmp_path / "candidate16.tif"
+    mask_path = tmp_path / "materials_v3_masks.npz"
+    Image.fromarray(np.zeros((8, 8), dtype=np.uint16), mode="I;16").save(reference_path)
+    Image.fromarray(np.zeros((8, 8), dtype=np.uint16), mode="I;16").save(candidate_path)
+    mask_builder(mask_path)
+    evalset_path = _write_evalset(
+        tmp_path,
+        reference_path,
+        dataset_tier="canonical_apex",
+        asset_overrides={
+            "asset_role": "canonical_apex_reference",
+            "canonical_bit_depth": 16,
+            "canonical_format": "tiff",
+            "canonical_scoring_eligible": True,
+            "evaluate_at_native_resolution": True,
+            "preserve_16bit_intermediates": True,
+        },
+    )
+
+    report = build_apex_eval_report(
+        evalset_path,
+        output_dir=tmp_path / "report",
+        candidate_outputs={"materials_v3": {"unit_image": candidate_path}},
+        candidate_masks={"materials_v3": {"unit_image": mask_path}},
+        repo_root=tmp_path,
+    )
+
+    candidate_report = report["assets"][0]["candidates"][0]
+    assert candidate_report["status"] == "metrics_not_computed"
+    assert candidate_report["metrics_authoritative"] is False
+    assert candidate_report["mask_evidence"] == {
+        "status": "invalid",
+        "reason": expected_reason,
+        "reported_path": str(mask_path),
+    }
+    assert candidate_report["metrics"]["outside_mask_delta"]["status"] == "invalid_input"
+    assert candidate_report["metrics"]["outside_mask_delta"]["reason"] == expected_reason
+    assert candidate_report["metrics"]["outside_mask_delta"]["status"] != "mask_missing"
+    assert candidate_report["metrics"]["seam_halo_score"]["status"] == "invalid_input"
+    assert candidate_report["metrics"]["seam_halo_score"]["reason"] == expected_reason
 
 
 def test_candidate_dimension_mismatch_fails_closed_without_resizing(tmp_path):
@@ -780,6 +931,33 @@ def test_run_apex_eval_uses_report_output_dir_for_evidence_bundle(tmp_path, monk
     assert module.main() == 0
     assert calls["output_dir"] == resolved_report.parent
     assert calls["repo_root"] == repo_root
+
+
+def test_run_apex_eval_passes_candidate_masks_to_report_builder(tmp_path, monkeypatch):
+    module = _load_tool_module("run_apex_eval.py", "run_apex_eval_candidate_masks_unit")
+    calls = {}
+
+    def fake_build_report(*args, **kwargs):
+        calls.update(kwargs)
+        return {"report_path": str(tmp_path / "apex_eval_report.json"), "assets": []}
+
+    monkeypatch.setattr(module, "build_apex_eval_report", fake_build_report)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_apex_eval.py",
+            "--evalset",
+            "evalsets/picacho_apex",
+            "--output-dir",
+            str(tmp_path / "report"),
+            "--candidate-mask",
+            "materials_v3:unit_image=output/materials_v3_masks.npz",
+        ],
+    )
+
+    assert module.main() == 0
+    assert calls["candidate_masks"] == {"materials_v3": {"unit_image": Path("output/materials_v3_masks.npz")}}
 
 
 def test_benchmark_depth_backends_returns_stable_input_error_for_missing_evalset(tmp_path, monkeypatch, capsys):

--- a/tests/evals/test_apex_visual.py
+++ b/tests/evals/test_apex_visual.py
@@ -225,14 +225,14 @@ def test_candidate_mask_npz_enables_mask_aware_metrics(tmp_path):
     reference_path = tmp_path / "reference16.tif"
     candidate_path = tmp_path / "candidate16.tif"
     mask_path = tmp_path / "materials_v3_masks.npz"
-    reference = np.zeros((8, 8), dtype=np.uint16)
+    reference = np.zeros((6, 8), dtype=np.uint16)
     candidate = reference.copy()
-    candidate[1:7, 1:7] = 50000
-    mask = np.zeros((8, 8), dtype=np.float32)
-    mask[2:6, 2:6] = 1.0
+    candidate[1:5, 1:7] = 50000
+    mask = np.zeros((6, 8), dtype=np.float32)
+    mask[2:4, 2:6] = 1.0
     Image.fromarray(reference, mode="I;16").save(reference_path)
     Image.fromarray(candidate, mode="I;16").save(candidate_path)
-    np.savez(mask_path, z_mask=mask, a_mask=np.zeros((8, 8), dtype=np.float32))
+    np.savez(mask_path, z_mask=mask, a_mask=np.zeros((6, 8), dtype=np.float32))
     evalset_path = _write_evalset(
         tmp_path,
         reference_path,
@@ -267,8 +267,8 @@ def test_candidate_mask_npz_enables_mask_aware_metrics(tmp_path):
         "reported_path": str(mask_path),
         "format": "npz",
         "mask_count": 2,
-        "union_shape": [8, 8],
-        "union_nonzero_pixels": 16,
+        "union_shape": [8, 6],
+        "union_nonzero_pixels": 8,
         "source": "candidate_mask",
     }
 
@@ -304,6 +304,43 @@ def test_absent_candidate_mask_preserves_mask_missing_metric_status(tmp_path):
     assert candidate_report["metrics"]["outside_mask_delta"]["status"] == "mask_missing"
     assert candidate_report["metrics"]["seam_halo_score"]["status"] == "not_applicable"
     assert candidate_report["metrics"]["seam_halo_score"]["reason"] == "mask_missing"
+
+
+def test_candidate_mask_supplied_but_output_missing_is_not_evaluated(tmp_path):
+    reference_path = tmp_path / "reference16.tif"
+    missing_candidate_path = tmp_path / "missing_candidate.tif"
+    mask_path = tmp_path / "materials_v3_masks.npz"
+    Image.fromarray(np.zeros((8, 8), dtype=np.uint16), mode="I;16").save(reference_path)
+    np.savez(mask_path, glass=np.ones((8, 8), dtype=np.float32))
+    evalset_path = _write_evalset(
+        tmp_path,
+        reference_path,
+        dataset_tier="canonical_apex",
+        asset_overrides={
+            "asset_role": "canonical_apex_reference",
+            "canonical_bit_depth": 16,
+            "canonical_format": "tiff",
+            "canonical_scoring_eligible": True,
+            "evaluate_at_native_resolution": True,
+            "preserve_16bit_intermediates": True,
+        },
+    )
+
+    report = build_apex_eval_report(
+        evalset_path,
+        output_dir=tmp_path / "report",
+        candidate_outputs={"materials_v3": {"unit_image": missing_candidate_path}},
+        candidate_masks={"materials_v3": {"unit_image": mask_path}},
+        repo_root=tmp_path,
+    )
+
+    candidate_report = report["assets"][0]["candidates"][0]
+    assert candidate_report["status"] == "missing_candidate"
+    assert candidate_report["mask_evidence"] == {
+        "status": "not_evaluated",
+        "reason": "candidate_output_missing",
+        "reported_path": str(mask_path),
+    }
 
 
 @pytest.mark.parametrize(

--- a/tests/evals/test_apex_visual.py
+++ b/tests/evals/test_apex_visual.py
@@ -343,11 +343,17 @@ def test_candidate_mask_supplied_but_output_missing_is_not_evaluated(tmp_path):
     }
 
 
+def _write_npy_mask_payload(path: Path) -> None:
+    with path.open("wb") as handle:
+        np.save(handle, np.ones((8, 8), dtype=np.float32))
+
+
 @pytest.mark.parametrize(
     ("mask_builder", "expected_reason"),
     [
         (lambda path: None, "candidate_mask_missing"),
         (lambda path: path.write_text("not an npz", encoding="utf-8"), "candidate_mask_invalid_npz"),
+        (_write_npy_mask_payload, "candidate_mask_invalid_npz"),
         (lambda path: np.savez(path), "candidate_mask_empty"),
         (lambda path: np.savez(path, glass=np.zeros((8, 8), dtype=np.float32)), "candidate_mask_empty"),
         (lambda path: np.savez(path, overlay=np.ones((8, 8, 3), dtype=np.float32)), "candidate_mask_no_2d_arrays"),

--- a/tools/run_apex_eval.py
+++ b/tools/run_apex_eval.py
@@ -7,7 +7,11 @@ import argparse
 import sys
 from pathlib import Path
 
-from transformation_portal.evals.apex_visual import build_apex_eval_report, parse_candidate_outputs
+from transformation_portal.evals.apex_visual import (
+    build_apex_eval_report,
+    parse_candidate_masks,
+    parse_candidate_outputs,
+)
 from transformation_portal.evals.apex_evidence_bundle import build_apex_evidence_bundle, parse_candidate_evidence
 
 
@@ -22,6 +26,13 @@ def build_parser() -> argparse.ArgumentParser:
         default=[],
         metavar="CANDIDATE:ASSET_ID=PATH",
         help="Optional candidate output image for APEX metric evaluation. May be repeated.",
+    )
+    parser.add_argument(
+        "--candidate-mask",
+        action="append",
+        default=[],
+        metavar="CANDIDATE:ASSET_ID=PATH",
+        help="Optional candidate Materials V3 mask NPZ for mask-aware APEX metrics. May be repeated.",
     )
     parser.add_argument(
         "--emit-report",
@@ -63,11 +74,13 @@ def main() -> int:
 
     try:
         candidate_outputs = parse_candidate_outputs(args.candidate_output)
+        candidate_masks = parse_candidate_masks(args.candidate_mask)
         candidate_evidence = parse_candidate_evidence(args.candidate_evidence)
         report = build_apex_eval_report(
             Path(args.evalset),
             output_dir=Path(args.output_dir),
             candidate_outputs=candidate_outputs,
+            candidate_masks=candidate_masks,
             asset_root=args.asset_root,
         )
         if args.emit_evidence_bundle == "on" or candidate_evidence:


### PR DESCRIPTION
## Summary
- Wires explicit Materials V3 mask NPZ evidence into the existing APEX metric path.
- Preserves current no-mask promotion behavior while making invalid explicitly supplied masks fail closed through existing invalid_metrics.

## Changes
- Adds --candidate-mask CANDIDATE:ASSET_ID=PATH to tools/run_apex_eval.py.
- Adds candidate mask parsing and strict NPZ loading with sorted 2D-mask union in the APEX eval report builder.
- Passes valid mask unions into compute_apex_metrics so outside_mask_delta and seam_halo_score become mask-aware.
- Emits additive mask_evidence in APEX reports and evidence bundle cases using reported_path only.
- Adds tests for parser mapping, valid masks, absent masks, invalid masks, bundle propagation, and invalid masks not falling back to mask_missing.

## Validation
Proven green:
- /Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin/pytest -q tests/evals/test_apex_metrics.py tests/evals/test_apex_visual.py tests/evals/test_apex_candidate_evidence.py tests/evals/test_apex_docs_commands.py

Still failing:
- None observed.

Failure classification:
- Not applicable.

## Risk
- Additive CLI/report behavior. Existing runs without --candidate-mask retain mask_missing/not_applicable metrics and no new promotion blocker.
- Explicit invalid masks block through existing invalid_metrics, which is fail-closed and revert-safe.
- No schema version bump, route, selector, auth, or managed frontdoor changes.
