### PR TITLE
feat(apex): add offline model-family characterization matrix

### DIFF
--- a/config/apex_family_matrix.json
+++ b/config/apex_family_matrix.json
@@ -1,0 +1,41 @@
+{
+  "schema_version": "apex_family_matrix.v1",
+  "default_governance": {
+    "non_commercial_ok": false,
+    "accept_depth_pro_license": false
+  },
+  "families": [
+    {
+      "depth_backend": "da3",
+      "segmentation_backend": "efficientsam",
+      "materials_version": 3,
+      "quality_tier": "apex",
+      "pbr_enabled": false,
+      "v2_enabled": false
+    },
+    {
+      "depth_backend": "da3",
+      "segmentation_backend": "sam2",
+      "materials_version": 3,
+      "quality_tier": "apex",
+      "pbr_enabled": false,
+      "v2_enabled": false
+    },
+    {
+      "depth_backend": "depth_pro",
+      "segmentation_backend": "efficientsam",
+      "materials_version": 3,
+      "quality_tier": "apex",
+      "pbr_enabled": false,
+      "v2_enabled": false
+    },
+    {
+      "depth_backend": "depth_pro",
+      "segmentation_backend": "sam2",
+      "materials_version": 3,
+      "quality_tier": "apex",
+      "pbr_enabled": false,
+      "v2_enabled": false
+    }
+  ]
+}

--- a/docs/validation/APEX_MODEL_FAMILY_CHARACTERIZATION_PROTOCOL.md
+++ b/docs/validation/APEX_MODEL_FAMILY_CHARACTERIZATION_PROTOCOL.md
@@ -1,0 +1,143 @@
+# APEX Model-Family Characterization Protocol
+
+This protocol defines the offline model-family characterization matrix for APEX
+quality work. The report compares explicit depth and segmentation families
+without running models, reading raw artifacts, or changing existing evidence
+schemas.
+
+The characterization report is not a promotion verdict. It sits above local
+evidence such as `apex_evidence_bundle.v1` and records which families are
+declared, governed, observed, and comparable.
+
+## Scope
+
+`tools/characterize_apex_model_families.py` emits
+`apex_model_family_characterization_report.v1`.
+
+The tool does not:
+
+- run model inference
+- call `tools/run_apex_eval.py`
+- read run cards, batch files, combined manifests, provenance files, TIFFs,
+  NPZ masks, NPY arrays, or PNG debug artifacts
+- tune Materials V3 thresholds or depth gates
+- mutate `apex_evidence_bundle.v1` or `apex_eval_report.v1`
+
+Observed local evidence must be reduced to an `apex_redacted_summary.v1` file
+before it is attached to a family row.
+
+## Family Names
+
+Canonical family names always include tier:
+
+```text
+materials_v{N}_{depth}_{seg}_{quality_tier}[_pbr][_v2]
+```
+
+Examples:
+
+```text
+materials_v3_da3_efficientsam_apex
+materials_v3_depthpro_sam2_premium_pbr
+```
+
+`materials_version` defaults to `3`. If `candidate_family` is omitted from a
+family spec, the tool derives it. If it is supplied and does not match the
+canonical name, the row is marked `spec_validation.status: name_mismatch`.
+
+## Command
+
+Use the checked-in default matrix:
+
+```bash
+.venv/bin/python tools/characterize_apex_model_families.py \
+  --family-file config/apex_family_matrix.json \
+  --non-commercial-ok off \
+  --accept-depth-pro-license off \
+  --output output/apex_model_family_characterization_report.json \
+  --now 2026-04-25T00:00:00Z
+```
+
+Use a matrix expression for local exploration:
+
+```bash
+.venv/bin/python tools/characterize_apex_model_families.py \
+  --matrix "depth_backend=da3,depth_pro;segmentation_backend=sam2,efficientsam;quality_tier=apex;pbr_enabled=false;v2_enabled=false" \
+  --output output/apex_model_family_characterization_report.json \
+  --now 2026-04-25T00:00:00Z
+```
+
+Attach mocked observations only by explicit family binding:
+
+```bash
+.venv/bin/python tools/characterize_apex_model_families.py \
+  --family "depth_backend=da3,segmentation_backend=efficientsam,quality_tier=apex,pbr_enabled=false,v2_enabled=false" \
+  --observation "candidate_family=materials_v3_da3_efficientsam_apex,source=mock_v1,status=mocked,fallback_used=false,runtime_ms=1234,promotion_verdict=eligible,metric_contract=apex_metrics.v1,mask_evidence_status=ok" \
+  --output output/apex_model_family_characterization_report.json \
+  --now 2026-04-25T00:00:00Z
+```
+
+## Governance
+
+DA3 rows are `commercial_ready`.
+
+Depth Pro rows are `license_blocked` unless both acknowledgements are supplied:
+
+```text
+--non-commercial-ok on
+--accept-depth-pro-license on
+```
+
+With both acknowledgements, Depth Pro rows are `research_only`, not
+commercial-ready.
+
+## Redacted Summaries
+
+`observed_local` rows must use `apex_redacted_summary.v1`. Required fields are:
+
+```text
+schema_version
+source_evidence_sha256
+candidate_family
+```
+
+Only aggregate fields are allowed. Path-like values and metadata-bearing keys
+are rejected, including EXIF/IPTC/XMP/GPS, camera/lens/serial/creator/copyright,
+run cards, batch files, combined/provenance JSON, TIFF, NPZ, NPY, and PNG
+references.
+
+The controlled local `materials_v3` evidence maps externally to:
+
+```text
+materials_v3_da3_efficientsam_apex
+```
+
+The exploratory Depth Pro/SAM2/PBR premium evidence maps separately to:
+
+```text
+materials_v3_depthpro_sam2_premium_pbr
+```
+
+Do not rewrite existing evidence bundle candidate IDs to encode this mapping.
+
+## Artifact Guardrail
+
+Do not commit real local evidence or provenance artifacts:
+
+```text
+output/apex_eval_real*
+output/lux_depth_v3_apex/
+run_card_*.json
+batch_*.json
+*_combined.json
+*_combined_provenance.json
+*.npz
+*.npy
+*.tif
+*.tiff
+*.png
+```
+
+Real provenance and debug artifacts can include creator/copyright fields, camera
+serials, GPS/drone metadata, local paths, EXIF/IPTC/XMP history, and source file
+names. Keep them local unless explicitly redacted under fixture policy.

--- a/src/transformation_portal/evals/__init__.py
+++ b/src/transformation_portal/evals/__init__.py
@@ -28,6 +28,12 @@ from transformation_portal.evals.apex_llava_integration import (
     create_production_harness,
     create_quality_max_harness,
 )
+from transformation_portal.evals.apex_model_family import (
+    build_apex_model_family_characterization_report,
+    collect_family_specs,
+    parse_family_spec,
+    parse_matrix_spec,
+)
 from transformation_portal.evals.apex_visual import (
     ApexEvalAsset,
     ApexEvalSet,
@@ -76,8 +82,12 @@ __all__ = [
     "ApexEvalSet",
     "DepthBackendRunResult",
     "build_apex_eval_report",
+    "build_apex_model_family_characterization_report",
     "build_depth_backend_benchmark_report",
+    "collect_family_specs",
     "load_apex_evalset",
+    "parse_family_spec",
+    "parse_matrix_spec",
     # Benchmark suite
     "BenchmarkResult",
     "BenchmarkSuite",

--- a/src/transformation_portal/evals/apex_model_family.py
+++ b/src/transformation_portal/evals/apex_model_family.py
@@ -1,0 +1,717 @@
+"""Offline APEX model-family characterization report builder."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from itertools import product
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+from transformation_portal.evals.apex_model_family_schema import (
+    ALLOWED_DEPTH_BACKENDS,
+    ALLOWED_OBSERVATION_STATUSES,
+    ALLOWED_QUALITY_TIERS,
+    ALLOWED_SEGMENTATION_BACKENDS,
+    BLOCKER_LICENSE_BLOCKED,
+    BLOCKER_OBSERVATION_MISSING,
+    BLOCKER_SPEC_INVALID,
+    COMPARABLE_OBSERVATION_STATUSES,
+    FAMILY_FILE_GOVERNANCE_KEYS,
+    FAMILY_FILE_TOP_LEVEL_KEYS,
+    FAMILY_SPEC_KEYS,
+    FAMILY_SPEC_REQUIRED_KEYS,
+    GOVERNANCE_COMMERCIAL_READY,
+    GOVERNANCE_LICENSE_BLOCKED,
+    GOVERNANCE_RESEARCH_ONLY,
+    GOVERNANCE_UNKNOWN,
+    GROUP_BLOCKER_MEMBER_NOT_COMPARABLE,
+    GROUP_BLOCKER_ONLY_ONE_MEMBER,
+    INPUT_DIGEST_VERSION,
+    MATRIX_SCHEMA_VERSION,
+    OBSERVATION_EVIDENCE_MISSING,
+    OBSERVATION_KEYS,
+    OBSERVATION_MOCKED,
+    OBSERVATION_NOT_RUN,
+    OBSERVATION_OBSERVED_LOCAL,
+    RECONCILIATION_INVARIANTS,
+    REPORT_SCHEMA_VERSION,
+    SOURCE_MOCK_V1,
+    SOURCE_REDACTED_SUMMARY_V1,
+    SPEC_STATUS_INVALID,
+    SPEC_STATUS_NAME_MISMATCH,
+    SPEC_STATUS_OK,
+    SUMMARY_SCHEMA_VERSION,
+    TOOL_VERSION,
+    FamilySpec,
+    canonical_family_name,
+)
+from transformation_portal.evals.apex_redacted_summary_schema import (
+    reject_raw_summary_path,
+    validate_redacted_summary,
+)
+
+NOW_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+class ApexModelFamilyError(ValueError):
+    """Base error for model-family report construction."""
+
+
+class DuplicateFamilyError(ApexModelFamilyError):
+    """Raised when family labels are duplicated."""
+
+
+class ObservationBindingError(ApexModelFamilyError):
+    """Raised when observations cannot be bound to family rows."""
+
+
+class ObservationValidationError(ApexModelFamilyError):
+    """Raised when an observation or redacted summary is invalid."""
+
+
+class ReconciliationError(ApexModelFamilyError):
+    """Raised when report self-checks fail."""
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    """Serialize a value using deterministic canonical JSON bytes."""
+
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False).encode("utf-8")
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def validate_now(value: str) -> str:
+    if not NOW_RE.match(str(value or "")):
+        raise ValueError("--now must use UTC format YYYY-MM-DDTHH:MM:SSZ")
+    return str(value)
+
+
+def parse_bool(value: Any, *, field: str) -> bool:
+    normalized = str(value).strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    raise ValueError(f"{field} must be boolean-like, got {value!r}")
+
+
+def parse_int(value: Any, *, field: str) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field} must be an integer, got {value!r}") from exc
+    return parsed
+
+
+def parse_float(value: Any, *, field: str) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field} must be numeric, got {value!r}") from exc
+
+
+def _normalize_token(value: Any) -> str:
+    return str(value or "").strip().lower().replace("-", "_")
+
+
+def _parse_key_values(value: str, *, label: str, item_separator: str, allowed_keys: frozenset[str]) -> dict[str, str]:
+    parsed: dict[str, str] = {}
+    for raw_part in str(value or "").split(item_separator):
+        part = raw_part.strip()
+        if not part:
+            continue
+        key, separator, raw_value = part.partition("=")
+        if separator != "=":
+            raise ValueError(f"Invalid {label} spec {value!r}; expected key=value pairs")
+        normalized_key = key.strip()
+        if normalized_key not in allowed_keys:
+            raise ValueError(f"Unsupported {label} field {normalized_key!r}")
+        if normalized_key in parsed:
+            raise ValueError(f"Duplicate {label} field {normalized_key!r}")
+        parsed[normalized_key] = raw_value.strip()
+    return parsed
+
+
+def parse_family_spec(value: str | Mapping[str, Any]) -> dict[str, Any]:
+    """Parse a family spec into a normalized report dictionary."""
+
+    if isinstance(value, Mapping):
+        raw = {str(key): value[key] for key in value}
+        unknown = sorted(set(raw) - FAMILY_SPEC_KEYS)
+        if unknown:
+            raise ValueError(f"Unsupported family field(s): {', '.join(unknown)}")
+    else:
+        raw = _parse_key_values(str(value), label="family", item_separator=",", allowed_keys=FAMILY_SPEC_KEYS)
+
+    missing = sorted(FAMILY_SPEC_REQUIRED_KEYS - set(raw))
+    if missing:
+        raise ValueError(f"Family spec missing required field(s): {', '.join(missing)}")
+
+    spec = {
+        "depth_backend": _normalize_token(raw["depth_backend"]),
+        "segmentation_backend": _normalize_token(raw["segmentation_backend"]),
+        "materials_version": parse_int(raw.get("materials_version", 3), field="materials_version"),
+        "quality_tier": _normalize_token(raw["quality_tier"]),
+        "pbr_enabled": parse_bool(raw.get("pbr_enabled", False), field="pbr_enabled"),
+        "v2_enabled": parse_bool(raw.get("v2_enabled", False), field="v2_enabled"),
+    }
+    errors = _spec_errors(spec)
+    if not errors:
+        expected_name = canonical_family_name(FamilySpec(**spec))
+    else:
+        expected_name = ""
+    provided_name = _normalize_token(raw.get("candidate_family", ""))
+    spec["candidate_family"] = provided_name or expected_name
+    return spec
+
+
+def _spec_errors(spec: Mapping[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if spec.get("depth_backend") not in ALLOWED_DEPTH_BACKENDS:
+        errors.append("unsupported_depth_backend")
+    if spec.get("segmentation_backend") not in ALLOWED_SEGMENTATION_BACKENDS:
+        errors.append("unsupported_segmentation_backend")
+    if spec.get("quality_tier") not in ALLOWED_QUALITY_TIERS:
+        errors.append("unsupported_quality_tier")
+    if int(spec.get("materials_version", 0)) <= 0:
+        errors.append("invalid_materials_version")
+    return errors
+
+
+def spec_validation_for(spec: Mapping[str, Any]) -> dict[str, Any]:
+    errors = _spec_errors(spec)
+    expected_name = None
+    if not errors:
+        expected_name = canonical_family_name(spec)
+        if spec.get("candidate_family") != expected_name:
+            errors.append("candidate_family_name_mismatch")
+            return {
+                "status": SPEC_STATUS_NAME_MISMATCH,
+                "errors": errors,
+                "expected_candidate_family": expected_name,
+            }
+    return {
+        "status": SPEC_STATUS_OK if not errors else SPEC_STATUS_INVALID,
+        "errors": errors,
+        "expected_candidate_family": expected_name,
+    }
+
+
+def parse_matrix_spec(value: str) -> list[dict[str, Any]]:
+    raw = _parse_key_values(str(value), label="matrix", item_separator=";", allowed_keys=FAMILY_SPEC_KEYS)
+    if "candidate_family" in raw:
+        raise ValueError("Matrix specs must not include candidate_family; it is derived per row")
+    missing = sorted(FAMILY_SPEC_REQUIRED_KEYS - set(raw))
+    if missing:
+        raise ValueError(f"Matrix spec missing required field(s): {', '.join(missing)}")
+
+    dimensions = {
+        key: [item.strip() for item in str(raw.get(key, "")).split(",") if item.strip()]
+        for key in ("depth_backend", "segmentation_backend", "quality_tier", "materials_version", "pbr_enabled", "v2_enabled")
+    }
+    dimensions["materials_version"] = dimensions["materials_version"] or ["3"]
+    dimensions["pbr_enabled"] = dimensions["pbr_enabled"] or ["false"]
+    dimensions["v2_enabled"] = dimensions["v2_enabled"] or ["false"]
+
+    specs = []
+    for depth, seg, tier, version, pbr, v2 in product(
+        dimensions["depth_backend"],
+        dimensions["segmentation_backend"],
+        dimensions["quality_tier"],
+        dimensions["materials_version"],
+        dimensions["pbr_enabled"],
+        dimensions["v2_enabled"],
+    ):
+        specs.append(
+            parse_family_spec(
+                {
+                    "depth_backend": depth,
+                    "segmentation_backend": seg,
+                    "quality_tier": tier,
+                    "materials_version": version,
+                    "pbr_enabled": pbr,
+                    "v2_enabled": v2,
+                }
+            )
+        )
+    return specs
+
+
+def load_family_file(path: Path) -> tuple[list[dict[str, Any]], dict[str, bool]]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("Family file must be a JSON object")
+    unknown = sorted(set(payload) - FAMILY_FILE_TOP_LEVEL_KEYS)
+    if unknown:
+        raise ValueError(f"Family file contains unsupported top-level field(s): {', '.join(unknown)}")
+    if payload.get("schema_version") != MATRIX_SCHEMA_VERSION:
+        raise ValueError(f"Family file schema_version must be {MATRIX_SCHEMA_VERSION!r}")
+    default_governance = payload.get("default_governance", {})
+    if not isinstance(default_governance, dict):
+        raise ValueError("Family file default_governance must be an object")
+    unknown_governance = sorted(set(default_governance) - FAMILY_FILE_GOVERNANCE_KEYS)
+    if unknown_governance:
+        raise ValueError(f"Family file default_governance contains unsupported field(s): {', '.join(unknown_governance)}")
+    families = payload.get("families", [])
+    if not isinstance(families, list):
+        raise ValueError("Family file families must be a list")
+    specs = [parse_family_spec(item) for item in families]
+    governance = {
+        "non_commercial_ok": parse_bool(default_governance.get("non_commercial_ok", False), field="non_commercial_ok"),
+        "accept_depth_pro_license": parse_bool(
+            default_governance.get("accept_depth_pro_license", False),
+            field="accept_depth_pro_license",
+        ),
+    }
+    return specs, governance
+
+
+def parse_mock_observation(value: str | Mapping[str, Any]) -> dict[str, Any]:
+    if isinstance(value, Mapping):
+        raw = {str(key): value[key] for key in value}
+        unknown = sorted(set(raw) - OBSERVATION_KEYS)
+        if unknown:
+            raise ObservationValidationError(f"Unsupported observation field(s): {', '.join(unknown)}")
+    else:
+        raw = _parse_key_values(str(value), label="observation", item_separator=",", allowed_keys=OBSERVATION_KEYS)
+    if "candidate_family" not in raw:
+        raise ObservationValidationError("Observation spec missing candidate_family")
+    source = str(raw.get("source") or SOURCE_MOCK_V1)
+    if source != SOURCE_MOCK_V1:
+        raise ObservationValidationError("--observation only accepts source=mock_v1")
+    status = _normalize_token(raw.get("status", OBSERVATION_MOCKED))
+    if status != OBSERVATION_MOCKED:
+        raise ObservationValidationError("source=mock_v1 observations must use status=mocked")
+    observation = _default_observation()
+    observation.update(
+        {
+            "status": OBSERVATION_MOCKED,
+            "source": SOURCE_MOCK_V1,
+            "fallback_used": _optional_bool(raw.get("fallback_used"), field="fallback_used"),
+            "runtime_ms": _optional_float(raw.get("runtime_ms"), field="runtime_ms"),
+            "promotion_verdict": raw.get("promotion_verdict") or None,
+            "metric_contract": raw.get("metric_contract") or None,
+            "mask_evidence_status": raw.get("mask_evidence_status") or None,
+        }
+    )
+    return {"candidate_family": _normalize_token(raw["candidate_family"]), "observation": observation}
+
+
+def parse_redacted_summary_binding(value: str | Mapping[str, Any]) -> dict[str, Any]:
+    allowed_keys = frozenset({"candidate_family", "path"})
+    if isinstance(value, Mapping):
+        raw = {str(key): value[key] for key in value}
+        unknown = sorted(set(raw) - allowed_keys)
+        if unknown:
+            raise ObservationValidationError(f"Unsupported redacted-summary field(s): {', '.join(unknown)}")
+    else:
+        raw = _parse_key_values(str(value), label="redacted-summary", item_separator=",", allowed_keys=allowed_keys)
+    if "candidate_family" not in raw or "path" not in raw:
+        raise ObservationValidationError("Redacted summary binding requires candidate_family and path")
+    path = Path(str(raw["path"]))
+    reject_raw_summary_path(path)
+    payload = validate_redacted_summary(json.loads(path.read_text(encoding="utf-8")))
+    candidate_family = _normalize_token(raw["candidate_family"])
+    if payload["candidate_family"] != candidate_family:
+        raise ObservationValidationError("Redacted summary candidate_family does not match binding")
+    summary_sha256 = sha256_file(path)
+    observation = _default_observation()
+    observation.update(
+        {
+            "status": OBSERVATION_OBSERVED_LOCAL,
+            "source": SOURCE_REDACTED_SUMMARY_V1,
+            "fallback_used": payload.get("fallback_used"),
+            "runtime_ms": payload.get("runtime_ms"),
+            "promotion_verdict": payload.get("promotion_verdict"),
+            "metric_contract": payload.get("metric_contract"),
+            "mask_evidence_status": payload.get("mask_evidence_status"),
+            "evidence_ref": {
+                "summary_path": str(path),
+                "summary_sha256": summary_sha256,
+                "summary_schema_version": SUMMARY_SCHEMA_VERSION,
+                "originating_bundle_schema": "apex_evidence_bundle.v1",
+                "source_evidence_sha256": payload["source_evidence_sha256"],
+            },
+            "summary": {key: payload[key] for key in sorted(payload) if key not in {"schema_version", "candidate_family"}},
+        }
+    )
+    return {"candidate_family": candidate_family, "observation": observation}
+
+
+def _optional_bool(value: Any, *, field: str) -> bool | None:
+    if value is None or str(value).strip() == "":
+        return None
+    return parse_bool(value, field=field)
+
+
+def _optional_float(value: Any, *, field: str) -> float | None:
+    if value is None or str(value).strip() == "":
+        return None
+    return parse_float(value, field=field)
+
+
+def _default_observation() -> dict[str, Any]:
+    return {
+        "status": OBSERVATION_NOT_RUN,
+        "source": None,
+        "fallback_used": None,
+        "runtime_ms": None,
+        "promotion_verdict": None,
+        "metric_contract": None,
+        "mask_evidence_status": None,
+    }
+
+
+def _governance(spec: Mapping[str, Any], *, non_commercial_ok: bool, accept_depth_pro_license: bool) -> dict[str, Any]:
+    if spec.get("depth_backend") == "depth_pro":
+        acknowledged = bool(non_commercial_ok and accept_depth_pro_license)
+        return {
+            "status": GOVERNANCE_RESEARCH_ONLY if acknowledged else GOVERNANCE_LICENSE_BLOCKED,
+            "license_tier": "research_non_commercial",
+            "non_commercial_ok": bool(non_commercial_ok),
+            "accept_depth_pro_license": bool(accept_depth_pro_license),
+            "blocked_reason": None if acknowledged else "depth_pro_license_acknowledgments_required",
+        }
+    if spec.get("depth_backend") == "da3":
+        return {
+            "status": GOVERNANCE_COMMERCIAL_READY,
+            "license_tier": "commercial_safe",
+            "non_commercial_ok": bool(non_commercial_ok),
+            "accept_depth_pro_license": bool(accept_depth_pro_license),
+            "blocked_reason": None,
+        }
+    return {
+        "status": GOVERNANCE_UNKNOWN,
+        "license_tier": "unknown",
+        "non_commercial_ok": bool(non_commercial_ok),
+        "accept_depth_pro_license": bool(accept_depth_pro_license),
+        "blocked_reason": "unsupported_depth_backend",
+    }
+
+
+def _comparison_blockers(
+    spec_validation: Mapping[str, Any], governance: Mapping[str, Any], observation: Mapping[str, Any]
+) -> list[str]:
+    blockers = []
+    if spec_validation.get("status") != SPEC_STATUS_OK:
+        blockers.append(BLOCKER_SPEC_INVALID)
+    if observation.get("status") not in COMPARABLE_OBSERVATION_STATUSES:
+        blockers.append(BLOCKER_OBSERVATION_MISSING)
+    if governance.get("status") == GOVERNANCE_LICENSE_BLOCKED:
+        blockers.append(BLOCKER_LICENSE_BLOCKED)
+    return blockers
+
+
+def _binding_candidate_family(value: str | Mapping[str, Any], *, label: str) -> str:
+    if isinstance(value, Mapping):
+        raw = {str(key): value[key] for key in value}
+    else:
+        raw = _parse_key_values(
+            str(value), label=label, item_separator=",", allowed_keys=frozenset({"candidate_family", "path"})
+        )
+    candidate_family = raw.get("candidate_family")
+    if not candidate_family:
+        raise ObservationBindingError(f"{label} binding missing candidate_family")
+    return _normalize_token(candidate_family)
+
+
+def _bind_observations(
+    family_names: set[str],
+    observations: Iterable[str | Mapping[str, Any]] | None,
+    redacted_summaries: Iterable[str | Mapping[str, Any]] | None,
+    *,
+    allow_observation_invalid: bool = False,
+) -> dict[str, dict[str, Any]]:
+    bound: dict[str, dict[str, Any]] = {}
+    for raw in observations or ():
+        parsed = parse_mock_observation(raw)
+        _bind_one_observation(bound, family_names, parsed)
+    for raw in redacted_summaries or ():
+        try:
+            parsed = parse_redacted_summary_binding(raw)
+        except (OSError, ObservationValidationError, ValueError) as exc:
+            if not allow_observation_invalid:
+                raise ObservationValidationError(str(exc)) from exc
+            candidate_family = _binding_candidate_family(raw, label="redacted-summary")
+            parsed = {
+                "candidate_family": candidate_family,
+                "observation": {
+                    **_default_observation(),
+                    "status": OBSERVATION_EVIDENCE_MISSING,
+                    "source": SOURCE_REDACTED_SUMMARY_V1,
+                    "error": str(exc),
+                },
+            }
+        _bind_one_observation(bound, family_names, parsed)
+    return bound
+
+
+def _bind_one_observation(bound: dict[str, dict[str, Any]], family_names: set[str], parsed: Mapping[str, Any]) -> None:
+    candidate_family = str(parsed["candidate_family"])
+    if candidate_family not in family_names:
+        raise ObservationBindingError(f"Observation references unknown candidate_family {candidate_family!r}")
+    if candidate_family in bound:
+        raise ObservationBindingError(f"Duplicate observation for candidate_family {candidate_family!r}")
+    bound[candidate_family] = dict(parsed["observation"])
+
+
+def _summary(rows: list[dict[str, Any]]) -> dict[str, int]:
+    family_count = len(rows)
+    return {
+        "family_count": family_count,
+        "spec_valid_count": sum(1 for row in rows if row["spec_validation"]["status"] == SPEC_STATUS_OK),
+        "spec_invalid_count": sum(1 for row in rows if row["spec_validation"]["status"] != SPEC_STATUS_OK),
+        "not_run_count": sum(1 for row in rows if row["observation"]["status"] == OBSERVATION_NOT_RUN),
+        "mocked_count": sum(1 for row in rows if row["observation"]["status"] == OBSERVATION_MOCKED),
+        "observed_local_count": sum(1 for row in rows if row["observation"]["status"] == OBSERVATION_OBSERVED_LOCAL),
+        "evidence_missing_count": sum(1 for row in rows if row["observation"]["status"] == OBSERVATION_EVIDENCE_MISSING),
+        "commercial_ready_count": sum(1 for row in rows if row["governance"]["status"] == GOVERNANCE_COMMERCIAL_READY),
+        "research_only_count": sum(1 for row in rows if row["governance"]["status"] == GOVERNANCE_RESEARCH_ONLY),
+        "license_blocked_count": sum(1 for row in rows if row["governance"]["status"] == GOVERNANCE_LICENSE_BLOCKED),
+        "governance_unknown_count": sum(1 for row in rows if row["governance"]["status"] == GOVERNANCE_UNKNOWN),
+        "comparable_count": sum(1 for row in rows if row["comparable"]),
+    }
+
+
+def _self_check(rows: list[dict[str, Any]], summary: Mapping[str, int]) -> dict[str, Any]:
+    failures = []
+    family_count = int(summary["family_count"])
+    checks = {
+        "family_count_matches_rows": family_count == len(rows),
+        "spec_counts_partition_family_count": summary["spec_valid_count"] + summary["spec_invalid_count"] == family_count,
+        "observation_counts_partition_family_count": (
+            summary["not_run_count"]
+            + summary["mocked_count"]
+            + summary["observed_local_count"]
+            + summary["evidence_missing_count"]
+            == family_count
+        ),
+        "governance_counts_partition_family_count": (
+            summary["commercial_ready_count"]
+            + summary["research_only_count"]
+            + summary["license_blocked_count"]
+            + summary["governance_unknown_count"]
+            == family_count
+        ),
+        "comparable_count_matches_rule": summary["comparable_count"] == sum(1 for row in rows if row["comparable"]),
+    }
+    for invariant in RECONCILIATION_INVARIANTS:
+        if not checks[invariant]:
+            failures.append({"invariant": invariant})
+    return {"status": "ok" if not failures else "failed", "failures": failures}
+
+
+def _comparison_groups(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    axes = {
+        "segmentation_axis": ("depth_backend", "quality_tier", "pbr_enabled", "v2_enabled"),
+        "depth_axis": ("segmentation_backend", "quality_tier", "pbr_enabled", "v2_enabled"),
+        "pbr_axis": ("depth_backend", "segmentation_backend", "quality_tier", "v2_enabled"),
+        "v2_axis": ("depth_backend", "segmentation_backend", "quality_tier", "pbr_enabled"),
+        "tier_axis": ("depth_backend", "segmentation_backend", "pbr_enabled", "v2_enabled"),
+    }
+    groups = []
+    for axis, fixed_fields in axes.items():
+        buckets: dict[tuple[Any, ...], list[dict[str, Any]]] = {}
+        for row in rows:
+            spec = row["family_spec"]
+            key = tuple(spec[field] for field in fixed_fields)
+            buckets.setdefault(key, []).append(row)
+        for key, members in sorted(buckets.items(), key=lambda item: tuple(str(part) for part in item[0])):
+            member_names = sorted(row["family_spec"]["candidate_family"] for row in members)
+            blockers = []
+            if len(members) < 2:
+                blockers.append(GROUP_BLOCKER_ONLY_ONE_MEMBER)
+            if any(not row["comparable"] for row in members):
+                blockers.append(GROUP_BLOCKER_MEMBER_NOT_COMPARABLE)
+            groups.append(
+                {
+                    "axis": axis,
+                    "fixed": {field: value for field, value in zip(fixed_fields, key)},
+                    "members": member_names,
+                    "comparable": not blockers,
+                    "blocking_reasons": blockers,
+                }
+            )
+    return groups
+
+
+def collect_family_specs(
+    *,
+    families: Iterable[str | Mapping[str, Any]] | None = None,
+    matrices: Iterable[str] | None = None,
+    family_files: Iterable[Path] | None = None,
+) -> tuple[list[dict[str, Any]], dict[str, bool]]:
+    specs = [parse_family_spec(item) for item in families or ()]
+    for matrix in matrices or ():
+        specs.extend(parse_matrix_spec(matrix))
+    file_governance = {"non_commercial_ok": False, "accept_depth_pro_license": False}
+    for family_file in family_files or ():
+        file_specs, governance = load_family_file(Path(family_file))
+        specs.extend(file_specs)
+        file_governance.update(governance)
+    return specs, file_governance
+
+
+def _input_digest_payload(
+    *,
+    specs: list[dict[str, Any]],
+    observations: Mapping[str, Mapping[str, Any]],
+    non_commercial_ok: bool,
+    accept_depth_pro_license: bool,
+    output_format: str,
+) -> dict[str, Any]:
+    observation_bindings = []
+    for candidate_family, observation in sorted(observations.items()):
+        evidence_ref = observation.get("evidence_ref") if isinstance(observation.get("evidence_ref"), dict) else {}
+        observation_bindings.append(
+            {
+                "candidate_family": candidate_family,
+                "status": observation.get("status"),
+                "source": observation.get("source"),
+                "summary_sha256": evidence_ref.get("summary_sha256"),
+            }
+        )
+    return {
+        "schema_version": INPUT_DIGEST_VERSION,
+        "tool_version": TOOL_VERSION,
+        "families": sorted(specs, key=lambda item: item.get("candidate_family", "")),
+        "observation_bindings": observation_bindings,
+        "governance": {
+            "non_commercial_ok": bool(non_commercial_ok),
+            "accept_depth_pro_license": bool(accept_depth_pro_license),
+        },
+        "format": output_format,
+    }
+
+
+def build_apex_model_family_characterization_report(
+    *,
+    family_specs: Iterable[str | Mapping[str, Any]],
+    output_path: Path | str,
+    observations: Iterable[str | Mapping[str, Any]] | None = None,
+    redacted_summaries: Iterable[str | Mapping[str, Any]] | None = None,
+    non_commercial_ok: bool = False,
+    accept_depth_pro_license: bool = False,
+    output_format: str = "json",
+    created_at: str = "1970-01-01T00:00:00Z",
+    allow_observation_invalid: bool = False,
+) -> dict[str, Any]:
+    """Build and persist an offline APEX model-family characterization report."""
+
+    created_at = validate_now(created_at)
+    specs = [parse_family_spec(spec) for spec in family_specs]
+    if not specs:
+        raise ValueError("At least one family spec is required")
+    family_names = [str(spec.get("candidate_family") or "") for spec in specs]
+    duplicate_names = sorted({name for name in family_names if family_names.count(name) > 1})
+    if duplicate_names:
+        raise DuplicateFamilyError(f"Duplicate candidate_family value(s): {', '.join(duplicate_names)}")
+
+    observations_by_family = _bind_observations(
+        set(family_names),
+        observations,
+        redacted_summaries,
+        allow_observation_invalid=allow_observation_invalid,
+    )
+    rows = []
+    for spec in specs:
+        spec_validation = spec_validation_for(spec)
+        governance = _governance(
+            spec,
+            non_commercial_ok=non_commercial_ok,
+            accept_depth_pro_license=accept_depth_pro_license,
+        )
+        observation = observations_by_family.get(spec["candidate_family"], _default_observation())
+        blockers = _comparison_blockers(spec_validation, governance, observation)
+        rows.append(
+            {
+                "family_spec": dict(spec),
+                "spec_validation": spec_validation,
+                "governance": governance,
+                "observation": observation,
+                "comparable": not blockers,
+                "comparison_blockers": blockers,
+            }
+        )
+    rows.sort(key=lambda row: row["family_spec"]["candidate_family"])
+    summary = _summary(rows)
+    self_check = _self_check(rows, summary)
+    digest_payload = _input_digest_payload(
+        specs=specs,
+        observations=observations_by_family,
+        non_commercial_ok=non_commercial_ok,
+        accept_depth_pro_license=accept_depth_pro_license,
+        output_format=output_format,
+    )
+    report = {
+        "schema_version": REPORT_SCHEMA_VERSION,
+        "tool_version": TOOL_VERSION,
+        "report_mode": "offline",
+        "created_at": created_at,
+        "input_digest": {"schema_version": INPUT_DIGEST_VERSION, "sha256": sha256_bytes(canonical_json_bytes(digest_payload))},
+        "families": rows,
+        "summary": summary,
+        "comparison_groups": _comparison_groups(rows),
+        "self_check": self_check,
+        "notes": [
+            "This report does not run models.",
+            "This report does not replace apex_evidence_bundle.v1.",
+            "Real artifacts remain external and uncommitted.",
+        ],
+    }
+    if self_check["status"] != "ok":
+        raise ReconciliationError("APEX model-family report self-check failed")
+    write_report(report, Path(output_path), output_format=output_format)
+    return report
+
+
+def write_report(report: Mapping[str, Any], output_path: Path, *, output_format: str) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    if output_format == "json":
+        output_path.write_text(json.dumps(report, indent=2, sort_keys=True, ensure_ascii=False) + "\n", encoding="utf-8")
+    elif output_format == "markdown":
+        output_path.write_text(render_markdown(report), encoding="utf-8")
+    else:
+        raise ValueError("output_format must be json or markdown")
+
+
+def render_markdown(report: Mapping[str, Any]) -> str:
+    lines = [
+        "# APEX Model-Family Characterization",
+        "",
+        f"schema_version: {report['schema_version']}",
+        f"created_at: {report['created_at']}",
+        "",
+        "| candidate_family | depth_backend | segmentation_backend | quality_tier | pbr_enabled | v2_enabled | governance.status | observation.status | comparable |",
+        "| --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    for row in sorted(report.get("families", []), key=lambda item: item["family_spec"]["candidate_family"]):
+        spec = row["family_spec"]
+        lines.append(
+            "| {candidate_family} | {depth_backend} | {segmentation_backend} | {quality_tier} | {pbr_enabled} | {v2_enabled} | {governance_status} | {observation_status} | {comparable} |".format(
+                candidate_family=spec["candidate_family"],
+                depth_backend=spec["depth_backend"],
+                segmentation_backend=spec["segmentation_backend"],
+                quality_tier=spec["quality_tier"],
+                pbr_enabled=str(spec["pbr_enabled"]).lower(),
+                v2_enabled=str(spec["v2_enabled"]).lower(),
+                governance_status=row["governance"]["status"],
+                observation_status=row["observation"]["status"],
+                comparable=str(row["comparable"]).lower(),
+            )
+        )
+    return "\n".join(line.rstrip() for line in lines) + "\n"

--- a/src/transformation_portal/evals/apex_model_family.py
+++ b/src/transformation_portal/evals/apex_model_family.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 import re
+from collections import Counter
 from itertools import product
 from pathlib import Path
 from typing import Any, Iterable, Mapping
@@ -51,6 +53,7 @@ from transformation_portal.evals.apex_redacted_summary_schema import (
     reject_raw_summary_path,
     validate_redacted_summary,
 )
+from transformation_portal.ingest.canonical_json import canonicalize_json, dump_json
 
 NOW_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
 SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
@@ -79,7 +82,7 @@ class ReconciliationError(ApexModelFamilyError):
 def canonical_json_bytes(value: Any) -> bytes:
     """Serialize a value using deterministic canonical JSON bytes."""
 
-    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False).encode("utf-8")
+    return canonicalize_json(value)
 
 
 def sha256_bytes(data: bytes) -> str:
@@ -119,9 +122,12 @@ def parse_int(value: Any, *, field: str) -> int:
 
 def parse_float(value: Any, *, field: str) -> float:
     try:
-        return float(value)
+        parsed = float(value)
     except (TypeError, ValueError) as exc:
         raise ValueError(f"{field} must be numeric, got {value!r}") from exc
+    if not math.isfinite(parsed):
+        raise ValueError(f"{field} must be finite, got {value!r}")
+    return parsed
 
 
 def _normalize_token(value: Any) -> str:
@@ -340,7 +346,6 @@ def parse_redacted_summary_binding(value: str | Mapping[str, Any]) -> dict[str, 
             "metric_contract": payload.get("metric_contract"),
             "mask_evidence_status": payload.get("mask_evidence_status"),
             "evidence_ref": {
-                "summary_path": str(path),
                 "summary_sha256": summary_sha256,
                 "summary_schema_version": SUMMARY_SCHEMA_VERSION,
                 "originating_bundle_schema": "apex_evidence_bundle.v1",
@@ -453,7 +458,7 @@ def _bind_observations(
                     **_default_observation(),
                     "status": OBSERVATION_EVIDENCE_MISSING,
                     "source": SOURCE_REDACTED_SUMMARY_V1,
-                    "error": str(exc),
+                    "error_code": _observation_error_code(exc),
                 },
             }
         _bind_one_observation(bound, family_names, parsed)
@@ -467,6 +472,21 @@ def _bind_one_observation(bound: dict[str, dict[str, Any]], family_names: set[st
     if candidate_family in bound:
         raise ObservationBindingError(f"Duplicate observation for candidate_family {candidate_family!r}")
     bound[candidate_family] = dict(parsed["observation"])
+
+
+def _observation_error_code(exc: BaseException) -> str:
+    message = str(exc).lower()
+    if "raw artifact" in message:
+        return "raw_artifact_rejected"
+    if "path-like" in message:
+        return "path_like_value_rejected"
+    if "missing required" in message:
+        return "required_key_missing"
+    if "unsupported field" in message:
+        return "unsupported_field"
+    if "schema_version" in message:
+        return "schema_version_invalid"
+    return "redacted_summary_invalid"
 
 
 def _summary(rows: list[dict[str, Any]]) -> dict[str, int]:
@@ -517,11 +537,11 @@ def _self_check(rows: list[dict[str, Any]], summary: Mapping[str, int]) -> dict[
 
 def _comparison_groups(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
     axes = {
-        "segmentation_axis": ("depth_backend", "quality_tier", "pbr_enabled", "v2_enabled"),
-        "depth_axis": ("segmentation_backend", "quality_tier", "pbr_enabled", "v2_enabled"),
-        "pbr_axis": ("depth_backend", "segmentation_backend", "quality_tier", "v2_enabled"),
-        "v2_axis": ("depth_backend", "segmentation_backend", "quality_tier", "pbr_enabled"),
-        "tier_axis": ("depth_backend", "segmentation_backend", "pbr_enabled", "v2_enabled"),
+        "segmentation_axis": ("materials_version", "depth_backend", "quality_tier", "pbr_enabled", "v2_enabled"),
+        "depth_axis": ("materials_version", "segmentation_backend", "quality_tier", "pbr_enabled", "v2_enabled"),
+        "pbr_axis": ("materials_version", "depth_backend", "segmentation_backend", "quality_tier", "v2_enabled"),
+        "v2_axis": ("materials_version", "depth_backend", "segmentation_backend", "quality_tier", "pbr_enabled"),
+        "tier_axis": ("materials_version", "depth_backend", "segmentation_backend", "pbr_enabled", "v2_enabled"),
     }
     groups = []
     for axis, fixed_fields in axes.items():
@@ -617,7 +637,7 @@ def build_apex_model_family_characterization_report(
     if not specs:
         raise ValueError("At least one family spec is required")
     family_names = [str(spec.get("candidate_family") or "") for spec in specs]
-    duplicate_names = sorted({name for name in family_names if family_names.count(name) > 1})
+    duplicate_names = sorted(name for name, count in Counter(family_names).items() if count > 1)
     if duplicate_names:
         raise DuplicateFamilyError(f"Duplicate candidate_family value(s): {', '.join(duplicate_names)}")
 
@@ -682,7 +702,9 @@ def build_apex_model_family_characterization_report(
 def write_report(report: Mapping[str, Any], output_path: Path, *, output_format: str) -> None:
     output_path.parent.mkdir(parents=True, exist_ok=True)
     if output_format == "json":
-        output_path.write_text(json.dumps(report, indent=2, sort_keys=True, ensure_ascii=False) + "\n", encoding="utf-8")
+        with output_path.open("w", encoding="utf-8") as handle:
+            dump_json(report, handle, indent=2, sort_keys=True, ensure_ascii=False, allow_nan=False)
+            handle.write("\n")
     elif output_format == "markdown":
         output_path.write_text(render_markdown(report), encoding="utf-8")
     else:

--- a/src/transformation_portal/evals/apex_model_family_schema.py
+++ b/src/transformation_portal/evals/apex_model_family_schema.py
@@ -1,0 +1,149 @@
+"""Schema constants for offline APEX model-family characterization."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, TypedDict
+
+REPORT_SCHEMA_VERSION = "apex_model_family_characterization_report.v1"
+SUMMARY_SCHEMA_VERSION = "apex_redacted_summary.v1"
+MATRIX_SCHEMA_VERSION = "apex_family_matrix.v1"
+INPUT_DIGEST_VERSION = "input_digest.v1"
+TOOL_VERSION = "characterize_apex_model_families/0.1.0"
+
+SPEC_STATUS_OK = "ok"
+SPEC_STATUS_NAME_MISMATCH = "name_mismatch"
+SPEC_STATUS_INVALID = "invalid_family_spec"
+
+GOVERNANCE_COMMERCIAL_READY = "commercial_ready"
+GOVERNANCE_RESEARCH_ONLY = "research_only"
+GOVERNANCE_LICENSE_BLOCKED = "license_blocked"
+GOVERNANCE_UNKNOWN = "unknown"
+
+OBSERVATION_NOT_RUN = "not_run"
+OBSERVATION_MOCKED = "mocked"
+OBSERVATION_OBSERVED_LOCAL = "observed_local"
+OBSERVATION_EVIDENCE_MISSING = "evidence_missing"
+
+SOURCE_MOCK_V1 = "mock_v1"
+SOURCE_REDACTED_SUMMARY_V1 = "redacted_summary_v1"
+
+BLOCKER_SPEC_INVALID = "spec_invalid"
+BLOCKER_OBSERVATION_MISSING = "observation_missing"
+BLOCKER_LICENSE_BLOCKED = "license_blocked"
+
+GROUP_BLOCKER_ONLY_ONE_MEMBER = "only_one_member"
+GROUP_BLOCKER_MEMBER_NOT_COMPARABLE = "member_not_comparable"
+
+ALLOWED_DEPTH_BACKENDS = frozenset({"da3", "depth_pro"})
+ALLOWED_SEGMENTATION_BACKENDS = frozenset({"efficientsam", "sam2"})
+ALLOWED_QUALITY_TIERS = frozenset({"apex", "premium"})
+ALLOWED_OBSERVATION_STATUSES = frozenset(
+    {OBSERVATION_NOT_RUN, OBSERVATION_MOCKED, OBSERVATION_OBSERVED_LOCAL, OBSERVATION_EVIDENCE_MISSING},
+)
+ALLOWED_SOURCES = frozenset({SOURCE_MOCK_V1, SOURCE_REDACTED_SUMMARY_V1})
+COMPARABLE_OBSERVATION_STATUSES = frozenset({OBSERVATION_MOCKED, OBSERVATION_OBSERVED_LOCAL})
+CLOSED_COMPARISON_BLOCKERS = frozenset(
+    {BLOCKER_SPEC_INVALID, BLOCKER_OBSERVATION_MISSING, BLOCKER_LICENSE_BLOCKED},
+)
+CLOSED_GROUP_BLOCKERS = frozenset({GROUP_BLOCKER_ONLY_ONE_MEMBER, GROUP_BLOCKER_MEMBER_NOT_COMPARABLE})
+
+DEPTH_FAMILY_TOKENS = {"da3": "da3", "depth_pro": "depthpro"}
+SEGMENTATION_FAMILY_TOKENS = {"efficientsam": "efficientsam", "sam2": "sam2"}
+
+FAMILY_SPEC_KEYS = frozenset(
+    {
+        "candidate_family",
+        "depth_backend",
+        "segmentation_backend",
+        "materials_version",
+        "quality_tier",
+        "pbr_enabled",
+        "v2_enabled",
+    },
+)
+FAMILY_SPEC_REQUIRED_KEYS = frozenset({"depth_backend", "segmentation_backend", "quality_tier"})
+OBSERVATION_KEYS = frozenset(
+    {
+        "candidate_family",
+        "source",
+        "status",
+        "fallback_used",
+        "runtime_ms",
+        "promotion_verdict",
+        "metric_contract",
+        "mask_evidence_status",
+    },
+)
+FAMILY_FILE_TOP_LEVEL_KEYS = frozenset({"schema_version", "default_governance", "families"})
+FAMILY_FILE_GOVERNANCE_KEYS = frozenset({"non_commercial_ok", "accept_depth_pro_license"})
+
+RECONCILIATION_INVARIANTS = (
+    "family_count_matches_rows",
+    "spec_counts_partition_family_count",
+    "observation_counts_partition_family_count",
+    "governance_counts_partition_family_count",
+    "comparable_count_matches_rule",
+)
+
+
+class FamilySpecDict(TypedDict):
+    candidate_family: str
+    depth_backend: str
+    segmentation_backend: str
+    materials_version: int
+    quality_tier: str
+    pbr_enabled: bool
+    v2_enabled: bool
+
+
+@dataclass(frozen=True)
+class FamilySpec:
+    """Declarative APEX family identity."""
+
+    depth_backend: str
+    segmentation_backend: str
+    quality_tier: str
+    materials_version: int = 3
+    pbr_enabled: bool = False
+    v2_enabled: bool = False
+    candidate_family: str | None = None
+
+    def to_report_dict(self) -> FamilySpecDict:
+        return {
+            "candidate_family": self.candidate_family or canonical_family_name(self),
+            "depth_backend": self.depth_backend,
+            "segmentation_backend": self.segmentation_backend,
+            "materials_version": self.materials_version,
+            "quality_tier": self.quality_tier,
+            "pbr_enabled": self.pbr_enabled,
+            "v2_enabled": self.v2_enabled,
+        }
+
+
+def canonical_family_name(spec: FamilySpec | dict[str, Any]) -> str:
+    """Return the canonical APEX model-family label."""
+
+    if isinstance(spec, FamilySpec):
+        materials_version = spec.materials_version
+        depth_backend = spec.depth_backend
+        segmentation_backend = spec.segmentation_backend
+        quality_tier = spec.quality_tier
+        pbr_enabled = spec.pbr_enabled
+        v2_enabled = spec.v2_enabled
+    else:
+        materials_version = int(spec.get("materials_version", 3))
+        depth_backend = str(spec.get("depth_backend", ""))
+        segmentation_backend = str(spec.get("segmentation_backend", ""))
+        quality_tier = str(spec.get("quality_tier", ""))
+        pbr_enabled = bool(spec.get("pbr_enabled", False))
+        v2_enabled = bool(spec.get("v2_enabled", False))
+
+    depth_token = DEPTH_FAMILY_TOKENS[depth_backend]
+    seg_token = SEGMENTATION_FAMILY_TOKENS[segmentation_backend]
+    suffix = ""
+    if pbr_enabled:
+        suffix += "_pbr"
+    if v2_enabled:
+        suffix += "_v2"
+    return f"materials_v{materials_version}_{depth_token}_{seg_token}_{quality_tier}{suffix}"

--- a/src/transformation_portal/evals/apex_redacted_summary_schema.py
+++ b/src/transformation_portal/evals/apex_redacted_summary_schema.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import re
 from pathlib import Path
 from typing import Any, Mapping
@@ -64,7 +65,8 @@ RAW_JSON_NAME_PATTERNS = (
     "_provenance.json",
 )
 PATH_VALUE_PATTERNS = (
-    re.compile(r"(^|[\"' ])/(Users|Volumes)/"),
+    re.compile(r"(^|[\"' ])/(?!/)"),
+    re.compile(r"(^|[\"' ])\.\.?/"),
     re.compile(r"^[A-Za-z]:\\"),
     re.compile(r"\.(tif|tiff|npz|npy|png)$", re.IGNORECASE),
     re.compile(r"(run_card_|batch_|_combined\.json|_combined_provenance\.json|_provenance\.json)", re.IGNORECASE),
@@ -88,6 +90,8 @@ def _reject_forbidden_value(value: Any, *, key: str) -> None:
         for item in value:
             _reject_forbidden_value(item, key=key)
         return
+    if isinstance(value, float) and not math.isfinite(value):
+        raise ValueError(f"Redacted summary field {key!r} must be finite")
     if not isinstance(value, str):
         return
     for pattern in PATH_VALUE_PATTERNS:

--- a/src/transformation_portal/evals/apex_redacted_summary_schema.py
+++ b/src/transformation_portal/evals/apex_redacted_summary_schema.py
@@ -1,0 +1,121 @@
+"""Validation for redacted APEX observation summaries."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any, Mapping
+
+from transformation_portal.evals.apex_model_family_schema import SUMMARY_SCHEMA_VERSION
+
+ALLOWED_SUMMARY_KEYS = frozenset(
+    {
+        "schema_version",
+        "source_evidence_sha256",
+        "candidate_family",
+        "depth_backend",
+        "segmentation_backend",
+        "quality_tier",
+        "pbr_enabled",
+        "v2_enabled",
+        "fallback_used",
+        "runtime_ms",
+        "promotion_verdict",
+        "metric_contract",
+        "mask_evidence_status",
+        "outside_mask_delta_status",
+        "seam_halo_score_status",
+        "applied_ops_count",
+        "blocked_ops_count",
+        "canonical_asset_count",
+        "case_count",
+        "passing_case_count",
+        "metrics_valid_count",
+    },
+)
+REQUIRED_SUMMARY_KEYS = frozenset({"schema_version", "source_evidence_sha256", "candidate_family"})
+
+FORBIDDEN_KEY_PARTS = (
+    "path",
+    "file",
+    "filename",
+    "sourcefile",
+    "directory",
+    "working_directory",
+    "host",
+    "exif",
+    "iptc",
+    "xmp",
+    "gps",
+    "serial",
+    "creator",
+    "copyright",
+    "artist",
+    "owner",
+    "camera",
+    "lens",
+)
+RAW_ARTIFACT_SUFFIXES = (".npz", ".npy", ".tif", ".tiff", ".png")
+RAW_JSON_NAME_PATTERNS = (
+    "run_card_",
+    "batch_",
+    "_combined.json",
+    "_combined_provenance.json",
+    "_provenance.json",
+)
+PATH_VALUE_PATTERNS = (
+    re.compile(r"(^|[\"' ])/(Users|Volumes)/"),
+    re.compile(r"^[A-Za-z]:\\"),
+    re.compile(r"\.(tif|tiff|npz|npy|png)$", re.IGNORECASE),
+    re.compile(r"(run_card_|batch_|_combined\.json|_combined_provenance\.json|_provenance\.json)", re.IGNORECASE),
+)
+HEX_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+def reject_raw_summary_path(path: Path) -> None:
+    """Reject direct raw artifact/run-card paths before file ingestion."""
+
+    name = path.name
+    lower_name = name.lower()
+    if lower_name.endswith(RAW_ARTIFACT_SUFFIXES) or any(pattern in lower_name for pattern in RAW_JSON_NAME_PATTERNS):
+        raise ValueError(f"Observed local inputs must use {SUMMARY_SCHEMA_VERSION}, not raw artifact {path}")
+
+
+def _reject_forbidden_value(value: Any, *, key: str) -> None:
+    if isinstance(value, Mapping):
+        raise ValueError(f"Redacted summary field {key!r} must not contain nested objects")
+    if isinstance(value, list):
+        for item in value:
+            _reject_forbidden_value(item, key=key)
+        return
+    if not isinstance(value, str):
+        return
+    for pattern in PATH_VALUE_PATTERNS:
+        if pattern.search(value):
+            raise ValueError(f"Redacted summary field {key!r} contains path-like or raw artifact value")
+
+
+def validate_redacted_summary(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate and return an allowlisted APEX redacted summary payload."""
+
+    keys = set(payload)
+    missing = sorted(REQUIRED_SUMMARY_KEYS - keys)
+    if missing:
+        raise ValueError(f"Redacted summary missing required field(s): {', '.join(missing)}")
+    unknown = sorted(keys - ALLOWED_SUMMARY_KEYS)
+    if unknown:
+        raise ValueError(f"Redacted summary contains unsupported field(s): {', '.join(unknown)}")
+
+    for key in keys:
+        normalized_key = key.lower()
+        if any(part in normalized_key for part in FORBIDDEN_KEY_PARTS):
+            raise ValueError(f"Redacted summary contains forbidden metadata field {key!r}")
+        _reject_forbidden_value(payload[key], key=key)
+
+    if payload.get("schema_version") != SUMMARY_SCHEMA_VERSION:
+        raise ValueError(f"Redacted summary schema_version must be {SUMMARY_SCHEMA_VERSION!r}")
+    source_hash = str(payload.get("source_evidence_sha256") or "")
+    if not HEX_SHA256_RE.match(source_hash):
+        raise ValueError("Redacted summary source_evidence_sha256 must be a lowercase SHA-256 digest")
+
+    return {key: payload[key] for key in sorted(keys)}

--- a/tests/evals/fixtures/batch_raw_should_reject.json
+++ b/tests/evals/fixtures/batch_raw_should_reject.json
@@ -1,0 +1,4 @@
+{
+  "schema_version": "batch.v1",
+  "artifact_path": "/Users/example/output/batch_2026.json"
+}

--- a/tests/evals/fixtures/redacted_summary_valid.json
+++ b/tests/evals/fixtures/redacted_summary_valid.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": "apex_redacted_summary.v1",
+  "source_evidence_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "candidate_family": "materials_v3_da3_efficientsam_apex",
+  "depth_backend": "da3",
+  "segmentation_backend": "efficientsam",
+  "quality_tier": "apex",
+  "pbr_enabled": false,
+  "v2_enabled": false,
+  "fallback_used": false,
+  "runtime_ms": 1234.0,
+  "promotion_verdict": "eligible",
+  "metric_contract": "apex_metrics.v1",
+  "mask_evidence_status": "ok",
+  "outside_mask_delta_status": "ok",
+  "seam_halo_score_status": "ok",
+  "applied_ops_count": 4,
+  "blocked_ops_count": 2,
+  "canonical_asset_count": 3,
+  "case_count": 3,
+  "passing_case_count": 3,
+  "metrics_valid_count": 3
+}

--- a/tests/evals/fixtures/redacted_summary_with_exif_should_reject.json
+++ b/tests/evals/fixtures/redacted_summary_with_exif_should_reject.json
@@ -1,0 +1,6 @@
+{
+  "schema_version": "apex_redacted_summary.v1",
+  "source_evidence_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "candidate_family": "materials_v3_da3_efficientsam_apex",
+  "exif_camera_serial": "LOCAL-SERIAL"
+}

--- a/tests/evals/fixtures/run_card_raw_should_reject.json
+++ b/tests/evals/fixtures/run_card_raw_should_reject.json
@@ -1,0 +1,4 @@
+{
+  "schema_version": "run_card.v1",
+  "local_path": "/Users/example/output/run_card_2026.json"
+}

--- a/tests/evals/test_apex_docs_commands.py
+++ b/tests/evals/test_apex_docs_commands.py
@@ -14,6 +14,7 @@ pytestmark = pytest.mark.unit
 REPO_ROOT = Path(__file__).resolve().parents[2]
 APEX_CLI_MODULES = {
     "tools/audit_apex_assets.py": "audit_apex_assets_docs_unit",
+    "tools/characterize_apex_model_families.py": "characterize_apex_model_families_docs_unit",
     "tools/run_apex_eval.py": "run_apex_eval_docs_unit",
 }
 REAL_CANONICAL_RUNBOOK = "APEX_REAL_CANONICAL_EVIDENCE_RUNBOOK.md"

--- a/tests/evals/test_apex_model_family_characterization.py
+++ b/tests/evals/test_apex_model_family_characterization.py
@@ -229,17 +229,24 @@ def test_redacted_summary_required_keys_and_unknown_keys_rejected(tmp_path: Path
 
 
 def test_redacted_summary_rejects_path_like_values_and_raw_artifacts(tmp_path: Path) -> None:
-    path_like = tmp_path / "path_like_summary.json"
-    payload = json.loads(VALID_SUMMARY.read_text(encoding="utf-8"))
-    payload["promotion_verdict"] = "/Users/example/output/file.tif"
-    path_like.write_text(json.dumps(payload), encoding="utf-8")
+    for value in (
+        "/Users/example/output/file.tif",
+        "/tmp/private/report.json",
+        "/home/user/data.json",
+        "./local/file.json",
+        "../secrets.json",
+    ):
+        path_like = tmp_path / f"path_like_{hashlib.sha256(value.encode('utf-8')).hexdigest()}.json"
+        payload = json.loads(VALID_SUMMARY.read_text(encoding="utf-8"))
+        payload["promotion_verdict"] = value
+        path_like.write_text(json.dumps(payload), encoding="utf-8")
 
-    with pytest.raises(ValueError, match="path-like"):
-        _build(
-            tmp_path,
-            family_specs=[DA3_ESAM_SPEC],
-            redacted_summaries=[f"candidate_family=materials_v3_da3_efficientsam_apex,path={path_like}"],
-        )
+        with pytest.raises(ValueError, match="path-like"):
+            _build(
+                tmp_path,
+                family_specs=[DA3_ESAM_SPEC],
+                redacted_summaries=[f"candidate_family=materials_v3_da3_efficientsam_apex,path={path_like}"],
+            )
 
     for raw_path in (RAW_RUN_CARD, RAW_BATCH):
         with pytest.raises(ValueError, match="raw artifact"):
@@ -279,7 +286,47 @@ def test_redacted_summary_observed_local_and_digest_includes_summary_hash(tmp_pa
     assert row["observation"]["status"] == "observed_local"
     assert row["observation"]["source"] == "redacted_summary_v1"
     assert row["observation"]["evidence_ref"]["summary_schema_version"] == "apex_redacted_summary.v1"
+    assert "summary_path" not in row["observation"]["evidence_ref"]
     assert first["input_digest"]["sha256"] != second["input_digest"]["sha256"]
+
+
+def test_non_finite_runtime_is_rejected_for_mock_and_redacted_summary(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="finite"):
+        _build(
+            tmp_path,
+            family_specs=[DA3_ESAM_SPEC],
+            observations=["candidate_family=materials_v3_da3_efficientsam_apex,source=mock_v1,status=mocked,runtime_ms=nan"],
+        )
+
+    non_finite = tmp_path / "non_finite_summary.json"
+    payload = json.loads(VALID_SUMMARY.read_text(encoding="utf-8"))
+    non_finite.write_text(
+        json.dumps({**payload, "runtime_ms": float("inf")}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="finite"):
+        _build(
+            tmp_path,
+            family_specs=[DA3_ESAM_SPEC],
+            redacted_summaries=[f"candidate_family=materials_v3_da3_efficientsam_apex,path={non_finite}"],
+        )
+
+
+def test_allow_observation_invalid_uses_sanitized_error_code(tmp_path: Path) -> None:
+    report = build_apex_model_family_characterization_report(
+        family_specs=[DA3_ESAM_SPEC],
+        redacted_summaries=[f"candidate_family=materials_v3_da3_efficientsam_apex,path={RAW_RUN_CARD}"],
+        output_path=tmp_path / "report.json",
+        allow_observation_invalid=True,
+    )
+
+    observation = report["families"][0]["observation"]
+    assert observation["status"] == "evidence_missing"
+    assert observation["error_code"] == "raw_artifact_rejected"
+    serialized = canonical_json_bytes(report).decode("utf-8")
+    assert str(RAW_RUN_CARD) not in serialized
+    assert "run_card_raw_should_reject.json" not in serialized
 
 
 def test_input_digest_stable_under_key_reordering_and_excludes_now(tmp_path: Path) -> None:
@@ -324,6 +371,40 @@ def test_comparison_groups_require_two_members_and_closed_reasons(tmp_path: Path
         assert set(group["blocking_reasons"]) <= {"only_one_member", "member_not_comparable"}
     segmentation_groups = [group for group in groups if group["axis"] == "segmentation_axis"]
     assert any(len(group["members"]) >= 2 and not group["comparable"] for group in segmentation_groups)
+
+
+def test_comparison_groups_keep_materials_version_fixed(tmp_path: Path) -> None:
+    report = _build(
+        tmp_path,
+        family_specs=[
+            {
+                "depth_backend": "da3",
+                "segmentation_backend": "efficientsam",
+                "materials_version": 3,
+                "quality_tier": "apex",
+                "pbr_enabled": False,
+                "v2_enabled": False,
+            },
+            {
+                "depth_backend": "da3",
+                "segmentation_backend": "efficientsam",
+                "materials_version": 4,
+                "quality_tier": "apex",
+                "pbr_enabled": False,
+                "v2_enabled": False,
+            },
+        ],
+        observations=[
+            "candidate_family=materials_v3_da3_efficientsam_apex,source=mock_v1,status=mocked",
+            "candidate_family=materials_v4_da3_efficientsam_apex,source=mock_v1,status=mocked",
+        ],
+    )
+
+    for group in report["comparison_groups"]:
+        assert set(group["members"]) != {
+            "materials_v3_da3_efficientsam_apex",
+            "materials_v4_da3_efficientsam_apex",
+        }
 
 
 def test_self_check_reconciliation_counts(tmp_path: Path) -> None:
@@ -479,6 +560,7 @@ def test_static_ast_import_guard() -> None:
         "transformation_portal.evals.apex_model_family",
         "transformation_portal.evals.apex_model_family_schema",
         "transformation_portal.evals.apex_redacted_summary_schema",
+        "transformation_portal.ingest.canonical_json",
     }
     forbidden_prefixes = (
         "transformation_portal.depth",

--- a/tests/evals/test_apex_model_family_characterization.py
+++ b/tests/evals/test_apex_model_family_characterization.py
@@ -1,0 +1,551 @@
+"""Tests for offline APEX model-family characterization."""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from transformation_portal.evals.apex_model_family import (
+    DuplicateFamilyError,
+    ObservationBindingError,
+    build_apex_model_family_characterization_report,
+    canonical_json_bytes,
+    collect_family_specs,
+    parse_family_spec,
+    parse_matrix_spec,
+)
+from transformation_portal.evals.apex_model_family_schema import (
+    ALLOWED_DEPTH_BACKENDS,
+    ALLOWED_QUALITY_TIERS,
+    ALLOWED_SEGMENTATION_BACKENDS,
+    REPORT_SCHEMA_VERSION,
+    FamilySpec,
+    canonical_family_name,
+)
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+VALID_SUMMARY = FIXTURES / "redacted_summary_valid.json"
+INVALID_EXIF_SUMMARY = FIXTURES / "redacted_summary_with_exif_should_reject.json"
+RAW_RUN_CARD = FIXTURES / "run_card_raw_should_reject.json"
+RAW_BATCH = FIXTURES / "batch_raw_should_reject.json"
+
+DA3_ESAM_SPEC = "depth_backend=da3,segmentation_backend=efficientsam,quality_tier=apex,pbr_enabled=false,v2_enabled=false"
+DA3_SAM2_SPEC = "depth_backend=da3,segmentation_backend=sam2,quality_tier=apex,pbr_enabled=false,v2_enabled=false"
+DEPTHPRO_SAM2_SPEC = "depth_backend=depth_pro,segmentation_backend=sam2,quality_tier=apex,pbr_enabled=false,v2_enabled=false"
+
+
+def _load_tool_module(script_name: str, module_name: str):
+    script_path = REPO_ROOT / "tools" / script_name
+    spec = importlib.util.spec_from_file_location(module_name, script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _build(tmp_path: Path, **kwargs):
+    return build_apex_model_family_characterization_report(output_path=tmp_path / "report.json", **kwargs)
+
+
+def test_canonical_name_round_trips_for_all_tier_values() -> None:
+    for depth in sorted(ALLOWED_DEPTH_BACKENDS):
+        for seg in sorted(ALLOWED_SEGMENTATION_BACKENDS):
+            for tier in sorted(ALLOWED_QUALITY_TIERS):
+                for pbr in (False, True):
+                    for v2 in (False, True):
+                        spec = FamilySpec(
+                            depth_backend=depth,
+                            segmentation_backend=seg,
+                            quality_tier=tier,
+                            pbr_enabled=pbr,
+                            v2_enabled=v2,
+                        )
+                        name = canonical_family_name(spec)
+                        parsed = parse_family_spec(
+                            {
+                                "candidate_family": name,
+                                "depth_backend": depth,
+                                "segmentation_backend": seg,
+                                "quality_tier": tier,
+                                "pbr_enabled": pbr,
+                                "v2_enabled": v2,
+                            }
+                        )
+                        assert parsed["candidate_family"] == name
+
+
+def test_quality_tier_naming_default_materials_version_and_suffix_order() -> None:
+    spec = parse_family_spec(
+        "depth_backend=depth_pro,segmentation_backend=sam2,quality_tier=premium,pbr_enabled=true,v2_enabled=true"
+    )
+
+    assert spec["materials_version"] == 3
+    assert spec["candidate_family"] == "materials_v3_depthpro_sam2_premium_pbr_v2"
+
+
+def test_name_mismatch_becomes_spec_validation_status(tmp_path: Path) -> None:
+    report = _build(
+        tmp_path,
+        family_specs=[
+            "candidate_family=materials_v3_depthpro_sam2_v2_pbr,depth_backend=depth_pro,segmentation_backend=sam2,quality_tier=apex,pbr_enabled=true,v2_enabled=true"
+        ],
+    )
+
+    row = report["families"][0]
+    assert row["spec_validation"]["status"] == "name_mismatch"
+    assert row["spec_validation"]["expected_candidate_family"] == "materials_v3_depthpro_sam2_apex_pbr_v2"
+    assert row["comparison_blockers"] == ["spec_invalid", "observation_missing", "license_blocked"]
+
+
+def test_matrix_expands_and_sorts_candidate_families(tmp_path: Path) -> None:
+    specs = parse_matrix_spec(
+        "depth_backend=da3,depth_pro;segmentation_backend=sam2,efficientsam;quality_tier=apex;pbr_enabled=false;v2_enabled=false"
+    )
+    report = _build(tmp_path, family_specs=specs)
+
+    assert [row["family_spec"]["candidate_family"] for row in report["families"]] == [
+        "materials_v3_da3_efficientsam_apex",
+        "materials_v3_da3_sam2_apex",
+        "materials_v3_depthpro_efficientsam_apex",
+        "materials_v3_depthpro_sam2_apex",
+    ]
+
+
+def test_family_file_import_rejects_observations(tmp_path: Path) -> None:
+    family_file = tmp_path / "matrix.json"
+    family_file.write_text(
+        json.dumps(
+            {
+                "schema_version": "apex_family_matrix.v1",
+                "default_governance": {},
+                "families": [],
+                "observations": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="unsupported top-level"):
+        collect_family_specs(family_files=[family_file])
+
+
+def test_default_family_file_shape() -> None:
+    specs, governance = collect_family_specs(family_files=[REPO_ROOT / "config" / "apex_family_matrix.json"])
+
+    assert governance == {"non_commercial_ok": False, "accept_depth_pro_license": False}
+    assert len(specs) == 4
+    assert {spec["candidate_family"] for spec in specs} == {
+        "materials_v3_da3_efficientsam_apex",
+        "materials_v3_da3_sam2_apex",
+        "materials_v3_depthpro_efficientsam_apex",
+        "materials_v3_depthpro_sam2_apex",
+    }
+
+
+def test_observation_binding_duplicate_and_unknown_family(tmp_path: Path) -> None:
+    with pytest.raises(ObservationBindingError, match="unknown candidate_family"):
+        _build(
+            tmp_path,
+            family_specs=[DA3_ESAM_SPEC],
+            observations=["candidate_family=unknown_family,source=mock_v1,status=mocked"],
+        )
+
+    with pytest.raises(ObservationBindingError, match="Duplicate observation"):
+        _build(
+            tmp_path,
+            family_specs=[DA3_ESAM_SPEC],
+            observations=[
+                "candidate_family=materials_v3_da3_efficientsam_apex,source=mock_v1,status=mocked",
+                "candidate_family=materials_v3_da3_efficientsam_apex,source=mock_v1,status=mocked",
+            ],
+        )
+
+
+def test_depth_pro_license_blocked_and_research_only(tmp_path: Path) -> None:
+    blocked = _build(tmp_path, family_specs=[DEPTHPRO_SAM2_SPEC])
+    assert blocked["families"][0]["governance"]["status"] == "license_blocked"
+    assert blocked["families"][0]["comparable"] is False
+
+    research = build_apex_model_family_characterization_report(
+        family_specs=[DEPTHPRO_SAM2_SPEC],
+        output_path=tmp_path / "research.json",
+        non_commercial_ok=True,
+        accept_depth_pro_license=True,
+    )
+    assert research["families"][0]["governance"]["status"] == "research_only"
+
+
+def test_not_run_fallback_used_is_null(tmp_path: Path) -> None:
+    report = _build(tmp_path, family_specs=[DA3_ESAM_SPEC])
+
+    assert report["families"][0]["observation"]["status"] == "not_run"
+    assert report["families"][0]["observation"]["fallback_used"] is None
+
+
+def test_mock_observation_records_comparable_summary(tmp_path: Path) -> None:
+    report = _build(
+        tmp_path,
+        family_specs=[DA3_ESAM_SPEC],
+        observations=[
+            "candidate_family=materials_v3_da3_efficientsam_apex,source=mock_v1,status=mocked,fallback_used=false,runtime_ms=1234,promotion_verdict=eligible,metric_contract=apex_metrics.v1,mask_evidence_status=ok"
+        ],
+    )
+
+    row = report["families"][0]
+    assert row["comparable"] is True
+    assert row["comparison_blockers"] == []
+    assert row["observation"]["fallback_used"] is False
+    assert row["observation"]["runtime_ms"] == pytest.approx(1234.0)
+    assert row["observation"]["promotion_verdict"] == "eligible"
+    assert row["observation"]["metric_contract"] == "apex_metrics.v1"
+    assert row["observation"]["mask_evidence_status"] == "ok"
+
+
+def test_redacted_summary_required_keys_and_unknown_keys_rejected(tmp_path: Path) -> None:
+    missing = tmp_path / "summary.json"
+    missing.write_text(json.dumps({"schema_version": "apex_redacted_summary.v1"}), encoding="utf-8")
+    unknown = tmp_path / "unknown.json"
+    payload = json.loads(VALID_SUMMARY.read_text(encoding="utf-8"))
+    payload["unexpected"] = "value"
+    unknown.write_text(json.dumps(payload), encoding="utf-8")
+
+    for path in (missing, unknown):
+        with pytest.raises(ValueError):
+            _build(
+                tmp_path,
+                family_specs=[DA3_ESAM_SPEC],
+                redacted_summaries=[f"candidate_family=materials_v3_da3_efficientsam_apex,path={path}"],
+            )
+
+
+def test_redacted_summary_rejects_path_like_values_and_raw_artifacts(tmp_path: Path) -> None:
+    path_like = tmp_path / "path_like_summary.json"
+    payload = json.loads(VALID_SUMMARY.read_text(encoding="utf-8"))
+    payload["promotion_verdict"] = "/Users/example/output/file.tif"
+    path_like.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="path-like"):
+        _build(
+            tmp_path,
+            family_specs=[DA3_ESAM_SPEC],
+            redacted_summaries=[f"candidate_family=materials_v3_da3_efficientsam_apex,path={path_like}"],
+        )
+
+    for raw_path in (RAW_RUN_CARD, RAW_BATCH):
+        with pytest.raises(ValueError, match="raw artifact"):
+            _build(
+                tmp_path,
+                family_specs=[DA3_ESAM_SPEC],
+                redacted_summaries=[f"candidate_family=materials_v3_da3_efficientsam_apex,path={raw_path}"],
+            )
+
+
+def test_redacted_summary_with_exif_rejected(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="unsupported field"):
+        _build(
+            tmp_path,
+            family_specs=[DA3_ESAM_SPEC],
+            redacted_summaries=[f"candidate_family=materials_v3_da3_efficientsam_apex,path={INVALID_EXIF_SUMMARY}"],
+        )
+
+
+def test_redacted_summary_observed_local_and_digest_includes_summary_hash(tmp_path: Path) -> None:
+    first = _build(
+        tmp_path,
+        family_specs=[DA3_ESAM_SPEC],
+        redacted_summaries=[f"candidate_family=materials_v3_da3_efficientsam_apex,path={VALID_SUMMARY}"],
+    )
+    changed = tmp_path / "changed_summary.json"
+    payload = json.loads(VALID_SUMMARY.read_text(encoding="utf-8"))
+    payload["runtime_ms"] = 9999.0
+    changed.write_text(json.dumps(payload), encoding="utf-8")
+    second = build_apex_model_family_characterization_report(
+        family_specs=[DA3_ESAM_SPEC],
+        redacted_summaries=[f"candidate_family=materials_v3_da3_efficientsam_apex,path={changed}"],
+        output_path=tmp_path / "second.json",
+    )
+
+    row = first["families"][0]
+    assert row["observation"]["status"] == "observed_local"
+    assert row["observation"]["source"] == "redacted_summary_v1"
+    assert row["observation"]["evidence_ref"]["summary_schema_version"] == "apex_redacted_summary.v1"
+    assert first["input_digest"]["sha256"] != second["input_digest"]["sha256"]
+
+
+def test_input_digest_stable_under_key_reordering_and_excludes_now(tmp_path: Path) -> None:
+    spec_a = {
+        "depth_backend": "da3",
+        "segmentation_backend": "efficientsam",
+        "quality_tier": "apex",
+        "pbr_enabled": False,
+        "v2_enabled": False,
+    }
+    spec_b = {
+        "v2_enabled": False,
+        "pbr_enabled": False,
+        "quality_tier": "apex",
+        "segmentation_backend": "efficientsam",
+        "depth_backend": "da3",
+    }
+    first = build_apex_model_family_characterization_report(
+        family_specs=[spec_a],
+        output_path=tmp_path / "first.json",
+        created_at="2026-04-25T00:00:00Z",
+    )
+    second = build_apex_model_family_characterization_report(
+        family_specs=[spec_b],
+        output_path=tmp_path / "second.json",
+        created_at="2026-04-26T00:00:00Z",
+    )
+
+    assert first["input_digest"]["sha256"] == second["input_digest"]["sha256"]
+
+
+def test_comparison_groups_require_two_members_and_closed_reasons(tmp_path: Path) -> None:
+    report = _build(
+        tmp_path,
+        family_specs=[DA3_ESAM_SPEC, DA3_SAM2_SPEC],
+        observations=["candidate_family=materials_v3_da3_efficientsam_apex,source=mock_v1,status=mocked"],
+    )
+
+    groups = report["comparison_groups"]
+    assert groups
+    for group in groups:
+        assert set(group["blocking_reasons"]) <= {"only_one_member", "member_not_comparable"}
+    segmentation_groups = [group for group in groups if group["axis"] == "segmentation_axis"]
+    assert any(len(group["members"]) >= 2 and not group["comparable"] for group in segmentation_groups)
+
+
+def test_self_check_reconciliation_counts(tmp_path: Path) -> None:
+    report = _build(tmp_path, family_specs=[DA3_ESAM_SPEC, DEPTHPRO_SAM2_SPEC])
+
+    assert report["self_check"] == {"status": "ok", "failures": []}
+    summary = report["summary"]
+    assert summary["family_count"] == 2
+    assert summary["spec_valid_count"] + summary["spec_invalid_count"] == summary["family_count"]
+    assert summary["not_run_count"] == 2
+    assert summary["license_blocked_count"] == 1
+
+
+def test_markdown_output_byte_stable_with_fixed_now(tmp_path: Path) -> None:
+    first_path = tmp_path / "first.md"
+    second_path = tmp_path / "second.md"
+    kwargs = {
+        "family_specs": [DA3_SAM2_SPEC, DA3_ESAM_SPEC],
+        "output_format": "markdown",
+        "created_at": "2026-04-25T00:00:00Z",
+    }
+    build_apex_model_family_characterization_report(output_path=first_path, **kwargs)
+    build_apex_model_family_characterization_report(output_path=second_path, **kwargs)
+
+    assert hashlib.sha256(first_path.read_bytes()).hexdigest() == hashlib.sha256(second_path.read_bytes()).hexdigest()
+    assert first_path.read_text(encoding="utf-8").endswith("\n")
+
+
+def test_now_format_rejects_offsets_and_fractional_seconds(tmp_path: Path) -> None:
+    for bad_now in ("2026-04-25T00:00:00+00:00", "2026-04-25T00:00:00.000Z"):
+        with pytest.raises(ValueError, match="UTC format"):
+            build_apex_model_family_characterization_report(
+                family_specs=[DA3_ESAM_SPEC],
+                output_path=tmp_path / "report.json",
+                created_at=bad_now,
+            )
+
+
+def test_cli_exit_codes_and_invalid_allow_flags(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+    module = _load_tool_module("characterize_apex_model_families.py", "characterize_apex_model_families_exit_unit")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "characterize_apex_model_families.py",
+            "--family",
+            "candidate_family=bad_name,depth_backend=da3,segmentation_backend=efficientsam,quality_tier=apex",
+            "--output",
+            str(tmp_path / "report.json"),
+        ],
+    )
+
+    assert module.main() == 2
+    assert "spec validation failed" in capsys.readouterr().err
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "characterize_apex_model_families.py",
+            "--family",
+            DA3_ESAM_SPEC,
+            "--redacted-summary",
+            f"candidate_family=materials_v3_da3_efficientsam_apex,path={RAW_RUN_CARD}",
+            "--output",
+            str(tmp_path / "report2.json"),
+        ],
+    )
+    assert module.main() == 3
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "characterize_apex_model_families.py",
+            "--family",
+            DA3_ESAM_SPEC,
+            "--redacted-summary",
+            "candidate_family=missing_family,path=missing.json",
+            "--output",
+            str(tmp_path / "report3.json"),
+            "--allow-observation-invalid",
+            "on",
+        ],
+    )
+    assert module.main() == 4
+
+
+def test_exit_code_5_overrides_allow_invalid_flags(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_tool_module("characterize_apex_model_families.py", "characterize_apex_model_families_self_check_unit")
+
+    def fake_builder(**_kwargs):
+        return {
+            "families": [],
+            "self_check": {"status": "failed", "failures": [{"invariant": "forced"}]},
+        }
+
+    monkeypatch.setattr(module, "build_apex_model_family_characterization_report", fake_builder)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "characterize_apex_model_families.py",
+            "--family",
+            DA3_ESAM_SPEC,
+            "--output",
+            str(tmp_path / "report.json"),
+            "--allow-spec-invalid",
+            "on",
+            "--allow-observation-invalid",
+            "on",
+        ],
+    )
+
+    assert module.main() == 5
+
+
+def test_cli_family_file_command_writes_report(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_tool_module("characterize_apex_model_families.py", "characterize_apex_model_families_file_unit")
+    output = tmp_path / "report.json"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "characterize_apex_model_families.py",
+            "--family-file",
+            str(REPO_ROOT / "config" / "apex_family_matrix.json"),
+            "--non-commercial-ok",
+            "off",
+            "--accept-depth-pro-license",
+            "off",
+            "--output",
+            str(output),
+            "--now",
+            "2026-04-25T00:00:00Z",
+        ],
+    )
+
+    assert module.main() == 0
+    report = json.loads(output.read_text(encoding="utf-8"))
+    assert report["schema_version"] == REPORT_SCHEMA_VERSION
+    assert report["summary"]["family_count"] == 4
+
+
+def test_static_ast_import_guard() -> None:
+    targets = [
+        REPO_ROOT / "src/transformation_portal/evals/apex_model_family.py",
+        REPO_ROOT / "src/transformation_portal/evals/apex_model_family_schema.py",
+        REPO_ROOT / "src/transformation_portal/evals/apex_redacted_summary_schema.py",
+        REPO_ROOT / "tools/characterize_apex_model_families.py",
+    ]
+    allowed_project_imports = {
+        "transformation_portal.evals.apex_model_family",
+        "transformation_portal.evals.apex_model_family_schema",
+        "transformation_portal.evals.apex_redacted_summary_schema",
+    }
+    forbidden_prefixes = (
+        "transformation_portal.depth",
+        "transformation_portal.segmentation",
+        "transformation_portal.candidates",
+        "transformation_portal.runners",
+        "torch",
+        "tensorflow",
+        "onnxruntime",
+        "transformers",
+        "diffusers",
+        "requests",
+        "httpx",
+        "urllib",
+        "urllib3",
+        "socket",
+        "ssl",
+        "http",
+        "ftplib",
+        "smtplib",
+        "telnetlib",
+        "xmlrpc",
+        "boto3",
+        "google.cloud",
+        "subprocess",
+    )
+    violations = []
+    for path in targets:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            names = []
+            if isinstance(node, ast.Import):
+                names = [alias.name for alias in node.names]
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                names = [node.module]
+            for name in names:
+                if name.startswith("transformation_portal.") and name not in allowed_project_imports:
+                    violations.append(f"{path.name}: disallowed project import {name}")
+                if name.startswith(forbidden_prefixes):
+                    violations.append(f"{path.name}: forbidden import {name}")
+    assert not violations
+
+
+def test_filesystem_guard_reads_only_declared_inputs_and_writes_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    opened = []
+    original_open = Path.open
+
+    def recording_open(self, *args, **kwargs):
+        opened.append((Path(self), args[0] if args else kwargs.get("mode", "r")))
+        return original_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", recording_open)
+    output = tmp_path / "report.json"
+    build_apex_model_family_characterization_report(
+        family_specs=[DA3_ESAM_SPEC],
+        redacted_summaries=[f"candidate_family=materials_v3_da3_efficientsam_apex,path={VALID_SUMMARY}"],
+        output_path=output,
+    )
+
+    read_paths = {path for path, mode in opened if "r" in str(mode)}
+    write_paths = {path for path, mode in opened if "w" in str(mode)}
+    assert read_paths == {VALID_SUMMARY}
+    assert write_paths == {output}
+
+
+def test_canonical_json_bytes_is_key_order_stable() -> None:
+    assert canonical_json_bytes({"b": 1, "a": 2}) == canonical_json_bytes({"a": 2, "b": 1})

--- a/tools/characterize_apex_model_families.py
+++ b/tools/characterize_apex_model_families.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Emit an offline APEX model-family characterization matrix."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from transformation_portal.evals.apex_model_family import (
+    DuplicateFamilyError,
+    ObservationBindingError,
+    ObservationValidationError,
+    ReconciliationError,
+    build_apex_model_family_characterization_report,
+    collect_family_specs,
+    validate_now,
+)
+
+EXIT_SPEC_INVALID = 2
+EXIT_OBSERVATION_INVALID = 3
+EXIT_BINDING_INVALID = 4
+EXIT_SELF_CHECK_FAILED = 5
+EXIT_USAGE = 64
+
+
+class CharacterizationArgumentParser(argparse.ArgumentParser):
+    def error(self, message: str) -> None:
+        self.print_usage(sys.stderr)
+        self.exit(EXIT_USAGE, f"{self.prog}: error: {message}\n")
+
+
+def _bool_flag(value: str) -> bool:
+    normalized = value.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    raise argparse.ArgumentTypeError(f"Expected boolean-like value, got {value!r}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = CharacterizationArgumentParser(
+        description=(
+            "Emit a declarative, offline-only APEX model-family characterization matrix. "
+            "This command does not run models or read raw evidence artifacts."
+        )
+    )
+    parser.add_argument("--family", action="append", default=[], help="Explicit comma-separated family key=value spec.")
+    parser.add_argument("--matrix", action="append", default=[], help="Semicolon-separated matrix key=value spec.")
+    parser.add_argument("--family-file", action="append", default=[], help="JSON apex_family_matrix.v1 spec file.")
+    parser.add_argument("--observation", action="append", default=[], help="Mock observation bound by candidate_family.")
+    parser.add_argument("--redacted-summary", action="append", default=[], help="Redacted summary binding: candidate_family=...,path=...")
+    parser.add_argument("--format", choices=("json", "markdown"), default="json")
+    parser.add_argument("--now", default="1970-01-01T00:00:00Z", help="UTC timestamp YYYY-MM-DDTHH:MM:SSZ.")
+    parser.add_argument("--allow-spec-invalid", type=_bool_flag, default=False)
+    parser.add_argument("--allow-observation-invalid", type=_bool_flag, default=False)
+    parser.add_argument("--non-commercial-ok", type=_bool_flag, default=None)
+    parser.add_argument("--accept-depth-pro-license", type=_bool_flag, default=None)
+    parser.add_argument("--output", required=True, help="Output report path.")
+    return parser
+
+
+def _print_error(message: str) -> None:
+    print(f"APEX model-family characterization error: {message}", file=sys.stderr)
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    try:
+        validate_now(args.now)
+    except ValueError as exc:
+        _print_error(str(exc))
+        return EXIT_USAGE
+
+    if not (args.family or args.matrix or args.family_file):
+        _print_error("at least one of --family, --matrix, or --family-file is required")
+        return EXIT_USAGE
+
+    try:
+        specs, file_governance = collect_family_specs(
+            families=args.family,
+            matrices=args.matrix,
+            family_files=[Path(path) for path in args.family_file],
+        )
+        non_commercial_ok = (
+            bool(args.non_commercial_ok)
+            if args.non_commercial_ok is not None
+            else bool(file_governance.get("non_commercial_ok", False))
+        )
+        accept_depth_pro_license = (
+            bool(args.accept_depth_pro_license)
+            if args.accept_depth_pro_license is not None
+            else bool(file_governance.get("accept_depth_pro_license", False))
+        )
+        report = build_apex_model_family_characterization_report(
+            family_specs=specs,
+            observations=args.observation,
+            redacted_summaries=args.redacted_summary,
+            output_path=Path(args.output),
+            non_commercial_ok=non_commercial_ok,
+            accept_depth_pro_license=accept_depth_pro_license,
+            output_format=args.format,
+            created_at=args.now,
+            allow_observation_invalid=args.allow_observation_invalid,
+        )
+    except DuplicateFamilyError as exc:
+        _print_error(str(exc))
+        return EXIT_BINDING_INVALID
+    except ObservationBindingError as exc:
+        _print_error(str(exc))
+        return EXIT_BINDING_INVALID
+    except ObservationValidationError as exc:
+        _print_error(str(exc))
+        return EXIT_OBSERVATION_INVALID
+    except ReconciliationError as exc:
+        _print_error(str(exc))
+        return EXIT_SELF_CHECK_FAILED
+    except (OSError, ValueError) as exc:
+        _print_error(str(exc))
+        return EXIT_USAGE
+
+    spec_failures = [
+        row["family_spec"]["candidate_family"]
+        for row in report["families"]
+        if row["spec_validation"]["status"] != "ok"
+    ]
+    if spec_failures and not args.allow_spec_invalid:
+        _print_error("spec validation failed for: " + ", ".join(spec_failures))
+        return EXIT_SPEC_INVALID
+    if report["self_check"]["status"] != "ok":
+        _print_error("self-check failed")
+        return EXIT_SELF_CHECK_FAILED
+
+    print(args.output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Adds an offline-only APEX model-family characterization matrix and CLI.
- Keeps characterization declarative: no model execution, no raw artifact ingestion, no candidate runner imports, no run_apex_eval.py calls, no evidence schema mutation, and no threshold tuning.

## Changes
- Adds centralized schema constants and typed report construction for `apex_model_family_characterization_report.v1`, `apex_redacted_summary.v1`, `apex_family_matrix.v1`, and `input_digest.v1`.
- Adds explicit, matrix, and JSON family-file CLI modes for `tools/characterize_apex_model_families.py`.
- Enforces canonical family naming as `materials_v{N}_{depth}_{seg}_{quality_tier}[_pbr][_v2]`.
- Separates `spec_validation`, `governance`, and `observation` status axes with derived comparability and comparison groups.
- Adds strict redacted-summary validation with allowlisted keys, source evidence hash requirements, raw artifact rejection, path-like value rejection, and metadata leakage guards.
- Adds default safe matrix config and protocol docs.

## Validation
Proven green:
- `.venv/bin/pytest -q tests/evals/test_apex_model_family_characterization.py` -> 25 passed
- `.venv/bin/pytest -q tests/evals/test_apex_visual.py -k "depth_backend_benchmark or model_family"` -> 2 passed, 52 deselected
- `.venv/bin/pytest -q tests/evals/test_apex_docs_commands.py` -> 7 passed
- `.venv/bin/python tools/characterize_apex_model_families.py --help` -> passed
- `.venv/bin/python tools/characterize_apex_model_families.py --family-file config/apex_family_matrix.json --non-commercial-ok off --accept-depth-pro-license off --output output/apex_model_family_characterization_report.json --now 2026-04-25T00:00:00Z` -> passed
- `make test-fast` -> 73 passed
- Research-mode report check -> Depth Pro rows become `research_only`, remain `not_run`, and remain `comparable: false`
- Deterministic JSON check -> repeated fixed-`--now` outputs matched with `cmp`
- Commit pre-commit hooks -> passed

Still failing:
- None known.

## Risk
- Bounded to an additive offline reporting layer and safe fixtures.
- Generated reports remain under ignored `output/` and are not committed.
- Real evidence artifacts, TIFFs, masks, arrays, run cards, batch files, combined/provenance JSON, and metadata-bearing outputs remain out of scope.
- Revert-safe: no existing APEX evidence schemas, candidate runners, depth gates, Materials V3 thresholds, or `tools/run_apex_eval.py` behavior changed.