### PR TITLE
chore(ci): harden workflows from audit findings

### DIFF
--- a/.github/workflows/apex_performance.yml
+++ b/.github/workflows/apex_performance.yml
@@ -180,7 +180,7 @@ jobs:
       - name: Download Results
         id: download_results
         continue-on-error: true
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           path: apex_downloaded_results
           pattern: apex-results-*
@@ -357,7 +357,7 @@ jobs:
           pip install -e .
 
       - name: Download Ledger
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: apex-ledger
 

--- a/.github/workflows/ci-quality-firewall.yml
+++ b/.github/workflows/ci-quality-firewall.yml
@@ -201,8 +201,13 @@ jobs:
           set -euo pipefail
 
           # Install only the gitleaks binary to avoid scanning extracted archive docs/examples.
-          archive="gitleaks_8.21.2_linux_x64.tar.gz"
-          wget -q "https://github.com/gitleaks/gitleaks/releases/download/v8.21.2/${archive}"
+          # SHA256 pinned to the upstream gitleaks_8.21.2_checksums.txt entry; rejecting a
+          # mismatched download keeps a hijacked release asset out of the secret-scan path.
+          GITLEAKS_VERSION="8.21.2"
+          GITLEAKS_SHA256="5bc41815076e6ed6ef8fbecc9d9b75bcae31f39029ceb55da08086315316e3ba"
+          archive="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          wget -q "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${archive}"
+          echo "${GITLEAKS_SHA256}  ${archive}" | sha256sum -c -
           tar -xzf "${archive}" gitleaks
           chmod +x gitleaks
           mkdir -p "${RUNNER_TEMP}/gitleaks-bin"

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -22,12 +22,14 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: write  # Required to submit dependencies to the dependency graph
+  contents: read
 
 jobs:
   submit-pypi:
     name: Submit Python Dependencies
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Required to submit dependencies to the dependency graph
 
     steps:
       - name: Maximize available disk space

--- a/.github/workflows/determinism-cross-isa.yml
+++ b/.github/workflows/determinism-cross-isa.yml
@@ -31,7 +31,7 @@ jobs:
       artifact_id: ${{ steps.capture.outputs.artifact_id }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Install system compiler toolchain
         run: |
@@ -86,7 +86,7 @@ jobs:
           PY
 
       - name: Upload harness report
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.0
         with:
           name: harness-report-x86_64
           path: run_result.json
@@ -101,7 +101,7 @@ jobs:
       artifact_id: ${{ steps.capture.outputs.artifact_id }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Install system compiler toolchain
         run: |
@@ -155,7 +155,7 @@ jobs:
           PY
 
       - name: Upload harness report
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.0
         with:
           name: harness-report-arm64
           path: run_result.json
@@ -169,7 +169,7 @@ jobs:
       - candidate-arm
     steps:
       - name: Download harness reports
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           pattern: harness-report-*
           merge-multiple: true

--- a/.github/workflows/determinism-gate.yml
+++ b/.github/workflows/determinism-gate.yml
@@ -18,11 +18,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Setup Python 3.11
         id: setup-python-311
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.11"
 
@@ -150,7 +150,7 @@ jobs:
 
       - name: Setup Python 3.12
         id: setup-python-312
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/diagnostic-trial.yml
+++ b/.github/workflows/diagnostic-trial.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Setup Python 3.11
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.11"
 
@@ -178,7 +178,7 @@ jobs:
 
       - name: Upload trial outputs on failure
         if: failure()
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.0
         with:
           name: diagnostic-trial-outputs
           path: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,10 +33,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: '3.12'
           cache: 'pip'
@@ -69,7 +69,7 @@ jobs:
           fi
 
       - name: Upload documentation artifact
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.0
         with:
           name: api-documentation
           path: docs/api/_build/html
@@ -80,7 +80,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Check markdown files exist
         run: |
@@ -98,33 +98,13 @@ jobs:
           fi
           echo "✅ Basic markdown validation complete"
 
-  validate-links:
-    name: Validate Documentation Links
-    runs-on: ubuntu-latest
-    needs: build-docs
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Download documentation
-        uses: actions/download-artifact@v8.0.1
-        with:
-          name: api-documentation
-          path: docs/api/_build/html
-
-      - name: Check for broken links
-        run: |
-          echo "✓ Link validation passed (placeholder)"
-          # Future: Add linkchecker or similar tool
-
   update-navigation:
     name: Verify Navigation Links
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Check README links
         run: |

--- a/.github/workflows/evalsuite_contract_validation.yml
+++ b/.github/workflows/evalsuite_contract_validation.yml
@@ -51,10 +51,10 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.11"
           cache: "pip"

--- a/.github/workflows/machine_mode_contract_validation.yml
+++ b/.github/workflows/machine_mode_contract_validation.yml
@@ -52,10 +52,10 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.11"
           cache: "pip"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -106,7 +106,8 @@ jobs:
             echo "baseline_file=$FIRST_BASELINE_FILE" >> "$GITHUB_OUTPUT"
             echo "has_baseline=true" >> "$GITHUB_OUTPUT"
           else
-            echo "No benchmark baseline file found; regression comparison will be skipped."
+            echo "::warning::No benchmark baseline file found at tools/benchmarks/baseline.json or tests/benchmarks/baselines/*.json — perf regression comparison will be skipped"
+            echo "⚠️ Perf regression comparison skipped: no baseline file present" >> "$GITHUB_STEP_SUMMARY"
             echo "has_baseline=false" >> "$GITHUB_OUTPUT"
           fi
 

--- a/.github/workflows/security-unified.yml
+++ b/.github/workflows/security-unified.yml
@@ -9,7 +9,9 @@ name: Security Unified
 on:
   schedule:
     - cron: '0 6 * * *'
-    - cron: '27 22 * * 2'
+    # Staggered 20 minutes after codeql.yml (27 22 * * 2) to avoid a Tuesday-night runner
+    # contention spike when both security workflows fire at the same minute.
+    - cron: '47 22 * * 2'
 
   push:
     branches: [main]

--- a/.github/workflows/tag_retention_prune_preservation_tags.yml
+++ b/.github/workflows/tag_retention_prune_preservation_tags.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           fetch-depth: 0
 

--- a/tests/structural/test_gitleaks_hook_registered.py
+++ b/tests/structural/test_gitleaks_hook_registered.py
@@ -12,6 +12,7 @@ is cheap and runs in Layer 1.
 from __future__ import annotations
 
 import re
+import sys
 from pathlib import Path
 from typing import List, Tuple
 
@@ -76,8 +77,21 @@ def _ci_gitleaks_pin() -> str:
     body = CI_FIREWALL_WORKFLOW.read_text(encoding="utf-8")
     # Search for the pinned archive name, e.g. gitleaks_8.21.2_linux_x64.tar.gz.
     match = re.search(r"gitleaks_(\d+\.\d+\.\d+)_linux_x64\.tar\.gz", body)
-    assert match, "could not locate gitleaks archive pin in ci-quality-firewall.yml"
-    return f"v{match.group(1)}"
+    if match:
+        return f"v{match.group(1)}"
+
+    # The hardened workflow keeps the version in one explicit shell variable and
+    # derives the archive name and release URL from that value before verifying a
+    # SHA256 pin. Accept that shape without weakening local/CI version parity.
+    version_match = re.search(r"GITLEAKS_VERSION=[\"'](\d+\.\d+\.\d+)[\"']", body)
+    assert version_match, "could not locate gitleaks archive pin in ci-quality-firewall.yml"
+    assert (
+        'archive="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"' in body
+    ), "ci-quality-firewall.yml must derive the gitleaks archive name from GITLEAKS_VERSION"
+    assert (
+        "releases/download/v${GITLEAKS_VERSION}/${archive}" in body
+    ), "ci-quality-firewall.yml must derive the gitleaks release URL from GITLEAKS_VERSION"
+    return f"v{version_match.group(1)}"
 
 
 def test_gitleaks_hook_registered() -> None:
@@ -119,6 +133,21 @@ def test_gitleaks_hook_rev_matches_ci_pin() -> None:
         f"gitleaks hook rev ({rev!r}) must match the CI archive pin ({expected!r}) "
         "so local and CI produce the same verdict."
     )
+
+
+def test_ci_gitleaks_pin_accepts_version_variable_archive(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    workflow = tmp_path / "ci-quality-firewall.yml"
+    workflow.write_text(
+        """
+          GITLEAKS_VERSION="8.21.2"
+          archive="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          wget -q "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${archive}"
+        """,
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(sys.modules[__name__], "CI_FIREWALL_WORKFLOW", workflow)
+
+    assert _ci_gitleaks_pin() == "v8.21.2"
 
 
 def test_gitleaks_hook_args_match_ci_invocation() -> None:


### PR DESCRIPTION
## Summary

Audit of `.github/workflows/` (30 YAML files) surfaced inconsistencies and risks where ~8 newer/secondary workflows had drifted from the SHA-pinning + tight-permissions baseline used by the rest of the suite. This PR realigns them and addresses a few unrelated findings from the same audit.

- **Pin floating action tags to commit SHAs** across 8 workflows (`actions/checkout@v6`, `actions/setup-python@v6`, `actions/upload-artifact@v7.0.0`, `actions/download-artifact@v8.0.1` → SHA pins already canonical elsewhere in this repo).
- **Verify gitleaks 8.21.2 binary** against its upstream SHA256 in `ci-quality-firewall.yml` before unpacking, so a hijacked release asset can't reach the secret-scan path.
- **Stagger Tuesday cron collision** — `security-unified.yml` moved from `27 22 * * 2` to `47 22 * * 2` (20-min gap from `codeql.yml`).
- **Drop `validate-links` job** in `docs.yml` whose only step was `echo "✓ Link validation passed (placeholder)"` — an always-pass stub masking the absence of a real link checker.
- **Promote silent baseline-skip to `::warning::`** in `nightly.yml` so a missing perf baseline is visible in step summary instead of silently disabling regression comparison.
- **Tighten `dependency-submission.yml` permissions** by moving `contents: write` from workflow root to the single job that needs it.

Findings explicitly verified as false positives (no change made): the `pull_request` (not `pull_request_target`) checkout in `ingest_contract_validation.yml`; the `dependency-update.yml` token (actively used to open PRs immediately after); the `apex_performance.yml` interpolation (only `pr.number` and `repository`, both controlled values).

## Test plan

- [x] `make validate-ci` passes locally (workflow syntax, concurrency contract, gitleaks contract, dependency-update contract, dependabot contract — all 5 green)
- [x] `pre-commit run --files <12 changed files>` passes (incl. gitleaks scan; embedded SHA256 does not false-positive)
- [x] All 30 `.github/workflows/*.yml` parse via `yaml.safe_load`
- [x] `grep -rnE 'uses:.*@v[0-9]+(\.[0-9]+)*\s*$' .github/workflows/*.yml` returns no hits
- [x] Only `codeql.yml` retains the `27 22 * * 2` cron after the stagger
- [ ] CI on this PR — first end-to-end run on GitHub runners for: pinned action SHA resolution, the new `sha256sum -c -` verification step, and the job-level `contents: write` override

https://claude.ai/code/session_01JAUUqhURukXm7Pyf5jmuuD

---
_Generated by [Claude Code](https://claude.ai/code/session_01JAUUqhURukXm7Pyf5jmuuD)_