### PR TITLE
fix(archive-gate): preflight fixity index roots

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+import csv
+import gzip
 import hashlib
 import hmac
 import json
@@ -1229,6 +1231,8 @@ ARCHIVE_GATE_ALLOWED_COMMANDS = {
     "archive-gate-b": {"bag-build", "bag-validate", "dedup-plan"},
     "archive-gate-c": {"mets-export", "prov-export", "stac-export"},
 }
+ARCHIVE_INDEX_REQUIRED_COLUMNS = {"origin_drive", "partition", "relpath"}
+ARCHIVE_INDEX_PREFLIGHT_EXAMPLE_LIMIT = 5
 ALLOWED_QUALITY = {"standard", "premium", "apex"}
 ALLOWED_BACKENDS = {"da3", "depth_pro"}
 ALLOWED_DEPTH_DEVICES = {"cpu", "cuda", "mps"}
@@ -1273,6 +1277,7 @@ VALIDATION_REASON_CODES = {
     "Invalid archive integer option": "invalid_archive_integer_option",
 }
 PORTAL_SAFE_ERROR_MESSAGES = {
+    "archive_index_root_mismatch": "Archive index rows must resolve under the selected archive root.",
     "archive_index_required": "An archive index artifact is required before dispatch.",
     "archive_runner_unavailable": "The selected archive command is unavailable in this environment.",
     "bag_dir_required": "A bag directory is required before dispatch.",
@@ -1714,6 +1719,242 @@ def _validate_existing_path(
     return resolved, None
 
 
+def _archive_index_preflight_example(
+    *,
+    row: int,
+    relpath: str,
+    reason: str,
+) -> Dict[str, Any]:
+    return {
+        "row": row,
+        "relpath": relpath,
+        "reason": reason,
+    }
+
+
+def _archive_index_preflight_result(
+    *,
+    rows_total: int,
+    blocked_rows: int,
+    examples: List[Dict[str, Any]],
+) -> Dict[str, Any]:
+    return {
+        "ok": blocked_rows == 0 and rows_total > 0,
+        "rows_total": rows_total,
+        "blocked_rows": blocked_rows,
+        "examples": examples[:ARCHIVE_INDEX_PREFLIGHT_EXAMPLE_LIMIT],
+    }
+
+
+def _archive_index_preflight_message(result: Mapping[str, Any]) -> str:
+    rows_total = int(result.get("rows_total") or 0)
+    blocked_rows = int(result.get("blocked_rows") or 0)
+    examples = result.get("examples") if isinstance(result.get("examples"), list) else []
+    example_text = "; ".join(
+        f"row {item.get('row')}: {item.get('relpath')!r} ({item.get('reason')})"
+        for item in examples[:ARCHIVE_INDEX_PREFLIGHT_EXAMPLE_LIMIT]
+        if isinstance(item, Mapping)
+    )
+    if not example_text:
+        example_text = "no valid archive index rows found"
+    if rows_total == 0:
+        return (
+            "Archive index does not match the selected archive root: "
+            f"{blocked_rows} blocking issue before row validation. Examples: {example_text}."
+        )
+    return (
+        "Archive index does not match the selected archive root: "
+        f"{blocked_rows}/{rows_total} rows blocked. Examples: {example_text}."
+    )
+
+
+def _is_drive_prefixed_relpath(raw_relpath: str) -> bool:
+    return bool(re.match(r"^[A-Za-z]:", raw_relpath))
+
+
+def _validate_archive_index_relpath(
+    raw_relpath: Any,
+    *,
+    archive_root: Path,
+) -> Tuple[bool, str, str]:
+    relpath = str(raw_relpath or "").strip()
+    if not relpath:
+        return False, relpath, "empty_relpath"
+    if "\x00" in relpath:
+        return False, relpath, "nul_relpath"
+    if relpath.startswith(("/", "\\")):
+        return False, relpath, "absolute_relpath"
+    if _is_drive_prefixed_relpath(relpath):
+        return False, relpath, "drive_prefixed_relpath"
+
+    normalized = relpath.replace("\\", "/")
+    parts = tuple(part for part in normalized.split("/") if part and part != ".")
+    if not parts:
+        return False, relpath, "empty_relpath"
+    if any(part == ".." for part in parts):
+        return False, relpath, "parent_traversal"
+
+    target = archive_root.joinpath(*parts)
+    try:
+        target_real = Path(os.path.realpath(target))
+        target_real.relative_to(archive_root)
+    except (OSError, RuntimeError, ValueError):
+        return False, relpath, "outside_archive_root"
+
+    current = archive_root
+    for part in parts:
+        current = current / part
+        try:
+            current.lstat()
+        except FileNotFoundError:
+            return False, relpath, "missing"
+        except (OSError, RuntimeError):
+            return False, relpath, "unreadable"
+        if current.is_symlink():
+            return False, relpath, "symlink_traversal"
+
+    try:
+        if current.is_dir():
+            return False, relpath, "directory"
+        if not current.is_file():
+            return False, relpath, "not_regular_file"
+    except (OSError, RuntimeError):
+        return False, relpath, "unreadable"
+
+    return True, relpath, "ok"
+
+
+def _validate_archive_index_against_root(
+    archive_index: Path,
+    archive_root: Path,
+) -> Dict[str, Any]:
+    try:
+        archive_root_real = Path(os.path.realpath(archive_root))
+    except (OSError, RuntimeError, ValueError):
+        return _archive_index_preflight_result(
+            rows_total=0,
+            blocked_rows=1,
+            examples=[
+                _archive_index_preflight_example(
+                    row=0,
+                    relpath=str(archive_root),
+                    reason="archive_root_invalid",
+                )
+            ],
+        )
+
+    try:
+        if archive_root_real.is_symlink():
+            return _archive_index_preflight_result(
+                rows_total=0,
+                blocked_rows=1,
+                examples=[
+                    _archive_index_preflight_example(
+                        row=0,
+                        relpath=str(archive_root),
+                        reason="archive_root_symlink",
+                    )
+                ],
+            )
+        if not archive_root_real.is_dir():
+            return _archive_index_preflight_result(
+                rows_total=0,
+                blocked_rows=1,
+                examples=[
+                    _archive_index_preflight_example(
+                        row=0,
+                        relpath=str(archive_root),
+                        reason="archive_root_not_directory",
+                    )
+                ],
+            )
+    except (OSError, RuntimeError):
+        return _archive_index_preflight_result(
+            rows_total=0,
+            blocked_rows=1,
+            examples=[
+                _archive_index_preflight_example(
+                    row=0,
+                    relpath=str(archive_root),
+                    reason="archive_root_unreadable",
+                )
+            ],
+        )
+
+    rows_total = 0
+    blocked_rows = 0
+    examples: List[Dict[str, Any]] = []
+
+    try:
+        opener: Callable[..., Any]
+        opener = gzip.open if archive_index.name.endswith(".gz") else open
+        with opener(archive_index, "rt", encoding="utf-8", newline="") as handle:
+            reader = csv.DictReader(handle)
+            fieldnames = set(reader.fieldnames or [])
+            missing_columns = sorted(ARCHIVE_INDEX_REQUIRED_COLUMNS - fieldnames)
+            if missing_columns:
+                return _archive_index_preflight_result(
+                    rows_total=0,
+                    blocked_rows=1,
+                    examples=[
+                        _archive_index_preflight_example(
+                            row=1,
+                            relpath="",
+                            reason=f"missing_columns:{','.join(missing_columns)}",
+                        )
+                    ],
+                )
+
+            for row_number, row in enumerate(reader, start=2):
+                rows_total += 1
+                ok, relpath, reason = _validate_archive_index_relpath(
+                    row.get("relpath"),
+                    archive_root=archive_root_real,
+                )
+                if ok:
+                    continue
+                blocked_rows += 1
+                if len(examples) < ARCHIVE_INDEX_PREFLIGHT_EXAMPLE_LIMIT:
+                    examples.append(
+                        _archive_index_preflight_example(
+                            row=row_number,
+                            relpath=relpath,
+                            reason=reason,
+                        )
+                    )
+    except (csv.Error, gzip.BadGzipFile, OSError, RuntimeError, UnicodeDecodeError) as exc:
+        return _archive_index_preflight_result(
+            rows_total=rows_total,
+            blocked_rows=max(1, blocked_rows),
+            examples=[
+                _archive_index_preflight_example(
+                    row=max(1, rows_total + 1),
+                    relpath=str(archive_index),
+                    reason=f"archive_index_unreadable:{type(exc).__name__}",
+                )
+            ],
+        )
+
+    if rows_total == 0:
+        return _archive_index_preflight_result(
+            rows_total=0,
+            blocked_rows=1,
+            examples=[
+                _archive_index_preflight_example(
+                    row=1,
+                    relpath="",
+                    reason="empty_archive_index",
+                )
+            ],
+        )
+
+    return _archive_index_preflight_result(
+        rows_total=rows_total,
+        blocked_rows=blocked_rows,
+        examples=examples,
+    )
+
+
 def _lux_depth_readiness(args: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     runner_available = _lux_depth_runner_available()
     canary_runtime = _resolve_lux_depth_canary_runtime()
@@ -1847,7 +2088,7 @@ def _archive_gate_readiness(
         if command == "fixity-scan":
             archive_index_value = _pick(args or {}, "archive_index", "archiveIndex", default="")
             if require_dispatch_inputs:
-                _, issue = _validate_existing_path(
+                archive_index_path, issue = _validate_existing_path(
                     archive_index_value,
                     field="archive_index",
                     allowed_roots=ALLOWED_PATH_ROOTS,
@@ -1857,6 +2098,37 @@ def _archive_gate_readiness(
                     required=True,
                 )
                 _append_issue(issue)
+                archive_root_value = _pick(
+                    args or {},
+                    "archive_root",
+                    "archiveRoot",
+                    default=_pick(args or {}, "input_dir", "inputDir", default=""),
+                )
+                archive_root_path, archive_root_issue = _validate_existing_path(
+                    archive_root_value,
+                    field="archive_root",
+                    allowed_roots=ALLOWED_INPUT_ROOTS,
+                    missing_reason="input_dir_required",
+                    missing_message="Provide an existing archive root before dispatch.",
+                    expected_type="dir",
+                    required=True,
+                )
+                _append_issue(archive_root_issue)
+                if archive_index_path and archive_root_path and issue is None and archive_root_issue is None:
+                    index_preflight = _validate_archive_index_against_root(
+                        Path(archive_index_path),
+                        Path(archive_root_path),
+                    )
+                    if not index_preflight["ok"]:
+                        issues.append(
+                            _readiness_issue(
+                                "archive_index_root_mismatch",
+                                severity="blocked",
+                                message=_archive_index_preflight_message(index_preflight),
+                                field="archive_index",
+                                path=archive_index_path,
+                            )
+                        )
             else:
                 issues.append(
                     _readiness_issue(
@@ -4392,6 +4664,51 @@ def _build_archive_config_preview(
             continue
         normalized_args[canonical_field] = parsed
 
+    archive_path_error_fields = {
+        str(item.get("field") or "")
+        for item in errors
+        if isinstance(item, Mapping)
+    }
+    if (
+        command == "fixity-scan"
+        and "archive_index" not in archive_path_error_fields
+        and "input_dir" not in archive_path_error_fields
+        and "archive_root" not in archive_path_error_fields
+    ):
+        archive_index_text = str(normalized_args.get("archive_index") or "").strip()
+        archive_root_text = str(
+            normalized_args.get("archive_root")
+            or normalized_args.get("input_dir")
+            or ""
+        ).strip()
+        if archive_index_text and archive_root_text:
+            try:
+                archive_index_path = _resolve_allowed_request_path(
+                    archive_index_text,
+                    ALLOWED_PATH_ROOTS,
+                )
+                archive_root_path = _resolve_allowed_request_path(
+                    archive_root_text,
+                    ALLOWED_INPUT_ROOTS,
+                )
+            except _PortalValidationReasonError:
+                archive_index_path = None
+                archive_root_path = None
+            if archive_index_path is not None and archive_root_path is not None:
+                index_preflight = _validate_archive_index_against_root(
+                    archive_index_path,
+                    archive_root_path,
+                )
+                if not index_preflight["ok"]:
+                    errors.append(
+                        _portal_issue(
+                            "archive_index",
+                            "archive_index_root_mismatch",
+                            _archive_index_preflight_message(index_preflight),
+                            suggestion="Rebuild the archive index from the selected archive root.",
+                        )
+                    )
+
     if readiness_snapshot is None:
         readiness_snapshot = _evaluate_pipeline_readiness(
             pipeline,
@@ -5890,13 +6207,7 @@ def _archive_gate_argv(
                 str(workers),
             ]
         )
-        strict = _pick(args, "strict")
-        if strict is not None:
-            argv.append("--strict" if _as_bool(strict) else "--no-strict")
-        strict_identity = _pick(args, "strict_identity", "strictIdentity")
-        if strict_identity is not None:
-            flag = "--strict-identity" if _as_bool(strict_identity) else "--no-strict-identity"
-            argv.append(flag)
+        argv.extend(["--strict", "--strict-identity"])
         validate_schemas = _pick(args, "validate_schemas", "validateSchemas")
         if validate_schemas is not None:
             flag = "--validate-schemas" if _as_bool(validate_schemas, default=True) else "--no-validate-schemas"

--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import csv
 import gzip
 import hashlib
@@ -1233,6 +1234,11 @@ ARCHIVE_GATE_ALLOWED_COMMANDS = {
 }
 ARCHIVE_INDEX_REQUIRED_COLUMNS = {"origin_drive", "partition", "relpath"}
 ARCHIVE_INDEX_PREFLIGHT_EXAMPLE_LIMIT = 5
+ARCHIVE_INDEX_PREFLIGHT_PREVIEW_ROW_LIMIT = 256
+ARCHIVE_INDEX_PREFLIGHT_CACHE_MAX = 64
+ARCHIVE_INDEX_PREFLIGHT_SCAN_MODES = {"preview", "full"}
+_ARCHIVE_INDEX_PREFLIGHT_CACHE_LOCK = threading.Lock()
+_ARCHIVE_INDEX_PREFLIGHT_CACHE: Dict[Tuple[str, int, int, str, str], Dict[str, Any]] = {}
 ALLOWED_QUALITY = {"standard", "premium", "apex"}
 ALLOWED_BACKENDS = {"da3", "depth_pro"}
 ALLOWED_DEPTH_DEVICES = {"cpu", "cuda", "mps"}
@@ -1737,12 +1743,16 @@ def _archive_index_preflight_result(
     rows_total: int,
     blocked_rows: int,
     examples: List[Dict[str, Any]],
+    scan_mode: str = "full",
+    truncated: bool = False,
 ) -> Dict[str, Any]:
     return {
         "ok": blocked_rows == 0 and rows_total > 0,
         "rows_total": rows_total,
         "blocked_rows": blocked_rows,
         "examples": examples[:ARCHIVE_INDEX_PREFLIGHT_EXAMPLE_LIMIT],
+        "scan_mode": scan_mode,
+        "truncated": bool(truncated),
     }
 
 
@@ -1768,8 +1778,93 @@ def _archive_index_preflight_message(result: Mapping[str, Any]) -> str:
     )
 
 
+def _archive_index_preflight_primary_reason(result: Mapping[str, Any]) -> str:
+    examples = result.get("examples") if isinstance(result.get("examples"), list) else []
+    first = examples[0] if examples and isinstance(examples[0], Mapping) else {}
+    return str(first.get("reason") or "").strip()
+
+
+def _archive_index_preflight_root_reason(result: Mapping[str, Any]) -> Optional[str]:
+    reason = _archive_index_preflight_primary_reason(result)
+    if reason.startswith("archive_root_"):
+        return reason
+    return None
+
+
 def _is_drive_prefixed_relpath(raw_relpath: str) -> bool:
     return bool(re.match(r"^[A-Za-z]:", raw_relpath))
+
+
+def _archive_index_preflight_scan_mode(scan_mode: str) -> str:
+    normalized = str(scan_mode or "full").strip().lower()
+    return normalized if normalized in ARCHIVE_INDEX_PREFLIGHT_SCAN_MODES else "full"
+
+
+def _archive_index_preflight_row_limit(scan_mode: str) -> Optional[int]:
+    if _archive_index_preflight_scan_mode(scan_mode) == "preview":
+        return ARCHIVE_INDEX_PREFLIGHT_PREVIEW_ROW_LIMIT
+    return None
+
+
+def _copy_archive_index_preflight_result(result: Mapping[str, Any]) -> Dict[str, Any]:
+    return copy.deepcopy(dict(result))
+
+
+def _archive_index_preflight_cache_key(
+    archive_index: Path,
+    archive_root: Path,
+    *,
+    scan_mode: str,
+) -> Tuple[str, int, int, str, str]:
+    stat_result = archive_index.stat()
+    return (
+        str(archive_index),
+        int(stat_result.st_mtime_ns),
+        int(stat_result.st_size),
+        str(archive_root),
+        _archive_index_preflight_scan_mode(scan_mode),
+    )
+
+
+def _trusted_existing_entry_without_realpath(
+    path_value: Any,
+    allowed_roots: List[Path],
+) -> Optional[Path]:
+    raw = str(path_value or "").strip()
+    if not raw or raw.startswith("~") or "\x00" in raw:
+        return None
+    try:
+        candidate = Path(raw)
+    except (OSError, RuntimeError, ValueError):
+        return None
+    if not candidate.is_absolute():
+        candidate = REPO_ROOT / candidate
+    try:
+        candidate_absolute = Path(os.path.abspath(candidate))
+    except (OSError, RuntimeError, ValueError):
+        return None
+
+    for root in allowed_roots:
+        try:
+            root_real = Path(os.path.realpath(root))
+            relative_parts = candidate_absolute.relative_to(root_real).parts
+        except (OSError, RuntimeError, ValueError):
+            continue
+        current = root_real
+        if not relative_parts:
+            return current
+        for part in relative_parts:
+            if part in {"", ".", ".."} or _UNSAFE_PATH_SEGMENT_RE.search(part):
+                return None
+            try:
+                next_path = next((child for child in current.iterdir() if child.name == part), None)
+            except (NotADirectoryError, FileNotFoundError, OSError, RuntimeError, ValueError):
+                return None
+            if next_path is None:
+                return None
+            current = next_path
+        return current
+    return None
 
 
 def _validate_archive_index_relpath(
@@ -1794,24 +1889,22 @@ def _validate_archive_index_relpath(
     if any(part == ".." for part in parts):
         return False, relpath, "parent_traversal"
 
-    target = archive_root.joinpath(*parts)
-    try:
-        target_real = Path(os.path.realpath(target))
-        target_real.relative_to(archive_root)
-    except (OSError, RuntimeError, ValueError):
-        return False, relpath, "outside_archive_root"
-
     current = archive_root
     for part in parts:
-        current = current / part
         try:
-            current.lstat()
+            next_path = next((child for child in current.iterdir() if child.name == part), None)
         except FileNotFoundError:
             return False, relpath, "missing"
+        except (NotADirectoryError, OSError, RuntimeError, ValueError):
+            return False, relpath, "unreadable"
+        if next_path is None:
+            return False, relpath, "missing"
+        try:
+            if next_path.is_symlink():
+                return False, relpath, "symlink_traversal"
         except (OSError, RuntimeError):
             return False, relpath, "unreadable"
-        if current.is_symlink():
-            return False, relpath, "symlink_traversal"
+        current = next_path
 
     try:
         if current.is_dir():
@@ -1827,10 +1920,28 @@ def _validate_archive_index_relpath(
 def _validate_archive_index_against_root(
     archive_index: Path,
     archive_root: Path,
+    *,
+    scan_mode: str = "full",
 ) -> Dict[str, Any]:
+    scan_mode = _archive_index_preflight_scan_mode(scan_mode)
     try:
-        archive_root_real = Path(os.path.realpath(archive_root))
-    except (OSError, RuntimeError, ValueError):
+        trusted_archive_index = _ensure_safe_regular_file_path(archive_index, ALLOWED_PATH_ROOTS)
+    except (OSError, RuntimeError, ValueError, _PortalValidationReasonError):
+        return _archive_index_preflight_result(
+            rows_total=0,
+            blocked_rows=1,
+            examples=[
+                _archive_index_preflight_example(
+                    row=0,
+                    relpath=str(archive_index),
+                    reason="archive_index_unreadable",
+                )
+            ],
+            scan_mode=scan_mode,
+        )
+
+    trusted_archive_root = _trusted_existing_entry_without_realpath(archive_root, ALLOWED_INPUT_ROOTS)
+    if trusted_archive_root is None:
         return _archive_index_preflight_result(
             rows_total=0,
             blocked_rows=1,
@@ -1838,13 +1949,13 @@ def _validate_archive_index_against_root(
                 _archive_index_preflight_example(
                     row=0,
                     relpath=str(archive_root),
-                    reason="archive_root_invalid",
+                    reason="archive_root_not_directory",
                 )
             ],
+            scan_mode=scan_mode,
         )
-
     try:
-        if archive_root_real.is_symlink():
+        if trusted_archive_root.is_symlink():
             return _archive_index_preflight_result(
                 rows_total=0,
                 blocked_rows=1,
@@ -1855,8 +1966,9 @@ def _validate_archive_index_against_root(
                         reason="archive_root_symlink",
                     )
                 ],
+                scan_mode=scan_mode,
             )
-        if not archive_root_real.is_dir():
+        if not trusted_archive_root.is_dir():
             return _archive_index_preflight_result(
                 rows_total=0,
                 blocked_rows=1,
@@ -1867,7 +1979,9 @@ def _validate_archive_index_against_root(
                         reason="archive_root_not_directory",
                     )
                 ],
+                scan_mode=scan_mode,
             )
+        archive_root_real = Path(os.path.realpath(trusted_archive_root))
     except (OSError, RuntimeError):
         return _archive_index_preflight_result(
             rows_total=0,
@@ -1879,16 +1993,43 @@ def _validate_archive_index_against_root(
                     reason="archive_root_unreadable",
                 )
             ],
+            scan_mode=scan_mode,
         )
+
+    try:
+        cache_key = _archive_index_preflight_cache_key(
+            trusted_archive_index,
+            archive_root_real,
+            scan_mode=scan_mode,
+        )
+    except OSError:
+        return _archive_index_preflight_result(
+            rows_total=0,
+            blocked_rows=1,
+            examples=[
+                _archive_index_preflight_example(
+                    row=0,
+                    relpath=str(archive_index),
+                    reason="archive_index_unreadable",
+                )
+            ],
+            scan_mode=scan_mode,
+        )
+
+    with _ARCHIVE_INDEX_PREFLIGHT_CACHE_LOCK:
+        cached = _ARCHIVE_INDEX_PREFLIGHT_CACHE.get(cache_key)
+    if cached is not None:
+        return _copy_archive_index_preflight_result(cached)
 
     rows_total = 0
     blocked_rows = 0
     examples: List[Dict[str, Any]] = []
+    row_limit = _archive_index_preflight_row_limit(scan_mode)
+    truncated = False
 
     try:
-        opener: Callable[..., Any]
-        opener = gzip.open if archive_index.name.endswith(".gz") else open
-        with opener(archive_index, "rt", encoding="utf-8", newline="") as handle:
+        opener: Callable[..., Any] = gzip.open if trusted_archive_index.name.endswith(".gz") else Path.open
+        with opener(trusted_archive_index, "rt", encoding="utf-8", newline="") as handle:
             reader = csv.DictReader(handle)
             fieldnames = set(reader.fieldnames or [])
             missing_columns = sorted(ARCHIVE_INDEX_REQUIRED_COLUMNS - fieldnames)
@@ -1903,6 +2044,7 @@ def _validate_archive_index_against_root(
                             reason=f"missing_columns:{','.join(missing_columns)}",
                         )
                     ],
+                    scan_mode=scan_mode,
                 )
 
             for row_number, row in enumerate(reader, start=2):
@@ -1911,7 +2053,11 @@ def _validate_archive_index_against_root(
                     row.get("relpath"),
                     archive_root=archive_root_real,
                 )
+                if row_limit is not None and rows_total >= row_limit:
+                    truncated = True
                 if ok:
+                    if truncated:
+                        break
                     continue
                 blocked_rows += 1
                 if len(examples) < ARCHIVE_INDEX_PREFLIGHT_EXAMPLE_LIMIT:
@@ -1922,6 +2068,8 @@ def _validate_archive_index_against_root(
                             reason=reason,
                         )
                     )
+                if truncated:
+                    break
     except (csv.Error, gzip.BadGzipFile, OSError, RuntimeError, UnicodeDecodeError) as exc:
         return _archive_index_preflight_result(
             rows_total=rows_total,
@@ -1929,10 +2077,11 @@ def _validate_archive_index_against_root(
             examples=[
                 _archive_index_preflight_example(
                     row=max(1, rows_total + 1),
-                    relpath=str(archive_index),
+                    relpath=str(trusted_archive_index),
                     reason=f"archive_index_unreadable:{type(exc).__name__}",
                 )
             ],
+            scan_mode=scan_mode,
         )
 
     if rows_total == 0:
@@ -1946,13 +2095,21 @@ def _validate_archive_index_against_root(
                     reason="empty_archive_index",
                 )
             ],
+            scan_mode=scan_mode,
         )
 
-    return _archive_index_preflight_result(
+    result = _archive_index_preflight_result(
         rows_total=rows_total,
         blocked_rows=blocked_rows,
         examples=examples,
+        scan_mode=scan_mode,
+        truncated=truncated,
     )
+    with _ARCHIVE_INDEX_PREFLIGHT_CACHE_LOCK:
+        if len(_ARCHIVE_INDEX_PREFLIGHT_CACHE) >= ARCHIVE_INDEX_PREFLIGHT_CACHE_MAX:
+            _ARCHIVE_INDEX_PREFLIGHT_CACHE.pop(next(iter(_ARCHIVE_INDEX_PREFLIGHT_CACHE)), None)
+        _ARCHIVE_INDEX_PREFLIGHT_CACHE[cache_key] = _copy_archive_index_preflight_result(result)
+    return result
 
 
 def _lux_depth_readiness(args: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
@@ -2028,6 +2185,7 @@ def _archive_gate_readiness(
     args: Optional[Dict[str, Any]] = None,
     *,
     require_dispatch_inputs: bool,
+    archive_index_scan_mode: str = "full",
 ) -> Dict[str, Any]:
     command = ARCHIVE_GATE_DEFAULT_COMMANDS[pipeline]
     if args:
@@ -2104,9 +2262,14 @@ def _archive_gate_readiness(
                     "archiveRoot",
                     default=_pick(args or {}, "input_dir", "inputDir", default=""),
                 )
+                archive_root_field = (
+                    "archive_root"
+                    if _pick(args or {}, "archive_root", "archiveRoot", default=None) is not None
+                    else "input_dir"
+                )
                 archive_root_path, archive_root_issue = _validate_existing_path(
                     archive_root_value,
-                    field="archive_root",
+                    field=archive_root_field,
                     allowed_roots=ALLOWED_INPUT_ROOTS,
                     missing_reason="input_dir_required",
                     missing_message="Provide an existing archive root before dispatch.",
@@ -2116,10 +2279,26 @@ def _archive_gate_readiness(
                 _append_issue(archive_root_issue)
                 if archive_index_path and archive_root_path and issue is None and archive_root_issue is None:
                     index_preflight = _validate_archive_index_against_root(
-                        Path(archive_index_path),
-                        Path(archive_root_path),
+                        Path(str(archive_index_value)),
+                        Path(str(archive_root_value)),
+                        scan_mode=archive_index_scan_mode,
                     )
-                    if not index_preflight["ok"]:
+                    root_reason = _archive_index_preflight_root_reason(index_preflight)
+                    if root_reason is not None:
+                        issues.append(
+                            _readiness_issue(
+                                "input_dir_required" if root_reason != "archive_root_symlink" else "unsafe_path",
+                                severity="blocked",
+                                message=(
+                                    "Archive root must be an existing directory before dispatch."
+                                    if root_reason != "archive_root_symlink"
+                                    else "Archive root must be a real directory, not a symlink."
+                                ),
+                                field=archive_root_field,
+                                path=archive_root_path,
+                            )
+                        )
+                    elif not index_preflight["ok"]:
                         issues.append(
                             _readiness_issue(
                                 "archive_index_root_mismatch",
@@ -2294,6 +2473,7 @@ def _evaluate_pipeline_readiness(
     args: Optional[Dict[str, Any]] = None,
     *,
     require_dispatch_inputs: bool = False,
+    archive_index_scan_mode: str = "full",
 ) -> Dict[str, Any]:
     if pipeline not in ALLOWED_PIPELINES:
         return {
@@ -2323,6 +2503,7 @@ def _evaluate_pipeline_readiness(
             pipeline,
             normalized_args,
             require_dispatch_inputs=require_dispatch_inputs,
+            archive_index_scan_mode=archive_index_scan_mode,
         )
 
     if normalization_errors:
@@ -4527,12 +4708,14 @@ def _build_archive_config_preview(
     args: Dict[str, Any],
     *,
     readiness_snapshot: Optional[Dict[str, Any]] = None,
+    archive_index_scan_mode: str = "preview",
 ) -> Dict[str, Any]:
     args, path_warnings, path_errors = _normalize_operator_payload_paths(pipeline, args)
     errors: List[Dict[str, Any]] = []
     warnings: List[Dict[str, Any]] = list(path_warnings)
     path_errors_by_field = _preview_path_errors_by_field(path_errors)
     normalized_args = dict(args)
+    handled_path_fields: set[str] = set()
 
     def _set_archive_path_field(
         field: str,
@@ -4558,6 +4741,7 @@ def _build_archive_config_preview(
             must_be_file=must_be_file,
             must_be_dir=must_be_dir,
         )
+        handled_path_fields.add(field)
         for key in keys:
             normalized_args.pop(key, None)
         if value or required:
@@ -4591,6 +4775,13 @@ def _build_archive_config_preview(
             required=command in {"fixity-scan", "manifest-build"},
             must_exist=command in {"fixity-scan", "manifest-build"},
             must_be_file=command in {"fixity-scan", "manifest-build"},
+        )
+    if command == "fixity-scan" and any(key in args for key in ("archive_root", "archiveRoot")):
+        _set_archive_path_field(
+            "archive_root",
+            ("archive_root", "archiveRoot"),
+            must_exist=True,
+            must_be_dir=True,
         )
     if command in {"fixity-verify", "manifest-build"}:
         _set_archive_path_field(
@@ -4626,6 +4817,8 @@ def _build_archive_config_preview(
         )
 
     for field, keys, _scope in PATH_FIELD_SPECS:
+        if field in handled_path_fields:
+            continue
         if field in normalized_args:
             continue
         if not any(key in args for key in keys):
@@ -4675,45 +4868,57 @@ def _build_archive_config_preview(
         and "input_dir" not in archive_path_error_fields
         and "archive_root" not in archive_path_error_fields
     ):
-        archive_index_text = str(normalized_args.get("archive_index") or "").strip()
+        archive_index_text = str(
+            _pick(args, "archive_index", "archiveIndex", default=normalized_args.get("archive_index") or "")
+            or ""
+        ).strip()
+        archive_root_was_explicit = _pick(args, "archive_root", "archiveRoot", default=None) is not None
         archive_root_text = str(
-            normalized_args.get("archive_root")
-            or normalized_args.get("input_dir")
+            _pick(
+                args,
+                "archive_root",
+                "archiveRoot",
+                default=_pick(args, "input_dir", "inputDir", default=normalized_args.get("input_dir") or ""),
+            )
             or ""
         ).strip()
         if archive_index_text and archive_root_text:
-            try:
-                archive_index_path = _resolve_allowed_request_path(
-                    archive_index_text,
-                    ALLOWED_PATH_ROOTS,
-                )
-                archive_root_path = _resolve_allowed_request_path(
-                    archive_root_text,
-                    ALLOWED_INPUT_ROOTS,
-                )
-            except _PortalValidationReasonError:
-                archive_index_path = None
-                archive_root_path = None
-            if archive_index_path is not None and archive_root_path is not None:
-                index_preflight = _validate_archive_index_against_root(
-                    archive_index_path,
-                    archive_root_path,
-                )
-                if not index_preflight["ok"]:
-                    errors.append(
-                        _portal_issue(
-                            "archive_index",
-                            "archive_index_root_mismatch",
-                            _archive_index_preflight_message(index_preflight),
-                            suggestion="Rebuild the archive index from the selected archive root.",
-                        )
+            index_preflight = _validate_archive_index_against_root(
+                Path(archive_index_text),
+                Path(archive_root_text),
+                scan_mode=archive_index_scan_mode,
+            )
+            root_reason = _archive_index_preflight_root_reason(index_preflight)
+            if root_reason is not None:
+                archive_root_field = "archive_root" if archive_root_was_explicit else "input_dir"
+                errors.append(
+                    _portal_issue(
+                        archive_root_field,
+                        "not_a_directory" if root_reason != "archive_root_symlink" else "invalid_path_value",
+                        (
+                            f"{archive_root_field} must be an existing directory."
+                            if root_reason != "archive_root_symlink"
+                            else f"{archive_root_field} must be a real directory, not a symlink."
+                        ),
+                        suggestion=f"Choose an existing directory for {archive_root_field} under the allowed input roots.",
                     )
+                )
+            elif not index_preflight["ok"]:
+                errors.append(
+                    _portal_issue(
+                        "archive_index",
+                        "archive_index_root_mismatch",
+                        _archive_index_preflight_message(index_preflight),
+                        suggestion="Rebuild the archive index from the selected archive root.",
+                    )
+                )
 
     if readiness_snapshot is None:
         readiness_snapshot = _evaluate_pipeline_readiness(
             pipeline,
             normalized_args,
             require_dispatch_inputs=True,
+            archive_index_scan_mode=archive_index_scan_mode,
         )
 
     argv_preview = ""
@@ -4759,6 +4964,7 @@ def _build_config_preview(
     payload: Dict[str, Any],
     *,
     readiness_snapshot: Optional[Dict[str, Any]] = None,
+    archive_index_scan_mode: str = "preview",
 ) -> Dict[str, Any]:
     pipeline = str(payload.get("pipeline") or "").strip()
     args = payload.get("args")
@@ -4771,6 +4977,7 @@ def _build_config_preview(
             pipeline,
             args,
             readiness_snapshot=readiness_snapshot,
+            archive_index_scan_mode=archive_index_scan_mode,
         )
     raise ValueError("Unsupported pipeline")
 
@@ -7910,6 +8117,7 @@ async def _create_job(payload: Dict[str, Any], *, api_version: str = "v1") -> JS
     try:
         preview = _build_config_preview(
             payload,
+            archive_index_scan_mode="full",
         )
     except ValueError:
         return _error_response(

--- a/tests/test_app_orchestrator_contract_http.py
+++ b/tests/test_app_orchestrator_contract_http.py
@@ -843,6 +843,39 @@ def test_archive_gate_a_config_preview_blocks_archive_index_root_mismatch(
     assert preview["argv_preview"] == ""
 
 
+def test_archive_gate_a_config_preview_reports_missing_archive_root_on_root_field(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    archive_root = (tmp_path / "missing-root").resolve()
+    archive_index = (tmp_path / "archive_index_normalized.csv.gz").resolve()
+    _write_archive_index(archive_index, ["asset-001.dng"])
+    output_dir = (tmp_path / "preview-output").resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    response = client.post(
+        "/v1/config-preview",
+        json={
+            "pipeline": "archive-gate-a",
+            "args": {
+                "input_dir": str(tmp_path),
+                "output_dir": str(output_dir),
+                "archive_command": "fixity-scan",
+                "archive_root": str(archive_root),
+                "archive_index": str(archive_index),
+            },
+        },
+    )
+    body = response.json()
+
+    assert response.status_code == 200
+    preview = body["data"]
+    errors = {item["field"]: item for item in preview["field_errors"]}
+    assert errors["archive_root"]["code"] in {"missing", "not_a_directory"}
+    assert "archive_index" not in errors
+    assert preview["argv_preview"] == ""
+
+
 def test_config_preview_contract_normalizes_inactive_reconstruction_fields(
     client: TestClient,
     tmp_path: Path,
@@ -2527,6 +2560,42 @@ def test_archive_gate_pipeline_submission_rejects_archive_index_root_mismatch(
         "field": "archive_index",
         "reason": "archive_index_root_mismatch",
     }
+
+
+def test_archive_gate_pipeline_submission_reports_missing_archive_root_on_root_field(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    async def fake_run_job(job, _argv):  # noqa: ANN001
+        raise AssertionError("missing archive root must be rejected before dispatch")
+
+    monkeypatch.setattr(orchestrator_app, "_run_job", fake_run_job)
+    archive_index = tmp_path / "archive_index_normalized.csv.gz"
+    _write_archive_index(archive_index, ["asset-001.dng"])
+    archive_root = tmp_path / "missing-root"
+
+    response = client.post(
+        "/v1/jobs",
+        json={
+            "pipeline": "archive-gate-a",
+            "args": {
+                "input_dir": str(tmp_path),
+                "output_dir": str(tmp_path / "out"),
+                "archive_command": "fixity-scan",
+                "archive_index": str(archive_index),
+                "archive_root": str(archive_root),
+            },
+        },
+    )
+    body = response.json()
+
+    assert response.status_code == 400
+    assert body["schema"] == "tp.orchestrator.error.v1"
+    assert body["success"] is False
+    assert body["error"]["code"] == "INVALID_ARGUMENT"
+    assert body["error"]["details"]["field"] == "archive_root"
+    assert body["error"]["details"]["reason"] in {"missing", "not_a_directory"}
 
 
 def test_create_job_preserves_raw_request_and_internal_execution_args(

--- a/tests/test_app_orchestrator_contract_http.py
+++ b/tests/test_app_orchestrator_contract_http.py
@@ -5,6 +5,8 @@
 from __future__ import annotations
 
 import asyncio
+import csv
+import gzip
 import importlib
 import json
 import logging
@@ -20,6 +22,26 @@ from starlette.requests import Request as StarletteRequest
 pytestmark = pytest.mark.unit
 
 orchestrator_app = importlib.import_module("app")
+
+
+def _write_archive_index(path: Path, relpaths: list[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    opener = gzip.open if path.name.endswith(".gz") else open
+    with opener(path, "wt", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=["origin_drive", "partition", "relpath"],
+            lineterminator="\n",
+        )
+        writer.writeheader()
+        for relpath in relpaths:
+            writer.writerow(
+                {
+                    "origin_drive": "local",
+                    "partition": "test",
+                    "relpath": relpath,
+                }
+            )
 
 
 def _collect_sse_events(response) -> List[Tuple[str, Dict[str, Any]]]:
@@ -745,8 +767,9 @@ def test_archive_gate_a_config_preview_returns_authoritative_readiness_and_argv(
 ) -> None:
     archive_root = (tmp_path / "archive_root").resolve()
     archive_root.mkdir(parents=True, exist_ok=True)
+    (archive_root / "asset-001.dng").write_bytes(b"raw")
     archive_index = (tmp_path / "archive_index_normalized.csv.gz").resolve()
-    archive_index.write_bytes(b"fixture-index")
+    _write_archive_index(archive_index, ["asset-001.dng"])
     output_dir = (tmp_path / "preview-output").resolve()
     output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -779,6 +802,45 @@ def test_archive_gate_a_config_preview_returns_authoritative_readiness_and_argv(
     assert "fixity-scan" in preview["argv_preview"]
     assert "--archive-index" in preview["argv_preview"]
     assert preview["execution_args"] == preview["normalized_args"]
+
+
+def test_archive_gate_a_config_preview_blocks_archive_index_root_mismatch(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    archive_root = (tmp_path / "raw_root").resolve()
+    archive_root.mkdir(parents=True, exist_ok=True)
+    (archive_root / "DJI_0018.DNG").write_bytes(b"raw")
+    archive_index = (
+        Path(__file__).resolve().parents[1] / "tests" / "fixtures" / "archive_small" / "archive_index_normalized.csv.gz"
+    )
+    output_dir = (tmp_path / "preview-output").resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    response = client.post(
+        "/v1/config-preview",
+        json={
+            "pipeline": "archive-gate-a",
+            "args": {
+                "input_dir": str(archive_root),
+                "output_dir": str(output_dir),
+                "archive_command": "fixity-scan",
+                "archive_root": str(archive_root),
+                "archive_index": str(archive_index),
+            },
+        },
+    )
+    body = response.json()
+
+    assert response.status_code == 200
+    assert body["schema"] == "tp.orchestrator.config_preview.v1"
+    assert body["success"] is True
+    preview = body["data"]
+    errors = {item["field"]: item for item in preview["field_errors"]}
+    assert errors["archive_index"]["code"] == "archive_index_root_mismatch"
+    assert "3/3 rows blocked" in errors["archive_index"]["message"]
+    assert preview["readiness"]["status"] == "blocked"
+    assert preview["argv_preview"] == ""
 
 
 def test_config_preview_contract_normalizes_inactive_reconstruction_fields(
@@ -2401,8 +2463,9 @@ def test_archive_gate_pipeline_submission_returns_job_envelope(
     monkeypatch.setattr(orchestrator_app, "_run_job", fake_run_job)
     archive_root = tmp_path / "archive_root"
     archive_root.mkdir(parents=True, exist_ok=True)
+    (archive_root / "asset-001.dng").write_bytes(b"raw")
     archive_index = tmp_path / "archive_index_normalized.csv.gz"
-    archive_index.write_bytes(b"fixture-index")
+    _write_archive_index(archive_index, ["asset-001.dng"])
 
     response = client.post(
         "/v1/jobs",
@@ -2423,6 +2486,47 @@ def test_archive_gate_pipeline_submission_returns_job_envelope(
     assert body["success"] is True
     assert body["error"] is None
     assert body["data"]["id"].startswith("job_")
+
+
+def test_archive_gate_pipeline_submission_rejects_archive_index_root_mismatch(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    async def fake_run_job(job, _argv):  # noqa: ANN001
+        raise AssertionError("mismatched archive index must be rejected before dispatch")
+
+    monkeypatch.setattr(orchestrator_app, "_run_job", fake_run_job)
+    archive_root = tmp_path / "raw_root"
+    archive_root.mkdir(parents=True, exist_ok=True)
+    (archive_root / "DJI_0018.DNG").write_bytes(b"raw")
+    archive_index = (
+        Path(__file__).resolve().parents[1] / "tests" / "fixtures" / "archive_small" / "archive_index_normalized.csv.gz"
+    )
+
+    response = client.post(
+        "/v1/jobs",
+        json={
+            "pipeline": "archive-gate-a",
+            "args": {
+                "input_dir": str(archive_root),
+                "output_dir": str(tmp_path / "out"),
+                "archive_command": "fixity-scan",
+                "archive_index": str(archive_index),
+                "archive_root": str(archive_root),
+            },
+        },
+    )
+    body = response.json()
+
+    assert response.status_code == 400
+    assert body["schema"] == "tp.orchestrator.error.v1"
+    assert body["success"] is False
+    assert body["error"]["code"] == "INVALID_ARGUMENT"
+    assert body["error"]["details"] == {
+        "field": "archive_index",
+        "reason": "archive_index_root_mismatch",
+    }
 
 
 def test_create_job_preserves_raw_request_and_internal_execution_args(

--- a/tests/test_app_orchestrator_runtime.py
+++ b/tests/test_app_orchestrator_runtime.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures
+import csv
+import gzip
 import hashlib
 import importlib
 import io
@@ -49,6 +51,26 @@ class _FakeRequest:
 def _flag_value(argv: list[str], flag: str) -> str:
     idx = argv.index(flag)
     return argv[idx + 1]
+
+
+def _write_archive_index(path: Path, relpaths: list[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    opener = gzip.open if path.name.endswith(".gz") else open
+    with opener(path, "wt", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=["origin_drive", "partition", "relpath"],
+            lineterminator="\n",
+        )
+        writer.writeheader()
+        for relpath in relpaths:
+            writer.writerow(
+                {
+                    "origin_drive": "local",
+                    "partition": "test",
+                    "relpath": relpath,
+                }
+            )
 
 
 @lru_cache(maxsize=1)
@@ -3342,6 +3364,10 @@ def test_argv_archive_gate_a_defaults_to_fixity_scan_runner() -> None:
     assert _flag_value(argv, "--archive-index") == expected_archive_index
     assert _flag_value(argv, "--archive-root") == expected_archive_root
     assert _flag_value(argv, "--out-dir") == expected_out_dir
+    assert "--strict" in argv
+    assert "--strict-identity" in argv
+    assert "--no-strict" not in argv
+    assert "--no-strict-identity" not in argv
 
 
 def test_argv_archive_gate_b_allows_command_override_and_sign_maps_to_bagit_validation() -> None:
@@ -3518,6 +3544,53 @@ def test_archive_gate_a_readiness_is_degraded_until_archive_index_is_supplied() 
     assert readiness["status"] == "degraded"
     assert readiness["canonical_command"] == "fixity-scan"
     assert readiness["missing_prerequisites"][0]["reason"] == "archive_index_required"
+
+
+def test_archive_gate_a_readiness_blocks_fixture_index_against_nonmatching_root(tmp_path: Path) -> None:
+    raw_root = tmp_path / "Raw_16-bit_Source"
+    raw_root.mkdir()
+    (raw_root / "DJI_0018.DNG").write_bytes(b"raw")
+    fixture_index = orchestrator_app.REPO_ROOT / "tests" / "fixtures" / "archive_small" / "archive_index_normalized.csv.gz"
+
+    readiness = orchestrator_app._archive_gate_readiness(
+        "archive-gate-a",
+        args={
+            "input_dir": str(raw_root),
+            "output_dir": str(tmp_path / "out"),
+            "archive_command": "fixity-scan",
+            "archive_root": str(raw_root),
+            "archive_index": str(fixture_index),
+        },
+        require_dispatch_inputs=True,
+    )
+
+    assert readiness["status"] == "blocked"
+    issues = {item["reason"]: item for item in readiness["missing_prerequisites"]}
+    assert issues["archive_index_root_mismatch"]["field"] == "archive_index"
+    assert "3/3 rows blocked" in issues["archive_index_root_mismatch"]["message"]
+
+
+def test_archive_gate_a_readiness_is_ready_when_index_matches_root(tmp_path: Path) -> None:
+    archive_root = tmp_path / "archive_root"
+    archive_root.mkdir()
+    (archive_root / "asset-001.dng").write_bytes(b"raw")
+    archive_index = tmp_path / "archive_index_normalized.csv.gz"
+    _write_archive_index(archive_index, ["asset-001.dng"])
+
+    readiness = orchestrator_app._archive_gate_readiness(
+        "archive-gate-a",
+        args={
+            "input_dir": str(archive_root),
+            "output_dir": str(tmp_path / "out"),
+            "archive_command": "fixity-scan",
+            "archive_root": str(archive_root),
+            "archive_index": str(archive_index),
+        },
+        require_dispatch_inputs=True,
+    )
+
+    assert readiness["status"] == "ready"
+    assert readiness["missing_prerequisites"] == []
 
 
 def test_archive_gate_b_readiness_fails_closed_without_manifest_jsonl() -> None:

--- a/tests/test_app_orchestrator_runtime.py
+++ b/tests/test_app_orchestrator_runtime.py
@@ -3593,6 +3593,182 @@ def test_archive_gate_a_readiness_is_ready_when_index_matches_root(tmp_path: Pat
     assert readiness["missing_prerequisites"] == []
 
 
+def test_archive_gate_a_readiness_reports_missing_archive_root_on_root_field(tmp_path: Path) -> None:
+    archive_index = tmp_path / "archive_index_normalized.csv.gz"
+    _write_archive_index(archive_index, ["asset-001.dng"])
+    missing_root = tmp_path / "missing-root"
+
+    readiness = orchestrator_app._archive_gate_readiness(
+        "archive-gate-a",
+        args={
+            "input_dir": str(tmp_path),
+            "output_dir": str(tmp_path / "out"),
+            "archive_command": "fixity-scan",
+            "archive_root": str(missing_root),
+            "archive_index": str(archive_index),
+        },
+        require_dispatch_inputs=True,
+    )
+
+    assert readiness["status"] == "blocked"
+    issues = {item["field"]: item for item in readiness["missing_prerequisites"] if "field" in item}
+    assert issues["archive_root"]["reason"] == "input_dir_required"
+    assert "archive_index_root_mismatch" not in {item["reason"] for item in readiness["missing_prerequisites"]}
+
+
+def test_archive_gate_a_readiness_rejects_symlink_archive_root(tmp_path: Path) -> None:
+    real_root = tmp_path / "real-root"
+    real_root.mkdir()
+    (real_root / "asset-001.dng").write_bytes(b"raw")
+    archive_index = tmp_path / "archive_index_normalized.csv.gz"
+    _write_archive_index(archive_index, ["asset-001.dng"])
+    link_root = tmp_path / "link-root"
+    try:
+        link_root.symlink_to(real_root, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"symlink creation unavailable: {exc}")
+
+    readiness = orchestrator_app._archive_gate_readiness(
+        "archive-gate-a",
+        args={
+            "input_dir": str(real_root),
+            "output_dir": str(tmp_path / "out"),
+            "archive_command": "fixity-scan",
+            "archive_root": str(link_root),
+            "archive_index": str(archive_index),
+        },
+        require_dispatch_inputs=True,
+    )
+
+    assert readiness["status"] == "blocked"
+    issues = {item["field"]: item for item in readiness["missing_prerequisites"] if "field" in item}
+    assert issues["archive_root"]["reason"] == "unsafe_path"
+    assert "archive_index_root_mismatch" not in {item["reason"] for item in readiness["missing_prerequisites"]}
+
+
+@pytest.mark.parametrize(
+    ("relpath", "reason"),
+    [
+        ("../escape.dng", "parent_traversal"),
+        ("/absolute.dng", "absolute_relpath"),
+        ("C:/absolute.dng", "drive_prefixed_relpath"),
+        ("", "empty_relpath"),
+        ("missing.dng", "missing"),
+        ("folder", "directory"),
+    ],
+)
+def test_archive_index_preflight_rejects_invalid_relpaths(tmp_path: Path, relpath: str, reason: str) -> None:
+    archive_root = tmp_path / "archive_root"
+    archive_root.mkdir()
+    (archive_root / "folder").mkdir()
+    archive_index = tmp_path / f"archive_index_{reason}.csv.gz"
+    _write_archive_index(archive_index, [relpath])
+
+    result = orchestrator_app._validate_archive_index_against_root(
+        archive_index,
+        archive_root,
+        scan_mode="full",
+    )
+
+    assert result["ok"] is False
+    assert result["blocked_rows"] == 1
+    assert result["examples"][0]["reason"] == reason
+
+
+def test_archive_index_preflight_rejects_symlink_relpath(tmp_path: Path) -> None:
+    archive_root = tmp_path / "archive_root"
+    archive_root.mkdir()
+    outside = tmp_path / "outside.dng"
+    outside.write_bytes(b"outside")
+    link_path = archive_root / "asset-link.dng"
+    try:
+        link_path.symlink_to(outside)
+    except OSError as exc:
+        pytest.skip(f"symlink creation unavailable: {exc}")
+    archive_index = tmp_path / "archive_index_symlink.csv.gz"
+    _write_archive_index(archive_index, ["asset-link.dng"])
+
+    result = orchestrator_app._validate_archive_index_against_root(
+        archive_index,
+        archive_root,
+        scan_mode="full",
+    )
+
+    assert result["ok"] is False
+    assert result["examples"][0]["reason"] == "symlink_traversal"
+
+
+def test_archive_index_preflight_rejects_missing_columns_and_bad_gzip(tmp_path: Path) -> None:
+    archive_root = tmp_path / "archive_root"
+    archive_root.mkdir()
+    missing_columns = tmp_path / "archive_index_missing_columns.csv"
+    missing_columns.write_text("relpath\nasset-001.dng\n", encoding="utf-8")
+    bad_gzip = tmp_path / "archive_index_bad.csv.gz"
+    bad_gzip.write_bytes(b"not a gzip stream")
+
+    missing_columns_result = orchestrator_app._validate_archive_index_against_root(
+        missing_columns,
+        archive_root,
+        scan_mode="full",
+    )
+    bad_gzip_result = orchestrator_app._validate_archive_index_against_root(
+        bad_gzip,
+        archive_root,
+        scan_mode="full",
+    )
+
+    assert missing_columns_result["ok"] is False
+    assert missing_columns_result["examples"][0]["reason"].startswith("missing_columns:")
+    assert bad_gzip_result["ok"] is False
+    assert bad_gzip_result["examples"][0]["reason"] == "archive_index_unreadable:BadGzipFile"
+
+
+def test_archive_index_preflight_preview_is_bounded_and_cached(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    archive_root = tmp_path / "archive_root"
+    archive_root.mkdir()
+    existing_relpaths = [f"asset-{idx:03d}.dng" for idx in range(orchestrator_app.ARCHIVE_INDEX_PREFLIGHT_PREVIEW_ROW_LIMIT)]
+    for relpath in existing_relpaths:
+        (archive_root / relpath).write_bytes(b"raw")
+    relpaths = [*existing_relpaths, "late-missing.dng"]
+    archive_index = tmp_path / "archive_index_bounded.csv.gz"
+    _write_archive_index(archive_index, relpaths)
+
+    with orchestrator_app._ARCHIVE_INDEX_PREFLIGHT_CACHE_LOCK:
+        orchestrator_app._ARCHIVE_INDEX_PREFLIGHT_CACHE.clear()
+
+    preview_result = orchestrator_app._validate_archive_index_against_root(
+        archive_index,
+        archive_root,
+        scan_mode="preview",
+    )
+    assert preview_result["ok"] is True
+    assert preview_result["truncated"] is True
+    assert preview_result["rows_total"] == orchestrator_app.ARCHIVE_INDEX_PREFLIGHT_PREVIEW_ROW_LIMIT
+
+    def fail_if_rescanned(*_args, **_kwargs):
+        raise AssertionError("cached preview result should avoid rescanning rows")
+
+    monkeypatch.setattr(orchestrator_app, "_validate_archive_index_relpath", fail_if_rescanned)
+    cached_preview = orchestrator_app._validate_archive_index_against_root(
+        archive_index,
+        archive_root,
+        scan_mode="preview",
+    )
+    assert cached_preview == preview_result
+
+    monkeypatch.undo()
+    full_result = orchestrator_app._validate_archive_index_against_root(
+        archive_index,
+        archive_root,
+        scan_mode="full",
+    )
+    assert full_result["ok"] is False
+    assert full_result["examples"][0]["reason"] == "missing"
+
+
 def test_archive_gate_b_readiness_fails_closed_without_manifest_jsonl() -> None:
     readiness = orchestrator_app._archive_gate_readiness(
         "archive-gate-b",
@@ -5359,8 +5535,9 @@ def test_create_job_preflight_sanitizes_exception_derived_messages(
 def test_create_job_uses_preview_errors_before_readiness_preflight(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    def fake_preview(_payload, *, readiness_snapshot=None):  # noqa: ANN001
+    def fake_preview(_payload, *, readiness_snapshot=None, archive_index_scan_mode="preview"):  # noqa: ANN001
         del readiness_snapshot
+        del archive_index_scan_mode
         return {
             "pipeline": "lux-depth-v3",
             "execution_args": {


### PR DESCRIPTION
## Summary
- Root cause: Portal-dispatched archive-gate-a fixity scans could pair a valid archive index with the wrong archive root, producing all-missing fixity output that still dispatched without strict failure semantics.
- Added a Portal-side archive index preflight that verifies index relpaths against the selected archive root before config preview/job dispatch.

## Changes
- Read `.csv` and `.csv.gz` archive indexes and require `origin_drive`, `partition`, and `relpath` columns.
- Reject unsafe or non-resolving `relpath` values, including empty, NUL, absolute, parent-traversing, drive-prefixed, outside-root, missing, unreadable, directory, and symlink-traversing rows.
- Return an `archive_index` field error with blocked row counts and examples when an index/root mismatch is detected.
- Force Portal-dispatched `archive-gate-a fixity-scan` argv to include `--strict` and `--strict-identity`; direct `tools/archive_governance.py fixity-scan` defaults are unchanged.
- Added runtime and HTTP contract coverage for strict argv flags, mismatch rejection, and matching-root readiness.

## Validation
Proven green:
- `.venv/bin/pytest -q tests/test_app_orchestrator_runtime.py -k "archive_gate"`
- `.venv/bin/pytest -q tests/test_app_orchestrator_contract_http.py -k "archive_gate"`
- `make test-portal-contract`
- `make test-fast`

Manual acceptance:
- Fixture archive index + RAW root is blocked before dispatch with `archive_index_root_mismatch`.
- Fresh RAW index + RAW root previews ready and scans with `hashed_ok: 6`, `missing: 0`.
- Portal-generated fixity argv includes `--strict` and `--strict-identity`.

Still failing:
- None observed in the validation above.

## Risk
- Compatibility risk is bounded to Portal-dispatched `archive-gate-a fixity-scan`; direct archive governance CLI defaults are preserved.
- The change is fail-closed for governance-sensitive archive dispatch and revert-safe because it is additive preflight plus focused argv hardening.
- Operational risk: archive indexes with stale or cross-root relpaths now fail before job creation instead of producing reviewable-but-invalid all-missing fixity artifacts.