### PR TITLE
feat(api): wire response_model on health/readiness routes (Phase 1.2 PR B)

### DIFF
--- a/app.py
+++ b/app.py
@@ -41,6 +41,11 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.middleware.trustedhost import TrustedHostMiddleware
 from starlette.responses import Response, StreamingResponse
 
+from transformation_portal.api.v1 import (
+    HealthzResponse,
+    ReadinessEnvelope,
+    ReadyResponse,
+)
 from transformation_portal.determinism.trace import get_or_create_trace_context
 from transformation_portal.ingest.upload_staging import (
     DEFAULT_CAPTURE_METADATA_CONFIG_PATH,
@@ -7819,7 +7824,7 @@ async def portal_bootstrap() -> JSONResponse:
     )
 
 
-@app.get("/healthz")
+@app.get("/healthz", response_model=HealthzResponse)
 async def healthz() -> JSONResponse:
     """Lightweight health check endpoint for managed front door and load balancers.
 
@@ -7834,7 +7839,15 @@ async def healthz() -> JSONResponse:
     )
 
 
-@app.get("/ready")
+@app.get(
+    "/ready",
+    response_model=ReadyResponse,
+    # Preserve current wire shape: when TP_READY_VERBOSE=false, the handler
+    # returns a dict WITHOUT the cli/jobs/security keys. Without this flag,
+    # FastAPI would fill in those Optional fields as null and emit them,
+    # which is a wire-format change external probes shouldn't see.
+    response_model_exclude_none=True,
+)
 async def ready() -> Dict[str, Any]:
     response: Dict[str, Any] = {
         "ok": True,
@@ -7867,7 +7880,7 @@ async def ready() -> Dict[str, Any]:
     return response
 
 
-@app.get("/v1/readiness")
+@app.get("/v1/readiness", response_model=ReadinessEnvelope)
 async def readiness() -> JSONResponse:
     pipeline_data: Dict[str, Any] = {}
     for pipeline_name in ("lux-depth-v3", "archive-gate-a", "archive-gate-b", "archive-gate-c"):

--- a/src/transformation_portal/api/v1/__init__.py
+++ b/src/transformation_portal/api/v1/__init__.py
@@ -2,6 +2,13 @@
 
 from transformation_portal.api.v1.envelopes import ApiEnvelope, ErrorEnvelope
 from transformation_portal.api.v1.errors import ErrorCode, ErrorObject
+from transformation_portal.api.v1.health import (
+    HealthzResponse,
+    ReadinessData,
+    ReadinessEnvelope,
+    ReadinessServer,
+    ReadyResponse,
+)
 from transformation_portal.api.v1.schemas import SchemaName
 
 __all__ = [
@@ -9,5 +16,10 @@ __all__ = [
     "ErrorCode",
     "ErrorEnvelope",
     "ErrorObject",
+    "HealthzResponse",
+    "ReadinessData",
+    "ReadinessEnvelope",
+    "ReadinessServer",
+    "ReadyResponse",
     "SchemaName",
 ]

--- a/src/transformation_portal/api/v1/health.py
+++ b/src/transformation_portal/api/v1/health.py
@@ -1,0 +1,110 @@
+"""Typed response models for the orchestrator's health/readiness routes.
+
+Three routes are wired in PR B of the Phase 1.2 sequence:
+
+- ``GET /healthz``  — minimal liveness probe; raw JSON, NOT enveloped.
+- ``GET /ready``    — verbose-toggleable readiness; raw JSON, NOT enveloped.
+- ``GET /v1/readiness`` — pipeline readiness; enveloped under
+  ``tp.orchestrator.readiness.v1`` via ``ApiEnvelope[ReadinessData]``.
+
+The first two intentionally bypass the orchestrator envelope because external
+load balancers and Kubernetes probes expect a raw ``{"ok": ...}`` shape (see
+``tests/test_app_orchestrator_contract_http.py::test_ready_keeps_non_enveloped_shape``).
+The contract test asserts neither ``schema`` nor ``success`` keys are present.
+
+Internal nested fields (``cli``, ``jobs``, ``security``, per-pipeline data) are
+modeled as ``dict[str, Any]`` rather than fully-typed nested classes because
+their internals churn (especially ``security`` which exposes new feature flags
+as they're rolled out) and the typing-vs-maintenance trade-off favors keeping
+those dicts open.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+from transformation_portal.api.v1.envelopes import ApiEnvelope
+
+
+class HealthzResponse(BaseModel):
+    """Response shape for ``GET /healthz`` (raw, not enveloped).
+
+    Mirrors ``app.py``'s explicit ``JSONResponse({"ok": True, "time": _now()})``.
+    Closed schema: any extra keys would surprise the load balancers / probes
+    that consume this endpoint, so ``extra="forbid"`` is correct.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    ok: bool
+    time: float
+
+
+class ReadyResponse(BaseModel):
+    """Response shape for ``GET /ready`` (raw, not enveloped).
+
+    Always-present fields: ``ok``, ``time``, ``version``.
+    Verbose-only fields (when ``TP_READY_VERBOSE=true``): ``cli``, ``jobs``,
+    ``security``. Each is a churning dict of internal-state telemetry; we
+    model them as ``dict[str, Any]`` rather than nested classes so adding a
+    new feature flag to the security dict doesn't require a model bump.
+
+    ``extra="allow"`` lets unrecognised top-level fields pass through unchanged
+    instead of failing FastAPI response validation. (The handler returns
+    ``Dict[str, Any]`` directly — unlike ``/healthz`` which returns
+    ``JSONResponse`` — so response_model IS enforced at runtime here.)
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    ok: bool
+    time: float
+    version: str
+    cli: dict[str, Any] | None = None
+    jobs: dict[str, Any] | None = None
+    security: dict[str, Any] | None = None
+
+
+class ReadinessServer(BaseModel):
+    """The ``server`` block inside a readiness envelope's ``data`` payload."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    time: float
+    version: str
+    auth_mode: str
+    backend_live: bool
+
+
+class ReadinessData(BaseModel):
+    """Payload of the readiness envelope (``ApiEnvelope[ReadinessData]``).
+
+    ``pipelines`` is a mapping from pipeline name (e.g. ``"lux-depth-v3"``,
+    ``"archive-gate-a"``) to a per-pipeline readiness dict. Per-pipeline
+    contents come from ``app.py:_evaluate_pipeline_readiness`` and vary by
+    pipeline; modeling each variant would couple this file to deep
+    pipeline-specific logic, so we keep it ``dict[str, Any]``.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    server: ReadinessServer
+    pipelines: dict[str, dict[str, Any]]
+
+
+ReadinessEnvelope = ApiEnvelope[ReadinessData]
+"""Convenience alias for the typed envelope wrapping ``ReadinessData``.
+
+Use this as the ``response_model`` on the ``/v1/readiness`` route so FastAPI's
+OpenAPI generation picks up both the envelope shape and the readiness payload.
+"""
+
+__all__ = [
+    "HealthzResponse",
+    "ReadinessData",
+    "ReadinessEnvelope",
+    "ReadinessServer",
+    "ReadyResponse",
+]

--- a/tests/api/v1/test_health_models.py
+++ b/tests/api/v1/test_health_models.py
@@ -9,6 +9,8 @@ response validation in CI's contract tests.
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 from pydantic import ValidationError
 
@@ -21,9 +23,78 @@ from transformation_portal.api.v1 import (
     ReadyResponse,
 )
 
+pytestmark = pytest.mark.unit
+
+
+def _lux_depth_pipeline_payload() -> dict[str, Any]:
+    return {
+        "status": "ready",
+        "canonical_command": "lux-depth-v3",
+        "missing_prerequisites": [],
+        "runner_details": {
+            "type": "python_module",
+            "available": True,
+            "module": "transformation_portal.lux_depth_v3",
+            "command": ["/usr/bin/python", "-m", "transformation_portal.lux_depth_v3"],
+            "python_executable": "/usr/bin/python",
+        },
+        "notes": ["Base readiness covers runner invocation, path safety, and orchestrator preflight."],
+        "canary_status": "ready",
+    }
+
+
+def _archive_gate_pipeline_payload(
+    pipeline: str,
+    *,
+    status: str,
+    missing_prerequisites: list[dict[str, Any]],
+) -> dict[str, Any]:
+    command_by_pipeline = {
+        "archive-gate-a": "fixity-scan",
+        "archive-gate-b": "bag-build",
+        "archive-gate-c": "mets-export",
+    }
+    note_by_pipeline = {
+        "archive-gate-a": "Canonical archive-gate-a dispatch expects fixity-scan with an existing archive index.",
+        "archive-gate-b": "Canonical dispatch for this archive stage requires a prior rights-manifest artifact.",
+        "archive-gate-c": "Canonical dispatch for this archive stage requires a prior rights-manifest artifact.",
+    }
+    command = command_by_pipeline[pipeline]
+    return {
+        "status": status,
+        "canonical_command": command,
+        "missing_prerequisites": missing_prerequisites,
+        "runner_details": {
+            "type": "python_script",
+            "available": True,
+            "script_path": "/repo/tools/archive_governance.py",
+            "python_executable": "/usr/bin/python",
+            "command": ["/usr/bin/python", "/repo/tools/archive_governance.py", "--json", command],
+        },
+        "notes": [note_by_pipeline[pipeline]],
+    }
+
+
+def _archive_index_required_issue() -> dict[str, Any]:
+    return {
+        "reason": "archive_index_required",
+        "severity": "degraded",
+        "message": "An existing archive index is required at dispatch time.",
+        "field": "archive_index",
+    }
+
+
+def _rights_manifest_required_issue() -> dict[str, Any]:
+    return {
+        "reason": "rights_manifest_required",
+        "severity": "blocked",
+        "message": "A rights-manifest JSONL artifact from a prior archive stage is required.",
+        "field": "manifest_jsonl",
+    }
+
 
 class TestHealthzResponse:
-    """Mirrors ``app.py`` line 7831: ``JSONResponse({"ok": True, "time": _now()})``."""
+    """Mirrors ``healthz()``: ``JSONResponse({"ok": True, "time": _now()})``."""
 
     def test_minimal_valid_input(self) -> None:
         h = HealthzResponse(ok=True, time=1234.5)
@@ -44,7 +115,7 @@ class TestHealthzResponse:
 
 
 class TestReadyResponse:
-    """Mirrors ``app.py`` line 7842: minimal vs verbose shapes."""
+    """Mirrors ``ready()``: minimal vs verbose shapes."""
 
     def test_minimal_shape_when_verbose_false(self) -> None:
         # When TP_READY_VERBOSE=false, the handler returns just ok/time/version.
@@ -112,26 +183,41 @@ class TestReadinessServer:
 
     def test_extra_keys_rejected(self) -> None:
         with pytest.raises(ValidationError):
-            ReadinessServer(time=1.0, version="0.1.0", auth_mode="direct_debug", backend_live=True, x="y")  # type: ignore[call-arg]
+            ReadinessServer(
+                time=1.0,
+                version="0.1.0",
+                auth_mode="direct_debug",
+                backend_live=True,
+                x="y",  # type: ignore[call-arg]
+            )
 
 
 class TestReadinessData:
     def test_envelope_payload_shape(self) -> None:
         data = ReadinessData(
             server=ReadinessServer(time=1.0, version="0.1.0", auth_mode="direct_debug", backend_live=True),
-            pipelines={"lux-depth-v3": {"ready": True}, "archive-gate-a": {"ready": False, "reason": "x"}},
+            pipelines={
+                "lux-depth-v3": _lux_depth_pipeline_payload(),
+                "archive-gate-a": _archive_gate_pipeline_payload(
+                    "archive-gate-a",
+                    status="degraded",
+                    missing_prerequisites=[_archive_index_required_issue()],
+                ),
+            },
         )
         dumped = data.model_dump(mode="json")
         assert set(dumped.keys()) == {"server", "pipelines"}
-        assert dumped["pipelines"]["lux-depth-v3"]["ready"] is True
-        assert dumped["pipelines"]["archive-gate-a"]["reason"] == "x"
+        assert dumped["pipelines"]["lux-depth-v3"]["status"] == "ready"
+        assert dumped["pipelines"]["lux-depth-v3"]["canonical_command"] == "lux-depth-v3"
+        assert dumped["pipelines"]["archive-gate-a"]["status"] == "degraded"
+        assert dumped["pipelines"]["archive-gate-a"]["missing_prerequisites"][0]["reason"] == "archive_index_required"
 
 
 class TestReadinessEnvelope:
     """``ApiEnvelope[ReadinessData]`` — the wire shape of GET /v1/readiness."""
 
     def test_full_round_trip_matches_handler_shape(self) -> None:
-        # Construct the envelope the way the handler does at app.py:7888-7901.
+        # Construct the envelope the way readiness() does through _api_envelope.
         env = ReadinessEnvelope(
             schema="tp.orchestrator.readiness.v1",
             success=True,
@@ -143,10 +229,22 @@ class TestReadinessEnvelope:
                     backend_live=True,
                 ),
                 pipelines={
-                    "lux-depth-v3": {"ready": True},
-                    "archive-gate-a": {"ready": True},
-                    "archive-gate-b": {"ready": False, "reason": "manifest_missing"},
-                    "archive-gate-c": {"ready": True},
+                    "lux-depth-v3": _lux_depth_pipeline_payload(),
+                    "archive-gate-a": _archive_gate_pipeline_payload(
+                        "archive-gate-a",
+                        status="degraded",
+                        missing_prerequisites=[_archive_index_required_issue()],
+                    ),
+                    "archive-gate-b": _archive_gate_pipeline_payload(
+                        "archive-gate-b",
+                        status="blocked",
+                        missing_prerequisites=[_rights_manifest_required_issue()],
+                    ),
+                    "archive-gate-c": _archive_gate_pipeline_payload(
+                        "archive-gate-c",
+                        status="blocked",
+                        missing_prerequisites=[_rights_manifest_required_issue()],
+                    ),
                 },
             ),
         )
@@ -158,11 +256,15 @@ class TestReadinessEnvelope:
         assert dumped["error"] is None
         # Payload shape
         assert dumped["data"]["server"]["backend_live"] is True
-        assert dumped["data"]["pipelines"]["archive-gate-b"]["reason"] == "manifest_missing"
+        archive_gate_b = dumped["data"]["pipelines"]["archive-gate-b"]
+        assert archive_gate_b["status"] == "blocked"
+        assert archive_gate_b["missing_prerequisites"][0]["reason"] == "rights_manifest_required"
 
     def test_alias_is_apienvelope_specialization(self) -> None:
         # ReadinessEnvelope is just sugar for ApiEnvelope[ReadinessData];
-        # the underlying type identity matters for FastAPI's OpenAPI generation.
+        # the underlying generic specialization matters for FastAPI's OpenAPI
+        # generation, but parameterized generic object identity is not stable
+        # across all Python/Pydantic versions.
         # NOTE: by design, the alias does NOT lock the schema field to
         # "tp.orchestrator.readiness.v1" — any valid SchemaName is accepted at
         # the model layer, and the route handler is responsible for setting the
@@ -170,7 +272,10 @@ class TestReadinessEnvelope:
         # api/v1/ (only ErrorEnvelope locks its schema, because there's a single
         # canonical error schema). If a future refactor wants per-route schema
         # locking, that's a subclassing exercise, not an alias change.
-        assert ReadinessEnvelope is ApiEnvelope[ReadinessData]
+        metadata = ReadinessEnvelope.__pydantic_generic_metadata__
+        assert issubclass(ReadinessEnvelope, ApiEnvelope)
+        assert metadata["origin"] is ApiEnvelope
+        assert metadata["args"] == (ReadinessData,)
 
     def test_unrecognised_schema_string_rejected_at_literal_level(self) -> None:
         # The SchemaName Literal does still reject unknown strings — the

--- a/tests/api/v1/test_health_models.py
+++ b/tests/api/v1/test_health_models.py
@@ -1,0 +1,186 @@
+"""Unit tests for the health/readiness response models (Phase 1.2 PR B).
+
+These tests verify the typed models in
+``transformation_portal.api.v1.health`` accept and reject the wire shapes
+that ``app.py``'s ``/healthz``, ``/ready``, and ``/v1/readiness`` handlers
+produce. Wire-shape regressions are caught here BEFORE they reach FastAPI's
+response validation in CI's contract tests.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from transformation_portal.api.v1 import (
+    ApiEnvelope,
+    HealthzResponse,
+    ReadinessData,
+    ReadinessEnvelope,
+    ReadinessServer,
+    ReadyResponse,
+)
+
+
+class TestHealthzResponse:
+    """Mirrors ``app.py`` line 7831: ``JSONResponse({"ok": True, "time": _now()})``."""
+
+    def test_minimal_valid_input(self) -> None:
+        h = HealthzResponse(ok=True, time=1234.5)
+        assert h.model_dump(mode="json") == {"ok": True, "time": 1234.5}
+
+    def test_field_order_matches_handler(self) -> None:
+        h = HealthzResponse(ok=True, time=1.0)
+        assert list(h.model_dump(mode="json").keys()) == ["ok", "time"]
+
+    def test_extra_keys_are_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            HealthzResponse(ok=True, time=1.0, extra_field="nope")  # type: ignore[call-arg]
+
+    def test_int_time_is_coerced_to_float(self) -> None:
+        # _now() returns a float, but accept ints too — JSON conflates the two.
+        h = HealthzResponse(ok=True, time=1234)  # type: ignore[arg-type]
+        assert h.time == 1234.0
+
+
+class TestReadyResponse:
+    """Mirrors ``app.py`` line 7842: minimal vs verbose shapes."""
+
+    def test_minimal_shape_when_verbose_false(self) -> None:
+        # When TP_READY_VERBOSE=false, the handler returns just ok/time/version.
+        # The route is wired with response_model_exclude_none=True so the
+        # serialized output matches.
+        r = ReadyResponse(ok=True, time=1.0, version="0.1.0")
+        dumped = r.model_dump(mode="json", exclude_none=True)
+        assert dumped == {"ok": True, "time": 1.0, "version": "0.1.0"}
+
+    def test_verbose_shape_includes_cli_jobs_security(self) -> None:
+        r = ReadyResponse(
+            ok=True,
+            time=1.0,
+            version="0.1.0",
+            cli={"lux-depth-v3": True, "archive-governance": True, "python": "3.11.15"},
+            jobs={"active": 0, "total": 5},
+            security={
+                "api_key_enforced_for_jobs": True,
+                "rate_limit_per_minute": 60,
+                "max_concurrent_jobs": 4,
+                "max_request_bytes": 65536,
+                "trusted_hosts_enabled": True,
+                "trust_x_forwarded_for": False,
+                "trusted_proxy_ips_count": 0,
+                "allowed_input_roots_count": 1,
+                "allowed_output_roots_count": 1,
+                "allow_sse_query_api_key": False,
+                "docs_enabled": False,
+            },
+        )
+        dumped = r.model_dump(mode="json")
+        assert dumped["ok"] is True
+        assert dumped["cli"] == {"lux-depth-v3": True, "archive-governance": True, "python": "3.11.15"}
+        assert dumped["jobs"]["active"] == 0
+        assert dumped["security"]["api_key_enforced_for_jobs"] is True
+
+    def test_extra_top_level_keys_pass_through(self) -> None:
+        # extra="allow" — the security dict churns and we don't want a strict
+        # model to reject a new field added to the handler.
+        r = ReadyResponse(ok=True, time=1.0, version="0.1.0", future_field="ok")
+        # extra fields are accepted; they appear in dump
+        assert r.model_dump(mode="json")["future_field"] == "ok"
+
+    def test_unknown_keys_inside_security_are_tolerated(self) -> None:
+        # The security sub-dict is `dict[str, Any]`, so any new feature flag
+        # rolls through without a model bump.
+        r = ReadyResponse(
+            ok=True,
+            time=1.0,
+            version="0.1.0",
+            security={"api_key_enforced_for_jobs": True, "future_flag_2027": "rolled out"},
+        )
+        assert r.security == {"api_key_enforced_for_jobs": True, "future_flag_2027": "rolled out"}
+
+
+class TestReadinessServer:
+    def test_required_fields(self) -> None:
+        s = ReadinessServer(time=1.0, version="0.1.0", auth_mode="direct_debug", backend_live=True)
+        assert s.model_dump(mode="json") == {
+            "time": 1.0,
+            "version": "0.1.0",
+            "auth_mode": "direct_debug",
+            "backend_live": True,
+        }
+
+    def test_extra_keys_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ReadinessServer(time=1.0, version="0.1.0", auth_mode="direct_debug", backend_live=True, x="y")  # type: ignore[call-arg]
+
+
+class TestReadinessData:
+    def test_envelope_payload_shape(self) -> None:
+        data = ReadinessData(
+            server=ReadinessServer(time=1.0, version="0.1.0", auth_mode="direct_debug", backend_live=True),
+            pipelines={"lux-depth-v3": {"ready": True}, "archive-gate-a": {"ready": False, "reason": "x"}},
+        )
+        dumped = data.model_dump(mode="json")
+        assert set(dumped.keys()) == {"server", "pipelines"}
+        assert dumped["pipelines"]["lux-depth-v3"]["ready"] is True
+        assert dumped["pipelines"]["archive-gate-a"]["reason"] == "x"
+
+
+class TestReadinessEnvelope:
+    """``ApiEnvelope[ReadinessData]`` — the wire shape of GET /v1/readiness."""
+
+    def test_full_round_trip_matches_handler_shape(self) -> None:
+        # Construct the envelope the way the handler does at app.py:7888-7901.
+        env = ReadinessEnvelope(
+            schema="tp.orchestrator.readiness.v1",
+            success=True,
+            data=ReadinessData(
+                server=ReadinessServer(
+                    time=1.0,
+                    version="0.1.0",
+                    auth_mode="direct_debug",
+                    backend_live=True,
+                ),
+                pipelines={
+                    "lux-depth-v3": {"ready": True},
+                    "archive-gate-a": {"ready": True},
+                    "archive-gate-b": {"ready": False, "reason": "manifest_missing"},
+                    "archive-gate-c": {"ready": True},
+                },
+            ),
+        )
+        dumped = env.model_dump(mode="json")
+        # Top-level envelope keys in the standard order
+        assert list(dumped.keys()) == ["schema", "success", "data", "error"]
+        assert dumped["schema"] == "tp.orchestrator.readiness.v1"
+        assert dumped["success"] is True
+        assert dumped["error"] is None
+        # Payload shape
+        assert dumped["data"]["server"]["backend_live"] is True
+        assert dumped["data"]["pipelines"]["archive-gate-b"]["reason"] == "manifest_missing"
+
+    def test_alias_is_apienvelope_specialization(self) -> None:
+        # ReadinessEnvelope is just sugar for ApiEnvelope[ReadinessData];
+        # the underlying type identity matters for FastAPI's OpenAPI generation.
+        # NOTE: by design, the alias does NOT lock the schema field to
+        # "tp.orchestrator.readiness.v1" — any valid SchemaName is accepted at
+        # the model layer, and the route handler is responsible for setting the
+        # right schema string. This matches the alias pattern used elsewhere in
+        # api/v1/ (only ErrorEnvelope locks its schema, because there's a single
+        # canonical error schema). If a future refactor wants per-route schema
+        # locking, that's a subclassing exercise, not an alias change.
+        assert ReadinessEnvelope is ApiEnvelope[ReadinessData]
+
+    def test_unrecognised_schema_string_rejected_at_literal_level(self) -> None:
+        # The SchemaName Literal does still reject unknown strings — the
+        # alias just doesn't pin the field to a single value.
+        with pytest.raises(ValidationError):
+            ReadinessEnvelope(
+                schema="tp.orchestrator.not_a_real_schema.v1",
+                success=True,
+                data=ReadinessData(
+                    server=ReadinessServer(time=1.0, version="0.1.0", auth_mode="direct_debug", backend_live=True),
+                    pipelines={},
+                ),
+            )


### PR DESCRIPTION
## Summary

Phase 1.2 **PR B** of the remediation plan from #1558. Builds on PR A (#1561, merged) by wiring `response_model=` on the smallest exposed route group: `/healthz`, `/ready`, `/v1/readiness`. Three routes, four files, +324/−3.

This is the first PR in Phase 1.2 that actually touches `app.py`. The handler logic is **unchanged** — only decorators get a `response_model=` parameter and a 3-line import is added. Runtime serialization is identical to before.

## What ships

`src/transformation_portal/api/v1/health.py` (new):
- `HealthzResponse` — closed schema for `/healthz` `{ok, time}`
- `ReadyResponse` — open schema for `/ready` (`extra="allow"` + optional `cli/jobs/security` verbose dicts; matches the handler's churning shape so a new feature flag added to the security dict doesn't require a model bump)
- `ReadinessServer` + `ReadinessData` — typed payload for `/v1/readiness`
- `ReadinessEnvelope = ApiEnvelope[ReadinessData]` — typed envelope alias

`app.py`: 3 route decorators get `response_model=…` plus a 3-line import. The `/ready` decorator also gets `response_model_exclude_none=True` (see *Wire-shape preservation* below).

`tests/api/v1/test_health_models.py` (new): 14 unit tests covering each shape, verbose vs minimal `/ready`, schema-name validation, and the envelope round-trip.

## Wire-shape preservation

Critical invariant: **the wire shape returned by all three routes is unchanged**. PR A's test suite (the byte-equivalence golden tests) plus the existing `tests/test_app_orchestrator_contract_http.py` enforce this. Per-route notes:

| Route | Handler returns | response_model effect |
|---|---|---|
| `/healthz` | `JSONResponse({"ok": ..., "time": ...})` | **OpenAPI-only** — when a handler returns `JSONResponse`, FastAPI bypasses response_model serialization. The decorator is documentation-only here. |
| `/ready` | `Dict[str, Any]` | **Enforced** — FastAPI runs the dict through the model. To preserve the existing wire shape (no `cli/jobs/security` keys when `TP_READY_VERBOSE=false`), the decorator sets `response_model_exclude_none=True`. Without that flag the model's optional fields would be serialized as `null` and external probes might break. |
| `/v1/readiness` | `JSONResponse(_api_envelope(...))` | **OpenAPI-only** — same as `/healthz`. |

So the runtime behavior changes for **zero routes** with this PR; the only observable difference is OpenAPI documentation quality if `ENABLE_API_DOCS=true`.

## Verification

| Check | Result |
|---|---|
| `pytest tests/api/v1/` | ✅ 59 passed (was 45; +14 new health tests) |
| `pytest tests/test_app_orchestrator_contract_http.py -k 'healthz or ready or readiness'` | ✅ 5 passed — `test_ready_keeps_non_enveloped_shape`, `test_healthz_returns_minimal_health_response`, `test_readiness_contract_reports_pipeline_status_matrix`, etc. all green |
| `mypy --config-file=mypy.ini src/transformation_portal/api/` | ✅ no issues in 6 source files |
| `black --check` / `isort --check-only` | ✅ |
| `make validate-ci` | ✅ workflow contracts still green |
| `scripts/governance/check_*` (3 scripts) | ✅ all clean |
| `scripts/setup/pre-commit-check.sh --all` | ✅ |

## Implementation note: alias vs subclass for `ReadinessEnvelope`

`ReadinessEnvelope` is `ApiEnvelope[ReadinessData]` (a generic alias), not a subclass that locks the schema field to `tp.orchestrator.readiness.v1`. This means the model accepts any valid `SchemaName` — the route handler is responsible for setting the correct schema string. Same pattern as the rest of `api/v1/`, except `ErrorEnvelope` which subclasses to lock its schema (because there's only one canonical error schema).

If a future refactor wants per-route schema locking, that's a subclassing exercise rather than an alias change. The test file documents this design choice explicitly.

## What this PR deliberately does NOT do

- **Does not enable `/docs`** (`ENABLE_API_DOCS`). Wiring `response_model=` makes the OpenAPI schema richer, but flipping the docs gate is a separate decision that should land after enough routes are wired to render a useful schema.
- **Does not migrate `_error_response` callers**. Same as PR A's note.
- **Does not fully type the verbose `/ready` sub-dicts** (`cli`, `jobs`, `security`). They're modeled as `dict[str, Any]` because their internal fields churn and the typing-vs-maintenance trade-off favors keeping them open. If a caller ever needs strict types there, that can be a focused follow-up.
- **Does not touch the `/v1/jobs`, `/v1/presets`, `/v1/config-*`, `/v1/portal/*`, `/v1/uploads/staging` routes**. Those are PRs C / D / E.

## Next in the sequence

- **PR C** — Job lifecycle routes (POST/GET/cancel for `/v1/jobs` + `/v2/jobs` mirrors). Largest payoff — most extensive existing test coverage. Needs `JobCreateRequest` and `JobResponse` models with care because the handlers mix `JSONResponse` and dict returns.
- **PR D** — Config/presets routes
- **PR E** — Telemetry + uploads routes

After PR E lands, Phase 1.2 is complete and Phase 2 (durable job persistence — replace the in-memory `JOBS` dict) has the typed contract surface it needs.

## Related

- Builds on the architectural review and remediation plan from #1558 (merged)
- Builds on the typed envelope foundation from #1561 (merged)
- Companion to #1559 (Phase 1.3, merged) and #1560 (Phase 1.4, merged)

https://claude.ai/code/session_01PLN8LgZE36roWFApu5dJke

---
_Generated by [Claude Code](https://claude.ai/code/session_01PLN8LgZE36roWFApu5dJke)_