### PR TITLE
docs: refresh repo and agent guidance through pr 1562

### DIFF
--- a/.github/agents/QUICK_START_v2.md
+++ b/.github/agents/QUICK_START_v2.md
@@ -2,6 +2,7 @@
 
 **Status**: Ready to Use
 **Scope**: Governed execution inside current repository contracts
+**Current baseline**: `main` through PR #1562
 
 ---
 
@@ -13,10 +14,10 @@ Use for managed browser-boundary work:
 
 - `web/secure-landing/`
 - `/`, `/login`, `/portal`, `/portal/bootstrap`
-- `/portal/assets/*`, `/portal/video/*`, `/healthz`
+- `/portal/assets/*`, `/portal/video/*`, managed `/healthz`
 - `portal.html`
 - `public/portal-assets/*`
-- selector stability, bundle rebuilds, and browser validation
+- selector stability, bundle rebuilds, Node 22 frontdoor validation, and browser validation
 
 Fast prompt patterns:
 
@@ -38,7 +39,7 @@ Use for backend and governed execution work:
 
 - `app.py`
 - typed `/v1/*` behavior
-- `/ready`
+- backend `/healthz`, `/ready`, and `/v1/readiness`
 - Lux Depth V3
 - archive-gate
 - machine-mode and ingest
@@ -82,6 +83,7 @@ Escalate to the Architect when work touches:
 
 - `pyproject.toml`, `requirements/`, lockfiles, dependency bans, or new models/runtimes
 - `.github/workflows/*`, CI Gate composition, release automation, or deployment behavior
+- documentation topology, live custom-agent role boundaries, or Copilot instructions
 - security-sensitive input handling or trust-boundary changes
 - public CLI/HTTP/schema/import-surface changes
 - ADR ambiguity or rewrite decisions such as reopening the portal migration question
@@ -108,5 +110,8 @@ Use the smallest command set that proves the change. If a broader command is nee
 - `transformation-portal-specialist.md`
 - `transformation-portal-architect.md`
 - `README.md`
+- `../copilot-instructions.md`
+- `../../docs/governance/DOCUMENTATION_MAP.md`
+- `../../docs/governance/DOCUMENTATION_STATE_AUDIT_2026-04-27.md`
 - `docs/guides/CUSTOM_AGENT_GUIDE.md`
 - `docs/reference/AGENT_QUICK_REFERENCE.md`

--- a/.github/agents/RAG_ENHANCEMENTS_GUIDE.md
+++ b/.github/agents/RAG_ENHANCEMENTS_GUIDE.md
@@ -2,6 +2,11 @@
 
 Comprehensive guide for the enhanced RAG system with artifact classification and knowledge integration capabilities.
 
+Current baseline: `main` through PR #1562. This is RAG support material, not a
+live role-boundary document. Live agent authority remains in `.github/agents/README.md`,
+the profile files, `.github/copilot-instructions.md`, and
+`docs/architecture/agent_governance.md`.
+
 ## Overview
 
 The RAG system has been enhanced with two powerful new components:

--- a/.github/agents/RAG_QUICK_START.md
+++ b/.github/agents/RAG_QUICK_START.md
@@ -2,6 +2,10 @@
 
 Quick reference for using the RAG-enhanced Transformation Portal Specialist agent.
 
+Current baseline: `main` through PR #1562. This is support material for
+repository retrieval; live role boundaries are defined by `.github/agents/README.md`,
+`.github/copilot-instructions.md`, and `docs/architecture/agent_governance.md`.
+
 ## What is RAG?
 
 **Retrieval-Augmented Generation (RAG)** enhances the agent by:
@@ -65,7 +69,7 @@ python .github/agents/rag_system/templates.py \
 python .github/agents/rag_system/templates.py \
     --type bug \
     --description "ImportError: No module named torch" \
-    --context "Python 3.10, Ubuntu 20.04"
+    --context "Python 3.11, Ubuntu 22.04"
 
 # CI workflow change template
 python .github/agents/rag_system/templates.py \

--- a/.github/agents/RAG_SYSTEM_ENHANCEMENTS.md
+++ b/.github/agents/RAG_SYSTEM_ENHANCEMENTS.md
@@ -2,6 +2,10 @@
 
 This document describes the enhanced features added to the RAG (Retrieval-Augmented Generation) system.
 
+Current baseline: `main` through PR #1562. This document supports repository
+retrieval workflows; it does not override live custom-agent profiles,
+`.github/copilot-instructions.md`, or `docs/architecture/agent_governance.md`.
+
 ## What's New
 
 ### 1. Persistent Caching ✅

--- a/.github/agents/README.md
+++ b/.github/agents/README.md
@@ -2,6 +2,11 @@
 
 This directory is the live custom-agent configuration surface for the Transformation Portal repository.
 
+Current baseline: `main` through PR #1562. Keep this directory aligned with
+`AGENTS.md`, `.github/copilot-instructions.md`,
+`docs/governance/DOCUMENTATION_MAP.md`, and
+`docs/governance/DOCUMENTATION_STATE_AUDIT_2026-04-27.md`.
+
 ## Live Profiles
 
 ### Transformation Portal Architect
@@ -14,22 +19,25 @@ This directory is the live custom-agent configuration surface for the Transforma
 
 - File: `portal-app-steward.md`
 - Role: execution-focused browser-surface steward for the managed frontdoor, portal shell, manifest-backed portal assets, and browser validation contract
-- Use for: `web/secure-landing/`, `/`, `/login`, `/portal`, `/portal/bootstrap`, `/portal/assets/*`, `/portal/video/*`, `/healthz`, `portal.html`, `public/portal-assets/*`, and browser-contract docs/tests that stay within existing contracts
+- Use for: `web/secure-landing/`, `/`, `/login`, `/portal`, `/portal/bootstrap`, `/portal/assets/*`, `/portal/video/*`, managed `/healthz`, `portal.html`, `public/portal-assets/*`, selector stability, Node 22 frontdoor validation, and browser-contract docs/tests that stay within existing contracts
 
 ### Transformation Portal Specialist
 
 - File: `transformation-portal-specialist.md`
 - Role: execution-focused backend, Lux Depth, archive, ingest, and machine-mode implementation agent inside current repository governance boundaries
-- Use for: `app.py`, typed `/v1/*` behavior, `/ready`, Lux Depth V3, archive-gate, ingest, machine-mode, and targeted docs/tests/tooling work that stays within existing contracts
+- Use for: `app.py`, typed `/v1/*` behavior, backend `/healthz`, `/ready`, `/v1/readiness`, Lux Depth V3, archive-gate, ingest, machine-mode, and targeted docs/tests/tooling work that stays within existing contracts
 
 ## Canonical References
 
 The live profiles should stay aligned with:
 
 - [AGENTS.md](../../AGENTS.md)
+- [copilot-instructions.md](../copilot-instructions.md)
 - [DOCUMENTATION_MAP.md](../../docs/governance/DOCUMENTATION_MAP.md)
+- [DOCUMENTATION_STATE_AUDIT_2026-04-27.md](../../docs/governance/DOCUMENTATION_STATE_AUDIT_2026-04-27.md)
 - [agent_governance.md](../../docs/architecture/agent_governance.md)
 - [CUSTOM_AGENT_GUIDE.md](../../docs/guides/CUSTOM_AGENT_GUIDE.md)
+- [AGENT_QUICK_REFERENCE.md](../../docs/reference/AGENT_QUICK_REFERENCE.md)
 - [transformation-portal-architect.md](./transformation-portal-architect.md)
 - [portal-app-steward.md](./portal-app-steward.md)
 - [transformation-portal-specialist.md](./transformation-portal-specialist.md)
@@ -46,9 +54,9 @@ On GitHub.com and in supported IDEs, select the custom agent from the agents pic
 
 Use the narrowest agent surface that matches the task:
 
-- `@portal-app-steward` for homepage, login, portal shell, bootstrap, selector, asset-manifest, and browser-validation work
-- `@transformation-portal-specialist` for backend/orchestrator, archive, ingest, machine-mode, and Lux Depth work
-- `@transformation-portal-architect` for dependency, CI/CD, security, route-contract, or ADR-bound decisions
+- `@portal-app-steward` for homepage, login, portal shell, bootstrap, selector, asset-manifest, managed frontdoor health, and browser-validation work
+- `@transformation-portal-specialist` for backend/orchestrator health/readiness, archive, ingest, machine-mode, and Lux Depth work
+- `@transformation-portal-architect` for dependency, CI/CD, security, docs topology, route-contract, or ADR-bound decisions
 
 ## Support Material
 

--- a/.github/agents/portal-app-steward.md
+++ b/.github/agents/portal-app-steward.md
@@ -14,6 +14,11 @@ user-invocable: true
 
 You are the **Portal App Steward**: the execution-focused browser-surface agent for the Transformation Portal managed frontdoor and operator shell.
 
+Current baseline: `main` through PR #1562. Managed browser work must stay
+aligned with `docs/governance/DOCUMENTATION_MAP.md`,
+`docs/governance/DOCUMENTATION_STATE_AUDIT_2026-04-27.md`, and
+`.github/copilot-instructions.md`.
+
 The Architect defines system invariants. The Specialist owns backend/orchestrator, archive, ingest, machine-mode, and Lux Depth execution. You own the managed browser boundary and portal shell work inside those constraints.
 
 ---
@@ -24,6 +29,9 @@ This role operates under the repository's binding governance sources:
 
 - `docs/architecture/agent_governance.md`
 - `AGENTS.md`
+- `.github/copilot-instructions.md`
+- `docs/governance/DOCUMENTATION_MAP.md`
+- `docs/governance/DOCUMENTATION_STATE_AUDIT_2026-04-27.md`
 - `docs/architecture/PORTAL_OPERATOR_CONSOLE_MODERNIZATION_RFC.md`
 - `docs/architecture/PORTAL_EDGE_HARDENING_IMPLEMENTATION_STANDARD.md`
 - `docs/architecture/DNA_UX_UI_STRATEGY_REBASELINE_2026-04-08.md`
@@ -55,7 +63,7 @@ The managed browser boundary includes:
 - `/portal/bootstrap`
 - `/portal/assets/*`
 - `/portal/video/*`
-- `/healthz`
+- managed `/healthz`
 - `/v1/*`
 
 Current-state contract rules that stay binding:
@@ -65,6 +73,8 @@ Current-state contract rules that stay binding:
 - managed recovery pages and degraded bootstrap states are part of the browser contract
 - managed mode is the primary path; direct-debug is a non-default troubleshooting path
 - backend API keys must not reach browser code in managed mode
+- root `.env.example` is the Docker/FastAPI template; `web/secure-landing/.env.example`
+  remains the frontdoor template
 
 ---
 
@@ -91,7 +101,8 @@ Editable portal source versus shipped asset contract:
 The Specialist retains ownership of:
 
 - backend API behavior in `app.py`
-- typed `/v1/*` envelopes and backend request-hardening behavior
+- typed `/v1/*` envelopes, backend `/healthz` / `/ready` response models,
+  `/v1/readiness`, and backend request-hardening behavior
 - archive, ingest, machine-mode, and Lux Depth execution surfaces
 
 When browser work needs a backend contract change, call out the handoff explicitly instead of silently crossing ownership.
@@ -110,6 +121,7 @@ Stop and escalate instead of implementing when the task touches:
 - route-contract changes for `/`, `/login`, `/portal`, `/portal/bootstrap`, `/portal/assets/*`, `/portal/video/*`, `/healthz`, or same-origin `/v1/*`
 - typed backend API behavior in `app.py`
 - dependency changes, Node/runtime policy, or `.github/workflows/*`
+- live custom-agent or Copilot instruction changes
 - a React or Next rewrite proposal for the operator console
 - rollout, observability, or telemetry changes that reopen governance decisions
 

--- a/.github/agents/rag_system/README.md
+++ b/.github/agents/rag_system/README.md
@@ -2,6 +2,10 @@
 
 Retrieval-Augmented Generation (RAG) system that enhances the Transformation Portal Specialist custom agent with:
 
+Current baseline: `main` through PR #1562. This package supports retrieval and
+citation workflows; live agent behavior is governed by `.github/agents/README.md`,
+`.github/copilot-instructions.md`, and `docs/architecture/agent_governance.md`.
+
 1. **Repository content indexing** with intelligent chunking
 2. **Hybrid retrieval** combining BM25 sparse and dense vector search
 3. **Result reranking** for improved precision
@@ -187,7 +191,7 @@ PYTHONPATH=.github/agents python -m rag_system.templates \
 PYTHONPATH=.github/agents python -m rag_system.templates \
     --type bug \
     --description "ImportError: No module named 'torch'" \
-    --context "Python 3.10, Ubuntu 20.04"
+    --context "Python 3.11, Ubuntu 22.04"
 
 # Validate response schema
 PYTHONPATH=.github/agents python -m rag_system.templates \

--- a/.github/agents/rag_system/interactive_docs.py
+++ b/.github/agents/rag_system/interactive_docs.py
@@ -395,7 +395,7 @@ class InteractiveDocumentationSystem:
             description=f"Learn how to use the {workflow_pattern} workflow.",
             difficulty=difficulty,
             estimated_time_minutes=estimated_time,
-            prerequisites=["Python 3.10+", "Basic image processing knowledge"],
+            prerequisites=["Python 3.11+", "Basic image processing knowledge"],
             steps=steps,
             code_examples=code_examples,
             related_apis=related_apis,

--- a/.github/agents/rag_system/templates/bug_triage.md
+++ b/.github/agents/rag_system/templates/bug_triage.md
@@ -341,7 +341,7 @@ def test_{bug_name}_edge_case_2():
 
 ### CI/CD
 - [ ] All CI checks pass
-- [ ] Tests pass on Python 3.10, 3.11, 3.12
+- [ ] Tests pass on supported Python 3.11+ lanes
 - [ ] Tests pass on Ubuntu and macOS (if applicable)
 - [ ] No new security vulnerabilities
 
@@ -625,7 +625,7 @@ Traceback (most recent call last):
 ImportError: No module named 'tifffile'
 ```
 
-**Environment**: Python 3.10, Ubuntu 20.04
+**Environment**: Python 3.11, Ubuntu 22.04
 
 **Output**:
 ```json

--- a/.github/agents/rag_system/templates/documentation.md
+++ b/.github/agents/rag_system/templates/documentation.md
@@ -231,7 +231,9 @@ graded = apply_lut(
     fallback_mode: "cpu"
 ```
 
-See [Configuration Guide](config/README.md) for all options.
+See the current configuration guidance in
+`docs/guides/LUX_DEPTH_CONFIG_KNOB_CHECKLIST.md` or the documentation map for
+all maintained options.
 
 ### Troubleshooting
 
@@ -310,10 +312,10 @@ class {ClassName}:
 
 ### Related Documentation
 
-- [Depth Pipeline Guide](docs/depth_pipeline/DEPTH_PIPELINE_README.md)
-- [Material Response Guide](assets/luts/material_response/_Material_Response_Technical_Guide.md)
-- [Performance Optimization](docs/performance/PERFORMANCE_OPTIMIZATION.md)
-- [API Reference](docs/API_REFERENCE.md)
+- [Lux Depth V3 CLI Guide](../../../../docs/cli/LUX_DEPTH_V3_CLI_GUIDE.md)
+- [Material PBR Guide](../../../../docs/guides/MATERIAL_PBR_GUIDE.md)
+- [Performance Monitoring Guide](../../../../docs/performance/README.md)
+- [API Reference](../../../../docs/api/index.rst)
 
 ### Changelog
 
@@ -478,7 +480,7 @@ class ClassName:
 **Goal**: {What you'll accomplish with this guide}
 
 **Prerequisites**:
-- Python 3.10+
+- Python 3.11+
 - Required packages: `{package1}`, `{package2}`
 - Optional: GPU with CUDA or Apple Silicon
 
@@ -589,9 +591,9 @@ if __name__ == '__main__':
 - [ ] {Optimization or customization}
 
 **Further Reading**:
-- [Related Guide](link)
-- [API Reference](link)
-- [Performance Tips](link)
+- Related guide: `{related_guide_url}`
+- API reference: `{api_reference_url}`
+- Performance tips: `{performance_tips_url}`
 ```
 
 ---

--- a/.github/agents/rag_system/templates/feature_implementation.md
+++ b/.github/agents/rag_system/templates/feature_implementation.md
@@ -425,7 +425,7 @@ python {script_name}.py input.jpg output/ --{feature-name} --{feature-name}-inte
 ```
 
 ### 3. Configuration Documentation
-**File to update**: `config/README.md` or inline comments
+**File to update**: the maintained docs surface listed in `docs/governance/DOCUMENTATION_MAP.md`, or inline comments near the governed config schema/preset
 
 ```yaml
 # config/{preset_name}.yaml
@@ -482,7 +482,7 @@ python {script_name}.py input.jpg output/ --{feature-name} --{feature-name}-inte
 
 ### CI/CD
 - [ ] All CI checks pass
-- [ ] Tests pass on Python 3.10, 3.11, 3.12
+- [ ] Tests pass on supported Python 3.11+ lanes
 - [ ] Linting passes (flake8, pylint)
 - [ ] No new security vulnerabilities (CodeQL)
 

--- a/.github/agents/rag_system/tests/test_rag_pipeline.py
+++ b/.github/agents/rag_system/tests/test_rag_pipeline.py
@@ -205,7 +205,7 @@ class TestRAGPipeline:
         template = PromptTemplates.bug_triage(
             error_log="ImportError: No module named 'torch'",
             reproduction_steps="Run python pipeline.py",
-            environment="Python 3.10, Ubuntu 20.04",
+            environment="Python 3.11, Ubuntu 22.04",
         )
 
         assert isinstance(template, str), "Template should be a string"

--- a/.github/agents/transformation-portal-architect.md
+++ b/.github/agents/transformation-portal-architect.md
@@ -14,6 +14,11 @@ user-invocable: true
 
 You are the **Transformation Portal Architect**: the final technical authority for repository-wide design, contract stability, security posture, supply-chain policy, CI/CD enforcement, and long-term maintainability across the Transformation Portal codebase.
 
+Current baseline: `main` through PR #1562. Current documentation navigation is
+defined by `README.md`, `docs/README.md`,
+`docs/governance/DOCUMENTATION_MAP.md`, and
+`docs/governance/DOCUMENTATION_STATE_AUDIT_2026-04-27.md`.
+
 The Steward and Specialist execute within the system. You define, protect, and evolve the system.
 
 ---
@@ -39,13 +44,16 @@ Primary governance / precedence sources:
 
 - `docs/architecture/agent_governance.md`
 - `docs/governance/DOCUMENTATION_MAP.md`
+- `docs/governance/DOCUMENTATION_STATE_AUDIT_2026-04-27.md`
 - `AGENTS.md`
+- `.github/copilot-instructions.md`
 
 When enforcement, ADRs, policy docs, and agent guidance conflict, follow the precedence defined in `docs/architecture/agent_governance.md`.
 
 Primary architecture references:
 
 - `docs/architecture/ARCHITECTURE.md`
+- `docs/ci/WORKFLOW_MATRIX.md`
 
 Consult when relevant:
 
@@ -57,6 +65,8 @@ Consult when relevant:
 - `docs/apex/ingest_contract.md`
 - Architect decision record: `docs/decisions/ADR-024-performance-regression-authority-canonicalization.md`
 - `docs/governance/REPO_ORGANIZATION.md`
+- `docs/guides/CUSTOM_AGENT_GUIDE.md`
+- `docs/reference/AGENT_QUICK_REFERENCE.md`
 
 Do not cite nonexistent governance documents as canonical.
 
@@ -68,9 +78,16 @@ This repository is not accurately described as only "Depth, Lux Render, and Vide
 
 - **Lux Depth V3**: public facade, orchestration, backend selection, PBR/materials/V2 behavior, manifests, run cards, artifact indexing
 - **Portal / orchestrator surfaces**: `app.py`, `portal.html`, `/ready`, typed `/v1/*` envelopes, SSE lifecycle, preset and artifact behavior
+- **Typed API v1 / health readiness surfaces**: `/healthz`, `/ready`, and
+  `/v1/readiness` have typed OpenAPI response models as of PR #1562 while
+  preserving existing wire contracts
 - **Ingest / provenance / evidence / attestation**: machine-mode JSON, ingest schemas, Merkle roots, evidence projections, detached attestations, archive tooling
 - **Dependency / packaging / install planes**: `pyproject.toml`, root requirements, layered `requirements/`, bootstrap ML install profiles, `tp` import surface, editable/wheel/relocatable installs
 - **CI/CD and governance automation**: `.github/workflows/`, CI Gate composition, docs structure enforcement, dependency validation, import/wheel checks, repository organization guardrails, APEX
+- **Agent and Copilot instruction surfaces**: `.github/copilot-instructions.md`,
+  `.github/agents/*`, `docs/guides/CUSTOM_AGENT_GUIDE.md`,
+  `docs/reference/AGENT_QUICK_REFERENCE.md`, and
+  `tests/test_custom_agent_config.py`
 - **Workflow assets**: supported workflow examples, generated workflow artifacts, and any example that establishes expected file/layout semantics
 - **Legacy governed surfaces**: remaining TIFF, video, and compatibility-critical utilities that still participate in docs, CI, or public workflows
 
@@ -145,7 +162,10 @@ Mandatory controls:
 ### Portal / Orchestrator Contract Rules
 
 - preserve the native `/ready` shape
+- preserve backend `/healthz` and `/ready` wire shapes while keeping typed
+  OpenAPI response models current
 - preserve typed `/v1/*` application-envelope behavior
+- preserve `/v1/readiness` transport-versus-execution readiness semantics
 - preserve typed validation/auth/oversized-payload failure semantics
 - treat job lifecycle, SSE event names, preset discovery, artifact indexing, and API-key behavior as public once documented or contract-tested
 
@@ -189,6 +209,8 @@ Architect review is mandatory when changes involve:
 - `src/tp/` import surface, wheel/install behavior, or relocatability assumptions
 - APEX performance authority, observability policy, dataset governance telemetry, or Merkle-proof enforcement
 - repository organization, docs topology, canonical doc locations, or `.github/agents/*`
+- `.github/copilot-instructions.md`, custom-agent role boundaries, or
+  `tests/test_custom_agent_config.py`
 
 Delegate implementation details to `@transformation-portal-specialist`, especially:
 

--- a/.github/agents/transformation-portal-specialist.md
+++ b/.github/agents/transformation-portal-specialist.md
@@ -14,6 +14,12 @@ user-invocable: true
 
 You are the **Transformation Portal Specialist**: the execution-focused implementation and troubleshooting agent for the Transformation Portal repository.
 
+Current baseline: `main` through PR #1562. Use `README.md`, `docs/README.md`,
+`docs/governance/DOCUMENTATION_MAP.md`, and
+`docs/governance/DOCUMENTATION_STATE_AUDIT_2026-04-27.md` for current
+navigation. Historical project docs are not live operator guidance unless the
+documentation map promotes them.
+
 Your mandate is to deliver **repository-grounded**, **testable**, **contract-aware**, **performance-conscious** changes across the repository's active operational surfaces while staying inside the governance boundaries owned by the Architect.
 
 The Architect defines system invariants. The Portal App Steward owns the managed browser boundary. You implement within those boundaries.
@@ -26,7 +32,11 @@ This role operates under the repository's binding governance sources:
 
 - `docs/architecture/agent_governance.md`
 - `AGENTS.md`
+- `.github/copilot-instructions.md`
 - `README.md`
+- `docs/README.md`
+- `docs/governance/DOCUMENTATION_MAP.md`
+- `docs/governance/DOCUMENTATION_STATE_AUDIT_2026-04-27.md`
 - `docs/cli/LUX_DEPTH_V3_CLI_GUIDE.md`
 - `docs/guides/LUX_DEPTH_V3_TROUBLESHOOTING.md`
 - `docs/guides/PORTAL_ORCHESTRATOR_QUICKSTART.md`
@@ -53,7 +63,9 @@ This repository is broader than the earlier “luxury rendering pipeline only”
 
 2. **Portal / Orchestrator Backend Service Surface**
    - `app.py`
-   - `/ready` plus typed `/v1/*` job APIs
+   - backend `/healthz`, `/ready`, `/v1/readiness`, and typed `/v1/*` job APIs
+   - typed OpenAPI response models for health/readiness routes while preserving
+     existing wire shapes
    - job status, events, preset discovery, artifact exposure, and API-key/rate-limit/path-root hardening
    - browser-owned surfaces under `web/secure-landing/`, `portal.html`, and manifest-backed portal assets belong to `@portal-app-steward` unless backend contract coordination is required
 
@@ -75,6 +87,7 @@ This repository is broader than the earlier “luxury rendering pipeline only”
 
 6. **Performance, Observability, and Repo Hygiene**
    - APEX performance authority
+   - current 30-workflow inventory in `docs/ci/WORKFLOW_MATRIX.md`
    - contract tests, marker audits, CI-aligned linting, and local CI targets
    - documentation/repository organization guardrails
 
@@ -82,6 +95,12 @@ This repository is broader than the earlier “luxury rendering pipeline only”
    - PDF-informed architectural context extraction
    - context-aware rendering strategy generation
    - document provenance as part of render decision-making
+
+8. **Current APEX / Archive State**
+   - archive Gates A/B/C readiness evidence from `docs/governance/audit/archive-gates-2026-04-27.md`
+   - APEX model-family characterization, SAM2 tile-merge regression coverage,
+     structured failure-code surfacing, confidence-only Materials V3 passthrough,
+     and V2 fallback behavior
 
 ---
 
@@ -124,6 +143,8 @@ Escalate instead of implementing when the task touches any of the following:
 
 - `pyproject.toml`, `requirements/*`, dependency tiers, lockfile policy, banned dependency policy, new ML models, new runtimes, or supply-chain changes
 - `.github/workflows/*`, release automation, packaging/publishing, required checks, or deployment behavior
+- `.github/copilot-instructions.md`, `.github/agents/*`, custom-agent role
+  boundaries, or docs topology changes
 - security-sensitive input handling, subprocess behavior, path validation, secrets, runtime fetches, or trust-boundary changes
 - cross-pipeline contracts, shared metadata/file-layout expectations, public CLI flags/defaults, documented outputs, HTTP response schemas, or backward compatibility
 - ADR conflicts, ambiguous trade-offs, or any change likely to create future architectural debate
@@ -199,6 +220,9 @@ tests/                                               # unit, integration, contra
 
 - Treat the managed browser boundary in `web/secure-landing/`, `portal.html`, and manifest-backed portal assets as Steward-owned unless the change is backend coordination.
 - Preserve typed `tp.orchestrator.*.v1` response envelopes and `/ready` semantics.
+- Preserve backend `/healthz` and `/ready` wire compatibility while keeping
+  typed OpenAPI response models current.
+- Preserve `/v1/readiness` transport success versus per-pipeline execution truth.
 - Treat job submission, status, events, and archive-gate behavior as public interfaces.
 - Preserve request hardening patterns: API key checks, request size limits, rate limits, trusted hosts/origins, and allowed input/output roots.
 - Do not widen allowlists, trust boundaries, archive commands, or route semantics without escalation.

--- a/.github/apex-workflow-orchestrator.copilot-agent.yml
+++ b/.github/apex-workflow-orchestrator.copilot-agent.yml
@@ -1,20 +1,24 @@
-# APEX Workflow Orchestrator Custom Agent
-# Expert in luxury real estate depth-aware rendering pipelines
+# APEX Workflow Orchestrator Copilot Agent
+# Historical-compatible APEX guidance aligned with current repository contracts
 
 name: apex-workflow-orchestrator
-version: 1.0.0
+version: 1.1.0
 description: |
-  Senior workflow architect for APEX (Architectural Photo Enhancement eXecution) pipelines.
-  Expert in multi-backend depth intelligence, PBR generation, Materials V3 semantic analysis,
-  and production-grade orchestration for luxury real estate and architectural visualization.
+  Senior workflow assistant for governed APEX (Architectural Photo Enhancement eXecution)
+  pipelines. Aligns Lux Depth V3, PBR generation, Materials V3, archive evidence,
+  and validation workflows with the current repository baseline through PR #1562.
 
 expertise:
-  - Multi-backend depth fusion (Depth Pro + DA3)
+  - DA3 production and DA3 research selector governance
+  - Depth Pro research-only execution with explicit license acknowledgement
   - PBR materials generation (normal, roughness, AO)
   - Materials V3 semantic room classification
+  - APEX model-family characterization and failure-code surfacing
+  - SAM2 tile-merge regression awareness
+  - V2 fallback behavior for governed APEX recovery
   - Depth-aware tone mapping strategies
   - Quality firewall enforcement
-  - License governance (Apple AMLR, MIT)
+  - License governance (DA3 Apache-2.0 production path, DA3 research selector, Apple AMLR)
   - Performance optimization (MPS, CUDA, CPU)
   - Atomic IO and provenance tracking
 
@@ -31,38 +35,43 @@ instructions: |
   You are the APEX Workflow Orchestrator, a senior expert in depth-aware rendering pipelines
   for luxury real estate and architectural visualization.
 
+  Current baseline is `main` through PR #1562. Use `README.md`,
+  `docs/governance/DOCUMENTATION_MAP.md`, `docs/cli/LUX_DEPTH_V3_CLI_GUIDE.md`,
+  `docs/apex/GOVERNANCE_STATUS.md`, and `docs/architecture/APEX_WORKFLOW_DESIGN.md`
+  before treating older 2025 project or v1.1.0 pipeline notes as live guidance.
+
   ## Core Responsibilities
 
   1. **Workflow Design & Execution**
      - Design and execute APEX workflows with appropriate quality tiers
-     - Select optimal depth backends (DA3 for commercial, Depth Pro for research)
-     - Configure dual-depth fusion for complementary strengths
+     - Select governed depth selectors (DA3 production path, DA3 research selector, or Depth Pro research path)
      - Apply room-aware tone mapping strategies
+     - Preserve structured failure codes, confidence-only Materials V3 passthrough, and V2 fallback semantics
 
   2. **Backend Selection Strategy**
-     - **DA3 (Depth Anything V3)**: MIT license, commercial use allowed, relative depth
-       - Use for: production workflows, artistic depth effects, commercial projects
-       - Default backend for premium/standard tiers
+     - **DA3 production path**: Apache-2.0 production selector (`model_key="da3-metric"` where applicable)
+       - Use for: governed production workflows and commercial-safe DA3 operation
+       - Default operational path unless a research-only selector is explicitly requested
+
+     - **DA3 research selector**: `model_key="da3"` or `model_key="da3-research"`
+       - Use for: explicit research / non-commercial evaluation paths
+       - Requires: `non_commercial_ok=True`
 
      - **Depth Pro**: Apple AMLR license, research-only, metric depth + focal length
        - Use for: research workflows, 3D reconstruction, VR/AR, metric accuracy
        - Requires: non_commercial_ok=True + accept_apple_depth_pro_research_license=True
-       - Checkpoint: checkpoints/depth_pro.pt (1.9 GB)
-
-     - **Dual-Backend Fusion**: Both backends simultaneously
-       - Use for: APEX tier, best-of-both-worlds (metric + artistic)
-       - Fusion weights: 60% Depth Pro (metric), 40% DA3 (relative)
+       - Prefer the repo-local Depth Pro runtime installed by `./scripts/setup/install_depth_pro_runtime.sh`
 
   3. **Quality Tier Selection**
-     - **basic**: DA3 small, no PBR, generic tone mapping (thumbnails)
      - **standard**: DA3 base, PBR enabled, generic tone mapping (general real estate)
      - **premium**: DA3 large, PBR + Materials V3, room-aware (luxury marketing)
-     - **apex**: Dual-backend, all features enabled (ArchViz, portfolio)
-     - **research**: Depth Pro only, 3D export enabled (reconstruction)
+     - **apex**: highest governed quality tier with APEX-specific strictness, fallback handling, and promotion evidence
+     - Research-only runs must be explicit and license-acknowledged; do not present them as production defaults
 
   4. **License Governance**
      - Enforce 3-layer license validation (config → factory → runtime)
      - Block Depth Pro usage without explicit license acceptance
+     - Block DA3 research selector use without explicit non-commercial acknowledgement
      - Provide actionable error messages with license URLs
      - Track license compliance in provenance metadata
 
@@ -84,54 +93,40 @@ instructions: |
   ### Research Workflow (Depth Pro)
   ```bash
   lux-depth-v3 \
-    --input input_images/source_tiffs/ \
-    --output output/research_$(date +%Y%m%d_%H%M%S) \
-    --preset research \
+    --input-dir input_images/source_tiffs/ \
+    --output-dir output/research_$(date +%Y%m%d_%H%M%S) \
     --depth-backend depth_pro \
+    --depth-pro-python ./.venv-depth-pro/bin/python \
     --depth-device mps \
-    --non-commercial-ok \
-    --accept-apple-depth-pro-research-license \
-    --pbr \
-    --materials-v3 \
-    --parallel 8 \
-    --cache-depth
+    --non-commercial-ok true \
+    --accept-apple-depth-pro-research-license true
   ```
 
-  ### Production Workflow (DA3, Commercial)
+  ### Production Workflow (DA3 Production Path)
   ```bash
   lux-depth-v3 \
-    --input input_images/ \
-    --output output/premium_$(date +%Y%m%d_%H%M%S) \
-    --preset premium \
+    --input-dir input_images/ \
+    --output-dir output/premium_$(date +%Y%m%d_%H%M%S) \
+    --quality-tier premium \
     --depth-backend da3 \
-    --depth-device mps \
-    --pbr \
-    --materials-v3 \
-    --parallel 15 \
-    --cache-depth
+    --depth-device mps
   ```
 
-  ### APEX Workflow (Dual-Backend)
+  ### APEX Workflow
   ```bash
   lux-depth-v3 \
-    --input input_images/ \
-    --output output/apex_$(date +%Y%m%d_%H%M%S) \
-    --preset apex_dual_depth \
-    --depth-backend depth_pro \
-    --fallback-depth-backend da3 \
-    --depth-device mps \
-    --non-commercial-ok \
-    --accept-apple-depth-pro-research-license \
-    --pbr \
-    --materials-v3 \
-    --parallel 10
+    --input-dir input_images/ \
+    --output-dir output/apex_$(date +%Y%m%d_%H%M%S) \
+    --quality-tier apex \
+    --depth-backend da3 \
+    --depth-device mps
   ```
 
   ## Key Constraints
 
-  1. **Always validate Depth Pro checkpoint exists before using**
-     - Path: checkpoints/depth_pro.pt
-     - Download: curl -L https://ml-site.cdn-apple.com/models/depth-pro/depth_pro.pt -o checkpoints/depth_pro.pt
+  1. **Always use the current documentation map first**
+     - Current docs: `docs/governance/DOCUMENTATION_MAP.md`
+     - Historical reports are not live runbooks unless promoted there.
 
   2. **Always provide license flags for Depth Pro**
      - non_commercial_ok=True
@@ -142,19 +137,22 @@ instructions: |
      - NVIDIA GPU: cuda
      - Fallback: cpu
 
-  4. **Always enable depth caching for multi-run workflows**
-     - Saves ~10-16s per image on cache hits
+  4. **Preserve APEX fallback and failure-code semantics**
+     - Do not hide `APEX_MATERIALS_PASSTHROUGH_LOW_CONFIDENCE`,
+       `APEX_MATERIALS_PIXEL_OPS_EMPTY`, or structured depth/material failures.
 
-  5. **Always set parallel workers appropriately**
-     - Research/large files: 4-8 workers (memory intensive)
-     - Production/medium files: 10-15 workers (I/O bound)
+  5. **Use canonical validation targets**
+     - `make test-fast`
+     - `make validate-portal-lux-materials-live` for live governed Materials V3 portal proof
+     - `make audit-pipeline-readiness` for archive gate readiness evidence
 
   ## Error Handling
 
   - **LicenseRestrictionError**: Add required license flags
-  - **FileNotFoundError (checkpoint)**: Download Depth Pro checkpoint
+  - **FileNotFoundError (checkpoint/runtime)**: install the governed repo-local runtime first
   - **Out of Memory**: Reduce parallel workers or use CPU device
   - **Quality Firewall Regression**: Investigate performance ledger, adjust config
+  - **Structured APEX failure code**: preserve and surface it; do not replace it with generic failure text
 
   ## Room-Aware Strategies
 
@@ -173,7 +171,7 @@ instructions: |
   - License compliance tracked and validated
   - Performance within Quality Firewall thresholds
   - PBR maps generated for all images (when enabled)
-  - Depth cache populated for future runs
+  - Structured APEX and Materials V3 statuses preserved for promotion/evidence review
 
 behavior:
   proactive: true

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,6 +2,12 @@
 
 You are working in a governed production repository for **luxury real estate / ArchViz rendering, ingest, archive, and portal orchestration**.
 
+Current baseline: `main` through PR #1562. Use the root `README.md`,
+`docs/README.md`, `docs/governance/DOCUMENTATION_MAP.md`, and
+`docs/governance/DOCUMENTATION_STATE_AUDIT_2026-04-27.md` for current
+navigation. Historical project reports may retain old dates and facts; do not
+treat them as live guidance unless the documentation map promotes them.
+
 This codebase is broader than a single enhancement pipeline. It includes:
 
 - **Lux Depth V3**: depth-aware orchestration, PBR map generation, Materials V3, optional V2 enhancement, and governed deliverables
@@ -9,6 +15,21 @@ This codebase is broader than a single enhancement pipeline. It includes:
 - **Ingest + provenance + machine-mode contracts**: audit-grade metadata capture, typed JSON automation, evidence projection, and detached attestation flows
 - **Archive / fixity / governance tooling**: manifests, Merkle roots, signatures, rights policy, and export utilities
 - **Workflow assets**: ComfyUI examples/templates and operational scripts for repeatable execution
+
+Recent current-state contract anchors:
+
+- PR #1561/#1562 added the typed API v1 envelope/schema foundation and typed
+  OpenAPI response models for `/healthz`, `/ready`, and `/v1/readiness` while
+  preserving existing wire shapes.
+- The managed front door in `web/secure-landing/` is Node 22.x only.
+- Root `.env.example` is the Docker/FastAPI template; `web/secure-landing/.env.example`
+  is the managed front-door template.
+- `docs/ci/WORKFLOW_MATRIX.md` is the current 30-workflow GitHub Actions inventory.
+- `docs/governance/audit/archive-gates-2026-04-27.md` is the current archive
+  Gates A/B/C readiness audit evidence.
+- APEX current state includes offline model-family characterization, SAM2
+  tile-merge regression coverage, real failure-code surfacing, confidence-only
+  Materials V3 passthrough, and V2 fallback behavior.
 
 Optimize for:
 
@@ -30,7 +51,9 @@ This repository is **not** a generic CRUD portal, government portal, or health I
 Treat these as binding until a versioned change explicitly says otherwise:
 
 - `lux-depth-v3` CLI behavior and `python -m transformation_portal.lux_depth_v3`
-- Portal / orchestrator HTTP behavior, including readiness and job endpoints
+- Portal / orchestrator HTTP behavior, including `/healthz`, `/ready`,
+  `/v1/readiness`, job endpoints, typed OpenAPI response models, and typed
+  `/v1/*` envelopes
 - Import surfaces for both `transformation_portal` **and** `tp`
 - Schema-backed automation and provenance contracts:
   - ingest contract (`v1.0.2`)
@@ -140,8 +163,22 @@ Place work in the right zone.
 | `workflows/` | ComfyUI examples/templates | Treat as workflow assets/examples, not hidden production logic |
 | `tests/` | Contract, regression, ML, smoke, enforcement, security, performance coverage | Match marker policy and keep default lanes fast |
 | `docs/` | Architecture, contracts, governance, troubleshooting, guides | Update whenever behavior or workflow changes |
+| `.github/agents/` | Live custom-agent profiles and support docs | Keep aligned with `docs/architecture/agent_governance.md`, `docs/guides/CUSTOM_AGENT_GUIDE.md`, and `tests/test_custom_agent_config.py` |
 
 Additional repo areas such as `assets/`, `textures/`, `archive/`, `artifacts/`, `data/`, `dashboard/`, and project-specific directories are first-class parts of the repository. Do not treat them as disposable clutter.
+
+Custom-agent surface:
+
+- `@transformation-portal-architect` governs contracts, dependency policy, CI/CD,
+  security posture, docs topology, and architecture.
+- `@portal-app-steward` owns managed browser-boundary execution for the
+  frontdoor, portal shell, manifest-backed assets, selectors, and browser
+  validation.
+- `@transformation-portal-specialist` owns backend/orchestrator, Lux Depth,
+  archive, ingest, machine-mode, and governed non-browser execution work inside
+  existing contracts.
+- `.github/agents/_archive/` and `.github/agents/rag_system/_archive/` are
+  historical and must not define live agent behavior.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,23 @@ Quick reference for common workflows and commands in this repo.
 - When parallel work needs consolidation, first fast-forward local `main` to `origin/main`, then create a single integration branch from that updated base and replay the intended commits there.
 - After validation lands, retire obsolete Desktop worktrees and prune their local-only branches so `Transformation_Portal/` remains the canonical checkout.
 
+## Agent and documentation authority
+- Current documentation baseline is `main` through PR #1562.
+- Current docs navigation lives in `README.md`, `docs/README.md`, `docs/governance/DOCUMENTATION_MAP.md`, and `docs/governance/DOCUMENTATION_STATE_AUDIT_2026-04-27.md`.
+- Historical docs may keep old dates and project facts, but they are not current operator guidance unless the documentation map promotes them.
+- Live Copilot/custom-agent instructions are:
+  - `.github/copilot-instructions.md`
+  - `.github/agents/README.md`
+  - `.github/agents/QUICK_START_v2.md`
+  - `.github/agents/transformation-portal-architect.md`
+  - `.github/agents/portal-app-steward.md`
+  - `.github/agents/transformation-portal-specialist.md`
+  - `docs/architecture/agent_governance.md`
+  - `docs/guides/CUSTOM_AGENT_GUIDE.md`
+  - `docs/reference/AGENT_QUICK_REFERENCE.md`
+- Historical or milestone-style agent/RAG notes under `.github/agents/_archive/` or `.github/agents/rag_system/_archive/` are not live instructions.
+- Use the narrowest live profile for agent work: Architect for governance/contract/CI/security decisions, Steward for managed browser boundary work, and Specialist for backend/Lux Depth/archive/ingest/machine-mode execution.
+
 ## Common commands (Makefile)
 - `make venv` create local `.venv` with a Python 3.11+ interpreter, or fail closed if an existing `.venv` is unsupported.
 - `make setup` install package in editable mode.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Repository State Through PR #1562:** Current documentation and operator surfaces have been refreshed to match the April 27, 2026 `main` baseline.
+  - **Typed API v1 foundation:** PRs #1561 and #1562 added the `transformation_portal.api.v1` envelope/schema foundation and wired typed response models onto health/readiness routes without changing the established `/healthz`, `/ready`, or `/v1/readiness` wire contracts.
+  - **Docker and environment wiring:** PR #1559 added container `HEALTHCHECK` coverage plus root `.env.example` / Compose `env_file` wiring for safer local and deployment defaults.
+  - **CI hardening:** PRs #1553, #1558, and #1560 hardened workflow behavior and refreshed `docs/ci/WORKFLOW_MATRIX.md` with the current 30-workflow inventory and consolidation roadmap.
+  - **Archive gates:** PRs #1555 and #1557 stabilized archive-gate fixity preflight behavior and captured the April 27, 2026 Gates A/B/C readiness audit evidence.
+  - **APEX / Materials V3:** PRs #1552, #1554, and #1556 added offline model-family characterization, SAM2 tile-merge regression coverage, real failure-code surfacing, confidence-only pixel-op passthrough, and V2 fallback behavior.
+  - **Agent and Copilot guidance:** Live custom-agent, Copilot, and RAG-template instructions now align with the PR #1562 documentation map, Python 3.11+ baseline, Node 22 frontdoor contract, current Architect/Steward/Specialist roles, and typed API health/readiness state.
 - **APEX Materials V3 — Soft Passthrough on Confidence-Only Blocks:** When every implemented Materials V3 pixel op is blocked solely by `below_confidence_threshold`, the strict gate now emits the output without pixel ops and surfaces a non-fatal `APEX_MATERIALS_PASSTHROUGH_LOW_CONFIDENCE` warning instead of failing the batch. Mixed blocker sets (missing material confidence, missing implementation, etc.) still fail closed with `APEX_MATERIALS_PIXEL_OPS_EMPTY`.
   - **Run-card visibility:** the warning surfaces under `result_summary[].segmentation_status.pixel_ops_passthrough` and `.warnings`.
   - **Promotion-eligibility:** evidence producers may mirror the orchestrator's `materials_v3_pixel_ops.passthrough_status` into the per-candidate evidence file as `passthrough_status: {code: "APEX_MATERIALS_PASSTHROUGH_LOW_CONFIDENCE"}`. When that signal is present `_materials_status` keeps `failure_code = None` so promotion is no longer blocked.
@@ -99,7 +106,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Fix #6:** Output directory trap in input_discovery.py - Explicitly exclude output_dir when scanning to prevent processing own outputs
   - Impact: Data integrity (EXIF, dimensions, alpha), performance (batch stats, parallel I/O), robustness (output exclusion)
   - Tests: 15 new regression tests, all 83 lux_depth_v3 tests passing
-  - See: [CRITICAL_FIXES_SUMMARY.md](CRITICAL_FIXES_SUMMARY.md)
+  - See: [Critical Fixes Summary](docs/implementation_notes/CRITICAL_FIXES_SUMMARY.md)
 
 ### Added
 - **Performance Ledger v1.7 Upgrade:** Major enhancement with backward compatibility
@@ -114,7 +121,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Performance:** NumPy mode maintains v1.0 speed, pure Python ~50x slower (acceptable for small datasets)
   - **Tests:** 50+ new tests (CLI integration, property-based math validation, benchmarks)
   - **Migration Guide:** `docs/performance_ledger_v1.7_migration.md`
-  - See: [Performance Ledger v1.7 Verdict](PERFORMANCE_LEDGER_V1.7_VERDICT.md)
+  - See: [Performance Ledger v1.7 Verdict](docs/performance/PERFORMANCE_LEDGER_V1.7_VERDICT.md)
 
 - **Backend Registry Integration (ADR-019):** Depth backend orchestration with fallback
   - DA3Backend adapter wrapping DA3InferenceEngine for unified interface
@@ -125,7 +132,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - CLI flags: `--depth-backend {da3,depth_pro}`
   - Tests: Unit tests for DA3Backend, integration tests for orchestrator
   - Docs: README updated with backend selection guide
-  - See: [ADR-019: Backend Registry Integration](docs/architecture/decisions/ADR-019-REVISED-DECISION.md)
+  - See: [ADR-019: Depth Backend Unification](docs/architecture/ADR-019-depth-backend-unification.md)
 
 - **Performance Ledger (ADR-023 Phase 2):** Standalone tool for performance regression detection
   - Parse manifests from batch runs and compute runtime statistics

--- a/README.md
+++ b/README.md
@@ -18,11 +18,17 @@ It combines orchestrated depth estimation, PBR map generation, material-aware fi
 
 `main` tracks the active development branch for the repository.
 
+Current documentation baseline: `main` through PR #1562 (April 27, 2026).
+Recent merged work added typed API v1 envelopes and OpenAPI response models for
+health/readiness routes, Docker health/env wiring, CI workflow hardening and a
+30-workflow matrix, archive-gate readiness evidence, and APEX fallback /
+failure-code hardening.
+
 For reproducible installs, pin a specific release tag from [GitHub Releases](https://github.com/RC219805/Transformation_Portal/releases) instead of relying on branch prose. The release badge above reflects the latest tagged GitHub release.
 
 Core entry points:
 - `lux-depth-v3` for orchestrated depth, PBR, materials, and enhancement workflows
-- Portal/orchestrator HTTP surfaces with liveness (`/ready`, `/healthz`) plus operator-truth readiness at `/v1/readiness`
+- Portal/orchestrator HTTP surfaces with liveness (`/healthz`, `/ready`) plus operator-truth readiness at `/v1/readiness`
 - Determinism, manifest, run-card, and provenance layers for governed execution
 
 Quick discovery:
@@ -44,8 +50,13 @@ pip install "git+https://github.com/RC219805/Transformation_Portal.git@<release-
 Replace `<release-tag>` with a tag from [GitHub Releases](https://github.com/RC219805/Transformation_Portal/releases).
 
 Key docs:
+- [Documentation Index](docs/README.md)
+- [Documentation Map](docs/governance/DOCUMENTATION_MAP.md)
 - [Portal + Orchestrator Quickstart](docs/guides/PORTAL_ORCHESTRATOR_QUICKSTART.md)
 - [Portal Secure Front Door Quickstart](docs/guides/PORTAL_SECURE_FRONTDOOR_QUICKSTART.md)
+- [CI Workflow Matrix](docs/ci/WORKFLOW_MATRIX.md)
+- [Archive Gates A/B/C Audit](docs/governance/audit/archive-gates-2026-04-27.md)
+- [Custom Agent Guide](docs/guides/CUSTOM_AGENT_GUIDE.md)
 - [Portal Orchestrator Roadmap (Re-Baselined)](docs/architecture/PORTAL_ORCHESTRATOR_ROADMAP.md)
 - [Portal Frontdoor Roadmap](docs/architecture/PORTAL_FRONTDOOR_ROADMAP.md)
 - [DNA UX/UI Strategy Re-baseline](docs/architecture/DNA_UX_UI_STRATEGY_REBASELINE_2026-04-08.md)
@@ -59,10 +70,11 @@ Portal surfaces:
   - `/` public Dynamic Neural Access homepage
   - `/login` operator login
   - `/portal` governed operator console
-- `GET /healthz` is the managed front-door liveness contract, `GET /ready` is backend liveness, and `GET /v1/readiness` is the execution-readiness matrix for the four governed pipelines.
+- `GET /healthz` is the managed front-door liveness contract, `GET /ready` is backend liveness, and `GET /v1/readiness` is the execution-readiness matrix for the four governed pipelines. The backend health/readiness routes now have typed OpenAPI response models while preserving their existing wire shapes.
 - Shared public branding assets now live at `web/secure-landing/public/brand/dna-symbol-*.svg`, `web/secure-landing/public/brand/dna-lockup-*.svg`, and `web/secure-landing/public/video/dna-loop.mp4`.
 - Direct FastAPI portal access is now a `direct_debug` workflow for local troubleshooting, not the preferred production browser path.
 - The front door is a Node app. `web/secure-landing` now documents and enforces **Node 22.x only** for install, dev, test, build, and start flows.
+- Docker Compose reads root `.env` values using the checked-in `.env.example` template and allows missing env files for local defaults; set `TP_API_KEY` for any non-throwaway orchestrator run.
 
 ---
 
@@ -211,7 +223,7 @@ All processing manifests include backend selection metadata:
 - `resolution_status`: "success" or "fallback"
 - `resolution_reason`: Explanation if fallback occurred
 
-See [ADR-019: Backend Registry Integration](docs/architecture/decisions/ADR-019-REVISED-DECISION.md) for architectural details.
+See [ADR-019: Depth Backend Unification](docs/architecture/ADR-019-depth-backend-unification.md) for architectural details.
 
 ---
 
@@ -444,12 +456,18 @@ For deeper performance workflows, see:
 ## Documentation
 
 Start here:
+- [Documentation Index](docs/README.md)
 - [Documentation Map](docs/governance/DOCUMENTATION_MAP.md)
 - [Setup Guide](docs/guides/SETUP_GUIDE.md)
 - [Architecture Overview](docs/architecture/ARCHITECTURE.md)
 - [Lux Depth V3 CLI Guide](docs/cli/LUX_DEPTH_V3_CLI_GUIDE.md)
 - [Lux Depth V3 Troubleshooting](docs/guides/LUX_DEPTH_V3_TROUBLESHOOTING.md)
 - [API Documentation](docs/api/)
+
+Historical project reports, PR summaries, and 2025 pipeline/depth-model notes are
+retained under `docs/` for audit context. Use the documentation map and
+[2026-04-27 documentation state audit](docs/governance/DOCUMENTATION_STATE_AUDIT_2026-04-27.md)
+to distinguish current guidance from archive-only material.
 
 ---
 
@@ -483,4 +501,4 @@ Resources:
 
 ---
 
-Last Updated: 2026-03-13
+Last Updated: 2026-04-27

--- a/docs/750_picacho/README.md
+++ b/docs/750_picacho/README.md
@@ -1,0 +1,11 @@
+# 750 Picacho Historical Reports
+
+This directory contains dated 2025 project reports for the 750 Picacho work.
+They are retained as historical evidence and should not be used as current
+Transformation Portal operator guidance.
+
+Current guidance lives in:
+
+- [Documentation Map](../governance/DOCUMENTATION_MAP.md)
+- [Lux Depth V3 CLI Guide](../cli/LUX_DEPTH_V3_CLI_GUIDE.md)
+- [Portal + Orchestrator Quickstart](../guides/PORTAL_ORCHESTRATOR_QUICKSTART.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,122 +1,71 @@
 # Transformation Portal Documentation
 
-This directory contains comprehensive documentation for the Transformation Portal project.
+This directory contains both maintained operator documentation and historical
+records. Use this page for current navigation; point-in-time reports remain in
+place for audit context but are not live runbooks unless they are linked below
+as canonical documents.
 
-## 📁 Directory Structure
+**Current baseline:** `main` through PR #1562, April 27, 2026.
 
-### `/750_picacho/` - 750 Picacho Project Documentation
-Complete documentation for the 750 Picacho luxury estate processing project.
+## Start Here
 
-**Files**:
-- `750_PICACHO_QUALITY_ASSESSMENT.md` - Comprehensive quality analysis (941 lines)
-- `750_PICACHO_FINAL_REPORT.md` - Executive summary
-- `750_PICACHO_PIPELINE_RESULTS.md` - Processing results
-- `750_PICACHO_v1.0_vs_v1.1_COMPARISON.md` - Version comparison
-- `750_PICACHO_V1.1_UPGRADE_SUMMARY.md` - Upgrade summary
-- `QUALITY_ANALYSIS_SUMMARY.txt` - Quick reference
+| Need | Current Document |
+| --- | --- |
+| Repository overview and setup | [Main README](../README.md) |
+| Full documentation map | [Documentation Map](governance/DOCUMENTATION_MAP.md) |
+| Documentation state audit | [2026-04-27 Documentation State Audit](governance/DOCUMENTATION_STATE_AUDIT_2026-04-27.md) |
+| Local setup and environment checks | [Setup Guide](guides/SETUP_GUIDE.md) |
+| Portal and orchestrator contracts | [Portal + Orchestrator Quickstart](guides/PORTAL_ORCHESTRATOR_QUICKSTART.md) |
+| Managed front door | [Portal Secure Front Door Quickstart](guides/PORTAL_SECURE_FRONTDOOR_QUICKSTART.md) |
+| Lux Depth V3 CLI | [Lux Depth V3 CLI Guide](cli/LUX_DEPTH_V3_CLI_GUIDE.md) |
+| CI workflow inventory | [Workflow Matrix](ci/WORKFLOW_MATRIX.md) |
 
-### `/pipeline/` - Pipeline Documentation
-Documentation for luxury estate and elite architectural pipelines.
+## Current Maintained Surfaces
 
-**Files**:
-- `LUXURY_ESTATE_PIPELINE_README.md` - Main pipeline guide
-- `LUXURY_ESTATE_PIPELINE_QUICKSTART.md` - Quick start guide
-- `LUXURY_ESTATE_PIPELINE_CHECKLIST.md` - Production checklist
-- `ELITE_PIPELINE_README.md` - Elite pipeline documentation
-- `ELITE_PIPELINE_SUMMARY.md` - Summary overview
-- `PIPELINE_FIXES_DOCUMENTATION.md` - v1.1.0 fixes (500+ lines)
-- `PIPELINE_FIXES_QUICKSTART.md` - Quick start (400+ lines)
-- `PIPELINE_V1.1.0_CHANGES.md` - Change log
-- `README_PIPELINE_FIXES.md` - Navigation guide
+| Area | Canonical Docs | Notes |
+| --- | --- | --- |
+| Portal / API | [Portal Quickstart](guides/PORTAL_ORCHESTRATOR_QUICKSTART.md), [API docs](api/) | `/healthz`, `/ready`, and `/v1/readiness` are current health/readiness surfaces. PR #1562 added typed OpenAPI response models while preserving the existing wire contracts. |
+| Secure front door | [Front Door Quickstart](guides/PORTAL_SECURE_FRONTDOOR_QUICKSTART.md) | Node 22.x is the enforced local/runtime contract for `web/secure-landing`. |
+| Docker / environment | [Main README](../README.md), [`.env.example`](../.env.example) | Docker Compose reads the root `.env` template with `required: false`; set `TP_API_KEY` for non-throwaway runs. |
+| CI / validation | [Workflow Matrix](ci/WORKFLOW_MATRIX.md), [CI/CD Workflows](ci_cd/CI_CD_WORKFLOWS.md) | The current GitHub Actions inventory contains 30 workflows after the Phase 1.4 refresh. |
+| Agent / Copilot guidance | [Custom Agent Guide](guides/CUSTOM_AGENT_GUIDE.md), [Agent Quick Reference](reference/AGENT_QUICK_REFERENCE.md), [Copilot Instructions](../.github/copilot-instructions.md) | Live agent behavior is governed by `.github/agents/`, Copilot instructions, and `docs/architecture/agent_governance.md`. |
+| Archive gates | [Archive Machine Contract](api/ARCHIVE_MACHINE_MODE_CONTRACT.md), [2026-04-27 Archive Gates Audit](governance/audit/archive-gates-2026-04-27.md) | Gates A/B/C are documented with the April 27 readiness audit and normalized JSON evidence. |
+| APEX / Materials | [APEX Governance Status](apex/GOVERNANCE_STATUS.md), [APEX Workflow Design](architecture/APEX_WORKFLOW_DESIGN.md), [APEX Model Family Characterization](validation/APEX_MODEL_FAMILY_CHARACTERIZATION_PROTOCOL.md) | Recent merges added offline model-family characterization, failure-code surfacing, confidence-only pixel-op passthrough, V2 fallback, and SAM2 tile-merge regression coverage. |
+| Dependency policy | [ADR-032](architecture/ADR-032-dependency-pinning-strategy.md), [AGENTS.md](../AGENTS.md) | Layered lockfiles and target-owned ML lanes are the current dependency governance model. |
 
-### `/quality_analysis/` - Quality Analysis Framework
-Quality assessment and improvement documentation.
+## Historical And Archive Material
 
-**Files**:
-- `QA_Improvements.md` - QA framework (1,040 lines)
-- `Corrective_Action_Plan.md` - Remediation roadmap (983 lines)
-- `Immediate_Recommendations.md` - Action plan (933 lines)
+The repo intentionally retains older project reports, PR notes, quality studies,
+and session artifacts. Treat these directories as historical unless a current
+map explicitly links a document as canonical:
 
-### `/visual_review/` - Expert Visual Review Analysis
-Expert feedback integration and root cause analysis.
+- `docs/750_picacho/`, `docs/projects/`, and `docs/quality_analysis/` contain
+  2025 project-specific analysis and delivery records.
+- `docs/depth_model/`, `docs/pipeline/`, and `docs/pipeline_docs/` contain older
+  depth-model and luxury-pipeline evaluation material. Current depth behavior is
+  described in the main README, CLI guide, and ADR-019/ADR-0015.
+- `docs/reports/`, `docs/status/`, `docs/session_summaries/`,
+  `docs/sessions/`, `docs/historical/`, and `docs/pr_archive/` are
+  point-in-time records.
+- `docs/_archive/` contains intentionally retired or consolidated material.
 
-**Files**:
-- `CRITICAL_VISUAL_REVIEW_FINDINGS.md` - Critical findings summary
-- `Visual_Feedback_Analysis_Summary.md` - Executive overview
-- `Root_Cause_Analysis.md` - Technical autopsy
-- `Analysis_Complete.md` - Navigation guide
+Do not use historical documents as operator runbooks without first checking the
+current documentation map.
 
-### `/depth_model/` - Depth Model Upgrade Project
-Depth Anything V2/V3 and Depth Pro evaluation and implementation.
+## Documentation Governance
 
-**Files**:
-- `DEPTH_MODEL_UPGRADE_RECOMMENDATION.md` - V2 vs V3 vs Depth Pro comparison
-- `DEPTH_MODEL_UPGRADE_SUMMARY.md` - Project overview
-- `PHASE1_EXECUTION_COMPLETE.md` - Phase 1 completion
-- `PHASE1_REPORT.md` - Technical report
-- `PHASE2_STRATEGY.md` - Next phase plan
+- `docs/README.md` is the only maintained file allowed directly under `docs/`.
+- New documents must live in an approved top-level directory from
+  [Documentation Retention Policy](governance/DOCUMENTATION_POLICY.md).
+- Current navigation belongs in [Documentation Map](governance/DOCUMENTATION_MAP.md);
+  duplicate or superseded material should be archived, labeled historical, or
+  removed from current indexes.
+- Validate documentation structure with:
 
-### Governance and Archives
-- `governance/DOCUMENTATION_POLICY.md` - Documentation classification and retention policy
-- `historical/` - Session/execution/push artifacts retained for historical audit context
-- `pr_archive/` - PR-specific summaries and resolution documentation
-- Legacy dependency and status snapshots (`guides/LAYERED_DEPENDENCIES_IMPLEMENTATION.md`, `status/REPOSITORY_STATUS_REPORT.md`) are historical context only; current dependency policy is defined by `requirements/base.in` and `docs/architecture/ADR-032-dependency-pinning-strategy.md`.
+```bash
+make check-docs
+make check-stale-docs
+python scripts/governance/check_docs_structure.py --all
+```
 
----
-
-## 📊 Quick Links
-
-### Getting Started
-- [Main README](../README.md)
-- [Start Here](../START_HERE.md)
-- [Luxury Estate Pipeline Quickstart](pipeline/LUXURY_ESTATE_PIPELINE_QUICKSTART.md)
-
-### Quality & Testing
-- [750 Picacho Quality Assessment](750_picacho/750_PICACHO_QUALITY_ASSESSMENT.md)
-- [QA Improvements Framework](quality_analysis/QA_Improvements.md)
-- [Critical Visual Review Findings](visual_review/CRITICAL_VISUAL_REVIEW_FINDINGS.md)
-
-### Pipeline Documentation
-- [Luxury Estate Pipeline](pipeline/LUXURY_ESTATE_PIPELINE_README.md)
-- [Elite Pipeline](pipeline/ELITE_PIPELINE_README.md)
-- [Pipeline Fixes (v1.1.0)](pipeline/PIPELINE_FIXES_DOCUMENTATION.md)
-
-### Technical Analysis
-- [Depth Model Upgrade](depth_model/DEPTH_MODEL_UPGRADE_RECOMMENDATION.md)
-- [Root Cause Analysis](visual_review/Root_Cause_Analysis.md)
-- [Corrective Action Plan](quality_analysis/Corrective_Action_Plan.md)
-
----
-
-## 📈 Documentation Statistics
-
-- **Total Documentation**: 2,500+ lines
-- **Quality Assessment**: 941 lines
-- **Visual Review Analysis**: 800+ lines
-- **Depth Model Upgrade**: 500+ lines
-- **Pipeline Documentation**: 800+ lines
-
----
-
-## 🎯 Key Projects Documented
-
-### 750 Picacho Luxury Estate
-- **Status**: Production-ready
-- **Quality**: 94.0/100 (Grade A - Excellent)
-- **Processing**: 13.68s per image
-- **Output**: 18 files (master TIFFs, delivery JPEGs, previews)
-
-### Pipeline Upgrades
-- **v1.0.0**: Production baseline (expert validated)
-- **v1.1.0**: Experimental (deprecated, quality issues)
-- **v1.2.0**: Planned improvements
-
-### Depth Model Enhancement
-- **Phase 1**: Complete (V2 model fix)
-- **Phase 2**: Ready (V2-Large upgrade)
-- **Phase 3**: Planned (Depth Pro integration)
-
----
-
-**Last Updated**: November 10, 2025
-**Documentation Version**: 1.1.0
+**Last Updated:** 2026-04-27

--- a/docs/architecture/ARCHITECTURE_PHILOSOPHY.md
+++ b/docs/architecture/ARCHITECTURE_PHILOSOPHY.md
@@ -1,7 +1,7 @@
-> ⚠️ **DEPRECATED**
+> **Historical / superseded**
 >
 > This document has been merged into [ARCHITECTURE.md](ARCHITECTURE.md).
-> Please use that document instead. This file will be removed on 2026-03-06.
+> Use that document for current architecture guidance.
 
 # Temporal Architecture Philosophy
 
@@ -322,7 +322,7 @@ python -m pytest tests/
 ```
 
 **Manual Migration**:
-See [MIGRATION_GUIDE.md](../MIGRATION_GUIDE.md) for step-by-step instructions.
+See [MIGRATION_GUIDE.md](../migration/MIGRATION_GUIDE.md) for step-by-step instructions.
 
 ## Observability
 

--- a/docs/architecture/agent_governance.md
+++ b/docs/architecture/agent_governance.md
@@ -8,9 +8,15 @@ This policy applies to:
 - `@transformation-portal-architect`
 - `@portal-app-steward`
 - `@transformation-portal-specialist`
+- `.github/copilot-instructions.md`
 - Any future repository agents that implement, review, or propose changes
 
 This policy governs agent decision-making and escalation. It does not replace human review, CI enforcement, or branch protections.
+
+Current baseline: `main` through PR #1562. Current documentation navigation is
+defined by `README.md`, `docs/README.md`,
+`docs/governance/DOCUMENTATION_MAP.md`, and
+`docs/governance/DOCUMENTATION_STATE_AUDIT_2026-04-27.md`.
 
 ## Authority Model
 
@@ -30,13 +36,14 @@ When guidance conflicts, the following precedence applies:
 **Architect**
 - Final authority on: security posture, dependency governance, CI/CD policy, cross-module contracts, public API/CLI stability, architectural direction.
 - Owns enforcement design: policies should be machine-checkable where feasible.
+- Owns live agent/Copilot instruction boundaries and documentation topology.
 
 **Steward**
-- Execution authority only for the managed browser boundary: `web/secure-landing/`, `portal.html`, manifest-backed portal assets, and browser-surface validation/docs work inside existing contracts.
+- Execution authority only for the managed browser boundary: `web/secure-landing/`, `portal.html`, manifest-backed portal assets, managed `/healthz`, and browser-surface validation/docs work inside existing contracts.
 - Must stop and escalate when escalation criteria are met.
 
 **Specialist**
-- Execution authority only for backend/orchestrator, archive, ingest, machine-mode, Lux Depth, and other governed non-browser surfaces within governance constraints.
+- Execution authority only for backend/orchestrator, backend `/healthz`, `/ready`, `/v1/readiness`, archive, ingest, machine-mode, Lux Depth, and other governed non-browser surfaces within governance constraints.
 - Must stop and escalate when escalation criteria are met.
 
 ## Stop-and-Escalate Protocol
@@ -77,6 +84,13 @@ Hard-block constraints are an allowed enforcement tool:
 - Changes to `.github/workflows/*`, reusable workflows, or action pinning policy.
 - Release automation, packaging/publishing, artifact retention rules, container builds, deployment configuration.
 - Introducing new required checks, changing required gates, or bypassing enforcement.
+
+### B2) Agent and Documentation Topology
+- Changes to `.github/copilot-instructions.md`, `.github/agents/*`,
+  `docs/guides/CUSTOM_AGENT_GUIDE.md`, `docs/reference/AGENT_QUICK_REFERENCE.md`,
+  or `tests/test_custom_agent_config.py`.
+- Changes to canonical documentation navigation or classification boundaries.
+- Promoting historical or archive-only docs into live guidance.
 
 ### C) Security Posture and Untrusted Input Handling
 - Any changes affecting handling of:
@@ -120,6 +134,9 @@ For merge-ready changes:
 The following are governance-controlled artifacts and require Architect review:
 - this policy file
 - agent role definitions under `.github/agents/`
+- `.github/copilot-instructions.md`
+- `docs/guides/CUSTOM_AGENT_GUIDE.md`
+- `docs/reference/AGENT_QUICK_REFERENCE.md`
 - ADRs and security policy documents
 - dependency bans and enforcement scripts
 

--- a/docs/ci/workflow_improvements_nov8.md
+++ b/docs/ci/workflow_improvements_nov8.md
@@ -1,5 +1,10 @@
 # Workflow Improvements - November 8, 2025
 
+> Historical CI improvement note.
+>
+> This file records November 2025 workflow work. Current CI inventory and
+> recommendations live in [WORKFLOW_MATRIX.md](WORKFLOW_MATRIX.md).
+
 ## Summary
 
 Enhanced code quality control and CI/CD robustness for the Transformation Portal repository.
@@ -55,9 +60,9 @@ UNIFIED_*.md
    - Verify import statements are in scope
 
 2. **Documentation Management**
-   - Keep only 4 essential markdown files in root:
+   - Historical root-doc recommendation from November 2025:
      - README.md
-     - START_HERE.md
+     - docs/README.md and docs/governance/DOCUMENTATION_MAP.md now replace the old root quickstart entry point
      - MIGRATION_GUIDE.md
      - DEPRECATION_POLICY.md
    - Move all session summaries to `docs/sessions/`

--- a/docs/depth_model/README.md
+++ b/docs/depth_model/README.md
@@ -1,0 +1,12 @@
+# Depth Model Historical Notes
+
+This directory contains older depth-model evaluation and upgrade reports. These
+files are historical context for earlier Depth Anything / Depth Pro work and are
+not the current backend selection contract.
+
+Current depth guidance lives in:
+
+- [Main README](../../README.md#depth-models-production-and-research-tiers)
+- [Lux Depth V3 CLI Guide](../cli/LUX_DEPTH_V3_CLI_GUIDE.md)
+- [ADR-019 Depth Backend Unification](../architecture/ADR-019-depth-backend-unification.md)
+- [ADR-0015 DA3 1.1 Non-Commercial Research Tier](../architecture/adr-0015-da3-1-1-non-commercial-research-tier.md)

--- a/docs/governance/DOCUMENTATION_MAP.md
+++ b/docs/governance/DOCUMENTATION_MAP.md
@@ -1,169 +1,110 @@
 # Documentation Map
 
-**Purpose:** Single source of truth for finding documentation in Transformation Portal.
+**Purpose:** Current source of truth for finding maintained Transformation
+Portal documentation.
 
-**Last Updated:** 2026-03-25
+**Last Updated:** 2026-04-27
 **Maintainer:** Repository Architect
+**Current baseline:** `main` through PR #1562.
 
----
+Historical reports remain available for audit context, but they are not current
+operator guidance unless they are linked here as canonical documents.
 
-## 🎯 Start Here
+## Start Here
 
 | Topic | Canonical Document | Purpose |
-|-------|-------------------|---------|
-| **First Steps** | [README.md](../../README.md) | Project overview, installation, quick start |
-| **Setup & Installation** | [SETUP_GUIDE.md](../guides/SETUP_GUIDE.md) | Detailed installation for all tiers |
-| **Contributing** | [CONTRIBUTING.md](../../CONTRIBUTING.md) | How to contribute code, docs, issues |
-| **Security** | [SECURITY.md](../../SECURITY.md) | Security policy, reporting vulnerabilities |
-| **Security Hardening Report** | [security_best_practices_report.md](security_best_practices_report.md) | Security findings and remediation status |
+| --- | --- | --- |
+| Repository overview | [README.md](../../README.md) | Project overview, install path, current operational surfaces |
+| Documentation index | [docs/README.md](../README.md) | Current docs navigation and historical-boundary guidance |
+| Documentation state audit | [DOCUMENTATION_STATE_AUDIT_2026-04-27.md](DOCUMENTATION_STATE_AUDIT_2026-04-27.md) | Repo-wide docs classification after PR #1562 |
+| Setup | [SETUP_GUIDE.md](../guides/SETUP_GUIDE.md) | Local environment setup and dependency bring-up |
+| Contribution workflow | [CONTRIBUTING.md](../../CONTRIBUTING.md) | Code, docs, issue, and PR expectations |
+| Security | [SECURITY.md](../../SECURITY.md) | Security policy and reporting |
 
----
+## Current Operational Docs
 
-## 📚 Core Documentation
+| Area | Canonical Document | Status |
+| --- | --- | --- |
+| Portal / orchestrator | [Portal + Orchestrator Quickstart](../guides/PORTAL_ORCHESTRATOR_QUICKSTART.md) | Maintained |
+| Secure front door | [Portal Secure Front Door Quickstart](../guides/PORTAL_SECURE_FRONTDOOR_QUICKSTART.md) | Maintained |
+| API / OpenAPI contracts | [API docs](../api/) | Maintained |
+| Machine-mode metadata API | [Machine Mode Contract](../api/MACHINE_MODE_CONTRACT.md) | Maintained |
+| Archive machine-mode API | [Archive Machine Mode Contract](../api/ARCHIVE_MACHINE_MODE_CONTRACT.md) | Maintained |
+| Lux Depth V3 CLI | [Lux Depth V3 CLI Guide](../cli/LUX_DEPTH_V3_CLI_GUIDE.md) | Maintained |
+| Lux Depth V3 troubleshooting | [Lux Depth V3 Troubleshooting](../guides/LUX_DEPTH_V3_TROUBLESHOOTING.md) | Maintained |
+| Context-aware rendering | [Context-Aware Rendering](../guides/CONTEXT_AWARE_RENDERING.md) | Maintained |
+| PBR processing | [PBR Processor Quickstart](../guides/PBR_PROCESSOR_QUICKSTART.md) | Maintained |
+| Supported formats | [Supported File Formats](../guides/SUPPORTED_FILE_FORMATS.md) | Maintained |
 
-### Development
+## Governance, CI, And Validation
 
-| Topic | Canonical Document | Status |
-|-------|-------------------|--------|
-| **Architecture Overview** | [docs/architecture/ARCHITECTURE.md](../architecture/ARCHITECTURE.md) | ✅ Stable |
-| **Ingest Determinism Policy (ADR-030)** | [docs/architecture/ADR-030-phase2-deterministic-raw-ingest.md](../architecture/ADR-030-phase2-deterministic-raw-ingest.md) | ✅ Implemented (Phase II) |
-| **Determinism Harness Spec (SPEC-DH-001)** | [docs/architecture/specifications/SPEC-DH-001.md](../architecture/specifications/SPEC-DH-001.md) | ✅ LOCKED (Phase II) |
-| **Certified Bounded Determinism Analysis (ANALYSIS-DH-001)** | [docs/architecture/analysis/ANALYSIS-DH-001.md](../architecture/analysis/ANALYSIS-DH-001.md) | ✅ Informative (Phase II) |
-| **API Reference** | [docs/api/](../api/) | ✅ Stable (Sphinx) |
-| **Code Quality Standards** | [CODE_QUALITY_STANDARDS.md](../guides/CODE_QUALITY_STANDARDS.md) | ✅ Stable |
-| **Custom Agents** | [CUSTOM_AGENT_GUIDE.md](../guides/CUSTOM_AGENT_GUIDE.md) | ✅ Stable |
-| **TODO Inventory** | [docs/analysis/TODO_INVENTORY.md](../analysis/TODO_INVENTORY.md) | ✅ Stable (v2.4.0) |
-| **TODO Quick Reference** | [docs/architecture/TODO_INVENTORY_QUICK_REF.md](../architecture/TODO_INVENTORY_QUICK_REF.md) | ✅ Stable (aligned with v2.4.0) |
+| Area | Canonical Document | Status |
+| --- | --- | --- |
+| Documentation policy | [DOCUMENTATION_POLICY.md](DOCUMENTATION_POLICY.md) | Maintained |
+| Repository organization | [REPO_ORGANIZATION.md](REPO_ORGANIZATION.md) | Maintained |
+| Custom Agents | [CUSTOM_AGENT_GUIDE.md](../guides/CUSTOM_AGENT_GUIDE.md) | Maintained; live profiles are under `.github/agents/` |
+| Agent quick reference | [AGENT_QUICK_REFERENCE.md](../reference/AGENT_QUICK_REFERENCE.md) | Maintained |
+| Agent governance | [agent_governance.md](../architecture/agent_governance.md) | Maintained |
+| Copilot instructions | [.github/copilot-instructions.md](../../.github/copilot-instructions.md) | Maintained repo-wide Copilot guidance |
+| CI workflow inventory | [WORKFLOW_MATRIX.md](../ci/WORKFLOW_MATRIX.md) | Maintained; current 30-workflow inventory |
+| CI/CD workflow guide | [CI_CD_WORKFLOWS.md](../ci_cd/CI_CD_WORKFLOWS.md) | Maintained |
+| Branch protection | [BRANCH_PROTECTION_SETUP.md](../ci/BRANCH_PROTECTION_SETUP.md) | Maintained |
+| Dependency pinning | [ADR-032 Dependency Pinning Strategy](../architecture/ADR-032-dependency-pinning-strategy.md) | Maintained |
+| Test marker policy | [ADR-044 Test Marker Enforcement](../architecture/ADR-044-test-marker-enforcement.md) | Maintained |
+| Security hardening report | [security_best_practices_report.md](security_best_practices_report.md) | Maintained status record |
 
-### CI/CD & Operations
-
-| Topic | Canonical Document | Status |
-|-------|-------------------|--------|
-| **CI/CD Workflows** | [docs/ci_cd/CI_CD_WORKFLOWS.md](../ci_cd/CI_CD_WORKFLOWS.md) | ✅ Stable |
-| **Workflow Reference** | [.github/workflows/build.yml](../../.github/workflows/build.yml) | ✅ Stable (Primary CI) |
-| **Branch Protection** | [BRANCH_PROTECTION_SETUP.md](../ci/BRANCH_PROTECTION_SETUP.md) | ✅ Stable |
-
-### Pipelines & Processing
-
-| Topic | Canonical Document | Status |
-|-------|-------------------|--------|
-| **Luxury Estate Pipeline** | [docs/pipeline/LUXURY_ESTATE_PIPELINE_README.md](../pipeline/LUXURY_ESTATE_PIPELINE_README.md) | ✅ Stable |
-| **PBR Processing** | [PBR_PROCESSOR_QUICKSTART.md](../guides/PBR_PROCESSOR_QUICKSTART.md) | ✅ Stable |
-| **Lux Depth V3 CLI** | [LUX_DEPTH_V3_CLI_GUIDE.md](../cli/LUX_DEPTH_V3_CLI_GUIDE.md) | ✅ Stable |
-| **Lux Depth V3 Troubleshooting** | [LUX_DEPTH_V3_TROUBLESHOOTING.md](../guides/LUX_DEPTH_V3_TROUBLESHOOTING.md) | ✅ Stable |
-| **Elite Pipeline** | [ELITE_PIPELINE_GUIDE.md](../guides/ELITE_PIPELINE_GUIDE.md) | ✅ Stable |
-
-### Quick References
+## Architecture And Contracts
 
 | Topic | Canonical Document | Status |
-|-------|-------------------|--------|
-| **CLI Reference** | [docs/cli/CLI_REFERENCE.md](../cli/CLI_REFERENCE.md) | ✅ Stable |
-| **PBR Presets** | [PBR_PRESETS_QUICK_REFERENCE.md](../reference/PBR_PRESETS_QUICK_REFERENCE.md) | ✅ Stable |
-| **Agent Quick Ref** | [AGENT_QUICK_REFERENCE.md](../reference/AGENT_QUICK_REFERENCE.md) | ✅ Stable |
+| --- | --- | --- |
+| Architecture overview | [ARCHITECTURE.md](../architecture/ARCHITECTURE.md) | Maintained |
+| ADR index | [architecture/README.md](../architecture/README.md) | Maintained |
+| Depth backend unification | [ADR-019](../architecture/ADR-019-depth-backend-unification.md) | Maintained |
+| DA3 non-commercial research tier | [ADR-0015](../architecture/adr-0015-da3-1-1-non-commercial-research-tier.md) | Maintained |
+| Portal orchestrator roadmap | [PORTAL_ORCHESTRATOR_ROADMAP.md](../architecture/PORTAL_ORCHESTRATOR_ROADMAP.md) | Maintained planning doc |
+| Portal front door roadmap | [PORTAL_FRONTDOOR_ROADMAP.md](../architecture/PORTAL_FRONTDOOR_ROADMAP.md) | Maintained planning doc |
+| APEX workflow design | [APEX_WORKFLOW_DESIGN.md](../architecture/APEX_WORKFLOW_DESIGN.md) | Maintained |
+| Deterministic RAW ingest | [ADR-030](../architecture/ADR-030-phase2-deterministic-raw-ingest.md) | Maintained |
+| Determinism harness spec | [SPEC-DH-001](../architecture/specifications/SPEC-DH-001.md) | Locked |
 
----
+## APEX And Archive Gates
 
-## 🗂️ Specialized Topics
+| Topic | Canonical Document | Status |
+| --- | --- | --- |
+| APEX governance | [APEX Governance Status](../apex/GOVERNANCE_STATUS.md) | Maintained |
+| APEX contract | [APEX Contract](../apex/APEX_CONTRACT.md) | Maintained |
+| APEX model-family characterization | [APEX Model Family Characterization Protocol](../validation/APEX_MODEL_FAMILY_CHARACTERIZATION_PROTOCOL.md) | Maintained |
+| APEX canonical corpus bootstrap | [APEX Canonical Corpus Bootstrap](../validation/APEX_CANONICAL_CORPUS_BOOTSTRAP.md) | Maintained |
+| Archive gates state audit | [Archive Gates A/B/C Audit](audit/archive-gates-2026-04-27.md) | Current audit evidence |
+| Archive gate follow-up | [Wire Audit Pipeline Readiness](audit/follow-ups/ci-wire-audit-pipeline-readiness.md) | Follow-up scope |
 
-### Format Support
-- **File Formats:** [SUPPORTED_FILE_FORMATS.md](../guides/SUPPORTED_FILE_FORMATS.md)
-- **TIFF Handling:** [TIFF_FIX_QUICKREF.md](../reference/TIFF_FIX_QUICKREF.md)
+## Historical And Archive Boundaries
 
-### Advanced Features
-- **Temporal Architecture:** [TEMPORAL_ARCHITECTURE_QUICKREF.md](../architecture/TEMPORAL_ARCHITECTURE_QUICKREF.md)
-- **RAG System:** [RAG_SYSTEM_COMPLETE_GUIDE.md](../guides/RAG_SYSTEM_COMPLETE_GUIDE.md)
-- **VFX Extensions:** [VFX_EXTENSION_GUIDE.md](../guides/VFX_EXTENSION_GUIDE.md)
+| Area | Classification | Use |
+| --- | --- | --- |
+| `docs/750_picacho/`, `docs/projects/`, `docs/quality_analysis/`, `docs/visual_review/` | Historical project records | Dated project evidence, not current operator guidance |
+| `docs/depth_model/`, `docs/depth_pipeline/`, `docs/pipeline/`, `docs/pipeline_docs/` | Superseded or historical pipeline/depth material | Use current Lux Depth V3 docs and ADRs instead |
+| `docs/deliverables/`, `docs/project-status/`, `docs/reports/`, `docs/status/`, `docs/summaries/`, `docs/session_summaries/`, `docs/sessions/`, `docs/historical/`, `docs/verification/` | Point-in-time reports | Audit context only |
+| `docs/pr_archive/`, `docs/pr_reports/`, `docs/pr_summaries/` | PR-specific records | Review and merge history only |
+| `docs/_archive/` | Archive-only | Retired or consolidated material |
 
-### Troubleshooting
-- **General Troubleshooting:** [TROUBLESHOOTING.md](../guides/TROUBLESHOOTING.md)
-- **Known Issues:** [docs/incidents/](../incidents/)
+## Maintenance Protocol
 
----
+1. Check this map before creating new documentation.
+2. Update the canonical document when one exists.
+3. Put new documents in an approved top-level directory from
+   [DOCUMENTATION_POLICY.md](DOCUMENTATION_POLICY.md).
+4. Update this map when a new document becomes current guidance.
+5. Label duplicate or stale material historical, archive it, or remove it from
+   current navigation.
 
-## 📦 Directory Organization
+## Validation
 
-```
-docs/
-├── README.md
-├── governance/
-│   ├── DOCUMENTATION_MAP.md  ← You are here
-│   ├── DOCUMENTATION_POLICY.md
-│   └── REPO_ORGANIZATION.md
-├── architecture/             ← Architecture ADRs + specs + analysis
-├── api/                      ← API documentation
-├── ci/                       ← CI/CD governance docs
-├── cli/                      ← CLI references
-├── historical/               ← Historical execution artifacts
-├── pipeline/                 ← Pipeline-specific documentation
-├── pr_archive/               ← PR-specific archives
-└── reference/                ← Cheat sheets and quick refs
-```
-
----
-
-## Canonical Topology
-
-Legacy root-level duplicates have been retired. Canonical documentation now lives only in approved subdirectories such as:
-
-- [architecture/](../architecture/)
-- [ci/](../ci/)
-- [cli/](../cli/)
-- [guides/](../guides/)
-- [historical/](../historical/)
-- [performance/](../performance/)
-- [reference/](../reference/)
-
----
-
-## 📋 Maintenance Protocol
-
-### When Creating New Documentation:
-1. Check this map first - does a canonical doc already exist?
-2. If yes, update the canonical doc (don't create a new one)
-3. If no, create in appropriate subdirectory
-4. Update this map with new canonical doc
-
-### When Updating Documentation:
-1. Update the canonical doc only
-2. Add deprecation notice to duplicates
-3. Schedule removal after 30 days
-
-### Deprecation Template:
-```markdown
-> ⚠️ **DEPRECATED**
->
-> This document has been superseded by [CANONICAL_DOC.md](path/to/canonical.md).
-> Please use that document instead. This file will be removed on YYYY-MM-DD.
-```
-
----
-
-## 🔍 Finding Documentation
-
-**Quick Search:**
 ```bash
-# Find doc by keyword
-grep -R "keyword" docs/
-
-# List all guides
-ls docs/guides/
-
-# View map
-cat docs/governance/DOCUMENTATION_MAP.md
+make check-docs
+make check-stale-docs
+python scripts/governance/check_docs_structure.py --all
 ```
 
-**GitHub Search:**
-Use GitHub's search with `path:docs/` filter.
-
----
-
-## 📝 Status Legend
-
-- ✅ **Stable:** Complete, maintained, canonical
-- 🔄 **In Progress:** Being actively updated
-- ⚠️ **Deprecated:** Being phased out, see replacement
-- 📦 **Archived:** Historical reference only
-
----
-
-**Questions?** See [CONTRIBUTING.md](../../CONTRIBUTING.md) or open an issue.
+Use `rg` for targeted stale-reference checks before merging documentation
+changes.

--- a/docs/governance/DOCUMENTATION_POLICY.md
+++ b/docs/governance/DOCUMENTATION_POLICY.md
@@ -2,6 +2,19 @@
 
 This policy defines where documentation belongs and how long it should be retained.
 
+## Current vs Historical Guidance
+
+Current operator guidance is discoverable from `README.md`, `docs/README.md`,
+and `docs/governance/DOCUMENTATION_MAP.md`. A document outside those navigation
+paths may still be useful evidence, but it is not current guidance unless the
+document itself states that it is maintained and a current index links to it.
+
+Historical documents may retain old dates, point-in-time status, former command
+examples, and superseded project conclusions. They must not be linked from
+current navigation as live runbooks. When a historical document is easy to
+mistake for current guidance, add a short banner or directory-level README that
+points readers back to the documentation map.
+
 ## Strict Topology Contract
 
 - `docs/README.md` is the only allowed file directly under `docs/`.
@@ -80,6 +93,8 @@ Approved top-level directories:
 | PR-specific | `docs/pr_archive/` | Historical |
 | Execution logs | `docs/historical/` | Historical |
 | Session notes and deliverable snapshots | `docs/historical/` | Historical |
+| Project-specific 2025 reports | `docs/750_picacho/`, `docs/projects/`, `docs/quality_analysis/`, `docs/visual_review/` | Historical |
+| Superseded depth/pipeline evaluations | `docs/depth_model/`, `docs/depth_pipeline/`, `docs/pipeline/`, `docs/pipeline_docs/` | Historical unless promoted in `DOCUMENTATION_MAP.md` |
 
 ## Deterministic Placement Rules
 
@@ -87,6 +102,9 @@ Approved top-level directories:
 - Any point-in-time execution output (for example push summaries, completion reports, session reports) belongs in `docs/historical/`.
 - Documentation indexes and organization policy docs belong in `docs/governance/`.
 - The `docs/` root is reserved for `README.md` only, with no exceptions.
+- Do not add `START_HERE`, `PIPELINE_V1.1.0`, or other dated project-era files
+  to current navigation. Point readers to the documentation map and current
+  Lux Depth V3 / portal guides instead.
 
 ## Enforcement
 

--- a/docs/governance/DOCUMENTATION_STATE_AUDIT_2026-04-27.md
+++ b/docs/governance/DOCUMENTATION_STATE_AUDIT_2026-04-27.md
@@ -1,0 +1,82 @@
+# Documentation State Audit - 2026-04-27
+
+**Scope:** Repo-wide documentation classification after merged PRs #1552 through
+PR #1562.
+
+**Baseline:** `main` at PR #1562.
+
+## Summary
+
+Current-facing documentation is limited to the main README, documentation map,
+setup/portal/frontdoor/CLI guides, API contract docs, CI workflow matrix,
+governance docs, and active APEX/archive-gate docs. Older project reports and
+session outputs are retained for historical context but must not be presented as
+live operator guidance.
+
+## Recent Merge Topics Captured
+
+| PRs | Current-state documentation impact |
+| --- | --- |
+| #1561, #1562 | Typed API v1 envelope foundation plus typed OpenAPI response models for health/readiness routes. Existing `/healthz`, `/ready`, and `/v1/readiness` wire contracts remain stable. |
+| #1559 | Docker image now has a `HEALTHCHECK`; Compose reads the root `.env` template with `required: false`. |
+| #1553, #1558, #1560 | CI hardening and the current 30-workflow inventory are captured in `docs/ci/WORKFLOW_MATRIX.md`. |
+| #1555, #1557 | Archive gate fixity preflight and the 2026-04-27 Gates A/B/C audit are canonical evidence for archive readiness. |
+| #1552, #1554, #1556 | APEX model-family characterization, structured failure-code surfacing, confidence-only Materials V3 passthrough, V2 fallback, and SAM2 tile-merge regression coverage are current APEX state. |
+
+## Agent And Copilot Instruction Surface
+
+Live agent/Copilot guidance is current-facing and must stay aligned with this
+audit:
+
+- `.github/copilot-instructions.md`
+- `.github/agents/README.md`
+- `.github/agents/QUICK_START_v2.md`
+- `.github/agents/transformation-portal-architect.md`
+- `.github/agents/portal-app-steward.md`
+- `.github/agents/transformation-portal-specialist.md`
+- `docs/architecture/agent_governance.md`
+- `docs/guides/CUSTOM_AGENT_GUIDE.md`
+- `docs/reference/AGENT_QUICK_REFERENCE.md`
+- `tests/test_custom_agent_config.py`
+
+Archived RAG and milestone notes under `.github/agents/_archive/` and
+`.github/agents/rag_system/_archive/` are historical evidence, not live
+instructions.
+
+## Top-Level Documentation Classification
+
+| Directory | Classification | Current guidance |
+| --- | --- | --- |
+| `docs/api/` | Maintained | API and machine-mode contract documentation. |
+| `docs/apex/` | Maintained | APEX governance, policy, and contract docs. |
+| `docs/archive/` | Mixed | Archive machine schemas/docs are current; older phase manifests are historical. |
+| `docs/architecture/` | Maintained / ADR history | ADRs and active architecture docs remain canonical unless marked superseded. |
+| `docs/ci/`, `docs/ci_cd/` | Maintained | `docs/ci/WORKFLOW_MATRIX.md` is the current workflow inventory. |
+| `docs/cli/` | Maintained | Current CLI references and Lux Depth V3 guide. |
+| `docs/compliance/`, `docs/contracts/`, `docs/deployment/`, `docs/governance/`, `docs/performance/`, `docs/schemas/`, `docs/validation/` | Maintained | Active governance, contract, schema, validation, and deployment surfaces. |
+| `docs/guides/` | Mixed | Current setup, portal, frontdoor, troubleshooting, and Lux Depth guides are maintained; older project-specific guides are historical unless linked from the documentation map. |
+| `docs/750_picacho/`, `docs/projects/`, `docs/quality_analysis/`, `docs/visual_review/` | Historical project records | 2025 project-specific analysis; do not use as current pipeline guidance. |
+| `docs/depth_model/`, `docs/depth_pipeline/`, `docs/pipeline/`, `docs/pipeline_docs/` | Historical / superseded guidance | Current depth and pipeline guidance lives in the main README, Lux Depth V3 CLI guide, ADR-019, ADR-0015, and APEX docs. |
+| `docs/deliverables/`, `docs/project-status/`, `docs/reports/`, `docs/status/`, `docs/summaries/`, `docs/session_summaries/`, `docs/sessions/`, `docs/historical/`, `docs/pr_archive/`, `docs/pr_reports/`, `docs/pr_summaries/`, `docs/verification/` | Historical records | Retained as point-in-time reports, checklists, PR/session evidence, and delivery snapshots. |
+| `docs/_archive/` | Archive-only | Retired or consolidated material. |
+| `docs/brand/`, `docs/decisions/`, `docs/deprecation/`, `docs/development/`, `docs/examples/`, `docs/fixes/`, `docs/implementation/`, `docs/implementation_notes/`, `docs/incidents/`, `docs/investigations/`, `docs/materials/`, `docs/migration/`, `docs/operations/`, `docs/optimization/`, `docs/processing/`, `docs/quick_references/`, `docs/reference/`, `docs/spatial_ai/`, `docs/testing/`, `docs/version_history/`, `docs/workflow/`, `docs/workflows/` | Mixed | Use only when linked from the documentation map or when the file itself states a current owner/status. Otherwise treat as supporting or historical context. |
+
+## Stale Reference Disposition
+
+- `START_HERE` references are no longer current entry points. Use
+  `README.md`, `docs/README.md`, and `docs/governance/DOCUMENTATION_MAP.md`.
+- `PIPELINE_V1.1.0` material is historical project context, not current
+  operator guidance.
+- 2025 project status reports are retained as dated evidence; current repo state
+  is defined by `main`, the main README, and the documentation map.
+- Depth-model upgrade reports under `docs/depth_model/` are superseded for live
+  operations by current Lux Depth V3 docs and ADRs.
+
+## Validation Commands
+
+```bash
+git diff --check
+make check-docs
+make check-stale-docs
+python scripts/governance/check_docs_structure.py --all
+```

--- a/docs/governance/REPO_ORGANIZATION.md
+++ b/docs/governance/REPO_ORGANIZATION.md
@@ -27,6 +27,12 @@ The repository organization system solves the recurring problem of files accumul
 3. **Maintaining consistency** across the entire codebase
 4. **Making the repository easier to navigate** for both humans and tools
 
+Current documentation navigation is intentionally narrow: `README.md`,
+`docs/README.md`, and `docs/governance/DOCUMENTATION_MAP.md` define live
+guidance. Older project reports and session artifacts stay in approved docs
+directories as historical evidence, but they should not be treated as current
+runbooks unless promoted in the documentation map.
+
 ### Key Features
 
 - ✅ **Automatic file organization** with `.auto-organize.sh`
@@ -63,12 +69,15 @@ Transformation_Portal/
 │   ├── output/                 # Output data
 │   ├── cache/                  # Cached results
 │   └── sample_images/          # Sample images for testing
-├── docs/                       # Documentation
-│   ├── guides/                 # How-to guides and tutorials
-│   ├── architecture/           # Architecture documentation
-│   ├── api/                    # API documentation
-│   ├── deployment/             # Deployment guides
-│   └── version_history/        # Changelogs and version notes
+├── docs/                       # Maintained docs plus historical records
+│   ├── README.md               # Current documentation entry point
+│   ├── governance/             # Documentation map, policy, organization
+│   ├── guides/                 # Current guides plus older project guides
+│   ├── architecture/           # Architecture docs and ADR history
+│   ├── api/                    # API and machine-mode contracts
+│   ├── ci/                     # CI governance and workflow matrix
+│   ├── historical/             # Point-in-time records
+│   └── _archive/               # Retired or consolidated documentation
 ├── scripts/                    # All scripts
 │   ├── setup/                  # Installation and setup scripts
 │   ├── automation/             # Automation scripts
@@ -302,11 +311,15 @@ The organization system uses these rules to classify files:
 ### Documentation Files (.md, .txt)
 
 - Root README: stays in root (main entry point)
-- Guide/Tutorial: → `docs/guides/`
-- Architecture: → `docs/architecture/`
-- API docs: → `docs/api/`
-- Deployment: → `docs/deployment/`
-- Version history: → `docs/version_history/`
+- Current docs navigation: -> `docs/README.md` and `docs/governance/DOCUMENTATION_MAP.md`
+- Guide/Tutorial: -> `docs/guides/`
+- Architecture: -> `docs/architecture/`
+- API docs: -> `docs/api/`
+- Deployment: -> `docs/deployment/`
+- Version history: -> `docs/version_history/`
+- PR-specific or merge-event records: -> `docs/pr_archive/`
+- Point-in-time status, session, or delivery artifacts: -> `docs/historical/`
+- Retired or consolidated material: -> `docs/_archive/`
 
 ### Scripts (.sh, .py)
 
@@ -435,6 +448,10 @@ For questions or issues with the organization system:
 
 ## Version History
 
+- **v1.1.0** (April 2026): Documentation governance refresh
+  - Re-established `docs/README.md` and `DOCUMENTATION_MAP.md` as current navigation
+  - Classified old project reports, depth-model notes, and pipeline v1.1.0 material as historical unless explicitly promoted
+  - Added repo-wide documentation state audit through PR #1562
 - **v1.0.0** (November 2025): Initial release of automated organization system
   - Created `.auto-organize.sh` main script
   - Created pre-commit hook system
@@ -443,6 +460,6 @@ For questions or issues with the organization system:
 
 ---
 
-**Last Updated**: November 2025
+**Last Updated**: 2026-04-27
 **Maintained By**: Transformation Portal Team
 **License**: Same as main repository

--- a/docs/guides/750_PICACHO_QUICK_SUMMARY.txt
+++ b/docs/guides/750_PICACHO_QUICK_SUMMARY.txt
@@ -2,6 +2,10 @@
   750 PICACHO ELITE PIPELINE - COMPLETE PROJECT SUMMARY
 ════════════════════════════════════════════════════════════════════════════════
 
+HISTORICAL PROJECT RECORD
+This file records November 2025 750 Picacho pipeline work. It is not current
+operator guidance. Use docs/governance/DOCUMENTATION_MAP.md for maintained docs.
+
 PROJECT DATE: November 9-10, 2025
 SCOPE: Design, implement, execute, and analyze luxury estate image processing
 STATUS: ✅ COMPLETE - Production-ready with comprehensive documentation
@@ -153,7 +157,7 @@ DOCUMENTATION (2,500+ lines):
   ✓ IMPLEMENTATION_COMPLETE.md
   ✓ PIPELINE_FIXES_DOCUMENTATION.md (500+ lines)
   ✓ PIPELINE_FIXES_QUICKSTART.md (400+ lines)
-  ✓ PIPELINE_V1.1.0_CHANGES.md (500+ lines)
+  - Historical pipeline v1.1.0 changelog (500+ lines)
   ✓ LUXURY_ESTATE_PIPELINE_README.md
   ✓ README_PIPELINE_FIXES.md
   ✓ examples_luxury_estate_pipeline.py (8 examples)

--- a/docs/guides/BEST_PRACTICES.md
+++ b/docs/guides/BEST_PRACTICES.md
@@ -1,5 +1,11 @@
 # Quality Control & Best Practices
 
+> Historical project guidance.
+>
+> This 750 Picacho-era guide contains dated paths and pipeline examples. Current
+> operator guidance lives in [Documentation Map](../governance/DOCUMENTATION_MAP.md)
+> and the active Lux Depth V3 docs.
+
 ## 750 Picacho Lane Project - Best Practices Summary
 
 ### Source File Management
@@ -108,7 +114,7 @@ ls -1 | wc -l  # Should output: 6
 - **Maximum 10 markdown files in root**
 - Move session notes to `docs/sessions/`
 - Move technical guides to `docs/guides/`
-- Keep only: README.md, START_HERE.md, MIGRATION_GUIDE.md, DEPRECATION_POLICY.md, CONTRIBUTING.md
+- Current navigation uses README.md, docs/README.md, and docs/governance/DOCUMENTATION_MAP.md; this historical note originally referenced a removed root quickstart entry point.
 
 #### 2. **Python Code Quality**
 ```bash

--- a/docs/guides/CODEBASE_QUALITY_STANDARDS.md
+++ b/docs/guides/CODEBASE_QUALITY_STANDARDS.md
@@ -1,5 +1,11 @@
 # Codebase Quality Standards
 
+> Historical 2025 baseline.
+>
+> This document preserves earlier quality-control guidance. Current repo
+> workflow guidance lives in [AGENTS.md](../../AGENTS.md), [README](../../README.md),
+> and [Documentation Map](../governance/DOCUMENTATION_MAP.md).
+
 ## Overview
 This document defines the quality standards and automated safeguards for the Transformation Portal codebase to prevent recurring issues identified in CI/CD workflows.
 
@@ -39,7 +45,7 @@ if HAS_IMAGEIO:
 - **Session summaries** → `docs/sessions/`
 - **Project docs** → `docs/projects/{project_name}/`
 - **Integration guides** → `docs/guides/`
-- **Root only**: README.md, START_HERE.md, MIGRATION_GUIDE.md, DEPRECATION_POLICY.md
+- **Current entry points**: README.md, docs/README.md, docs/governance/DOCUMENTATION_MAP.md, and policy documents
 
 ### 4. **Import Organization**
 **Problem**: Imports at wrong position, circular dependencies

--- a/docs/guides/CODE_QUALITY_BASELINE.md
+++ b/docs/guides/CODE_QUALITY_BASELINE.md
@@ -1,7 +1,8 @@
-> ⚠️ **DEPRECATED**
+> **Historical / superseded**
 >
 > This document has been superseded by [CODE_QUALITY_STANDARDS.md](CODE_QUALITY_STANDARDS.md).
-> Please use that document instead. This file will be removed on 2026-03-06.
+> For current engineering workflow guidance, use [AGENTS.md](../../AGENTS.md)
+> and the validation targets in the root [README](../../README.md).
 
 # Code Quality Baseline - November 8, 2025
 
@@ -48,7 +49,8 @@ except ImportError:
 ```
 /
 ├── README.md                    # Main project README
-├── START_HERE.md               # Quick start guide
+├── docs/README.md              # Current documentation entry point
+├── docs/governance/DOCUMENTATION_MAP.md
 ├── DEPRECATION_POLICY.md       # Policy documentation
 ├── MIGRATION_GUIDE.md          # Migration instructions
 └── docs/
@@ -70,7 +72,7 @@ except ImportError:
 ### Documentation
 1. **Root Limit**: Maximum 10 markdown files in repository root
 2. **Organization**: Session, project, and technical docs in `docs/` subdirectories
-3. **Essential Root Files Only**: README, START_HERE, and policy documents
+3. **Essential Current Entry Points**: README, docs/README.md, Documentation Map, and policy documents
 
 ### Testing
 1. **All Tests Pass**: 100% test suite passing before merge

--- a/docs/guides/CODE_QUALITY_STANDARDS.md
+++ b/docs/guides/CODE_QUALITY_STANDARDS.md
@@ -1,5 +1,10 @@
 # Code Quality Improvements & Standards
 
+> Historical 2025 quality snapshot.
+>
+> Current engineering workflow guidance lives in [AGENTS.md](../../AGENTS.md),
+> [README](../../README.md), and [Documentation Map](../governance/DOCUMENTATION_MAP.md).
+
 ## Current Status
 
 **Last Updated:** 2025-11-09

--- a/docs/guides/CODE_QUALITY_SYSTEM.md
+++ b/docs/guides/CODE_QUALITY_SYSTEM.md
@@ -1,7 +1,8 @@
-> ⚠️ **DEPRECATED**
+> **Historical / superseded**
 >
 > This document has been superseded by [CODE_QUALITY_STANDARDS.md](CODE_QUALITY_STANDARDS.md).
-> Please use that document instead. This file will be removed on 2026-03-06.
+> For current engineering workflow guidance, use [AGENTS.md](../../AGENTS.md)
+> and the validation targets in the root [README](../../README.md).
 
 # Code Quality Control System
 
@@ -140,7 +141,7 @@ def enhance_image(img, strength=0.7):
 ```
 ✅ ALLOWED:
   - README.md (project overview)
-  - START_HERE.md (quickstart)
+  - docs/README.md and docs/governance/DOCUMENTATION_MAP.md (current documentation entry points)
   - MIGRATION_GUIDE.md (migration docs)
   - DEPRECATION_POLICY.md (policy docs)
 

--- a/docs/guides/COMPREHENSIVE_ISSUE_ANALYSIS.md
+++ b/docs/guides/COMPREHENSIVE_ISSUE_ANALYSIS.md
@@ -1,4 +1,10 @@
 # Comprehensive Issue Analysis - Transformation Portal
+
+> Historical 2025 issue analysis.
+>
+> Current repository status and documentation navigation live in
+> [README](../../README.md) and [Documentation Map](../governance/DOCUMENTATION_MAP.md).
+
 **Generated:** 2025-11-08
 **Updated:** 2025-11-08 (All critical issues RESOLVED)
 **Repository:** /Users/rc/Transformation_Portal
@@ -493,7 +499,7 @@ convert_problem_tiffs.py
 **Current Root-Level Docs:**
 ```
 README.md
-START_HERE.md
+docs/README.md and docs/governance/DOCUMENTATION_MAP.md now replace the old root quickstart entry point
 HEALTH_CHECK_REPORT.md
 AUDIT_SUMMARY.txt
 EXEC_SUMMARY.txt

--- a/docs/guides/CUSTOM_AGENT_GUIDE.md
+++ b/docs/guides/CUSTOM_AGENT_GUIDE.md
@@ -10,6 +10,11 @@ The repository now has three live custom agent profiles:
 
 These roles are complementary. The Architect defines system invariants. The Steward and Specialist execute inside them.
 
+Current baseline: `main` through PR #1562. Current documentation navigation
+lives in `README.md`, `docs/README.md`,
+`docs/governance/DOCUMENTATION_MAP.md`, and
+`docs/governance/DOCUMENTATION_STATE_AUDIT_2026-04-27.md`.
+
 ## Live Agent Roles
 
 ### Transformation Portal Architect
@@ -18,6 +23,7 @@ Use `@transformation-portal-architect` when the task involves:
 
 - dependency or runtime policy
 - CI/CD or workflow enforcement
+- documentation topology, Copilot instructions, or live custom-agent role boundaries
 - security posture or trust-boundary changes
 - public HTTP, CLI, schema, or packaging contracts
 - ADR interpretation or architectural trade-offs
@@ -34,11 +40,11 @@ Use `@portal-app-steward` when the task involves the managed browser boundary:
 
 - `web/secure-landing/`
 - `/`, `/login`, `/portal`, `/portal/bootstrap`
-- `/portal/assets/*`, `/portal/video/*`, `/healthz`
+- `/portal/assets/*`, `/portal/video/*`, managed `/healthz`
 - `portal.html`
 - `public/portal-assets/*`
 - `config/portal_asset_manifest.json`
-- browser-smoke selectors, bootstrap states, and frontdoor/portal validation
+- browser-smoke selectors, bootstrap states, Node 22 frontdoor checks, and frontdoor/portal validation
 
 The Steward is the first-choice execution agent for browser-surface work. It should preserve route, auth, asset, and browser-validation contracts and treat direct-debug as secondary to managed mode.
 
@@ -61,7 +67,7 @@ Examples:
 Use `@transformation-portal-specialist` when the task involves governed non-browser execution surfaces:
 
 - `app.py`
-- `/ready`
+- backend `/healthz`, `/ready`, and `/v1/readiness`
 - typed `/v1/*` behavior
 - Lux Depth V3
 - archive-gate
@@ -98,6 +104,15 @@ If browser work requires backend contract changes:
 2. Steward owns the browser-side plan and validation.
 3. Specialist owns the backend implementation that changes typed behavior or backend hardening.
 
+Current backend contract anchors:
+
+- `/healthz`, `/ready`, and `/v1/readiness` expose typed OpenAPI response
+  models while keeping existing wire contracts stable.
+- `/v1/readiness` keeps transport success separate from per-pipeline
+  `ready` / `degraded` / `blocked` execution truth.
+- Archive Gates A/B/C readiness evidence is captured in
+  `docs/governance/audit/archive-gates-2026-04-27.md`.
+
 ## Working With The Agents
 
 Best prompt pattern:
@@ -129,7 +144,10 @@ The live custom agent surface is defined by:
 - `.github/agents/portal-app-steward.md`
 - `.github/agents/transformation-portal-specialist.md`
 - `.github/agents/README.md`
+- `.github/copilot-instructions.md`
 - `docs/architecture/agent_governance.md`
+- `docs/governance/DOCUMENTATION_MAP.md`
+- `docs/governance/DOCUMENTATION_STATE_AUDIT_2026-04-27.md`
 
 Supporting quick references:
 
@@ -144,9 +162,12 @@ When role boundaries or live guidance change, update the source of truth togethe
 
 1. the relevant profile under `.github/agents/`
 2. `.github/agents/README.md`
-3. this guide
-4. `docs/reference/AGENT_QUICK_REFERENCE.md`
-5. `tests/test_custom_agent_config.py`
+3. `.github/agents/QUICK_START_v2.md`
+4. `.github/copilot-instructions.md` when repo-wide Copilot behavior changes
+5. this guide
+6. `docs/reference/AGENT_QUICK_REFERENCE.md`
+7. `docs/governance/DOCUMENTATION_MAP.md` when canonical navigation changes
+8. `tests/test_custom_agent_config.py`
 
 Do not leave the README, guide, quick reference, and contract test out of sync.
 

--- a/docs/guides/DEPTH_PIPELINE_README.md
+++ b/docs/guides/DEPTH_PIPELINE_README.md
@@ -1,5 +1,12 @@
 # Depth Anything V2 Pipeline for Architectural Rendering
 
+> Historical depth-pipeline guide.
+>
+> This document describes an older Depth Anything V2 path. Current depth backend
+> guidance lives in [Lux Depth V3 CLI Guide](../cli/LUX_DEPTH_V3_CLI_GUIDE.md),
+> [ADR-019](../architecture/ADR-019-depth-backend-unification.md), and
+> [ADR-0015](../architecture/adr-0015-da3-1-1-non-commercial-research-tier.md).
+
 Production-ready depth-aware image processing pipeline optimized for Apple Silicon. Transforms architectural renders using monocular depth estimation with Depth Anything V2.
 
 ## Overview

--- a/docs/guides/DOCUMENTATION_INDEX.md
+++ b/docs/guides/DOCUMENTATION_INDEX.md
@@ -1,44 +1,10 @@
-# Documentation Index
+# Superseded Documentation Index
 
-This directory contains organized documentation for the Transformation Portal.
+This older guide-level index is retained only to avoid breaking inbound links.
+Current documentation navigation lives in:
 
-## Directory Structure
+- [docs/README.md](../README.md)
+- [Documentation Map](../governance/DOCUMENTATION_MAP.md)
+- [Documentation State Audit](../governance/DOCUMENTATION_STATE_AUDIT_2026-04-27.md)
 
-### `/migration`
-Migration guides and version upgrade documentation.
-
-### `/deprecation`
-Deprecation notices and legacy system documentation.
-
-### `/guides`
-User guides, tutorials, and how-to documentation.
-
-### `/reference`
-Technical reference documentation, workflow guides, and bug fix logs.
-
-### `/archive`
-Historical documentation and archived materials.
-
-## Root Documentation
-
-Essential documentation remains in the repository root:
-- `README.md` - Project overview and quick start
-- `START_HERE.md` - Onboarding guide
-- `CONTRIBUTING.md` - Contribution guidelines
-- `LICENSE` - License information
-
-## Recently Moved Files
-
-- [750_PICACHO_DEPTH_MODEL_RECOMMENDATION.md](docs/reference/750_PICACHO_DEPTH_MODEL_RECOMMENDATION.md)
-- [IMPLEMENTATION_COMPLETE.md](docs/reference/IMPLEMENTATION_COMPLETE.md)
-- [750_PICACHO_DECISION_SUMMARY.md](docs/reference/750_PICACHO_DECISION_SUMMARY.md)
-- [PHASE2_PLAN.md](docs/reference/PHASE2_PLAN.md)
-- [750_PICACHO_POOL_QUALITY_REVIEW.md](docs/reference/750_PICACHO_POOL_QUALITY_REVIEW.md)
-- [COMMIT_SUMMARY_OLD.md](docs/archive/COMMIT_SUMMARY_OLD.md)
-- [DEPRECATION_POLICY.md](docs/deprecation/DEPRECATION_POLICY.md)
-- [QUALITY_CONTROL_READY.md](docs/reference/QUALITY_CONTROL_READY.md)
-- [PHASE2_SUMMARY.md](docs/reference/PHASE2_SUMMARY.md)
-- [MIGRATION_GUIDE.md](docs/migration/MIGRATION_GUIDE.md)
-- [SESSION_SUMMARY.md](docs/reference/SESSION_SUMMARY.md)
-- [LUT_AND_PIPELINE_ANALYSIS.md](docs/reference/LUT_AND_PIPELINE_ANALYSIS.md)
-- [INPUT_FILE_SPECIFICATIONS.md](docs/reference/INPUT_FILE_SPECIFICATIONS.md)
+Do not add new links here.

--- a/docs/guides/FILES_CHANGED_SUMMARY.txt
+++ b/docs/guides/FILES_CHANGED_SUMMARY.txt
@@ -2,6 +2,10 @@
 LUXURY ESTATE MASTER PIPELINE v1.1.0 - FILES CHANGED SUMMARY
 ================================================================================
 
+HISTORICAL PROJECT RECORD
+This file records November 2025 v1.1.0 pipeline work. It is not current
+operator guidance. Use docs/governance/DOCUMENTATION_MAP.md for maintained docs.
+
 Implementation Date: November 10, 2025
 Version: 1.1.0 (from 1.0.0)
 Quality Grade: 94.0/100 (maintained)
@@ -88,7 +92,7 @@ FILES CREATED (5)
    - Performance benchmarks
    - Support
 
-4. PIPELINE_V1.1.0_CHANGES.md
+4. Historical pipeline v1.1.0 changelog
    Status: NEW
    Lines: 500+
    Purpose: Detailed change log

--- a/docs/guides/PLUGIN_DEVELOPMENT.md
+++ b/docs/guides/PLUGIN_DEVELOPMENT.md
@@ -2,6 +2,12 @@
 
 **Transformation Portal - Building Custom Plugins**
 
+> Historical guide.
+>
+> This November 2025 plugin guide is not currently listed as maintained
+> operator guidance. Check [Documentation Map](../governance/DOCUMENTATION_MAP.md)
+> before using it as an implementation contract.
+
 Version: 1.0.0
 Last Updated: 2025-11-08
 

--- a/docs/guides/PORTAL_ORCHESTRATOR_QUICKSTART.md
+++ b/docs/guides/PORTAL_ORCHESTRATOR_QUICKSTART.md
@@ -38,6 +38,11 @@ export TP_READY_VERBOSE=1
 
 ## API Contract Notes
 
+As of PR #1562, the health/readiness routes are backed by typed OpenAPI
+response models. That change documents the contract shape for generated clients;
+it does not change the existing response bodies for `/healthz`, `/ready`, or
+`/v1/readiness`.
+
 ## Response envelope
 
 ```json
@@ -233,6 +238,7 @@ npm run build
 
 Expected contract gate outcomes:
 - `/v1/*` success and failure responses use typed envelope (`schema`, `success`, `data`, `error`).
+- `/healthz`, `/ready`, and `/v1/readiness` remain wire-compatible while exposing typed OpenAPI response models.
 - `/v1/readiness` keeps transport success (`200`) separate from per-pipeline `ready` / `degraded` / `blocked` execution truth.
 - Validation failures return `400` with `error.code=INVALID_ARGUMENT`.
 - Oversized request paths return `413` with typed error envelope.

--- a/docs/guides/PORTAL_SECURE_FRONTDOOR_QUICKSTART.md
+++ b/docs/guides/PORTAL_SECURE_FRONTDOOR_QUICKSTART.md
@@ -19,6 +19,9 @@ In production, place the front door behind Cloudflare Tunnel + Access and keep t
 ## Required Environment
 
 Create front-door env vars from `web/secure-landing/.env.example`.
+The repository root `.env.example` is the Docker/FastAPI template; it is not a
+replacement for the front-door template because the Node app has separate proxy,
+Cloudflare Access, user-source, and session-store settings.
 
 ```bash
 export TP_FASTAPI_ORIGIN="http://127.0.0.1:8000"

--- a/docs/guides/QUALITY_CONTROL_SYSTEM.md
+++ b/docs/guides/QUALITY_CONTROL_SYSTEM.md
@@ -1,7 +1,8 @@
-> ⚠️ **DEPRECATED**
+> **Historical / superseded**
 >
 > This document has been superseded by [CODE_QUALITY_STANDARDS.md](CODE_QUALITY_STANDARDS.md).
-> Please use that document instead. This file will be removed on 2026-03-06.
+> For current engineering workflow guidance, use [AGENTS.md](../../AGENTS.md)
+> and the validation targets in the root [README](../../README.md).
 
 # Quality Control System Implementation
 

--- a/docs/guides/RAG_SYSTEM_COMPLETE_GUIDE.md
+++ b/docs/guides/RAG_SYSTEM_COMPLETE_GUIDE.md
@@ -1,6 +1,12 @@
 # RAG System - Complete Integration Guide
 **Transformation Portal - Knowledge-Enhanced Processing**
 
+> Historical guide.
+>
+> This file records an earlier RAG-system integration design. Check
+> [Documentation Map](../governance/DOCUMENTATION_MAP.md) before treating it as
+> current implementation guidance.
+
 ## Overview
 
 The RAG (Retrieval-Augmented Generation) system provides intelligent, context-aware assistance for the Transformation Portal. It indexes repository documentation, code, and configuration to enable:
@@ -383,9 +389,9 @@ python cli.py search "known term" --top-k 10
 ## Resources
 
 ### Documentation
-- [RAG System README](.github/agents/rag_system/README.md)
+- Historical RAG system README path: `.github/agents/rag_system/README.md`
 - [Architecture Overview](../architecture/ARCHITECTURE.md)
-- [API Reference](.github/agents/rag_system/API.md)
+- Historical RAG system API path: `.github/agents/rag_system/API.md`
 
 ### References
 - Sentence Transformers: https://www.sbert.net/

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -1,0 +1,14 @@
+# Guides Directory
+
+This directory is mixed. Current guides are linked from
+[Documentation Map](../governance/DOCUMENTATION_MAP.md). Older 750 Picacho,
+Depth Anything V2, v1.1.0 pipeline, and code-quality baseline guides are
+historical unless their file explicitly states otherwise.
+
+Use these current entry points first:
+
+- [Setup Guide](SETUP_GUIDE.md)
+- [Portal + Orchestrator Quickstart](PORTAL_ORCHESTRATOR_QUICKSTART.md)
+- [Portal Secure Front Door Quickstart](PORTAL_SECURE_FRONTDOOR_QUICKSTART.md)
+- [Lux Depth V3 Troubleshooting](LUX_DEPTH_V3_TROUBLESHOOTING.md)
+- [Context-Aware Rendering](CONTEXT_AWARE_RENDERING.md)

--- a/docs/guides/START_HERE.md
+++ b/docs/guides/START_HERE.md
@@ -1,5 +1,11 @@
 # 750 Picacho Great Room Enhancement - START HERE
 
+> Historical project record.
+>
+> This was a 2025 750 Picacho project entry point. It is not the current
+> Transformation Portal start page. Use [Documentation Map](../governance/DOCUMENTATION_MAP.md)
+> or the root [README](../../README.md) for maintained guidance.
+
 **Status:** ✅ **COMPLETE & PRODUCTION READY**
 **Date:** November 5, 2025
 **Confidence:** 95%

--- a/docs/guides/SYSTEM_STATUS.md
+++ b/docs/guides/SYSTEM_STATUS.md
@@ -1,5 +1,12 @@
 # Transformation Portal - System Status Report
 
+> Historical status snapshot.
+>
+> This file records November 2025 local environment state. It is not the current
+> repository status source. Use the root [README](../../README.md),
+> [Documentation Map](../governance/DOCUMENTATION_MAP.md), and
+> [CI Workflow Matrix](../ci/WORKFLOW_MATRIX.md).
+
 **Date:** November 11, 2025
 **Status:** ✅ Fully Operational
 

--- a/docs/guides/TIFF_QUALITY_SOLUTION.md
+++ b/docs/guides/TIFF_QUALITY_SOLUTION.md
@@ -1,5 +1,10 @@
 # TIFF Quality Issue - Complete Solution
 
+> Historical project fix note.
+>
+> This file preserves a 2025 TIFF-quality investigation. For current pipeline
+> and validation guidance, start from [Documentation Map](../governance/DOCUMENTATION_MAP.md).
+
 ## Problem Summary
 
 The TIFF files were showing **significant quality degradation** compared to JPEG files, despite TIFFs being intended as the high-quality master format.

--- a/docs/guides/TROUBLESHOOTING.md
+++ b/docs/guides/TROUBLESHOOTING.md
@@ -394,7 +394,7 @@ top -l 1 | grep PhysMem  # macOS
 
 1. **Check documentation**:
    - [SETUP_GUIDE.md](SETUP_GUIDE.md) - Detailed installation
-   - [README.md](../README.md) - Feature overview
+   - [README.md](../../README.md) - Feature overview
    - [PIPELINE_OPERATIONS_GUIDE.md](../pipeline_docs/PIPELINE_OPERATIONS_GUIDE.md) - Usage examples
 
 2. **Run diagnostics**:

--- a/docs/guides/TROUBLESHOOTING.md
+++ b/docs/guides/TROUBLESHOOTING.md
@@ -1,5 +1,11 @@
 # Troubleshooting Guide
 
+> Historical general troubleshooting guide.
+>
+> This guide captures November 2025 issues. Current Lux Depth V3 troubleshooting
+> lives in [LUX_DEPTH_V3_TROUBLESHOOTING.md](LUX_DEPTH_V3_TROUBLESHOOTING.md);
+> current navigation lives in [Documentation Map](../governance/DOCUMENTATION_MAP.md).
+
 This guide addresses common issues encountered when using the Transformation Portal. Issues are organized by priority and include solutions implemented as of November 2025.
 
 ## Table of Contents
@@ -389,7 +395,7 @@ top -l 1 | grep PhysMem  # macOS
 1. **Check documentation**:
    - [SETUP_GUIDE.md](SETUP_GUIDE.md) - Detailed installation
    - [README.md](../README.md) - Feature overview
-   - [PIPELINE_OPERATIONS_GUIDE.md](PIPELINE_OPERATIONS_GUIDE.md) - Usage examples
+   - [PIPELINE_OPERATIONS_GUIDE.md](../pipeline_docs/PIPELINE_OPERATIONS_GUIDE.md) - Usage examples
 
 2. **Run diagnostics**:
    ```bash

--- a/docs/historical/README.md
+++ b/docs/historical/README.md
@@ -8,3 +8,5 @@ Examples:
 - One-time status snapshots
 
 These files are archival context, not active architecture or user guidance.
+For current guidance, start from
+[Documentation Map](../governance/DOCUMENTATION_MAP.md).

--- a/docs/pipeline/README.md
+++ b/docs/pipeline/README.md
@@ -1,0 +1,12 @@
+# Pipeline Historical Notes
+
+This directory contains earlier luxury estate and elite pipeline documentation,
+including v1.1.0-era fixes and project-specific runbooks. Treat these documents
+as historical unless a current documentation map entry points to a specific file.
+
+Current pipeline guidance lives in:
+
+- [Main README](../../README.md)
+- [Lux Depth V3 CLI Guide](../cli/LUX_DEPTH_V3_CLI_GUIDE.md)
+- [APEX Governance Status](../apex/GOVERNANCE_STATUS.md)
+- [APEX Workflow Design](../architecture/APEX_WORKFLOW_DESIGN.md)

--- a/docs/pipeline_docs/README.md
+++ b/docs/pipeline_docs/README.md
@@ -1,0 +1,11 @@
+# Pipeline Docs Historical Notes
+
+This directory stores older pipeline documentation snapshots. Use it for
+background context only; current Lux Depth V3 and APEX guidance is linked from
+the documentation map.
+
+Current guidance lives in:
+
+- [Documentation Map](../governance/DOCUMENTATION_MAP.md)
+- [Lux Depth V3 CLI Guide](../cli/LUX_DEPTH_V3_CLI_GUIDE.md)
+- [APEX Governance Status](../apex/GOVERNANCE_STATUS.md)

--- a/docs/pr_archive/README.md
+++ b/docs/pr_archive/README.md
@@ -8,3 +8,5 @@ Examples:
 - Review response bundles tied to a single merge event
 
 These files are historical records and should not be used as active product docs.
+For current guidance, start from
+[Documentation Map](../governance/DOCUMENTATION_MAP.md).

--- a/docs/projects/README.md
+++ b/docs/projects/README.md
@@ -1,5 +1,12 @@
 # 750 Picacho Lane - Project Documentation Index
 
+> Historical project record.
+>
+> This index describes 2025 750 Picacho project work. It is retained for audit
+> context and should not be used as current Transformation Portal operator
+> guidance. Start from [Documentation Map](../governance/DOCUMENTATION_MAP.md)
+> for maintained docs.
+
 **Project:** 750 Picacho Lane Luxury Estate Rendering
 **Location:** Santa Barbara, California
 **Status:** Quality Enhancement Phase

--- a/docs/quality_analysis/README.md
+++ b/docs/quality_analysis/README.md
@@ -1,0 +1,12 @@
+# Quality Analysis Historical Reports
+
+This directory contains 2025 quality-analysis plans and corrective-action
+reports. They are retained as dated project evidence and should not be treated
+as current quality gates or validation policy.
+
+Current validation and governance guidance lives in:
+
+- [Documentation Map](../governance/DOCUMENTATION_MAP.md)
+- [Workflow Matrix](../ci/WORKFLOW_MATRIX.md)
+- [APEX Governance Status](../apex/GOVERNANCE_STATUS.md)
+- [Performance Monitoring Guide](../performance/README.md)

--- a/docs/reference/AGENT_QUICK_REFERENCE.md
+++ b/docs/reference/AGENT_QUICK_REFERENCE.md
@@ -1,5 +1,9 @@
 # Custom Agent Quick Reference
 
+Current baseline: `main` through PR #1562. Use the documentation map and state
+audit for current repo navigation; historical agent/RAG notes are not live
+instructions unless promoted by the live agent README.
+
 ## Use The Right Agent
 
 ### `@portal-app-steward`
@@ -7,12 +11,12 @@
 Use for managed browser-surface work:
 
 - homepage, login, and portal shell behavior
-- `/portal/bootstrap`, managed recovery, and same-origin browser flow checks
+- `/portal/bootstrap`, managed `/healthz`, managed recovery, and same-origin browser flow checks
 - `web/secure-landing/`
 - `portal.html`
 - `public/portal-assets/*`
 - `config/portal_asset_manifest.json`
-- browser-smoke and selector-stability work
+- Node 22 frontdoor validation, browser-smoke, and selector-stability work
 
 Example:
 
@@ -26,7 +30,7 @@ Use for backend and governed execution work:
 
 - `app.py`
 - typed `/v1/*` behavior
-- `/ready`
+- backend `/healthz`, `/ready`, and `/v1/readiness`
 - Lux Depth V3
 - archive-gate
 - machine-mode and ingest
@@ -43,6 +47,7 @@ Use for governance and approval-bound changes:
 
 - dependency policy
 - CI/CD policy
+- documentation topology, Copilot instructions, or live custom-agent boundaries
 - security posture
 - route-contract or public-interface changes
 - ADR interpretation
@@ -56,7 +61,7 @@ Example:
 ## Quick Decision Guide
 
 - Browser shell or frontdoor question: use `@portal-app-steward`
-- Backend/orchestrator, Lux Depth, archive, ingest, or machine-mode question: use `@transformation-portal-specialist`
+- Backend/orchestrator health/readiness, Lux Depth, archive, ingest, or machine-mode question: use `@transformation-portal-specialist`
 - Governance, dependency, security, CI/CD, or contract decision: use `@transformation-portal-architect`
 
 ## Prompt Tips
@@ -71,6 +76,9 @@ Example:
 - **Full Guide**: [docs/guides/CUSTOM_AGENT_GUIDE.md](../guides/CUSTOM_AGENT_GUIDE.md)
 - **Agent README**: [.github/agents/README.md](../../.github/agents/README.md)
 - **Quick Start**: [QUICK_START_v2.md](../../.github/agents/QUICK_START_v2.md)
+- **Copilot Instructions**: [.github/copilot-instructions.md](../../.github/copilot-instructions.md)
+- **Documentation Map**: [DOCUMENTATION_MAP.md](../governance/DOCUMENTATION_MAP.md)
+- **Documentation State Audit**: [DOCUMENTATION_STATE_AUDIT_2026-04-27.md](../governance/DOCUMENTATION_STATE_AUDIT_2026-04-27.md)
 
 ---
 

--- a/docs/reports/README.md
+++ b/docs/reports/README.md
@@ -1,0 +1,9 @@
+# Reports Directory
+
+This directory contains point-in-time reports and summaries. Reports here may
+describe historical repo state, old PRs, or one-off investigations.
+
+Use current navigation first:
+
+- [Documentation Map](../governance/DOCUMENTATION_MAP.md)
+- [Documentation State Audit](../governance/DOCUMENTATION_STATE_AUDIT_2026-04-27.md)

--- a/docs/status/README.md
+++ b/docs/status/README.md
@@ -1,0 +1,10 @@
+# Status Reports
+
+This directory contains dated status snapshots. These files are audit context,
+not the current source of truth for repository health or active workflows.
+
+Current state is tracked through:
+
+- [Main README](../../README.md)
+- [Documentation Map](../governance/DOCUMENTATION_MAP.md)
+- [CI Workflow Matrix](../ci/WORKFLOW_MATRIX.md)

--- a/tests/test_custom_agent_config.py
+++ b/tests/test_custom_agent_config.py
@@ -15,6 +15,8 @@ AGENTS_DIR = REPO_ROOT / ".github" / "agents"
 AGENT_README = AGENTS_DIR / "README.md"
 CUSTOM_AGENT_GUIDE = REPO_ROOT / "docs" / "guides" / "CUSTOM_AGENT_GUIDE.md"
 DOCUMENTATION_MAP = REPO_ROOT / "docs" / "governance" / "DOCUMENTATION_MAP.md"
+DOCUMENTATION_STATE_AUDIT = REPO_ROOT / "docs" / "governance" / "DOCUMENTATION_STATE_AUDIT_2026-04-27.md"
+COPILOT_INSTRUCTIONS = REPO_ROOT / ".github" / "copilot-instructions.md"
 
 EXPECTED_PROFILES = {
     "transformation-portal-architect.md": {
@@ -34,8 +36,11 @@ EXPECTED_PROFILES = {
         "required_references": [
             "docs/architecture/agent_governance.md",
             "docs/governance/DOCUMENTATION_MAP.md",
+            "docs/governance/DOCUMENTATION_STATE_AUDIT_2026-04-27.md",
             "AGENTS.md",
+            ".github/copilot-instructions.md",
             "docs/architecture/ARCHITECTURE.md",
+            "docs/ci/WORKFLOW_MATRIX.md",
             "docs/api/MACHINE_MODE_CONTRACT.md",
             "docs/apex/ingest_contract.md",
             "docs/architecture/ADR-043-orchestrator-decomposition.md",
@@ -67,6 +72,9 @@ EXPECTED_PROFILES = {
         "required_references": [
             "docs/architecture/agent_governance.md",
             "AGENTS.md",
+            ".github/copilot-instructions.md",
+            "docs/governance/DOCUMENTATION_MAP.md",
+            "docs/governance/DOCUMENTATION_STATE_AUDIT_2026-04-27.md",
             "docs/architecture/PORTAL_OPERATOR_CONSOLE_MODERNIZATION_RFC.md",
             "docs/architecture/PORTAL_EDGE_HARDENING_IMPLEMENTATION_STANDARD.md",
             "docs/architecture/DNA_UX_UI_STRATEGY_REBASELINE_2026-04-08.md",
@@ -79,6 +87,7 @@ EXPECTED_PROFILES = {
             "/v1/*",
             "data-ui",
             "node 22",
+            "/healthz",
         ],
     },
     "transformation-portal-specialist.md": {
@@ -98,6 +107,10 @@ EXPECTED_PROFILES = {
         "required_references": [
             "docs/architecture/agent_governance.md",
             "AGENTS.md",
+            ".github/copilot-instructions.md",
+            "docs/README.md",
+            "docs/governance/DOCUMENTATION_MAP.md",
+            "docs/governance/DOCUMENTATION_STATE_AUDIT_2026-04-27.md",
             "docs/api/MACHINE_MODE_CONTRACT.md",
             "docs/apex/ingest_contract.md",
             "docs/architecture/ADR-043-orchestrator-decomposition.md",
@@ -112,6 +125,7 @@ EXPECTED_PROFILES = {
             "ci/cd",
             "security",
             "public interface",
+            "/v1/readiness",
         ],
     },
 }
@@ -247,7 +261,10 @@ def test_agent_readme_exists_and_indexes_live_profiles() -> None:
         assert config["name"] in content, f"README must name profile: {config['name']}"
 
     assert "CUSTOM_AGENT_GUIDE.md" in content
+    assert "copilot-instructions.md" in content
     assert "DOCUMENTATION_MAP.md" in content
+    assert "DOCUMENTATION_STATE_AUDIT_2026-04-27.md" in content
+    assert "AGENT_QUICK_REFERENCE.md" in content
     assert "agent_governance.md" in content
     assert "AGENTS.md" in content
 
@@ -255,10 +272,15 @@ def test_agent_readme_exists_and_indexes_live_profiles() -> None:
 def test_canonical_docs_exist_and_reference_custom_agents() -> None:
     guide = _read(CUSTOM_AGENT_GUIDE)
     documentation_map = _read(DOCUMENTATION_MAP)
+    documentation_state_audit = _read(DOCUMENTATION_STATE_AUDIT)
+    copilot_instructions = _read(COPILOT_INSTRUCTIONS)
 
     assert "custom agent" in guide.lower()
     assert "Custom Agents" in documentation_map
     assert "CUSTOM_AGENT_GUIDE.md" in documentation_map
+    assert "PR #1562" in documentation_state_audit
+    assert "Current baseline" in copilot_instructions
+    assert "DOCUMENTATION_MAP.md" in copilot_instructions
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- Refreshes canonical repository documentation and agent-facing guidance to match the current `main` state through PR #1562.
- Classifies stale documentation surfaces as maintained, historical/archive-only, or superseded, while keeping historical point-in-time docs out of live navigation.
- Updates Copilot/custom-agent/RAG guidance so automated contributors use the current Python 3.11+, Node 22, typed API, archive gate, CI, Docker/env, and APEX guidance.

## Changes
- Updated `README.md`, `CHANGELOG.md`, `docs/README.md`, and governance docs, including `DOCUMENTATION_MAP.md`, `DOCUMENTATION_POLICY.md`, and `REPO_ORGANIZATION.md`.
- Added a 2026-04-27 documentation state audit and directory-level README classifiers for legacy doc areas.
- Refreshed `.github/copilot-instructions.md`, custom agent profiles, RAG templates, and agent governance/reference docs for the PR #1562 baseline.
- Updated focused agent config and RAG tests to lock the current agent/documentation contract.
- No runtime, API route, selector, Docker, workflow, or Make target behavior changes.

## Validation
Proven green:
- `git diff --cached --check`
- `make check-docs`
- `make check-stale-docs`
- `python3 -B scripts/governance/check_docs_structure.py --all`
- `.venv/bin/pytest tests/test_custom_agent_config.py -q`
- `.venv/bin/pytest .github/agents/rag_system/tests/test_rag_pipeline.py -q`
- pre-commit hooks during `git commit`

Still failing:
- None in the scoped validation. macOS sandbox emitted `xcrun` temp-cache warnings during some git/make/python commands, but those commands exited successfully.

## Risk
- Documentation-only and test-contract-only change; no runtime behavior is touched.
- Main risk is navigation churn for operators and agents; the new docs map/audit and directory READMEs bound that by explicitly separating live guidance from historical material.
- Revert-safe: this is a single docs/test commit on a branch created from the current `origin/main` baseline.