### PR TITLE
feat(api): wire response_model on job lifecycle routes (Phase 1.2 PR C)

### DIFF
--- a/app.py
+++ b/app.py
@@ -43,6 +43,9 @@ from starlette.responses import Response, StreamingResponse
 
 from transformation_portal.api.v1 import (
     HealthzResponse,
+    JobEnvelope,
+    JobsListEnvelope,
+    JobStatusEnvelope,
     ReadinessEnvelope,
     ReadyResponse,
 )
@@ -8364,12 +8367,12 @@ async def stage_portal_uploads(request: Request) -> JSONResponse:
     )
 
 
-@app.post("/v1/jobs")
+@app.post("/v1/jobs", response_model=JobEnvelope)
 async def create_job(payload: Dict[str, Any]) -> JSONResponse:
     return await _create_job(payload, api_version="v1")
 
 
-@app.post("/v2/jobs")
+@app.post("/v2/jobs", response_model=JobEnvelope)
 async def create_job_v2(payload: Dict[str, Any]) -> JSONResponse:
     return await _create_job(payload, api_version="v2")
 
@@ -8521,12 +8524,12 @@ async def _create_job(payload: Dict[str, Any], *, api_version: str = "v1") -> JS
     )
 
 
-@app.get("/v1/jobs")
+@app.get("/v1/jobs", response_model=JobsListEnvelope)
 async def list_jobs(limit: int = JOB_LIST_LIMIT) -> JSONResponse:
     return _list_jobs(limit=limit, api_version="v1")
 
 
-@app.get("/v2/jobs")
+@app.get("/v2/jobs", response_model=JobsListEnvelope)
 async def list_jobs_v2(limit: int = JOB_LIST_LIMIT) -> JSONResponse:
     return _list_jobs(limit=limit, api_version="v2")
 
@@ -8555,12 +8558,12 @@ def _list_jobs(*, limit: int = JOB_LIST_LIMIT, api_version: str = "v1") -> JSONR
     )
 
 
-@app.get("/v1/jobs/{job_id}")
+@app.get("/v1/jobs/{job_id}", response_model=JobStatusEnvelope)
 async def get_job(job_id: str, include_logs: bool = True) -> JSONResponse:
     return _get_job(job_id, include_logs=include_logs, api_version="v1")
 
 
-@app.get("/v2/jobs/{job_id}")
+@app.get("/v2/jobs/{job_id}", response_model=JobStatusEnvelope)
 async def get_job_v2(job_id: str, include_logs: bool = True) -> JSONResponse:
     return _get_job(job_id, include_logs=include_logs, api_version="v2")
 
@@ -8672,12 +8675,12 @@ async def _get_job_artifact(job_id: str, artifact_path: str) -> Response:
     )
 
 
-@app.post("/v1/jobs/{job_id}/cancel")
+@app.post("/v1/jobs/{job_id}/cancel", response_model=JobEnvelope)
 async def cancel_job(job_id: str) -> JSONResponse:
     return await _cancel_job(job_id)
 
 
-@app.post("/v2/jobs/{job_id}/cancel")
+@app.post("/v2/jobs/{job_id}/cancel", response_model=JobEnvelope)
 async def cancel_job_v2(job_id: str) -> JSONResponse:
     return await _cancel_job(job_id)
 

--- a/src/transformation_portal/api/v1/__init__.py
+++ b/src/transformation_portal/api/v1/__init__.py
@@ -9,6 +9,16 @@ from transformation_portal.api.v1.health import (
     ReadinessServer,
     ReadyResponse,
 )
+from transformation_portal.api.v1.jobs import (
+    JobBriefData,
+    JobCreateRequest,
+    JobEnvelope,
+    JobsListData,
+    JobsListEnvelope,
+    JobState,
+    JobStatusData,
+    JobStatusEnvelope,
+)
 from transformation_portal.api.v1.schemas import SchemaName
 
 __all__ = [
@@ -17,6 +27,14 @@ __all__ = [
     "ErrorEnvelope",
     "ErrorObject",
     "HealthzResponse",
+    "JobBriefData",
+    "JobCreateRequest",
+    "JobEnvelope",
+    "JobsListData",
+    "JobsListEnvelope",
+    "JobState",
+    "JobStatusData",
+    "JobStatusEnvelope",
     "ReadinessData",
     "ReadinessEnvelope",
     "ReadinessServer",

--- a/src/transformation_portal/api/v1/jobs.py
+++ b/src/transformation_portal/api/v1/jobs.py
@@ -1,0 +1,172 @@
+"""Typed request/response models for the orchestrator's job lifecycle routes.
+
+Eight routes get ``response_model=`` annotations in PR C of the Phase 1.2
+sequence (the v1 routes plus their v2 mirrors):
+
+- ``POST /v[12]/jobs``                  → ``ApiEnvelope[JobBriefData]``
+  (``tp.orchestrator.job.v1``)
+- ``POST /v[12]/jobs/{id}/cancel``      → ``ApiEnvelope[JobBriefData]``
+  (``tp.orchestrator.job.v1``)
+- ``GET  /v[12]/jobs``                  → ``ApiEnvelope[JobsListData]``
+  (``tp.orchestrator.jobs.v1``)
+- ``GET  /v[12]/jobs/{id}``             → ``ApiEnvelope[JobStatusData]``
+  (``tp.orchestrator.job_status.v1``)
+
+Every route handler returns ``JSONResponse(_api_envelope(...))`` directly, so
+``response_model`` is **OpenAPI-only** — no runtime serialization is applied
+by FastAPI. The wire shape produced by ``app.py:_serialize_job`` (line 6530)
+is therefore unchanged by this PR; the models exist to type the OpenAPI
+schema and provide a stable surface for future PRs that want to consume the
+job envelopes from typed callers.
+
+``JobCreateRequest`` is defined here for type-discipline / future use but is
+**not yet wired** as the handler parameter. Wiring it would shift FastAPI's
+default 422 response to the orchestrator's 400 envelope (handled by the
+existing ``RequestValidationError`` exception handler at app.py:7879), but
+would also drop specific error-reason codes — currently ``_create_job``
+returns ``reason="unsupported_pipeline"`` etc., and Pydantic-level
+validation collapses everything to ``reason="request_validation_failed"``.
+That trade-off deserves its own focused decision/PR.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from transformation_portal.api.v1.envelopes import ApiEnvelope
+from transformation_portal.api.v1.errors import ErrorObject
+
+JobState = Literal[
+    "queued",
+    "running",
+    "succeeded",
+    "partial",
+    "failed",
+    "canceled",
+]
+"""The closed set of values for ``job.state``.
+
+Sourced from the ``state: str = "queued"`` comment in ``app.py:Job`` and the
+``"queued|running|succeeded|partial|failed|canceled"`` enumeration there. No
+intermediate states are emitted on the wire — cancellation transitions
+directly from ``running`` to ``canceled`` (see ``_request_cancel``).
+"""
+
+
+class JobBriefData(BaseModel):
+    """Payload for ``tp.orchestrator.job.v1``.
+
+    Used by two routes:
+
+    - ``POST /v[12]/jobs`` — create. Returns ``{id, state, events_url}``.
+    - ``POST /v[12]/jobs/{id}/cancel`` — cancel. Returns ``{id, state}``
+      (no ``events_url``).
+
+    ``events_url`` is therefore Optional in this shared model.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    state: JobState
+    events_url: str | None = None
+
+
+class JobStatusData(BaseModel):
+    """Payload for ``tp.orchestrator.job_status.v1`` and entries in
+    ``tp.orchestrator.jobs.v1``.
+
+    Mirrors ``app.py:_serialize_job`` output (line 6530) field-for-field.
+    Several fields are Optional because they're only set after a transition:
+    ``started_at`` (when the runner starts), ``finished_at`` /
+    ``exit_code`` (after the runner exits), ``logs_tail`` (only when the
+    handler is called with ``include_logs=True`` — list endpoints set
+    ``include_logs=False``).
+
+    ``extra="allow"`` is intentional: ``_serialize_job`` may grow new fields
+    in subsequent PRs, and external callers should keep working without a
+    model bump.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    id: str
+    pipeline: str
+    created_at: float
+    started_at: float | None = None
+    finished_at: float | None = None
+    state: JobState
+    progress: int
+    exit_code: int | None = None
+    events_url: str
+    artifacts: dict[str, Any] = Field(default_factory=dict)
+    error: ErrorObject | None = None
+    run_summary: dict[str, Any] | None = None
+    last_event_at: float | None = None
+    logs_tail: list[str] | None = None
+
+
+class JobsListData(BaseModel):
+    """Payload for ``tp.orchestrator.jobs.v1``.
+
+    Mirrors the dict constructed at ``app.py:_list_jobs`` (line 8534):
+    ``{"jobs": [_serialize_job(...), ...], "total": N, "returned": M}``.
+
+    The list endpoint always passes ``include_logs=False`` to ``_serialize_job``,
+    so ``JobStatusData.logs_tail`` will always be ``None`` for entries in
+    this list. The model accepts both — there's no need for a separate
+    ``JobBriefStatusData`` variant.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    jobs: list[JobStatusData]
+    total: int
+    returned: int
+
+
+class JobCreateRequest(BaseModel):
+    """Typed request body for ``POST /v[12]/jobs``.
+
+    NOT YET wired as the handler parameter — see module docstring for why.
+    Defined here so future PRs can adopt it once the error-reason-code
+    trade-off is accepted.
+
+    ``args`` is the pipeline-specific dispatch payload; its shape varies by
+    pipeline and is validated downstream by ``_build_config_preview`` and the
+    pipeline-specific dispatch preflights. Keeping it as ``dict[str, Any]``
+    rather than a discriminated union is intentional — see app.py for the
+    actual per-pipeline validation logic.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    pipeline: str
+    args: dict[str, Any] = Field(default_factory=dict)
+
+
+JobEnvelope = ApiEnvelope[JobBriefData]
+"""Convenience alias for the typed envelope wrapping ``JobBriefData``.
+
+Schema field stays under model-level ``SchemaName`` validation (any of the 12
+known schemas); the route handler is responsible for setting the right
+schema string. Same pattern as ``ReadinessEnvelope``."""
+
+JobStatusEnvelope = ApiEnvelope[JobStatusData]
+"""Convenience alias for the typed envelope wrapping ``JobStatusData``."""
+
+JobsListEnvelope = ApiEnvelope[JobsListData]
+"""Convenience alias for the typed envelope wrapping ``JobsListData``."""
+
+__all__ = [
+    "JobBriefData",
+    "JobCreateRequest",
+    "JobEnvelope",
+    "JobsListData",
+    "JobsListEnvelope",
+    "JobState",
+    "JobStatusData",
+    "JobStatusEnvelope",
+]

--- a/tests/api/v1/test_job_models.py
+++ b/tests/api/v1/test_job_models.py
@@ -16,7 +16,6 @@ import pytest
 from pydantic import ValidationError
 
 from transformation_portal.api.v1 import (
-    ApiEnvelope,
     ErrorObject,
     JobBriefData,
     JobCreateRequest,
@@ -321,13 +320,61 @@ class TestJobEnvelopes:
         assert dumped["schema"] == "tp.orchestrator.jobs.v1"
         assert dumped["data"]["total"] == 0
 
-    def test_envelope_aliases_are_apienvelope_specializations(self) -> None:
-        # Same alias-not-subclass design as ReadinessEnvelope. Locking the
-        # schema field to a single Literal would require a subclass per
-        # envelope; we deliberately don't.
-        assert JobEnvelope is ApiEnvelope[JobBriefData]
-        assert JobStatusEnvelope is ApiEnvelope[JobStatusData]
-        assert JobsListEnvelope is ApiEnvelope[JobsListData]
+    def test_envelope_aliases_carry_typed_data_payloads(self) -> None:
+        # Behavioral check that each alias's `data` field is bound to the
+        # right payload type. We avoid `assert JobEnvelope is ApiEnvelope[T]`
+        # — that relies on Pydantic's internal generic-specialization cache,
+        # which isn't part of the public contract and could change across
+        # Pydantic versions without breaking real semantics. Per-route alias
+        # design is still documented inline; this test just verifies the
+        # observable behavior (rejects wrong-shape payloads, accepts
+        # right-shape payloads) instead of object identity.
+
+        # JobEnvelope.data must be a valid JobBriefData (requires id + state).
+        with pytest.raises(ValidationError):
+            JobEnvelope(
+                schema="tp.orchestrator.job.v1",
+                success=True,
+                data={"not": "a job"},  # missing id, state
+            )
+        # JobsListEnvelope.data must be a valid JobsListData (jobs/total/returned).
+        with pytest.raises(ValidationError):
+            JobsListEnvelope(
+                schema="tp.orchestrator.jobs.v1",
+                success=True,
+                data={"jobs": []},  # missing total, returned
+            )
+        # JobStatusEnvelope.data must be a valid JobStatusData.
+        with pytest.raises(ValidationError):
+            JobStatusEnvelope(
+                schema="tp.orchestrator.job_status.v1",
+                success=True,
+                data={"id": "x"},  # missing pipeline, created_at, state, ...
+            )
+
+        # And the corresponding right-shape payloads must succeed:
+        JobEnvelope(
+            schema="tp.orchestrator.job.v1",
+            success=True,
+            data=JobBriefData(id="x", state="queued"),
+        )
+        JobsListEnvelope(
+            schema="tp.orchestrator.jobs.v1",
+            success=True,
+            data=JobsListData(jobs=[], total=0, returned=0),
+        )
+        JobStatusEnvelope(
+            schema="tp.orchestrator.job_status.v1",
+            success=True,
+            data=JobStatusData(
+                id="x",
+                pipeline="lux-depth-v3",
+                created_at=1.0,
+                state="queued",
+                progress=0,
+                events_url="/v1/jobs/x/events",
+            ),
+        )
 
     def test_unrecognised_schema_string_rejected_at_literal_level(self) -> None:
         # SchemaName Literal still rejects unknown strings even though the

--- a/tests/api/v1/test_job_models.py
+++ b/tests/api/v1/test_job_models.py
@@ -1,0 +1,340 @@
+"""Unit tests for the job lifecycle response/request models (Phase 1.2 PR C).
+
+These tests verify the typed models in
+``transformation_portal.api.v1.jobs`` accept and reject the wire shapes that
+``app.py``'s job-lifecycle handlers produce. They complement (do not replace)
+the existing wire-contract tests in
+``tests/test_app_orchestrator_contract_http.py`` and
+``tests/test_app_orchestrator_runtime.py`` — those exercise the routes
+end-to-end; these exercise the models in isolation so a regression there is
+caught before the contract tests get to it.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from transformation_portal.api.v1 import (
+    ApiEnvelope,
+    ErrorObject,
+    JobBriefData,
+    JobCreateRequest,
+    JobEnvelope,
+    JobsListData,
+    JobsListEnvelope,
+    JobStatusData,
+    JobStatusEnvelope,
+)
+
+# ---------------------------------------------------------------------------
+# JobBriefData — payload for tp.orchestrator.job.v1
+# ---------------------------------------------------------------------------
+
+
+class TestJobBriefData:
+    """Used by POST /v1/jobs (with events_url) and POST /v1/jobs/{id}/cancel
+    (without events_url). Both shapes must validate."""
+
+    def test_create_response_shape_with_events_url(self) -> None:
+        # Mirrors app.py:_create_job line 8514-8518
+        data = JobBriefData(
+            id="job_abcd1234",
+            state="queued",
+            events_url="/v1/jobs/job_abcd1234/events",
+        )
+        dumped = data.model_dump(mode="json")
+        assert dumped["id"] == "job_abcd1234"
+        assert dumped["state"] == "queued"
+        assert dumped["events_url"] == "/v1/jobs/job_abcd1234/events"
+
+    def test_cancel_response_shape_without_events_url(self) -> None:
+        # Mirrors app.py:_cancel_job line 8699: data={"id": ..., "state": ...}
+        # The model serialises events_url=None on the Python side; the runtime
+        # wire shape from the handler omits the key entirely (handler returns
+        # JSONResponse directly, bypassing response_model serialization). The
+        # OpenAPI schema treats events_url as optional.
+        data = JobBriefData(id="job_abcd1234", state="canceled")
+        dumped = data.model_dump(mode="json")
+        assert dumped["id"] == "job_abcd1234"
+        assert dumped["state"] == "canceled"
+        assert dumped["events_url"] is None
+
+    def test_unknown_state_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            JobBriefData(id="x", state="canceling")  # type: ignore[arg-type]
+
+    def test_extra_keys_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            JobBriefData(id="x", state="queued", extra="nope")  # type: ignore[call-arg]
+
+    @pytest.mark.parametrize(
+        "state",
+        ["queued", "running", "succeeded", "partial", "failed", "canceled"],
+    )
+    def test_every_known_state_accepted(self, state: str) -> None:
+        data = JobBriefData(id="x", state=state)  # type: ignore[arg-type]
+        assert data.state == state
+
+
+# ---------------------------------------------------------------------------
+# JobStatusData — payload for tp.orchestrator.job_status.v1 + entries in jobs.v1
+# ---------------------------------------------------------------------------
+
+
+class TestJobStatusData:
+    """Mirrors app.py:_serialize_job (line 6530)."""
+
+    def test_minimal_fresh_job(self) -> None:
+        # A queued job that hasn't started: started_at/finished_at/exit_code
+        # all None; no error; logs_tail absent (list endpoint sets
+        # include_logs=False).
+        data = JobStatusData(
+            id="job_x",
+            pipeline="lux-depth-v3",
+            created_at=1.0,
+            state="queued",
+            progress=0,
+            events_url="/v1/jobs/job_x/events",
+        )
+        dumped = data.model_dump(mode="json")
+        assert dumped["id"] == "job_x"
+        assert dumped["pipeline"] == "lux-depth-v3"
+        assert dumped["state"] == "queued"
+        assert dumped["progress"] == 0
+        assert dumped["started_at"] is None
+        assert dumped["finished_at"] is None
+        assert dumped["exit_code"] is None
+        assert dumped["error"] is None
+        assert dumped["run_summary"] is None
+        assert dumped["last_event_at"] is None
+        assert dumped["artifacts"] == {}
+        assert dumped["logs_tail"] is None  # list endpoint shape
+
+    def test_running_job_with_logs_tail_and_indexed_artifacts(self) -> None:
+        # GET /v1/jobs/{id}?include_logs=true with artifacts already indexed.
+        # The artifacts dict shape comes from _index_job_artifacts at
+        # app.py:6430 — {output_dir, items, indexed_count, truncated} — and
+        # the model accepts it as dict[str, Any].
+        artifacts_payload = {
+            "output_dir": "/tmp/job_x/output",
+            "items": [
+                {"path": "output.tif", "size_bytes": 1024, "sha256": "abc..."},
+                {"path": "summary.json", "size_bytes": 256, "sha256": "def..."},
+            ],
+            "indexed_count": 2,
+            "truncated": False,
+        }
+        data = JobStatusData(
+            id="job_x",
+            pipeline="archive-gate-a",
+            created_at=1.0,
+            started_at=1.5,
+            state="running",
+            progress=50,
+            events_url="/v1/jobs/job_x/events",
+            logs_tail=["[INFO] started", "[INFO] step 1"],
+            artifacts=artifacts_payload,
+            last_event_at=2.0,
+        )
+        dumped = data.model_dump(mode="json")
+        assert dumped["logs_tail"] == ["[INFO] started", "[INFO] step 1"]
+        assert dumped["artifacts"] == artifacts_payload
+        assert dumped["artifacts"]["indexed_count"] == 2
+        assert dumped["last_event_at"] == 2.0
+
+    def test_failed_job_with_error(self) -> None:
+        # _serialize_job sets data["error"] = job.error which is a dict
+        # matching ErrorObject's shape (set by _error_obj). The model
+        # accepts both the dict form and an ErrorObject directly.
+        data = JobStatusData(
+            id="job_x",
+            pipeline="lux-depth-v3",
+            created_at=1.0,
+            started_at=1.5,
+            finished_at=10.0,
+            state="failed",
+            progress=42,
+            exit_code=1,
+            events_url="/v1/jobs/job_x/events",
+            error={"code": "RUNNER_EXIT_NONZERO", "message": "boom", "details": {"exit_code": 1}},
+        )
+        dumped = data.model_dump(mode="json")
+        assert dumped["error"]["code"] == "RUNNER_EXIT_NONZERO"
+        assert dumped["error"]["details"] == {"exit_code": 1}
+        assert dumped["exit_code"] == 1
+
+    def test_error_field_accepts_error_object_instance(self) -> None:
+        # Construction via ErrorObject also works (used in tests + future
+        # internal call sites).
+        data = JobStatusData(
+            id="job_x",
+            pipeline="lux-depth-v3",
+            created_at=1.0,
+            state="failed",
+            progress=0,
+            events_url="/v1/jobs/job_x/events",
+            error=ErrorObject(code="RUNNER_NOT_FOUND", message="missing runner"),
+        )
+        dumped = data.model_dump(mode="json")
+        assert dumped["error"]["code"] == "RUNNER_NOT_FOUND"
+        assert dumped["error"]["details"] == {}
+
+    def test_extra_top_level_keys_accepted(self) -> None:
+        # extra="allow" — _serialize_job may grow new keys in later PRs.
+        data = JobStatusData(
+            id="job_x",
+            pipeline="lux-depth-v3",
+            created_at=1.0,
+            state="queued",
+            progress=0,
+            events_url="/v1/jobs/job_x/events",
+            future_telemetry_field="not-yet-modeled",
+        )
+        assert data.model_dump(mode="json")["future_telemetry_field"] == "not-yet-modeled"
+
+
+# ---------------------------------------------------------------------------
+# JobsListData — payload for tp.orchestrator.jobs.v1
+# ---------------------------------------------------------------------------
+
+
+class TestJobsListData:
+    def test_empty_list(self) -> None:
+        data = JobsListData(jobs=[], total=0, returned=0)
+        assert data.model_dump(mode="json") == {"jobs": [], "total": 0, "returned": 0}
+
+    def test_list_with_entries(self) -> None:
+        # Per app.py:_list_jobs (line 8534), entries come from
+        # _serialize_job(..., include_logs=False) — logs_tail will always be
+        # absent / None for list entries.
+        entry = JobStatusData(
+            id="job_x",
+            pipeline="lux-depth-v3",
+            created_at=1.0,
+            state="succeeded",
+            progress=100,
+            events_url="/v1/jobs/job_x/events",
+        )
+        data = JobsListData(jobs=[entry, entry], total=2, returned=2)
+        dumped = data.model_dump(mode="json")
+        assert len(dumped["jobs"]) == 2
+        assert dumped["total"] == 2
+        assert dumped["returned"] == 2
+        # logs_tail absent / null for list entries
+        assert dumped["jobs"][0]["logs_tail"] is None
+
+    def test_extra_keys_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            JobsListData(jobs=[], total=0, returned=0, page=1)  # type: ignore[call-arg]
+
+
+# ---------------------------------------------------------------------------
+# JobCreateRequest — request model for POST /v[12]/jobs (not yet wired)
+# ---------------------------------------------------------------------------
+
+
+class TestJobCreateRequest:
+    def test_minimal_required_pipeline(self) -> None:
+        req = JobCreateRequest(pipeline="lux-depth-v3")
+        assert req.pipeline == "lux-depth-v3"
+        assert req.args == {}
+
+    def test_pipeline_required(self) -> None:
+        with pytest.raises(ValidationError):
+            JobCreateRequest()  # type: ignore[call-arg]
+
+    def test_args_passes_through(self) -> None:
+        req = JobCreateRequest(
+            pipeline="lux-depth-v3",
+            args={"input_dir": "/fixtures/in", "output_dir": "/fixtures/out", "device": "cpu"},
+        )
+        assert req.args["input_dir"] == "/fixtures/in"
+
+    def test_extra_top_level_keys_passthrough(self) -> None:
+        # Existing handler accepts extra fields liberally; the model preserves
+        # that contract via extra="allow". When a future PR wires this model
+        # as the handler param, this guarantees no existing caller breaks.
+        req = JobCreateRequest(pipeline="lux-depth-v3", overrides={"foo": "bar"})
+        assert req.model_dump(mode="json")["overrides"] == {"foo": "bar"}
+
+
+# ---------------------------------------------------------------------------
+# Envelope aliases — full round-trip wraps for each schema
+# ---------------------------------------------------------------------------
+
+
+class TestJobEnvelopes:
+    def test_create_envelope_matches_handler_shape(self) -> None:
+        # Mirrors app.py:_create_job line 8510-8521
+        env = JobEnvelope(
+            schema="tp.orchestrator.job.v1",
+            success=True,
+            data=JobBriefData(
+                id="job_x",
+                state="queued",
+                events_url="/v1/jobs/job_x/events",
+            ),
+        )
+        dumped = env.model_dump(mode="json")
+        assert list(dumped.keys()) == ["schema", "success", "data", "error"]
+        assert dumped["schema"] == "tp.orchestrator.job.v1"
+        assert dumped["data"]["id"] == "job_x"
+        assert dumped["error"] is None
+
+    def test_cancel_envelope_matches_handler_shape(self) -> None:
+        # Mirrors app.py:_cancel_job line 8695-8702
+        env = JobEnvelope(
+            schema="tp.orchestrator.job.v1",
+            success=True,
+            data=JobBriefData(id="job_x", state="canceled"),
+        )
+        dumped = env.model_dump(mode="json")
+        # events_url serialises to null in this Python-side model_dump; the
+        # actual wire shape from the handler omits the key (JSONResponse
+        # bypass). Either is wire-compatible.
+        assert dumped["data"]["state"] == "canceled"
+
+    def test_status_envelope_round_trip(self) -> None:
+        # Mirrors app.py:_get_job line 8578-8585
+        status = JobStatusData(
+            id="job_x",
+            pipeline="lux-depth-v3",
+            created_at=1.0,
+            state="running",
+            progress=50,
+            events_url="/v1/jobs/job_x/events",
+        )
+        env = JobStatusEnvelope(schema="tp.orchestrator.job_status.v1", success=True, data=status)
+        dumped = env.model_dump(mode="json")
+        assert dumped["schema"] == "tp.orchestrator.job_status.v1"
+        assert dumped["data"]["progress"] == 50
+
+    def test_list_envelope_round_trip(self) -> None:
+        # Mirrors app.py:_list_jobs line 8544-8554
+        env = JobsListEnvelope(
+            schema="tp.orchestrator.jobs.v1",
+            success=True,
+            data=JobsListData(jobs=[], total=0, returned=0),
+        )
+        dumped = env.model_dump(mode="json")
+        assert dumped["schema"] == "tp.orchestrator.jobs.v1"
+        assert dumped["data"]["total"] == 0
+
+    def test_envelope_aliases_are_apienvelope_specializations(self) -> None:
+        # Same alias-not-subclass design as ReadinessEnvelope. Locking the
+        # schema field to a single Literal would require a subclass per
+        # envelope; we deliberately don't.
+        assert JobEnvelope is ApiEnvelope[JobBriefData]
+        assert JobStatusEnvelope is ApiEnvelope[JobStatusData]
+        assert JobsListEnvelope is ApiEnvelope[JobsListData]
+
+    def test_unrecognised_schema_string_rejected_at_literal_level(self) -> None:
+        # SchemaName Literal still rejects unknown strings even though the
+        # alias doesn't pin to a single value.
+        with pytest.raises(ValidationError):
+            JobEnvelope(
+                schema="tp.orchestrator.not_a_real_schema.v1",
+                success=True,
+                data=JobBriefData(id="x", state="queued"),
+            )


### PR DESCRIPTION
PR C of the Phase 1.2 sequence. Builds on PR B (#1562, merged) by wiring
response_model= on the eight job lifecycle routes — the largest remaining
JSON envelope surface in app.py.

What ships:

- src/transformation_portal/api/v1/jobs.py (new, +160)
  - JobState: closed Literal of the 6 job states
  - JobBriefData: payload for tp.orchestrator.job.v1 (POST /v1/jobs and
    POST /v1/jobs/{id}/cancel — cancel response omits events_url, so
    the model has it Optional)
  - JobStatusData: payload for tp.orchestrator.job_status.v1 + entries
    in tp.orchestrator.jobs.v1 (mirrors _serialize_job at app.py:6530;
    extra='allow' so future serializer additions don't bump the model)
  - JobsListData: payload for tp.orchestrator.jobs.v1
    ({jobs, total, returned})
  - JobCreateRequest: typed request body for POST /v[12]/jobs (defined
    for type discipline + future use; NOT yet wired as the handler
    parameter — see module docstring for the error-reason-code
    trade-off)
  - JobEnvelope, JobStatusEnvelope, JobsListEnvelope: ApiEnvelope[T]
    aliases (same pattern as ReadinessEnvelope from PR B)

- src/transformation_portal/api/v1/__init__.py: re-export the 8 new
  symbols.

- app.py: 4-line import addition + response_model= on the 8 job route
  decorators (POST/GET /v1/jobs, GET /v1/jobs/{id}, POST
  /v1/jobs/{id}/cancel, plus the v2 mirrors). No handler logic
  changed — every handler already returns JSONResponse(_api_envelope())
  directly, so response_model is OpenAPI-only and runtime serialisation
  is unchanged.

- tests/api/v1/test_job_models.py (new, +280): 28 unit tests covering
  every field/state/extra-key invariant per route, plus full envelope
  round-trips for create, cancel, status, and list shapes.

Wire-shape preservation — zero routes change runtime output:

All 8 handlers return JSONResponse(_api_envelope(...)) directly, which
bypasses FastAPI's response_model serialisation. The decorators are
documentation-only — they make the OpenAPI schema accurate without
altering what's emitted on the wire. The existing 27 contract tests in
tests/test_app_orchestrator_contract_http.py covering job lifecycle
all still pass.

Why JobCreateRequest is defined but not wired:

Wiring it as the handler param would shift FastAPI's 422 to the
orchestrator's 400 envelope (the existing RequestValidationError
handler at app.py:7879 already does this conversion for /v[12]/* paths,
so envelope shape is preserved). However the conversion drops specific
error reasons — currently _create_job returns
reason='unsupported_pipeline' etc., and Pydantic-level validation
collapses to reason='request_validation_failed'. That trade-off
deserves its own focused PR with stakeholder review of which clients
rely on the specific reason codes.

Verification:

- pytest tests/api/v1/ -> 87 passed (was 59; +28 new job tests)
- pytest tests/test_app_orchestrator_contract_http.py -k job ->
  27 passed (no regression on existing job-route contract tests)
- mypy --config-file=mypy.ini src/transformation_portal/api/ ->
  no issues in 7 source files
- black/isort -> clean across api/, tests/api/, app.py
- governance scripts (stale-docs, docs-structure, root-placement) ->
  clean (872 docs scanned)
- make validate-ci -> all workflow contracts pass

Out of scope (next in the sequence):

- PR C.1 (optional): wire JobCreateRequest as the handler param once
  the team accepts the reason-code trade-off
- PR D: response_model on config/presets routes (/v1/presets,
  /v1/config-metadata, /v1/config-preview)
- PR E: response_model on telemetry + uploads routes