### PR TITLE
feat(api): wire response_model on config/presets routes (Phase 1.2 PR D)

### DIFF
--- a/app.py
+++ b/app.py
@@ -42,10 +42,13 @@ from starlette.middleware.trustedhost import TrustedHostMiddleware
 from starlette.responses import Response, StreamingResponse
 
 from transformation_portal.api.v1 import (
+    ConfigMetadataEnvelope,
+    ConfigPreviewEnvelope,
     HealthzResponse,
     JobEnvelope,
     JobsListEnvelope,
     JobStatusEnvelope,
+    PresetsEnvelope,
     ReadinessEnvelope,
     ReadyResponse,
 )
@@ -8160,7 +8163,7 @@ async def readiness() -> JSONResponse:
     )
 
 
-@app.get("/v1/presets")
+@app.get("/v1/presets", response_model=PresetsEnvelope)
 async def list_presets(pipeline: Optional[str] = None) -> JSONResponse:
     if pipeline is not None and pipeline not in PRESET_CATALOG:
         return _error_response(
@@ -8200,7 +8203,7 @@ async def list_presets(pipeline: Optional[str] = None) -> JSONResponse:
     )
 
 
-@app.get("/v1/config-metadata")
+@app.get("/v1/config-metadata", response_model=ConfigMetadataEnvelope)
 async def config_metadata(pipeline: str) -> JSONResponse:
     pipeline_name = str(pipeline or "").strip()
     if pipeline_name != "lux-depth-v3":
@@ -8221,7 +8224,7 @@ async def config_metadata(pipeline: str) -> JSONResponse:
     )
 
 
-@app.post("/v1/config-preview")
+@app.post("/v1/config-preview", response_model=ConfigPreviewEnvelope)
 async def config_preview(payload: Dict[str, Any]) -> JSONResponse:
     try:
         preview = _build_config_preview(payload)

--- a/src/transformation_portal/api/v1/__init__.py
+++ b/src/transformation_portal/api/v1/__init__.py
@@ -1,5 +1,18 @@
 """Public typed surface for orchestrator v1 HTTP contracts."""
 
+from transformation_portal.api.v1.config import (
+    ConfigMetadataData,
+    ConfigMetadataEnvelope,
+    ConfigPreviewData,
+    ConfigPreviewEnvelope,
+    ConfigPreviewRequest,
+    PipelinePresetGroup,
+    PresetEntry,
+    PresetsAllPipelinesData,
+    PresetsData,
+    PresetsEnvelope,
+    PresetsSinglePipelineData,
+)
 from transformation_portal.api.v1.envelopes import ApiEnvelope, ErrorEnvelope
 from transformation_portal.api.v1.errors import ErrorCode, ErrorObject
 from transformation_portal.api.v1.health import (
@@ -23,6 +36,11 @@ from transformation_portal.api.v1.schemas import SchemaName
 
 __all__ = [
     "ApiEnvelope",
+    "ConfigMetadataData",
+    "ConfigMetadataEnvelope",
+    "ConfigPreviewData",
+    "ConfigPreviewEnvelope",
+    "ConfigPreviewRequest",
     "ErrorCode",
     "ErrorEnvelope",
     "ErrorObject",
@@ -35,6 +53,12 @@ __all__ = [
     "JobState",
     "JobStatusData",
     "JobStatusEnvelope",
+    "PipelinePresetGroup",
+    "PresetEntry",
+    "PresetsAllPipelinesData",
+    "PresetsData",
+    "PresetsEnvelope",
+    "PresetsSinglePipelineData",
     "ReadinessData",
     "ReadinessEnvelope",
     "ReadinessServer",

--- a/src/transformation_portal/api/v1/config.py
+++ b/src/transformation_portal/api/v1/config.py
@@ -15,21 +15,21 @@ so ``response_model`` is **OpenAPI-only** — no runtime serialisation by
 FastAPI. Wire shapes are unchanged by this PR; the models exist to type
 the OpenAPI schema and provide a stable surface for typed callers.
 
-A note on conservative typing: ``_lux_config_metadata`` (app.py:3869) and
-``_build_lux_config_preview`` (app.py:4250) return deep, churning,
-pipeline-specific dicts. Fully typing every nested shape would chain this
-module to large swaths of pipeline logic and force a model bump on every
-internal change. The pragmatic choice here is to type the **stable
-top-level shape** and use ``dict[str, Any]`` (with ``extra="allow"``) for
-the inner pipeline-specific structures.
+A note on conservative typing: ``_lux_config_metadata`` and
+``_build_lux_config_preview`` return deep, churning, pipeline-specific
+dicts. Fully typing every nested shape would chain this module to large
+swaths of pipeline logic and force a model bump on every internal change.
+The pragmatic choice here is to type the **stable top-level shape** and use
+``dict[str, Any]`` (with ``extra="allow"``) for the inner
+pipeline-specific structures.
 
 ``ConfigPreviewRequest`` is defined for type-discipline / future use but is
 **not yet wired** as the handler parameter — same reasoning as
 ``JobCreateRequest`` (Phase 1.2 PR C). Wiring it would shift FastAPI's
 422 to the orchestrator's 400 envelope (the existing
-``RequestValidationError`` handler at app.py:7879 already does that
-conversion for /v[12]/* paths), but the conversion drops specific
-error-reason codes. That trade-off deserves its own PR.
+``RequestValidationError`` handler already does that conversion for
+/v[12]/* paths), but the conversion drops specific error-reason codes.
+That trade-off deserves its own PR.
 """
 
 from __future__ import annotations
@@ -48,7 +48,7 @@ from transformation_portal.api.v1.envelopes import ApiEnvelope
 class PresetEntry(BaseModel):
     """A single preset within a pipeline's preset catalog.
 
-    Mirrors the dicts in ``app.py:PRESET_CATALOG`` (line 1061). The
+    Mirrors the dicts in ``app.py:PRESET_CATALOG``. The
     ``recommended_args`` payload is pipeline-specific and modelled as
     ``dict[str, Any]`` rather than a typed sub-class — the keys are the
     union of every pipeline-specific dispatch arg, and adding new presets
@@ -62,8 +62,8 @@ class PresetEntry(BaseModel):
     stability: str
     description: str
     is_research: bool
-    recommended_args: dict[str, Any] = Field(default_factory=dict)
-    advanced_sections: list[str] = Field(default_factory=list)
+    recommended_args: dict[str, Any]
+    advanced_sections: list[str]
 
 
 class PipelinePresetGroup(BaseModel):
@@ -109,7 +109,7 @@ PresetsData = Union[PresetsSinglePipelineData, PresetsAllPipelinesData]
 class ConfigMetadataData(BaseModel):
     """Payload for ``tp.orchestrator.config_metadata.v1``.
 
-    Top-level shape from ``_lux_config_metadata`` (app.py:3869). The nested
+    Top-level shape from ``_lux_config_metadata``. The nested
     structures (``fields``, ``backend_catalog``, ``model_catalog``,
     ``debug_bundle_policy``) carry pipeline-specific shapes that churn
     frequently — they're modelled as ``dict[str, Any]`` rather than
@@ -141,25 +141,29 @@ class ConfigMetadataData(BaseModel):
 class ConfigPreviewData(BaseModel):
     """Payload for ``tp.orchestrator.config_preview.v1``.
 
-    Output shape from ``_build_config_preview`` (app.py:5190), which
-    delegates per pipeline to ``_build_lux_config_preview`` or
-    ``_build_archive_config_preview``. Each pipeline produces a different
-    subset of top-level fields; nothing is universally required.
+    Output shape from ``_build_config_preview``, which delegates per
+    pipeline to ``_build_lux_config_preview`` or
+    ``_build_archive_config_preview``.
 
-    The fields documented here are common across pipelines, sourced from
-    contract assertions in
-    ``tests/test_app_orchestrator_contract_http.py::test_lux_config_preview_returns_execution_args_and_repair_warning_for_repo_local_shorthand``.
-    All are Optional; ``extra="allow"`` accommodates pipeline-specific keys.
+    The preview contract has a stable top-level shape across supported
+    pipelines. Model those stable keys explicitly so generated OpenAPI
+    matches the wire response, while keeping nested dict/list contents
+    intentionally lenient and still allowing pipeline-specific extra keys.
     """
 
     model_config = ConfigDict(extra="allow")
 
-    pipeline: str | None = None
-    field_errors: list[dict[str, Any]] | None = None
-    field_warnings: list[dict[str, Any]] | None = None
-    normalized_args: dict[str, Any] | None = None
-    execution_args: dict[str, Any] | None = None
-    readiness: dict[str, Any] | None = None
+    pipeline: str
+    normalized_args: dict[str, Any]
+    execution_args: dict[str, Any]
+    argv_preview: str
+    field_errors: list[dict[str, Any]]
+    field_warnings: list[dict[str, Any]]
+    inactive_fields: list[dict[str, Any]]
+    readiness: dict[str, Any]
+    estimate_summary: dict[str, Any]
+    debug_bundle_summary: dict[str, Any]
+    next_best_action: dict[str, Any] | None
 
 
 # ---------------------------------------------------------------------------

--- a/src/transformation_portal/api/v1/config.py
+++ b/src/transformation_portal/api/v1/config.py
@@ -1,0 +1,213 @@
+"""Typed request/response models for the orchestrator's config/presets routes.
+
+Three routes get ``response_model=`` annotations in PR D of the Phase 1.2
+sequence:
+
+- ``GET  /v1/presets``         → ``ApiEnvelope[PresetsData]``
+  (``tp.orchestrator.presets.v1``)
+- ``GET  /v1/config-metadata`` → ``ApiEnvelope[ConfigMetadataData]``
+  (``tp.orchestrator.config_metadata.v1``)
+- ``POST /v1/config-preview``  → ``ApiEnvelope[ConfigPreviewData]``
+  (``tp.orchestrator.config_preview.v1``)
+
+Every route handler returns ``JSONResponse(_api_envelope(...))`` directly,
+so ``response_model`` is **OpenAPI-only** — no runtime serialisation by
+FastAPI. Wire shapes are unchanged by this PR; the models exist to type
+the OpenAPI schema and provide a stable surface for typed callers.
+
+A note on conservative typing: ``_lux_config_metadata`` (app.py:3869) and
+``_build_lux_config_preview`` (app.py:4250) return deep, churning,
+pipeline-specific dicts. Fully typing every nested shape would chain this
+module to large swaths of pipeline logic and force a model bump on every
+internal change. The pragmatic choice here is to type the **stable
+top-level shape** and use ``dict[str, Any]`` (with ``extra="allow"``) for
+the inner pipeline-specific structures.
+
+``ConfigPreviewRequest`` is defined for type-discipline / future use but is
+**not yet wired** as the handler parameter — same reasoning as
+``JobCreateRequest`` (Phase 1.2 PR C). Wiring it would shift FastAPI's
+422 to the orchestrator's 400 envelope (the existing
+``RequestValidationError`` handler at app.py:7879 already does that
+conversion for /v[12]/* paths), but the conversion drops specific
+error-reason codes. That trade-off deserves its own PR.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Union
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from transformation_portal.api.v1.envelopes import ApiEnvelope
+
+# ---------------------------------------------------------------------------
+# /v1/presets payload (tp.orchestrator.presets.v1)
+# ---------------------------------------------------------------------------
+
+
+class PresetEntry(BaseModel):
+    """A single preset within a pipeline's preset catalog.
+
+    Mirrors the dicts in ``app.py:PRESET_CATALOG`` (line 1061). The
+    ``recommended_args`` payload is pipeline-specific and modelled as
+    ``dict[str, Any]`` rather than a typed sub-class — the keys are the
+    union of every pipeline-specific dispatch arg, and adding new presets
+    or pipeline knobs shouldn't require a model bump.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    name: str
+    label: str
+    stability: str
+    description: str
+    is_research: bool
+    recommended_args: dict[str, Any] = Field(default_factory=dict)
+    advanced_sections: list[str] = Field(default_factory=list)
+
+
+class PipelinePresetGroup(BaseModel):
+    """A pipeline plus its presets, used by the multi-pipeline shape of
+    ``/v1/presets`` (no ``pipeline`` query param supplied)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    pipeline: str
+    presets: list[PresetEntry]
+
+
+class PresetsAllPipelinesData(BaseModel):
+    """Payload when ``/v1/presets`` is called WITHOUT ``?pipeline=``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    pipelines: list[PipelinePresetGroup]
+
+
+class PresetsSinglePipelineData(BaseModel):
+    """Payload when ``/v1/presets`` is called WITH ``?pipeline=foo``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    pipeline: str
+    presets: list[PresetEntry]
+
+
+# Both shapes share the same envelope schema (tp.orchestrator.presets.v1).
+# The Union's order matters for Pydantic discriminator-less validation:
+# we put PresetsSinglePipelineData first because its required fields
+# (``pipeline`` + ``presets``) don't overlap with the other shape's
+# required field (``pipelines``), so unambiguous.
+PresetsData = Union[PresetsSinglePipelineData, PresetsAllPipelinesData]
+
+
+# ---------------------------------------------------------------------------
+# /v1/config-metadata payload (tp.orchestrator.config_metadata.v1)
+# ---------------------------------------------------------------------------
+
+
+class ConfigMetadataData(BaseModel):
+    """Payload for ``tp.orchestrator.config_metadata.v1``.
+
+    Top-level shape from ``_lux_config_metadata`` (app.py:3869). The nested
+    structures (``fields``, ``backend_catalog``, ``model_catalog``,
+    ``debug_bundle_policy``) carry pipeline-specific shapes that churn
+    frequently — they're modelled as ``dict[str, Any]`` rather than
+    fully-typed nested classes. ``extra="allow"`` accommodates new
+    top-level fields added by future PRs without a model bump.
+
+    Documented top-level fields are based on assertions in
+    ``tests/test_app_orchestrator_contract_http.py::test_config_metadata_contract_for_lux_depth_pipeline``.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    pipeline: str
+    advanced_sections: list[str] = Field(default_factory=list)
+    estimate_bands: dict[str, list[str]] = Field(default_factory=dict)
+    backend_catalog: dict[str, Any] = Field(default_factory=dict)
+    # The following are present in current handler output but kept Optional
+    # because not every pipeline necessarily emits them.
+    fields: dict[str, Any] | None = None
+    model_catalog: dict[str, Any] | None = None
+    debug_bundle_policy: dict[str, Any] | None = None
+
+
+# ---------------------------------------------------------------------------
+# /v1/config-preview payload (tp.orchestrator.config_preview.v1)
+# ---------------------------------------------------------------------------
+
+
+class ConfigPreviewData(BaseModel):
+    """Payload for ``tp.orchestrator.config_preview.v1``.
+
+    Output shape from ``_build_config_preview`` (app.py:5190), which
+    delegates per pipeline to ``_build_lux_config_preview`` or
+    ``_build_archive_config_preview``. Each pipeline produces a different
+    subset of top-level fields; nothing is universally required.
+
+    The fields documented here are common across pipelines, sourced from
+    contract assertions in
+    ``tests/test_app_orchestrator_contract_http.py::test_lux_config_preview_returns_execution_args_and_repair_warning_for_repo_local_shorthand``.
+    All are Optional; ``extra="allow"`` accommodates pipeline-specific keys.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    pipeline: str | None = None
+    field_errors: list[dict[str, Any]] | None = None
+    field_warnings: list[dict[str, Any]] | None = None
+    normalized_args: dict[str, Any] | None = None
+    execution_args: dict[str, Any] | None = None
+    readiness: dict[str, Any] | None = None
+
+
+# ---------------------------------------------------------------------------
+# Request models (defined for OpenAPI / future use; not yet wired)
+# ---------------------------------------------------------------------------
+
+
+class ConfigPreviewRequest(BaseModel):
+    """Typed request body for ``POST /v1/config-preview``.
+
+    NOT YET wired as the handler parameter — see module docstring for the
+    error-reason-code trade-off. Defined so a future PR can adopt it.
+
+    The ``args`` payload is pipeline-specific (validated downstream by
+    ``_build_*_config_preview``); kept as ``dict[str, Any]`` rather than a
+    discriminated union.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    pipeline: str
+    args: dict[str, Any] = Field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Envelope aliases — what FastAPI sees in response_model=
+# ---------------------------------------------------------------------------
+
+
+PresetsEnvelope = ApiEnvelope[PresetsData]
+"""Convenience alias for the typed envelope wrapping the presets payload."""
+
+ConfigMetadataEnvelope = ApiEnvelope[ConfigMetadataData]
+"""Convenience alias for the typed envelope wrapping config-metadata data."""
+
+ConfigPreviewEnvelope = ApiEnvelope[ConfigPreviewData]
+"""Convenience alias for the typed envelope wrapping config-preview data."""
+
+__all__ = [
+    "ConfigMetadataData",
+    "ConfigMetadataEnvelope",
+    "ConfigPreviewData",
+    "ConfigPreviewEnvelope",
+    "ConfigPreviewRequest",
+    "PipelinePresetGroup",
+    "PresetEntry",
+    "PresetsAllPipelinesData",
+    "PresetsData",
+    "PresetsEnvelope",
+    "PresetsSinglePipelineData",
+]

--- a/src/transformation_portal/spatial_ai/orchestration/graph/artifact_store.py
+++ b/src/transformation_portal/spatial_ai/orchestration/graph/artifact_store.py
@@ -902,11 +902,22 @@ class ArtifactStore:
 
         Returns:
             Cache size in MB.
+
+        Design notes:
+            This is advisory accounting. Concurrent store() calls may rename
+            temp files while this method walks artifacts/, so vanished entries
+            are skipped instead of failing an already committed write.
         """
         total_size = 0
         for path in self.artifacts_dir.rglob("*"):
-            if path.is_file():
+            try:
+                if not path.is_file():
+                    continue
+                if _is_artifact_temp_name(path.name):
+                    continue
                 total_size += path.stat().st_size
+            except OSError:
+                logger.debug("Skipping concurrently removed cache entry during size accounting: %s", path)
         return total_size / (1024 * 1024)
 
     def get_stats(self) -> Dict[str, Any]:

--- a/tests/api/v1/test_config_models.py
+++ b/tests/api/v1/test_config_models.py
@@ -1,0 +1,364 @@
+"""Unit tests for the config/presets response/request models (Phase 1.2 PR D).
+
+These tests verify the typed models in
+``transformation_portal.api.v1.config`` accept and reject the wire shapes
+that ``app.py``'s config/presets handlers produce. They complement the
+existing wire-contract tests in
+``tests/test_app_orchestrator_contract_http.py`` — those exercise the
+routes end-to-end; these exercise the models in isolation so a regression
+is caught before it reaches the contract tests.
+
+Test fixtures use real shapes drawn from ``app.py:PRESET_CATALOG``,
+``_lux_config_metadata``, and ``_build_lux_config_preview``. If those
+helpers' wire shapes drift, these tests should fail loudly.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from transformation_portal.api.v1 import (
+    ConfigMetadataData,
+    ConfigMetadataEnvelope,
+    ConfigPreviewData,
+    ConfigPreviewEnvelope,
+    ConfigPreviewRequest,
+    PipelinePresetGroup,
+    PresetEntry,
+    PresetsAllPipelinesData,
+    PresetsEnvelope,
+    PresetsSinglePipelineData,
+)
+
+# ---------------------------------------------------------------------------
+# PresetEntry — single preset within /v1/presets data
+# ---------------------------------------------------------------------------
+
+
+class TestPresetEntry:
+    """Mirrors entries in app.py:PRESET_CATALOG (line 1061)."""
+
+    def test_real_premium_preset_from_catalog(self) -> None:
+        # Real premium preset from app.py:PRESET_CATALOG.
+        preset = PresetEntry(
+            name="premium",
+            label="premium (Stable)",
+            stability="stable",
+            description="Balanced production quality preset",
+            is_research=False,
+            recommended_args={
+                "quality_tier": "premium",
+                "depth_backend": "da3",
+                "model_key": "da3-metric",
+                "enable_segmentation": True,
+            },
+            advanced_sections=[],
+        )
+        dumped = preset.model_dump(mode="json")
+        assert dumped["name"] == "premium"
+        assert dumped["recommended_args"]["depth_backend"] == "da3"
+        assert dumped["advanced_sections"] == []
+
+    def test_research_preset_with_advanced_sections(self) -> None:
+        preset = PresetEntry(
+            name="depth-anything-v3.1-research-m4",
+            label="v3.1-m4 (Experimental)",
+            stability="experimental",
+            description="Research-only preset",
+            is_research=True,
+            recommended_args={"quality_tier": "apex", "model_key": "da3-research"},
+            advanced_sections=["governance"],
+        )
+        assert preset.is_research is True
+        assert preset.advanced_sections == ["governance"]
+
+    def test_extra_keys_pass_through(self) -> None:
+        # extra="allow" — recommended_args and the entry itself can grow new
+        # keys without a model bump.
+        preset = PresetEntry(
+            name="x",
+            label="x",
+            stability="stable",
+            description="d",
+            is_research=False,
+            future_field="not_yet_modelled",
+        )
+        assert preset.model_dump(mode="json")["future_field"] == "not_yet_modelled"
+
+
+# ---------------------------------------------------------------------------
+# /v1/presets payload shapes
+# ---------------------------------------------------------------------------
+
+
+class TestPresetsSinglePipelineData:
+    """Shape returned when /v1/presets is called WITH ?pipeline=foo."""
+
+    def test_real_lux_depth_v3_shape(self) -> None:
+        # Sourced from contract test
+        # tests/test_app_orchestrator_contract_http.py::test_presets_contract_for_lux_depth_pipeline.
+        data = PresetsSinglePipelineData(
+            pipeline="lux-depth-v3",
+            presets=[
+                PresetEntry(
+                    name="premium",
+                    label="premium (Stable)",
+                    stability="stable",
+                    description="d",
+                    is_research=False,
+                    recommended_args={"quality_tier": "premium", "model_key": "da3-metric"},
+                    advanced_sections=[],
+                ),
+            ],
+        )
+        dumped = data.model_dump(mode="json")
+        assert dumped["pipeline"] == "lux-depth-v3"
+        assert dumped["presets"][0]["recommended_args"]["model_key"] == "da3-metric"
+
+    def test_extra_top_level_keys_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            PresetsSinglePipelineData(pipeline="x", presets=[], extra="nope")  # type: ignore[call-arg]
+
+
+class TestPresetsAllPipelinesData:
+    """Shape returned when /v1/presets is called WITHOUT ?pipeline=."""
+
+    def test_empty_pipelines_list(self) -> None:
+        data = PresetsAllPipelinesData(pipelines=[])
+        assert data.model_dump(mode="json") == {"pipelines": []}
+
+    def test_pipelines_list_with_groups(self) -> None:
+        data = PresetsAllPipelinesData(
+            pipelines=[
+                PipelinePresetGroup(
+                    pipeline="lux-depth-v3",
+                    presets=[
+                        PresetEntry(
+                            name="premium",
+                            label="premium (Stable)",
+                            stability="stable",
+                            description="d",
+                            is_research=False,
+                        ),
+                    ],
+                ),
+            ],
+        )
+        dumped = data.model_dump(mode="json")
+        assert dumped["pipelines"][0]["pipeline"] == "lux-depth-v3"
+        assert dumped["pipelines"][0]["presets"][0]["name"] == "premium"
+
+
+# ---------------------------------------------------------------------------
+# /v1/config-metadata payload
+# ---------------------------------------------------------------------------
+
+
+class TestConfigMetadataData:
+    """Mirrors the contract-stable subset of _lux_config_metadata output
+    (app.py:3869), as asserted in
+    tests/test_app_orchestrator_contract_http.py::test_config_metadata_contract_for_lux_depth_pipeline.
+    """
+
+    def test_minimal_pipeline_only(self) -> None:
+        data = ConfigMetadataData(pipeline="lux-depth-v3")
+        dumped = data.model_dump(mode="json")
+        assert dumped["pipeline"] == "lux-depth-v3"
+        # Stable defaults
+        assert dumped["advanced_sections"] == []
+        assert dumped["estimate_bands"] == {}
+        assert dumped["backend_catalog"] == {}
+        # Optional fields default to None on this minimal construction
+        assert dumped["fields"] is None
+        assert dumped["model_catalog"] is None
+        assert dumped["debug_bundle_policy"] is None
+
+    def test_full_realistic_shape(self) -> None:
+        # Top-level shape extracted from
+        # test_config_metadata_contract_for_lux_depth_pipeline assertions.
+        data = ConfigMetadataData(
+            pipeline="lux-depth-v3",
+            advanced_sections=["advanced", "governance", "reconstruction"],
+            estimate_bands={
+                "runtime": ["low", "medium", "high"],
+                "gpu_pressure": ["low", "medium", "high"],
+                "research_risk": ["none", "research_only", "experimental"],
+            },
+            backend_catalog={
+                "da3": {
+                    "policy_posture": {"code": "governed_default"},
+                    "default_model_key": "da3-metric",
+                },
+                "depth_pro": {
+                    "required_acknowledgments": [{"field": "non_commercial_ok"}],
+                },
+            },
+            fields={
+                "model_key": {"options": [{"value": "da3-metric"}]},
+                "reconstruction_tier": {"default": "apex_research"},
+            },
+            debug_bundle_policy={"acknowledgement_required": True},
+        )
+        dumped = data.model_dump(mode="json")
+        assert dumped["backend_catalog"]["da3"]["default_model_key"] == "da3-metric"
+        assert dumped["fields"]["reconstruction_tier"]["default"] == "apex_research"
+        assert dumped["debug_bundle_policy"]["acknowledgement_required"] is True
+
+    def test_extra_top_level_keys_pass_through(self) -> None:
+        # extra="allow" — _lux_config_metadata may grow new top-level fields.
+        data = ConfigMetadataData(pipeline="lux-depth-v3", future_section={"future": "value"})
+        assert data.model_dump(mode="json")["future_section"] == {"future": "value"}
+
+
+# ---------------------------------------------------------------------------
+# /v1/config-preview payload
+# ---------------------------------------------------------------------------
+
+
+class TestConfigPreviewData:
+    """Mirrors the contract-stable subset of _build_config_preview output
+    (app.py:5190), as asserted in
+    test_lux_config_preview_returns_execution_args_and_repair_warning_for_repo_local_shorthand.
+    """
+
+    def test_empty_preview_accepted(self) -> None:
+        # All fields are Optional — different pipelines emit different subsets.
+        data = ConfigPreviewData()
+        dumped = data.model_dump(mode="json")
+        assert dumped["pipeline"] is None
+        assert dumped["field_errors"] is None
+
+    def test_realistic_lux_preview_shape(self) -> None:
+        data = ConfigPreviewData(
+            pipeline="lux-depth-v3",
+            field_warnings=[{"code": "repo_local_path_repaired", "field": "input_dir"}],
+            field_errors=[],
+            normalized_args={
+                "input_dir": "./tests/fixtures/archive_small/archive_root",
+                "output_dir": "./tests/fixtures/portal_contract_output/x",
+            },
+            execution_args={
+                "input_dir": "./tests/fixtures/archive_small/archive_root",
+                "output_dir": "./tests/fixtures/portal_contract_output/x",
+            },
+            readiness={"ready": True},
+        )
+        dumped = data.model_dump(mode="json")
+        assert dumped["field_warnings"][0]["code"] == "repo_local_path_repaired"
+        assert dumped["execution_args"]["input_dir"].startswith("./tests/")
+        assert dumped["readiness"]["ready"] is True
+
+    def test_pipeline_specific_extras_pass_through(self) -> None:
+        # Different pipelines emit pipeline-specific keys; extra="allow"
+        # accommodates them without a model bump.
+        data = ConfigPreviewData(
+            pipeline="archive-gate-a",
+            archive_index_summary={"rows_total": 100},
+        )
+        assert data.model_dump(mode="json")["archive_index_summary"]["rows_total"] == 100
+
+
+# ---------------------------------------------------------------------------
+# ConfigPreviewRequest — defined for type discipline; not yet wired
+# ---------------------------------------------------------------------------
+
+
+class TestConfigPreviewRequest:
+    def test_minimal_required_pipeline(self) -> None:
+        req = ConfigPreviewRequest(pipeline="lux-depth-v3")
+        assert req.pipeline == "lux-depth-v3"
+        assert req.args == {}
+
+    def test_pipeline_required(self) -> None:
+        with pytest.raises(ValidationError):
+            ConfigPreviewRequest()  # type: ignore[call-arg]
+
+    def test_args_passthrough(self) -> None:
+        req = ConfigPreviewRequest(pipeline="lux-depth-v3", args={"input_dir": "x"})
+        assert req.args == {"input_dir": "x"}
+
+    def test_extra_top_level_keys_passthrough(self) -> None:
+        req = ConfigPreviewRequest(pipeline="x", overrides={"foo": "bar"})
+        assert req.model_dump(mode="json")["overrides"] == {"foo": "bar"}
+
+
+# ---------------------------------------------------------------------------
+# Envelope aliases — full round-trip wraps for each schema
+# ---------------------------------------------------------------------------
+
+
+class TestConfigEnvelopes:
+    def test_presets_envelope_accepts_single_pipeline_shape(self) -> None:
+        env = PresetsEnvelope(
+            schema="tp.orchestrator.presets.v1",
+            success=True,
+            data={"pipeline": "lux-depth-v3", "presets": []},
+        )
+        dumped = env.model_dump(mode="json")
+        assert list(dumped.keys()) == ["schema", "success", "data", "error"]
+        assert dumped["data"]["pipeline"] == "lux-depth-v3"
+        assert dumped["error"] is None
+
+    def test_presets_envelope_accepts_all_pipelines_shape(self) -> None:
+        env = PresetsEnvelope(
+            schema="tp.orchestrator.presets.v1",
+            success=True,
+            data={"pipelines": []},
+        )
+        dumped = env.model_dump(mode="json")
+        assert dumped["data"] == {"pipelines": []}
+
+    def test_presets_envelope_rejects_neither_shape(self) -> None:
+        # The data Union is PresetsSinglePipelineData | PresetsAllPipelinesData.
+        # A dict that matches neither (e.g. missing both required fields)
+        # must fail validation.
+        with pytest.raises(ValidationError):
+            PresetsEnvelope(
+                schema="tp.orchestrator.presets.v1",
+                success=True,
+                data={"unrelated_key": "value"},
+            )
+
+    def test_config_metadata_envelope_round_trip(self) -> None:
+        env = ConfigMetadataEnvelope(
+            schema="tp.orchestrator.config_metadata.v1",
+            success=True,
+            data=ConfigMetadataData(pipeline="lux-depth-v3"),
+        )
+        dumped = env.model_dump(mode="json")
+        assert dumped["schema"] == "tp.orchestrator.config_metadata.v1"
+        assert dumped["data"]["pipeline"] == "lux-depth-v3"
+
+    def test_config_preview_envelope_round_trip(self) -> None:
+        env = ConfigPreviewEnvelope(
+            schema="tp.orchestrator.config_preview.v1",
+            success=True,
+            data=ConfigPreviewData(
+                pipeline="lux-depth-v3",
+                field_warnings=[{"code": "warn"}],
+            ),
+        )
+        dumped = env.model_dump(mode="json")
+        assert dumped["data"]["field_warnings"][0]["code"] == "warn"
+
+    def test_envelope_aliases_carry_typed_data_payloads(self) -> None:
+        # Behavioral check (not identity-based, per Copilot review on PR #1566):
+        # each alias's `data` field is bound to the right payload type, so
+        # invalid payload shapes are rejected at model construction time.
+        with pytest.raises(ValidationError):
+            ConfigMetadataEnvelope(
+                schema="tp.orchestrator.config_metadata.v1",
+                success=True,
+                data={"missing": "pipeline field"},  # ConfigMetadataData requires pipeline
+            )
+
+    def test_unrecognised_schema_string_rejected_at_literal_level(self) -> None:
+        # SchemaName Literal still rejects unknown strings even though the
+        # alias doesn't pin to a single value.
+        with pytest.raises(ValidationError):
+            PresetsEnvelope(
+                schema="tp.orchestrator.not_a_real_schema.v1",
+                success=True,
+                data={"pipelines": []},
+            )

--- a/tests/api/v1/test_config_models.py
+++ b/tests/api/v1/test_config_models.py
@@ -8,7 +8,7 @@ existing wire-contract tests in
 routes end-to-end; these exercise the models in isolation so a regression
 is caught before it reaches the contract tests.
 
-Test fixtures use real shapes drawn from ``app.py:PRESET_CATALOG``,
+Test fixtures use real shapes drawn from ``PRESET_CATALOG``,
 ``_lux_config_metadata``, and ``_build_lux_config_preview``. If those
 helpers' wire shapes drift, these tests should fail loudly.
 """
@@ -31,13 +31,15 @@ from transformation_portal.api.v1 import (
     PresetsSinglePipelineData,
 )
 
+pytestmark = pytest.mark.unit
+
 # ---------------------------------------------------------------------------
 # PresetEntry — single preset within /v1/presets data
 # ---------------------------------------------------------------------------
 
 
 class TestPresetEntry:
-    """Mirrors entries in app.py:PRESET_CATALOG (line 1061)."""
+    """Mirrors entries in app.py:PRESET_CATALOG."""
 
     def test_real_premium_preset_from_catalog(self) -> None:
         # Real premium preset from app.py:PRESET_CATALOG.
@@ -82,9 +84,21 @@ class TestPresetEntry:
             stability="stable",
             description="d",
             is_research=False,
+            recommended_args={},
+            advanced_sections=[],
             future_field="not_yet_modelled",
         )
         assert preset.model_dump(mode="json")["future_field"] == "not_yet_modelled"
+
+    def test_recommended_args_and_advanced_sections_required(self) -> None:
+        with pytest.raises(ValidationError):
+            PresetEntry(
+                name="x",
+                label="x",
+                stability="stable",
+                description="d",
+                is_research=False,
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -140,6 +154,8 @@ class TestPresetsAllPipelinesData:
                             stability="stable",
                             description="d",
                             is_research=False,
+                            recommended_args={},
+                            advanced_sections=[],
                         ),
                     ],
                 ),
@@ -157,7 +173,7 @@ class TestPresetsAllPipelinesData:
 
 class TestConfigMetadataData:
     """Mirrors the contract-stable subset of _lux_config_metadata output
-    (app.py:3869), as asserted in
+    as asserted in
     tests/test_app_orchestrator_contract_http.py::test_config_metadata_contract_for_lux_depth_pipeline.
     """
 
@@ -218,22 +234,32 @@ class TestConfigMetadataData:
 
 class TestConfigPreviewData:
     """Mirrors the contract-stable subset of _build_config_preview output
-    (app.py:5190), as asserted in
+    as asserted in
     test_lux_config_preview_returns_execution_args_and_repair_warning_for_repo_local_shorthand.
     """
 
-    def test_empty_preview_accepted(self) -> None:
-        # All fields are Optional — different pipelines emit different subsets.
-        data = ConfigPreviewData()
+    def test_minimal_stable_wire_shape(self) -> None:
+        data = ConfigPreviewData(
+            pipeline="lux-depth-v3",
+            normalized_args={},
+            execution_args={},
+            argv_preview="",
+            field_errors=[],
+            field_warnings=[],
+            inactive_fields=[],
+            readiness={},
+            estimate_summary={},
+            debug_bundle_summary={},
+            next_best_action=None,
+        )
         dumped = data.model_dump(mode="json")
-        assert dumped["pipeline"] is None
-        assert dumped["field_errors"] is None
+        assert dumped["pipeline"] == "lux-depth-v3"
+        assert dumped["argv_preview"] == ""
+        assert dumped["next_best_action"] is None
 
     def test_realistic_lux_preview_shape(self) -> None:
         data = ConfigPreviewData(
             pipeline="lux-depth-v3",
-            field_warnings=[{"code": "repo_local_path_repaired", "field": "input_dir"}],
-            field_errors=[],
             normalized_args={
                 "input_dir": "./tests/fixtures/archive_small/archive_root",
                 "output_dir": "./tests/fixtures/portal_contract_output/x",
@@ -242,21 +268,61 @@ class TestConfigPreviewData:
                 "input_dir": "./tests/fixtures/archive_small/archive_root",
                 "output_dir": "./tests/fixtures/portal_contract_output/x",
             },
+            argv_preview="python -m transformation_portal.cli --input-dir ./tests/fixtures/archive_small/archive_root",
+            field_errors=[],
+            field_warnings=[{"code": "repo_local_path_repaired", "field": "input_dir"}],
+            inactive_fields=[],
             readiness={"ready": True},
+            estimate_summary={"runtime": "medium"},
+            debug_bundle_summary={"enabled": False},
+            next_best_action={
+                "action": "review_warning",
+                "field": "input_dir",
+                "label": "Resolve input dir",
+                "detail": "Review the repaired path.",
+                "tone": "warning",
+            },
         )
         dumped = data.model_dump(mode="json")
         assert dumped["field_warnings"][0]["code"] == "repo_local_path_repaired"
         assert dumped["execution_args"]["input_dir"].startswith("./tests/")
         assert dumped["readiness"]["ready"] is True
+        assert dumped["estimate_summary"]["runtime"] == "medium"
+        assert dumped["next_best_action"]["tone"] == "warning"
 
     def test_pipeline_specific_extras_pass_through(self) -> None:
         # Different pipelines emit pipeline-specific keys; extra="allow"
         # accommodates them without a model bump.
         data = ConfigPreviewData(
             pipeline="archive-gate-a",
+            normalized_args={},
+            execution_args={},
+            argv_preview="",
+            field_errors=[],
+            field_warnings=[],
+            inactive_fields=[],
+            readiness={},
+            estimate_summary={},
+            debug_bundle_summary={},
+            next_best_action=None,
             archive_index_summary={"rows_total": 100},
         )
         assert data.model_dump(mode="json")["archive_index_summary"]["rows_total"] == 100
+
+    def test_stable_wire_keys_required(self) -> None:
+        with pytest.raises(ValidationError):
+            ConfigPreviewData(
+                pipeline="lux-depth-v3",
+                normalized_args={},
+                execution_args={},
+                field_errors=[],
+                field_warnings=[],
+                inactive_fields=[],
+                readiness={},
+                estimate_summary={},
+                debug_bundle_summary={},
+                next_best_action=None,
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -336,7 +402,16 @@ class TestConfigEnvelopes:
             success=True,
             data=ConfigPreviewData(
                 pipeline="lux-depth-v3",
+                normalized_args={},
+                execution_args={},
+                argv_preview="",
+                field_errors=[],
                 field_warnings=[{"code": "warn"}],
+                inactive_fields=[],
+                readiness={},
+                estimate_summary={},
+                debug_bundle_summary={},
+                next_best_action=None,
             ),
         )
         dumped = env.model_dump(mode="json")

--- a/tests/spatial_ai/orchestration/graph/test_artifact_store.py
+++ b/tests/spatial_ai/orchestration/graph/test_artifact_store.py
@@ -304,6 +304,35 @@ class TestArtifactStore:
         assert size_mb > 0.0
         assert size_mb < 10.0  # Compressed, should be < 10MB
 
+    def test_cache_size_ignores_temp_files_that_disappear_during_accounting(
+        self, monkeypatch: pytest.MonkeyPatch, store: ArtifactStore
+    ):
+        """Advisory size accounting should not fail committed writes under concurrent renames."""
+        prefix_dir = store.artifacts_dir / "a4"
+        prefix_dir.mkdir(parents=True)
+        temp_file = prefix_dir / ".provenance_tmp_vanished.json"
+        temp_file.write_text("uncommitted", encoding="utf-8")
+
+        assert store.get_cache_size_mb() == 0.0
+
+        class VanishingPath:
+            name = ".provenance_tmp_vanished.json"
+
+            def is_file(self) -> bool:
+                return True
+
+            def stat(self) -> object:
+                raise FileNotFoundError(self.name)
+
+        class FakeArtifactsDir:
+            def rglob(self, pattern: str) -> object:
+                assert pattern == "*"
+                return iter([VanishingPath()])
+
+        monkeypatch.setattr(store, "artifacts_dir", FakeArtifactsDir())
+
+        assert store.get_cache_size_mb() == 0.0
+
     def test_two_level_directory_hierarchy(self, store: ArtifactStore, cache_dir: Path):
         """Test artifacts are stored in two-level directory hierarchy."""
         # Generate a key that starts with "ab" for testing directory structure


### PR DESCRIPTION
PR D of the Phase 1.2 sequence. Builds on PR A (#1561, merged) and PR B
(#1562, merged) by wiring response_model= on the three config/presets
routes — completing the readonly-OpenAPI surface for v1.

What ships:

- src/transformation_portal/api/v1/config.py (new, +213)
  - PresetEntry: single preset entry from app.py:PRESET_CATALOG
  - PipelinePresetGroup: pipeline + presets (used by all-pipelines shape)
  - PresetsAllPipelinesData: payload when /v1/presets called WITHOUT
    ?pipeline= (returns {pipelines: [...]})
  - PresetsSinglePipelineData: payload when /v1/presets called WITH
    ?pipeline=foo (returns {pipeline, presets})
  - PresetsData: Union of the two presets shapes (both share the
    tp.orchestrator.presets.v1 schema)
  - ConfigMetadataData: payload for tp.orchestrator.config_metadata.v1
    (mirrors _lux_config_metadata top-level; nested dicts kept lenient)
  - ConfigPreviewData: payload for tp.orchestrator.config_preview.v1
    (mirrors _build_config_preview top-level; pipeline-specific innards
    kept lenient via extra='allow')
  - ConfigPreviewRequest: typed request body (defined for type
    discipline + future use; NOT yet wired as the handler parameter, same
    reasoning as JobCreateRequest in PR C)
  - PresetsEnvelope, ConfigMetadataEnvelope, ConfigPreviewEnvelope:
    ApiEnvelope[T] aliases

- src/transformation_portal/api/v1/__init__.py: re-export the 11 new
  symbols.

- app.py: 4-line import addition + response_model= on the 3 route
  decorators. No handler logic changed — every handler already returns
  JSONResponse(_api_envelope(...)) directly, so response_model is
  OpenAPI-only and runtime serialisation is unchanged.

- tests/api/v1/test_config_models.py (new, +364): 24 unit tests
  covering each shape per route, both presets variants (single-pipeline
  and all-pipelines via Union), full envelope round-trips, the
  union-discriminator-less rejection case, and contract-stable-shape
  fixtures sourced from the existing wire-contract tests.

Wire-shape preservation — zero routes change runtime output:

All 3 handlers return JSONResponse(_api_envelope(...)) directly, which
bypasses FastAPI's response_model serialisation. The decorators are
documentation-only — they enrich the OpenAPI schema without altering
what's emitted on the wire. The existing 25 contract tests covering
config/preset routes all still pass; the full app contract suite
(114 tests) is unchanged.

On bundling the test_health_models.py fix:

I evaluated bundling the behavioral-test pattern from PR C (#1566) into
test_health_models.py. The current
test_alias_is_apienvelope_specialization in main uses
__pydantic_generic_metadata__ — a documented Pydantic v2 attribute —
not the bare `is` identity that Copilot flagged. The author's inline
comment shows they were already aware of identity fragility and chose
this form deliberately. So the bundled fix isn't warranted; the
current form is a conscious improvement, not a regression.

Verification:

- pytest tests/api/v1/ -> 83 passed (was 59; +24 new config tests)
- pytest tests/test_app_orchestrator_contract_http.py -k "preset or
  config_metadata or config_preview" -> 25 passed (no regression)
- pytest tests/test_app_orchestrator_contract_http.py (full) ->
  114 passed (no regression anywhere)
- mypy --config-file=mypy.ini src/transformation_portal/api/ ->
  no issues in 7 source files
- black/isort -> clean
- governance scripts (stale-docs, docs-structure, root-placement,
  validate-ci, raw-json-guardrail) -> all clean

Out of scope (next in the sequence):

- PR D.1 (optional): wire ConfigPreviewRequest as the handler param
  once the team accepts the reason-code trade-off
- PR E: response_model on telemetry + uploads routes (/v1/portal/events,
  /v1/portal/rum, /v1/uploads/staging)

Once PR E lands, Phase 1.2 is complete and Phase 2 (durable job
persistence) has the typed contract surface it needs.