### PR TITLE
fix(ci): gate coverage artifact upload to core legs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -711,8 +711,9 @@ jobs:
 
           exit "$rc"
 
+      # Only core legs generate coverage.xml/htmlcov; ML deliberately runs with --no-cov for fast PR feedback.
       - name: Upload coverage reports
-        if: always()
+        if: always() && matrix.test-type == 'core'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: coverage-${{ matrix.python-version }}-${{ matrix.test-type }}

--- a/scripts/validate_ci_config.py
+++ b/scripts/validate_ci_config.py
@@ -35,6 +35,18 @@ class CIValidator:
 
     MIN_CHECKOUT_MAJOR = 4
     REQUIRED_FLAKE8_FATAL_CODES = {"E9", "F63", "F7", "F82"}
+    ML_NO_COV_BLOCK_PATTERN = re.compile(
+        r'if\s+\[\s*"\$\{\{\s*matrix\.test-type\s*\}\}"\s*=\s*"ml"\s*\]\s*;\s*then\s*\n\s*'
+        r'COV_FLAGS="--no-cov"'
+    )
+    CORE_COV_FLAGS_PATTERN = re.compile(r'else\s*\n\s*COV_FLAGS="(?P<flags>[^"]*)"')
+    REQUIRED_CORE_COVERAGE_FLAGS = (
+        "--cov=src/transformation_portal",
+        "--cov=lux_depth_v3",
+        "--cov-report=xml",
+        "--cov-report=html",
+        "--cov-fail-under",
+    )
 
     def __init__(self, repo_root: Path, fix_mode: bool = False):
         self.repo_root = repo_root
@@ -261,10 +273,7 @@ class CIValidator:
             self.log_error("build.yml:test: Missing 'Run tests' step for coverage artifact contract")
             valid = False
         else:
-            run_script = run_tests_step.get("run", "")
-            if not isinstance(run_script, str) or 'COV_FLAGS="--no-cov"' not in run_script:
-                self.log_error('build.yml:test: ML test leg must keep COV_FLAGS="--no-cov" for fast PR feedback')
-                valid = False
+            valid = self._validate_run_tests_coverage_contract(run_tests_step.get("run")) and valid
 
         upload_step = self._find_step_by_name(steps, "Upload coverage reports")
         if upload_step is None:
@@ -285,6 +294,34 @@ class CIValidator:
             if required_path not in upload_paths:
                 self.log_error(f"build.yml:test: Coverage upload path must include {required_path!r}")
                 valid = False
+
+        return valid
+
+    def _validate_run_tests_coverage_contract(self, run_script: object) -> bool:
+        """Validate coverage flag scoping in the build.yml Run tests shell script."""
+        valid = True
+        if not isinstance(run_script, str):
+            self.log_error("build.yml:test: 'Run tests' step must define a run script")
+            return False
+
+        if not self.ML_NO_COV_BLOCK_PATTERN.search(run_script):
+            self.log_error(
+                "build.yml:test: 'Run tests' must scope '--no-cov' to the ML matrix leg with an explicit "
+                "matrix.test-type == 'ml' conditional"
+            )
+            valid = False
+
+        core_flags_match = self.CORE_COV_FLAGS_PATTERN.search(run_script)
+        if core_flags_match is None:
+            self.log_error("build.yml:test: Core test leg must define COV_FLAGS in the non-ML branch")
+            return False
+
+        core_flags = core_flags_match.group("flags")
+        missing_core_flags = [flag for flag in self.REQUIRED_CORE_COVERAGE_FLAGS if flag not in core_flags]
+        if missing_core_flags:
+            missing = ", ".join(repr(flag) for flag in missing_core_flags)
+            self.log_error(f"build.yml:test: Core test leg must retain coverage generation flags: {missing}")
+            valid = False
 
         return valid
 

--- a/scripts/validate_ci_config.py
+++ b/scripts/validate_ci_config.py
@@ -239,6 +239,72 @@ class CIValidator:
 
         return valid
 
+    def validate_build_coverage_contract(self, workflow_path: Path, config: Dict) -> bool:
+        """Validate the canonical PR gate coverage artifact contract."""
+        if workflow_path.name != "build.yml":
+            return True
+
+        valid = True
+        jobs = config.get("jobs", {})
+        test_job = jobs.get("test") if isinstance(jobs, dict) else None
+        if not isinstance(test_job, dict):
+            self.log_error("build.yml:test: Missing test job for coverage artifact contract")
+            return False
+
+        steps = test_job.get("steps", [])
+        if not isinstance(steps, list):
+            self.log_error("build.yml:test: Steps must be a list for coverage artifact contract")
+            return False
+
+        run_tests_step = self._find_step_by_name(steps, "Run tests")
+        if run_tests_step is None:
+            self.log_error("build.yml:test: Missing 'Run tests' step for coverage artifact contract")
+            valid = False
+        else:
+            run_script = run_tests_step.get("run", "")
+            if not isinstance(run_script, str) or 'COV_FLAGS="--no-cov"' not in run_script:
+                self.log_error('build.yml:test: ML test leg must keep COV_FLAGS="--no-cov" for fast PR feedback')
+                valid = False
+
+        upload_step = self._find_step_by_name(steps, "Upload coverage reports")
+        if upload_step is None:
+            self.log_error("build.yml:test: Missing 'Upload coverage reports' step for coverage artifact contract")
+            return False
+
+        expected_if = "always() && matrix.test-type == 'core'"
+        if upload_step.get("if") != expected_if:
+            self.log_error(
+                "build.yml:test: Coverage upload step must be guarded by "
+                f"{expected_if!r} because only core legs generate coverage artifacts"
+            )
+            valid = False
+
+        with_config = upload_step.get("with", {})
+        upload_paths = self._normalize_upload_paths(with_config.get("path") if isinstance(with_config, dict) else None)
+        for required_path in ("coverage.xml", "htmlcov/"):
+            if required_path not in upload_paths:
+                self.log_error(f"build.yml:test: Coverage upload path must include {required_path!r}")
+                valid = False
+
+        return valid
+
+    @staticmethod
+    def _find_step_by_name(steps: List[Dict], name: str) -> Optional[Dict]:
+        """Return the first workflow step with the supplied display name."""
+        for step in steps:
+            if isinstance(step, dict) and step.get("name") == name:
+                return step
+        return None
+
+    @staticmethod
+    def _normalize_upload_paths(path_config: object) -> Set[str]:
+        """Return normalized artifact upload paths from workflow action config."""
+        if isinstance(path_config, str):
+            return {line.strip() for line in path_config.splitlines() if line.strip()}
+        if isinstance(path_config, list):
+            return {str(item).strip() for item in path_config if str(item).strip()}
+        return set()
+
     def validate_workflow(self, workflow_path: Path) -> bool:
         """Validate a single workflow file."""
         print(f"\n→ Validating {workflow_path.name}...")
@@ -256,6 +322,7 @@ class CIValidator:
             self.validate_checkout_action(workflow_path, config),
             self.validate_common_issues(workflow_path, config),
             self.validate_flake8_config(workflow_path, config),
+            self.validate_build_coverage_contract(workflow_path, config),
         ]
 
         return all(validations)

--- a/tests/test_validate_ci_config.py
+++ b/tests/test_validate_ci_config.py
@@ -31,6 +31,16 @@ def _mutated_build_workflow(tmp_path: Path, old: str, new: str) -> Path:
     return path
 
 
+def _build_workflow_without_upload_path(tmp_path: Path, upload_path: str) -> Path:
+    lines = BUILD_WORKFLOW_PATH.read_text(encoding="utf-8").splitlines(keepends=True)
+    filtered_lines = [line for line in lines if line.strip() != upload_path]
+    assert len(filtered_lines) == len(lines) - 1
+
+    path = tmp_path / "build.yml"
+    path.write_text("".join(filtered_lines), encoding="utf-8")
+    return path
+
+
 def test_build_workflow_coverage_contract_passes_repo_config() -> None:
     validator, config = _load_config(BUILD_WORKFLOW_PATH)
 
@@ -55,11 +65,33 @@ def test_build_workflow_ml_leg_keeps_no_cov_fast_path(tmp_path: Path) -> None:
     validator, config = _load_config(workflow_path)
 
     assert validator.validate_build_coverage_contract(workflow_path, config) is False
-    assert any('ML test leg must keep COV_FLAGS="--no-cov"' in error for error in validator.errors)
+    assert any("must scope '--no-cov' to the ML matrix leg" in error for error in validator.errors)
+
+
+def test_build_workflow_ml_no_cov_must_be_scoped_to_ml_branch(tmp_path: Path) -> None:
+    workflow_path = _mutated_build_workflow(
+        tmp_path,
+        'if [ "${{ matrix.test-type }}" = "ml" ]; then',
+        "if true; then",
+    )
+    validator, config = _load_config(workflow_path)
+
+    assert validator.validate_build_coverage_contract(workflow_path, config) is False
+    assert any("must scope '--no-cov' to the ML matrix leg" in error for error in validator.errors)
+
+
+def test_build_workflow_core_leg_keeps_xml_coverage_generation(tmp_path: Path) -> None:
+    workflow_path = _mutated_build_workflow(tmp_path, "--cov-report=xml ", "")
+    validator, config = _load_config(workflow_path)
+
+    assert validator.validate_build_coverage_contract(workflow_path, config) is False
+    assert any(
+        "Core test leg must retain coverage generation flags: '--cov-report=xml'" in error for error in validator.errors
+    )
 
 
 def test_build_workflow_coverage_upload_keeps_html_artifact_path(tmp_path: Path) -> None:
-    workflow_path = _mutated_build_workflow(tmp_path, "            htmlcov/\n", "")
+    workflow_path = _build_workflow_without_upload_path(tmp_path, "htmlcov/")
     validator, config = _load_config(workflow_path)
 
     assert validator.validate_build_coverage_contract(workflow_path, config) is False

--- a/tests/test_validate_ci_config.py
+++ b/tests/test_validate_ci_config.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+TOOL_PATH = PROJECT_ROOT / "scripts" / "validate_ci_config.py"
+BUILD_WORKFLOW_PATH = PROJECT_ROOT / ".github" / "workflows" / "build.yml"
+SPEC = importlib.util.spec_from_file_location("validate_ci_config", TOOL_PATH)
+assert SPEC is not None and SPEC.loader is not None
+validate_ci_config = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(validate_ci_config)
+
+
+def _load_config(path: Path) -> tuple[object, dict]:
+    validator = validate_ci_config.CIValidator(PROJECT_ROOT)
+    config = validator.validate_yaml_syntax(path)
+    assert config is not None
+    return validator, config
+
+
+def _mutated_build_workflow(tmp_path: Path, old: str, new: str) -> Path:
+    source = BUILD_WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert old in source
+    path = tmp_path / "build.yml"
+    path.write_text(source.replace(old, new, 1), encoding="utf-8")
+    return path
+
+
+def test_build_workflow_coverage_contract_passes_repo_config() -> None:
+    validator, config = _load_config(BUILD_WORKFLOW_PATH)
+
+    assert validator.validate_build_coverage_contract(BUILD_WORKFLOW_PATH, config) is True
+    assert validator.errors == []
+
+
+def test_build_workflow_coverage_upload_must_be_core_only(tmp_path: Path) -> None:
+    workflow_path = _mutated_build_workflow(
+        tmp_path,
+        "if: always() && matrix.test-type == 'core'",
+        "if: always()",
+    )
+    validator, config = _load_config(workflow_path)
+
+    assert validator.validate_build_coverage_contract(workflow_path, config) is False
+    assert any("Coverage upload step must be guarded" in error for error in validator.errors)
+
+
+def test_build_workflow_ml_leg_keeps_no_cov_fast_path(tmp_path: Path) -> None:
+    workflow_path = _mutated_build_workflow(tmp_path, 'COV_FLAGS="--no-cov"', 'COV_FLAGS=""')
+    validator, config = _load_config(workflow_path)
+
+    assert validator.validate_build_coverage_contract(workflow_path, config) is False
+    assert any('ML test leg must keep COV_FLAGS="--no-cov"' in error for error in validator.errors)
+
+
+def test_build_workflow_coverage_upload_keeps_html_artifact_path(tmp_path: Path) -> None:
+    workflow_path = _mutated_build_workflow(tmp_path, "            htmlcov/\n", "")
+    validator, config = _load_config(workflow_path)
+
+    assert validator.validate_build_coverage_contract(workflow_path, config) is False
+    assert any("Coverage upload path must include 'htmlcov/'" in error for error in validator.errors)


### PR DESCRIPTION
## Summary
- Root cause: `build.yml` intentionally disables coverage for the ML PR matrix leg, but still ran the coverage artifact upload step for all matrix legs.
- Gate the coverage artifact upload to core legs only while preserving the ML `--no-cov` fast path.

## Changes
- Changed the `Upload coverage reports` step to run only when `matrix.test-type == 'core'`.
- Added a `build.yml` coverage artifact contract to `scripts/validate_ci_config.py`.
- Added focused tests for the core-only upload guard, ML `--no-cov` contract, and coverage artifact paths.
- No changes to Codecov, `ci.yml`, `ci-quality-firewall.yml`, dependency pins, or ML marker selection.

## Validation
Proven green:
- `.venv/bin/pytest tests/test_validate_ci_config.py`
- `make validate-ci`
- `git diff --check`
- `git diff --cached --check`
- pre-commit hooks during `git commit`

Still failing:
- None locally.

Failure classification:
- `make validate-ci` and git status commands printed macOS `xcrun` temp-cache warnings in the local sandbox, but exited 0.

## Risk
- Low operational risk: this only skips an upload step on the ML leg that intentionally produces no `coverage.xml` or `htmlcov/` artifacts.
- Revert-safe and bounded to CI workflow validation; selector, route, API, and test marker contracts are unchanged.