### PR TITLE
feat(api): wire response_model on telemetry/upload routes (Phase 1.2 PR E)

### DIFF
--- a/app.py
+++ b/app.py
@@ -48,9 +48,12 @@ from transformation_portal.api.v1 import (
     JobEnvelope,
     JobsListEnvelope,
     JobStatusEnvelope,
+    PortalEventEnvelope,
+    PortalRumIngestEnvelope,
     PresetsEnvelope,
     ReadinessEnvelope,
     ReadyResponse,
+    UploadStagingEnvelope,
 )
 from transformation_portal.determinism.trace import get_or_create_trace_context
 from transformation_portal.ingest.upload_staging import (
@@ -8246,7 +8249,7 @@ async def config_preview(payload: Dict[str, Any]) -> JSONResponse:
     )
 
 
-@app.post("/v1/portal/events")
+@app.post("/v1/portal/events", response_model=PortalEventEnvelope)
 async def portal_events(payload: Dict[str, Any]) -> JSONResponse:
     record, reason = _record_portal_event(payload)
     if reason is not None:
@@ -8270,7 +8273,7 @@ async def portal_events(payload: Dict[str, Any]) -> JSONResponse:
     )
 
 
-@app.post("/v1/portal/rum")
+@app.post("/v1/portal/rum", response_model=PortalRumIngestEnvelope)
 async def portal_rum(request: Request, payload: Dict[str, Any]) -> JSONResponse:
     if not _portal_rum_enabled(_portal_actor_from_request(request)):
         return JSONResponse(
@@ -8304,7 +8307,7 @@ async def portal_rum(request: Request, payload: Dict[str, Any]) -> JSONResponse:
     )
 
 
-@app.post("/v1/uploads/staging")
+@app.post("/v1/uploads/staging", response_model=UploadStagingEnvelope)
 async def stage_portal_uploads(request: Request) -> JSONResponse:
     if not _portal_staged_uploads_enabled(_portal_actor_from_request(request)):
         return _error_response(

--- a/src/transformation_portal/api/v1/__init__.py
+++ b/src/transformation_portal/api/v1/__init__.py
@@ -33,6 +33,18 @@ from transformation_portal.api.v1.jobs import (
     JobStatusEnvelope,
 )
 from transformation_portal.api.v1.schemas import SchemaName
+from transformation_portal.api.v1.telemetry import (
+    PortalEventData,
+    PortalEventEnvelope,
+    PortalRumIngestData,
+    PortalRumIngestEnvelope,
+)
+from transformation_portal.api.v1.uploads import (
+    UploadArtifacts,
+    UploadStagingData,
+    UploadStagingEnvelope,
+    UploadSummary,
+)
 
 __all__ = [
     "ApiEnvelope",
@@ -54,6 +66,10 @@ __all__ = [
     "JobStatusData",
     "JobStatusEnvelope",
     "PipelinePresetGroup",
+    "PortalEventData",
+    "PortalEventEnvelope",
+    "PortalRumIngestData",
+    "PortalRumIngestEnvelope",
     "PresetEntry",
     "PresetsAllPipelinesData",
     "PresetsData",
@@ -64,4 +80,8 @@ __all__ = [
     "ReadinessServer",
     "ReadyResponse",
     "SchemaName",
+    "UploadArtifacts",
+    "UploadStagingData",
+    "UploadStagingEnvelope",
+    "UploadSummary",
 ]

--- a/src/transformation_portal/api/v1/telemetry.py
+++ b/src/transformation_portal/api/v1/telemetry.py
@@ -1,0 +1,89 @@
+"""Typed request/response models for the orchestrator's telemetry routes.
+
+Two routes get ``response_model=`` annotations in PR E of the Phase 1.2
+sequence:
+
+- ``POST /v1/portal/events``  → ``ApiEnvelope[PortalEventData]``
+  (``tp.orchestrator.portal_event.v1``)
+- ``POST /v1/portal/rum``     → ``ApiEnvelope[PortalRumIngestData]``
+  (``tp.orchestrator.portal_rum_ingest.v1``)
+
+Every route handler returns ``JSONResponse(_api_envelope(...))`` directly,
+so ``response_model`` is **OpenAPI-only** — no runtime serialisation by
+FastAPI. Wire shapes are unchanged by this PR; the models exist to type
+the OpenAPI schema and provide a stable surface for typed callers.
+
+The ``event`` field on both payloads is a sanitised record dict whose
+internal keys churn as new event types and RUM metrics are added. Keeping
+it as ``dict[str, Any]`` rather than a typed sub-class is intentional —
+the record structure is validated upstream by ``_record_portal_event`` and
+``_record_portal_rum``; fully typing it here would chain this module to
+those internals and force a model bump on every new event or metric kind.
+
+Request bodies are accepted as ``Dict[str, Any]`` by the existing handlers
+and are **not yet wired** as Pydantic parameters here — same reasoning as
+``JobCreateRequest`` (Phase 1.2 PR C). Wiring them would shift FastAPI's
+422 to the orchestrator's 400 envelope but would also drop specific
+error-reason codes produced by the validation helpers.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+from transformation_portal.api.v1.envelopes import ApiEnvelope
+
+
+class PortalEventData(BaseModel):
+    """Payload for ``tp.orchestrator.portal_event.v1``.
+
+    Mirrors the ``data`` dict returned by ``portal_events`` in ``app.py``:
+    ``{"accepted": True, "event": record}``.
+
+    ``event`` holds the sanitised record written by ``_record_portal_event``
+    (schema, timestamp, event_type, pipeline, surface, field, metadata,
+    reasons). ``extra="allow"`` lets the model absorb new top-level keys
+    without a bump if the handler adds them in a later PR.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    accepted: bool
+    event: dict[str, Any] | None = None
+
+
+class PortalRumIngestData(BaseModel):
+    """Payload for ``tp.orchestrator.portal_rum_ingest.v1``.
+
+    Three shapes are possible:
+
+    - RUM disabled: ``{"accepted": False, "disabled": True}``
+    - Invalid payload (→ error envelope, not this model)
+    - Accepted: ``{"accepted": True, "event": record}``
+
+    ``disabled`` is ``None`` on the accepted path; ``event`` is ``None``
+    on the disabled path. Both are Optional so a single model covers all
+    non-error shapes. ``extra="allow"`` accommodates future additions.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    accepted: bool
+    disabled: bool | None = None
+    event: dict[str, Any] | None = None
+
+
+PortalEventEnvelope = ApiEnvelope[PortalEventData]
+"""Convenience alias for the typed envelope wrapping ``PortalEventData``."""
+
+PortalRumIngestEnvelope = ApiEnvelope[PortalRumIngestData]
+"""Convenience alias for the typed envelope wrapping ``PortalRumIngestData``."""
+
+__all__ = [
+    "PortalEventData",
+    "PortalEventEnvelope",
+    "PortalRumIngestData",
+    "PortalRumIngestEnvelope",
+]

--- a/src/transformation_portal/api/v1/telemetry.py
+++ b/src/transformation_portal/api/v1/telemetry.py
@@ -29,7 +29,7 @@ error-reason codes produced by the validation helpers.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict
 
@@ -39,8 +39,12 @@ from transformation_portal.api.v1.envelopes import ApiEnvelope
 class PortalEventData(BaseModel):
     """Payload for ``tp.orchestrator.portal_event.v1``.
 
-    Mirrors the ``data`` dict returned by ``portal_events`` in ``app.py``:
-    ``{"accepted": True, "event": record}``.
+    The ``portal_events`` handler has exactly one non-error response shape:
+    ``{"accepted": True, "event": record}``. Invalid payloads return an
+    ``ErrorEnvelope`` — ``PortalEventData`` is never emitted with
+    ``accepted=False``. ``accepted`` is therefore narrowed to
+    ``Literal[True]`` and ``event`` is required (never ``None`` on the
+    success path).
 
     ``event`` holds the sanitised record written by ``_record_portal_event``
     (schema, timestamp, event_type, pipeline, surface, field, metadata,
@@ -50,22 +54,25 @@ class PortalEventData(BaseModel):
 
     model_config = ConfigDict(extra="allow")
 
-    accepted: bool
-    event: dict[str, Any] | None = None
+    accepted: Literal[True]
+    event: dict[str, Any]
 
 
 class PortalRumIngestData(BaseModel):
     """Payload for ``tp.orchestrator.portal_rum_ingest.v1``.
 
-    Three shapes are possible:
+    Two non-error shapes are possible:
 
     - RUM disabled: ``{"accepted": False, "disabled": True}``
-    - Invalid payload (→ error envelope, not this model)
-    - Accepted: ``{"accepted": True, "event": record}``
+    - Accepted:     ``{"accepted": True, "event": record}``
 
-    ``disabled`` is ``None`` on the accepted path; ``event`` is ``None``
-    on the disabled path. Both are Optional so a single model covers all
-    non-error shapes. ``extra="allow"`` accommodates future additions.
+    Invalid payloads return an ``ErrorEnvelope``, not this model.
+
+    ``disabled`` and ``event`` are Optional so a single model covers both
+    non-error shapes. On the wire, the existing handler *omits* the
+    opposite-path key rather than emitting it with ``null`` — for example,
+    ``disabled`` is absent on the accepted path, and ``event`` is absent on
+    the disabled path. ``extra="allow"`` accommodates future additions.
     """
 
     model_config = ConfigDict(extra="allow")

--- a/src/transformation_portal/api/v1/uploads.py
+++ b/src/transformation_portal/api/v1/uploads.py
@@ -1,0 +1,91 @@
+"""Typed response models for the orchestrator's upload staging route.
+
+One route gets a ``response_model=`` annotation in PR E of the Phase 1.2
+sequence:
+
+- ``POST /v1/uploads/staging`` → ``ApiEnvelope[UploadStagingData]``
+  (``tp.orchestrator.upload_staging.v1``)
+
+The route handler returns ``JSONResponse(_api_envelope(...))`` directly, so
+``response_model`` is **OpenAPI-only** — no runtime serialisation by FastAPI.
+The wire shape is produced by ``StagedUploadResult.to_response_data()`` in
+``src/transformation_portal/ingest/upload_staging.py:154``; the models here
+mirror that output field-for-field.
+
+The nested ``artifacts`` and ``summary`` dicts have stable, closed shapes
+in the current implementation. They are modelled as explicit sub-classes
+(rather than ``dict[str, Any]``) because ``to_response_data`` constructs them
+from typed dataclass attributes — their keys are unlikely to churn.
+``extra="allow"`` is still set on all three models so future additions to
+``to_response_data`` don't require an immediate model bump.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+from transformation_portal.api.v1.envelopes import ApiEnvelope
+
+
+class UploadArtifacts(BaseModel):
+    """Nested ``artifacts`` dict from ``StagedUploadResult.to_response_data``.
+
+    All three values are absolute path strings produced by
+    ``stage_upload_batch`` and written into the batch directory.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    baseline_manifest_path: str
+    capture_metadata_path: str
+    upload_receipt_path: str
+
+
+class UploadSummary(BaseModel):
+    """Nested ``summary`` dict from ``StagedUploadResult.to_response_data``.
+
+    Mirrors the ``summary`` sub-dict exactly: counts, flags, root paths,
+    and any advisory warnings emitted during staging.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    file_count: int
+    total_bytes: int
+    capture_metadata_enabled: bool
+    capture_metadata_record_count: int
+    top_level_roots: list[str]
+    warnings: list[str]
+
+
+class UploadStagingData(BaseModel):
+    """Payload for ``tp.orchestrator.upload_staging.v1``.
+
+    Mirrors the top-level dict returned by
+    ``StagedUploadResult.to_response_data`` (upload_staging.py:154).
+    ``input_dir`` and ``metadata_dir`` are absolute path strings;
+    ``received_at_epoch_seconds`` is a Unix timestamp float.
+
+    ``extra="allow"`` at the top level lets future additions to
+    ``to_response_data`` pass through without a model bump.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    batch_id: str
+    input_dir: str
+    metadata_dir: str
+    artifacts: UploadArtifacts
+    received_at_epoch_seconds: float
+    summary: UploadSummary
+
+
+UploadStagingEnvelope = ApiEnvelope[UploadStagingData]
+"""Convenience alias for the typed envelope wrapping ``UploadStagingData``."""
+
+__all__ = [
+    "UploadArtifacts",
+    "UploadStagingData",
+    "UploadStagingEnvelope",
+    "UploadSummary",
+]

--- a/tests/api/v1/test_telemetry_models.py
+++ b/tests/api/v1/test_telemetry_models.py
@@ -18,7 +18,6 @@ from transformation_portal.api.v1 import (
     PortalRumIngestEnvelope,
 )
 
-
 # ---------------------------------------------------------------------------
 # PortalEventData — payload for tp.orchestrator.portal_event.v1
 # ---------------------------------------------------------------------------

--- a/tests/api/v1/test_telemetry_models.py
+++ b/tests/api/v1/test_telemetry_models.py
@@ -1,0 +1,156 @@
+"""Unit tests for the telemetry response models (Phase 1.2 PR E).
+
+These tests verify the typed models in
+``transformation_portal.api.v1.telemetry`` accept and reject the wire shapes
+that ``app.py``'s telemetry handlers produce. They complement (do not replace)
+the end-to-end route tests in ``tests/test_app_orchestrator_contract_http.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from transformation_portal.api.v1 import (
+    ApiEnvelope,
+    PortalEventData,
+    PortalEventEnvelope,
+    PortalRumIngestData,
+    PortalRumIngestEnvelope,
+)
+
+
+# ---------------------------------------------------------------------------
+# PortalEventData — payload for tp.orchestrator.portal_event.v1
+# ---------------------------------------------------------------------------
+
+
+class TestPortalEventData:
+    def test_accepted_with_event_validates(self) -> None:
+        record = {
+            "schema": "tp.orchestrator.portal_event.v1",
+            "timestamp": 1700000000,
+            "event_type": "config_exported",
+            "pipeline": "lux-depth-v3",
+            "surface": "effective_config",
+            "field": "reconstruction_tier",
+            "metadata": {"mode": "auto"},
+            "reasons": ["preview_ready"],
+        }
+        data = PortalEventData(accepted=True, event=record)
+        dumped = data.model_dump(mode="json")
+        assert dumped["accepted"] is True
+        assert dumped["event"]["event_type"] == "config_exported"
+
+    def test_rejected_with_none_event_validates(self) -> None:
+        data = PortalEventData(accepted=False)
+        dumped = data.model_dump(mode="json")
+        assert dumped["accepted"] is False
+        assert dumped["event"] is None
+
+    def test_extra_keys_are_preserved(self) -> None:
+        data = PortalEventData(accepted=True, event={"x": 1}, future_field="y")
+        dumped = data.model_dump(mode="json")
+        assert dumped["future_field"] == "y"
+
+    def test_accepted_is_required(self) -> None:
+        with pytest.raises(ValidationError):
+            PortalEventData(event={"x": 1})  # type: ignore[call-arg]
+
+
+class TestPortalEventEnvelope:
+    def test_envelope_round_trip(self) -> None:
+        payload = PortalEventEnvelope(
+            **{
+                "schema": "tp.orchestrator.portal_event.v1",
+                "success": True,
+                "data": {"accepted": True, "event": {"event_type": "config_exported"}},
+                "error": None,
+            }
+        )
+        dumped = payload.model_dump(mode="json")
+        assert dumped["schema"] == "tp.orchestrator.portal_event.v1"
+        assert dumped["success"] is True
+        assert dumped["data"]["accepted"] is True
+
+    def test_envelope_alias_is_api_envelope(self) -> None:
+        assert PortalEventEnvelope is ApiEnvelope[PortalEventData]
+
+
+# ---------------------------------------------------------------------------
+# PortalRumIngestData — payload for tp.orchestrator.portal_rum_ingest.v1
+# ---------------------------------------------------------------------------
+
+
+class TestPortalRumIngestData:
+    def test_disabled_path_validates(self) -> None:
+        # Mirrors app.py portal_rum handler when RUM is disabled
+        data = PortalRumIngestData(accepted=False, disabled=True)
+        dumped = data.model_dump(mode="json")
+        assert dumped["accepted"] is False
+        assert dumped["disabled"] is True
+        assert dumped["event"] is None
+
+    def test_accepted_path_with_event_validates(self) -> None:
+        record = {
+            "schema": "tp.orchestrator.portal_rum.v1",
+            "timestamp": 1700000000,
+            "event_type": "page_view",
+            "route": "/portal",
+            "view": "portal",
+            "metric": "",
+            "value": 0.0,
+            "unit": "count",
+            "metadata": {},
+            "trace_id": "abc123",
+            "cohort_bucket": 42,
+            "auth_mode": "direct",
+        }
+        data = PortalRumIngestData(accepted=True, event=record)
+        dumped = data.model_dump(mode="json")
+        assert dumped["accepted"] is True
+        assert dumped["disabled"] is None
+        assert dumped["event"]["event_type"] == "page_view"
+
+    def test_extra_keys_are_preserved(self) -> None:
+        data = PortalRumIngestData(accepted=True, future_metric="p99")
+        dumped = data.model_dump(mode="json")
+        assert dumped["future_metric"] == "p99"
+
+    def test_accepted_is_required(self) -> None:
+        with pytest.raises(ValidationError):
+            PortalRumIngestData(disabled=True)  # type: ignore[call-arg]
+
+
+class TestPortalRumIngestEnvelope:
+    def test_envelope_round_trip_disabled(self) -> None:
+        payload = PortalRumIngestEnvelope(
+            **{
+                "schema": "tp.orchestrator.portal_rum_ingest.v1",
+                "success": True,
+                "data": {"accepted": False, "disabled": True},
+                "error": None,
+            }
+        )
+        dumped = payload.model_dump(mode="json")
+        assert dumped["schema"] == "tp.orchestrator.portal_rum_ingest.v1"
+        assert dumped["data"]["accepted"] is False
+        assert dumped["data"]["disabled"] is True
+
+    def test_envelope_round_trip_accepted(self) -> None:
+        payload = PortalRumIngestEnvelope(
+            **{
+                "schema": "tp.orchestrator.portal_rum_ingest.v1",
+                "success": True,
+                "data": {
+                    "accepted": True,
+                    "event": {"event_type": "timing", "value": 1.23},
+                },
+                "error": None,
+            }
+        )
+        dumped = payload.model_dump(mode="json")
+        assert dumped["data"]["event"]["value"] == 1.23
+
+    def test_envelope_alias_is_api_envelope(self) -> None:
+        assert PortalRumIngestEnvelope is ApiEnvelope[PortalRumIngestData]

--- a/tests/api/v1/test_telemetry_models.py
+++ b/tests/api/v1/test_telemetry_models.py
@@ -12,7 +12,6 @@ import pytest
 from pydantic import ValidationError
 
 from transformation_portal.api.v1 import (
-    ApiEnvelope,
     PortalEventData,
     PortalEventEnvelope,
     PortalRumIngestData,
@@ -73,8 +72,28 @@ class TestPortalEventEnvelope:
         assert dumped["success"] is True
         assert dumped["data"]["accepted"] is True
 
-    def test_envelope_alias_is_api_envelope(self) -> None:
-        assert PortalEventEnvelope is ApiEnvelope[PortalEventData]
+    def test_envelope_validates_portal_event_data_shape(self) -> None:
+        payload = PortalEventEnvelope(
+            **{
+                "schema": "tp.orchestrator.portal_event.v1",
+                "success": True,
+                "data": {"accepted": True, "event": {"event_type": "config_exported"}},
+                "error": None,
+            }
+        )
+        assert payload.data.accepted is True
+        assert payload.data.event is not None
+        assert payload.data.event["event_type"] == "config_exported"
+
+        with pytest.raises(ValidationError):
+            PortalEventEnvelope(
+                **{
+                    "schema": "tp.orchestrator.portal_event.v1",
+                    "success": True,
+                    "data": {"event": {"event_type": "config_exported"}},
+                    "error": None,
+                }
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -152,5 +171,25 @@ class TestPortalRumIngestEnvelope:
         dumped = payload.model_dump(mode="json")
         assert dumped["data"]["event"]["value"] == 1.23
 
-    def test_envelope_alias_is_api_envelope(self) -> None:
-        assert PortalRumIngestEnvelope is ApiEnvelope[PortalRumIngestData]
+    def test_envelope_validates_portal_rum_ingest_data_shape(self) -> None:
+        payload = PortalRumIngestEnvelope(
+            **{
+                "schema": "tp.orchestrator.portal_rum_ingest.v1",
+                "success": True,
+                "data": {"accepted": True, "event": {"event_type": "timing", "value": 1.23}},
+                "error": None,
+            }
+        )
+        assert payload.data.accepted is True
+        assert payload.data.event is not None
+        assert payload.data.event["value"] == 1.23
+
+        with pytest.raises(ValidationError):
+            PortalRumIngestEnvelope(
+                **{
+                    "schema": "tp.orchestrator.portal_rum_ingest.v1",
+                    "success": True,
+                    "data": {"event": {"event_type": "timing"}},
+                    "error": None,
+                }
+            )

--- a/tests/api/v1/test_telemetry_models.py
+++ b/tests/api/v1/test_telemetry_models.py
@@ -40,20 +40,23 @@ class TestPortalEventData:
         assert dumped["accepted"] is True
         assert dumped["event"]["event_type"] == "config_exported"
 
-    def test_rejected_with_none_event_validates(self) -> None:
-        data = PortalEventData(accepted=False)
-        dumped = data.model_dump(mode="json")
-        assert dumped["accepted"] is False
-        assert dumped["event"] is None
-
     def test_extra_keys_are_preserved(self) -> None:
         data = PortalEventData(accepted=True, event={"x": 1}, future_field="y")
         dumped = data.model_dump(mode="json")
         assert dumped["future_field"] == "y"
 
+    def test_accepted_literal_true_rejects_false(self) -> None:
+        # portal_events never emits accepted=False; Literal[True] enforces this.
+        with pytest.raises(ValidationError):
+            PortalEventData(accepted=False, event={"x": 1})  # type: ignore[arg-type]
+
     def test_accepted_is_required(self) -> None:
         with pytest.raises(ValidationError):
             PortalEventData(event={"x": 1})  # type: ignore[call-arg]
+
+    def test_event_is_required(self) -> None:
+        with pytest.raises(ValidationError):
+            PortalEventData(accepted=True)  # type: ignore[call-arg]
 
 
 class TestPortalEventEnvelope:
@@ -102,12 +105,11 @@ class TestPortalEventEnvelope:
 
 class TestPortalRumIngestData:
     def test_disabled_path_validates(self) -> None:
-        # Mirrors app.py portal_rum handler when RUM is disabled
+        # Mirrors app.py portal_rum handler when RUM is disabled:
+        # emits {"accepted": False, "disabled": True} — "event" key absent.
         data = PortalRumIngestData(accepted=False, disabled=True)
-        dumped = data.model_dump(mode="json")
-        assert dumped["accepted"] is False
-        assert dumped["disabled"] is True
-        assert dumped["event"] is None
+        dumped = data.model_dump(mode="json", exclude_none=True)
+        assert dumped == {"accepted": False, "disabled": True}
 
     def test_accepted_path_with_event_validates(self) -> None:
         record = {
@@ -124,10 +126,12 @@ class TestPortalRumIngestData:
             "cohort_bucket": 42,
             "auth_mode": "direct",
         }
+        # Mirrors app.py portal_rum handler on the accepted path:
+        # emits {"accepted": True, "event": record} — "disabled" key absent.
         data = PortalRumIngestData(accepted=True, event=record)
-        dumped = data.model_dump(mode="json")
+        dumped = data.model_dump(mode="json", exclude_none=True)
         assert dumped["accepted"] is True
-        assert dumped["disabled"] is None
+        assert "disabled" not in dumped
         assert dumped["event"]["event_type"] == "page_view"
 
     def test_extra_keys_are_preserved(self) -> None:

--- a/tests/api/v1/test_upload_models.py
+++ b/tests/api/v1/test_upload_models.py
@@ -1,0 +1,165 @@
+"""Unit tests for the upload staging response models (Phase 1.2 PR E).
+
+These tests verify the typed models in
+``transformation_portal.api.v1.uploads`` accept the wire shapes produced by
+``StagedUploadResult.to_response_data()`` in
+``src/transformation_portal/ingest/upload_staging.py``. They complement the
+end-to-end route tests in ``tests/test_app_orchestrator_contract_http.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from transformation_portal.api.v1 import (
+    ApiEnvelope,
+    UploadArtifacts,
+    UploadStagingData,
+    UploadStagingEnvelope,
+    UploadSummary,
+)
+
+
+# Reference shape from StagedUploadResult.to_response_data()
+_SAMPLE_RESPONSE_DATA: dict = {
+    "batch_id": "upload_1700000000_abcd1234",
+    "input_dir": "/uploads/batches/upload_1700000000_abcd1234/input",
+    "metadata_dir": "/uploads/batches/upload_1700000000_abcd1234/portal",
+    "artifacts": {
+        "baseline_manifest_path": "/uploads/batches/upload_1700000000_abcd1234/portal/baseline_manifest.json",
+        "capture_metadata_path": "/uploads/batches/upload_1700000000_abcd1234/portal/capture_metadata.json",
+        "upload_receipt_path": "/uploads/batches/upload_1700000000_abcd1234/portal/upload_receipt.json",
+    },
+    "received_at_epoch_seconds": 1700000000.0,
+    "summary": {
+        "file_count": 3,
+        "total_bytes": 2097152,
+        "capture_metadata_enabled": False,
+        "capture_metadata_record_count": 0,
+        "top_level_roots": ["photo1.jpg", "photo2.jpg", "photo3.jpg"],
+        "warnings": [],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# UploadArtifacts
+# ---------------------------------------------------------------------------
+
+
+class TestUploadArtifacts:
+    def test_valid_shape_validates(self) -> None:
+        arts = UploadArtifacts(**_SAMPLE_RESPONSE_DATA["artifacts"])
+        assert arts.baseline_manifest_path.endswith("baseline_manifest.json")
+        assert arts.capture_metadata_path.endswith("capture_metadata.json")
+        assert arts.upload_receipt_path.endswith("upload_receipt.json")
+
+    def test_extra_keys_are_preserved(self) -> None:
+        arts = UploadArtifacts(
+            baseline_manifest_path="/a",
+            capture_metadata_path="/b",
+            upload_receipt_path="/c",
+            future_artifact="/d",
+        )
+        dumped = arts.model_dump(mode="json")
+        assert dumped["future_artifact"] == "/d"
+
+    def test_missing_required_field_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            UploadArtifacts(
+                baseline_manifest_path="/a",
+                capture_metadata_path="/b",
+                # upload_receipt_path omitted
+            )  # type: ignore[call-arg]
+
+
+# ---------------------------------------------------------------------------
+# UploadSummary
+# ---------------------------------------------------------------------------
+
+
+class TestUploadSummary:
+    def test_valid_shape_validates(self) -> None:
+        summary = UploadSummary(**_SAMPLE_RESPONSE_DATA["summary"])
+        assert summary.file_count == 3
+        assert summary.total_bytes == 2097152
+        assert summary.capture_metadata_enabled is False
+        assert summary.top_level_roots == ["photo1.jpg", "photo2.jpg", "photo3.jpg"]
+        assert summary.warnings == []
+
+    def test_with_warnings_validates(self) -> None:
+        summary = UploadSummary(
+            file_count=1,
+            total_bytes=512,
+            capture_metadata_enabled=True,
+            capture_metadata_record_count=1,
+            top_level_roots=["img.jpg"],
+            warnings=["duplicate_filename_detected"],
+        )
+        assert summary.warnings == ["duplicate_filename_detected"]
+
+    def test_extra_keys_are_preserved(self) -> None:
+        data = dict(_SAMPLE_RESPONSE_DATA["summary"], future_stat=99)
+        summary = UploadSummary(**data)
+        dumped = summary.model_dump(mode="json")
+        assert dumped["future_stat"] == 99
+
+
+# ---------------------------------------------------------------------------
+# UploadStagingData — full payload
+# ---------------------------------------------------------------------------
+
+
+class TestUploadStagingData:
+    def test_full_response_data_shape_validates(self) -> None:
+        data = UploadStagingData(**_SAMPLE_RESPONSE_DATA)
+        assert data.batch_id == "upload_1700000000_abcd1234"
+        assert data.received_at_epoch_seconds == 1700000000.0
+        assert isinstance(data.artifacts, UploadArtifacts)
+        assert isinstance(data.summary, UploadSummary)
+
+    def test_model_dump_round_trip(self) -> None:
+        data = UploadStagingData(**_SAMPLE_RESPONSE_DATA)
+        dumped = data.model_dump(mode="json")
+        assert dumped["batch_id"] == _SAMPLE_RESPONSE_DATA["batch_id"]
+        assert dumped["artifacts"]["baseline_manifest_path"] == (
+            _SAMPLE_RESPONSE_DATA["artifacts"]["baseline_manifest_path"]
+        )
+        assert dumped["summary"]["file_count"] == 3
+
+    def test_extra_top_level_keys_are_preserved(self) -> None:
+        extended = dict(_SAMPLE_RESPONSE_DATA, future_field="v2")
+        data = UploadStagingData(**extended)
+        dumped = data.model_dump(mode="json")
+        assert dumped["future_field"] == "v2"
+
+    def test_missing_batch_id_raises(self) -> None:
+        incomplete = {k: v for k, v in _SAMPLE_RESPONSE_DATA.items() if k != "batch_id"}
+        with pytest.raises(ValidationError):
+            UploadStagingData(**incomplete)
+
+
+# ---------------------------------------------------------------------------
+# UploadStagingEnvelope — full envelope round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestUploadStagingEnvelope:
+    def test_envelope_round_trip(self) -> None:
+        payload = UploadStagingEnvelope(
+            **{
+                "schema": "tp.orchestrator.upload_staging.v1",
+                "success": True,
+                "data": _SAMPLE_RESPONSE_DATA,
+                "error": None,
+            }
+        )
+        dumped = payload.model_dump(mode="json")
+        assert dumped["schema"] == "tp.orchestrator.upload_staging.v1"
+        assert dumped["success"] is True
+        assert dumped["data"]["batch_id"] == _SAMPLE_RESPONSE_DATA["batch_id"]
+        assert dumped["data"]["summary"]["file_count"] == 3
+
+    def test_envelope_alias_is_api_envelope(self) -> None:
+        assert UploadStagingEnvelope is ApiEnvelope[UploadStagingData]

--- a/tests/api/v1/test_upload_models.py
+++ b/tests/api/v1/test_upload_models.py
@@ -19,7 +19,6 @@ from transformation_portal.api.v1 import (
     UploadSummary,
 )
 
-
 # Reference shape from StagedUploadResult.to_response_data().
 # Filenames and paths mirror the constants in upload_staging.py:
 #   BASELINE_MANIFEST_FILENAME = "baseline_manifest.tp.meta.baseline_manifest.v1.json"
@@ -129,9 +128,7 @@ class TestUploadStagingData:
         data = UploadStagingData(**_SAMPLE_RESPONSE_DATA)
         dumped = data.model_dump(mode="json")
         assert dumped["batch_id"] == _SAMPLE_RESPONSE_DATA["batch_id"]
-        assert dumped["artifacts"]["baseline_manifest_path"] == (
-            _SAMPLE_RESPONSE_DATA["artifacts"]["baseline_manifest_path"]
-        )
+        assert dumped["artifacts"]["baseline_manifest_path"] == (_SAMPLE_RESPONSE_DATA["artifacts"]["baseline_manifest_path"])
         assert dumped["summary"]["file_count"] == 3
 
     def test_extra_top_level_keys_are_preserved(self) -> None:

--- a/tests/api/v1/test_upload_models.py
+++ b/tests/api/v1/test_upload_models.py
@@ -13,7 +13,6 @@ import pytest
 from pydantic import ValidationError
 
 from transformation_portal.api.v1 import (
-    ApiEnvelope,
     UploadArtifacts,
     UploadStagingData,
     UploadStagingEnvelope,
@@ -21,15 +20,22 @@ from transformation_portal.api.v1 import (
 )
 
 
-# Reference shape from StagedUploadResult.to_response_data()
+# Reference shape from StagedUploadResult.to_response_data().
+# Filenames and paths mirror the constants in upload_staging.py:
+#   BASELINE_MANIFEST_FILENAME = "baseline_manifest.tp.meta.baseline_manifest.v1.json"
+#   CAPTURE_METADATA_FILENAME  = "capture_metadata.tp.meta.capture.v1.json"
+#   UPLOAD_RECEIPT_FILENAME    = "upload_receipt.tp.orchestrator.upload_staging.v1.json"
+# portal_dir is built as batch_root / "_portal" (upload_staging.py:472).
+_BATCH = "upload_1700000000_abcd1234"
+_PORTAL = f"/uploads/batches/{_BATCH}/_portal"
 _SAMPLE_RESPONSE_DATA: dict = {
-    "batch_id": "upload_1700000000_abcd1234",
-    "input_dir": "/uploads/batches/upload_1700000000_abcd1234/input",
-    "metadata_dir": "/uploads/batches/upload_1700000000_abcd1234/portal",
+    "batch_id": _BATCH,
+    "input_dir": f"/uploads/batches/{_BATCH}/input",
+    "metadata_dir": _PORTAL,
     "artifacts": {
-        "baseline_manifest_path": "/uploads/batches/upload_1700000000_abcd1234/portal/baseline_manifest.json",
-        "capture_metadata_path": "/uploads/batches/upload_1700000000_abcd1234/portal/capture_metadata.json",
-        "upload_receipt_path": "/uploads/batches/upload_1700000000_abcd1234/portal/upload_receipt.json",
+        "baseline_manifest_path": f"{_PORTAL}/baseline_manifest.tp.meta.baseline_manifest.v1.json",
+        "capture_metadata_path": f"{_PORTAL}/capture_metadata.tp.meta.capture.v1.json",
+        "upload_receipt_path": f"{_PORTAL}/upload_receipt.tp.orchestrator.upload_staging.v1.json",
     },
     "received_at_epoch_seconds": 1700000000.0,
     "summary": {
@@ -51,9 +57,9 @@ _SAMPLE_RESPONSE_DATA: dict = {
 class TestUploadArtifacts:
     def test_valid_shape_validates(self) -> None:
         arts = UploadArtifacts(**_SAMPLE_RESPONSE_DATA["artifacts"])
-        assert arts.baseline_manifest_path.endswith("baseline_manifest.json")
-        assert arts.capture_metadata_path.endswith("capture_metadata.json")
-        assert arts.upload_receipt_path.endswith("upload_receipt.json")
+        assert arts.baseline_manifest_path.endswith("baseline_manifest.tp.meta.baseline_manifest.v1.json")
+        assert arts.capture_metadata_path.endswith("capture_metadata.tp.meta.capture.v1.json")
+        assert arts.upload_receipt_path.endswith("upload_receipt.tp.orchestrator.upload_staging.v1.json")
 
     def test_extra_keys_are_preserved(self) -> None:
         arts = UploadArtifacts(
@@ -161,5 +167,25 @@ class TestUploadStagingEnvelope:
         assert dumped["data"]["batch_id"] == _SAMPLE_RESPONSE_DATA["batch_id"]
         assert dumped["data"]["summary"]["file_count"] == 3
 
-    def test_envelope_alias_is_api_envelope(self) -> None:
-        assert UploadStagingEnvelope is ApiEnvelope[UploadStagingData]
+    def test_envelope_validates_upload_staging_data_shape(self) -> None:
+        payload = UploadStagingEnvelope(
+            **{
+                "schema": "tp.orchestrator.upload_staging.v1",
+                "success": True,
+                "data": _SAMPLE_RESPONSE_DATA,
+                "error": None,
+            }
+        )
+        assert isinstance(payload.data, UploadStagingData)
+        assert payload.data.batch_id == _SAMPLE_RESPONSE_DATA["batch_id"]
+
+        invalid_data = {k: v for k, v in _SAMPLE_RESPONSE_DATA.items() if k != "batch_id"}
+        with pytest.raises(ValidationError):
+            UploadStagingEnvelope(
+                **{
+                    "schema": "tp.orchestrator.upload_staging.v1",
+                    "success": True,
+                    "data": invalid_data,
+                    "error": None,
+                }
+            )


### PR DESCRIPTION
Completes Phase 1.2 API modernisation by adding response_model= annotations
to the three remaining untyped orchestrator routes:

- POST /v1/portal/events  → ApiEnvelope[PortalEventData]
- POST /v1/portal/rum     → ApiEnvelope[PortalRumIngestData]
- POST /v1/uploads/staging → ApiEnvelope[UploadStagingData]

All three handlers continue to return JSONResponse(_api_envelope(...))
directly; response_model is OpenAPI-only — no wire behaviour changes.

New modules:
- api/v1/telemetry.py  — PortalEventData, PortalRumIngestData + envelope aliases
- api/v1/uploads.py    — UploadArtifacts, UploadSummary, UploadStagingData + alias

New tests (25 passing):
- tests/api/v1/test_telemetry_models.py
- tests/api/v1/test_upload_models.py

Full v1 suite: 138 passed.

https://claude.ai/code/session_012CDvEHyyYN7pMRd553QgpV