### PR TITLE
chore(deps): roll up python dependency bumps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     # Exact versions are enforced in requirements/base.in and compiled lockfiles.
     "fastapi>=0.121.0,<0.137",
     "starlette>=0.49.1,<1.1",  # direct runtime import + curated Starlette 1.x validation window
-    "uvicorn>=0.29.0,<0.46",
+    "uvicorn>=0.29.0,<0.47",
     "aiofiles>=23.2.1,<26",
     "tifffile>=2023.7.18,<2027",
     "imagecodecs>=2023.9.18,<2027",
@@ -109,7 +109,7 @@ spatial-ai = [
 ]
 # Optional detached signing support for archive attestation CLIs
 archive-signing = [
-    "cryptography>=46.0,<47",
+    "cryptography>=46.0,<48",
 ]
 # Development tools - see requirements/dev.in for pinned versions
 dev = [
@@ -118,7 +118,7 @@ dev = [
     "httpx>=0.28,<1",  # required for FastAPI/Starlette TestClient in HTTP contract tests
     "hypothesis>=6.0,<7",
     "jsonschema>=4.21.0,<5",  # required for machine-mode contract schema validation tests
-    "cryptography>=46.0,<47",  # required for Phase 3.1 signing CLI tests
+    "cryptography>=46.0,<48",  # required for Phase 3.1 signing CLI tests
     "mypy>=1.10",
     "flake8>=7.0",
     "pylint>=3.0",

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -31,4 +31,4 @@ opencv-python-headless>=4.8.0,<5 ; platform_system == "Linux"
 opencv-python>=4.8.0,<5 ; platform_system != "Linux"
 
 # Required for detached Merkle signing/verification CLI tests
-cryptography>=46.0,<47
+cryptography>=46.0,<48

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,7 +14,7 @@ jsonschema>=4.21.0,<5
 httpx>=0.28,<1
 
 # Optional Phase 3.1 detached signing support (tools + tests)
-cryptography>=46.0,<47
+cryptography>=46.0,<48
 
 # Linters, formatters, type checkers
 mypy>=1.10

--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -30,7 +30,7 @@ bandit==1.9.4
     # via -r ci.in
 black==26.3.1
     # via -r dev.in
-build==1.4.3
+build==1.4.4
     # via -r ci.in
 cachetools==7.0.5
     # via tox
@@ -54,7 +54,7 @@ colorama==0.4.6
     # via tox
 coverage[toml]==7.13.5
     # via pytest-cov
-cryptography==46.0.7
+cryptography==47.0.0
     # via
     #   -r dev.in
     #   secretstorage
@@ -68,7 +68,7 @@ docutils==0.22.4
     # via readme-renderer
 execnet==2.1.2
     # via pytest-xdist
-fastapi==0.136.0
+fastapi==0.136.1
     # via -r base.in
 filelock==3.25.2
     # via
@@ -144,7 +144,7 @@ more-itertools==11.0.2
     # via
     #   jaraco-classes
     #   jaraco-functools
-mypy==1.20.1
+mypy==1.20.2
     # via -r dev.in
 mypy-extensions==1.1.0
     # via
@@ -331,7 +331,7 @@ urllib3==2.6.3
     #   id
     #   requests
     #   twine
-uvicorn==0.45.0
+uvicorn==0.46.0
     # via -r base.in
 virtualenv==21.2.1
     # via tox

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -16,9 +16,9 @@ tqdm>=4.66,<5              # progress bar utility
 
 # Web orchestration service stack (exact pins for API/UI parity)
 # Security: keep FastAPI + Starlette on patched baseline for CVE-2025-62727.
-fastapi==0.136.0           # orchestrator API framework (validated against curated Starlette 1.x upgrade)
+fastapi==0.136.1           # orchestrator API framework (validated against curated Starlette 1.x upgrade)
 starlette==1.0.0           # direct runtime import + curated Starlette 1.x validation target
-uvicorn==0.45.0            # ASGI server runtime pin
+uvicorn==0.46.0            # ASGI server runtime pin
 aiofiles==25.1.0           # async file I/O support for FastAPI file responses
 
 # Schema validation (required for ingest contract)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -31,7 +31,7 @@ click==8.3.2
     #   -c all.txt
     #   typer
     #   uvicorn
-fastapi==0.136.0
+fastapi==0.136.1
     # via
     #   -c all.txt
     #   -r base.in
@@ -165,7 +165,7 @@ typing-inspection==0.4.2
     #   -c all.txt
     #   fastapi
     #   pydantic
-uvicorn==0.45.0
+uvicorn==0.46.0
     # via
     #   -c all.txt
     #   -r base.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -12,7 +12,7 @@ bandit==1.9.4
     # via
     #   -c all.txt
     #   -r ci.in
-build==1.4.3
+build==1.4.4
     # via
     #   -c all.txt
     #   -r ci.in
@@ -36,7 +36,7 @@ colorama==0.4.6
     # via
     #   -c all.txt
     #   tox
-cryptography==46.0.7
+cryptography==47.0.0
     # via
     #   -c all.txt
     #   secretstorage

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -14,7 +14,7 @@ diff-cover>=9.0,<10  # diff coverage for PR validation (Phase 0 coverage infrast
 httpx>=0.28,<1  # required for FastAPI/Starlette TestClient in HTTP contract tests
 hypothesis>=6.0,<7
 jsonschema>=4.21.0,<5  # required for machine-mode contract schema validation tests
-cryptography==46.0.7  # CAS determinism + Security: CVE-2024-0727 / GHSA-9v9h-cgj8-h64p fixed
+cryptography==47.0.0  # CAS determinism + Security: CVE-2024-0727 / GHSA-9v9h-cgj8-h64p fixed
 
 # Type checking and linting
 mypy>=1.10

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -46,7 +46,7 @@ coverage[toml]==7.13.5
     # via
     #   -c all.txt
     #   pytest-cov
-cryptography==46.0.7
+cryptography==47.0.0
     # via
     #   -c all.txt
     #   -r dev.in
@@ -125,7 +125,7 @@ mccabe==0.7.0
     #   -c all.txt
     #   flake8
     #   pylint
-mypy==1.20.1
+mypy==1.20.2
     # via
     #   -c all.txt
     #   -r dev.in

--- a/requirements/tools-archive.in
+++ b/requirements/tools-archive.in
@@ -5,6 +5,6 @@
 numpy>=2.2,<2.5
 pandas>=2.2,<3.1
 jsonschema>=4.23,<5
-cryptography>=46.0,<47
+cryptography>=46.0,<48
 bagit>=1.8,<2
 pyyaml>=6.0,<7

--- a/requirements/tools-archive.txt
+++ b/requirements/tools-archive.txt
@@ -15,7 +15,7 @@ cffi==2.0.0
     # via
     #   -c all.txt
     #   cryptography
-cryptography==46.0.7
+cryptography==47.0.0
     # via
     #   -c all.txt
     #   -r tools-archive.in


### PR DESCRIPTION
## Summary
- Integrates Dependabot Python bumps for FastAPI, Uvicorn, cryptography, mypy, and build in one curated lockfile update.
- Regenerates the generic requirements layers while preserving platform-marked OpenCV and Linux keyring-chain lock contract pins.
- Supersedes Dependabot PRs #1575, #1576, #1577, #1578, and #1579 after this rollup merges.

## Changes
- Bumps FastAPI to 0.136.1 and Uvicorn to 0.46.0 in runtime inputs and locks; widens the Uvicorn package range to <0.47.
- Bumps cryptography to 47.0.0 and widens signing, dev, and archive ranges to <48.
- Bumps mypy to 1.20.2 and build to 1.4.4 in the generated generic locks.
- Leaves product API, route, selector, and schema contracts unchanged.

## Validation
Proven green:
- python3 scripts/validation/check_requirements_lock_contract.py
- make check-requirements-lock-contract
- make check
- make check-ci-sync
- make test-fast
- make test-orchestrator-contract
- .venv/bin/pytest tests/security/test_task_signing.py tests/security/test_signing_tls_helpers.py tests/attestation/

Still failing:
- None locally.

Environment/tooling:
- Downgraded local .venv pip from 26.1 to 25.3 because pip-tools 7.5.2 is not compatible with the pip 26 PackageFinder API.
- pip-tools emitted --strip-extras future warnings during lock checks.

## Risk
- Runtime risk is bounded to dependency updates already proposed by Dependabot; Uvicorn is a minor update and cryptography is a major update covered by orchestrator plus signing and attestation tests.
- Revert-safe as a dependency-only lock/input change with no product contract changes.