### PR TITLE
fix(deps): require secure pytorch baseline

### DIFF
--- a/docs/guides/COMPREHENSIVE_ISSUE_ANALYSIS.md
+++ b/docs/guides/COMPREHENSIVE_ISSUE_ANALYSIS.md
@@ -638,7 +638,7 @@ dependencies = [...]  # All dependencies listed as required
 ```toml
 [project.optional-dependencies]
 ml = [
-    "torch>=2.0,<3",
+    "torch>=2.8.0,<3",
     "diffusers>=0.20,<1",
     "transformers>=4.35.0,<5",
 ]

--- a/docs/guides/PLUGIN_DEVELOPMENT.md
+++ b/docs/guides/PLUGIN_DEVELOPMENT.md
@@ -365,8 +365,8 @@ my_plugin/
   "license": "MIT",
   "homepage": "https://github.com/yourusername/my_plugin",
   "dependencies": [
-    "torch>=2.0",
-    "torchvision>=0.15"
+    "torch>=2.8.0",
+    "torchvision>=0.23.0"
   ],
   "min_portal_version": "0.1.0"
 }

--- a/docs/status/REPOSITORY_STATUS_REPORT.md
+++ b/docs/status/REPOSITORY_STATUS_REPORT.md
@@ -206,7 +206,7 @@ RAG system: 10.00/10 (perfect)
 - Pillow>=10,<12
 - scipy>=1.10,<2
 - scikit-learn>=1.4.0,<2
-- torch>=2.0,<3 (CPU/GPU/MPS)
+- torch>=2.8.0,<3 (supported ML security baseline)
 
 ### **ML/AI Stack**
 - diffusers>=0.20,<1 (Stable Diffusion)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,8 +64,8 @@ classifiers = [
 
 # ML Core - Cross-platform ML baseline (minimal spec, see ml-core.in for pins)
 ml-core = [
-    "torch>=2.0",
-    "torchvision>=0.15",
+    "torch>=2.8.0",
+    "torchvision>=0.23.0",
     "diffusers>=0.30",
     "transformers>=4.40",
     "huggingface-hub>=0.19",
@@ -86,8 +86,8 @@ raw = [
 #   CoreML: ./scripts/bootstrap/install_ml_stack.sh --profile core-cpu,coreml (macOS only)
 #   Full:   ./scripts/bootstrap/install_ml_stack.sh --profile full (same as ml.txt)
 ml = [
-    "torch>=2.0",
-    "torchvision>=0.15",
+    "torch>=2.8.0",
+    "torchvision>=0.23.0",
     "diffusers>=0.30",
     "transformers>=4.40",
     "rawpy>=0.18.0",

--- a/requirements/README.md
+++ b/requirements/README.md
@@ -321,7 +321,10 @@ make install-ml-coreml
 make install-ml
 ```
 
-Or use the package extras (installs latest allowed versions, not pinned):
+Or use the package extras (installs latest allowed versions, not pinned).
+The ML extras require the supported PyTorch security baseline
+(`torch>=2.8.0`, `torchvision>=0.23.0`); frozen historical ML locks are
+not remediation targets for Dependabot alerts.
 
 ```bash
 # Install ML core support only

--- a/requirements/ml-core-darwin-x86_64.in
+++ b/requirements/ml-core-darwin-x86_64.in
@@ -18,14 +18,15 @@
 #
 # SECURITY NOTE (CVE-2025-32434):
 #   torch < 2.6.0 has a critical RCE vulnerability via torch.load()
-#   MITIGATION: All torch.load() calls use weights_only=True at runtime
-#   This preserves CAS determinism while mitigating the vulnerability.
+#   This frozen lane is not a supported remediation target. weights_only=True
+#   remains mandatory defense in depth, but it is not considered a complete
+#   fix for this historical torch baseline.
 #
 # See: requirements/README.md for layering rationale.
 
 # --- PyTorch (macOS, deterministic) ---
 # CAS DETERMINISM: Pinned versions for reproducible environment fingerprints
-# SECURITY: CVE-2025-32434 mitigated via weights_only=True at runtime
+# SECURITY: frozen unsupported lane; do not treat runtime hardening as a fix
 torch==2.2.2  # CAS determinism: cross-platform reproducibility
 torchvision==0.17.2  # CAS determinism: matches torch 2.2.2
 

--- a/scripts/bootstrap/install_ml_stack.sh
+++ b/scripts/bootstrap/install_ml_stack.sh
@@ -285,19 +285,19 @@ install_profile() {
     local platform_id
 
     # SECURITY BLOCK: macOS Intel (x86_64) is NOT SUPPORTED for ML workloads
-    # CVE-2025-32434 cannot be fully mitigated on this platform due to
-    # lack of secure PyTorch wheels. This is a HARD FAIL, not a warning.
+    # CVE-2025-32434 cannot be remediated on this platform due to lack of
+    # supported secure PyTorch wheels. This is a HARD FAIL, not a warning.
     if [[ "$(python_platform_os)" == "Darwin" ]] && [[ "$(python_platform_arch)" == "x86_64" ]]; then
         log_error "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
         log_error "SECURITY BLOCK: macOS Intel (x86_64) ML Stack NOT SUPPORTED"
         log_error "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
         log_error ""
-        log_error "PyTorch does not provide torch>=2.6.0 wheels for macOS Intel."
+        log_error "PyTorch does not provide the repo-supported torch>=2.8.0 baseline for macOS Intel."
         log_error "The frozen macOS Intel lane remains on torch==2.2.2, which is"
         log_error "vulnerable to CVE-2025-32434 (CVSS 9.8 Critical RCE via torch.load)."
         log_error ""
-        log_error "While runtime mitigation (weights_only=True) exists, macOS Intel"
-        log_error "cannot receive a secure PyTorch version upgrade path."
+        log_error "While runtime hardening (weights_only=True) remains mandatory,"
+        log_error "macOS Intel cannot receive a supported PyTorch version upgrade path."
         log_error ""
         log_error "REQUIRED ACTION:"
         log_error "  Migrate to macOS Apple Silicon (arm64) or Linux."

--- a/scripts/validation/check_unsafe_torch_load.py
+++ b/scripts/validation/check_unsafe_torch_load.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 """CI validation script to detect unsafe torch.load() usage.
 
-This script scans the codebase for raw torch.load() calls that don't use
-weights_only=True, which would bypass CVE-2025-32434 mitigation.
+This script scans the codebase for raw torch.load() calls that do not use
+weights_only=True, which would bypass mandatory checkpoint-loading hardening.
 
 SECURITY CONTEXT:
     CVE-2025-32434 is a critical RCE vulnerability (CVSS 9.8) in torch.load().
-    Instead of upgrading torch (which would break CAS determinism), we mitigate
-    at runtime by enforcing weights_only=True on all torch.load() calls.
+    Supported repository lanes require a patched PyTorch baseline. Runtime
+    enforcement of weights_only=True remains mandatory defense in depth.
 
     This CI gate ensures no raw torch.load() usage slips through code review.
 
@@ -31,11 +31,13 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterator, List, Sequence
 
-
 # Directories to skip
 SKIP_DIRS = {
     ".git",
     ".venv",
+    ".venv-da3",
+    ".venv-depth-pro",
+    ".runtime",
     "venv",
     "__pycache__",
     ".pytest_cache",
@@ -52,30 +54,26 @@ ALLOWED_FILES = {
     "src/transformation_portal/core/security/torch_security.py",
     # Test files for security module
     "tests/test_torch_security.py",
+    "tests/security/test_platform_security_profile.py",
     # This validation script discusses torch.load in documentation
     "scripts/validation/check_unsafe_torch_load.py",
 }
 
 # Pattern to detect torch.load() calls
 # This matches: torch.load(...) where ... doesn't contain weights_only=True
-TORCH_LOAD_PATTERN = re.compile(
-    r'\btorch\.load\s*\('
-)
+TORCH_LOAD_PATTERN = re.compile(r"\btorch\.load\s*\(")
 
 # Pattern to detect safe usage with weights_only=True
-SAFE_USAGE_PATTERN = re.compile(
-    r'\btorch\.load\s*\([^)]*weights_only\s*=\s*True'
-)
+SAFE_USAGE_PATTERN = re.compile(r"\btorch\.load\s*\([^)]*weights_only\s*=\s*True")
 
 # Pattern to detect our safe_load() wrapper
-SAFE_LOAD_PATTERN = re.compile(
-    r'\bsafe_load\s*\('
-)
+SAFE_LOAD_PATTERN = re.compile(r"\bsafe_load\s*\(")
 
 
 @dataclass
 class Violation:
     """Represents an unsafe torch.load() usage."""
+
     file: Path
     line_number: int
     line_content: str
@@ -113,7 +111,7 @@ def is_in_string(line: str, pattern: re.Pattern) -> bool:
     if not match:
         return False
 
-    before_match = line[:match.start()]
+    before_match = line[: match.start()]
 
     # Track quote context more carefully
     # We look for unmatched quotes by scanning character by character
@@ -123,7 +121,7 @@ def is_in_string(line: str, pattern: re.Pattern) -> bool:
     while i < len(before_match):
         char = before_match[i]
         # Handle escape sequences
-        if i + 1 < len(before_match) and before_match[i] == '\\':
+        if i + 1 < len(before_match) and before_match[i] == "\\":
             i += 2  # Skip escaped character
             continue
         # Track quote state
@@ -233,7 +231,8 @@ def main(args: Sequence[str] | None = None) -> int:
         description="Check for unsafe torch.load() usage in codebase",
     )
     parser.add_argument(
-        "--verbose", "-v",
+        "--verbose",
+        "-v",
         action="store_true",
         help="Show verbose output including scanned files",
     )
@@ -295,7 +294,7 @@ def main(args: Sequence[str] | None = None) -> int:
     # Report results
     print()
     print("=" * 72)
-    print("TORCH.LOAD() SECURITY CHECK (CVE-2025-32434)")
+    print("TORCH.LOAD() CHECKPOINT HARDENING CHECK")
     print("=" * 72)
     print()
     print(f"Files scanned: {files_scanned}")
@@ -320,7 +319,7 @@ def main(args: Sequence[str] | None = None) -> int:
 
         print("-" * 72)
         print()
-        print("⛔ CI GATE FAILED: Unsafe torch.load() usage violates security policy")
+        print("CI GATE FAILED: Unsafe torch.load() usage violates security policy")
         print()
         print("Resolution:")
         print("  1. Import: from transformation_portal.core.security.torch_security import safe_load")
@@ -329,7 +328,7 @@ def main(args: Sequence[str] | None = None) -> int:
         print()
         print("Documentation:")
         print("  - See: src/transformation_portal/core/security/torch_security.py")
-        print("  - See: SECURITY.md for CVE-2025-32434 mitigation policy")
+        print("  - See: SECURITY.md for checkpoint-loading hardening policy")
         print()
 
         if parsed.ci_mode:

--- a/src/transformation_portal/core/platform_matrix.py
+++ b/src/transformation_portal/core/platform_matrix.py
@@ -199,10 +199,11 @@ class PlatformMatrix:
         Security Context:
             The supported Apple Silicon lane now pins torch==2.8.0.
             Linux and macOS Intel remain frozen unsupported historical ML lanes.
-            All platforms must use weights_only=True for torch.load() calls.
+            All platforms must use weights_only=True for torch.load() calls as
+            defense in depth.
         """
         base_mitigation = (
-            "All torch.load() calls must use weights_only=True. "
+            "All torch.load() calls must use weights_only=True as defense in depth. "
             "Use transformation_portal.core.security.torch_security.safe_load() "
             "or explicitly pass weights_only=True."
         )
@@ -214,10 +215,11 @@ class PlatformMatrix:
                 "platform": self.canonical_target,
                 "cve_2025_32434_note": (
                     "macOS Intel (x86_64) remains on the frozen torch==2.2.2 lane, "
-                    "which is vulnerable to CVE-2025-32434 and no longer supported for ML workloads."
+                    "which is vulnerable to CVE-2025-32434 and no longer supported for ML workloads. "
+                    "weights_only=True is not considered a complete remediation for this lane."
                 ),
                 "mitigation": base_mitigation,
-                "secure": False,  # macOS Intel has no torch>=2.6.0 wheels (dropped platform support)
+                "secure": False,  # macOS Intel has no supported torch>=2.8.0 baseline.
                 "ml_supported": allow_bypass,  # Only if explicitly bypassed
             }
         if self.is_apple_silicon:
@@ -265,7 +267,7 @@ class PlatformMatrix:
         """Emit warning if ML stack has known security considerations.
 
         Call this when initializing ML workloads to alert users about
-        security mitigations required for CVE-2025-32434.
+        security hardening required for checkpoint loading.
 
         Note: This is a warning, not a hard fail. Use assert_ml_supported()
         for enforcement.
@@ -567,7 +569,7 @@ def compute_cas_identity(
 # CAS Identity Schema Version (ADR-032)
 # Increment this when CAS identity computation changes to invalidate old artifacts
 # v1: Initial schema (platform_id, env_fingerprint, lockfile_hash)
-# v2: Added security_profile for CVE-2025-32434 mitigation tracking
+# v2: Added security_profile for checkpoint-loading security tracking
 CAS_IDENTITY_SCHEMA_VERSION = "adr-032-v2"
 
 

--- a/src/transformation_portal/core/security/torch_security.py
+++ b/src/transformation_portal/core/security/torch_security.py
@@ -1,16 +1,16 @@
 """PyTorch security utilities for checkpoint loading hardening.
 
-This module provides safe model loading functions that mitigate torch.load()
-checkpoint risks, including CVE-2025-32434 on legacy torch baselines.
+This module provides safe model loading functions that reduce checkpoint
+loading risk and preserve a single repository-wide torch.load() policy.
 
 MITIGATION STRATEGY:
-    Supported repository lanes now use torch >= 2.8.0, but runtime hardening
-    still enforces weights_only=True for all torch.load() calls. That keeps
-    the frozen Darwin x86_64 lane constrained, and it preserves a consistent
-    defense-in-depth posture across managed and subprocess runtimes.
+    Supported repository lanes require torch >= 2.8.0. Runtime hardening still
+    enforces weights_only=True for all torch.load() calls as defense in depth.
+    Frozen historical lanes are not considered remediated by runtime hardening.
 
     Benefits:
-    - Mitigates checkpoint RCE by disabling arbitrary code execution
+    - Keeps supported lanes on a patched PyTorch baseline
+    - Reduces checkpoint deserialization risk during model loading
     - Keeps managed/model-loading trust boundaries explicit
     - Maintains a single repository-wide torch.load() policy
 
@@ -19,7 +19,7 @@ CVE-2025-32434 Details:
     - CVSS Score: 9.8 (Critical)
     - Affected versions: torch < 2.6.0
     - Attack vector: Malicious .pt/.pth model files
-    - Mitigation: Use weights_only=True parameter
+    - Remediation: upgrade torch to a patched supported baseline
 
 ENFORCEMENT:
     This module provides MANDATORY global enforcement of safe_load() via:
@@ -51,7 +51,9 @@ from typing import Any, Optional, Union
 
 # Security profile version for CAS identity
 # Increment when security enforcement logic changes
-SECURITY_PROFILE_VERSION = "torch_safe_load_v1"
+SECURITY_PROFILE_VERSION = "torch_safe_load_v2"
+MINIMUM_SUPPORTED_TORCH_VERSION = "2.8.0"
+CVE_2025_32434_FIXED_TORCH_VERSION = "2.6.0"
 
 # Track whether enforcement has been installed
 _enforcement_installed = False
@@ -63,10 +65,11 @@ def safe_load(
     *,
     map_location: Optional[Any] = None,
 ) -> Any:
-    """Safely load PyTorch model weights with CVE-2025-32434 mitigation.
+    """Safely load PyTorch model weights with checkpoint hardening.
 
-    This function wraps torch.load() with weights_only=True to prevent
-    arbitrary code execution from malicious model files.
+    This function wraps torch.load() with weights_only=True to reduce
+    deserialization risk from model files. Supported deployments must still
+    use a patched torch baseline.
 
     Args:
         path: Path to the model file (.pt, .pth, etc.)
@@ -85,9 +88,9 @@ def safe_load(
         >>> model.load_state_dict(state_dict)
 
     Security:
-        This function enforces weights_only=True which disables arbitrary
-        code execution during model loading. Files containing custom classes
-        or functions will fail to load. This is intentional for security.
+        This function enforces weights_only=True for defense in depth. Files
+        containing custom classes or functions will fail to load. This is
+        intentional for security.
 
         If you need to load a file with custom objects, you must:
         1. Verify the source is trusted
@@ -113,13 +116,15 @@ def check_torch_security_compliance() -> dict[str, Any]:
         Dictionary with security compliance status:
         - torch_version: Installed torch version
         - cve_2025_32434_vulnerable: True if vulnerable to CVE-2025-32434
+        - minimum_supported_torch_version: Repository supported baseline
+        - supported_security_baseline_met: True if torch >= supported baseline
         - mitigation_available: True if weights_only mitigation is available
         - recommendation: Security recommendation string
 
     Example:
         >>> status = check_torch_security_compliance()
-        >>> if status["cve_2025_32434_vulnerable"]:
-        ...     print("Use safe_load() for all model loading")
+        >>> if not status["supported_security_baseline_met"]:
+        ...     print("Upgrade PyTorch to the supported baseline")
     """
     try:
         import torch
@@ -128,6 +133,8 @@ def check_torch_security_compliance() -> dict[str, Any]:
         return {
             "torch_version": None,
             "cve_2025_32434_vulnerable": None,
+            "minimum_supported_torch_version": MINIMUM_SUPPORTED_TORCH_VERSION,
+            "supported_security_baseline_met": False,
             "mitigation_available": False,
             "recommendation": "PyTorch not installed",
         }
@@ -136,35 +143,41 @@ def check_torch_security_compliance() -> dict[str, Any]:
 
     try:
         version = Version(torch_version)
-        vulnerable = version < Version("2.6.0")
+        vulnerable = version < Version(CVE_2025_32434_FIXED_TORCH_VERSION)
+        supported_baseline_met = version >= Version(MINIMUM_SUPPORTED_TORCH_VERSION)
     except Exception:
         # Non-standard version string
         vulnerable = True
+        supported_baseline_met = False
 
     return {
         "torch_version": torch_version,
         "cve_2025_32434_vulnerable": vulnerable,
+        "minimum_supported_torch_version": MINIMUM_SUPPORTED_TORCH_VERSION,
+        "supported_security_baseline_met": supported_baseline_met,
         "mitigation_available": True,
         "recommendation": (
-            "Use safe_load() or weights_only=True for all torch.load() calls"
-            if vulnerable
-            else "Torch version includes CVE-2025-32434 fix"
+            f"Upgrade PyTorch to >={MINIMUM_SUPPORTED_TORCH_VERSION}; "
+            "weights_only=True or safe_load() remain mandatory defense in depth"
+            if not supported_baseline_met
+            else "Torch version meets the supported security baseline; keep weights_only=True or safe_load() for defense in depth"
         ),
     }
 
 
 def warn_if_vulnerable() -> None:
-    """Emit a warning if torch is vulnerable to CVE-2025-32434.
+    """Emit a warning if torch is below the supported security baseline.
 
     This can be called at module import time to alert users of vulnerable
-    torch installations and the need for mitigation.
+    or unsupported torch installations.
     """
     status = check_torch_security_compliance()
-    if status.get("cve_2025_32434_vulnerable"):
+    if not status.get("supported_security_baseline_met", False) and status.get("torch_version") is not None:
         warnings.warn(
-            f"PyTorch {status['torch_version']} is vulnerable to CVE-2025-32434. "
-            "Always use weights_only=True with torch.load() or use "
-            "transformation_portal.core.security.torch_security.safe_load().",
+            f"PyTorch {status['torch_version']} does not meet the supported "
+            f"security baseline >= {MINIMUM_SUPPORTED_TORCH_VERSION}. "
+            "Upgrade torch; weights_only=True and safe_load() remain mandatory "
+            "checkpoint-loading hardening.",
             UserWarning,
             stacklevel=2,
         )
@@ -182,7 +195,7 @@ def _enforced_torch_load(
 
     This function is installed as a replacement for torch.load when
     global enforcement is active. It ensures all model loading uses
-    weights_only=True to mitigate CVE-2025-32434.
+    weights_only=True for checkpoint-loading defense in depth.
 
     Args:
         f: File path or file-like object
@@ -213,7 +226,8 @@ def _enforced_torch_load(
     if not weights_only:
         raise SecurityError(
             "CVE-2025-32434: weights_only=False is blocked for security. "
-            "Use weights_only=True or safe_load() to load model files. "
+            "Use a supported torch baseline plus weights_only=True or safe_load() "
+            "to load model files. "
             "If you must load untrusted custom objects, document the trust "
             "boundary and use _unsafe_torch_load_bypass() with security review."
         )
@@ -231,7 +245,7 @@ class SecurityError(RuntimeError):
     """Raised when a security policy is violated.
 
     This exception indicates that code attempted to bypass security
-    mitigations, such as using torch.load() without weights_only=True.
+    hardening, such as using torch.load() without weights_only=True.
     """
 
     pass
@@ -245,8 +259,8 @@ def install_global_enforcement() -> bool:
     """Install global enforcement of safe torch.load behavior.
 
     This function patches torch.load to enforce weights_only=True on ALL calls,
-    not just direct safe_load() usage. This ensures CVE-2025-32434 mitigation
-    is applied system-wide.
+    not just direct safe_load() usage. Supported deployments must also run on
+    a patched torch baseline.
 
     MUST be called at ML stack initialization before any model loading.
 
@@ -330,7 +344,7 @@ def uninstall_global_enforcement() -> bool:
         False if enforcement was not installed
 
     Security:
-        Calling this function removes CVE-2025-32434 protection.
+        Calling this function removes checkpoint-loading hardening.
         Only use for testing or in controlled environments.
     """
     global _enforcement_installed, _original_torch_load
@@ -360,7 +374,7 @@ def _unsafe_torch_load_bypass(
 ) -> Any:
     """Bypass security enforcement for trusted model files.
 
-    ⚠️ DANGER: This function bypasses CVE-2025-32434 protections.
+    DANGER: This function bypasses checkpoint-loading hardening.
 
     Only use this for:
     - Loading models with custom classes that CANNOT use weights_only=True
@@ -430,7 +444,8 @@ def get_security_profile_hash() -> str:
     # Runtime state (_enforcement_installed) would break determinism
     profile_data = {
         "policy_version": SECURITY_PROFILE_VERSION,
-        "cve_2025_32434_mitigation": "weights_only_enforced",
+        "minimum_supported_torch_version": MINIMUM_SUPPORTED_TORCH_VERSION,
+        "cve_2025_32434_posture": "fixed_by_supported_torch_baseline",
         "torch_load_policy": "weights_only_true",
     }
     # Use canonical JSON for deterministic hash (repo guardrail requires this)
@@ -461,7 +476,7 @@ def assert_enforcement_installed() -> None:
             "Torch security enforcement not installed. "
             "Call install_global_enforcement() at ML stack initialization "
             "BEFORE importing any modules that use torch.load(). "
-            "This is required for CVE-2025-32434 mitigation."
+            "This is required for checkpoint-loading hardening."
         )
 
 
@@ -481,7 +496,8 @@ def get_canonical_security_profile() -> dict[str, Any]:
     Example:
         >>> get_canonical_security_profile()
         {
-            'policy_version': 'torch_safe_load_v1',
+            'policy_version': 'torch_safe_load_v2',
+            'minimum_supported_torch_version': '2.8.0',
             'torch_load_enforced': True,
             'weights_only': True,
             'cve_mitigation': 'cve-2025-32434-v1'
@@ -489,7 +505,8 @@ def get_canonical_security_profile() -> dict[str, Any]:
     """
     return {
         "policy_version": SECURITY_PROFILE_VERSION,
+        "minimum_supported_torch_version": MINIMUM_SUPPORTED_TORCH_VERSION,
         "torch_load_enforced": True,  # Policy requirement, not runtime state
         "weights_only": True,  # Policy requirement
-        "cve_mitigation": "cve-2025-32434-v1",
+        "cve_mitigation": "fixed-by-supported-torch-baseline",
     }

--- a/tests/security/test_platform_security_profile.py
+++ b/tests/security/test_platform_security_profile.py
@@ -99,6 +99,7 @@ class TestTorchSecurityEnforcement:
     def test_security_profile_hash_uses_canonical_json(self):
         """Test hash uses canonical JSON serialization."""
         from transformation_portal.core.security.torch_security import (
+            MINIMUM_SUPPORTED_TORCH_VERSION,
             SECURITY_PROFILE_VERSION,
             get_security_profile_hash,
         )
@@ -107,7 +108,8 @@ class TestTorchSecurityEnforcement:
         # Manually compute expected hash
         profile_data = {
             "policy_version": SECURITY_PROFILE_VERSION,
-            "cve_2025_32434_mitigation": "weights_only_enforced",
+            "minimum_supported_torch_version": MINIMUM_SUPPORTED_TORCH_VERSION,
+            "cve_2025_32434_posture": "fixed_by_supported_torch_baseline",
             "torch_load_policy": "weights_only_true",
         }
         expected_bytes = canonicalize_json(profile_data)
@@ -134,11 +136,30 @@ class TestTorchSecurityEnforcement:
         # Should return static policy values (matches actual implementation)
         assert "policy_version" in profile
         assert "cve_mitigation" in profile
+        assert "minimum_supported_torch_version" in profile
         assert "torch_load_enforced" in profile
         assert "weights_only" in profile
+        assert profile["minimum_supported_torch_version"] == "2.8.0"
+        assert profile["cve_mitigation"] == "fixed-by-supported-torch-baseline"
 
         # Should NOT include runtime state
         assert "enforcement_installed" not in profile
+
+    def test_torch_security_compliance_reports_supported_baseline(self):
+        """Test compliance status preserves legacy keys and reports supported baseline."""
+        from transformation_portal.core.security.torch_security import (
+            MINIMUM_SUPPORTED_TORCH_VERSION,
+            check_torch_security_compliance,
+        )
+
+        status = check_torch_security_compliance()
+
+        assert "torch_version" in status
+        assert "cve_2025_32434_vulnerable" in status
+        assert "mitigation_available" in status
+        assert "recommendation" in status
+        assert status["minimum_supported_torch_version"] == MINIMUM_SUPPORTED_TORCH_VERSION
+        assert "supported_security_baseline_met" in status
 
     def test_install_enforcement_idempotent(self):
         """Test install_global_enforcement is idempotent."""

--- a/tests/validation/test_check_unsafe_torch_load.py
+++ b/tests/validation/test_check_unsafe_torch_load.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+TOOL_PATH = PROJECT_ROOT / "scripts" / "validation" / "check_unsafe_torch_load.py"
+SPEC = importlib.util.spec_from_file_location("check_unsafe_torch_load", TOOL_PATH)
+assert SPEC is not None and SPEC.loader is not None
+checker = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = checker
+SPEC.loader.exec_module(checker)
+
+
+def test_find_python_files_skips_repo_local_runtime_envs(tmp_path: Path) -> None:
+    unsafe_runtime_file = tmp_path / ".runtime" / "Depth-Anything-3" / "loader.py"
+    unsafe_runtime_file.parent.mkdir(parents=True)
+    unsafe_runtime_file.write_text("import torch\ntorch.load('model.pt')\n", encoding="utf-8")
+    unsafe_venv_file = tmp_path / ".venv-da3" / "site-packages" / "loader.py"
+    unsafe_venv_file.parent.mkdir(parents=True)
+    unsafe_venv_file.write_text("import torch\ntorch.load('model.pt')\n", encoding="utf-8")
+    repo_file = tmp_path / "src" / "loader.py"
+    repo_file.parent.mkdir()
+    repo_file.write_text("import torch\ntorch.load('model.pt', weights_only=True)\n", encoding="utf-8")
+
+    found = {path.relative_to(tmp_path) for path in checker.find_python_files(tmp_path)}
+
+    assert found == {Path("src/loader.py")}
+
+
+def test_platform_security_profile_test_is_allowed() -> None:
+    path = PROJECT_ROOT / "tests" / "security" / "test_platform_security_profile.py"
+
+    assert checker.is_allowed_file(path, PROJECT_ROOT)


### PR DESCRIPTION
## Summary
- Raises the supported ML extras to the secure PyTorch baseline so Dependabot alerts #172, #173, and #174 are no longer sourced from supported optional metadata.
- Keeps the target-owned ML policy intact: Apple Silicon remains supported, while macOS Intel and Linux historical locks remain frozen and unsupported.
- Updates checkpoint-loading posture so weights_only=True is defense in depth, not the remediation for vulnerable torch versions.

## Changes
- Changes pyproject ML extras to require torch>=2.8.0 and torchvision>=0.23.0.
- Adds a non-breaking minimum supported torch version field to torch security compliance and the canonical CAS security profile.
- Updates runtime/security wording in torch security, platform matrix, ML bootstrap, requirements docs, and plugin/dependency docs.
- Tightens the torch.load scanner to ignore repo-local runtime virtualenvs and covers that boundary with tests.

## Validation
Proven green:
- .venv/bin/python scripts/validation/check_unsafe_torch_load.py
- python3 scripts/validation/check_requirements_lock_contract.py
- make check-requirements-lock-contract
- make check
- make check-ci-sync
- .venv/bin/pytest tests/security/test_platform_security_profile.py tests/test_check_requirements_lock_contract.py tests/validation/test_check_unsafe_torch_load.py
- make test-fast
- .venv/bin/black --check src/transformation_portal/core/security/torch_security.py src/transformation_portal/core/platform_matrix.py scripts/validation/check_unsafe_torch_load.py tests/security/test_platform_security_profile.py tests/validation/test_check_unsafe_torch_load.py

Still failing:
- None locally.

Environment/tooling:
- `python` is not on PATH locally, so the torch-load scanner was run with `.venv/bin/python`.
- `make check` required running outside the read-only sandbox because `mktemp` needs a writable temp directory.
- pip-tools emitted existing `--strip-extras` future warnings during `make check`.

## Risk
- Dependency metadata risk is bounded to optional ML extras and docs; product API, route, selector, and schema contracts are unchanged.
- CAS identity changes intentionally through `torch_safe_load_v2` because the canonical security profile now includes the minimum supported torch baseline.
- Frozen historical ML locks are left untouched and remain explicit unsupported lanes, making the change revert-safe.