### PR TITLE
fix(portal): preserve hidden routed shells

### DIFF
--- a/public/portal-assets/portal.css
+++ b/public/portal-assets/portal.css
@@ -2994,7 +2994,7 @@ textarea,
   color: rgb(203 213 225);
 }
 .hidden {
-  display: none !important;
+  display: none;
 }
 @media (min-width: 1024px) {
 .lg\:flex {
@@ -3419,6 +3419,12 @@ textarea,
 }
 .inline-flex {
   display: inline-flex;
+}
+#overview-shell.hidden,
+#console-grid.hidden,
+#build-shell.hidden,
+#jobs-shell.hidden {
+  display: none;
 }
 .sr-only {
   position: absolute;

--- a/public/portal-assets/portal.css
+++ b/public/portal-assets/portal.css
@@ -2994,7 +2994,7 @@ textarea,
   color: rgb(203 213 225);
 }
 .hidden {
-  display: none;
+  display: none !important;
 }
 @media (min-width: 1024px) {
 .lg\:flex {

--- a/scripts/validation/validate_frontdoor_browser_smoke.py
+++ b/scripts/validation/validate_frontdoor_browser_smoke.py
@@ -391,9 +391,17 @@ def _frontdoor_state_probe_expression() -> str:
     const el = document.querySelector(selector);
     return el ? String(el.getAttribute(name) || '') : '';
   };
-  const hidden = (id) => {
+  const visibleById = (id) => {
     const el = document.getElementById(id);
-    return !!(el && el.classList.contains('hidden'));
+    if (!el) return false;
+    const style = window.getComputedStyle(el);
+    const rect = el.getBoundingClientRect();
+    return style.display !== 'none' && style.visibility !== 'hidden' && rect.width > 0 && rect.height > 0;
+  };
+  const hiddenById = (id) => {
+    const el = document.getElementById(id);
+    if (!el) return false;
+    return !visibleById(id);
   };
   return {
     title: document.title,
@@ -415,7 +423,10 @@ def _frontdoor_state_probe_expression() -> str:
     passwordPresent: !!document.querySelector('input[name="password"]'),
     authModeBadge: text('#authModeBadge'),
     currentView: document.body ? String(document.body.dataset.consoleView || '') : '',
-    apiKeySectionHidden: hidden('apiKeySection'),
+    apiKeySectionHidden: hiddenById('apiKeySection'),
+    buildViewVisible: visibleById('build-shell'),
+    overviewViewVisible: visibleById('overview-shell'),
+    operateViewVisible: visibleById('jobs-shell'),
     portalAccessStateReady: !!document.querySelector('[data-ui="portal-access-state"]')
   };
 })()
@@ -766,6 +777,9 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
                 and str(value.get("currentView", "")) == "build"
                 and "view=build" in str(value.get("locationSearch", ""))
                 and bool(value.get("apiKeySectionHidden"))
+                and bool(value.get("buildViewVisible"))
+                and not bool(value.get("overviewViewVisible"))
+                and not bool(value.get("operateViewVisible"))
                 and bool(value.get("portalAccessStateReady"))
                 and str(value.get("authModeBadge", "")).lower() == "managed"
             ),

--- a/scripts/validation/validate_frontdoor_browser_smoke.py
+++ b/scripts/validation/validate_frontdoor_browser_smoke.py
@@ -401,7 +401,15 @@ def _frontdoor_state_probe_expression() -> str:
   const hiddenById = (id) => {
     const el = document.getElementById(id);
     if (!el) return false;
-    return !visibleById(id);
+    const style = window.getComputedStyle(el);
+    const rect = el.getBoundingClientRect();
+    const isVisible = (
+      style.display !== 'none' &&
+      style.visibility !== 'hidden' &&
+      rect.width > 0 &&
+      rect.height > 0
+    );
+    return !isVisible;
   };
   return {
     title: document.title,

--- a/scripts/validation/validate_portal_browser_smoke.py
+++ b/scripts/validation/validate_portal_browser_smoke.py
@@ -896,16 +896,13 @@ def _state_probe_expression() -> str:
       return row ? String(row.getAttribute('data-job-id') || '') : '';
     })(),
     buildViewVisible: (() => {
-      const el = document.getElementById('build-shell');
-      return !!(el && !el.classList.contains('hidden'));
+      return visible('build-shell');
     })(),
     operateViewVisible: (() => {
-      const el = document.getElementById('jobs-shell');
-      return !!(el && !el.classList.contains('hidden'));
+      return visible('jobs-shell');
     })(),
     overviewViewVisible: (() => {
-      const el = document.getElementById('overview-shell');
-      return !!(el && !el.classList.contains('hidden'));
+      return visible('overview-shell');
     })(),
     buildStepperVisible: !!document.querySelector('[data-ui="build-stepper"]'),
     activeBuildStep: (() => {

--- a/tests/test_app_orchestrator_runtime.py
+++ b/tests/test_app_orchestrator_runtime.py
@@ -518,6 +518,17 @@ def test_portal_phase1_accessibility_tokens_align_focus_and_target_size() -> Non
     assert "#build-shell label:not(.sr-only)" in css_content
 
 
+def test_portal_hidden_utility_wins_over_later_display_utilities() -> None:
+    css_content = _portal_css_content()
+
+    hidden_rule = re.search(r"^\.hidden \{\s*display:\s*none\s*!important;\s*\}", css_content, re.M)
+    assert hidden_rule is not None
+    hidden_start = hidden_rule.start()
+    assert ".grid {" in css_content[hidden_start:]
+    assert ".inline-flex {" in css_content[hidden_start:]
+    assert ".lg\\:flex {" in css_content[hidden_start:]
+
+
 def test_portal_shell_veil_tokens_use_shell_namespace_and_ordered_opacity() -> None:
     css_content = _portal_css_content()
 

--- a/tests/test_app_orchestrator_runtime.py
+++ b/tests/test_app_orchestrator_runtime.py
@@ -518,15 +518,30 @@ def test_portal_phase1_accessibility_tokens_align_focus_and_target_size() -> Non
     assert "#build-shell label:not(.sr-only)" in css_content
 
 
-def test_portal_hidden_utility_wins_over_later_display_utilities() -> None:
+def test_portal_routed_shell_hidden_rules_preserve_responsive_display_utilities() -> None:
+    html_content = _portal_html_content()
     css_content = _portal_css_content()
 
-    hidden_rule = re.search(r"^\.hidden \{\s*display:\s*none\s*!important;\s*\}", css_content, re.M)
+    hidden_rule = re.search(r"^\.hidden\s*\{(?P<body>.*?)^}", css_content, re.M | re.S)
     assert hidden_rule is not None
-    hidden_start = hidden_rule.start()
-    assert ".grid {" in css_content[hidden_start:]
-    assert ".inline-flex {" in css_content[hidden_start:]
-    assert ".lg\\:flex {" in css_content[hidden_start:]
+    hidden_body = hidden_rule.group("body")
+    assert re.search(r"display:\s*none;", hidden_body)
+    assert "!important" not in hidden_body
+    assert 'class="topbar-status hidden lg:flex"' in html_content
+
+    route_shell_rule = re.search(
+        (
+            r"^#overview-shell\.hidden,\s*"
+            r"^#console-grid\.hidden,\s*"
+            r"^#build-shell\.hidden,\s*"
+            r"^#jobs-shell\.hidden\s*\{(?P<body>.*?)^}"
+        ),
+        css_content,
+        re.M | re.S,
+    )
+    assert route_shell_rule is not None
+    assert re.search(r"display:\s*none;", route_shell_rule.group("body"))
+    assert "!important" not in route_shell_rule.group("body")
 
 
 def test_portal_shell_veil_tokens_use_shell_namespace_and_ordered_opacity() -> None:

--- a/tests/validation/test_portal_smoke_scripts.py
+++ b/tests/validation/test_portal_smoke_scripts.py
@@ -164,6 +164,9 @@ def test_portal_browser_state_probe_tracks_contextual_action_controls():
     assert "reviewStatusState" in expression
     assert "connectionDetailsVisible" in expression
     assert "dispatchChecklistRows" in expression
+    assert "return visible('build-shell');" in expression
+    assert "return visible('jobs-shell');" in expression
+    assert "return visible('overview-shell');" in expression
     assert "enableSegmentationChecked" in expression
     assert "segmentationBackendValue" in expression
     assert "strictSegmentationChecked" in expression
@@ -679,6 +682,9 @@ def test_frontdoor_browser_waits_for_managed_portal_bootstrap_before_passing():
     assert 'and "returnTo=%2Fportal%3Fview%3Dbuild" in str(value.get("locationSearch", ""))' in content
     assert 'and str(value.get("currentView", "")) == "build"' in content
     assert 'and "view=build" in str(value.get("locationSearch", ""))' in content
+    assert 'and bool(value.get("buildViewVisible"))' in content
+    assert 'and not bool(value.get("overviewViewVisible"))' in content
+    assert 'and not bool(value.get("operateViewVisible"))' in content
     assert "/healthz" in content
     assert "--spawn-local-frontdoor" in content
     assert "--spawn-local-backend" in content


### PR DESCRIPTION
## Summary
- Root cause: routed portal shells can carry `hidden` plus later display utilities such as `grid` or `flex`, so a class-only hidden check was not enough to prove the inactive route was actually collapsed.
- Keep the shared `.hidden` utility Tailwind-compatible and make routed-shell hiding explicit with stable shell IDs.

## Changes
- Preserve `.hidden { display: none; }` so responsive overrides such as `hidden lg:flex` continue to work.
- Add routed-shell-specific hidden rules for `#overview-shell`, `#console-grid`, `#build-shell`, and `#jobs-shell`.
- Keep direct portal and managed frontdoor smoke probes on computed visibility rather than `classList.contains('hidden')`.
- Simplify the frontdoor `hiddenById` probe helper to avoid a double DOM lookup.
- Update the CSS contract test to assert semantic rule bodies instead of one-line formatting.
- No route, selector, `data-ui`, API envelope, or auth contract changes.

## Validation
Proven green:
- `/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin/pytest tests/test_app_orchestrator_runtime.py -k "routed_shell_hidden or accessibility_tokens"`
- `/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin/pytest tests/validation/test_portal_smoke_scripts.py -k "state_probe_tracks_contextual_action_controls or waits_for_managed_portal_bootstrap"`
- `make test-portal-contract PY=/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin/python`
- `PATH=/Users/richardcheetham/.nvm/versions/node/v22.22.2/bin:$PATH make validate-frontdoor-browser PY=/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin/python`
- `TRANSFORMATION_PORTAL_DA3_PYTHON=/Users/richardcheetham/Desktop/Transformation_Portal/.runtime/Depth-Anything-3/.venv-da3/bin/python make validate-portal-browser PY=/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin/python`
- `git diff --check`

Still failing:
- None.

Environment/tooling:
- Direct portal smoke fails in this clean PR worktree unless `TRANSFORMATION_PORTAL_DA3_PYTHON` points at the existing canonical DA3 runtime, because the worktree does not contain its own `.runtime/Depth-Anything-3` checkout.

## Risk
- Low, bounded to portal routed-shell CSS and validation probes.
- Shared utility behavior is compatible with existing responsive classes such as `hidden lg:flex`.
- Revert-safe: reverting removes the routed-shell override and restores the previous probe/test coverage.
