### PR TITLE
test(spatial_ai): deterministic out-of-range opacities in gaussian splat test

### DIFF
--- a/tests/spatial_ai/test_reconstruction.py
+++ b/tests/spatial_ai/test_reconstruction.py
@@ -343,7 +343,7 @@ class TestGaussianSplat:
     def test_invalid_opacities_range_raises(self):
         """Test that out-of-range opacities are rejected."""
         N = 10
-        bad_opacities = np.random.rand(N, 1).astype(np.float32) + 0.5  # > 1.0
+        bad_opacities = np.full((N, 1), 1.5, dtype=np.float32)
 
         with pytest.raises(ValueError, match="\\[0, 1\\]"):
             GaussianSplat(


### PR DESCRIPTION
The previous bad_opacities used np.random.rand(N, 1) + 0.5 with N=10,
producing values in [0.5, 1.5). With a ~1/1024 chance of all draws
falling in [0, 0.5), the test could spuriously pass without triggering
the > 1.0 validation. CI hit that case under parallel execution, where
upstream test order shifted the global RNG state.

Replace with a constant 1.5 array so the validation path is exercised
on every run.

https://claude.ai/code/session_018B7J5TYB6x9i1brZferoB4