### PR TITLE
test(governance): refresh skill progression contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,7 @@ Quick reference for common workflows and commands in this repo.
 - `make organize-docs` move markdown files into `docs/` (repo hygiene).
 - `make check-docs` dry-run docs organization.
 - `make check-stale-docs` detect changed-file references to deleted or moved docs root paths.
+- `make check-doc-heading-links` validate markdown links that target related TODO/quick-win/binary-cleanup document headings.
 - `python3 scripts/governance/check_docs_structure.py --all` run the canonical documentation structure validator across all docs.
 - `make lock` regenerate all requirements lockfiles.
 - `make lock-prod` regenerate `requirements.lock.txt`.

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ PHASE6_SMOKE_TESTS := \
 
 .PHONY: help test-fast test-novideo test-full test-integration test-structure test-utils test-orchestrator-contract test-orchestrator-http-contract test-portal-contract test-frontdoor-contract test-archive-gate-contract seed-frontdoor-user run-frontdoor-local validate-orchestrator-http validate-portal-lux-materials-live validate-portal-css-layer-parity validate-portal-browser validate-frontdoor-browser validate-frontdoor-deployment-gate audit-pipeline-readiness coverage-fast-scope coverage-report coverage-diff coverage-package venv repair-core-venv setup clean \
         lint lint-parity ci ci-full pre-commit install-hooks quality-check fix-quality validate-ci organize-docs check-json-serialization check-piptools-cache \
-        check-python-headers check-yaml-governance check-stale-docs lock lock-prod lock-ci lock-dev install-core install-ml install-ml-core install-ml-raw install-ml-sam2 install-ml-coreml docs docs-clean \
+        check-python-headers check-yaml-governance check-stale-docs check-doc-heading-links lock lock-prod lock-ci lock-dev install-core install-ml install-ml-core install-ml-raw install-ml-sam2 install-ml-coreml docs docs-clean \
         check check-test-markers check-ci-sync check-todo-governance check-environment check-portal-asset-budgets validate-full validate-quick clean-frontdoor clean-all check-worktree \
         compile-ml-darwin-arm64 update-ml-darwin-arm64 check-ml-darwin-arm64 \
         compile-ml-linux-x86_64 update-ml-linux-x86_64 check-ml-linux-x86_64 \
@@ -101,6 +101,7 @@ help:
 	@echo "  update-ml-darwin-x86_64  Retired unsupported Darwin x86_64 ML lane (fails closed)"
 	@echo "  check-ml-darwin-x86_64   Retired unsupported Darwin x86_64 ML lane (fails closed)"
 	@echo "  check-stale-docs   Detect changed-file references to deleted docs root paths"
+	@echo "  check-doc-heading-links  Validate markdown links that target related doc headings"
 	@echo "  check-test-markers Audit test marker coverage (ADR-044)"
 	@echo "  check-ci-sync      Verify CI dependency files are in sync (no drift)"
 	@echo "  check-todo-governance  Verify TODO governance compliance (tracking refs)"
@@ -492,6 +493,9 @@ check-quality:
 
 check-stale-docs:
 	@"$(PY)" scripts/governance/check_stale_docs_paths.py
+
+check-doc-heading-links:
+	@"$(PY)" scripts/validation/check_doc_heading_links.py
 
 # Validate CI configuration
 validate-ci:

--- a/docs/README.md
+++ b/docs/README.md
@@ -71,6 +71,7 @@ current documentation map.
 ```bash
 make check-docs
 make check-stale-docs
+make check-doc-heading-links
 python3 scripts/governance/check_docs_structure.py --all
 ```
 

--- a/docs/governance/DOCUMENTATION_MAP.md
+++ b/docs/governance/DOCUMENTATION_MAP.md
@@ -109,6 +109,7 @@ operator guidance unless they are linked here as canonical documents.
 ```bash
 make check-docs
 make check-stale-docs
+make check-doc-heading-links
 python3 scripts/governance/check_docs_structure.py --all
 ```
 

--- a/docs/guides/SKILL_PROGRESS_TRACKS.md
+++ b/docs/guides/SKILL_PROGRESS_TRACKS.md
@@ -9,6 +9,151 @@ Use the tracks after an automation run ranks one of these skills. Keep drills
 small, preserve existing route shapes and CLI contracts, and validate with the
 focused acceptance tests listed here before widening scope.
 
+## 2026-05-02 Review-Thread Refresh
+
+The `2026-04-30T21:19:09Z` automation window surfaced the following current
+practice tracks. Treat these as additive drills on top of the original tracks;
+where the reviewed defect is already fixed, add contract coverage that prevents
+regression instead of rewriting the landed implementation.
+
+### Portal CSS Governance And Parity Isolation
+
+Review evidence:
+
+- PR #1608: `scripts/validation/validate_portal_css_layer_parity.py` needed
+  parity probes to restore DOM, localStorage, theme, and review-banner state
+  after forcing visual states.
+- PR #1610: `web/secure-landing/scripts/check-portal-css-architecture.mjs`
+  needed stale historical ownership-report evidence to fail rather than
+  self-heal silently.
+
+Drill 1 - isolate parity probe mutations:
+
+- Target files: portal CSS parity validation probes and focused smoke-script
+  contract tests.
+- Expected behavior: every probe that changes DOM classes/attributes,
+  localStorage keys, or global portal state snapshots those fields and restores
+  them before the next probe.
+- Acceptance tests: assert review-banner, interaction-outline, skeleton,
+  snapshot, and runtime class-census probes all use the shared restore guard.
+
+Drill 2 - reject stale ownership evidence:
+
+- Target files: CSS architecture report validation and portal CSS architecture
+  tests.
+- Expected behavior: historical hash, rendered fingerprint, and deferred-count
+  fields are immutable evidence, not auto-repaired baseline data.
+- Acceptance tests: mutate each historical field in a fixture and assert the
+  validator exits non-zero with a stale-evidence message.
+
+### Deterministic Test And Lint Contracts
+
+Review evidence:
+
+- PR #1609: `scripts/ci/check_no_tautological_tests.py` needed table-driven
+  AST coverage for literal containers, real comment-only escapes, tag
+  word-boundaries, and dynamic-expression false positives.
+- PR #1605: Gaussian opacity validation needed deterministic boundary inputs
+  rather than random values that could accidentally avoid the intended edge.
+
+Drill 1 - table-drive lint AST cases:
+
+- Target files: tautological-assert lint tests and the lint helper when needed.
+- Expected behavior: constant-only truthy assertions are rejected, while dynamic
+  containers, fixture strings, falsey sentinels, and non-comment escape text are
+  not misclassified.
+- Acceptance tests: one parametrized positive table and one parametrized
+  negative table cover the AST shapes and escape hatch boundaries.
+
+Drill 2 - remove RNG from negative boundary checks:
+
+- Target files: one Gaussian/opacity validation test using random inputs for a
+  negative case.
+- Expected behavior: use fixed valid Gaussian fields plus explicit invalid
+  opacity boundaries below 0 and above 1.
+- Acceptance tests: repeat the invalid-boundary construction several times and
+  assert every run fails for the same validation reason.
+
+### Fail-Fast Input Validation And Path Containment
+
+Review evidence:
+
+- PR #1607: `SkyGANNode.time_of_day` needed to reject unknown values before
+  preset construction in `src/transformation_portal/comfyui/custom_nodes.py`.
+- PR #1609: CAS DAG lock naming needed traversal containment tests for
+  `_get_lock("../escape", ...)`.
+
+Drill 1 - validate user inputs before setup:
+
+- Target files: one ComfyUI or pipeline node with user-controlled inputs.
+- Expected behavior: reject invalid user options before importing heavy runtime
+  dependencies, converting images, or constructing preset/pipeline objects.
+- Acceptance tests: monkeypatch the expensive setup path to raise and prove the
+  validation error is raised first.
+
+Drill 2 - lock path containment exactly:
+
+- Target files: CAS DAG lock tests.
+- Expected behavior: sanitized lock files resolve directly under the configured
+  locks root.
+- Acceptance tests: assert both `resolved.is_relative_to(locks_root)` and
+  `resolved.parent == locks_root` for traversal and separator inputs.
+
+### Documentation Source-Of-Truth Governance
+
+Review evidence:
+
+- PR #1612: closure references across
+  `docs/fixes/BINARY_FILE_BEST_PRACTICES.md`,
+  `docs/deliverables/QUICK_WINS.md`, and
+  `docs/analysis/TODO_INVENTORY.md` needed valid section anchors.
+- PR #1611: `CLAUDE.md` placement/navigation guidance needed to stay aligned
+  with the root-file policy and live agent-doc navigation.
+
+Drill 1 - audit closure heading links:
+
+- Target files: docs validation scripts, TODO/quick-win closure docs, and their
+  tests.
+- Expected behavior: links or section references added during TODO/quick-win
+  closure resolve to headings in the referenced markdown file.
+- Acceptance tests: fixture docs with a valid heading pass; stale heading names
+  fail with the source path, target path, and missing heading.
+
+Drill 2 - update guidance and navigation together:
+
+- Target files: operator docs, documentation map/readme surfaces, and Makefile
+  help.
+- Expected behavior: introducing operator guidance or a new docs validation
+  target updates the live navigation and placement policy in the same patch.
+- Acceptance tests: docs checks include the new target and current navigation
+  still points at live guidance, not archived notes.
+
+### Security And Coverage Evidence Honesty
+
+Review evidence:
+
+- PR #1604: `tests/security/test_tenant_isolation_helpers.py` needed mutation
+  isolation coverage for nested default tenant policy fields.
+- PR #1609: `pyproject.toml` coverage configuration needed to avoid omitting
+  production packages as a way to improve metrics.
+
+Drill 1 - prove tenant policy mutation isolation:
+
+- Target files: tenant isolation helpers and tests.
+- Expected behavior: mutating one tenant's copied default policy cannot mutate
+  the manager default or another tenant's policy.
+- Acceptance tests: create two tenants from a default policy with mutable
+  fields, mutate one, and assert the other/default values are unchanged.
+
+Drill 2 - make zero coverage visible:
+
+- Target files: coverage configuration and coverage roadmap/docs tests.
+- Expected behavior: production packages remain in coverage measurement, and
+  zero-coverage packages are listed as explicit ratchet targets.
+- Acceptance tests: parse `pyproject.toml` and docs to prove production package
+  paths are not in `coverage.run.omit` and current zero-coverage packages are
+  named as ratchet targets.
+
 ## API Contract Parity
 
 Review evidence:

--- a/scripts/organize_docs.sh
+++ b/scripts/organize_docs.sh
@@ -59,7 +59,7 @@ is_git_tracked() {
 is_allowed_root_doc() {
     local file="$1"
     case "$file" in
-        README.md|CONTRIBUTING.md|SECURITY.md|CHANGELOG.md|AGENTS.md|LICENSE)
+        README.md|CONTRIBUTING.md|SECURITY.md|CHANGELOG.md|AGENTS.md|CLAUDE.md|LICENSE)
             return 0
             ;;
         requirements*.txt)

--- a/scripts/validation/check_doc_heading_links.py
+++ b/scripts/validation/check_doc_heading_links.py
@@ -12,7 +12,9 @@ from typing import Iterable
 
 
 MARKDOWN_LINK_RE = re.compile(r"\[[^\]]+\]\(([^)\s]+)\)")
-HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$")
+HEADING_RE = re.compile(r"^ {0,3}(#{1,6})\s+(.+?)\s*$")
+FENCE_RE = re.compile(r"^ {0,3}([`~]{3,})")
+INDENTED_CODE_RE = re.compile(r"^(?: {4,}|\t)")
 
 
 @dataclass(frozen=True)
@@ -54,7 +56,21 @@ def _default_heading_references() -> tuple[HeadingReference, ...]:
 
 def _heading_texts(path: Path) -> list[str]:
     headings: list[str] = []
+    fence: tuple[str, int] | None = None
     for raw_line in path.read_text(encoding="utf-8").splitlines():
+        fence_match = FENCE_RE.match(raw_line)
+        if fence is not None:
+            if fence_match:
+                marker = fence_match.group(1)
+                if marker[0] == fence[0] and len(marker) >= fence[1]:
+                    fence = None
+            continue
+        if fence_match:
+            marker = fence_match.group(1)
+            fence = (marker[0], len(marker))
+            continue
+        if INDENTED_CODE_RE.match(raw_line):
+            continue
         match = HEADING_RE.match(raw_line)
         if match:
             headings.append(match.group(2).strip())

--- a/scripts/validation/check_doc_heading_links.py
+++ b/scripts/validation/check_doc_heading_links.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Validate markdown links that target headings in related docs."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+MARKDOWN_LINK_RE = re.compile(r"\[[^\]]+\]\(([^)\s]+)\)")
+HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$")
+
+
+@dataclass(frozen=True)
+class HeadingReference:
+    source: Path
+    target: Path
+    heading_prefix: str
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _default_sources() -> tuple[Path, ...]:
+    root = _repo_root()
+    return (
+        root / "docs" / "fixes" / "BINARY_FILE_BEST_PRACTICES.md",
+        root / "docs" / "deliverables" / "QUICK_WINS.md",
+        root / "docs" / "analysis" / "TODO_INVENTORY.md",
+    )
+
+
+def _default_heading_references() -> tuple[HeadingReference, ...]:
+    root = _repo_root()
+    binary_best_practices = root / "docs" / "fixes" / "BINARY_FILE_BEST_PRACTICES.md"
+    return (
+        HeadingReference(
+            source=binary_best_practices,
+            target=root / "docs" / "deliverables" / "QUICK_WINS.md",
+            heading_prefix="QW-3:",
+        ),
+        HeadingReference(
+            source=binary_best_practices,
+            target=root / "docs" / "analysis" / "TODO_INVENTORY.md",
+            heading_prefix="4.1 Binary File Cleanup",
+        ),
+    )
+
+
+def _heading_texts(path: Path) -> list[str]:
+    headings: list[str] = []
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        match = HEADING_RE.match(raw_line)
+        if match:
+            headings.append(match.group(2).strip())
+    return headings
+
+
+def _slugify_heading(heading: str) -> str:
+    text = heading.strip().lower()
+    text = re.sub(r"`([^`]+)`", r"\1", text)
+    text = re.sub(r"[^\w\s.-]", "", text, flags=re.UNICODE)
+    text = re.sub(r"\s+", "-", text)
+    text = re.sub(r"-+", "-", text)
+    return text.strip("-")
+
+
+def _heading_slugs(path: Path) -> set[str]:
+    counts: dict[str, int] = {}
+    slugs: set[str] = set()
+    for heading in _heading_texts(path):
+        base = _slugify_heading(heading)
+        if not base:
+            continue
+        count = counts.get(base, 0)
+        counts[base] = count + 1
+        slugs.add(base if count == 0 else f"{base}-{count}")
+    return slugs
+
+
+def _iter_markdown_heading_links(source: Path) -> Iterable[tuple[Path, str]]:
+    text = source.read_text(encoding="utf-8")
+    for match in MARKDOWN_LINK_RE.finditer(text):
+        href = match.group(1).strip()
+        if href.startswith(("http://", "https://", "mailto:", "#")):
+            continue
+        if "#" not in href:
+            continue
+        raw_target, raw_anchor = href.split("#", 1)
+        if not raw_target.endswith(".md") or not raw_anchor:
+            continue
+        target = (source.parent / raw_target).resolve()
+        yield target, raw_anchor
+
+
+def _validate_markdown_links(sources: Iterable[Path]) -> list[str]:
+    failures: list[str] = []
+    slug_cache: dict[Path, set[str]] = {}
+    for source in sources:
+        if not source.is_file():
+            failures.append(f"{source}: source file is missing")
+            continue
+        for target, anchor in _iter_markdown_heading_links(source):
+            if not target.is_file():
+                failures.append(f"{source}: heading link target is missing: {target}")
+                continue
+            slugs = slug_cache.setdefault(target, _heading_slugs(target))
+            if anchor not in slugs:
+                failures.append(f"{source}: {target} has no heading anchor #{anchor}")
+    return failures
+
+
+def _validate_named_references(references: Iterable[HeadingReference]) -> list[str]:
+    failures: list[str] = []
+    heading_cache: dict[Path, list[str]] = {}
+    for reference in references:
+        if not reference.source.is_file():
+            failures.append(f"{reference.source}: source file is missing")
+            continue
+        if not reference.target.is_file():
+            failures.append(f"{reference.source}: heading reference target is missing: {reference.target}")
+            continue
+        headings = heading_cache.setdefault(reference.target, _heading_texts(reference.target))
+        if not any(heading.startswith(reference.heading_prefix) for heading in headings):
+            failures.append(
+                f"{reference.source}: {reference.target} has no heading starting with {reference.heading_prefix!r}"
+            )
+    return failures
+
+
+def check(paths: Iterable[Path]) -> list[str]:
+    sources = tuple(path.resolve() for path in paths) or _default_sources()
+    failures = _validate_markdown_links(sources)
+    if not paths:
+        failures.extend(_validate_named_references(_default_heading_references()))
+    return failures
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate markdown heading links in related documentation.")
+    parser.add_argument("paths", nargs="*", type=Path, help="Markdown source files to scan; defaults to TODO/QW closure docs.")
+    args = parser.parse_args(argv)
+
+    failures = check(args.paths)
+    if failures:
+        print("Doc heading link validation failed:", file=sys.stderr)
+        for failure in failures:
+            print(f"  - {failure}", file=sys.stderr)
+        return 1
+
+    print("doc heading links: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validation/validate_portal_css_layer_parity.py
+++ b/scripts/validation/validate_portal_css_layer_parity.py
@@ -412,90 +412,134 @@ def _style_settle_expression() -> str:
     return "new Promise((resolve) => window.setTimeout(() => resolve(true), 450))"
 
 
+def _portal_parity_probe_guard_source() -> str:
+    return r"""
+const createPortalParityProbeGuard = () => {
+  const root = document.documentElement;
+  const rootClassSnapshot = {
+    present: root.hasAttribute('class'),
+    value: root.getAttribute('class')
+  };
+  const storageSnapshots = new Map();
+  const nodeSnapshots = new Map();
+  const propertySnapshots = [];
+
+  const captureStorage = (...keys) => {
+    for (const key of keys) {
+      if (storageSnapshots.has(key)) continue;
+      try {
+        storageSnapshots.set(key, {
+          present: window.localStorage.getItem(key) !== null,
+          value: window.localStorage.getItem(key)
+        });
+      } catch (_error) {}
+    }
+  };
+
+  const captureNode = (node) => {
+    if (!node || nodeSnapshots.has(node)) return;
+    const attributes = {};
+    for (const attribute of Array.from(node.attributes || [])) {
+      attributes[attribute.name] = attribute.value;
+    }
+    nodeSnapshots.set(node, {
+      attributes,
+      hidden: Boolean(node.hidden),
+      styleCssText: node.style ? node.style.cssText : ''
+    });
+  };
+
+  const captureNodeAndAncestors = (node) => {
+    let current = node;
+    while (current && current !== document.body) {
+      captureNode(current);
+      current = current.parentElement;
+    }
+  };
+
+  const captureProperty = (owner, property) => {
+    if (!owner || typeof owner !== 'object') return;
+    propertySnapshots.push({
+      owner,
+      property,
+      present: Object.prototype.hasOwnProperty.call(owner, property),
+      value: owner[property]
+    });
+  };
+
+  const restore = () => {
+    for (const snapshot of propertySnapshots.slice().reverse()) {
+      if (snapshot.present) {
+        snapshot.owner[snapshot.property] = snapshot.value;
+      } else {
+        delete snapshot.owner[snapshot.property];
+      }
+    }
+    for (const [node, snapshot] of Array.from(nodeSnapshots.entries()).reverse()) {
+      for (const attribute of Array.from(node.attributes || [])) {
+        if (!Object.prototype.hasOwnProperty.call(snapshot.attributes, attribute.name)) {
+          node.removeAttribute(attribute.name);
+        }
+      }
+      for (const [name, value] of Object.entries(snapshot.attributes)) {
+        node.setAttribute(name, value);
+      }
+      node.hidden = snapshot.hidden;
+      if (node.style) {
+        node.style.cssText = snapshot.styleCssText;
+      }
+    }
+    for (const [key, snapshot] of storageSnapshots.entries()) {
+      try {
+        if (snapshot.present) {
+          window.localStorage.setItem(key, snapshot.value || '');
+        } else {
+          window.localStorage.removeItem(key);
+        }
+      } catch (_error) {}
+    }
+    if (rootClassSnapshot.present) {
+      root.setAttribute('class', rootClassSnapshot.value || '');
+    } else {
+      root.removeAttribute('class');
+    }
+  };
+
+  return { captureStorage, captureNode, captureNodeAndAncestors, captureProperty, restore };
+};
+"""
+
+
+def _portal_parity_probe_restore_expression() -> str:
+    return r"""
+(() => {
+  const guard = window.__portalParityProbeGuard;
+  window.__portalParityProbeGuard = null;
+  if (guard && typeof guard.restore === 'function') {
+    guard.restore();
+  }
+  return true;
+})()
+"""
+
+
 def _review_status_tone_probe_expression() -> str:
     tones = json.dumps(REVIEW_STATUS_TONES)
     themes = json.dumps(REVIEW_STATUS_THEMES)
+    probe_guard = _portal_parity_probe_guard_source()
     return f"""
 (async () => {{
+  {probe_guard}
   const tones = {tones};
   const themes = {themes};
   const results = [];
   const root = document.documentElement;
-  const rootClassSnapshot = {{
-    present: root.hasAttribute('class'),
-    value: root.getAttribute('class')
-  }};
-  const storageSnapshot = {{}};
-  for (const key of ['tp_theme', 'tp_theme_version']) {{
-    try {{
-      storageSnapshot[key] = {{
-        present: window.localStorage.getItem(key) !== null,
-        value: window.localStorage.getItem(key)
-      }};
-    }} catch (_error) {{}}
-  }}
   const banner = document.getElementById('reviewStatusBanner');
-  const mutatedNodes = [];
-  const bannerSnapshot = banner ? {{
-    innerHTML: banner.innerHTML,
-    attributes: ['data-tone', 'data-ui', 'aria-hidden'].map((name) => ({{
-      name,
-      present: banner.hasAttribute(name),
-      value: banner.getAttribute(name)
-    }}))
-  }} : null;
+  const guard = createPortalParityProbeGuard();
+  guard.captureStorage('tp_theme', 'tp_theme_version');
   if (banner) {{
-    let current = banner;
-    while (current && current !== document.body) {{
-      mutatedNodes.push({{
-        node: current,
-        className: current.className,
-        hidden: current.hidden,
-        hiddenAttributePresent: current.hasAttribute('hidden'),
-        hiddenAttributeValue: current.getAttribute('hidden'),
-        styleDisplay: current.style.display,
-        styleVisibility: current.style.visibility
-      }});
-      current = current.parentElement;
-    }}
+    guard.captureNodeAndAncestors(banner);
   }}
-  const restore = () => {{
-    if (rootClassSnapshot.present) {{
-      root.setAttribute('class', rootClassSnapshot.value || '');
-    }} else {{
-      root.removeAttribute('class');
-    }}
-    for (const [key, snapshot] of Object.entries(storageSnapshot)) {{
-      try {{
-        if (snapshot.present) {{
-          window.localStorage.setItem(key, snapshot.value || '');
-        }} else {{
-          window.localStorage.removeItem(key);
-        }}
-      }} catch (_error) {{}}
-    }}
-    for (const snapshot of mutatedNodes.reverse()) {{
-      snapshot.node.className = snapshot.className;
-      snapshot.node.hidden = snapshot.hidden;
-      if (snapshot.hiddenAttributePresent) {{
-        snapshot.node.setAttribute('hidden', snapshot.hiddenAttributeValue || '');
-      }} else {{
-        snapshot.node.removeAttribute('hidden');
-      }}
-      snapshot.node.style.display = snapshot.styleDisplay;
-      snapshot.node.style.visibility = snapshot.styleVisibility;
-    }}
-    if (banner && bannerSnapshot) {{
-      banner.innerHTML = bannerSnapshot.innerHTML;
-      for (const attribute of bannerSnapshot.attributes) {{
-        if (attribute.present) {{
-          banner.setAttribute(attribute.name, attribute.value || '');
-        }} else {{
-          banner.removeAttribute(attribute.name);
-        }}
-      }}
-    }}
-  }};
   try {{
     for (const theme of themes) {{
       try {{
@@ -543,7 +587,7 @@ def _review_status_tone_probe_expression() -> str:
     }}
     }}
   }} finally {{
-    restore();
+    guard.restore();
   }}
   return results;
 }})()
@@ -677,8 +721,19 @@ def _validate_overview_mobile_states(connection: DevToolsConnection) -> None:
 
 
 def _interaction_outline_setup_expression() -> str:
-    return r"""
+    probe_guard = _portal_parity_probe_guard_source()
+    return (
+        r"""
 (() => {
+  """
+        + probe_guard
+        + r"""
+  if (window.__portalParityProbeGuard && typeof window.__portalParityProbeGuard.restore === 'function') {
+    window.__portalParityProbeGuard.restore();
+  }
+  const guard = createPortalParityProbeGuard();
+  window.__portalParityProbeGuard = guard;
+  guard.captureStorage('tp_theme', 'tp_theme_version');
   try {
     window.localStorage.setItem('tp_theme', 'dark');
     window.localStorage.setItem('tp_theme_version', '2');
@@ -687,8 +742,12 @@ def _interaction_outline_setup_expression() -> str:
   document.documentElement.classList.add('dark');
   document.documentElement.classList.remove('performance-lite');
   if (typeof state === 'object' && state?.portalUi) {
+    guard.captureProperty(state.portalUi, 'buildStep');
+    guard.captureProperty(state.portalUi, 'disclosurePrefs');
     state.portalUi.buildStep = 4;
-    state.portalUi.disclosurePrefs = state.portalUi.disclosurePrefs || {};
+    const disclosurePrefs = state.portalUi.disclosurePrefs || {};
+    guard.captureProperty(disclosurePrefs, 'dispatchTools');
+    state.portalUi.disclosurePrefs = disclosurePrefs;
     state.portalUi.disclosurePrefs.dispatchTools = true;
   }
   if (typeof updateUIFromState === 'function') {
@@ -699,11 +758,13 @@ def _interaction_outline_setup_expression() -> str:
   }
   const dispatchTools = document.getElementById('dispatchToolsDetails');
   if (dispatchTools) {
+    guard.captureNode(dispatchTools);
     dispatchTools.open = true;
     dispatchTools.classList.remove('hidden');
     dispatchTools.removeAttribute('hidden');
   }
   const dispatchTool = document.querySelector('.dispatch-tool-btn:not(.dispatch-tool-btn-primary):not([disabled])');
+  guard.captureNodeAndAncestors(dispatchTool);
   let current = dispatchTool;
   while (current && current !== document.body) {
     current.classList.remove('hidden');
@@ -720,6 +781,7 @@ def _interaction_outline_setup_expression() -> str:
   };
 })()
 """
+    )
 
 
 def _node_id_for_selector(connection: DevToolsConnection, selector: str) -> int:
@@ -760,6 +822,13 @@ def _interaction_outline_read_expression(selector: str) -> str:
 
 
 def _validate_interaction_outline_states(connection: DevToolsConnection) -> None:
+    try:
+        _validate_interaction_outline_states_with_guard(connection)
+    finally:
+        connection.evaluate(_portal_parity_probe_restore_expression(), timeout_seconds=20.0)
+
+
+def _validate_interaction_outline_states_with_guard(connection: DevToolsConnection) -> None:
     setup = connection.evaluate(_interaction_outline_setup_expression(), timeout_seconds=20.0)
     if not isinstance(setup, dict):
         raise SmokeFailure("Interaction outline probe setup did not return a status object")
@@ -847,12 +916,17 @@ def _skeleton_visibility_probe_expression(parity_state: str) -> str:
     state_json = json.dumps(parity_state)
     skeleton_ids = json.dumps(SKELETON_STATE_IDS)
     probes = json.dumps(SKELETON_STYLE_PROBES)
+    probe_guard = _portal_parity_probe_guard_source()
     return f"""
 (() => {{
+  {probe_guard}
   const parityState = {state_json};
   const skeletonIds = {skeleton_ids};
   const probes = {probes};
   const theme = parityState === 'light' ? 'light' : 'dark';
+  const guard = createPortalParityProbeGuard();
+  guard.captureStorage('tp_theme', 'tp_theme_version');
+  try {{
   try {{
     window.localStorage.setItem('tp_theme', theme);
     window.localStorage.setItem('tp_theme_version', '2');
@@ -872,6 +946,7 @@ def _skeleton_visibility_probe_expression(parity_state: str) -> str:
       skeletonStates[id] = {{ present: false }};
       continue;
     }}
+    guard.captureNodeAndAncestors(node);
     let current = node;
     while (current && current !== document.body) {{
       current.classList.remove('hidden');
@@ -932,7 +1007,11 @@ def _skeleton_visibility_probe_expression(parity_state: str) -> str:
       }}
     }};
   }}
-  return {{ parityState, skeletonStates, styles }};
+  const result = {{ parityState, skeletonStates, styles }};
+  return result;
+  }} finally {{
+    guard.restore();
+  }}
 }})()
 """
 
@@ -1034,8 +1113,19 @@ def _restore_env(previous: dict[str, Optional[str]]) -> None:
 
 
 def _force_snapshot_state_expression() -> str:
-    return r"""
+    probe_guard = _portal_parity_probe_guard_source()
+    return (
+        r"""
 (() => {
+  """
+        + probe_guard
+        + r"""
+  if (window.__portalParityProbeGuard && typeof window.__portalParityProbeGuard.restore === 'function') {
+    window.__portalParityProbeGuard.restore();
+  }
+  const guard = createPortalParityProbeGuard();
+  window.__portalParityProbeGuard = guard;
+  guard.captureStorage('tp_theme', 'tp_theme_version');
   try {
     window.localStorage.setItem('tp_theme', 'dark');
     window.localStorage.setItem('tp_theme_version', '2');
@@ -1045,6 +1135,9 @@ def _force_snapshot_state_expression() -> str:
   document.documentElement.classList.remove('performance-lite');
   const portalState = typeof state === 'object' && state ? state : null;
   if (portalState?.auth?.features) {
+    guard.captureProperty(portalState.auth.features, 'artifactViewerModal');
+    guard.captureProperty(portalState.auth.features, 'reviewSurfaceDeferred');
+    guard.captureProperty(portalState.auth.features, 'stagedUploads');
     portalState.auth.features.artifactViewerModal = false;
     portalState.auth.features.reviewSurfaceDeferred = false;
     portalState.auth.features.stagedUploads = false;
@@ -1054,6 +1147,7 @@ def _force_snapshot_state_expression() -> str:
   }
   const artifactViewerModal = document.getElementById('artifactViewerModal');
   if (artifactViewerModal) {
+    guard.captureNode(artifactViewerModal);
     artifactViewerModal.classList.add('hidden');
     artifactViewerModal.classList.remove('flex');
     artifactViewerModal.setAttribute('aria-hidden', 'true');
@@ -1062,12 +1156,21 @@ def _force_snapshot_state_expression() -> str:
   return true;
 })()
 """
+    )
 
 
 def _force_census_state_expression(state: str) -> str:
     state_json = json.dumps(state)
+    probe_guard = _portal_parity_probe_guard_source()
     return f"""
 (async () => {{
+  {probe_guard}
+  if (window.__portalParityProbeGuard && typeof window.__portalParityProbeGuard.restore === 'function') {{
+    window.__portalParityProbeGuard.restore();
+  }}
+  const guard = createPortalParityProbeGuard();
+  window.__portalParityProbeGuard = guard;
+  guard.captureStorage('tp_theme', 'tp_theme_version');
   const parityState = {state_json};
   const theme = parityState === 'light' ? 'light' : 'dark';
   try {{
@@ -1081,6 +1184,10 @@ def _force_census_state_expression(state: str) -> str:
 
   const portalState = typeof state === 'object' && state ? state : null;
   if (portalState?.auth?.features) {{
+    guard.captureProperty(portalState.auth.features, 'stagedUploads');
+    guard.captureProperty(portalState.auth.features, 'artifactViewerModal');
+    guard.captureProperty(portalState.auth.features, 'reviewSurfaceDeferred');
+    guard.captureProperty(portalState, 'pipeline');
     if (parityState === 'staged-uploads') {{
       portalState.auth.features.stagedUploads = true;
       portalState.pipeline = 'lux-depth-v3';
@@ -1098,6 +1205,7 @@ def _force_census_state_expression(state: str) -> str:
   if (parityState === 'artifact-viewer-modal') {{
     const modal = document.getElementById('artifactViewerModal');
     if (modal) {{
+      guard.captureNode(modal);
       modal.classList.remove('hidden');
       modal.classList.add('flex');
       modal.setAttribute('aria-hidden', 'false');
@@ -1143,24 +1251,28 @@ def _collect_runtime_utility_classes(
             description=f"portal document ready for {view} view",
         )
         for state in states:
-            if state == "reduced-motion":
-                connection.call(
-                    "Emulation.setEmulatedMedia",
-                    {"features": [{"name": "prefers-reduced-motion", "value": "reduce"}]},
-                    timeout_seconds=20.0,
+            try:
+                if state == "reduced-motion":
+                    connection.call(
+                        "Emulation.setEmulatedMedia",
+                        {"features": [{"name": "prefers-reduced-motion", "value": "reduce"}]},
+                        timeout_seconds=20.0,
+                    )
+                else:
+                    connection.call("Emulation.setEmulatedMedia", {"features": []}, timeout_seconds=20.0)
+                connection.evaluate(_force_census_state_expression(state), timeout_seconds=20.0)
+                connection.evaluate(_style_settle_expression(), timeout_seconds=20.0)
+                runtime_classes = connection.evaluate(_class_census_expression(), timeout_seconds=20.0)
+                if not isinstance(runtime_classes, list):
+                    raise SmokeFailure("Runtime class census did not return a class list")
+                runtime_utility_classes.update(
+                    str(class_name)
+                    for class_name in runtime_classes
+                    if _is_utility_like_class_token(str(class_name))
                 )
-            else:
+            finally:
+                connection.evaluate(_portal_parity_probe_restore_expression(), timeout_seconds=20.0)
                 connection.call("Emulation.setEmulatedMedia", {"features": []}, timeout_seconds=20.0)
-            connection.evaluate(_force_census_state_expression(state), timeout_seconds=20.0)
-            connection.evaluate(_style_settle_expression(), timeout_seconds=20.0)
-            runtime_classes = connection.evaluate(_class_census_expression(), timeout_seconds=20.0)
-            if not isinstance(runtime_classes, list):
-                raise SmokeFailure("Runtime class census did not return a class list")
-            runtime_utility_classes.update(
-                str(class_name)
-                for class_name in runtime_classes
-                if _is_utility_like_class_token(str(class_name))
-            )
 
     return runtime_utility_classes
 
@@ -1335,9 +1447,12 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
             timeout_seconds=float(args.timeout_seconds),
             description="portal document ready",
         )
-        connection.evaluate(_force_snapshot_state_expression(), timeout_seconds=20.0)
-        connection.evaluate(_style_settle_expression(), timeout_seconds=20.0)
-        current = connection.evaluate(_style_snapshot_expression(), timeout_seconds=20.0)
+        try:
+            connection.evaluate(_force_snapshot_state_expression(), timeout_seconds=20.0)
+            connection.evaluate(_style_settle_expression(), timeout_seconds=20.0)
+            current = connection.evaluate(_style_snapshot_expression(), timeout_seconds=20.0)
+        finally:
+            connection.evaluate(_portal_parity_probe_restore_expression(), timeout_seconds=20.0)
 
         baseline_path = Path(str(args.baseline_path))
         if args.write_baseline:

--- a/src/transformation_portal/comfyui/custom_nodes.py
+++ b/src/transformation_portal/comfyui/custom_nodes.py
@@ -13,6 +13,7 @@ Node Categories:
 
 import json
 import logging
+import math
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -92,6 +93,7 @@ class FluxEnhancementNode(BaseNode):
     """FLUX diffusion enhancement node."""
 
     CATEGORY = "Transformation Portal/Enhancement"
+    _VALID_VARIANTS = ("dev", "schnell")
 
     @classmethod
     def INPUT_TYPES(cls):
@@ -115,6 +117,28 @@ class FluxEnhancementNode(BaseNode):
     def RETURN_TYPES(cls):
         return ("IMAGE",)
 
+    @classmethod
+    def _validate_inputs(cls, strength: float, num_steps: int, guidance_scale: float, variant: str) -> None:
+        if variant not in cls._VALID_VARIANTS:
+            raise ValueError(f"Unknown variant {variant!r}; expected one of {list(cls._VALID_VARIANTS)}")
+        numeric_checks = (
+            ("strength", strength, 0.0, 1.0),
+            ("guidance_scale", guidance_scale, 1.0, 20.0),
+        )
+        for name, value, minimum, maximum in numeric_checks:
+            try:
+                numeric_value = float(value)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(f"{name} must be numeric") from exc
+            if not math.isfinite(numeric_value) or numeric_value < minimum or numeric_value > maximum:
+                raise ValueError(f"{name} must be between {minimum} and {maximum}")
+        try:
+            step_count = int(num_steps)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("num_steps must be an integer") from exc
+        if step_count < 1 or step_count > 50:
+            raise ValueError("num_steps must be between 1 and 50")
+
     def execute(
         self,
         image: Any,
@@ -127,6 +151,8 @@ class FluxEnhancementNode(BaseNode):
         seed: int = -1,
         use_controlnet: bool = False,
     ) -> Tuple[Any]:
+        self._validate_inputs(strength=strength, num_steps=num_steps, guidance_scale=guidance_scale, variant=variant)
+
         from transformation_portal.diffusion import FLUXPipeline
 
         logger.info(f"Executing FLUX enhancement (variant={variant}, strength={strength})")

--- a/tests/core/test_cas_dag_executor_failure_paths.py
+++ b/tests/core/test_cas_dag_executor_failure_paths.py
@@ -387,6 +387,7 @@ def test_get_lock_sanitizes_cas_id_into_filename(tmp_path):
     # Sanitization must keep the file inside locks_dir.
     resolved = lock.lock_path.resolve()
     assert resolved.is_relative_to(executor.locks_dir.resolve())
+    assert resolved.parent == executor.locks_dir.resolve()
     # And the cas_id-derived suffix must not introduce a separator.
     name = lock.lock_path.name
     assert "/" not in name

--- a/tests/dev/test_skill_progress_tracks_docs.py
+++ b/tests/dev/test_skill_progress_tracks_docs.py
@@ -23,6 +23,14 @@ EXPECTED_TRACKS = {
     "APEX Evidence Semantics": ("PR #1564", "PR #1556"),
 }
 
+EXPECTED_2026_05_02_TRACKS = {
+    "Portal CSS Governance And Parity Isolation": ("PR #1608", "PR #1610"),
+    "Deterministic Test And Lint Contracts": ("PR #1609", "PR #1605"),
+    "Fail-Fast Input Validation And Path Containment": ("PR #1607", "PR #1609"),
+    "Documentation Source-Of-Truth Governance": ("PR #1612", "PR #1611"),
+    "Security And Coverage Evidence Honesty": ("PR #1604", "PR #1609"),
+}
+
 
 def _read(path: Path) -> str:
     assert path.exists(), f"Missing expected documentation file: {path}"
@@ -38,6 +46,16 @@ def _section(text: str, heading: str) -> str:
     return text[start:next_heading]
 
 
+def _subsection(text: str, heading: str) -> str:
+    marker = f"### {heading}\n"
+    start = text.index(marker) + len(marker)
+    next_heading = text.find("\n### ", start)
+    if next_heading == -1:
+        next_h2 = text.find("\n## ", start)
+        return text[start:] if next_h2 == -1 else text[start:next_h2]
+    return text[start:next_heading]
+
+
 def test_skill_progress_tracks_document_exists_and_links_from_current_guides() -> None:
     tracks_text = _read(TRACKS_PATH)
     automation_text = _read(AUTOMATION_GUIDE_PATH)
@@ -50,6 +68,7 @@ def test_skill_progress_tracks_document_exists_and_links_from_current_guides() -
     assert "SKILL_PROGRESS_TRACKS.md" in guides_readme
     assert "SKILL_PROGRESS_TRACKS.md" in docs_readme
     assert "SKILL_PROGRESS_TRACKS.md" in documentation_map
+    assert "## 2026-05-02 Review-Thread Refresh" in tracks_text
 
 
 @pytest.mark.parametrize("heading, evidence", EXPECTED_TRACKS.items())
@@ -73,6 +92,30 @@ def test_skill_progress_tracks_lock_reviewed_skill_names() -> None:
 
     for heading in EXPECTED_TRACKS:
         assert f"## {heading}" in text
+
+
+@pytest.mark.parametrize("heading, evidence", EXPECTED_2026_05_02_TRACKS.items())
+def test_2026_05_02_skill_progress_refresh_tracks_have_evidence_drills_and_acceptance(
+    heading: str,
+    evidence: tuple[str, str],
+) -> None:
+    refresh = _section(_read(TRACKS_PATH), "2026-05-02 Review-Thread Refresh")
+    section = _subsection(refresh, heading)
+
+    for pr_anchor in evidence:
+        assert pr_anchor in section
+
+    assert section.count("Drill 1 -") == 1
+    assert section.count("Drill 2 -") == 1
+    assert section.count("Acceptance tests:") == 2
+    assert "Expected behavior:" in section
+
+
+def test_2026_05_02_refresh_locks_reviewed_skill_names() -> None:
+    refresh = _section(_read(TRACKS_PATH), "2026-05-02 Review-Thread Refresh")
+
+    for heading in EXPECTED_2026_05_02_TRACKS:
+        assert f"### {heading}" in refresh
 
 
 def test_apex_track_uses_canonical_apex_codes_import_path() -> None:

--- a/tests/security/test_tenant_isolation_helpers.py
+++ b/tests/security/test_tenant_isolation_helpers.py
@@ -47,6 +47,26 @@ def test_tenant_manager_creates_tenant_directories_and_copies_default_policy(tmp
     assert default_policy.allowed_node_types == {"render"}
 
 
+def test_tenant_manager_default_policy_copies_are_isolated_between_tenants(tmp_path: Path) -> None:
+    default_policy = TenantPolicy(allowed_node_types={"render"})
+    manager = TenantManager(tmp_path / "workspaces", tmp_path / "cas", default_policy=default_policy)
+
+    manager.create_tenant("tenant_a")
+    manager.create_tenant("tenant_b")
+
+    policy_a = manager.get_policy("tenant_a")
+    policy_b = manager.get_policy("tenant_b")
+    assert policy_a is not None
+    assert policy_b is not None
+    assert policy_a is not policy_b
+
+    policy_a.allowed_node_types.add("composite")
+
+    assert policy_a.allowed_node_types == {"render", "composite"}
+    assert policy_b.allowed_node_types == {"render"}
+    assert default_policy.allowed_node_types == {"render"}
+
+
 def test_tenant_manager_rejects_duplicate_tenants(tmp_path: Path) -> None:
     manager = TenantManager(tmp_path / "workspaces", tmp_path / "cas")
     manager.create_tenant("tenant_a")

--- a/tests/spatial_ai/test_reconstruction.py
+++ b/tests/spatial_ai/test_reconstruction.py
@@ -87,6 +87,20 @@ def _normalize_quaternions(quats):
     return (quats / norms).astype(np.float32)
 
 
+def _deterministic_gaussian_fields(num_gaussians=10, *, opacities=None):
+    """Return fixed valid Gaussian fields for boundary-condition tests."""
+    axis = np.linspace(0.0, 1.0, num_gaussians, dtype=np.float32)
+    if opacities is None:
+        opacities = np.full((num_gaussians, 1), 0.5, dtype=np.float32)
+    return {
+        "positions": np.column_stack((axis, axis + 1.0, axis + 2.0)).astype(np.float32),
+        "colors": np.tile(np.array([[0.25, 0.5, 0.75]], dtype=np.float32), (num_gaussians, 1)),
+        "scales": np.full((num_gaussians, 3), 0.05, dtype=np.float32),
+        "rotations": np.tile(np.array([[1.0, 0.0, 0.0, 0.0]], dtype=np.float32), (num_gaussians, 1)),
+        "opacities": opacities,
+    }
+
+
 class TestCameraParams:
     """Test CameraParams contract validation."""
 
@@ -340,19 +354,15 @@ class TestGaussianSplat:
                 opacities=np.random.rand(N, 1).astype(np.float32),
             )
 
-    def test_invalid_opacities_range_raises(self):
+    @pytest.mark.parametrize("bad_opacity", [-0.01, 1.01])
+    def test_invalid_opacities_range_raises(self, bad_opacity):
         """Test that out-of-range opacities are rejected."""
         N = 10
-        bad_opacities = np.full((N, 1), 1.5, dtype=np.float32)
+        bad_opacities = np.full((N, 1), bad_opacity, dtype=np.float32)
 
-        with pytest.raises(ValueError, match="\\[0, 1\\]"):
-            GaussianSplat(
-                positions=np.random.rand(N, 3).astype(np.float32),
-                colors=np.random.rand(N, 3).astype(np.float32),
-                scales=np.random.rand(N, 3).astype(np.float32) * 0.1 + 0.01,
-                rotations=_normalize_quaternions(np.random.rand(N, 4).astype(np.float32)),
-                opacities=bad_opacities,
-            )
+        for _ in range(5):
+            with pytest.raises(ValueError, match="\\[0, 1\\]"):
+                GaussianSplat(**_deterministic_gaussian_fields(N, opacities=bad_opacities))
 
 
 class TestReconstructionInput:

--- a/tests/test_check_no_tautological_tests.py
+++ b/tests/test_check_no_tautological_tests.py
@@ -35,84 +35,40 @@ def _write(tmp_path, name, body):
 # ---------------------------------------------------------------------------
 
 
-def test_detects_assert_true(tmp_path):
-    path = _write(tmp_path, "test_offender.py", "def test_x():\n    assert True\n")
+@pytest.mark.parametrize(
+    "assertion",
+    [
+        "assert True",
+        "assert 1",
+        "assert 'hi'",
+        "assert not False",
+        "assert not 0",
+        "assert [1]",
+        "assert (1,)",
+        "assert {'k': 'v'}",
+        "assert {1}",
+    ],
+)
+def test_detects_constant_only_truthy_assertions(assertion: str, tmp_path: Path) -> None:
+    path = _write(tmp_path, "test_offender.py", f"def test_x():\n    {assertion}\n")
+
     offenders = find_tautological_asserts(path)
+
     assert [line for line, _ in offenders] == [2]
 
 
-def test_detects_assert_truthy_int(tmp_path):
-    path = _write(tmp_path, "test_offender.py", "def test_x():\n    assert 1\n")
-    offenders = find_tautological_asserts(path)
-    assert len(offenders) == 1
-
-
-def test_detects_assert_nonempty_string(tmp_path):
-    path = _write(tmp_path, "test_offender.py", "def test_x():\n    assert 'hi'\n")
-    offenders = find_tautological_asserts(path)
-    assert len(offenders) == 1
-
-
-def test_detects_assert_not_false(tmp_path):
-    path = _write(tmp_path, "test_offender.py", "def test_x():\n    assert not False\n")
-    offenders = find_tautological_asserts(path)
-    assert len(offenders) == 1
-
-
-def test_detects_assert_not_zero(tmp_path):
-    path = _write(tmp_path, "test_offender.py", "def test_x():\n    assert not 0\n")
-    offenders = find_tautological_asserts(path)
-    assert len(offenders) == 1
-
-
-def test_detects_assert_nonempty_list(tmp_path):
-    path = _write(tmp_path, "test_offender.py", "def test_x():\n    assert [1]\n")
-    offenders = find_tautological_asserts(path)
-    assert len(offenders) == 1
-
-
-def test_detects_assert_nonempty_tuple(tmp_path):
-    path = _write(tmp_path, "test_offender.py", "def test_x():\n    assert (1,)\n")
-    offenders = find_tautological_asserts(path)
-    assert len(offenders) == 1
-
-
-def test_detects_assert_nonempty_dict(tmp_path):
-    path = _write(tmp_path, "test_offender.py", "def test_x():\n    assert {'k': 'v'}\n")
-    offenders = find_tautological_asserts(path)
-    assert len(offenders) == 1
-
-
-def test_detects_assert_nonempty_set(tmp_path):
-    path = _write(tmp_path, "test_offender.py", "def test_x():\n    assert {1}\n")
-    offenders = find_tautological_asserts(path)
-    assert len(offenders) == 1
-
-
-def test_ignores_container_with_call_element(tmp_path):
-    """``assert [compute()]`` evaluates ``compute()`` for its side effect, so
-    it could legitimately raise — the assertion is not a tautology even
-    though the resulting non-empty list is always truthy."""
-    body = "def test_x():\n    def compute():\n        return 1\n    assert [compute()]\n"
+@pytest.mark.parametrize(
+    "body",
+    [
+        "def test_x():\n    def compute():\n        return 1\n    assert [compute()]\n",
+        "def test_x():\n    value = 1\n    assert [value]\n",
+        "def test_x():\n    value = 1\n    assert {'k': value}\n",
+        "def test_x():\n    key = 'k'\n    assert {key: 1}\n",
+    ],
+)
+def test_ignores_dynamic_container_assertions(body: str, tmp_path: Path) -> None:
     path = _write(tmp_path, "test_real.py", body)
-    assert find_tautological_asserts(path) == []
 
-
-def test_ignores_container_with_name_element(tmp_path):
-    body = "def test_x():\n    value = 1\n    assert [value]\n"
-    path = _write(tmp_path, "test_real.py", body)
-    assert find_tautological_asserts(path) == []
-
-
-def test_ignores_dict_with_dynamic_value(tmp_path):
-    body = "def test_x():\n    value = 1\n    assert {'k': value}\n"
-    path = _write(tmp_path, "test_real.py", body)
-    assert find_tautological_asserts(path) == []
-
-
-def test_ignores_dict_with_dynamic_key(tmp_path):
-    body = "def test_x():\n    key = 'k'\n    assert {key: 1}\n"
-    path = _write(tmp_path, "test_real.py", body)
     assert find_tautological_asserts(path) == []
 
 

--- a/tests/test_comfyui.py
+++ b/tests/test_comfyui.py
@@ -251,6 +251,29 @@ class TestFluxEnhancementNode:
 
         assert FluxEnhancementNode.CATEGORY == "Transformation Portal/Enhancement"
 
+    def test_execute_rejects_unknown_variant_before_image_conversion(self, monkeypatch):
+        """Unknown variant must fail before image/pipeline setup."""
+        from transformation_portal.comfyui.custom_nodes import FluxEnhancementNode
+
+        node = FluxEnhancementNode()
+
+        def _conversion_must_not_run(_image):
+            raise RuntimeError("image conversion should not run before variant validation")
+
+        monkeypatch.setattr(node, "_to_numpy", _conversion_must_not_run)
+
+        with pytest.raises(ValueError, match="Unknown variant") as exc_info:
+            node.execute(
+                image=np.zeros((2, 2, 3), dtype=np.float32),
+                strength=0.45,
+                num_steps=4,
+                guidance_scale=3.5,
+                variant="not_a_real_variant",
+            )
+
+        assert "dev" in str(exc_info.value)
+        assert "schnell" in str(exc_info.value)
+
 
 class TestSkyGANNode:
     """Tests for SkyGANNode."""

--- a/tests/test_coverage_config_contract.py
+++ b/tests/test_coverage_config_contract.py
@@ -1,0 +1,51 @@
+"""Coverage configuration honesty contracts."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PYPROJECT_PATH = REPO_ROOT / "pyproject.toml"
+COVERAGE_PLAN_PATH = REPO_ROOT / "docs" / "testing" / "test_coverage_improvement_plan.md"
+ZERO_COVERAGE_RATCHET_PACKAGES = (
+    "depth_intelligence/",
+    "diffusion/",
+    "dwm/",
+    "interfaces/",
+    "pfm/",
+)
+
+
+def _coverage_config() -> dict:
+    pyproject = tomllib.loads(PYPROJECT_PATH.read_text(encoding="utf-8"))
+    return pyproject["tool"]["coverage"]
+
+
+def test_coverage_source_keeps_production_packages_in_scope() -> None:
+    run_config = _coverage_config()["run"]
+
+    assert run_config["source"] == ["src"]
+
+    omitted = "\n".join(run_config.get("omit", []))
+    forbidden_omits = (
+        "src/transformation_portal",
+        "transformation_portal/*",
+        "*/src/*",
+        "*/src/transformation_portal/*",
+    )
+    for pattern in forbidden_omits:
+        assert pattern not in omitted
+
+
+def test_zero_coverage_production_packages_are_explicit_ratchet_targets() -> None:
+    coverage_plan = COVERAGE_PLAN_PATH.read_text(encoding="utf-8")
+
+    assert "### Zero-Coverage Production Packages (ratchet targets)" in coverage_plan
+    assert "NOT excluded from coverage measurement" in coverage_plan
+    for package in ZERO_COVERAGE_RATCHET_PACKAGES:
+        assert f"`{package}`" in coverage_plan

--- a/tests/test_organize_docs.py
+++ b/tests/test_organize_docs.py
@@ -126,6 +126,23 @@ def test_dry_run_output_is_stable_and_sorted(tmp_path: Path) -> None:
     assert sources == sorted(sources)
 
 
+def test_claude_root_guidance_matches_root_file_policy(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    _init_repo(repo_root)
+    _copy_repo_script(repo_root)
+
+    _write(repo_root / "README.md")
+    _write(repo_root / "CLAUDE.md")
+    _write(repo_root / "docs" / "README.md")
+    _track(repo_root, "README.md", "CLAUDE.md", "docs/README.md", "scripts/organize_docs.sh")
+
+    result = _run_organizer(repo_root)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "CLAUDE.md" not in result.stdout
+
+
 def test_classifier_uses_tokens_not_substrings_and_preserves_positive_routes(tmp_path: Path) -> None:
     repo_root = tmp_path / "repo"
     repo_root.mkdir()

--- a/tests/validation/test_check_doc_heading_links.py
+++ b/tests/validation/test_check_doc_heading_links.py
@@ -41,5 +41,40 @@ def test_heading_link_validator_rejects_missing_anchor(tmp_path: Path) -> None:
     assert "#missing-heading" in failures[0]
 
 
+def test_heading_link_validator_ignores_code_block_comment_lines(tmp_path: Path) -> None:
+    target = tmp_path / "target.md"
+    source = tmp_path / "source.md"
+    target.write_text(
+        "\n".join(
+            [
+                "# Target",
+                "",
+                "```bash",
+                "# fake fenced heading",
+                "```",
+                "",
+                "    # fake indented heading",
+                "",
+                "## Real Heading",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    source.write_text(
+        "[fenced](target.md#fake-fenced-heading)\n"
+        "[indented](target.md#fake-indented-heading)\n"
+        "[real](target.md#real-heading)\n",
+        encoding="utf-8",
+    )
+
+    failures = _module.check([source])
+
+    assert len(failures) == 2
+    assert any("#fake-fenced-heading" in failure for failure in failures)
+    assert any("#fake-indented-heading" in failure for failure in failures)
+    assert all("#real-heading" not in failure for failure in failures)
+
+
 def test_default_todo_quick_win_binary_cleanup_heading_references_are_current() -> None:
     assert _module.check([]) == []

--- a/tests/validation/test_check_doc_heading_links.py
+++ b/tests/validation/test_check_doc_heading_links.py
@@ -1,0 +1,45 @@
+"""Tests for markdown heading-link validation."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "validation" / "check_doc_heading_links.py"
+_spec = importlib.util.spec_from_file_location("check_doc_heading_links", SCRIPT_PATH)
+assert _spec is not None and _spec.loader is not None
+_module = importlib.util.module_from_spec(_spec)
+sys.modules["check_doc_heading_links"] = _module
+_spec.loader.exec_module(_module)
+
+
+def test_heading_link_validator_accepts_existing_anchor(tmp_path: Path) -> None:
+    target = tmp_path / "target.md"
+    source = tmp_path / "source.md"
+    target.write_text("# Target\n\n## Existing Heading\n", encoding="utf-8")
+    source.write_text("[target](target.md#existing-heading)\n", encoding="utf-8")
+
+    assert _module.check([source]) == []
+
+
+def test_heading_link_validator_rejects_missing_anchor(tmp_path: Path) -> None:
+    target = tmp_path / "target.md"
+    source = tmp_path / "source.md"
+    target.write_text("# Target\n\n## Different Heading\n", encoding="utf-8")
+    source.write_text("[target](target.md#missing-heading)\n", encoding="utf-8")
+
+    failures = _module.check([source])
+
+    assert len(failures) == 1
+    assert str(source.resolve()) in failures[0]
+    assert str(target.resolve()) in failures[0]
+    assert "#missing-heading" in failures[0]
+
+
+def test_default_todo_quick_win_binary_cleanup_heading_references_are_current() -> None:
+    assert _module.check([]) == []

--- a/tests/validation/test_portal_smoke_scripts.py
+++ b/tests/validation/test_portal_smoke_scripts.py
@@ -19,6 +19,7 @@ PORTAL_LUX_MATERIALS_SCRIPT_PATH = PROJECT_ROOT / "scripts/validation/validate_p
 FRONTDOOR_BROWSER_SCRIPT_PATH = PROJECT_ROOT / "scripts" / "validation" / "validate_frontdoor_browser_smoke.py"
 ORCHESTRATOR_HTTP_SCRIPT_PATH = PROJECT_ROOT / "scripts/validation/validate_orchestrator_http_smoke.py"
 AUDIT_PIPELINE_READINESS_SCRIPT_PATH = PROJECT_ROOT / "scripts/validation/audit_pipeline_readiness.py"
+PORTAL_CSS_LAYER_PARITY_SCRIPT_PATH = PROJECT_ROOT / "scripts/validation/validate_portal_css_layer_parity.py"
 
 
 def _load_module(module_path: Path, module_name: str):
@@ -28,6 +29,15 @@ def _load_module(module_path: Path, module_name: str):
     sys.modules[module_name] = module
     spec.loader.exec_module(module)
     return module
+
+
+def _load_portal_css_layer_parity_module(module_name: str):
+    script_dir = str(PORTAL_CSS_LAYER_PARITY_SCRIPT_PATH.parent)
+    sys.path.insert(0, script_dir)
+    try:
+        return _load_module(PORTAL_CSS_LAYER_PARITY_SCRIPT_PATH, module_name)
+    finally:
+        sys.path.remove(script_dir)
 
 
 def test_portal_browser_parse_args_does_not_probe_chrome_for_explicit_override(monkeypatch: pytest.MonkeyPatch):
@@ -172,6 +182,41 @@ def test_portal_browser_state_probe_tracks_contextual_action_controls():
     assert "strictSegmentationChecked" in expression
     assert "queueEmptyStateVisible" in expression
     assert "artifactEmptyStateVisible" in expression
+
+
+def test_portal_css_layer_parity_probe_guard_captures_mutated_state() -> None:
+    module = _load_portal_css_layer_parity_module("tests_validate_portal_css_layer_parity_guard")
+
+    guard_source = module._portal_parity_probe_guard_source()
+
+    assert "createPortalParityProbeGuard" in guard_source
+    assert "captureStorage" in guard_source
+    assert "captureNodeAndAncestors" in guard_source
+    assert "captureProperty" in guard_source
+    assert "rootClassSnapshot" in guard_source
+    assert "window.__portalParityProbeGuard" in module._portal_parity_probe_restore_expression()
+
+
+def test_portal_css_layer_parity_mutating_probes_use_probe_guard() -> None:
+    module = _load_portal_css_layer_parity_module("tests_validate_portal_css_layer_parity_probes")
+
+    expressions = {
+        "review status": module._review_status_tone_probe_expression(),
+        "interaction outline": module._interaction_outline_setup_expression(),
+        "skeleton": module._skeleton_visibility_probe_expression("dark"),
+        "snapshot": module._force_snapshot_state_expression(),
+        "class census": module._force_census_state_expression("dark"),
+    }
+
+    for label, expression in expressions.items():
+        assert "createPortalParityProbeGuard" in expression, label
+        assert "captureStorage('tp_theme', 'tp_theme_version')" in expression, label
+
+    assert "guard.restore();" in expressions["review status"]
+    assert "guard.restore();" in expressions["skeleton"]
+    assert "window.__portalParityProbeGuard = guard" in expressions["interaction outline"]
+    assert "window.__portalParityProbeGuard = guard" in expressions["snapshot"]
+    assert "window.__portalParityProbeGuard = guard" in expressions["class census"]
 
 
 def test_portal_browser_accessibility_probe_tracks_target_size_and_disclosure_contracts():

--- a/web/secure-landing/scripts/check-portal-css-architecture.mjs
+++ b/web/secure-landing/scripts/check-portal-css-architecture.mjs
@@ -2962,6 +2962,9 @@ if (phase10AdditiveFixtureIndex >= 0) {
   if (fixture.expectedState && JSON.stringify(fixture.phase10AdditiveConsolidationState || null) !== JSON.stringify(fixture.expectedState)) {
     fixtureFailures.push("phase10AdditiveConsolidationState is stale");
   }
+  if (fixture.historicalPhase10State) {
+    checkHistoricalPhase10State({ phase10AdditiveConsolidationState: fixture.historicalPhase10State }, fixtureFailures);
+  }
   if (fixtureFailures.length > 0) {
     for (const failure of fixtureFailures) {
       console.error(`ERROR: ${failure}`);

--- a/web/secure-landing/tests/portal-css-architecture.test.mjs
+++ b/web/secure-landing/tests/portal-css-architecture.test.mjs
@@ -200,6 +200,26 @@ function runPhase10AdditiveFixtureFailure(fixture) {
   assert.fail("Phase 10 additive fixture unexpectedly passed");
 }
 
+function expectedHistoricalPhase10State(overrides = {}) {
+  return {
+    phase: "phase-10-css-additive-duplicate-consolidation",
+    additiveDuplicateContextCountBefore: 30,
+    additiveDuplicateContextCountAfter: 29,
+    safeCandidateCountBefore: 1,
+    safeCandidateCountAfter: 0,
+    consolidatedCandidateCount: 1,
+    deferredCandidateCount: 29,
+    conflictingDuplicateContextCount: 56,
+    unownedDuplicateContextCount: 0,
+    hotspotDuplicateContextCount: 0,
+    generatedPortalCssHashAfter: "fce12e29f1800375b5c34e1f0e1ebc9d3981ab1a6f731bea6a3e0e0d2212151e",
+    renderedPortalCssFingerprintAfter: "d72696ab972c",
+    sentinelStatePreserved: true,
+    parityBaselineChanged: false,
+    ...overrides
+  };
+}
+
 function runPhase11SurfaceFixture(fixture) {
   const tempDir = mkdtempSync(path.join(tmpdir(), "portal-phase11-surface-"));
   const fixturePath = path.join(tempDir, "phase11.json");
@@ -777,6 +797,20 @@ test("portal CSS Phase 10 additive fixtures classify safe and deferred candidate
     }),
     /phase10AdditiveConsolidationState is stale/
   );
+
+  for (const [field, value] of [
+    ["deferredCandidateCount", 28],
+    ["generatedPortalCssHashAfter", "stale-hash"],
+    ["renderedPortalCssFingerprintAfter", "stale-fingerprint"]
+  ]) {
+    assert.match(
+      runPhase10AdditiveFixtureFailure({
+        duplicates: [safeDuplicate],
+        historicalPhase10State: expectedHistoricalPhase10State({ [field]: value })
+      }),
+      new RegExp(`phase10AdditiveConsolidationState ${field} must remain historical`)
+    );
+  }
 });
 
 test("portal CSS Phase 11 surface fixtures constrain selector-list consolidation", () => {
@@ -1918,12 +1952,15 @@ test("portal CSS parity census forces feature states and canonical theme hooks",
   assert.match(validator, /portalState\.auth\.features\.reviewSurfaceDeferred = true/);
   assert.match(validator, /REVIEW_STATUS_TONES = \("ready", "warning", "error", "info"\)/);
   assert.match(validator, /document\.getElementById\('reviewStatusBanner'\)/);
+  assert.match(validator, /createPortalParityProbeGuard/);
   assert.match(validator, /rootClassSnapshot/);
-  assert.match(validator, /storageSnapshot/);
-  assert.match(validator, /bannerSnapshot/);
+  assert.match(validator, /storageSnapshots/);
+  assert.match(validator, /captureStorage\('tp_theme', 'tp_theme_version'\)/);
+  assert.match(validator, /captureNodeAndAncestors\(banner\)/);
+  assert.doesNotMatch(validator, /bannerSnapshot/);
   assert.match(validator, /current\.classList\.remove\('hidden'\)/);
   assert.match(validator, /banner\.dataset\.tone = tone/);
-  assert.match(validator, /finally \{\{\n    restore\(\);/);
+  assert.match(validator, /finally \{\{\n    guard\.restore\(\);/);
   assert.match(validator, /_validate_review_status_tone_states\(connection\)/);
   assert.match(validator, /_validate_overview_mobile_states\(connection\)/);
   assert.match(validator, /_validate_interaction_outline_states\(connection\)/);


### PR DESCRIPTION
## Summary
- Refreshed the repo-backed skill progression contracts from the 2026-04-30T21:19:09Z review-thread evidence window.
- Added focused tests and validation hooks that lock the reviewed governance patterns without changing route, selector, API-envelope, or existing Make target semantics.

## Changes
- Added the 2026-05-02 review-thread refresh section to `docs/guides/SKILL_PROGRESS_TRACKS.md` and locked the track names, PR anchors, drill count, and acceptance structure in `tests/dev/test_skill_progress_tracks_docs.py`.
- Added `scripts/validation/check_doc_heading_links.py` and `make check-doc-heading-links`, with operator navigation updates in `AGENTS.md`, `docs/README.md`, and `docs/governance/DOCUMENTATION_MAP.md`.
- Refactored portal CSS parity probes to use a shared capture/restore guard for DOM, localStorage, theme, and portal global state across review-banner, interaction-outline, skeleton, snapshot, and runtime class-census probes.
- Added portal CSS ownership fixture coverage that rejects stale Phase 10 historical deferred-count, generated-hash, and rendered-fingerprint evidence.
- Converted tautological-assert lint coverage to table-driven constant-only versus dynamic-container AST cases, and replaced the Gaussian opacity negative test with fixed boundary inputs plus repeat-run proof.
- Added fail-fast `FluxEnhancementNode` input validation before image conversion or FLUX pipeline setup, plus exact lock parent containment assertions for CAS DAG lock paths.
- Strengthened tenant default-policy mutation isolation and added coverage configuration contract tests proving production packages remain in coverage scope with explicit zero-coverage ratchets.
- Aligned the docs organizer with the root-file policy for `CLAUDE.md`.
- Appended the run summary to external automation memory when write access was available; no repo-local memory workaround was added.

## Validation
Proven green:
- `.venv/bin/pytest tests/test_organize_docs.py tests/dev/test_skill_progress_tracks_docs.py tests/test_check_no_tautological_tests.py tests/test_comfyui.py tests/core/test_cas_dag_executor_failure_paths.py tests/security/test_tenant_isolation_helpers.py tests/test_stale_docs_paths.py tests/validation/test_check_doc_heading_links.py tests/test_coverage_config_contract.py tests/validation/test_portal_smoke_scripts.py tests/spatial_ai/test_reconstruction.py -q` (`173 passed, 44 skipped`)
- `make check-doc-heading-links`
- `make check-docs`
- `make check-stale-docs`
- `.venv/bin/python scripts/governance/check_docs_structure.py --all`
- `./scripts/setup/ensure_node_version.sh`
- `PATH="/Users/richardcheetham/.nvm/versions/node/v22.22.2/bin:$PATH" node --experimental-specifier-resolution=node --test tests/portal-css-architecture.test.mjs` (`18 passed`)
- `make validate-portal-css-layer-parity`
- Commit hooks during `git commit`: formatter, root placement, ML isolation, test markers, tautological assert lint, gitleaks.

Still failing:
- None after reruns under the required runtime and permissions.

Environment/tooling notes:
- A non-escalated Node test attempt used ambient Node 25 and could not create temp fixtures under the read-only sandbox; rerunning with Node 22 first in `PATH` and normal temp access passed.
- GitHub metadata lookup required escalated network access; rerun succeeded.

## Risk
- Compatibility risk is low: no routes, selectors, API envelopes, or existing Make target semantics changed.
- The new Make target is additive and defaults to the TODO/quick-win/binary-cleanup docs touched by this run.
- Portal CSS parity changes are bounded to validation probes and restore their mutations after each forced state.
- The change is revert-safe as one governance/test/docs patch; production runtime behavior changes are limited to earlier fail-fast validation for invalid Flux ComfyUI inputs.