### PR TITLE
test(comfyui)+fix(depth_tools): assert BaseNode is abstract; fix 4D output broadcasting

### DIFF
--- a/src/transformation_portal/depth/tools.py
+++ b/src/transformation_portal/depth/tools.py
@@ -624,7 +624,6 @@ def apply_depth_clarity(
     detail = img - blurred
 
     mask_strength = (1.0 - sky) * (0.6 + 0.4 * building)
-    mask_strength = mask_strength[..., None]
 
     enhanced = img + detail * (amount * w * mask_strength)
     return np.clip(enhanced, 0.0, 1.0)
@@ -738,7 +737,7 @@ def apply_depth_dof(
     # protector reduces blur on buildings and slightly reduces extreme sky blur
     reduce_on_building = 1.0 - BUILDING_BLUR_REDUCTION * building  # building=1 -> factor ~0.12
     slight_sky_protect = 1.0 - SKY_BLUR_REDUCTION * sky  # sky=1 -> factor ~0.7
-    protector = (reduce_on_building * slight_sky_protect)[..., None]
+    protector = reduce_on_building * slight_sky_protect
 
     w_protected = w_soft * protector
     out = img * (1 - w_protected) + blended * w_protected

--- a/src/transformation_portal/pipelines/depth_tools.py
+++ b/src/transformation_portal/pipelines/depth_tools.py
@@ -609,7 +609,6 @@ def apply_depth_clarity(
     detail = img - blurred
 
     mask_strength = (1.0 - sky) * (0.6 + 0.4 * building)
-    mask_strength = mask_strength[..., None]
 
     enhanced = img + detail * (amount * w * mask_strength)
     return np.clip(enhanced, 0.0, 1.0)
@@ -683,7 +682,7 @@ def apply_depth_dof(
     # protector reduces blur on buildings and slightly reduces extreme sky blur
     reduce_on_building = 1.0 - BUILDING_BLUR_REDUCTION * building  # building=1 -> factor ~0.12
     slight_sky_protect = 1.0 - SKY_BLUR_REDUCTION * sky  # sky=1 -> factor ~0.7
-    protector = (reduce_on_building * slight_sky_protect)[..., None]
+    protector = reduce_on_building * slight_sky_protect
 
     w_protected = w_soft * protector
     out = img * (1 - w_protected) + blended * w_protected

--- a/tests/test_comfyui.py
+++ b/tests/test_comfyui.py
@@ -116,11 +116,16 @@ class TestBaseNode:
         """BaseNode should require INPUT_TYPES, RETURN_TYPES, execute."""
         from transformation_portal.comfyui.custom_nodes import BaseNode
 
-        # Cannot instantiate abstract class
-        # Just verify the abstract methods exist
         assert hasattr(BaseNode, "INPUT_TYPES")
         assert hasattr(BaseNode, "RETURN_TYPES")
         assert hasattr(BaseNode, "execute")
+
+        assert getattr(BaseNode.INPUT_TYPES, "__isabstractmethod__", False)
+        assert getattr(BaseNode.RETURN_TYPES, "__isabstractmethod__", False)
+        assert getattr(BaseNode.execute, "__isabstractmethod__", False)
+
+        with pytest.raises(TypeError, match="abstract"):
+            BaseNode()  # type: ignore[abstract]
 
     def test_concrete_node_implements_interface(self):
         """Concrete nodes should implement required methods."""

--- a/tests/test_comfyui.py
+++ b/tests/test_comfyui.py
@@ -113,19 +113,19 @@ class TestBaseNode:
         assert BaseNode.CATEGORY == "Transformation Portal"
 
     def test_base_node_abstract_methods(self):
-        """BaseNode should require INPUT_TYPES, RETURN_TYPES, execute."""
+        """BaseNode should declare INPUT_TYPES, RETURN_TYPES, execute as abstract."""
         from transformation_portal.comfyui.custom_nodes import BaseNode
 
-        assert hasattr(BaseNode, "INPUT_TYPES")
-        assert hasattr(BaseNode, "RETURN_TYPES")
-        assert hasattr(BaseNode, "execute")
-
-        assert getattr(BaseNode.INPUT_TYPES, "__isabstractmethod__", False)
-        assert getattr(BaseNode.RETURN_TYPES, "__isabstractmethod__", False)
-        assert getattr(BaseNode.execute, "__isabstractmethod__", False)
-
-        with pytest.raises(TypeError, match="abstract"):
-            BaseNode()  # type: ignore[abstract]
+        # ABCMeta.__abstractmethods__ is the canonical, descriptor-agnostic
+        # invariant: it's the frozenset ABCMeta consults to block instantiation,
+        # and it's stable across Python versions and across classmethod /
+        # staticmethod / property descriptors (whereas BaseNode.INPUT_TYPES
+        # goes through the descriptor protocol and may not expose
+        # __isabstractmethod__ reliably).
+        expected = {"INPUT_TYPES", "RETURN_TYPES", "execute"}
+        assert expected <= BaseNode.__abstractmethods__, (
+            f"Expected {expected} ⊆ BaseNode.__abstractmethods__, " f"got {set(BaseNode.__abstractmethods__)}"
+        )
 
     def test_concrete_node_implements_interface(self):
         """Concrete nodes should implement required methods."""

--- a/tests/test_depth_tools.py
+++ b/tests/test_depth_tools.py
@@ -323,6 +323,16 @@ class TestMultiprocessing:
         assert len(output_files) == 4, "Expected 4 output files"
 
 
+# Both depth-tools modules ship the same effect functions and were both
+# affected by the broadcasting fix (mask_strength / protector were being
+# promoted to 4D by a stray [..., None]). Parametrise the shape regression
+# over both so neither module can drift back to a 4D output.
+_DEPTH_TOOLS_MODULES = [
+    "src.transformation_portal.pipelines.depth_tools",
+    "src.transformation_portal.depth.tools",
+]
+
+
 class TestDepthEffectShape:
     """Pin output shape so accidental [..., None] broadcasts can't return."""
 
@@ -333,24 +343,28 @@ class TestDepthEffectShape:
         depth = deterministic_rng.random((H, W)).astype("float32")
         return H, W, img, depth
 
-    def test_apply_depth_clarity_returns_hwc(self, hwc_inputs):
-        from src.transformation_portal.pipelines.depth_tools import apply_depth_clarity
+    @pytest.mark.parametrize("module_path", _DEPTH_TOOLS_MODULES)
+    def test_apply_depth_clarity_returns_hwc(self, module_path, hwc_inputs):
+        import importlib
+
+        apply_depth_clarity = importlib.import_module(module_path).apply_depth_clarity
 
         H, W, img, depth = hwc_inputs
-        out = apply_depth_clarity(img, depth)
-        assert out.shape == (H, W, 3)
+        assert apply_depth_clarity(img, depth).shape == (H, W, 3)
 
         sky = np.zeros((H, W), dtype="float32")
         building = np.ones((H, W), dtype="float32")
         out = apply_depth_clarity(img, depth, sky_mask=sky, building_mask=building)
         assert out.shape == (H, W, 3)
 
-    def test_apply_depth_dof_returns_hwc(self, hwc_inputs):
-        from src.transformation_portal.pipelines.depth_tools import apply_depth_dof
+    @pytest.mark.parametrize("module_path", _DEPTH_TOOLS_MODULES)
+    def test_apply_depth_dof_returns_hwc(self, module_path, hwc_inputs):
+        import importlib
+
+        apply_depth_dof = importlib.import_module(module_path).apply_depth_dof
 
         H, W, img, depth = hwc_inputs
-        out = apply_depth_dof(img, depth, edge_preserving=False)
-        assert out.shape == (H, W, 3)
+        assert apply_depth_dof(img, depth, edge_preserving=False).shape == (H, W, 3)
 
         sky = np.zeros((H, W), dtype="float32")
         building = np.ones((H, W), dtype="float32")

--- a/tests/test_depth_tools.py
+++ b/tests/test_depth_tools.py
@@ -9,6 +9,7 @@ Tests for depth_tools.py batch processing and error handling
 
 from pathlib import Path
 
+import numpy as np
 import pytest
 from PIL import Image
 
@@ -320,6 +321,41 @@ class TestMultiprocessing:
         # Check all output files were created
         output_files = list(Path(temp_dirs["output"]).glob("*_depthhaze.*"))
         assert len(output_files) == 4, "Expected 4 output files"
+
+
+class TestDepthEffectShape:
+    """Pin output shape so accidental [..., None] broadcasts can't return."""
+
+    @pytest.fixture
+    def hwc_inputs(self, deterministic_rng):
+        H, W = 32, 48
+        img = deterministic_rng.random((H, W, 3)).astype("float32")
+        depth = deterministic_rng.random((H, W)).astype("float32")
+        return H, W, img, depth
+
+    def test_apply_depth_clarity_returns_hwc(self, hwc_inputs):
+        from src.transformation_portal.pipelines.depth_tools import apply_depth_clarity
+
+        H, W, img, depth = hwc_inputs
+        out = apply_depth_clarity(img, depth)
+        assert out.shape == (H, W, 3)
+
+        sky = np.zeros((H, W), dtype="float32")
+        building = np.ones((H, W), dtype="float32")
+        out = apply_depth_clarity(img, depth, sky_mask=sky, building_mask=building)
+        assert out.shape == (H, W, 3)
+
+    def test_apply_depth_dof_returns_hwc(self, hwc_inputs):
+        from src.transformation_portal.pipelines.depth_tools import apply_depth_dof
+
+        H, W, img, depth = hwc_inputs
+        out = apply_depth_dof(img, depth, edge_preserving=False)
+        assert out.shape == (H, W, 3)
+
+        sky = np.zeros((H, W), dtype="float32")
+        building = np.ones((H, W), dtype="float32")
+        out = apply_depth_dof(img, depth, edge_preserving=False, sky_mask=sky, building_mask=building)
+        assert out.shape == (H, W, 3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Two related corrections, both surfaced while closing TODO_INVENTORY §2.2 (ComfyUI BaseNode abstractness):

## 1. test(comfyui): assert BaseNode is genuinely abstract

`tests/test_comfyui.py::TestBaseNode::test_base_node_abstract_methods` only checked `hasattr(BaseNode, ...)` — the comment claimed "Cannot instantiate abstract class" but never verified it. Now that `@abstractmethod` decorators are in place on `BaseNode` (per TODO_INVENTORY §2.2 / QW-1), the test asserts that the canonical `BaseNode.__abstractmethods__` set declares each method abstract.

`__abstractmethods__` is the frozenset ABCMeta itself consults when blocking instantiation, so it's the most stable / descriptor-agnostic invariant — preferable to per-attribute `__isabstractmethod__` lookups (which go through the descriptor protocol and aren't reliable across `classmethod` / `staticmethod` / `property`) or to constructing `BaseNode()` (which pylint flags as `E0110 abstract-class-instantiated`).

## 2. fix(depth_tools): drop redundant `[..., None]` producing 4D output

While verifying the change above against the broader CI parity, two pre-existing tests in `tests/test_depth_tools.py` failed with `PIL.Image.fromarray` rejecting `(1, 1, H, 3) |u1` arrays:

- `TestBatchProcessing::test_partial_failure_scenario`
- `TestCLIParsing::test_cli_allow_partial_success_flag`

`apply_depth_clarity` and `apply_depth_dof` both promote 2D `sky` / `building` masks to `(H, W, 1)` near the top of the function, then re-applied `[..., None]` to derived `mask_strength` / `protector` — operands already `(H, W, 1)` — promoting them to `(H, W, 1, 1)` and broadcasting the final result to `(H, H, W, 3)`. The fix removes the redundant `[..., None]` at both sites in both `src/transformation_portal/pipelines/depth_tools.py` and the canonical `src/transformation_portal/depth/tools.py`.

`TestDepthEffectShape` adds a parametrized regression that pins the `(H, W, 3)` invariant for both `apply_depth_clarity` and `apply_depth_dof`, against **both** depth-tools modules, with and without explicit sky / building masks — the kind of test that would have caught this directly.

## Files

| File | Change |
| ---- | ------ |
| `tests/test_comfyui.py` | Replace brittle hasattr/isabstractmethod check with canonical `__abstractmethods__` subset assertion. |
| `tests/test_depth_tools.py` | Add `TestDepthEffectShape`: parametrized `(H, W, 3)` shape regression for clarity / dof × `pipelines.depth_tools` / `depth.tools`. |
| `src/transformation_portal/pipelines/depth_tools.py` | Drop redundant `[..., None]` on `mask_strength` / `protector`. |
| `src/transformation_portal/depth/tools.py` | Same broadcasting fix. |

## Test plan

- [x] `pytest tests/test_depth_tools.py` — 17 passed (was 13 with 2 failing pre-fix).
- [x] `pytest tests/test_comfyui.py` — abstract test asserted directly via in-process import; rest skip on this env (no torch/cv2).
- [x] Pre-commit hooks (Black/isort/ML isolation/marker check/gitleaks/etc.) all green on changed files.
- [x] CI-parity `lint_runner.sh local` — flake8 clean; pylint advisory only (E0110 cleared).