### PR TITLE
feat(samples): generate minimal fixtures locally instead of via 3rd-party

### DIFF
--- a/scripts/download_samples.py
+++ b/scripts/download_samples.py
@@ -55,18 +55,23 @@ except ImportError:
 SAMPLE_REGISTRY: Dict[str, Dict] = {
     # ========================================================================
     # MINIMAL: Test fixtures for unit tests (synthetic images)
+    # Generated locally — no network or third-party hosting dependency.
     # ========================================================================
     "test_image_small": {
         "category": "minimal",
-        "url": "https://via.placeholder.com/100x100.jpg",  # Placeholder until release
+        "url": None,
+        "synthetic": "rgb_gradient",
+        "synthetic_kwargs": {"width": 100, "height": 100, "seed": 0},
         "size": "1KB",
         "path": "tests/fixtures/test_image_small.jpg",
-        "sha256": None,  # Add after upload
+        "sha256": None,
         "description": "Tiny test image for unit tests (100x100px)",
     },
     "test_depth_map": {
         "category": "minimal",
-        "url": "https://via.placeholder.com/256x256.jpg",  # Placeholder until release
+        "url": None,
+        "synthetic": "depth_gradient",
+        "synthetic_kwargs": {"width": 256, "height": 256, "seed": 1},
         "size": "5KB",
         "path": "tests/fixtures/test_depth.jpg",
         "sha256": None,
@@ -164,6 +169,54 @@ def verify_checksum(file_path: Path, expected_sha256: Optional[str]) -> bool:
     return True
 
 
+def _generate_synthetic_image(kind: str, output_path: Path, **kwargs) -> bool:
+    """Generate a deterministic synthetic image fixture.
+
+    Recognized kinds:
+        - "rgb_gradient": colorful gradient + low-amplitude noise (RGB JPEG)
+        - "depth_gradient": grayscale radial gradient (single-channel JPEG)
+
+    All output is fully deterministic given the same kwargs (uses a seeded RNG)
+    so committed fixtures stay reproducible without third-party hosting.
+    """
+    try:
+        import numpy as np
+        from PIL import Image
+    except ImportError as exc:
+        print(f"❌ Synthetic generation requires Pillow + numpy: {exc}")
+        return False
+
+    width = int(kwargs.get("width", 100))
+    height = int(kwargs.get("height", 100))
+    seed = int(kwargs.get("seed", 0))
+    rng = np.random.default_rng(seed)
+
+    if kind == "rgb_gradient":
+        ys = np.linspace(0, 255, height, dtype=np.float32)[:, None]
+        xs = np.linspace(0, 255, width, dtype=np.float32)[None, :]
+        red = np.broadcast_to(xs, (height, width))
+        green = np.broadcast_to(ys, (height, width))
+        blue = (xs + ys) * 0.5
+        rgb = np.stack([red, green, blue], axis=-1)
+        rgb = rgb + rng.uniform(-8.0, 8.0, size=rgb.shape).astype(np.float32)
+        image = Image.fromarray(np.clip(rgb, 0, 255).astype(np.uint8), mode="RGB")
+    elif kind == "depth_gradient":
+        cy, cx = (height - 1) / 2.0, (width - 1) / 2.0
+        yy, xx = np.indices((height, width), dtype=np.float32)
+        radius = np.hypot(yy - cy, xx - cx)
+        radius /= max(radius.max(), 1.0)
+        depth = (1.0 - radius) * 255.0
+        depth = depth + rng.uniform(-2.0, 2.0, size=depth.shape).astype(np.float32)
+        image = Image.fromarray(np.clip(depth, 0, 255).astype(np.uint8), mode="L")
+    else:
+        print(f"❌ Unknown synthetic kind: {kind!r}")
+        return False
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    image.save(output_path, format="JPEG", quality=90)
+    return True
+
+
 def download_file(url: str, output_path: Path, description: str, sha256: Optional[str] = None) -> bool:
     """Download a file with progress bar and checksum verification."""
     try:
@@ -236,6 +289,19 @@ def download_samples(categories: List[str], output_dir: Optional[Path] = None, f
         if output_path.exists() and not force:
             print(f"⏭️  Skipped {sample['name']} (already exists)")
             skipped += 1
+            continue
+
+        # Locally synthesized fixtures take precedence over remote URLs.
+        synthetic_kind = sample.get("synthetic")
+        if synthetic_kind:
+            success = _generate_synthetic_image(
+                synthetic_kind, output_path, **sample.get("synthetic_kwargs", {})
+            )
+            if success:
+                print(f"✅ Generated {sample['name']} ({sample['size']}, synthetic)")
+                downloaded += 1
+            else:
+                failed += 1
             continue
 
         # Check if URL is available
@@ -312,7 +378,12 @@ Categories:
             samples = get_samples_by_category(category)
             print(f"\n{category.upper()}:")
             for sample in samples:
-                status = "✅ Ready" if sample["url"] else "⏳ Pending v2.4.0"
+                if sample.get("synthetic"):
+                    status = "🛠  Synthetic (local)"
+                elif sample["url"]:
+                    status = "✅ Ready"
+                else:
+                    status = "⏳ Pending v2.4.0"
                 print(f"  - {sample['name']:30} ({sample['size']:>6}) {status}")
                 print(f"    {sample['description']}")
         print()

--- a/scripts/download_samples.py
+++ b/scripts/download_samples.py
@@ -294,9 +294,7 @@ def download_samples(categories: List[str], output_dir: Optional[Path] = None, f
         # Locally synthesized fixtures take precedence over remote URLs.
         synthetic_kind = sample.get("synthetic")
         if synthetic_kind:
-            success = _generate_synthetic_image(
-                synthetic_kind, output_path, **sample.get("synthetic_kwargs", {})
-            )
+            success = _generate_synthetic_image(synthetic_kind, output_path, **sample.get("synthetic_kwargs", {}))
             if success:
                 print(f"✅ Generated {sample['name']} ({sample['size']}, synthetic)")
                 downloaded += 1

--- a/scripts/download_samples.py
+++ b/scripts/download_samples.py
@@ -169,22 +169,25 @@ def verify_checksum(file_path: Path, expected_sha256: Optional[str]) -> bool:
     return True
 
 
-def _generate_synthetic_image(kind: str, output_path: Path, **kwargs) -> bool:
-    """Generate a deterministic synthetic image fixture.
+def _render_synthetic_image_bytes(kind: str, **kwargs) -> Optional[bytes]:
+    """Render a synthetic fixture to JPEG bytes in memory (no I/O).
 
     Recognized kinds:
         - "rgb_gradient": colorful gradient + low-amplitude noise (RGB JPEG)
         - "depth_gradient": grayscale radial gradient (single-channel JPEG)
 
-    All output is fully deterministic given the same kwargs (uses a seeded RNG)
-    so committed fixtures stay reproducible without third-party hosting.
+    Output is fully deterministic given the same kwargs (seeded RNG) so
+    committed fixtures stay reproducible without third-party hosting.
+    Returns None on dependency or input error.
     """
     try:
+        import io
+
         import numpy as np
         from PIL import Image
     except ImportError as exc:
         print(f"❌ Synthetic generation requires Pillow + numpy: {exc}")
-        return False
+        return None
 
     width = int(kwargs.get("width", 100))
     height = int(kwargs.get("height", 100))
@@ -210,11 +213,51 @@ def _generate_synthetic_image(kind: str, output_path: Path, **kwargs) -> bool:
         image = Image.fromarray(np.clip(depth, 0, 255).astype(np.uint8), mode="L")
     else:
         print(f"❌ Unknown synthetic kind: {kind!r}")
-        return False
+        return None
 
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    image.save(output_path, format="JPEG", quality=90)
-    return True
+    buf = io.BytesIO()
+    image.save(buf, format="JPEG", quality=90)
+    return buf.getvalue()
+
+
+def _generate_synthetic_image(kind: str, output_path: Path, **kwargs) -> str:
+    """Materialize a synthetic fixture at output_path.
+
+    Returns one of:
+        - "up_to_date": existing file already matches deterministic output
+        - "generated":  bytes were (re)written (migration from stale placeholder
+                        fixtures or first-time write)
+        - "failed":     dependency, render, or filesystem error
+    """
+    expected = _render_synthetic_image_bytes(kind, **kwargs)
+    if expected is None:
+        return "failed"
+
+    # Migration path: stale fixtures left behind by older versions of this
+    # script (placeholder downloads from a third party) get overwritten when
+    # their bytes don't match the current deterministic render. Matching
+    # bytes are left untouched to preserve idempotency and mtime.
+    if output_path.exists():
+        try:
+            if output_path.read_bytes() == expected:
+                return "up_to_date"
+        except OSError as exc:
+            print(f"❌ Could not read existing {output_path}: {exc}")
+            return "failed"
+
+    tmp_path = output_path.with_suffix(output_path.suffix + ".tmp")
+    try:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path.write_bytes(expected)
+        tmp_path.replace(output_path)
+        return "generated"
+    except OSError as exc:
+        print(f"❌ Failed to write {output_path}: {exc}")
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        return "failed"
 
 
 def download_file(url: str, output_path: Path, description: str, sha256: Optional[str] = None) -> bool:
@@ -285,21 +328,27 @@ def download_samples(categories: List[str], output_dir: Optional[Path] = None, f
     for sample in samples_to_download:
         output_path = output_dir / sample["path"]
 
-        # Skip if file exists and not forcing re-download
-        if output_path.exists() and not force:
-            print(f"⏭️  Skipped {sample['name']} (already exists)")
-            skipped += 1
-            continue
-
-        # Locally synthesized fixtures take precedence over remote URLs.
+        # Locally synthesized fixtures bypass the skip-if-exists short-circuit
+        # because regenerating costs ~1ms and we need to migrate stale
+        # placeholder fixtures from older script versions. The helper itself
+        # returns "up_to_date" when bytes already match, preserving idempotency.
         synthetic_kind = sample.get("synthetic")
         if synthetic_kind:
-            success = _generate_synthetic_image(synthetic_kind, output_path, **sample.get("synthetic_kwargs", {}))
-            if success:
+            status = _generate_synthetic_image(synthetic_kind, output_path, **sample.get("synthetic_kwargs", {}))
+            if status == "up_to_date":
+                print(f"⏭️  Skipped {sample['name']} (synthetic, up to date)")
+                skipped += 1
+            elif status == "generated":
                 print(f"✅ Generated {sample['name']} ({sample['size']}, synthetic)")
                 downloaded += 1
             else:
                 failed += 1
+            continue
+
+        # Skip if file exists and not forcing re-download (downloads only)
+        if output_path.exists() and not force:
+            print(f"⏭️  Skipped {sample['name']} (already exists)")
+            skipped += 1
             continue
 
         # Check if URL is available

--- a/tests/validation/test_download_samples.py
+++ b/tests/validation/test_download_samples.py
@@ -1,0 +1,108 @@
+"""Unit tests for the synthetic-fixture path in scripts/download_samples.py."""
+
+# pylint: disable=redefined-outer-name  # pytest fixtures
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+from PIL import Image
+
+pytestmark = [
+    pytest.mark.unit,
+]
+
+
+def _load_download_samples_module() -> ModuleType:
+    repo_root = Path(__file__).resolve().parents[2]
+    module_path = repo_root / "scripts" / "download_samples.py"
+    spec = importlib.util.spec_from_file_location("download_samples_under_test", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def download_samples() -> ModuleType:
+    return _load_download_samples_module()
+
+
+def test_rgb_gradient_dimensions_and_mode(download_samples: ModuleType, tmp_path: Path) -> None:
+    output_path = tmp_path / "rgb.jpg"
+    status = download_samples._generate_synthetic_image("rgb_gradient", output_path, width=100, height=100, seed=0)
+    assert status == "generated"
+    with Image.open(output_path) as img:
+        assert img.size == (100, 100)
+        assert img.mode == "RGB"
+
+
+def test_depth_gradient_dimensions_and_mode(download_samples: ModuleType, tmp_path: Path) -> None:
+    output_path = tmp_path / "depth.jpg"
+    status = download_samples._generate_synthetic_image("depth_gradient", output_path, width=256, height=256, seed=1)
+    assert status == "generated"
+    with Image.open(output_path) as img:
+        assert img.size == (256, 256)
+        assert img.mode == "L"
+
+
+def test_synthetic_output_is_deterministic(download_samples: ModuleType, tmp_path: Path) -> None:
+    """Same kwargs must produce byte-identical fixtures across runs."""
+    a = tmp_path / "a.jpg"
+    b = tmp_path / "b.jpg"
+    assert download_samples._generate_synthetic_image("rgb_gradient", a, width=100, height=100, seed=0) == "generated"
+    assert download_samples._generate_synthetic_image("rgb_gradient", b, width=100, height=100, seed=0) == "generated"
+    assert a.read_bytes() == b.read_bytes()
+
+
+def test_idempotent_when_existing_bytes_match(download_samples: ModuleType, tmp_path: Path) -> None:
+    """Re-running with an up-to-date fixture must report 'up_to_date' and leave bytes/mtime untouched."""
+    output_path = tmp_path / "rgb.jpg"
+    assert (
+        download_samples._generate_synthetic_image("rgb_gradient", output_path, width=100, height=100, seed=0) == "generated"
+    )
+    original_bytes = output_path.read_bytes()
+    original_mtime_ns = output_path.stat().st_mtime_ns
+
+    status = download_samples._generate_synthetic_image("rgb_gradient", output_path, width=100, height=100, seed=0)
+    assert status == "up_to_date"
+    assert output_path.read_bytes() == original_bytes
+    assert output_path.stat().st_mtime_ns == original_mtime_ns
+
+
+def test_stale_placeholder_fixture_is_migrated(download_samples: ModuleType, tmp_path: Path) -> None:
+    """Pre-existing fixture content from older script versions must be replaced."""
+    output_path = tmp_path / "rgb.jpg"
+    # Simulate a stale placeholder fixture left behind by the old via.placeholder.com path.
+    output_path.write_bytes(b"stale-placeholder-content")
+
+    status = download_samples._generate_synthetic_image("rgb_gradient", output_path, width=100, height=100, seed=0)
+    assert status == "generated"
+    assert output_path.read_bytes() != b"stale-placeholder-content"
+    with Image.open(output_path) as img:
+        assert img.size == (100, 100)
+        assert img.mode == "RGB"
+
+
+def test_unwritable_directory_returns_failed_without_partial_output(download_samples: ModuleType, tmp_path: Path) -> None:
+    """An unwritable target must yield status='failed' and leave no .tmp residue."""
+    blocker = tmp_path / "blocker"
+    blocker.write_bytes(b"i am a file, not a directory")
+    # Path traversal through a regular file -> mkdir/write raises OSError.
+    target = blocker / "nested" / "rgb.jpg"
+
+    status = download_samples._generate_synthetic_image("rgb_gradient", target, width=8, height=8, seed=0)
+    assert status == "failed"
+    # No partial fixture or .tmp file should be left in the parent.
+    leftover = list(tmp_path.glob("**/*.tmp"))
+    assert not leftover, f"Unexpected .tmp residue: {leftover}"
+
+
+def test_unknown_synthetic_kind_returns_failed(download_samples: ModuleType, tmp_path: Path) -> None:
+    output_path = tmp_path / "x.jpg"
+    status = download_samples._generate_synthetic_image("not_a_real_kind", output_path)
+    assert status == "failed"
+    assert not output_path.exists()


### PR DESCRIPTION
The "minimal" category in download_samples.py claimed to provide "tiny
synthetic images for unit tests" but actually fetched them from
via.placeholder.com — a third-party host that adds a network dependency
and unreliable SLA to test fixture provisioning.

Replace those URLs with deterministic, seeded local synthesis (RGB
gradient + low-amplitude noise, radial depth gradient) using PIL/numpy
that are already core deps. The minimal category now requires no network
and produces byte-identical output across runs.

The demo/full categories remain pending the GitHub Release upload tracked
under TODO_INVENTORY_QUICK_REF.md Finding #5.