### PR TITLE
docs(governance): inventory monolithic-file decomposition targets

### DIFF
--- a/docs/analysis/TODO_INVENTORY.md
+++ b/docs/analysis/TODO_INVENTORY.md
@@ -1934,4 +1934,21 @@ The previous v2.4.0 count of "12" tracked only `src/` and contained internal ari
 
 ---
 
+## 2026-05-04 Refresh — Monolithic-File TODO Audit
+
+**Trigger:** Branch `claude/fix-monolithic-file-todos-63mEO` review.
+**Scanner snapshot:** [`todo_scanner_snapshot.json`](todo_scanner_snapshot.json) (committed alongside this entry; reproducible via `python scripts/validation/scan_todo_inventory.py --json`).
+
+**Findings:**
+- `python scripts/validation/scan_todo_inventory.py --check-governance` → exit 0; **0 ungoverned TODOs** across 1,492 files scanned.
+- **25** `NotImplementedError` instances, all governed (abstract methods, phase gates, platform limits) — unchanged from the 2026-05-01 baseline in `TODO_INVENTORY_QUICK_REF.md`.
+- **Zero** `TODO|FIXME|XXX|HACK` markers in the five largest source modules: `app.py` (10,039 LOC), `lux_depth_v3/orchestrator.py` (7,257), `lux_depth_v3/segmentation_backend.py` (2,519), `pipelines/rendering_4k_pipeline.py` (2,380), `spatial_ai/orchestration/pipeline.py` (2,121 — only `TODO_INVENTORY.md` reference at line 1774, a governed phase gate for single-view reconstruction).
+- ADR-043 orchestrator decomposition is complete; the open guidance is residual slimming, captured in `DEVELOPMENT_ROADMAP_2026_Q2.md` lines 174–210.
+
+**Action taken:** No source changes. Authored a ranked seam target list at [`../architecture/MONOLITH_DECOMPOSITION_TARGETS.md`](../architecture/MONOLITH_DECOMPOSITION_TARGETS.md) and an ADR stub at [`../architecture/ADR-045-monolith-decomposition-residuals.md`](../architecture/ADR-045-monolith-decomposition-residuals.md) (status: Proposed). Future extraction PRs draw from that target list under the ADR-043 phased pattern.
+
+**Diff vs prior baseline:** none — counts and governance posture identical to the 2026-05-01 review. This refresh replaces the manual narrative drift control with a committed JSON snapshot.
+
+---
+
 **END OF TODO INVENTORY v2.0.0**

--- a/docs/analysis/todo_scanner_snapshot.json
+++ b/docs/analysis/todo_scanner_snapshot.json
@@ -1,0 +1,243 @@
+{
+  "summary": {
+    "total": 25,
+    "ungoverned": 0,
+    "files_scanned": 1492,
+    "by_type": {
+      "NotImplementedError": 25
+    }
+  },
+  "items": [
+    {
+      "path": "scripts/apex_verify_contract.py",
+      "lineno": 42,
+      "col_offset": 8,
+      "type": "NotImplementedError",
+      "message": "(no message)",
+      "has_governance_ref": true,
+      "governance_refs": []
+    },
+    {
+      "path": "scripts/pipelines/tiff_enhancement_pipeline.py",
+      "lineno": 157,
+      "col_offset": 8,
+      "type": "NotImplementedError",
+      "message": "(no message)",
+      "has_governance_ref": true,
+      "governance_refs": []
+    },
+    {
+      "path": "scripts/pipelines/unified_meta_pipeline.py",
+      "lineno": 171,
+      "col_offset": 8,
+      "type": "NotImplementedError",
+      "message": "(no message)",
+      "has_governance_ref": true,
+      "governance_refs": []
+    },
+    {
+      "path": "scripts/utilities/depth_anything_v2.py",
+      "lineno": 167,
+      "col_offset": 12,
+      "type": "NotImplementedError",
+      "message": "(no message)",
+      "has_governance_ref": true,
+      "governance_refs": []
+    },
+    {
+      "path": "src/transformation_portal/comfyui/custom_nodes.py",
+      "lineno": 62,
+      "col_offset": 8,
+      "type": "NotImplementedError",
+      "message": "(no message)",
+      "has_governance_ref": true,
+      "governance_refs": []
+    },
+    {
+      "path": "src/transformation_portal/comfyui/custom_nodes.py",
+      "lineno": 68,
+      "col_offset": 8,
+      "type": "NotImplementedError",
+      "message": "(no message)",
+      "has_governance_ref": true,
+      "governance_refs": []
+    },
+    {
+      "path": "src/transformation_portal/comfyui/custom_nodes.py",
+      "lineno": 73,
+      "col_offset": 8,
+      "type": "NotImplementedError",
+      "message": "(no message)",
+      "has_governance_ref": true,
+      "governance_refs": []
+    },
+    {
+      "path": "src/transformation_portal/depth/models/depth_anything_v2.py",
+      "lineno": 369,
+      "col_offset": 12,
+      "type": "NotImplementedError",
+      "message": "(no message)",
+      "has_governance_ref": true,
+      "governance_refs": []
+    },
+    {
+      "path": "src/transformation_portal/depth/processors/base.py",
+      "lineno": 38,
+      "col_offset": 8,
+      "type": "NotImplementedError",
+      "message": "Subclass must implement process()",
+      "has_governance_ref": true,
+      "governance_refs": []
+    },
+    {
+      "path": "src/transformation_portal/depth/processors/base.py",
+      "lineno": 49,
+      "col_offset": 8,
+      "type": "NotImplementedError",
+      "message": "Subclass must implement _get_config_params()",
+      "has_governance_ref": true,
+      "governance_refs": []
+    },
+    {
+      "path": "src/transformation_portal/execution_graph/nodes/base.py",
+      "lineno": 76,
+      "col_offset": 8,
+      "type": "NotImplementedError",
+      "message": "Subclasses must implement run()",
+      "has_governance_ref": true,
+      "governance_refs": []
+    },
+    {
+      "path": "src/transformation_portal/spatial_ai/orchestration/pipeline.py",
+      "lineno": 1772,
+      "col_offset": 12,
+      "type": "NotImplementedError",
+      "message": "3D reconstruction requires multi-view input. Single-view reconstruction is not yet implemented. (TODO_INVENTORY.md) Use SceneBuilder directly with multiple views for 3DGS.",
+      "has_governance_ref": true,
+      "governance_refs": [
+        "(TODO_INVENTORY.md)"
+      ]
+    },
+    {
+      "path": "src/transformation_portal/spatial_ai/reconstruction/gaussian_backend.py",
+      "lineno": 261,
+      "col_offset": 8,
+      "type": "NotImplementedError",
+      "message": "(no message)",
+      "has_governance_ref": true,
+      "governance_refs": []
+    },
+    {
+      "path": "src/transformation_portal/spatial_ai/reconstruction/scene_builder.py",
+      "lineno": 262,
+      "col_offset": 12,
+      "type": "NotImplementedError",
+      "message": "(no message)",
+      "has_governance_ref": true,
+      "governance_refs": []
+    },
+    {
+      "path": "src/transformation_portal/utils/security.py",
+      "lineno": 418,
+      "col_offset": 8,
+      "type": "NotImplementedError",
+      "message": "timeout() requires signal.SIGALRM (Unix-only). (TODO_INVENTORY.md \u00a72.4) Use multiprocessing or threading-based timeout on Windows.",
+      "has_governance_ref": true,
+      "governance_refs": [
+        "(TODO_INVENTORY.md \u00a72.4)"
+      ]
+    },
+    {
+      "path": "tests/spatial_ai/materials/test_protocol_validation.py",
+      "lineno": 30,
+      "col_offset": 8,
+      "type": "NotImplementedError",
+      "message": "(no message)",
+      "has_governance_ref": true,
+      "governance_refs": []
+    },
+    {
+      "path": "tests/spatial_ai/materials/test_protocol_validation.py",
+      "lineno": 58,
+      "col_offset": 8,
+      "type": "NotImplementedError",
+      "message": "(no message)",
+      "has_governance_ref": true,
+      "governance_refs": []
+    },
+    {
+      "path": "tests/unit/depth/test_depth_protocol.py",
+      "lineno": 284,
+      "col_offset": 16,
+      "type": "NotImplementedError",
+      "message": "(no message)",
+      "has_governance_ref": true,
+      "governance_refs": []
+    },
+    {
+      "path": "tests/unit/depth/test_depth_protocol.py",
+      "lineno": 307,
+      "col_offset": 16,
+      "type": "NotImplementedError",
+      "message": "(no message)",
+      "has_governance_ref": true,
+      "governance_refs": []
+    },
+    {
+      "path": "tests/unit/depth/test_depth_protocol.py",
+      "lineno": 327,
+      "col_offset": 16,
+      "type": "NotImplementedError",
+      "message": "(no message)",
+      "has_governance_ref": true,
+      "governance_refs": []
+    },
+    {
+      "path": "tests/unit/depth/test_depth_protocol.py",
+      "lineno": 391,
+      "col_offset": 16,
+      "type": "NotImplementedError",
+      "message": "(no message)",
+      "has_governance_ref": true,
+      "governance_refs": []
+    },
+    {
+      "path": "tests/unit/depth/test_depth_protocol.py",
+      "lineno": 413,
+      "col_offset": 16,
+      "type": "NotImplementedError",
+      "message": "(no message)",
+      "has_governance_ref": true,
+      "governance_refs": []
+    },
+    {
+      "path": "tests/unit/depth/test_depth_protocol.py",
+      "lineno": 450,
+      "col_offset": 16,
+      "type": "NotImplementedError",
+      "message": "(no message)",
+      "has_governance_ref": true,
+      "governance_refs": []
+    },
+    {
+      "path": "tests/unit/depth/test_depth_protocol.py",
+      "lineno": 472,
+      "col_offset": 16,
+      "type": "NotImplementedError",
+      "message": "(no message)",
+      "has_governance_ref": true,
+      "governance_refs": []
+    },
+    {
+      "path": "tests/unit/depth/test_depth_protocol.py",
+      "lineno": 526,
+      "col_offset": 16,
+      "type": "NotImplementedError",
+      "message": "(no message)",
+      "has_governance_ref": true,
+      "governance_refs": []
+    }
+  ],
+  "errors": [],
+  "governance_compliant": true
+}

--- a/docs/architecture/ADR-045-monolith-decomposition-residuals.md
+++ b/docs/architecture/ADR-045-monolith-decomposition-residuals.md
@@ -1,0 +1,154 @@
+# ADR-045: Monolith Decomposition Residuals — Governance Pattern
+
+**Status:** Proposed
+**Date:** 2026-05-04
+**Decision Makers:** Architect (review) + Specialist (implementation)
+**Replaces:** None
+**Supersedes:** None
+**Related:** [ADR-043 Orchestrator Decomposition Strategy](ADR-043-orchestrator-decomposition.md), [Development Roadmap Q2 2026 §4](DEVELOPMENT_ROADMAP_2026_Q2.md), [Monolith Decomposition Targets](MONOLITH_DECOMPOSITION_TARGETS.md)
+
+---
+
+## Context
+
+ADR-043 successfully decomposed `EnhanceOrchestrator` (was 6,108 LOC) into five focused seams (`config_resolver`, `pipeline_coordinator`, `execution_engine`, `artifact_manager`, `validators/`). It explicitly scoped that work to a single class and a single module. It did **not** establish a reusable governance pattern for the rest of the repo.
+
+The 2026-05-04 audit ([TODO Inventory refresh](../analysis/TODO_INVENTORY.md), snapshot at [`todo_scanner_snapshot.json`](../analysis/todo_scanner_snapshot.json)) confirms:
+
+- `src/` source-code TODOs about decomposition: **0** (CI-enforced via `enforcement.yml`).
+- Five known monoliths still exceed informal "acceptable" sizes: `app.py` (10,039 LOC), `lux_depth_v3/orchestrator.py` (7,257), `lux_depth_v3/segmentation_backend.py` (2,519), `pipelines/rendering_4k_pipeline.py` (2,380), `spatial_ai/orchestration/pipeline.py` (2,121).
+- The Q2 2026 roadmap (§4 "Orchestrator Residual Slimming & Boundary Enforcement") commits to ratcheting `orchestrator.py` down by ~200 LOC/quarter but does not bind the other four files.
+
+Without a shared governance pattern, future extractions will drift in shape, tests, and re-export contracts — undoing the consistency ADR-043 achieved.
+
+### Current Problems
+
+1. **No standing pattern:** Each future decomposition would re-derive its own seam discipline, risking inconsistency.
+2. **No persistent target list:** Without a tracked list of candidate seams, decomposition becomes ad-hoc and reactive.
+3. **No bright line for boundary drift:** Once a module is decomposed, helper logic can creep back without a stated invariant to point to.
+4. **No backward-compat contract:** ADR-043 chose re-export shims for compatibility, but that choice has not been generalized.
+
+### Metrics (informational only — this ADR does not bind specific values)
+
+| Module | LOC | TODO/FIXME markers | Has destination seams? |
+|---|---:|---:|---|
+| `app.py` | 10,039 | 0 | No (greenfield) |
+| `lux_depth_v3/orchestrator.py` | 7,257 | 0 | Yes (ADR-043 modules) |
+| `lux_depth_v3/segmentation_backend.py` | 2,519 | 0 | No |
+| `pipelines/rendering_4k_pipeline.py` | 2,380 | 0 | No |
+| `spatial_ai/orchestration/pipeline.py` | 2,121 | 0 (1 governed phase gate) | No |
+
+---
+
+## Decision
+
+Adopt a single, repo-wide governance pattern for monolith decomposition, recorded here, and tracked operationally via [`MONOLITH_DECOMPOSITION_TARGETS.md`](MONOLITH_DECOMPOSITION_TARGETS.md).
+
+### Pattern (binding when invoked)
+
+A decomposition PR claiming this ADR **must**:
+
+1. **Pick a named seam from the targets doc.** No ad-hoc seams; if a new seam is needed, the targets doc is amended in a separate PR first.
+2. **Extract by responsibility, not by line count.** Lines are an indicator, not the goal. The seam must encapsulate one cohesive responsibility and expose a minimal data-class or callable contract.
+3. **Add the new module + its unit tests first.** The new module lands green before any caller switches.
+4. **Maintain backward compatibility via re-exports** from the original file (e.g., `from .new_module import Symbol  # noqa: F401`). No call-site rewrites in unrelated modules during the same PR.
+5. **Keep imports acyclic.** Use `TYPE_CHECKING` guards if a circular type reference appears; never solve a cycle by re-merging modules.
+6. **Preserve lazy-import discipline.** Heavy ML imports must remain lazy in the new module — the CLAUDE.md "lazy imports are mandatory" rule still applies.
+7. **Run governance gates clean:** `python scripts/validation/scan_todo_inventory.py --check-governance`, `make check-json-serialization check-yaml-governance check-python-headers`, plus the per-target verification commands listed in the targets doc.
+8. **Cite this ADR and update the targets-doc status table** in the PR description.
+
+### Out of scope (binding)
+
+- This ADR does **not** schedule any specific extraction. Schedule lives in `MONOLITH_DECOMPOSITION_TARGETS.md` and the quarterly roadmap.
+- This ADR does **not** introduce new test markers, new linters, or new CI jobs. It reuses the existing scanner and contract tests.
+- This ADR does **not** override module-specific governance (`app.py` hardening, run-card contract, ingest contract, evidence/attestation layering). When a seam touches one of those, the relevant ADR is the binding authority and this one is supplementary.
+
+---
+
+## Alternatives Considered
+
+### Alternative 1 — Do nothing; rely on per-PR judgment
+Rejected. ADR-043's success came from a written pattern. Without one, future decompositions re-derive seam discipline and quickly diverge in shape.
+
+### Alternative 2 — One ADR per monolith
+Rejected. Five ADRs to repeat the same pattern is governance overhead. ADR-043 already exists for the orchestrator-specific decisions; subsequent work needs the *pattern*, not five copies of it.
+
+### Alternative 3 — Bind specific LOC ratchets per file
+Rejected. The Q2 roadmap already binds `orchestrator.py` to ~200 LOC/quarter. Binding the other monoliths the same way would force extractions where the seam isn't ready, encouraging line-count-driven (rather than responsibility-driven) splits.
+
+### Alternative 4 — Pattern ADR + persistent targets doc (selected)
+Selected. Captures the cross-cutting pattern once, lets per-target judgment live in a maintainable list, and keeps schedule in the roadmap.
+
+---
+
+## Consequences
+
+### Positive
+- Future decomposition PRs have a checklist instead of a debate.
+- The targets doc surfaces decomposition intent to reviewers without adding source-code TODOs.
+- Consistent backward-compat strategy (re-export shims) preserves call-sites.
+- `app.py`, `segmentation_backend.py`, `rendering_4k_pipeline.py`, and `spatial_ai/orchestration/pipeline.py` get a path to decomposition without each requiring its own ADR.
+
+### Negative
+- Adds a small bookkeeping cost: the targets doc must be kept current as seams land.
+- Risk that the targets doc becomes stale if not refreshed in the monthly inventory cadence.
+
+### Risks
+- **Boundary drift back into source modules.** Mitigation: continue the existing CLAUDE.md "do not re-monolithize" invariant; require PR descriptions to cite ADR-045.
+- **Premature extraction.** Mitigation: Pattern step 1 forbids ad-hoc seams; new seams must land in the targets doc in a separate PR with reviewer sign-off.
+- **Test coverage erosion.** Mitigation: Pattern step 3 mandates new tests on the new module before any caller switches.
+
+---
+
+## Implementation Plan
+
+This ADR is governance, not implementation. Activation follows three phases:
+
+### Phase 1 — Approve and link (this PR)
+- Land this ADR (status: Proposed) plus `MONOLITH_DECOMPOSITION_TARGETS.md` and the inventory refresh.
+- Cross-link from `TODO_INVENTORY_QUICK_REF.md` and `DEVELOPMENT_ROADMAP_2026_Q2.md` §4.
+
+### Phase 2 — First exercise (next PR, separate ticket)
+- Select a single seam from `MONOLITH_DECOMPOSITION_TARGETS.md` (recommended starter: Target 1, Seam 1A — config-fingerprint helpers).
+- Extract under this ADR's pattern. Update the targets-doc status table.
+
+### Phase 3 — Ratchet
+- Each subsequent quarter, the architect reviews the targets doc, retires shipped seams, and re-ranks remaining ones in light of new pressure.
+- Status of this ADR moves from `Proposed` → `Active` after the first successful exercise of the pattern lands on `main`.
+
+---
+
+## Success Criteria
+
+- [ ] First decomposition PR cites ADR-045 and follows the pattern checklist (target: 2026-Q2).
+- [ ] Targets doc status table is updated with each shipped seam.
+- [ ] No future PR introduces a new seam without first amending the targets doc.
+- [ ] `python scripts/validation/scan_todo_inventory.py --check-governance` continues to exit 0 across all decomposition PRs.
+- [ ] `orchestrator.py` continues to track the Q2 roadmap's ~200 LOC/quarter ratchet (or documents why the ratchet is infeasible for that quarter).
+
+---
+
+## Enforcement
+
+- **Code review:** PRs claiming "decomposition" or "extract" in the title must cite ADR-045 in the description; reviewers verify the eight pattern requirements.
+- **Governance scanner:** existing `scan_todo_inventory.py --check-governance` continues to block ungoverned TODOs; this ADR adds no new scanner rules.
+- **Boundary invariant:** CLAUDE.md "Lux Depth V3 is a decomposed orchestrator (do not re-monolithize)" generalizes — extracted seams across the repo must not be re-merged absent a superseding ADR.
+
+---
+
+## Review and Maintenance
+
+- **Owner:** Transformation Portal Architect
+- **Cadence:** Reviewed alongside the monthly TODO inventory refresh; updated when a new monolith is identified or an existing target is retired.
+- **Promotion criteria:** Move status `Proposed → Active` after the first successful pattern exercise (Phase 2). Move `Active → Superseded` only via a follow-on ADR.
+
+---
+
+## References
+
+- [ADR-043 Orchestrator Decomposition Strategy](ADR-043-orchestrator-decomposition.md) — predecessor; concrete instance the pattern generalizes.
+- [Monolith Decomposition Targets](MONOLITH_DECOMPOSITION_TARGETS.md) — operational target list.
+- [Development Roadmap Q2 2026 §4](DEVELOPMENT_ROADMAP_2026_Q2.md) — residual-slimming pressure.
+- [TODO Inventory 2026-05-04 Refresh](../analysis/TODO_INVENTORY.md) — audit that triggered this ADR.
+- [`docs/analysis/todo_scanner_snapshot.json`](../analysis/todo_scanner_snapshot.json) — reproducible scanner baseline.
+- [CLAUDE.md "do not re-monolithize"](../../CLAUDE.md) — invariant generalized by this ADR.

--- a/docs/architecture/ADR-045-monolith-decomposition-residuals.md
+++ b/docs/architecture/ADR-045-monolith-decomposition-residuals.md
@@ -55,7 +55,7 @@ A decomposition PR claiming this ADR **must**:
 5. **Keep imports acyclic.** Use `TYPE_CHECKING` guards if a circular type reference appears; never solve a cycle by re-merging modules.
 6. **Preserve lazy-import discipline.** Heavy ML imports must remain lazy in the new module — the CLAUDE.md "lazy imports are mandatory" rule still applies.
 7. **Run governance gates clean:** `python scripts/validation/scan_todo_inventory.py --check-governance`, `make check-json-serialization check-yaml-governance check-python-headers`, plus the per-target verification commands listed in the targets doc.
-8. **Cite this ADR and update the targets-doc status table** in the PR description.
+8. **Cite this ADR in the PR description and update the corresponding row in the targets-doc status table.**
 
 ### Out of scope (binding)
 

--- a/docs/architecture/DEVELOPMENT_ROADMAP_2026_Q2.md
+++ b/docs/architecture/DEVELOPMENT_ROADMAP_2026_Q2.md
@@ -204,6 +204,8 @@ Prevent new feature logic from accumulating in `orchestrator.py` and continue mo
 **Secondary indicator (directional):**
 Reduce `orchestrator.py` by **~200 LOC per quarter** or document why the ratchet is infeasible.
 
+**Target list:** Specific seam candidates for `orchestrator.py` (and other monoliths) live in [MONOLITH_DECOMPOSITION_TARGETS.md](MONOLITH_DECOMPOSITION_TARGETS.md); pattern is governed by [ADR-045](ADR-045-monolith-decomposition-residuals.md).
+
 **Effort:** 4–8 hours ongoing per quarter
 **Owner:** Architect (review) + Specialist (implementation)
 

--- a/docs/architecture/MONOLITH_DECOMPOSITION_TARGETS.md
+++ b/docs/architecture/MONOLITH_DECOMPOSITION_TARGETS.md
@@ -162,6 +162,25 @@ Track here but do **not** promote above the top 3 until at least target 1 ships 
 
 ---
 
+## Seam status table
+
+This table is the canonical progress ledger for extraction PRs that draw from the ranked targets above. Update the row for the shipped seam only; ranking changes require a separate governance refresh.
+
+| Seam | Source module | Destination | Status | Latest evidence |
+|---|---|---|---|---|
+| Target 1A — Config fingerprint helpers | `lux_depth_v3/orchestrator.py` | `lux_depth_v3/config_resolver.py` | Not started | Ranked 2026-05-04 |
+| Target 1B — Artifact reload / coercion helpers | `lux_depth_v3/orchestrator.py` | `lux_depth_v3/artifact_manager.py` | Not started | Ranked 2026-05-04 |
+| Target 1C — Backend resolution & state | `lux_depth_v3/orchestrator.py` | `lux_depth_v3/execution_engine.py` | Not started | Ranked 2026-05-04 |
+| Target 2A — Portal asset bundle | `app.py` | `src/transformation_portal/portal/asset_bundle.py` | Not started | Ranked 2026-05-04 |
+| Target 3A — Segmentation cache helpers | `lux_depth_v3/segmentation_backend.py` | `lux_depth_v3/segmentation/_cache.py` | Not started | Ranked 2026-05-04 |
+| Target 3B — Stub backend | `lux_depth_v3/segmentation_backend.py` | `lux_depth_v3/segmentation/stub.py` | Not started | Ranked 2026-05-04 |
+| Target 3C — EfficientSAM backend | `lux_depth_v3/segmentation_backend.py` | `lux_depth_v3/segmentation/efficient_sam.py` | Not started | Ranked 2026-05-04 |
+| Target 3D — SAM2 backend | `lux_depth_v3/segmentation_backend.py` | `lux_depth_v3/segmentation/sam2.py` | Not started | Ranked 2026-05-04 |
+| Target 3E — SAM ViT-H backend | `lux_depth_v3/segmentation_backend.py` | `lux_depth_v3/segmentation/sam_vit_h.py` | Not started | Ranked 2026-05-04 |
+| Target 3F — Segmentation registry | `lux_depth_v3/segmentation_backend.py` | `lux_depth_v3/segmentation/registry.py` | Not started | Ranked 2026-05-04 |
+
+---
+
 ## Process — extraction PRs draw from this list
 
 1. Pick a single seam from §"Top 3 Targets". Open a small PR titled `refactor(<area>): extract <seam> per ADR-045`.

--- a/docs/architecture/MONOLITH_DECOMPOSITION_TARGETS.md
+++ b/docs/architecture/MONOLITH_DECOMPOSITION_TARGETS.md
@@ -1,0 +1,172 @@
+# Monolith Decomposition — Ranked Seam Targets
+
+**Status:** Active inventory (2026-05-04)
+**Authority:** Companion to [ADR-043 Orchestrator Decomposition](ADR-043-orchestrator-decomposition.md) and [ADR-045 Monolith Decomposition Residuals](ADR-045-monolith-decomposition-residuals.md).
+**Source of pressure:** [Development Roadmap Q2 2026 §4 "Orchestrator Residual Slimming & Boundary Enforcement"](DEVELOPMENT_ROADMAP_2026_Q2.md).
+**Predecessor audit:** [TODO Inventory 2026-05-04 Refresh](../analysis/TODO_INVENTORY.md).
+
+---
+
+## Why this list exists
+
+The 2026-05-04 audit confirmed there are **zero `TODO|FIXME|XXX|HACK` markers** in the five largest source modules:
+
+| File | LOC | Markers | Governance signal |
+|---|---:|---:|---|
+| `app.py` | 10,039 | 0 | CLAUDE.md: known monolith; tested by feature surface |
+| `src/transformation_portal/lux_depth_v3/orchestrator.py` | 7,257 | 0 | ADR-043 complete; Q2 roadmap residual-slimming target |
+| `src/transformation_portal/lux_depth_v3/segmentation_backend.py` | 2,519 | 0 | None active |
+| `src/transformation_portal/pipelines/rendering_4k_pipeline.py` | 2,380 | 0 | None active |
+| `src/transformation_portal/spatial_ai/orchestration/pipeline.py` | 2,121 | 0 (1 governed phase gate at line 1774) | Single-view reconstruction phase gate only |
+
+Without source-code TODOs to crystallize the work, this document is the persistent target list. Each candidate names a seam, an extraction destination, and the verification pattern to use. **No extraction is performed by this document — only the prioritization.**
+
+---
+
+## Ranking criteria
+
+A seam is ranked higher when it satisfies more of:
+
+1. **Governance pressure exists** (an ADR, roadmap, or contract demands it).
+2. **Destination module already exists** so backward-compatible re-exports are cheap.
+3. **Surface is non-public-API** (no FastAPI route or contract envelope changes).
+4. **Existing tests cover the boundary** so regressions surface immediately.
+5. **Seam is structurally bounded** (continuous line range, single responsibility).
+
+Risk is rated by inverse blast-radius: contracts > security boundaries > model-lock semantics > pure data/caching helpers.
+
+---
+
+## Top 3 Targets
+
+### Target 1 — `lux_depth_v3/orchestrator.py` residual slimming
+
+**Why first:** Only target with explicit Q2 roadmap pressure; all destination modules already exist (config_resolver, pipeline_coordinator, execution_engine, artifact_manager, validators); ADR-043 establishes the phased pattern; backward-compat re-exports already in place at the facade.
+
+Three sub-seams, each independently extractable. Pick one per PR, ~200 LOC each, in line with the roadmap ratchet.
+
+**Seam 1A — Config fingerprint helpers** → `lux_depth_v3/config_resolver.py`
+
+| Symbol | Location |
+|---|---|
+| `_model_variant` | `orchestrator.py:583` |
+| `_initialize_depth_backend` | `orchestrator.py:589` |
+| `_resolve_backend_model_id` | `orchestrator.py:734` |
+| `_build_depth_cache_fingerprint` | `orchestrator.py:697` |
+| `_build_materials_fingerprint_payload` | `orchestrator.py:1082` |
+| `_build_pbr_fingerprint_payload` | `orchestrator.py:1089` |
+| `_build_apex_depth_gate_fingerprint_payload` | `orchestrator.py:1096` |
+| `_build_depth_cache_payload` | `orchestrator.py:1103` |
+| `compute_config_fingerprint` | `orchestrator.py:1114` |
+| `_finalize_run_card_config_fingerprint` | `orchestrator.py:1122` |
+| `_build_run_card_config_fingerprint` | `orchestrator.py:1135` |
+
+Risk: low. Pure-function helpers operating on already-resolved config; the existing `ConfigFingerprint` data class is the natural seam contract.
+
+**Seam 1B — Artifact reload / coercion helpers** → `lux_depth_v3/artifact_manager.py`
+
+| Symbol | Location |
+|---|---|
+| `_load_existing_manifest` | `orchestrator.py:1321` |
+| `_coerce_output_paths` | `orchestrator.py:1341` |
+| `_normalize_v2_status` | `orchestrator.py:1350` |
+| `_restore_materials_v3_from_manifest` | `orchestrator.py:1366` |
+| `_preserved_v2_result_from_manifest` | `orchestrator.py:1401` |
+| `_normalize_backend_provenance` | `orchestrator.py:1430` |
+| `_has_expanded_stage_a_fingerprint` | `orchestrator.py:1435` |
+| `_segmentation_mask_artifact_path` | `orchestrator.py:2615` |
+
+Risk: low–medium. Touches manifest schema; covered by `tests/test_backend_selection.py` and run-card contract tests.
+
+**Seam 1C — Backend resolution & state** → `lux_depth_v3/execution_engine.py`
+
+| Symbol | Location |
+|---|---|
+| `_resolve_runtime_backend_chain` | `orchestrator.py:677` |
+| `_expected_output_depth_units_for_backend` | `orchestrator.py:688` |
+| `_default_model_id_for_backend` | `orchestrator.py:716` |
+| `_derive_model_id_from_backend_instance` | `orchestrator.py:723` |
+| `_resolve_backend_model_artifact` | `orchestrator.py:770` |
+| `_seed_depth_attempts_from_selection_fallback` | `orchestrator.py:900` |
+| `_get_or_create_depth_backend` | `orchestrator.py:947` |
+| `_set_active_depth_state` | `orchestrator.py:995` |
+| `_build_backend_metadata_for_attempts` | `orchestrator.py:1006` |
+
+Risk: medium. Touches backend selection metadata that flows into manifests (`BackendSelectionMetadata` at `manifest.py:164–241`). Existing tests at `tests/test_backend_selection.py` plus `_capture_backend_metadata` (already at `orchestrator.py:1297`) prove the seam contract.
+
+**Verification per sub-seam:** `make test-orchestrator-contract` + `pytest tests/test_backend_selection.py -v`. Each PR is expected to drop ≥150 LOC from `orchestrator.py` while keeping it a thin facade.
+
+---
+
+### Target 2 — `app.py` first slice: portal asset bundle
+
+**Why second:** `app.py` is the largest monolith but also the riskiest (typed envelope contracts, security boundary, rate limits). The portal-asset bundle is a clean first slice: pure data + caching, no FastAPI routes, no auth or path-validation logic.
+
+**Seam:** Extract to `src/transformation_portal/portal/asset_bundle.py` (new module).
+
+| Symbol | Location |
+|---|---|
+| `PortalAssetSpec` | `app.py:86` |
+| `PortalAssetBundle` | `app.py:92` |
+| `PortalRenderedTextAsset` | `app.py:102` |
+| `_load_portal_asset_manifest` | `app.py:301` |
+| `_portal_asset_signature` | `app.py:339` |
+| `_fingerprint_bytes` | `app.py:344` |
+| `_portal_asset_route_path` | `app.py:348` |
+| `_portal_asset_versioned_url` | `app.py:353` |
+| `_render_portal_template` | `app.py:357` |
+| `_portal_direct_asset_signature` | `app.py:370` |
+| `_build_portal_direct_asset_fingerprint` | `app.py:375` |
+| `_get_portal_direct_asset_fingerprint` | `app.py:379` |
+| `_portal_css_dependency_asset_names` / `_portal_css_signature` / `_build_portal_css_asset` / `_get_portal_css_asset` | `app.py:383–420` |
+| `_portal_html_signature` / `_build_portal_asset_bundle` / `_get_portal_asset_bundle` | `app.py:424–470` |
+| `_requested_portal_asset_fingerprint` / `_portal_asset_cache_control` / `_portal_asset_etag` / `_portal_asset_request_etag_matches` / `_portal_asset_not_modified_response` | `app.py:474–501` |
+
+Approx LOC: ~415. Re-export from `app.py` as `from transformation_portal.portal.asset_bundle import *` to preserve internal callers.
+
+**Verification:** `make check-portal-asset-budgets`, `make validate-portal-css-layer-parity`, `pytest tests/test_app_orchestrator_contract_http.py -v`, `pytest tests/validation/test_portal_smoke_scripts.py -v`.
+
+**Deferred slices (track here, do not promote until 2A lands):**
+- *2B — Path resolution & security helpers* (`app.py:516–700`). High risk: hardening surface; allowed-roots, symlink safety, untrusted-path validation. Needs its own ADR addendum and security-review skill pass.
+- *2C — SAM2 checksum cache* (`app.py:773–827, 1336–1440`). Medium risk: model-lock semantics and bounded cache eviction. Defer until SAM2 model-lock manifest migration is settled.
+
+---
+
+### Target 3 — `lux_depth_v3/segmentation_backend.py` per-backend split
+
+**Why third:** Cleanest natural seams (four top-level classes, no shared mutable state besides cache helpers); no governance pressure; useful precedent before tackling `pipelines/rendering_4k_pipeline.py`.
+
+**Layout:** new package `src/transformation_portal/lux_depth_v3/segmentation/`.
+
+| New module | Source range |
+|---|---|
+| `segmentation/_cache.py` | helpers at `segmentation_backend.py:76–532` (`_build_segmentation_cache_key`, `_read_cached_material_masks`, `_write_cached_material_masks`, `_material_confidence_metadata`, `_mask_checksum`, etc.) |
+| `segmentation/stub.py` | `StubBackend` (`segmentation_backend.py:532–565`) |
+| `segmentation/efficient_sam.py` | `EfficientSAMBackend` (`segmentation_backend.py:565–1449`) |
+| `segmentation/sam2.py` | `SAM2SegmentationBackend` (`segmentation_backend.py:1449–1803`) — note it currently subclasses `EfficientSAMBackend`; preserve that import edge |
+| `segmentation/sam_vit_h.py` | `SAMVitHBackend` (`segmentation_backend.py:1803–2110`) |
+| `segmentation/registry.py` | `_get_sam_vit_h_instance`, `_get_backend_instance`, `segment_materials`, `get_last_segmentation_runtime_metadata` (`segmentation_backend.py:2110–2519`) |
+
+`segmentation_backend.py` becomes a thin re-export shim for backward compatibility.
+
+**Verification:** `pytest tests/test_segmentation*.py -v`, `make validate-portal-lux-materials-live` (live SAM2 only on Apple Silicon arm64), and the existing materials V3 contract tests.
+
+---
+
+## Lower-priority candidates (not yet ranked)
+
+Track here but do **not** promote above the top 3 until at least target 1 ships an extraction.
+
+- `pipelines/rendering_4k_pipeline.py` (2,380 LOC). Three plausible seams: config dataclasses (155–389), GPU memory + quality assessor (390–815), pipeline execution (1264–2257). No current governance pressure.
+- `spatial_ai/orchestration/pipeline.py` (2,121 LOC). Two plausible seams: `PipelineConfig` (378–632) and `SpatialAIPipeline` execution (633–2121). The single-view reconstruction phase gate at line 1774 stays in place — it is governed and unrelated to decomposition.
+
+---
+
+## Process — extraction PRs draw from this list
+
+1. Pick a single seam from §"Top 3 Targets". Open a small PR titled `refactor(<area>): extract <seam> per ADR-045`.
+2. Follow the ADR-043 phased pattern: add new module + tests first, switch internal callers, leave a re-export shim, only then strip dead code from the source.
+3. Cite this document and ADR-045 in the PR description; update this file's status table when a seam lands.
+4. Run the listed verification gates plus `python scripts/validation/scan_todo_inventory.py --check-governance` to confirm no ungoverned TODOs slip in.
+
+This document is itself read-only governance — extraction PRs may update only the seam status table, not the ranking.

--- a/docs/architecture/TODO_INVENTORY_QUICK_REF.md
+++ b/docs/architecture/TODO_INVENTORY_QUICK_REF.md
@@ -223,7 +223,7 @@ A: None identified. Repository health is excellent.
 ---
 
 **Quick Links:**
-- [Full Inventory](../../analysis/TODO_INVENTORY.md) (1,798 lines, comprehensive)
+- [Full Inventory](../analysis/TODO_INVENTORY.md) (1,954 lines, comprehensive)
 - [Executive Summary](TODO_INVENTORY_EXECUTIVE_SUMMARY.md) (2 pages, key findings)
 - [Agent Governance](agent_governance.md) (escalation protocol)
 - [Monolith Decomposition Targets](MONOLITH_DECOMPOSITION_TARGETS.md) — ranked seam list (companion to [ADR-045](ADR-045-monolith-decomposition-residuals.md))

--- a/docs/architecture/TODO_INVENTORY_QUICK_REF.md
+++ b/docs/architecture/TODO_INVENTORY_QUICK_REF.md
@@ -226,5 +226,6 @@ A: None identified. Repository health is excellent.
 - [Full Inventory](../../analysis/TODO_INVENTORY.md) (1,798 lines, comprehensive)
 - [Executive Summary](TODO_INVENTORY_EXECUTIVE_SUMMARY.md) (2 pages, key findings)
 - [Agent Governance](agent_governance.md) (escalation protocol)
+- [Monolith Decomposition Targets](MONOLITH_DECOMPOSITION_TARGETS.md) — ranked seam list (companion to [ADR-045](ADR-045-monolith-decomposition-residuals.md))
 - [CHANGELOG.md](../../CHANGELOG.md) (what's been completed)
 - [CONTRIBUTING.md](../../CONTRIBUTING.md) (process updates pending)


### PR DESCRIPTION
Audit shows zero source-code TODOs about monolithic files (CI-enforced
since 2026-03-25), so the "fix monolithic file TODOs" effort becomes a
governance task: persist the candidate seam list and the pattern that
future extraction PRs will follow.

- Capture reproducible scanner snapshot at
  docs/analysis/todo_scanner_snapshot.json (25 NotImplementedError, 0
  ungoverned, 1492 files; deterministic).
- Append a 2026-05-04 refresh section to TODO_INVENTORY.md citing the
  snapshot and the absence of TODO/FIXME markers in the five largest
  modules (app.py, lux_depth_v3/orchestrator.py, segmentation_backend.py,
  rendering_4k_pipeline.py, spatial_ai/orchestration/pipeline.py).
- Add MONOLITH_DECOMPOSITION_TARGETS.md with the top three ranked seams:
  orchestrator.py residual slimming (1A/1B/1C into existing ADR-043
  modules), app.py portal-asset-bundle first slice, and a per-backend
  split of segmentation_backend.py.
- Add ADR-045 (Proposed) generalising the ADR-043 pattern (seam-based,
  test-first, re-export shim, acyclic, lazy imports, cite-and-update).
- Cross-link from TODO_INVENTORY_QUICK_REF.md and the Q2 roadmap's
  residual-slimming section so future contributors land on the targets.

No source code or test changes. Verified with
scan_todo_inventory.py --check-governance (exit 0) and the
check-json-serialization / check-yaml-governance / check-python-headers
Make gates.

https://claude.ai/code/session_01PUB6upfnusnUPRc8jiekbJ