### PR TITLE
refactor(lux-depth): extract orchestrator residual helpers

### DIFF
--- a/docs/architecture/MONOLITH_DECOMPOSITION_TARGETS.md
+++ b/docs/architecture/MONOLITH_DECOMPOSITION_TARGETS.md
@@ -50,7 +50,6 @@ Three sub-seams, each independently extractable. Pick one per PR, ~200 LOC each,
 | Symbol | Location |
 |---|---|
 | `_model_variant` | `orchestrator.py:583` |
-| `_initialize_depth_backend` | `orchestrator.py:589` |
 | `_resolve_backend_model_id` | `orchestrator.py:734` |
 | `_build_depth_cache_fingerprint` | `orchestrator.py:697` |
 | `_build_materials_fingerprint_payload` | `orchestrator.py:1082` |
@@ -78,10 +77,11 @@ Risk: low. Pure-function helpers operating on already-resolved config; the exist
 
 Risk: low–medium. Touches manifest schema; covered by `tests/test_backend_selection.py` and run-card contract tests.
 
-**Seam 1C — Backend resolution & state** → `lux_depth_v3/execution_engine.py`
+**Seam 1C — Backend resolution & state** → `lux_depth_v3/pipeline_coordinator.py`
 
 | Symbol | Location |
 |---|---|
+| `_initialize_depth_backend` | `orchestrator.py:589` |
 | `_resolve_runtime_backend_chain` | `orchestrator.py:677` |
 | `_expected_output_depth_units_for_backend` | `orchestrator.py:688` |
 | `_default_model_id_for_backend` | `orchestrator.py:716` |
@@ -168,9 +168,9 @@ This table is the canonical progress ledger for extraction PRs that draw from th
 
 | Seam | Source module | Destination | Status | Latest evidence |
 |---|---|---|---|---|
-| Target 1A — Config fingerprint helpers | `lux_depth_v3/orchestrator.py` | `lux_depth_v3/config_resolver.py` | Not started | Ranked 2026-05-04 |
-| Target 1B — Artifact reload / coercion helpers | `lux_depth_v3/orchestrator.py` | `lux_depth_v3/artifact_manager.py` | Not started | Ranked 2026-05-04 |
-| Target 1C — Backend resolution & state | `lux_depth_v3/orchestrator.py` | `lux_depth_v3/execution_engine.py` | Not started | Ranked 2026-05-04 |
+| Target 1A — Config fingerprint helpers | `lux_depth_v3/orchestrator.py` | `lux_depth_v3/config_resolver.py` | Landed | This PR: config fingerprint helpers extracted |
+| Target 1B — Artifact reload / coercion helpers | `lux_depth_v3/orchestrator.py` | `lux_depth_v3/artifact_manager.py` | Landed | This PR: manifest reload/coercion helpers extracted |
+| Target 1C — Backend resolution & state | `lux_depth_v3/orchestrator.py` | `lux_depth_v3/pipeline_coordinator.py` | Partial | This PR: backend initialization state extracted; runtime state helpers remain ranked |
 | Target 2A — Portal asset bundle | `app.py` | `src/transformation_portal/portal/asset_bundle.py` | Not started | Ranked 2026-05-04 |
 | Target 3A — Segmentation cache helpers | `lux_depth_v3/segmentation_backend.py` | `lux_depth_v3/segmentation/_cache.py` | Not started | Ranked 2026-05-04 |
 | Target 3B — Stub backend | `lux_depth_v3/segmentation_backend.py` | `lux_depth_v3/segmentation/stub.py` | Not started | Ranked 2026-05-04 |

--- a/src/transformation_portal/lux_depth_v3/artifact_manager.py
+++ b/src/transformation_portal/lux_depth_v3/artifact_manager.py
@@ -34,12 +34,14 @@ Usage:
 
 from __future__ import annotations
 
+import copy
 import hashlib
 import logging
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from .manifest import compute_file_sha256
+from ._backend_contract import normalize_backend_provenance
+from .manifest import CombinedManifest, ConfigFingerprint, compute_file_sha256
 from .path_aliasing import normalize_lexical_path, relative_to_path_alias
 from .security import sanitize_path_component_nonlossy
 
@@ -174,6 +176,141 @@ def v2_log_filename(
     if batch_id:
         filename += "__" + sanitize_path_component_nonlossy(str(batch_id))
     return f"{filename}.log"
+
+
+def load_existing_manifest(
+    manifest_path: Path,
+    *,
+    purpose: str,
+) -> Optional[CombinedManifest]:
+    """Best-effort manifest loader for cached-run preservation paths."""
+    if not manifest_path.exists():
+        return None
+    try:
+        return CombinedManifest.load(manifest_path)
+    except Exception as exc:
+        logger.debug(
+            "Failed to load existing manifest for %s: %s",
+            purpose,
+            exc,
+        )
+        return None
+
+
+def coerce_output_paths(raw_paths: Any) -> List[str]:
+    """Normalize V2 output path payloads to a list of strings."""
+    if isinstance(raw_paths, str):
+        return [raw_paths] if raw_paths else []
+    if not isinstance(raw_paths, list):
+        return []
+    return [path_value for path_value in raw_paths if isinstance(path_value, str) and path_value]
+
+
+def normalize_v2_status(raw_status: Any) -> str:
+    """Map runner and manifest status values to the manifest V2 contract."""
+    if raw_status is None:
+        return "skipped"
+    if not isinstance(raw_status, str):
+        return str(raw_status)
+
+    normalized = raw_status.strip().lower()
+    if not normalized:
+        return "skipped"
+    if normalized in {"success", "ok"}:
+        return "ok"
+    if normalized in {"failed", "failure"}:
+        return "error"
+    return normalized
+
+
+def restore_materials_v3_from_manifest(
+    manifest: Optional[CombinedManifest],
+    expected_enhanced_path: Path,
+) -> tuple[Optional[dict], float, Optional[Path]]:
+    """Restore persisted Materials V3 metadata for cached-depth reruns."""
+    if manifest is None or manifest.materials_v3 is None:
+        return None, 0.0, None
+
+    materials_v3 = manifest.materials_v3
+    materials_v3_metadata: Dict[str, Any] = {
+        "version": materials_v3.version,
+    }
+    if materials_v3.segmentation_metadata is not None:
+        materials_v3_metadata["segmentation_metadata"] = copy.deepcopy(
+            materials_v3.segmentation_metadata,
+        )
+
+    enhanced_path: Optional[Path] = expected_enhanced_path if expected_enhanced_path.exists() else None
+    runtime_seconds = materials_v3.runtime_seconds
+    restored_runtime = float(runtime_seconds) if runtime_seconds is not None else 0.0
+    restored_result = {
+        "materials_v3_response_plan": copy.deepcopy(
+            materials_v3.response_plan,
+        ),
+        "materials_v3_pixel_ops": copy.deepcopy(
+            materials_v3.pixel_ops,
+        ),
+        "materials_v3_metadata": materials_v3_metadata,
+    }
+    return restored_result, restored_runtime, enhanced_path
+
+
+def preserved_v2_result_from_manifest(
+    manifest: Optional[CombinedManifest],
+) -> tuple[dict, Optional[Path]]:
+    """Rehydrate V2 result fields from the prior manifest when reruns skip V2."""
+    if manifest is None or manifest.v2 is None:
+        return {"status": "ok"}, None
+
+    previous_v2 = manifest.v2
+    preserved_result: Dict[str, Any] = {
+        "status": previous_v2.status,
+    }
+    if previous_v2.report_path:
+        preserved_result["report_path"] = previous_v2.report_path
+
+    output_paths = coerce_output_paths(previous_v2.output_paths)
+    if output_paths:
+        preserved_result["output_paths"] = output_paths
+        preserved_result["output"] = output_paths[0]
+
+    if previous_v2.error_message:
+        preserved_result["error"] = previous_v2.error_message
+
+    report_path = Path(previous_v2.report_path) if previous_v2.report_path else None
+    return preserved_result, report_path
+
+
+def normalize_backend_provenance_for_reuse(value: Any) -> Optional[str]:
+    """Normalize backend provenance identifiers for reuse checks."""
+    return normalize_backend_provenance(value)
+
+
+def has_expanded_stage_a_fingerprint(
+    config_fingerprint: Optional[ConfigFingerprint],
+) -> bool:
+    """Return True when manifest fingerprint carries the expanded Stage A contract."""
+    if config_fingerprint is None:
+        return False
+    return all(
+        getattr(config_fingerprint, field_name, None) is not None
+        for field_name in (
+            "quality_tier",
+            "materials_config",
+            "pbr_config",
+            "apex_depth_gate_config",
+            "emit_master16",
+            "emit_upscaled16",
+        )
+    )
+
+
+def segmentation_mask_artifact_path(
+    segmentation_dir: Path,
+    output_key: Path,
+) -> Path:
+    """Return canonical segmentation mask artifact path."""
+    return segmentation_dir / output_key.parent / f"{output_key.stem}_materials_v3_masks.npz"
 
 
 def build_artifact_index(

--- a/src/transformation_portal/lux_depth_v3/config_resolver.py
+++ b/src/transformation_portal/lux_depth_v3/config_resolver.py
@@ -41,7 +41,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from ..core.da3_runtime import REPO_LOCAL_DA3_PYTHON, find_repo_root, repo_local_da3_python_path
 from ..core.raw_runtime import RAW_RUNTIME_ENV_VAR, REPO_LOCAL_RAW_PYTHON, repo_local_raw_python_path
-from ..ingest.canonical_json import canonicalize_json
+from ..ingest.canonical_json import canonicalize_json, dumps_json
 from ._backend_contract import normalize_backend_id
 from .config import DA3Config, EnhanceConfig, ModelVariant, Preset
 from .manifest import ConfigFingerprint
@@ -510,6 +510,32 @@ def build_depth_cache_payload(
     }
 
 
+def require_model_variant(config: EnhanceConfig) -> ModelVariant:
+    """Return the resolved model variant required by orchestrator helpers."""
+    mv = config.model_variant
+    assert mv is not None, "model_variant must be set"
+    return mv
+
+
+def build_depth_cache_fingerprint(
+    config: EnhanceConfig,
+    model_variant: ModelVariant,
+    backend_id: str,
+    output_depth_units: str,
+) -> str:
+    """Build backend-scoped depth cache fingerprint."""
+    cache_payload = build_depth_cache_payload(config, model_variant)
+    base_fp = hashlib.sha256(
+        dumps_json(
+            cache_payload,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+    payload = f"{base_fp}|backend={backend_id}|units={output_depth_units}"
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
 def compute_config_fingerprint(
     config: EnhanceConfig,
     model_variant: Optional[ModelVariant] = None,
@@ -631,6 +657,85 @@ def build_run_card_config_fingerprint(
         "canonical_json": canonical_json_str,
         "sha256": hashlib.sha256(canonical_json_bytes).hexdigest(),
     }
+
+
+def finalize_run_card_config_fingerprint(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Attach canonical JSON and SHA-256 over the resolved fingerprint payload."""
+    canonical_payload = {
+        key: value for key, value in payload.items() if key not in {"hash_algorithm", "canonical_json", "sha256"}
+    }
+    canonical_json_bytes = canonicalize_json(canonical_payload)
+    return {
+        **canonical_payload,
+        "hash_algorithm": "sha256",
+        "canonical_json": canonical_json_bytes.decode("utf-8"),
+        "sha256": hashlib.sha256(canonical_json_bytes).hexdigest(),
+    }
+
+
+def build_orchestrator_run_card_config_fingerprint(
+    config: EnhanceConfig,
+    model_variant: ModelVariant,
+    backend_metadata: Optional[Any],
+    *,
+    backend_selection: Optional[Dict[str, Any]] = None,
+    run_card_version: Optional[str] = None,
+    include_proofs: Optional[bool] = None,
+) -> Dict[str, Any]:
+    """Build the orchestrator run-card config fingerprint payload."""
+    fingerprint = build_run_card_config_fingerprint(
+        config,
+        model_variant,
+        backend_metadata,
+    )
+    payload = {key: value for key, value in fingerprint.items() if key not in {"hash_algorithm", "canonical_json", "sha256"}}
+    resolved_backend = None
+    if isinstance(backend_selection, dict):
+        resolved_backend = backend_selection.get("resolved")
+        payload.update(
+            {
+                "resolved_model_id": backend_selection.get("model_id"),
+                "model_artifact_filename": backend_selection.get("model_artifact_filename"),
+                "model_artifact_sha256": backend_selection.get("model_artifact_sha256"),
+            }
+        )
+    if resolved_backend is None:
+        resolved_backend = getattr(backend_metadata, "resolved_backend", None)
+    normalized_resolved_backend = normalize_backend_id(resolved_backend)
+    if normalized_resolved_backend == "depth_pro":
+        payload["model_variant"] = "apple/ml-depth-pro"
+        payload["preset"] = "depth_pro"
+        payload["preset_requested"] = "depth_pro"
+        payload["preset_resolved"] = "backend:depth_pro"
+    payload["output_depth_units"] = "meters" if normalized_resolved_backend == "depth_pro" else "relative"
+    payload["depth_png_encoding"] = "normalized_u16_png"
+    materials_v3_enabled = bool(getattr(config, "enable_materials_v3", False))
+    material_segmentation_enabled = bool(
+        getattr(
+            config,
+            "enable_material_segmentation",
+            False,
+        )
+    )
+    payload["materials_v3_enabled"] = materials_v3_enabled
+    payload["material_segmentation_enabled"] = material_segmentation_enabled
+    payload["material_segmentation_backend"] = getattr(config, "material_segmentation_backend", None)
+    payload["strict_segmentation"] = bool(
+        materials_v3_enabled and material_segmentation_enabled and getattr(config, "strict_backend", False)
+    )
+    payload["pbr_enabled"] = bool(getattr(config, "generate_pbr", False))
+    payload["vlm_captioning_enabled"] = bool(getattr(config, "vlm_captioning_enabled", False))
+    payload["vlm_captioning_backend"] = getattr(config, "vlm_captioning_backend", "fastvlm")
+    payload["vlm_captioning_model"] = getattr(config, "vlm_captioning_model", "default")
+    payload["vlm_captioning_proxy_format"] = getattr(config, "vlm_captioning_proxy_format", "png")
+    payload["vlm_captioning_max_side_px"] = int(getattr(config, "vlm_captioning_max_side_px", 1600) or 1600)
+    payload["fastvlm_timeout_seconds"] = int(getattr(config, "fastvlm_timeout_seconds", 180) or 180)
+    if run_card_version is not None:
+        payload["run_card_version"] = run_card_version
+    if include_proofs is not None:
+        payload["run_card_include_proofs"] = bool(include_proofs)
+    payload["emit_run_card"] = bool(getattr(config, "emit_run_card", False))
+    return finalize_run_card_config_fingerprint(payload)
 
 
 class ConfigResolver:

--- a/src/transformation_portal/lux_depth_v3/orchestrator.py
+++ b/src/transformation_portal/lux_depth_v3/orchestrator.py
@@ -78,9 +78,17 @@ from .artifact_manager import (
     XXHASH_AVAILABLE,
     ArtifactManager,
     build_artifact_index,
+    coerce_output_paths,
     compute_artifact_merkle_root,
+    has_expanded_stage_a_fingerprint,
     infer_artifact_type,
+    load_existing_manifest,
     make_output_key,
+    normalize_backend_provenance_for_reuse,
+    normalize_v2_status,
+    preserved_v2_result_from_manifest,
+    restore_materials_v3_from_manifest,
+    segmentation_mask_artifact_path,
     v2_log_filename,
 )
 from .artifact_tree import build_artifact_tree
@@ -96,12 +104,16 @@ from .config_resolver import (
     apply_effective_da3_runtime_config,
     apply_effective_raw_runtime_config,
     build_apex_depth_gate_fingerprint_payload,
+    build_depth_cache_fingerprint,
     build_depth_cache_payload,
     build_materials_fingerprint_payload,
+    build_orchestrator_run_card_config_fingerprint,
     build_pbr_fingerprint_payload,
     build_run_card_config_fingerprint,
     compute_config_fingerprint,
     discover_presets,
+    finalize_run_card_config_fingerprint,
+    require_model_variant,
     resolve_preset,
 )
 from .depth_cache import DepthCache
@@ -177,6 +189,7 @@ from .pipeline_coordinator import (
     default_model_id_for_backend,
     derive_model_id_from_backend_instance,
     expected_output_depth_units_for_backend,
+    initialize_depth_backend_state,
     resolve_backend_model_id,
     resolve_requested_backend,
     resolve_runtime_backend_chain,
@@ -189,6 +202,8 @@ _expected_output_depth_units_for_backend = expected_output_depth_units_for_backe
 _default_model_id_for_backend = default_model_id_for_backend
 _derive_model_id_from_backend_instance = derive_model_id_from_backend_instance
 _resolve_backend_model_id = resolve_backend_model_id
+_resolve_requested_backend = resolve_requested_backend
+_select_backend = select_backend
 
 # ADR-043 Phase 6: Execution engine extracted to execution_engine.py
 # NOTE: The orchestrator keeps its own _generate_pbr_stage and _run_v2_stage methods
@@ -582,9 +597,7 @@ class EnhanceOrchestrator:
     @property
     def _model_variant(self) -> ModelVariant:
         """Return model_variant; guaranteed set after __init__."""
-        mv = self.config.model_variant
-        assert mv is not None, "model_variant must be set"
-        return mv
+        return require_model_variant(self.config)
 
     def _initialize_depth_backend(self) -> None:
         """Initialize depth backend using registry (ADR-019).
@@ -596,81 +609,20 @@ class EnhanceOrchestrator:
         4. Optionally fallback to synthetic in explicit test/CI mode
         5. Record selection decision in metadata
         """
-        self._depth_registry = DepthBackendRegistry()
-        self._depth_backend_cache: Dict[str, Any] = {}
-        self._backend_init_errors: Dict[str, str] = {}
-        allow_synthetic = bool(self.config.allow_synthetic_fallback) or os.getenv("TP_ALLOW_SYNTHETIC_FALLBACK") == "1"
-
-        try:
-            selection = select_backend(
-                self.config.depth_backend,
-                self.config,
-                self._depth_registry,
-                self._model_variant,
-            )
-            if not selection.is_success or selection.backend is None or selection.resolved_backend is None:
-                requested = resolve_requested_backend(self.config.depth_backend, self.config)
-                candidate_chain = resolve_runtime_backend_chain(requested, self.config)
-                if "synthetic" not in candidate_chain and (
-                    bool(self.config.allow_synthetic_fallback) or os.getenv("TP_ALLOW_SYNTHETIC_FALLBACK") == "1"
-                ):
-                    candidate_chain.append("synthetic")
-                if not allow_synthetic:
-                    raise RuntimeError(
-                        "No depth backend"
-                        " available from"
-                        " candidates"
-                        f" {candidate_chain}."
-                        f" Errors: {selection.init_errors}."
-                        " Install ML deps"
-                        " (torch, transformers)"
-                        " or explicitly enable"
-                        " synthetic fallback for"
-                        " testing (config"
-                        ".allow_synthetic_fallback"
-                        "=True or TP_ALLOW_"
-                        "SYNTHETIC_FALLBACK=1)."
-                    )
-                raise RuntimeError(
-                    "No depth backend"
-                    " available from"
-                    " candidates"
-                    f" {candidate_chain}."
-                    f" Errors: {selection.init_errors}"
-                )
-
-            self.depth_backend = selection.backend
-            self._backend_init_errors = dict(selection.init_errors or {})
-            self._depth_backend_cache[selection.resolved_backend] = selection.backend
-            self._backend_metadata = BackendSelectionMetadata(
-                requested_backend=selection.requested_backend,
-                resolved_backend=selection.resolved_backend,
-                resolution_status=selection.status,
-                resolution_reason=selection.reason,
-                model_id=self._resolve_backend_model_id(
-                    selection.resolved_backend,
-                    backend=selection.backend,
-                ),
-                device=self.config.depth_device,
-                attempts=[],
-            )
-            self._active_backend_metadata = self._backend_metadata
-            self._active_depth_attempts = []
-            self._active_selected_attempt_index = None
-
-            logger.info(
-                "Depth backend:" " requested=%s" " resolved=%s device=%s",
-                selection.requested_backend,
-                selection.resolved_backend,
-                self.config.depth_device,
-            )
-
-        except LicenseRestrictionError as e:
-            logger.error(f"License restriction: {e}")
-            raise
-        except Exception as e:
-            logger.error(f"Backend initialization failed: {e}")
-            raise
+        state = initialize_depth_backend_state(
+            self.config,
+            self._model_variant,
+            self._resolve_backend_model_id,
+            registry_factory=DepthBackendRegistry,
+        )
+        self._depth_registry = state.registry
+        self.depth_backend = state.depth_backend
+        self._backend_init_errors = state.init_errors
+        self._depth_backend_cache = state.backend_cache
+        self._backend_metadata = state.backend_metadata
+        self._active_backend_metadata = self._backend_metadata
+        self._active_depth_attempts = []
+        self._active_selected_attempt_index = None
 
     # ADR-043: Pipeline coordination methods now delegate to pipeline_coordinator module
 
@@ -699,19 +651,15 @@ class EnhanceOrchestrator:
         backend_id: str,
     ) -> str:
         """Build backend-scoped cache fingerprint."""
-        cache_payload = self._build_depth_cache_payload()
-        base_fp = hashlib.sha256(
-            json.dumps(
-                cache_payload,
-                sort_keys=True,
-                separators=(",", ":"),
-            ).encode("utf-8")
-        ).hexdigest()
         expected_units = self._expected_output_depth_units_for_backend(
             backend_id,
         )
-        payload = f"{base_fp}|backend={backend_id}" f"|units={expected_units}"
-        return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+        return build_depth_cache_fingerprint(
+            self.config,
+            self._model_variant,
+            backend_id,
+            expected_units,
+        )
 
     def _default_model_id_for_backend(self, backend_id: str) -> str:
         """Return canonical backend model identifier for provenance.
@@ -1121,16 +1069,7 @@ class EnhanceOrchestrator:
     @staticmethod
     def _finalize_run_card_config_fingerprint(payload: Dict[str, Any]) -> Dict[str, Any]:
         """Attach canonical JSON and SHA-256 over the resolved fingerprint payload."""
-        canonical_payload = {
-            key: value for key, value in payload.items() if key not in {"hash_algorithm", "canonical_json", "sha256"}
-        }
-        canonical_json_bytes = canonicalize_json(canonical_payload)
-        return {
-            **canonical_payload,
-            "hash_algorithm": "sha256",
-            "canonical_json": canonical_json_bytes.decode("utf-8"),
-            "sha256": hashlib.sha256(canonical_json_bytes).hexdigest(),
-        }
+        return finalize_run_card_config_fingerprint(payload)
 
     def _build_run_card_config_fingerprint(
         self,
@@ -1141,63 +1080,16 @@ class EnhanceOrchestrator:
     ) -> Dict[str, Any]:
         """Build run-card config fingerprint.
 
-        Delegates to config_resolver.build_run_card_config_fingerprint().
+        Delegates to config_resolver.build_orchestrator_run_card_config_fingerprint().
         """
-        fingerprint = build_run_card_config_fingerprint(
+        return build_orchestrator_run_card_config_fingerprint(
             self.config,
             self._model_variant,
             self._backend_metadata,
+            backend_selection=backend_selection,
+            run_card_version=run_card_version,
+            include_proofs=include_proofs,
         )
-        payload = {
-            key: value for key, value in fingerprint.items() if key not in {"hash_algorithm", "canonical_json", "sha256"}
-        }
-        resolved_backend = None
-        if isinstance(backend_selection, dict):
-            resolved_backend = backend_selection.get("resolved")
-            payload.update(
-                {
-                    "resolved_model_id": backend_selection.get("model_id"),
-                    "model_artifact_filename": backend_selection.get("model_artifact_filename"),
-                    "model_artifact_sha256": backend_selection.get("model_artifact_sha256"),
-                }
-            )
-        if resolved_backend is None:
-            resolved_backend = getattr(self._backend_metadata, "resolved_backend", None)
-        normalized_resolved_backend = normalize_backend_id(resolved_backend)
-        if normalized_resolved_backend == "depth_pro":
-            payload["model_variant"] = "apple/ml-depth-pro"
-            payload["preset"] = "depth_pro"
-            payload["preset_requested"] = "depth_pro"
-            payload["preset_resolved"] = "backend:depth_pro"
-        payload["output_depth_units"] = "meters" if normalized_resolved_backend == "depth_pro" else "relative"
-        payload["depth_png_encoding"] = "normalized_u16_png"
-        materials_v3_enabled = bool(getattr(self.config, "enable_materials_v3", False))
-        material_segmentation_enabled = bool(
-            getattr(
-                self.config,
-                "enable_material_segmentation",
-                False,
-            )
-        )
-        payload["materials_v3_enabled"] = materials_v3_enabled
-        payload["material_segmentation_enabled"] = material_segmentation_enabled
-        payload["material_segmentation_backend"] = getattr(self.config, "material_segmentation_backend", None)
-        payload["strict_segmentation"] = bool(
-            materials_v3_enabled and material_segmentation_enabled and getattr(self.config, "strict_backend", False)
-        )
-        payload["pbr_enabled"] = bool(getattr(self.config, "generate_pbr", False))
-        payload["vlm_captioning_enabled"] = bool(getattr(self.config, "vlm_captioning_enabled", False))
-        payload["vlm_captioning_backend"] = getattr(self.config, "vlm_captioning_backend", "fastvlm")
-        payload["vlm_captioning_model"] = getattr(self.config, "vlm_captioning_model", "default")
-        payload["vlm_captioning_proxy_format"] = getattr(self.config, "vlm_captioning_proxy_format", "png")
-        payload["vlm_captioning_max_side_px"] = int(getattr(self.config, "vlm_captioning_max_side_px", 1600) or 1600)
-        payload["fastvlm_timeout_seconds"] = int(getattr(self.config, "fastvlm_timeout_seconds", 180) or 180)
-        if run_card_version is not None:
-            payload["run_card_version"] = run_card_version
-        if include_proofs is not None:
-            payload["run_card_include_proofs"] = bool(include_proofs)
-        payload["emit_run_card"] = bool(getattr(self.config, "emit_run_card", False))
-        return self._finalize_run_card_config_fingerprint(payload)
 
     def _extract_v2_depth_handoff_status(
         self,
@@ -1325,43 +1217,17 @@ class EnhanceOrchestrator:
         purpose: str,
     ) -> Optional[CombinedManifest]:
         """Best-effort manifest loader for cached-run preservation paths."""
-        if not manifest_path.exists():
-            return None
-        try:
-            return CombinedManifest.load(manifest_path)
-        except Exception as exc:
-            logger.debug(
-                "Failed to load existing manifest for %s: %s",
-                purpose,
-                exc,
-            )
-            return None
+        return load_existing_manifest(manifest_path, purpose=purpose)
 
     @staticmethod
     def _coerce_output_paths(raw_paths: Any) -> List[str]:
         """Normalize V2 output path payloads to a list of strings."""
-        if isinstance(raw_paths, str):
-            return [raw_paths] if raw_paths else []
-        if not isinstance(raw_paths, list):
-            return []
-        return [path_value for path_value in raw_paths if isinstance(path_value, str) and path_value]
+        return coerce_output_paths(raw_paths)
 
     @staticmethod
     def _normalize_v2_status(raw_status: Any) -> str:
         """Map runner and manifest status values to the manifest V2 contract."""
-        if raw_status is None:
-            return "skipped"
-        if not isinstance(raw_status, str):
-            return str(raw_status)
-
-        normalized = raw_status.strip().lower()
-        if not normalized:
-            return "skipped"
-        if normalized in {"success", "ok"}:
-            return "ok"
-        if normalized in {"failed", "failure"}:
-            return "error"
-        return normalized
+        return normalize_v2_status(raw_status)
 
     def _restore_materials_v3_from_manifest(
         self,
@@ -1369,86 +1235,29 @@ class EnhanceOrchestrator:
         output_key: Path,
     ) -> tuple[Optional[dict], float, Optional[Path]]:
         """Restore persisted Materials V3 metadata for cached-depth reruns."""
-        if manifest is None or manifest.materials_v3 is None:
-            return None, 0.0, None
-
-        materials_v3 = manifest.materials_v3
-        materials_v3_metadata: Dict[str, Any] = {
-            "version": materials_v3.version,
-        }
-        if materials_v3.segmentation_metadata is not None:
-            materials_v3_metadata["segmentation_metadata"] = copy.deepcopy(
-                materials_v3.segmentation_metadata,
-            )
-
-        # Check if enhanced image exists, return path or None
-        expected_path = self._expected_materials_v3_enhanced_path(output_key)
-        enhanced_path: Optional[Path] = expected_path if expected_path.exists() else None
-
-        runtime_seconds = materials_v3.runtime_seconds
-        restored_runtime = float(runtime_seconds) if runtime_seconds is not None else 0.0
-        restored_result = {
-            "materials_v3_response_plan": copy.deepcopy(
-                materials_v3.response_plan,
-            ),
-            "materials_v3_pixel_ops": copy.deepcopy(
-                materials_v3.pixel_ops,
-            ),
-            "materials_v3_metadata": materials_v3_metadata,
-        }
-        return restored_result, restored_runtime, enhanced_path
+        return restore_materials_v3_from_manifest(
+            manifest,
+            self._expected_materials_v3_enhanced_path(output_key),
+        )
 
     def _preserved_v2_result_from_manifest(
         self,
         manifest: Optional[CombinedManifest],
     ) -> tuple[dict, Optional[Path]]:
         """Rehydrate V2 result fields from the prior manifest when reruns skip V2."""
-        if manifest is None or manifest.v2 is None:
-            return {"status": "ok"}, None
-
-        previous_v2 = manifest.v2
-        preserved_result: Dict[str, Any] = {
-            "status": previous_v2.status,
-        }
-        if previous_v2.report_path:
-            preserved_result["report_path"] = previous_v2.report_path
-
-        output_paths = self._coerce_output_paths(
-            previous_v2.output_paths,
-        )
-        if output_paths:
-            preserved_result["output_paths"] = output_paths
-            preserved_result["output"] = output_paths[0]
-
-        if previous_v2.error_message:
-            preserved_result["error"] = previous_v2.error_message
-
-        report_path = Path(previous_v2.report_path) if previous_v2.report_path else None
-        return preserved_result, report_path
+        return preserved_v2_result_from_manifest(manifest)
 
     @staticmethod
     def _normalize_backend_provenance(value: Any) -> Optional[str]:
         """Normalize backend provenance identifiers for reuse checks."""
-        return normalize_backend_provenance(value)
+        return normalize_backend_provenance_for_reuse(value)
 
     @staticmethod
     def _has_expanded_stage_a_fingerprint(
         config_fingerprint: Optional[ConfigFingerprint],
     ) -> bool:
         """Return True when manifest fingerprint carries the expanded Stage A contract."""
-        if config_fingerprint is None:
-            return False
-        return all(
-            getattr(config_fingerprint, field_name, None) is not None
-            for field_name in (
-                "quality_tier",
-                "materials_config",
-                "pbr_config",
-                "apex_depth_gate_config",
-                "emit_master16",
-                "emit_upscaled16",
-            )
-        )
+        return has_expanded_stage_a_fingerprint(config_fingerprint)
 
     def _compute_or_skip_hash(
         self,
@@ -2617,7 +2426,7 @@ class EnhanceOrchestrator:
         output_key: Path,
     ) -> Path:
         """Return canonical segmentation mask path."""
-        return self.segmentation_dir / output_key.parent / f"{output_key.stem}" "_materials_v3_masks.npz"
+        return segmentation_mask_artifact_path(self.segmentation_dir, output_key)
 
     @staticmethod
     def _resize_float_array_to_shape(

--- a/src/transformation_portal/lux_depth_v3/pipeline_coordinator.py
+++ b/src/transformation_portal/lux_depth_v3/pipeline_coordinator.py
@@ -37,7 +37,7 @@ from __future__ import annotations
 import logging
 import os
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from ..core.platform_matrix import CURRENT_PLATFORM, PlatformMatrix
 from ..depth.backends.protocol import LicenseRestrictionError
@@ -171,6 +171,17 @@ class ExecutionPlan:
     enable_materials_v3: bool = False
     enable_reconstruction: bool = False
     quality_tier: str = "standard"
+
+
+@dataclass
+class InitializedDepthBackendState:
+    """Initialized depth backend state for orchestrator startup."""
+
+    registry: Any
+    depth_backend: Any
+    backend_cache: Dict[str, Any]
+    init_errors: Dict[str, str]
+    backend_metadata: BackendSelectionMetadata
 
 
 def resolve_runtime_backend_chain(
@@ -487,6 +498,91 @@ def select_backend(
         device=config.depth_device,
         init_errors=init_errors,
     )
+
+
+def initialize_depth_backend_state(
+    config: EnhanceConfig,
+    model_variant: ModelVariant,
+    resolve_model_id: Callable[..., str],
+    *,
+    registry_factory: Optional[Callable[[], Any]] = None,
+) -> InitializedDepthBackendState:
+    """Initialize depth backend registry, backend cache, and metadata."""
+    if registry_factory is None:
+        from ..depth.backends.registry import DepthBackendRegistry
+
+        registry_factory = DepthBackendRegistry
+
+    registry = registry_factory()
+    backend_cache: Dict[str, Any] = {}
+    init_errors: Dict[str, str] = {}
+    allow_synthetic = bool(config.allow_synthetic_fallback) or os.getenv("TP_ALLOW_SYNTHETIC_FALLBACK") == "1"
+
+    try:
+        selection = select_backend(
+            config.depth_backend,
+            config,
+            registry,
+            model_variant,
+        )
+        if not selection.is_success or selection.backend is None or selection.resolved_backend is None:
+            requested = resolve_requested_backend(config.depth_backend, config)
+            candidate_chain = resolve_runtime_backend_chain(requested, config)
+            if not allow_synthetic:
+                raise RuntimeError(
+                    "No depth backend"
+                    " available from"
+                    " candidates"
+                    f" {candidate_chain}."
+                    f" Errors: {selection.init_errors}."
+                    " Install ML deps"
+                    " (torch, transformers)"
+                    " or explicitly enable"
+                    " synthetic fallback for"
+                    " testing (config"
+                    ".allow_synthetic_fallback"
+                    "=True or TP_ALLOW_"
+                    "SYNTHETIC_FALLBACK=1)."
+                )
+            raise RuntimeError(
+                "No depth backend" " available from" " candidates" f" {candidate_chain}." f" Errors: {selection.init_errors}"
+            )
+
+        init_errors = dict(selection.init_errors or {})
+        backend_cache[selection.resolved_backend] = selection.backend
+        backend_metadata = BackendSelectionMetadata(
+            requested_backend=selection.requested_backend,
+            resolved_backend=selection.resolved_backend,
+            resolution_status=selection.status,
+            resolution_reason=selection.reason,
+            model_id=resolve_model_id(
+                selection.resolved_backend,
+                backend=selection.backend,
+            ),
+            device=config.depth_device,
+            attempts=[],
+        )
+
+        logger.info(
+            "Depth backend:" " requested=%s" " resolved=%s device=%s",
+            selection.requested_backend,
+            selection.resolved_backend,
+            config.depth_device,
+        )
+        return InitializedDepthBackendState(
+            registry=registry,
+            depth_backend=selection.backend,
+            backend_cache=backend_cache,
+            init_errors=init_errors,
+            backend_metadata=backend_metadata,
+        )
+
+    except LicenseRestrictionError as e:
+        logger.error(f"License restriction: {e}")
+        raise
+    except Exception as e:
+        logger.error(f"Backend initialization failed: {e}")
+        raise
 
 
 class PipelineCoordinator:

--- a/tests/lux_depth_v3/test_artifact_manager.py
+++ b/tests/lux_depth_v3/test_artifact_manager.py
@@ -32,9 +32,17 @@ class TestArtifactManagerImports:
         from transformation_portal.lux_depth_v3.artifact_manager import (
             ArtifactManager,
             build_artifact_index,
+            coerce_output_paths,
             compute_artifact_merkle_root,
+            has_expanded_stage_a_fingerprint,
             infer_artifact_type,
+            load_existing_manifest,
             make_output_key,
+            normalize_backend_provenance_for_reuse,
+            normalize_v2_status,
+            preserved_v2_result_from_manifest,
+            restore_materials_v3_from_manifest,
+            segmentation_mask_artifact_path,
             v2_log_filename,
         )
 
@@ -43,6 +51,14 @@ class TestArtifactManagerImports:
         assert callable(compute_artifact_merkle_root)
         assert callable(make_output_key)
         assert callable(v2_log_filename)
+        assert callable(load_existing_manifest)
+        assert callable(coerce_output_paths)
+        assert callable(normalize_v2_status)
+        assert callable(restore_materials_v3_from_manifest)
+        assert callable(preserved_v2_result_from_manifest)
+        assert callable(normalize_backend_provenance_for_reuse)
+        assert callable(has_expanded_stage_a_fingerprint)
+        assert callable(segmentation_mask_artifact_path)
         assert ArtifactManager is not None
 
     def test_backward_compatible_orchestrator_imports(self):
@@ -133,6 +149,130 @@ class TestV2LogFilename:
         result = v2_log_filename("image", "2026-03-20_12:00:00")
         # Colons should be sanitized
         assert ":" not in result
+
+
+class TestArtifactReloadHelpers:
+    """Test manifest reload and coercion helpers."""
+
+    def test_load_existing_manifest_missing_or_invalid_returns_none(self, tmp_path: Path):
+        """Best-effort manifest loading should fail closed to None."""
+        from transformation_portal.lux_depth_v3.artifact_manager import load_existing_manifest
+
+        missing = tmp_path / "missing.json"
+        invalid = tmp_path / "invalid.json"
+        invalid.write_text("{not-json", encoding="utf-8")
+
+        assert load_existing_manifest(missing, purpose="test") is None
+        assert load_existing_manifest(invalid, purpose="test") is None
+
+    def test_coerce_output_paths_filters_to_nonempty_strings(self):
+        """Output path coercion preserves only nonempty strings."""
+        from transformation_portal.lux_depth_v3.artifact_manager import coerce_output_paths
+
+        assert coerce_output_paths("/path/to/output.png") == ["/path/to/output.png"]
+        assert coerce_output_paths(["one.png", None, 7, "", "two.png"]) == ["one.png", "two.png"]
+        assert coerce_output_paths(None) == []
+
+    def test_normalize_v2_status_maps_runner_values(self):
+        """V2 status normalization keeps manifest status stable."""
+        from transformation_portal.lux_depth_v3.artifact_manager import normalize_v2_status
+
+        assert normalize_v2_status("Success") == "ok"
+        assert normalize_v2_status("failure") == "error"
+        assert normalize_v2_status("   ") == "skipped"
+        assert normalize_v2_status(None) == "skipped"
+        assert normalize_v2_status(3) == "3"
+
+    def test_restore_materials_v3_from_manifest_deep_copies_payloads(self, tmp_path: Path):
+        """Restored Materials V3 metadata should not alias manifest internals."""
+        from transformation_portal.lux_depth_v3.artifact_manager import restore_materials_v3_from_manifest
+        from transformation_portal.lux_depth_v3.manifest import CombinedManifest, MaterialsV3Metadata
+
+        enhanced_path = tmp_path / "image_materials_v3_enhanced.png"
+        enhanced_path.write_bytes(b"png")
+        manifest = CombinedManifest(
+            materials_v3=MaterialsV3Metadata(
+                enabled=True,
+                version="3.1",
+                response_plan={"steps": ["tone"]},
+                pixel_ops={"applied": ["mask"]},
+                segmentation_metadata={"mask_artifact_path": "segmentation/masks.npz"},
+                runtime_seconds=1.25,
+            )
+        )
+
+        restored, runtime_seconds, resolved_path = restore_materials_v3_from_manifest(
+            manifest,
+            enhanced_path,
+        )
+
+        assert runtime_seconds == pytest.approx(1.25)
+        assert resolved_path == enhanced_path
+        assert restored is not None
+        assert restored["materials_v3_response_plan"] == {"steps": ["tone"]}
+        restored["materials_v3_metadata"]["segmentation_metadata"]["mask_artifact_path"] = "mutated"
+        assert manifest.materials_v3 is not None
+        assert manifest.materials_v3.segmentation_metadata == {"mask_artifact_path": "segmentation/masks.npz"}
+
+    def test_preserved_v2_result_from_manifest_rehydrates_outputs(self):
+        """Preserved V2 manifests restore output/report/error fields."""
+        from transformation_portal.lux_depth_v3.artifact_manager import preserved_v2_result_from_manifest
+        from transformation_portal.lux_depth_v3.manifest import CombinedManifest, V2Metadata
+
+        manifest = CombinedManifest(
+            v2=V2Metadata(
+                preset="luxury",
+                status="error",
+                output_paths=["one.png", "", "two.png"],
+                report_path="reports/v2.json",
+                error_message="failed",
+            )
+        )
+
+        preserved, report_path = preserved_v2_result_from_manifest(manifest)
+
+        assert preserved == {
+            "status": "error",
+            "report_path": "reports/v2.json",
+            "output_paths": ["one.png", "two.png"],
+            "output": "one.png",
+            "error": "failed",
+        }
+        assert report_path == Path("reports/v2.json")
+
+    def test_has_expanded_stage_a_fingerprint_requires_all_expanded_fields(self):
+        """Stage A reuse requires every expanded fingerprint field."""
+        from transformation_portal.lux_depth_v3.artifact_manager import has_expanded_stage_a_fingerprint
+        from transformation_portal.lux_depth_v3.manifest import ConfigFingerprint
+
+        minimal = ConfigFingerprint(
+            model_variant="metric-large",
+            depth_quantization="u16",
+            depth_device="cpu",
+        )
+        expanded = ConfigFingerprint(
+            model_variant="metric-large",
+            depth_quantization="u16",
+            depth_device="cpu",
+            quality_tier="standard",
+            materials_config={},
+            pbr_config={},
+            apex_depth_gate_config={},
+            emit_master16=False,
+            emit_upscaled16=False,
+        )
+
+        assert has_expanded_stage_a_fingerprint(None) is False
+        assert has_expanded_stage_a_fingerprint(minimal) is False
+        assert has_expanded_stage_a_fingerprint(expanded) is True
+
+    def test_segmentation_mask_artifact_path_preserves_output_key_parent(self, tmp_path: Path):
+        """Segmentation mask artifacts keep the output-key directory shape."""
+        from transformation_portal.lux_depth_v3.artifact_manager import segmentation_mask_artifact_path
+
+        assert segmentation_mask_artifact_path(tmp_path / "segmentation", Path("scene/image_jpg_abcd1234")) == (
+            tmp_path / "segmentation" / "scene" / "image_jpg_abcd1234_materials_v3_masks.npz"
+        )
 
 
 class TestMakeOutputKey:

--- a/tests/lux_depth_v3/test_config_resolver.py
+++ b/tests/lux_depth_v3/test_config_resolver.py
@@ -31,11 +31,15 @@ class TestConfigResolverImports:
             PresetInfo,
             ResolvedConfig,
             build_apex_depth_gate_fingerprint_payload,
+            build_depth_cache_fingerprint,
             build_materials_fingerprint_payload,
+            build_orchestrator_run_card_config_fingerprint,
             build_pbr_fingerprint_payload,
             build_run_card_config_fingerprint,
             compute_config_fingerprint,
             discover_presets,
+            finalize_run_card_config_fingerprint,
+            require_model_variant,
             resolve_preset,
         )
 
@@ -49,6 +53,10 @@ class TestConfigResolverImports:
         assert callable(build_pbr_fingerprint_payload)
         assert callable(build_apex_depth_gate_fingerprint_payload)
         assert callable(build_run_card_config_fingerprint)
+        assert callable(require_model_variant)
+        assert callable(build_depth_cache_fingerprint)
+        assert callable(finalize_run_card_config_fingerprint)
+        assert callable(build_orchestrator_run_card_config_fingerprint)
 
 
 class TestDiscoverPresets:
@@ -753,6 +761,89 @@ class TestBuildRunCardConfigFingerprint:
         fingerprint = build_run_card_config_fingerprint(EnhanceConfig())
 
         assert fingerprint["raw_python_executable"] == REPO_LOCAL_RAW_PYTHON
+
+
+class TestOrchestratorFingerprintHelpers:
+    """Test orchestrator-facing config fingerprint helpers."""
+
+    def test_require_model_variant_returns_resolved_variant(self):
+        """Resolved model variants are exposed for orchestrator delegates."""
+        from transformation_portal.lux_depth_v3.config import EnhanceConfig, ModelVariant
+        from transformation_portal.lux_depth_v3.config_resolver import require_model_variant
+
+        config = EnhanceConfig(model_variant=ModelVariant.METRIC_SMALL)
+
+        assert require_model_variant(config) is ModelVariant.METRIC_SMALL
+
+    def test_build_depth_cache_fingerprint_is_backend_and_units_scoped(self):
+        """Depth cache fingerprint should change with backend output units."""
+        from transformation_portal.lux_depth_v3.config import EnhanceConfig, ModelVariant
+        from transformation_portal.lux_depth_v3.config_resolver import build_depth_cache_fingerprint
+
+        config = EnhanceConfig(depth_backend="da3", model_variant=ModelVariant.METRIC_LARGE)
+
+        relative = build_depth_cache_fingerprint(
+            config,
+            ModelVariant.METRIC_LARGE,
+            "da3",
+            "relative",
+        )
+        metric = build_depth_cache_fingerprint(
+            config,
+            ModelVariant.METRIC_LARGE,
+            "da3",
+            "meters",
+        )
+
+        assert len(relative) == 64
+        assert relative != metric
+
+    def test_finalize_run_card_config_fingerprint_recomputes_canonical_hash(self):
+        """Finalization strips stale hash fields before canonicalization."""
+        from transformation_portal.lux_depth_v3.config_resolver import finalize_run_card_config_fingerprint
+
+        finalized = finalize_run_card_config_fingerprint(
+            {
+                "b": 2,
+                "a": 1,
+                "hash_algorithm": "stale",
+                "canonical_json": "stale",
+                "sha256": "stale",
+            }
+        )
+
+        assert finalized["hash_algorithm"] == "sha256"
+        assert finalized["canonical_json"] == '{"a":1,"b":2}'
+        assert len(finalized["sha256"]) == 64
+
+    def test_orchestrator_run_card_fingerprint_applies_depth_pro_overrides(self):
+        """The extracted orchestrator helper preserves Depth Pro run-card overrides."""
+        from transformation_portal.lux_depth_v3.config import EnhanceConfig, ModelVariant
+        from transformation_portal.lux_depth_v3.config_resolver import (
+            build_orchestrator_run_card_config_fingerprint,
+        )
+        from transformation_portal.lux_depth_v3.manifest import BackendSelectionMetadata
+
+        metadata = BackendSelectionMetadata(
+            requested_backend="depth_pro",
+            resolved_backend="depth_pro",
+            resolution_status="success",
+            resolution_reason="Depth Pro backend ready",
+            model_id="apple/ml-depth-pro",
+            device="cpu",
+            attempts=[],
+        )
+
+        fingerprint = build_orchestrator_run_card_config_fingerprint(
+            EnhanceConfig(depth_backend="depth_pro", model_variant=ModelVariant.METRIC_LARGE),
+            ModelVariant.METRIC_LARGE,
+            metadata,
+        )
+
+        assert fingerprint["model_variant"] == "apple/ml-depth-pro"
+        assert fingerprint["preset_resolved"] == "backend:depth_pro"
+        assert fingerprint["output_depth_units"] == "meters"
+        assert len(fingerprint["sha256"]) == 64
 
 
 class TestConfigResolverClass:


### PR DESCRIPTION
## Summary
- Extracts PR 1638 Target 1A and Target 1B from the lux-depth orchestrator residual backlog.
- Keeps private orchestrator compatibility wrappers while moving reusable logic into config_resolver.py, pipeline_coordinator.py, and artifact_manager.py.

## Changes
- Adds config fingerprint helper delegates and backend initialization state extraction.
- Moves manifest reload, V2 coercion, Materials V3 restoration, Stage A fingerprint detection, and segmentation mask artifact path helpers into artifact_manager.py.
- Updates the monolith decomposition status table for Target 1A and Target 1B.
- Adds focused helper tests and preserves import-boundary coverage.

## Validation
Proven green:
- .venv/bin/pytest tests/lux_depth_v3/test_config_resolver.py -v
- .venv/bin/pytest tests/test_orchestrator_improvements.py -k ConfigFingerprint_or_depth_cache -v
- .venv/bin/pytest tests/test_run_card_schema.py -k config_fingerprint_or_backend_model_id -v
- .venv/bin/pytest tests/lux_depth_v3/test_orchestrator_backend_resolution.py -v
- .venv/bin/pytest tests/lux_depth_v3/test_artifact_manager.py -v
- .venv/bin/pytest tests/lux_depth_v3/test_orchestrator_preview.py -k V2Status_or_CoerceOutputPaths_or_make_output_key -v
- .venv/bin/pytest tests/lux_depth_v3/test_import_integrity.py -v
- .venv/bin/pytest tests/test_backend_selection.py -v
- .venv/bin/pytest tests/test_run_card_schema.py -v
- make test-orchestrator-contract
- .venv/bin/python scripts/validation/scan_todo_inventory.py --check-governance
- make check-json-serialization check-yaml-governance check-python-headers
- .venv/bin/python -m black --check --target-version py311 on touched Python files
- git diff --check

Still failing:
- None.

## Risk
- Bounded refactor with no route, selector, CLI flag, public API, manifest schema, or run-card schema changes.
- Revert-safe because behavior is preserved through compatibility delegates and covered by focused helper tests plus orchestrator/run-card contract suites.