### PR TITLE
refactor(lux-depth): extract backend runtime state helpers

### DIFF
--- a/docs/architecture/MONOLITH_DECOMPOSITION_TARGETS.md
+++ b/docs/architecture/MONOLITH_DECOMPOSITION_TARGETS.md
@@ -170,7 +170,7 @@ This table is the canonical progress ledger for extraction PRs that draw from th
 |---|---|---|---|---|
 | Target 1A — Config fingerprint helpers | `lux_depth_v3/orchestrator.py` | `lux_depth_v3/config_resolver.py` | Landed | This PR: config fingerprint helpers extracted |
 | Target 1B — Artifact reload / coercion helpers | `lux_depth_v3/orchestrator.py` | `lux_depth_v3/artifact_manager.py` | Landed | This PR: manifest reload/coercion helpers extracted |
-| Target 1C — Backend resolution & state | `lux_depth_v3/orchestrator.py` | `lux_depth_v3/pipeline_coordinator.py` | Partial | This PR: backend initialization state extracted; runtime state helpers remain ranked |
+| Target 1C — Backend resolution & state | `lux_depth_v3/orchestrator.py` | `lux_depth_v3/pipeline_coordinator.py` | Landed | This PR: backend initialization and runtime attempt-state helpers extracted |
 | Target 2A — Portal asset bundle | `app.py` | `src/transformation_portal/portal/asset_bundle.py` | Not started | Ranked 2026-05-04 |
 | Target 3A — Segmentation cache helpers | `lux_depth_v3/segmentation_backend.py` | `lux_depth_v3/segmentation/_cache.py` | Not started | Ranked 2026-05-04 |
 | Target 3B — Stub backend | `lux_depth_v3/segmentation_backend.py` | `lux_depth_v3/segmentation/stub.py` | Not started | Ranked 2026-05-04 |

--- a/src/transformation_portal/lux_depth_v3/orchestrator.py
+++ b/src/transformation_portal/lux_depth_v3/orchestrator.py
@@ -186,14 +186,24 @@ from .pipeline_coordinator import (
     BackendSelection,
     ExecutionPlan,
     PipelineCoordinator,
+    build_active_depth_state,
+    build_backend_metadata_for_attempts,
     default_model_id_for_backend,
     derive_model_id_from_backend_instance,
     expected_output_depth_units_for_backend,
+    extract_model_artifact_from_attempts,
+    extract_model_id_from_attempts,
+    get_or_create_depth_backend,
+    infer_operational_error_code,
     initialize_depth_backend_state,
+    normalize_sha256,
+    resolve_backend_model_artifact,
     resolve_backend_model_id,
     resolve_requested_backend,
     resolve_runtime_backend_chain,
+    seed_depth_attempts_from_selection_fallback,
     select_backend,
+    typed_nullary_callable,
 )
 
 # ADR-043: Pipeline coordination backward-compatible aliases
@@ -701,19 +711,12 @@ class EnhanceOrchestrator:
     @staticmethod
     def _normalize_sha256(value: Any) -> Optional[str]:
         """Normalize SHA-256 digest to lowercase hex."""
-        if not isinstance(value, str):
-            return None
-        digest = value.strip().lower()
-        if len(digest) == 64 and all(ch in "0123456789abcdef" for ch in digest):
-            return digest
-        return None
+        return normalize_sha256(value)
 
     @staticmethod
     def _typed_nullary_callable(value: Any) -> Optional[Callable[[], Any]]:
         """Return a typed no-arg callable for dynamically loaded attributes."""
-        if callable(value):
-            return cast(Callable[[], Any], value)
-        return None
+        return typed_nullary_callable(value)
 
     def _resolve_backend_model_artifact(
         self,
@@ -723,53 +726,11 @@ class EnhanceOrchestrator:
         backend: Optional[Any] = None,
     ) -> Dict[str, Optional[str]]:
         """Resolve backend model artifact identity fields."""
-        artifact_filename: Optional[str] = None
-        artifact_sha256: Optional[str] = None
-
-        if str(backend_id).strip().lower() != "depth_pro":
-            return {
-                "model_artifact_filename": None,
-                "model_artifact_sha256": None,
-            }
-
-        metadata = result_metadata or {}
-        checkpoint_meta = metadata.get("checkpoint")
-        if isinstance(checkpoint_meta, dict):
-            path_value = checkpoint_meta.get("path")
-            if isinstance(path_value, str) and path_value.strip():
-                artifact_filename = Path(path_value).name
-            artifact_sha256 = self._normalize_sha256(checkpoint_meta.get("sha256"))
-
-        if artifact_filename is None and backend is not None:
-            checkpoint_path = getattr(backend, "_checkpoint_path", None)
-            if checkpoint_path is not None:
-                try:
-                    artifact_filename = Path(checkpoint_path).name
-                except TypeError:
-                    artifact_filename = None
-
-        if artifact_sha256 is None and backend is not None:
-            artifact_sha256 = self._normalize_sha256(
-                getattr(backend, "_checkpoint_hash_cached", None),
-            )
-
-        checkpoint_meta_present = isinstance(checkpoint_meta, dict)
-        if artifact_sha256 is None and checkpoint_meta_present and backend is not None:
-            checkpoint_hash_getter = self._typed_nullary_callable(
-                getattr(backend, "_get_checkpoint_hash", None),
-            )
-            if checkpoint_hash_getter is not None:
-                try:
-                    artifact_sha256 = self._normalize_sha256(
-                        checkpoint_hash_getter(),
-                    )
-                except Exception:  # pragma: no cover - best-effort provenance enrichment
-                    artifact_sha256 = None
-
-        return {
-            "model_artifact_filename": artifact_filename,
-            "model_artifact_sha256": artifact_sha256,
-        }
+        return resolve_backend_model_artifact(
+            backend_id,
+            result_metadata=result_metadata,
+            backend=backend,
+        )
 
     @staticmethod
     def _extract_model_id_from_attempts(
@@ -779,23 +740,11 @@ class EnhanceOrchestrator:
         selected_attempt_index: Optional[int] = None,
     ) -> Optional[str]:
         """Extract selected backend model id from attempt history."""
-        if selected_attempt_index is not None and 0 <= selected_attempt_index < len(attempts):
-            selected_attempt = attempts[selected_attempt_index]
-            if selected_attempt.get("backend") == selected_backend:
-                selected_attempt_model = selected_attempt.get("model_id")
-                if isinstance(selected_attempt_model, str) and selected_attempt_model.strip():
-                    return selected_attempt_model.strip()
-
-        for attempt in attempts:
-            if attempt.get("backend") != selected_backend:
-                continue
-            if attempt.get("status") != "success":
-                continue
-            attempt_model = attempt.get("model_id")
-            if isinstance(attempt_model, str) and attempt_model.strip():
-                return attempt_model.strip()
-
-        return None
+        return extract_model_id_from_attempts(
+            selected_backend,
+            attempts,
+            selected_attempt_index=selected_attempt_index,
+        )
 
     @staticmethod
     def _extract_model_artifact_from_attempts(
@@ -805,140 +754,40 @@ class EnhanceOrchestrator:
         selected_attempt_index: Optional[int] = None,
     ) -> Dict[str, Optional[str]]:
         """Extract selected backend model artifact identity from attempt history."""
-
-        def _normalize_digest(value: Any) -> Optional[str]:
-            if not isinstance(value, str):
-                return None
-            digest = value.strip().lower()
-            if len(digest) == 64 and all(ch in "0123456789abcdef" for ch in digest):
-                return digest
-            return None
-
-        def _extract_from_attempt(attempt: Dict[str, Any]) -> Dict[str, Optional[str]]:
-            raw_filename = attempt.get("model_artifact_filename")
-            artifact_filename = raw_filename.strip() if isinstance(raw_filename, str) and raw_filename.strip() else None
-            return {
-                "model_artifact_filename": artifact_filename,
-                "model_artifact_sha256": _normalize_digest(
-                    attempt.get("model_artifact_sha256"),
-                ),
-            }
-
-        if selected_attempt_index is not None and 0 <= selected_attempt_index < len(attempts):
-            selected_attempt = attempts[selected_attempt_index]
-            if selected_attempt.get("backend") == selected_backend:
-                selected_artifact = _extract_from_attempt(selected_attempt)
-                if selected_artifact["model_artifact_filename"] or selected_artifact["model_artifact_sha256"]:
-                    return selected_artifact
-
-        for attempt in attempts:
-            if attempt.get("backend") != selected_backend:
-                continue
-            if attempt.get("status") != "success":
-                continue
-            selected_artifact = _extract_from_attempt(attempt)
-            if selected_artifact["model_artifact_filename"] or selected_artifact["model_artifact_sha256"]:
-                return selected_artifact
-
-        return {
-            "model_artifact_filename": None,
-            "model_artifact_sha256": None,
-        }
+        return extract_model_artifact_from_attempts(
+            selected_backend,
+            attempts,
+            selected_attempt_index=selected_attempt_index,
+        )
 
     def _seed_depth_attempts_from_selection_fallback(self) -> List[Dict[str, Any]]:
         """Materialize backend-selection fallback into per-image attempt history."""
-        backend_metadata = getattr(self, "_backend_metadata", None)
-        init_errors = getattr(self, "_backend_init_errors", None) or {}
-        requested_backend = normalize_backend_id(getattr(backend_metadata, "requested_backend", None))
-        resolved_backend = normalize_backend_id(getattr(backend_metadata, "resolved_backend", None))
-
-        if (
-            not requested_backend
-            or not resolved_backend
-            or requested_backend == resolved_backend
-            or not isinstance(init_errors, dict)
-        ):
-            return []
-
-        requested_error = init_errors.get(requested_backend)
-        if not isinstance(requested_error, str) or not requested_error.strip():
-            return []
-
-        attempt: Dict[str, Any] = {
-            "attempt": 0,
-            "backend": requested_backend,
-            "model_id": self._default_model_id_for_backend(requested_backend),
-            "device": self.config.depth_device,
-            "status": "failed",
-            "failure_kind": "operational",
-            "error_code": self._infer_operational_error_code(
-                RuntimeError(requested_error),
-            ),
-            "error_message": requested_error,
-            "apex_gate_passed": False,
-            "cached": False,
-            "duration_s": 0.0,
-            "model_artifact_filename": None,
-            "model_artifact_sha256": None,
-        }
-
-        if requested_backend == "depth_pro":
-            checkpoint_path = Path(
-                getattr(self.config, "depth_pro_checkpoint_path", None)
-                or os.environ.get("TRANSFORMATION_PORTAL_DEPTH_PRO_CHECKPOINT")
-                or "checkpoints/depth_pro.pt"
-            )
-            attempt["model_artifact_filename"] = checkpoint_path.name
-
-        return [attempt]
+        return seed_depth_attempts_from_selection_fallback(
+            getattr(self, "_backend_metadata", None),
+            getattr(self, "_backend_init_errors", None),
+            self.config,
+            self._model_variant,
+        )
 
     def _get_or_create_depth_backend(
         self,
         backend_id: str,
     ) -> Any:
         """Fetch backend from cache or registry."""
-        # Respect an already-initialized active backend when it matches the
-        # requested backend id. This keeps injected test doubles stable and
-        # avoids unnecessary registry lookups.
-        active_backend = getattr(self, "depth_backend", None)
-        if (
-            active_backend is not None
-            and getattr(
-                active_backend,
-                "name",
-                None,
-            )
-            == backend_id
-        ):
-            self._depth_backend_cache[backend_id] = active_backend
-            return active_backend
-
-        cached = self._depth_backend_cache.get(backend_id)
-        if cached is not None:
-            return cached
-
-        backend = self._depth_registry.get_backend(backend_id, self.config)
-        backend.ensure_available()
-        self._depth_backend_cache[backend_id] = backend
-        return backend
+        return get_or_create_depth_backend(
+            backend_id,
+            active_backend=getattr(self, "depth_backend", None),
+            backend_cache=self._depth_backend_cache,
+            registry=self._depth_registry,
+            config=self.config,
+        )
 
     @staticmethod
     def _infer_operational_error_code(
         error: Exception,
     ) -> str:
         """Map backend exceptions to error codes."""
-        if isinstance(error, ImportError):
-            return "BACKEND_IMPORT_ERROR"
-        if isinstance(error, FileNotFoundError):
-            return "BACKEND_RESOURCE_MISSING"
-        message = str(error).lower()
-        if "torch not compiled with cuda enabled" in message:
-            return "CUDA_HARDCODED_IN_BACKEND"
-        if "cuda" in message and "not available" in message:
-            return "CUDA_UNAVAILABLE"
-        if "mps" in message and "not available" in message:
-            return "MPS_UNAVAILABLE"
-        return "BACKEND_RUNTIME_ERROR"
+        return infer_operational_error_code(error)
 
     def _set_active_depth_state(
         self,
@@ -947,9 +796,14 @@ class EnhanceOrchestrator:
         selected_attempt_index: Optional[int],
     ) -> None:
         """Persist per-image depth state for downstream error/reporting paths."""
-        self._active_backend_metadata = backend_metadata
-        self._active_depth_attempts = list(depth_attempts)
-        self._active_selected_attempt_index = selected_attempt_index
+        active_state = build_active_depth_state(
+            backend_metadata,
+            depth_attempts,
+            selected_attempt_index,
+        )
+        self._active_backend_metadata = active_state.backend_metadata
+        self._active_depth_attempts = active_state.depth_attempts
+        self._active_selected_attempt_index = active_state.selected_attempt_index
 
     def _build_backend_metadata_for_attempts(
         self,
@@ -959,70 +813,15 @@ class EnhanceOrchestrator:
         selected_attempt_index: Optional[int] = None,
     ) -> BackendSelectionMetadata:
         """Build per-image backend selection metadata."""
-        normalized_selected_backend = (
-            normalize_backend_id(
-                selected_backend,
-            )
-            or selected_backend
-        )
-        requested = normalize_backend_provenance(
-            self._backend_metadata.requested_backend or self._backend_metadata.resolved_backend,
-        )
-        resolution_status = "success" if normalized_selected_backend == requested else "fallback"
-        resolution_reason: Optional[str] = None
-        if resolution_status == "fallback":
-            startup_reason = getattr(self._backend_metadata, "resolution_reason", None)
-            if (
-                isinstance(startup_reason, str)
-                and startup_reason.strip()
-                and normalize_backend_provenance(self._backend_metadata.requested_backend) == requested
-                and normalize_backend_provenance(self._backend_metadata.resolved_backend) == normalized_selected_backend
-                and self._backend_metadata.resolution_status != "success"
-            ):
-                resolution_reason = startup_reason
-            else:
-                failed = [attempt for attempt in attempts if attempt.get("status") == "failed"]
-                if failed:
-                    first_failure = failed[0]
-                    failure_kind = first_failure.get(
-                        "failure_kind",
-                        "operational",
-                    )
-                    failure_code = first_failure.get(
-                        "error_code",
-                        "UNKNOWN",
-                    )
-                    resolution_reason = (
-                        f"Fallback from"
-                        f" '{requested}' to"
-                        f" '{normalized_selected_backend}'"
-                        f" after {failure_kind}"
-                        f" failure ({failure_code})"
-                    )
-                else:
-                    resolution_reason = f"Fallback from" f" '{requested}'" f" to '{normalized_selected_backend}'"
-
-        model_id = self._extract_model_id_from_attempts(
-            normalized_selected_backend,
+        return build_backend_metadata_for_attempts(
+            selected_backend,
             attempts,
+            self._backend_metadata,
+            self.config,
+            self._resolve_backend_model_id,
+            result_metadata=result_metadata,
             selected_attempt_index=selected_attempt_index,
-        )
-        if not model_id:
-            backend_cache = getattr(self, "_depth_backend_cache", {})
-            model_id = self._resolve_backend_model_id(
-                normalized_selected_backend,
-                result_metadata=result_metadata,
-                backend=backend_cache.get(normalized_selected_backend),
-            )
-
-        return BackendSelectionMetadata(
-            requested_backend=requested,
-            resolved_backend=normalized_selected_backend,
-            resolution_status=resolution_status,
-            resolution_reason=resolution_reason,
-            model_id=str(model_id),
-            device=self.config.depth_device,
-            attempts=attempts,
+            backend_cache=getattr(self, "_depth_backend_cache", {}),
         )
 
     # ADR-043: Config resolution methods now delegate to config_resolver module

--- a/src/transformation_portal/lux_depth_v3/pipeline_coordinator.py
+++ b/src/transformation_portal/lux_depth_v3/pipeline_coordinator.py
@@ -37,13 +37,14 @@ from __future__ import annotations
 import logging
 import os
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
 from ..core.platform_matrix import CURRENT_PLATFORM, PlatformMatrix
 from ..depth.backends.protocol import LicenseRestrictionError
 
 # Use absolute import to avoid circular dependencies
-from ._backend_contract import normalize_backend_id, normalize_backend_sequence
+from ._backend_contract import normalize_backend_id, normalize_backend_provenance, normalize_backend_sequence
 from .config import EnhanceConfig, ModelVariant
 from .config_resolver import (
     apply_effective_da3_runtime_config,
@@ -182,6 +183,15 @@ class InitializedDepthBackendState:
     backend_cache: Dict[str, Any]
     init_errors: Dict[str, str]
     backend_metadata: BackendSelectionMetadata
+
+
+@dataclass
+class ActiveDepthState:
+    """Per-image active backend state for orchestrator reporting paths."""
+
+    backend_metadata: Optional[BackendSelectionMetadata]
+    depth_attempts: List[Dict[str, Any]]
+    selected_attempt_index: Optional[int]
 
 
 def resolve_runtime_backend_chain(
@@ -384,6 +394,333 @@ def resolve_backend_model_id(
 
     # Fall back to default
     return default_model_id_for_backend(backend_id, model_variant, config=config)
+
+
+def normalize_sha256(value: Any) -> Optional[str]:
+    """Normalize SHA-256 digest to lowercase hex."""
+    if not isinstance(value, str):
+        return None
+    digest = value.strip().lower()
+    if len(digest) == 64 and all(ch in "0123456789abcdef" for ch in digest):
+        return digest
+    return None
+
+
+def typed_nullary_callable(value: Any) -> Optional[Callable[[], Any]]:
+    """Return a typed no-arg callable for dynamically loaded attributes."""
+    if callable(value):
+        return value
+    return None
+
+
+def resolve_backend_model_artifact(
+    backend_id: str,
+    *,
+    result_metadata: Optional[Dict[str, Any]] = None,
+    backend: Optional[Any] = None,
+) -> Dict[str, Optional[str]]:
+    """Resolve backend model artifact identity fields."""
+    artifact_filename: Optional[str] = None
+    artifact_sha256: Optional[str] = None
+
+    if str(backend_id).strip().lower() != "depth_pro":
+        return {
+            "model_artifact_filename": None,
+            "model_artifact_sha256": None,
+        }
+
+    metadata = result_metadata or {}
+    checkpoint_meta = metadata.get("checkpoint")
+    if isinstance(checkpoint_meta, dict):
+        path_value = checkpoint_meta.get("path")
+        if isinstance(path_value, str) and path_value.strip():
+            artifact_filename = Path(path_value).name
+        artifact_sha256 = normalize_sha256(checkpoint_meta.get("sha256"))
+
+    if artifact_filename is None and backend is not None:
+        checkpoint_path = getattr(backend, "_checkpoint_path", None)
+        if checkpoint_path is not None:
+            try:
+                artifact_filename = Path(checkpoint_path).name
+            except TypeError:
+                artifact_filename = None
+
+    if artifact_sha256 is None and backend is not None:
+        artifact_sha256 = normalize_sha256(
+            getattr(backend, "_checkpoint_hash_cached", None),
+        )
+
+    checkpoint_meta_present = isinstance(checkpoint_meta, dict)
+    if artifact_sha256 is None and checkpoint_meta_present and backend is not None:
+        checkpoint_hash_getter = typed_nullary_callable(
+            getattr(backend, "_get_checkpoint_hash", None),
+        )
+        if checkpoint_hash_getter is not None:
+            try:
+                artifact_sha256 = normalize_sha256(
+                    checkpoint_hash_getter(),
+                )
+            except Exception:  # pragma: no cover - best-effort provenance enrichment
+                artifact_sha256 = None
+
+    return {
+        "model_artifact_filename": artifact_filename,
+        "model_artifact_sha256": artifact_sha256,
+    }
+
+
+def extract_model_id_from_attempts(
+    selected_backend: str,
+    attempts: List[Dict[str, Any]],
+    *,
+    selected_attempt_index: Optional[int] = None,
+) -> Optional[str]:
+    """Extract selected backend model id from attempt history."""
+    if selected_attempt_index is not None and 0 <= selected_attempt_index < len(attempts):
+        selected_attempt = attempts[selected_attempt_index]
+        if selected_attempt.get("backend") == selected_backend:
+            selected_attempt_model = selected_attempt.get("model_id")
+            if isinstance(selected_attempt_model, str) and selected_attempt_model.strip():
+                return selected_attempt_model.strip()
+
+    for attempt in attempts:
+        if attempt.get("backend") != selected_backend:
+            continue
+        if attempt.get("status") != "success":
+            continue
+        attempt_model = attempt.get("model_id")
+        if isinstance(attempt_model, str) and attempt_model.strip():
+            return attempt_model.strip()
+
+    return None
+
+
+def extract_model_artifact_from_attempts(
+    selected_backend: str,
+    attempts: List[Dict[str, Any]],
+    *,
+    selected_attempt_index: Optional[int] = None,
+) -> Dict[str, Optional[str]]:
+    """Extract selected backend model artifact identity from attempt history."""
+
+    def _extract_from_attempt(attempt: Dict[str, Any]) -> Dict[str, Optional[str]]:
+        raw_filename = attempt.get("model_artifact_filename")
+        artifact_filename = raw_filename.strip() if isinstance(raw_filename, str) and raw_filename.strip() else None
+        return {
+            "model_artifact_filename": artifact_filename,
+            "model_artifact_sha256": normalize_sha256(
+                attempt.get("model_artifact_sha256"),
+            ),
+        }
+
+    if selected_attempt_index is not None and 0 <= selected_attempt_index < len(attempts):
+        selected_attempt = attempts[selected_attempt_index]
+        if selected_attempt.get("backend") == selected_backend:
+            selected_artifact = _extract_from_attempt(selected_attempt)
+            if selected_artifact["model_artifact_filename"] or selected_artifact["model_artifact_sha256"]:
+                return selected_artifact
+
+    for attempt in attempts:
+        if attempt.get("backend") != selected_backend:
+            continue
+        if attempt.get("status") != "success":
+            continue
+        selected_artifact = _extract_from_attempt(attempt)
+        if selected_artifact["model_artifact_filename"] or selected_artifact["model_artifact_sha256"]:
+            return selected_artifact
+
+    return {
+        "model_artifact_filename": None,
+        "model_artifact_sha256": None,
+    }
+
+
+def infer_operational_error_code(
+    error: Exception,
+) -> str:
+    """Map backend exceptions to error codes."""
+    if isinstance(error, ImportError):
+        return "BACKEND_IMPORT_ERROR"
+    if isinstance(error, FileNotFoundError):
+        return "BACKEND_RESOURCE_MISSING"
+    message = str(error).lower()
+    if "torch not compiled with cuda enabled" in message:
+        return "CUDA_HARDCODED_IN_BACKEND"
+    if "cuda" in message and "not available" in message:
+        return "CUDA_UNAVAILABLE"
+    if "mps" in message and "not available" in message:
+        return "MPS_UNAVAILABLE"
+    return "BACKEND_RUNTIME_ERROR"
+
+
+def seed_depth_attempts_from_selection_fallback(
+    backend_metadata: Optional[BackendSelectionMetadata],
+    init_errors: Optional[Dict[str, str]],
+    config: EnhanceConfig,
+    model_variant: ModelVariant,
+) -> List[Dict[str, Any]]:
+    """Materialize backend-selection fallback into per-image attempt history."""
+    effective_errors = init_errors or {}
+    requested_backend = normalize_backend_id(getattr(backend_metadata, "requested_backend", None))
+    resolved_backend = normalize_backend_id(getattr(backend_metadata, "resolved_backend", None))
+
+    if (
+        not requested_backend
+        or not resolved_backend
+        or requested_backend == resolved_backend
+        or not isinstance(effective_errors, dict)
+    ):
+        return []
+
+    requested_error = effective_errors.get(requested_backend)
+    if not isinstance(requested_error, str) or not requested_error.strip():
+        return []
+
+    attempt: Dict[str, Any] = {
+        "attempt": 0,
+        "backend": requested_backend,
+        "model_id": default_model_id_for_backend(requested_backend, model_variant, config=config),
+        "device": config.depth_device,
+        "status": "failed",
+        "failure_kind": "operational",
+        "error_code": infer_operational_error_code(
+            RuntimeError(requested_error),
+        ),
+        "error_message": requested_error,
+        "apex_gate_passed": False,
+        "cached": False,
+        "duration_s": 0.0,
+        "model_artifact_filename": None,
+        "model_artifact_sha256": None,
+    }
+
+    if requested_backend == "depth_pro":
+        checkpoint_path = Path(
+            getattr(config, "depth_pro_checkpoint_path", None)
+            or os.environ.get("TRANSFORMATION_PORTAL_DEPTH_PRO_CHECKPOINT")
+            or "checkpoints/depth_pro.pt"
+        )
+        attempt["model_artifact_filename"] = checkpoint_path.name
+
+    return [attempt]
+
+
+def get_or_create_depth_backend(
+    backend_id: str,
+    *,
+    active_backend: Optional[Any],
+    backend_cache: Dict[str, Any],
+    registry: Any,
+    config: EnhanceConfig,
+) -> Any:
+    """Fetch backend from cache or registry."""
+    if (
+        active_backend is not None
+        and getattr(
+            active_backend,
+            "name",
+            None,
+        )
+        == backend_id
+    ):
+        backend_cache[backend_id] = active_backend
+        return active_backend
+
+    cached = backend_cache.get(backend_id)
+    if cached is not None:
+        return cached
+
+    backend = registry.get_backend(backend_id, config)
+    backend.ensure_available()
+    backend_cache[backend_id] = backend
+    return backend
+
+
+def build_active_depth_state(
+    backend_metadata: Optional[BackendSelectionMetadata],
+    depth_attempts: List[Dict[str, Any]],
+    selected_attempt_index: Optional[int],
+) -> ActiveDepthState:
+    """Build per-image active backend state for downstream reporting paths."""
+    return ActiveDepthState(
+        backend_metadata=backend_metadata,
+        depth_attempts=list(depth_attempts),
+        selected_attempt_index=selected_attempt_index,
+    )
+
+
+def build_backend_metadata_for_attempts(
+    selected_backend: str,
+    attempts: List[Dict[str, Any]],
+    startup_backend_metadata: BackendSelectionMetadata,
+    config: EnhanceConfig,
+    resolve_model_id: Callable[..., str],
+    *,
+    result_metadata: Optional[Dict[str, Any]] = None,
+    selected_attempt_index: Optional[int] = None,
+    backend_cache: Optional[Dict[str, Any]] = None,
+) -> BackendSelectionMetadata:
+    """Build per-image backend selection metadata."""
+    normalized_selected_backend = normalize_backend_id(selected_backend) or selected_backend
+    requested = normalize_backend_provenance(
+        startup_backend_metadata.requested_backend or startup_backend_metadata.resolved_backend,
+    )
+    resolution_status = "success" if normalized_selected_backend == requested else "fallback"
+    resolution_reason: Optional[str] = None
+    if resolution_status == "fallback":
+        startup_reason = getattr(startup_backend_metadata, "resolution_reason", None)
+        if (
+            isinstance(startup_reason, str)
+            and startup_reason.strip()
+            and normalize_backend_provenance(startup_backend_metadata.requested_backend) == requested
+            and normalize_backend_provenance(startup_backend_metadata.resolved_backend) == normalized_selected_backend
+            and startup_backend_metadata.resolution_status != "success"
+        ):
+            resolution_reason = startup_reason
+        else:
+            failed = [attempt for attempt in attempts if attempt.get("status") == "failed"]
+            if failed:
+                first_failure = failed[0]
+                failure_kind = first_failure.get(
+                    "failure_kind",
+                    "operational",
+                )
+                failure_code = first_failure.get(
+                    "error_code",
+                    "UNKNOWN",
+                )
+                resolution_reason = (
+                    f"Fallback from"
+                    f" '{requested}' to"
+                    f" '{normalized_selected_backend}'"
+                    f" after {failure_kind}"
+                    f" failure ({failure_code})"
+                )
+            else:
+                resolution_reason = f"Fallback from" f" '{requested}'" f" to '{normalized_selected_backend}'"
+
+    model_id = extract_model_id_from_attempts(
+        normalized_selected_backend,
+        attempts,
+        selected_attempt_index=selected_attempt_index,
+    )
+    if not model_id:
+        effective_backend_cache = backend_cache or {}
+        model_id = resolve_model_id(
+            normalized_selected_backend,
+            result_metadata=result_metadata,
+            backend=effective_backend_cache.get(normalized_selected_backend),
+        )
+
+    return BackendSelectionMetadata(
+        requested_backend=requested,
+        resolved_backend=normalized_selected_backend,
+        resolution_status=resolution_status,
+        resolution_reason=resolution_reason,
+        model_id=str(model_id),
+        device=config.depth_device,
+        attempts=attempts,
+    )
 
 
 def select_backend(

--- a/tests/lux_depth_v3/test_pipeline_coordinator.py
+++ b/tests/lux_depth_v3/test_pipeline_coordinator.py
@@ -29,18 +29,30 @@ class TestPipelineCoordinatorImports:
     def test_import_from_pipeline_coordinator(self):
         """Test that we can import from the new pipeline_coordinator module."""
         from transformation_portal.lux_depth_v3.pipeline_coordinator import (
+            ActiveDepthState,
             BackendSelection,
             ExecutionPlan,
             PipelineCoordinator,
+            build_active_depth_state,
+            build_backend_metadata_for_attempts,
             default_model_id_for_backend,
             derive_model_id_from_backend_instance,
             expected_output_depth_units_for_backend,
+            extract_model_artifact_from_attempts,
+            extract_model_id_from_attempts,
+            get_or_create_depth_backend,
+            infer_operational_error_code,
+            normalize_sha256,
+            resolve_backend_model_artifact,
             resolve_backend_model_id,
             resolve_runtime_backend_chain,
+            seed_depth_attempts_from_selection_fallback,
             select_backend,
+            typed_nullary_callable,
         )
 
         assert PipelineCoordinator is not None
+        assert ActiveDepthState is not None
         assert BackendSelection is not None
         assert ExecutionPlan is not None
         assert callable(resolve_runtime_backend_chain)
@@ -49,6 +61,16 @@ class TestPipelineCoordinatorImports:
         assert callable(derive_model_id_from_backend_instance)
         assert callable(resolve_backend_model_id)
         assert callable(expected_output_depth_units_for_backend)
+        assert callable(normalize_sha256)
+        assert callable(typed_nullary_callable)
+        assert callable(resolve_backend_model_artifact)
+        assert callable(extract_model_id_from_attempts)
+        assert callable(extract_model_artifact_from_attempts)
+        assert callable(infer_operational_error_code)
+        assert callable(seed_depth_attempts_from_selection_fallback)
+        assert callable(get_or_create_depth_backend)
+        assert callable(build_active_depth_state)
+        assert callable(build_backend_metadata_for_attempts)
 
 
 class TestResolveRuntimeBackendChain:
@@ -264,6 +286,265 @@ class TestResolveBackendModelId:
 
         result = resolve_backend_model_id("synthetic")
         assert result == "synthetic/depth-analytic-v1"
+
+
+class TestRuntimeBackendStateHelpers:
+    """Test runtime backend state helpers extracted from orchestrator."""
+
+    def test_normalize_sha256_accepts_lowercase_hex_only(self):
+        """Test digest normalization rejects non-SHA256 values."""
+        from transformation_portal.lux_depth_v3.pipeline_coordinator import (
+            normalize_sha256,
+        )
+
+        digest = "A" * 64
+
+        assert normalize_sha256(f" {digest} ") == digest.lower()
+        assert normalize_sha256("not-a-digest") is None
+        assert normalize_sha256(None) is None
+
+    def test_resolve_backend_model_artifact_uses_depth_pro_metadata(self):
+        """Test Depth Pro artifact provenance comes from checkpoint metadata."""
+        from transformation_portal.lux_depth_v3.pipeline_coordinator import (
+            resolve_backend_model_artifact,
+        )
+
+        digest = "B" * 64
+
+        artifact = resolve_backend_model_artifact(
+            "depth_pro",
+            result_metadata={
+                "checkpoint": {
+                    "path": "/models/depth-pro-local.pt",
+                    "sha256": digest,
+                }
+            },
+        )
+
+        assert artifact == {
+            "model_artifact_filename": "depth-pro-local.pt",
+            "model_artifact_sha256": digest.lower(),
+        }
+
+    def test_resolve_backend_model_artifact_uses_depth_pro_backend_fallback(self):
+        """Test backend attributes are best-effort fallback provenance."""
+        from transformation_portal.lux_depth_v3.pipeline_coordinator import (
+            resolve_backend_model_artifact,
+        )
+
+        digest = "C" * 64
+        backend = MagicMock(spec=["_checkpoint_path", "_checkpoint_hash_cached", "_get_checkpoint_hash"])
+        backend._checkpoint_path = "/runtime/depth-pro-fallback.pt"
+        backend._checkpoint_hash_cached = None
+        backend._get_checkpoint_hash.return_value = digest
+
+        artifact = resolve_backend_model_artifact(
+            "depth_pro",
+            result_metadata={"checkpoint": {}},
+            backend=backend,
+        )
+
+        assert artifact == {
+            "model_artifact_filename": "depth-pro-fallback.pt",
+            "model_artifact_sha256": digest.lower(),
+        }
+
+    def test_extract_model_id_from_attempts_prefers_selected_attempt(self):
+        """Test selected runtime attempt wins over earlier successful attempts."""
+        from transformation_portal.lux_depth_v3.pipeline_coordinator import (
+            extract_model_id_from_attempts,
+        )
+
+        attempts = [
+            {"backend": "da3", "status": "success", "model_id": "model/first"},
+            {"backend": "da3", "status": "success", "model_id": "model/selected"},
+        ]
+
+        assert (
+            extract_model_id_from_attempts(
+                "da3",
+                attempts,
+                selected_attempt_index=1,
+            )
+            == "model/selected"
+        )
+
+    def test_extract_model_artifact_from_attempts_prefers_selected_attempt(self):
+        """Test selected runtime attempt wins for artifact identity."""
+        from transformation_portal.lux_depth_v3.pipeline_coordinator import (
+            extract_model_artifact_from_attempts,
+        )
+
+        selected_digest = "D" * 64
+        attempts = [
+            {
+                "backend": "depth_pro",
+                "status": "success",
+                "model_artifact_filename": "first.pt",
+                "model_artifact_sha256": "E" * 64,
+            },
+            {
+                "backend": "depth_pro",
+                "status": "success",
+                "model_artifact_filename": "selected.pt",
+                "model_artifact_sha256": selected_digest,
+            },
+        ]
+
+        assert extract_model_artifact_from_attempts(
+            "depth_pro",
+            attempts,
+            selected_attempt_index=1,
+        ) == {
+            "model_artifact_filename": "selected.pt",
+            "model_artifact_sha256": selected_digest.lower(),
+        }
+
+    def test_infer_operational_error_code_classifies_known_failures(self):
+        """Test backend error classification stays stable."""
+        from transformation_portal.lux_depth_v3.pipeline_coordinator import (
+            infer_operational_error_code,
+        )
+
+        assert infer_operational_error_code(ImportError("missing")) == "BACKEND_IMPORT_ERROR"
+        assert infer_operational_error_code(FileNotFoundError("missing")) == "BACKEND_RESOURCE_MISSING"
+        assert infer_operational_error_code(RuntimeError("cuda not available")) == "CUDA_UNAVAILABLE"
+        assert infer_operational_error_code(RuntimeError("mps not available")) == "MPS_UNAVAILABLE"
+
+    def test_seed_depth_attempts_from_selection_fallback_records_depth_pro_failure(self):
+        """Test startup fallback is materialized into per-image attempt history."""
+        from transformation_portal.lux_depth_v3.config import EnhanceConfig, ModelVariant
+        from transformation_portal.lux_depth_v3.manifest import BackendSelectionMetadata
+        from transformation_portal.lux_depth_v3.pipeline_coordinator import (
+            seed_depth_attempts_from_selection_fallback,
+        )
+
+        metadata = BackendSelectionMetadata(
+            requested_backend="depth_pro",
+            resolved_backend="da3",
+            resolution_status="fallback",
+            resolution_reason="Depth Pro unavailable",
+            model_id="depth-anything/Depth-Anything-3-Metric-Large",
+            device="cpu",
+        )
+        config = EnhanceConfig(
+            depth_device="cpu",
+            depth_pro_checkpoint_path="/models/depth-pro-local.pt",
+        )
+
+        attempts = seed_depth_attempts_from_selection_fallback(
+            metadata,
+            {"depth_pro": "checkpoint not found"},
+            config,
+            ModelVariant.METRIC_LARGE,
+        )
+
+        assert attempts == [
+            {
+                "attempt": 0,
+                "backend": "depth_pro",
+                "model_id": "apple/ml-depth-pro",
+                "device": "cpu",
+                "status": "failed",
+                "failure_kind": "operational",
+                "error_code": "BACKEND_RUNTIME_ERROR",
+                "error_message": "checkpoint not found",
+                "apex_gate_passed": False,
+                "cached": False,
+                "duration_s": 0.0,
+                "model_artifact_filename": "depth-pro-local.pt",
+                "model_artifact_sha256": None,
+            }
+        ]
+
+    def test_get_or_create_depth_backend_prefers_matching_active_backend(self):
+        """Test active backend injection is preserved over stale cache entries."""
+        from transformation_portal.lux_depth_v3.config import EnhanceConfig
+        from transformation_portal.lux_depth_v3.pipeline_coordinator import (
+            get_or_create_depth_backend,
+        )
+
+        active_backend = MagicMock()
+        active_backend.name = "da3"
+        stale_backend = MagicMock()
+        registry = MagicMock()
+        backend_cache = {"da3": stale_backend}
+
+        result = get_or_create_depth_backend(
+            "da3",
+            active_backend=active_backend,
+            backend_cache=backend_cache,
+            registry=registry,
+            config=EnhanceConfig(),
+        )
+
+        assert result is active_backend
+        assert backend_cache["da3"] is active_backend
+        registry.get_backend.assert_not_called()
+
+    def test_build_active_depth_state_copies_attempts(self):
+        """Test active depth state owns its attempt list copy."""
+        from transformation_portal.lux_depth_v3.pipeline_coordinator import (
+            build_active_depth_state,
+        )
+
+        attempts = [{"backend": "da3", "status": "success"}]
+
+        state = build_active_depth_state(None, attempts, 0)
+
+        assert state.backend_metadata is None
+        assert state.depth_attempts == attempts
+        assert state.depth_attempts is not attempts
+        assert state.selected_attempt_index == 0
+
+    def test_build_backend_metadata_for_attempts_records_runtime_fallback(self):
+        """Test per-image backend metadata preserves fallback audit semantics."""
+        from transformation_portal.lux_depth_v3.config import EnhanceConfig
+        from transformation_portal.lux_depth_v3.manifest import BackendSelectionMetadata
+        from transformation_portal.lux_depth_v3.pipeline_coordinator import (
+            build_backend_metadata_for_attempts,
+        )
+
+        startup_metadata = BackendSelectionMetadata(
+            requested_backend="da3",
+            resolved_backend="da3",
+            resolution_status="success",
+            resolution_reason=None,
+            model_id="model/startup",
+            device="cpu",
+        )
+        attempts = [
+            {
+                "backend": "da3",
+                "status": "failed",
+                "failure_kind": "operational",
+                "error_code": "CUDA_UNAVAILABLE",
+            },
+            {
+                "backend": "da2",
+                "status": "success",
+                "model_id": "model/selected-da2",
+            },
+        ]
+        resolve_model_id = MagicMock(return_value="model/fallback")
+
+        metadata = build_backend_metadata_for_attempts(
+            "da2",
+            attempts,
+            startup_metadata,
+            EnhanceConfig(depth_device="cpu"),
+            resolve_model_id,
+            selected_attempt_index=1,
+        )
+
+        assert metadata.requested_backend == "da3"
+        assert metadata.resolved_backend == "da2"
+        assert metadata.resolution_status == "fallback"
+        assert metadata.resolution_reason == ("Fallback from 'da3' to 'da2' after operational failure (CUDA_UNAVAILABLE)")
+        assert metadata.model_id == "model/selected-da2"
+        assert metadata.device == "cpu"
+        assert metadata.attempts == attempts
+        resolve_model_id.assert_not_called()
 
 
 class TestBackendSelection:


### PR DESCRIPTION
## Summary
- Completes PR #1638 Target 1C by moving backend runtime state helpers out of EnhanceOrchestrator.
- Keeps orchestrator private methods as compatibility delegates while making pipeline_coordinator.py the owner of runtime backend attempt/state logic.

## Changes
- Adds coordinator helpers for SHA-256 normalization, Depth Pro model artifact provenance, attempt model/artifact extraction, fallback attempt seeding, backend cache lookup, active depth state, and per-image BackendSelectionMetadata construction.
- Updates EnhanceOrchestrator backend-state private methods to delegate to pipeline_coordinator.py without renaming or removing the compatibility surface.
- Adds focused unit coverage for selected-attempt precedence, Depth Pro artifact fallback provenance, operational error classification, startup fallback attempt seeding, active backend cache preference, and fallback metadata construction.
- Marks Target 1C as Landed in docs/architecture/MONOLITH_DECOMPOSITION_TARGETS.md.
- No FastAPI route, manifest schema, run-card schema, selector, CLI flag, or public API contract changes.

## Validation
Proven green:
- .venv/bin/pytest tests/lux_depth_v3/test_pipeline_coordinator.py -v
- .venv/bin/pytest tests/lux_depth_v3/test_orchestrator_backend_resolution.py -v
- .venv/bin/pytest tests/test_backend_selection.py -v
- .venv/bin/pytest tests/test_orchestrator_backend_integration.py -v
- .venv/bin/pytest tests/test_orchestrator_improvements.py -k "ConfigFingerprint or depth_cache" -v
- .venv/bin/pytest tests/test_run_card_schema.py -k "config_fingerprint or backend_model_id" -v
- make test-orchestrator-contract
- make check-doc-heading-links
- python3 scripts/governance/check_docs_structure.py --all
- .venv/bin/python scripts/validation/scan_todo_inventory.py --check-governance
- make check-json-serialization check-yaml-governance check-python-headers
- git diff --check
- pre-commit hooks during commit, including Black, isort, root-file placement, test marker, tautological assertion, and gitleaks checks

Still failing:
- None observed.

Failure classification:
- No product logic, stale test, or environment/tooling failures remain. macOS emitted sandbox-style xcrun temp-cache warnings on some git/make/python invocations, but the commands completed successfully.

## Risk
- Compatibility risk is bounded by retaining the existing orchestrator private methods and only replacing their bodies with delegates.
- Backend selection metadata and attempt provenance are covered by targeted unit tests, backend selection tests, integration tests, run-card tests, and the orchestrator contract suite.
- Revert-safe: the change is isolated to lux_depth_v3 backend-state extraction plus the Target 1C governance ledger row.