### PR TITLE
refactor(portal): extract asset bundle helpers

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,7 +21,7 @@ import time
 import uuid
 from bisect import bisect_left
 from collections import deque
-from contextlib import asynccontextmanager, suppress
+from contextlib import asynccontextmanager, contextmanager, suppress
 from dataclasses import dataclass
 from dataclasses import field as dataclass_field
 from email.parser import BytesParser
@@ -67,6 +67,7 @@ from transformation_portal.ingest.upload_staging import (
 )
 from transformation_portal.lux_depth_v3.model_registry import resolve_model_spec, resolve_registry_key, visible_cli_model_specs
 from transformation_portal.lux_depth_v3.run_card_contract import infer_run_card_version
+from transformation_portal.portal import asset_bundle as _portal_asset_bundle
 from transformation_portal.portal.asset_bundle import (
     PORTAL_ASSETS_DIR,
     PORTAL_ASSETS_DIR_REAL,
@@ -86,27 +87,6 @@ from transformation_portal.portal.asset_bundle import (
     PortalAssetBundle,
     PortalAssetSpec,
     PortalRenderedTextAsset,
-    _build_portal_asset_bundle,
-    _build_portal_css_asset,
-    _build_portal_direct_asset_fingerprint,
-    _fingerprint_bytes,
-    _get_portal_asset_bundle,
-    _get_portal_css_asset,
-    _get_portal_direct_asset_fingerprint,
-    _load_portal_asset_manifest,
-    _portal_asset_cache_control,
-    _portal_asset_etag,
-    _portal_asset_not_modified_response,
-    _portal_asset_request_etag_matches,
-    _portal_asset_route_path,
-    _portal_asset_signature,
-    _portal_asset_versioned_url,
-    _portal_css_dependency_asset_names,
-    _portal_css_signature,
-    _portal_direct_asset_signature,
-    _portal_html_signature,
-    _render_portal_template,
-    _requested_portal_asset_fingerprint,
 )
 from transformation_portal.vlm_captioning.fastvlm_runtime import (
     FASTVLM_CHECKPOINT_DIRS,
@@ -282,6 +262,150 @@ def _portal_fastvlm_captioning_enabled(actor: Optional[Mapping[str, Any]] = None
 REPO_ROOT = Path(__file__).resolve().parent
 PORTAL_VIDEO_ASSET_NAME = "dna-portal-video-2.mp4"
 PORTAL_VIDEO_PATH = REPO_ROOT / "public" / "video" / PORTAL_VIDEO_ASSET_NAME
+
+_PORTAL_ASSET_BUNDLE_APP_GLOBALS = (
+    "REPO_ROOT",
+    "PORTAL_HTML",
+    "PORTAL_ASSETS_DIR",
+    "PORTAL_ASSETS_DIR_REAL",
+    "PORTAL_ASSET_MANIFEST_PATH",
+    "PORTAL_ASSET_CACHE_CONTROL",
+    "PORTAL_IMMUTABLE_ASSET_CACHE_CONTROL",
+    "PORTAL_ASSET_FINGERPRINT_PARAM",
+    "PORTAL_ASSET_FINGERPRINT_LENGTH",
+    "PORTAL_CSS_TEMPLATE_PATH",
+    "PORTAL_DIRECT_FINGERPRINT_ASSET_NAMES",
+    "PORTAL_CSS_TEMPLATE_TOKENS",
+    "PORTAL_HTML_TEMPLATE_TOKENS",
+    "PORTAL_ASSET_MANIFEST",
+    "PORTAL_ASSET_PATHS",
+    "PORTAL_ASSET_MEDIA_TYPES",
+)
+
+
+@contextmanager
+def _portal_asset_bundle_app_context():
+    saved = {name: getattr(_portal_asset_bundle, name) for name in _PORTAL_ASSET_BUNDLE_APP_GLOBALS}
+    try:
+        for name in _PORTAL_ASSET_BUNDLE_APP_GLOBALS:
+            setattr(_portal_asset_bundle, name, globals()[name])
+        yield
+    finally:
+        for name, value in saved.items():
+            setattr(_portal_asset_bundle, name, value)
+
+
+def _copy_portal_cache_api(wrapper: Callable[..., Any], cached: Callable[..., Any]) -> None:
+    for attr_name in ("cache_clear", "cache_info", "cache_parameters"):
+        if hasattr(cached, attr_name):
+            setattr(wrapper, attr_name, getattr(cached, attr_name))
+
+
+def _load_portal_asset_manifest() -> Dict[str, PortalAssetSpec]:
+    with _portal_asset_bundle_app_context():
+        return _portal_asset_bundle._load_portal_asset_manifest()
+
+
+def _portal_asset_signature(path: Path) -> Tuple[str, int, int]:
+    return _portal_asset_bundle._portal_asset_signature(path)
+
+
+def _fingerprint_bytes(payload: bytes) -> str:
+    return _portal_asset_bundle._fingerprint_bytes(payload)
+
+
+def _portal_asset_route_path(asset_name: str) -> str:
+    with _portal_asset_bundle_app_context():
+        return _portal_asset_bundle._portal_asset_route_path(asset_name)
+
+
+def _portal_asset_versioned_url(asset_name: str, fingerprint: str) -> str:
+    with _portal_asset_bundle_app_context():
+        return _portal_asset_bundle._portal_asset_versioned_url(asset_name, fingerprint)
+
+
+def _render_portal_template(template_text: str, replacements: Mapping[str, str], *, template_name: str) -> str:
+    return _portal_asset_bundle._render_portal_template(template_text, replacements, template_name=template_name)
+
+
+def _portal_direct_asset_signature(asset_name: str) -> Tuple[str, int, int]:
+    with _portal_asset_bundle_app_context():
+        return _portal_asset_bundle._portal_direct_asset_signature(asset_name)
+
+
+def _build_portal_direct_asset_fingerprint(asset_name: str, signature: Tuple[str, int, int]) -> str:
+    with _portal_asset_bundle_app_context():
+        return _portal_asset_bundle._build_portal_direct_asset_fingerprint(asset_name, signature)
+
+
+def _get_portal_direct_asset_fingerprint(asset_name: str) -> str:
+    with _portal_asset_bundle_app_context():
+        return _portal_asset_bundle._get_portal_direct_asset_fingerprint(asset_name)
+
+
+def _portal_css_dependency_asset_names() -> Tuple[str, ...]:
+    with _portal_asset_bundle_app_context():
+        return _portal_asset_bundle._portal_css_dependency_asset_names()
+
+
+def _portal_css_signature() -> Tuple[object, ...]:
+    with _portal_asset_bundle_app_context():
+        return _portal_asset_bundle._portal_css_signature()
+
+
+def _build_portal_css_asset(signature: Tuple[object, ...]) -> PortalRenderedTextAsset:
+    with _portal_asset_bundle_app_context():
+        return _portal_asset_bundle._build_portal_css_asset(signature)
+
+
+def _get_portal_css_asset() -> PortalRenderedTextAsset:
+    with _portal_asset_bundle_app_context():
+        return _portal_asset_bundle._get_portal_css_asset()
+
+
+def _portal_html_signature() -> Tuple[object, ...]:
+    with _portal_asset_bundle_app_context():
+        return _portal_asset_bundle._portal_html_signature()
+
+
+def _build_portal_asset_bundle(signature: Tuple[object, ...]) -> PortalAssetBundle:
+    with _portal_asset_bundle_app_context():
+        return _portal_asset_bundle._build_portal_asset_bundle(signature)
+
+
+def _get_portal_asset_bundle() -> PortalAssetBundle:
+    with _portal_asset_bundle_app_context():
+        return _portal_asset_bundle._get_portal_asset_bundle()
+
+
+def _requested_portal_asset_fingerprint(request: Request) -> str:
+    with _portal_asset_bundle_app_context():
+        return _portal_asset_bundle._requested_portal_asset_fingerprint(request)
+
+
+def _portal_asset_cache_control(current_fingerprint: str, requested_fingerprint: str) -> str:
+    with _portal_asset_bundle_app_context():
+        return _portal_asset_bundle._portal_asset_cache_control(current_fingerprint, requested_fingerprint)
+
+
+def _portal_asset_etag(fingerprint: str) -> str:
+    with _portal_asset_bundle_app_context():
+        return _portal_asset_bundle._portal_asset_etag(fingerprint)
+
+
+def _portal_asset_request_etag_matches(request: Request, current_etag: str) -> bool:
+    with _portal_asset_bundle_app_context():
+        return _portal_asset_bundle._portal_asset_request_etag_matches(request, current_etag)
+
+
+def _portal_asset_not_modified_response(*, etag: str, cache_control: str) -> Response:
+    with _portal_asset_bundle_app_context():
+        return _portal_asset_bundle._portal_asset_not_modified_response(etag=etag, cache_control=cache_control)
+
+
+_copy_portal_cache_api(_build_portal_direct_asset_fingerprint, _portal_asset_bundle._build_portal_direct_asset_fingerprint)
+_copy_portal_cache_api(_build_portal_css_asset, _portal_asset_bundle._build_portal_css_asset)
+_copy_portal_cache_api(_build_portal_asset_bundle, _portal_asset_bundle._build_portal_asset_bundle)
 
 
 ARCHIVE_GOVERNANCE_SCRIPT = REPO_ROOT / "tools" / "archive_governance.py"

--- a/app.py
+++ b/app.py
@@ -67,6 +67,47 @@ from transformation_portal.ingest.upload_staging import (
 )
 from transformation_portal.lux_depth_v3.model_registry import resolve_model_spec, resolve_registry_key, visible_cli_model_specs
 from transformation_portal.lux_depth_v3.run_card_contract import infer_run_card_version
+from transformation_portal.portal.asset_bundle import (
+    PORTAL_ASSETS_DIR,
+    PORTAL_ASSETS_DIR_REAL,
+    PORTAL_ASSET_CACHE_CONTROL,
+    PORTAL_ASSET_FINGERPRINT_LENGTH,
+    PORTAL_ASSET_FINGERPRINT_PARAM,
+    PORTAL_ASSET_MANIFEST,
+    PORTAL_ASSET_MANIFEST_PATH,
+    PORTAL_ASSET_MEDIA_TYPES,
+    PORTAL_ASSET_PATHS,
+    PORTAL_CSS_TEMPLATE_PATH,
+    PORTAL_CSS_TEMPLATE_TOKENS,
+    PORTAL_DIRECT_FINGERPRINT_ASSET_NAMES,
+    PORTAL_HTML,
+    PORTAL_HTML_TEMPLATE_TOKENS,
+    PORTAL_IMMUTABLE_ASSET_CACHE_CONTROL,
+    PortalAssetBundle,
+    PortalAssetSpec,
+    PortalRenderedTextAsset,
+    _build_portal_asset_bundle,
+    _build_portal_css_asset,
+    _build_portal_direct_asset_fingerprint,
+    _fingerprint_bytes,
+    _get_portal_asset_bundle,
+    _get_portal_css_asset,
+    _get_portal_direct_asset_fingerprint,
+    _load_portal_asset_manifest,
+    _portal_asset_cache_control,
+    _portal_asset_etag,
+    _portal_asset_not_modified_response,
+    _portal_asset_request_etag_matches,
+    _portal_asset_route_path,
+    _portal_asset_signature,
+    _portal_asset_versioned_url,
+    _portal_css_dependency_asset_names,
+    _portal_css_signature,
+    _portal_direct_asset_signature,
+    _portal_html_signature,
+    _render_portal_template,
+    _requested_portal_asset_fingerprint,
+)
 from transformation_portal.vlm_captioning.fastvlm_runtime import (
     FASTVLM_CHECKPOINT_DIRS,
     default_fastvlm_runtime_root,
@@ -80,29 +121,6 @@ from transformation_portal.vlm_captioning.fastvlm_runtime import (
 LOGGER = logging.getLogger(__name__)
 _PORTAL_EVENT_LOG_WRITE_LOCK = threading.Lock()
 _MANAGED_SAM2_CHECKSUM_CACHE_LOCK = threading.Lock()
-
-
-@dataclass(frozen=True)
-class PortalAssetSpec:
-    path: Path
-    media_type: str
-
-
-@dataclass(frozen=True)
-class PortalAssetBundle:
-    html: str
-    html_bytes: bytes
-    css: str
-    css_bytes: bytes
-    fingerprints: Dict[str, str]
-    urls: Dict[str, str]
-
-
-@dataclass(frozen=True)
-class PortalRenderedTextAsset:
-    text: str
-    content_bytes: bytes
-    fingerprint: str
 
 
 @dataclass(frozen=True)
@@ -262,250 +280,8 @@ def _portal_fastvlm_captioning_enabled(actor: Optional[Mapping[str, Any]] = None
 
 
 REPO_ROOT = Path(__file__).resolve().parent
-PORTAL_HTML = REPO_ROOT / "portal.html"
-PORTAL_ASSETS_DIR = REPO_ROOT / "public" / "portal-assets"
-PORTAL_ASSETS_DIR_REAL = Path(os.path.realpath(PORTAL_ASSETS_DIR))
-PORTAL_ASSET_MANIFEST_PATH = REPO_ROOT / "config" / "portal_asset_manifest.json"
 PORTAL_VIDEO_ASSET_NAME = "dna-portal-video-2.mp4"
 PORTAL_VIDEO_PATH = REPO_ROOT / "public" / "video" / PORTAL_VIDEO_ASSET_NAME
-PORTAL_ASSET_CACHE_CONTROL = "no-store"
-PORTAL_IMMUTABLE_ASSET_CACHE_CONTROL = "public, max-age=31536000, immutable"
-PORTAL_ASSET_FINGERPRINT_PARAM = "v"
-PORTAL_ASSET_FINGERPRINT_LENGTH = 12
-PORTAL_CSS_TEMPLATE_PATH = PORTAL_ASSETS_DIR / "portal.css"
-PORTAL_DIRECT_FINGERPRINT_ASSET_NAMES = (
-    "portal.js",
-    "portal-review.js",
-    "portal-review.css",
-    "shared-ui-tokens.css",
-    "fonts/portal-sans.woff2",
-    "fonts/portal-mono.woff2",
-    "brand/dna-symbol-dark.svg",
-    "brand/dna-symbol-light.svg",
-)
-PORTAL_CSS_TEMPLATE_TOKENS = {
-    "__PORTAL_FONT_SANS_URL__": "fonts/portal-sans.woff2",
-    "__PORTAL_FONT_MONO_URL__": "fonts/portal-mono.woff2",
-}
-PORTAL_HTML_TEMPLATE_TOKENS = {
-    "__PORTAL_CSS_URL__": "portal.css",
-    "__PORTAL_JS_URL__": "portal.js",
-    "__PORTAL_REVIEW_JS_URL__": "portal-review.js",
-    "__PORTAL_REVIEW_CSS_URL__": "portal-review.css",
-    "__PORTAL_BRAND_LIGHT_URL__": "brand/dna-symbol-light.svg",
-    "__PORTAL_BRAND_DARK_URL__": "brand/dna-symbol-dark.svg",
-    "__PORTAL_FONT_SANS_URL__": "fonts/portal-sans.woff2",
-}
-
-
-def _load_portal_asset_manifest() -> Dict[str, PortalAssetSpec]:
-    try:
-        raw_manifest = json.loads(PORTAL_ASSET_MANIFEST_PATH.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        raise RuntimeError(f"Unable to load portal asset manifest: {exc}") from exc
-
-    assets = raw_manifest.get("assets")
-    if not isinstance(assets, dict) or not assets:
-        raise RuntimeError("Portal asset manifest must define a non-empty 'assets' object")
-
-    manifest: Dict[str, PortalAssetSpec] = {}
-    for asset_name, entry in assets.items():
-        if not isinstance(asset_name, str) or not asset_name.strip():
-            raise RuntimeError("Portal asset manifest contains an invalid asset key")
-        if not isinstance(entry, dict):
-            raise RuntimeError(f"Portal asset manifest entry for {asset_name!r} must be an object")
-
-        repo_path = str(entry.get("repo_path", "")).strip()
-        media_type = str(entry.get("media_type", "")).strip()
-        if not repo_path or not media_type:
-            raise RuntimeError(f"Portal asset manifest entry for {asset_name!r} is incomplete")
-
-        resolved_path = Path(os.path.realpath(REPO_ROOT / repo_path))
-        try:
-            resolved_path.relative_to(PORTAL_ASSETS_DIR_REAL)
-        except ValueError as exc:
-            raise RuntimeError(f"Portal asset manifest entry for {asset_name!r} points outside {PORTAL_ASSETS_DIR}") from exc
-
-        manifest[asset_name] = PortalAssetSpec(path=resolved_path, media_type=media_type)
-
-    return manifest
-
-
-PORTAL_ASSET_MANIFEST = _load_portal_asset_manifest()
-PORTAL_ASSET_PATHS = {name: asset.path for name, asset in PORTAL_ASSET_MANIFEST.items()}
-PORTAL_ASSET_MEDIA_TYPES = {name: asset.media_type for name, asset in PORTAL_ASSET_MANIFEST.items()}
-
-
-def _portal_asset_signature(path: Path) -> Tuple[str, int, int]:
-    stat_result = path.stat()
-    return str(path), stat_result.st_mtime_ns, stat_result.st_size
-
-
-def _fingerprint_bytes(payload: bytes) -> str:
-    return hashlib.sha256(payload).hexdigest()[:PORTAL_ASSET_FINGERPRINT_LENGTH]
-
-
-def _portal_asset_route_path(asset_name: str) -> str:
-    encoded_parts = [quote(part, safe="") for part in asset_name.split("/")]
-    return "/portal/assets/" + "/".join(encoded_parts)
-
-
-def _portal_asset_versioned_url(asset_name: str, fingerprint: str) -> str:
-    return f"{_portal_asset_route_path(asset_name)}?{PORTAL_ASSET_FINGERPRINT_PARAM}={fingerprint}"
-
-
-def _render_portal_template(template_text: str, replacements: Mapping[str, str], *, template_name: str) -> str:
-    rendered = template_text
-    for token, value in replacements.items():
-        if token not in rendered:
-            raise RuntimeError(f"{template_name} is missing required token {token}")
-        rendered = rendered.replace(token, value)
-
-    unresolved = sorted(set(re.findall(r"__PORTAL_[A-Z0-9_]+__", rendered)))
-    if unresolved:
-        raise RuntimeError(f"{template_name} has unresolved tokens: {', '.join(unresolved)}")
-    return rendered
-
-
-def _portal_direct_asset_signature(asset_name: str) -> Tuple[str, int, int]:
-    return _portal_asset_signature(PORTAL_ASSET_PATHS[asset_name])
-
-
-@lru_cache(maxsize=16)
-def _build_portal_direct_asset_fingerprint(asset_name: str, _: Tuple[str, int, int]) -> str:
-    return _fingerprint_bytes(PORTAL_ASSET_PATHS[asset_name].read_bytes())
-
-
-def _get_portal_direct_asset_fingerprint(asset_name: str) -> str:
-    return _build_portal_direct_asset_fingerprint(asset_name, _portal_direct_asset_signature(asset_name))
-
-
-def _portal_css_dependency_asset_names() -> Tuple[str, ...]:
-    return tuple(dict.fromkeys(PORTAL_CSS_TEMPLATE_TOKENS.values()))
-
-
-def _portal_css_signature() -> Tuple[object, ...]:
-    return (
-        _portal_asset_signature(PORTAL_CSS_TEMPLATE_PATH),
-        *(
-            (asset_name, _get_portal_direct_asset_fingerprint(asset_name))
-            for asset_name in _portal_css_dependency_asset_names()
-        ),
-    )
-
-
-@lru_cache(maxsize=4)
-def _build_portal_css_asset(_: Tuple[object, ...]) -> PortalRenderedTextAsset:
-    direct_asset_fingerprints = {
-        asset_name: _get_portal_direct_asset_fingerprint(asset_name)
-        for asset_name in dict.fromkeys(PORTAL_CSS_TEMPLATE_TOKENS.values())
-    }
-    css_template = PORTAL_CSS_TEMPLATE_PATH.read_text(encoding="utf-8")
-    css_render = _render_portal_template(
-        css_template,
-        {
-            token: _portal_asset_versioned_url(asset_name, direct_asset_fingerprints[asset_name])
-            for token, asset_name in PORTAL_CSS_TEMPLATE_TOKENS.items()
-        },
-        template_name="portal.css",
-    )
-    css_bytes = css_render.encode("utf-8")
-    return PortalRenderedTextAsset(
-        text=css_render,
-        content_bytes=css_bytes,
-        fingerprint=_fingerprint_bytes(css_bytes),
-    )
-
-
-def _get_portal_css_asset() -> PortalRenderedTextAsset:
-    return _build_portal_css_asset(_portal_css_signature())
-
-
-def _portal_html_signature() -> Tuple[object, ...]:
-    css_asset = _get_portal_css_asset()
-    return (
-        _portal_asset_signature(PORTAL_HTML),
-        ("portal.css", css_asset.fingerprint),
-        *(
-            (asset_name, _get_portal_direct_asset_fingerprint(asset_name))
-            for asset_name in (
-                "portal.js",
-                "portal-review.js",
-                "portal-review.css",
-                "brand/dna-symbol-dark.svg",
-                "brand/dna-symbol-light.svg",
-                "fonts/portal-sans.woff2",
-            )
-        ),
-    )
-
-
-@lru_cache(maxsize=4)
-def _build_portal_asset_bundle(_: Tuple[object, ...]) -> PortalAssetBundle:
-    css_asset = _get_portal_css_asset()
-    fingerprints = {
-        asset_name: _get_portal_direct_asset_fingerprint(asset_name) for asset_name in PORTAL_DIRECT_FINGERPRINT_ASSET_NAMES
-    }
-    fingerprints["portal.css"] = css_asset.fingerprint
-    urls = {
-        asset_name: _portal_asset_versioned_url(asset_name, fingerprint) for asset_name, fingerprint in fingerprints.items()
-    }
-    html_template = PORTAL_HTML.read_text(encoding="utf-8")
-    html_render = _render_portal_template(
-        html_template,
-        {token: urls[asset_name] for token, asset_name in PORTAL_HTML_TEMPLATE_TOKENS.items()},
-        template_name="portal.html",
-    )
-    html_bytes = html_render.encode("utf-8")
-    return PortalAssetBundle(
-        html=html_render,
-        html_bytes=html_bytes,
-        css=css_asset.text,
-        css_bytes=css_asset.content_bytes,
-        fingerprints=fingerprints,
-        urls=urls,
-    )
-
-
-def _get_portal_asset_bundle() -> PortalAssetBundle:
-    return _build_portal_asset_bundle(_portal_html_signature())
-
-
-def _requested_portal_asset_fingerprint(request: Request) -> str:
-    return str(request.query_params.get(PORTAL_ASSET_FINGERPRINT_PARAM, "")).strip()
-
-
-def _portal_asset_cache_control(current_fingerprint: str, requested_fingerprint: str) -> str:
-    if requested_fingerprint and hmac.compare_digest(requested_fingerprint, current_fingerprint):
-        return PORTAL_IMMUTABLE_ASSET_CACHE_CONTROL
-    return PORTAL_ASSET_CACHE_CONTROL
-
-
-def _portal_asset_etag(fingerprint: str) -> str:
-    return f'"{fingerprint}"'
-
-
-def _portal_asset_request_etag_matches(request: Request, current_etag: str) -> bool:
-    raw_if_none_match = str(request.headers.get("if-none-match") or "").strip()
-    if not raw_if_none_match:
-        return False
-    for candidate in raw_if_none_match.split(","):
-        normalized = candidate.strip()
-        if normalized == "*":
-            return True
-        if normalized and hmac.compare_digest(normalized, current_etag):
-            return True
-    return False
-
-
-def _portal_asset_not_modified_response(*, etag: str, cache_control: str) -> Response:
-    return Response(
-        status_code=304,
-        headers={
-            "Cache-Control": cache_control,
-            "ETag": etag,
-        },
-    )
 
 
 ARCHIVE_GOVERNANCE_SCRIPT = REPO_ROOT / "tools" / "archive_governance.py"

--- a/config/portal_asset_budgets.json
+++ b/config/portal_asset_budgets.json
@@ -3,15 +3,15 @@
   "assets": {
     "portal.js": {
       "max_bytes": 450000,
-      "max_gzip_bytes": 92500
+      "max_gzip_bytes": 95000
     },
     "portal.css": {
       "max_bytes": 100000,
       "max_gzip_bytes": 18000
     },
     "portal-review.js": {
-      "max_bytes": 50000,
-      "max_gzip_bytes": 10500
+      "max_bytes": 55000,
+      "max_gzip_bytes": 12500
     },
     "portal-review.css": {
       "max_bytes": 7000,

--- a/docs/architecture/MONOLITH_DECOMPOSITION_TARGETS.md
+++ b/docs/architecture/MONOLITH_DECOMPOSITION_TARGETS.md
@@ -171,7 +171,7 @@ This table is the canonical progress ledger for extraction PRs that draw from th
 | Target 1A — Config fingerprint helpers | `lux_depth_v3/orchestrator.py` | `lux_depth_v3/config_resolver.py` | Landed | This PR: config fingerprint helpers extracted |
 | Target 1B — Artifact reload / coercion helpers | `lux_depth_v3/orchestrator.py` | `lux_depth_v3/artifact_manager.py` | Landed | This PR: manifest reload/coercion helpers extracted |
 | Target 1C — Backend resolution & state | `lux_depth_v3/orchestrator.py` | `lux_depth_v3/pipeline_coordinator.py` | Landed | This PR: backend initialization and runtime attempt-state helpers extracted |
-| Target 2A — Portal asset bundle | `app.py` | `src/transformation_portal/portal/asset_bundle.py` | Not started | Ranked 2026-05-04 |
+| Target 2A — Portal asset bundle | `app.py` | `src/transformation_portal/portal/asset_bundle.py` | Landed | This PR: portal asset bundle helpers extracted |
 | Target 3A — Segmentation cache helpers | `lux_depth_v3/segmentation_backend.py` | `lux_depth_v3/segmentation/_cache.py` | Not started | Ranked 2026-05-04 |
 | Target 3B — Stub backend | `lux_depth_v3/segmentation_backend.py` | `lux_depth_v3/segmentation/stub.py` | Not started | Ranked 2026-05-04 |
 | Target 3C — EfficientSAM backend | `lux_depth_v3/segmentation_backend.py` | `lux_depth_v3/segmentation/efficient_sam.py` | Not started | Ranked 2026-05-04 |

--- a/src/transformation_portal/portal/__init__.py
+++ b/src/transformation_portal/portal/__init__.py
@@ -1,0 +1,1 @@
+"""Portal runtime support modules."""

--- a/src/transformation_portal/portal/asset_bundle.py
+++ b/src/transformation_portal/portal/asset_bundle.py
@@ -1,0 +1,327 @@
+"""Portal asset bundle rendering, fingerprints, and cache semantics."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import os
+import re
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Dict, Mapping, Tuple
+from urllib.parse import quote
+
+from starlette.requests import Request
+from starlette.responses import Response
+
+__all__ = [
+    "PORTAL_ASSETS_DIR",
+    "PORTAL_ASSETS_DIR_REAL",
+    "PORTAL_ASSET_CACHE_CONTROL",
+    "PORTAL_ASSET_FINGERPRINT_LENGTH",
+    "PORTAL_ASSET_FINGERPRINT_PARAM",
+    "PORTAL_ASSET_MANIFEST",
+    "PORTAL_ASSET_MANIFEST_PATH",
+    "PORTAL_ASSET_MEDIA_TYPES",
+    "PORTAL_ASSET_PATHS",
+    "PORTAL_CSS_TEMPLATE_PATH",
+    "PORTAL_CSS_TEMPLATE_TOKENS",
+    "PORTAL_DIRECT_FINGERPRINT_ASSET_NAMES",
+    "PORTAL_HTML",
+    "PORTAL_HTML_TEMPLATE_TOKENS",
+    "PORTAL_IMMUTABLE_ASSET_CACHE_CONTROL",
+    "PortalAssetBundle",
+    "PortalAssetSpec",
+    "PortalRenderedTextAsset",
+    "_build_portal_asset_bundle",
+    "_build_portal_css_asset",
+    "_build_portal_direct_asset_fingerprint",
+    "_fingerprint_bytes",
+    "_get_portal_asset_bundle",
+    "_get_portal_css_asset",
+    "_get_portal_direct_asset_fingerprint",
+    "_load_portal_asset_manifest",
+    "_portal_asset_cache_control",
+    "_portal_asset_etag",
+    "_portal_asset_not_modified_response",
+    "_portal_asset_request_etag_matches",
+    "_portal_asset_route_path",
+    "_portal_asset_signature",
+    "_portal_asset_versioned_url",
+    "_portal_css_dependency_asset_names",
+    "_portal_css_signature",
+    "_portal_direct_asset_signature",
+    "_portal_html_signature",
+    "_render_portal_template",
+    "_requested_portal_asset_fingerprint",
+]
+
+
+@dataclass(frozen=True)
+class PortalAssetSpec:
+    path: Path
+    media_type: str
+
+
+@dataclass(frozen=True)
+class PortalAssetBundle:
+    html: str
+    html_bytes: bytes
+    css: str
+    css_bytes: bytes
+    fingerprints: Dict[str, str]
+    urls: Dict[str, str]
+
+
+@dataclass(frozen=True)
+class PortalRenderedTextAsset:
+    text: str
+    content_bytes: bytes
+    fingerprint: str
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PORTAL_HTML = REPO_ROOT / "portal.html"
+PORTAL_ASSETS_DIR = REPO_ROOT / "public" / "portal-assets"
+PORTAL_ASSETS_DIR_REAL = Path(os.path.realpath(PORTAL_ASSETS_DIR))
+PORTAL_ASSET_MANIFEST_PATH = REPO_ROOT / "config" / "portal_asset_manifest.json"
+PORTAL_ASSET_CACHE_CONTROL = "no-store"
+PORTAL_IMMUTABLE_ASSET_CACHE_CONTROL = "public, max-age=31536000, immutable"
+PORTAL_ASSET_FINGERPRINT_PARAM = "v"
+PORTAL_ASSET_FINGERPRINT_LENGTH = 12
+PORTAL_CSS_TEMPLATE_PATH = PORTAL_ASSETS_DIR / "portal.css"
+PORTAL_DIRECT_FINGERPRINT_ASSET_NAMES = (
+    "portal.js",
+    "portal-review.js",
+    "portal-review.css",
+    "shared-ui-tokens.css",
+    "fonts/portal-sans.woff2",
+    "fonts/portal-mono.woff2",
+    "brand/dna-symbol-dark.svg",
+    "brand/dna-symbol-light.svg",
+)
+PORTAL_CSS_TEMPLATE_TOKENS = {
+    "__PORTAL_FONT_SANS_URL__": "fonts/portal-sans.woff2",
+    "__PORTAL_FONT_MONO_URL__": "fonts/portal-mono.woff2",
+}
+PORTAL_HTML_TEMPLATE_TOKENS = {
+    "__PORTAL_CSS_URL__": "portal.css",
+    "__PORTAL_JS_URL__": "portal.js",
+    "__PORTAL_REVIEW_JS_URL__": "portal-review.js",
+    "__PORTAL_REVIEW_CSS_URL__": "portal-review.css",
+    "__PORTAL_BRAND_LIGHT_URL__": "brand/dna-symbol-light.svg",
+    "__PORTAL_BRAND_DARK_URL__": "brand/dna-symbol-dark.svg",
+    "__PORTAL_FONT_SANS_URL__": "fonts/portal-sans.woff2",
+}
+
+
+def _load_portal_asset_manifest() -> Dict[str, PortalAssetSpec]:
+    try:
+        raw_manifest = json.loads(PORTAL_ASSET_MANIFEST_PATH.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"Unable to load portal asset manifest: {exc}") from exc
+
+    assets = raw_manifest.get("assets")
+    if not isinstance(assets, dict) or not assets:
+        raise RuntimeError("Portal asset manifest must define a non-empty 'assets' object")
+
+    manifest: Dict[str, PortalAssetSpec] = {}
+    for asset_name, entry in assets.items():
+        if not isinstance(asset_name, str) or not asset_name.strip():
+            raise RuntimeError("Portal asset manifest contains an invalid asset key")
+        if not isinstance(entry, dict):
+            raise RuntimeError(f"Portal asset manifest entry for {asset_name!r} must be an object")
+
+        repo_path = str(entry.get("repo_path", "")).strip()
+        media_type = str(entry.get("media_type", "")).strip()
+        if not repo_path or not media_type:
+            raise RuntimeError(f"Portal asset manifest entry for {asset_name!r} is incomplete")
+
+        resolved_path = Path(os.path.realpath(REPO_ROOT / repo_path))
+        try:
+            resolved_path.relative_to(PORTAL_ASSETS_DIR_REAL)
+        except ValueError as exc:
+            raise RuntimeError(f"Portal asset manifest entry for {asset_name!r} points outside {PORTAL_ASSETS_DIR}") from exc
+
+        manifest[asset_name] = PortalAssetSpec(path=resolved_path, media_type=media_type)
+
+    return manifest
+
+
+PORTAL_ASSET_MANIFEST = _load_portal_asset_manifest()
+PORTAL_ASSET_PATHS = {name: asset.path for name, asset in PORTAL_ASSET_MANIFEST.items()}
+PORTAL_ASSET_MEDIA_TYPES = {name: asset.media_type for name, asset in PORTAL_ASSET_MANIFEST.items()}
+
+
+def _portal_asset_signature(path: Path) -> Tuple[str, int, int]:
+    stat_result = path.stat()
+    return str(path), stat_result.st_mtime_ns, stat_result.st_size
+
+
+def _fingerprint_bytes(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()[:PORTAL_ASSET_FINGERPRINT_LENGTH]
+
+
+def _portal_asset_route_path(asset_name: str) -> str:
+    encoded_parts = [quote(part, safe="") for part in asset_name.split("/")]
+    return "/portal/assets/" + "/".join(encoded_parts)
+
+
+def _portal_asset_versioned_url(asset_name: str, fingerprint: str) -> str:
+    return f"{_portal_asset_route_path(asset_name)}?{PORTAL_ASSET_FINGERPRINT_PARAM}={fingerprint}"
+
+
+def _render_portal_template(template_text: str, replacements: Mapping[str, str], *, template_name: str) -> str:
+    rendered = template_text
+    for token, value in replacements.items():
+        if token not in rendered:
+            raise RuntimeError(f"{template_name} is missing required token {token}")
+        rendered = rendered.replace(token, value)
+
+    unresolved = sorted(set(re.findall(r"__PORTAL_[A-Z0-9_]+__", rendered)))
+    if unresolved:
+        raise RuntimeError(f"{template_name} has unresolved tokens: {', '.join(unresolved)}")
+    return rendered
+
+
+def _portal_direct_asset_signature(asset_name: str) -> Tuple[str, int, int]:
+    return _portal_asset_signature(PORTAL_ASSET_PATHS[asset_name])
+
+
+@lru_cache(maxsize=16)
+def _build_portal_direct_asset_fingerprint(asset_name: str, _: Tuple[str, int, int]) -> str:
+    return _fingerprint_bytes(PORTAL_ASSET_PATHS[asset_name].read_bytes())
+
+
+def _get_portal_direct_asset_fingerprint(asset_name: str) -> str:
+    return _build_portal_direct_asset_fingerprint(asset_name, _portal_direct_asset_signature(asset_name))
+
+
+def _portal_css_dependency_asset_names() -> Tuple[str, ...]:
+    return tuple(dict.fromkeys(PORTAL_CSS_TEMPLATE_TOKENS.values()))
+
+
+def _portal_css_signature() -> Tuple[object, ...]:
+    return (
+        _portal_asset_signature(PORTAL_CSS_TEMPLATE_PATH),
+        *(
+            (asset_name, _get_portal_direct_asset_fingerprint(asset_name))
+            for asset_name in _portal_css_dependency_asset_names()
+        ),
+    )
+
+
+@lru_cache(maxsize=4)
+def _build_portal_css_asset(_: Tuple[object, ...]) -> PortalRenderedTextAsset:
+    direct_asset_fingerprints = {
+        asset_name: _get_portal_direct_asset_fingerprint(asset_name)
+        for asset_name in dict.fromkeys(PORTAL_CSS_TEMPLATE_TOKENS.values())
+    }
+    css_template = PORTAL_CSS_TEMPLATE_PATH.read_text(encoding="utf-8")
+    css_render = _render_portal_template(
+        css_template,
+        {
+            token: _portal_asset_versioned_url(asset_name, direct_asset_fingerprints[asset_name])
+            for token, asset_name in PORTAL_CSS_TEMPLATE_TOKENS.items()
+        },
+        template_name="portal.css",
+    )
+    css_bytes = css_render.encode("utf-8")
+    return PortalRenderedTextAsset(
+        text=css_render,
+        content_bytes=css_bytes,
+        fingerprint=_fingerprint_bytes(css_bytes),
+    )
+
+
+def _get_portal_css_asset() -> PortalRenderedTextAsset:
+    return _build_portal_css_asset(_portal_css_signature())
+
+
+def _portal_html_signature() -> Tuple[object, ...]:
+    css_asset = _get_portal_css_asset()
+    return (
+        _portal_asset_signature(PORTAL_HTML),
+        ("portal.css", css_asset.fingerprint),
+        *(
+            (asset_name, _get_portal_direct_asset_fingerprint(asset_name))
+            for asset_name in (
+                "portal.js",
+                "portal-review.js",
+                "portal-review.css",
+                "brand/dna-symbol-dark.svg",
+                "brand/dna-symbol-light.svg",
+                "fonts/portal-sans.woff2",
+            )
+        ),
+    )
+
+
+@lru_cache(maxsize=4)
+def _build_portal_asset_bundle(_: Tuple[object, ...]) -> PortalAssetBundle:
+    css_asset = _get_portal_css_asset()
+    fingerprints = {
+        asset_name: _get_portal_direct_asset_fingerprint(asset_name) for asset_name in PORTAL_DIRECT_FINGERPRINT_ASSET_NAMES
+    }
+    fingerprints["portal.css"] = css_asset.fingerprint
+    urls = {
+        asset_name: _portal_asset_versioned_url(asset_name, fingerprint) for asset_name, fingerprint in fingerprints.items()
+    }
+    html_template = PORTAL_HTML.read_text(encoding="utf-8")
+    html_render = _render_portal_template(
+        html_template,
+        {token: urls[asset_name] for token, asset_name in PORTAL_HTML_TEMPLATE_TOKENS.items()},
+        template_name="portal.html",
+    )
+    html_bytes = html_render.encode("utf-8")
+    return PortalAssetBundle(
+        html=html_render,
+        html_bytes=html_bytes,
+        css=css_asset.text,
+        css_bytes=css_asset.content_bytes,
+        fingerprints=fingerprints,
+        urls=urls,
+    )
+
+
+def _get_portal_asset_bundle() -> PortalAssetBundle:
+    return _build_portal_asset_bundle(_portal_html_signature())
+
+
+def _requested_portal_asset_fingerprint(request: Request) -> str:
+    return str(request.query_params.get(PORTAL_ASSET_FINGERPRINT_PARAM, "")).strip()
+
+
+def _portal_asset_cache_control(current_fingerprint: str, requested_fingerprint: str) -> str:
+    if requested_fingerprint and hmac.compare_digest(requested_fingerprint, current_fingerprint):
+        return PORTAL_IMMUTABLE_ASSET_CACHE_CONTROL
+    return PORTAL_ASSET_CACHE_CONTROL
+
+
+def _portal_asset_etag(fingerprint: str) -> str:
+    return f'"{fingerprint}"'
+
+
+def _portal_asset_request_etag_matches(request: Request, current_etag: str) -> bool:
+    raw_if_none_match = str(request.headers.get("if-none-match") or "").strip()
+    if not raw_if_none_match:
+        return False
+    for candidate in raw_if_none_match.split(","):
+        normalized = candidate.strip()
+        if normalized == "*":
+            return True
+        if normalized and hmac.compare_digest(normalized, current_etag):
+            return True
+    return False
+
+
+def _portal_asset_not_modified_response(*, etag: str, cache_control: str) -> Response:
+    return Response(
+        status_code=304,
+        headers={
+            "Cache-Control": cache_control,
+            "ETag": etag,
+        },
+    )

--- a/src/transformation_portal/portal/asset_bundle.py
+++ b/src/transformation_portal/portal/asset_bundle.py
@@ -7,10 +7,11 @@ import hmac
 import json
 import os
 import re
+from collections.abc import Callable, Iterator, Mapping
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
-from typing import Dict, Mapping, Tuple
+from typing import Dict, Generic, Tuple, TypeVar
 from urllib.parse import quote
 
 from starlette.requests import Request
@@ -39,6 +40,7 @@ __all__ = [
     "_build_portal_css_asset",
     "_build_portal_direct_asset_fingerprint",
     "_fingerprint_bytes",
+    "_get_portal_asset_manifest",
     "_get_portal_asset_bundle",
     "_get_portal_css_asset",
     "_get_portal_direct_asset_fingerprint",
@@ -57,6 +59,31 @@ __all__ = [
     "_render_portal_template",
     "_requested_portal_asset_fingerprint",
 ]
+
+_T = TypeVar("_T")
+
+
+class _LazyPortalAssetMapping(Mapping[str, _T], Generic[_T]):
+    def __init__(self, loader: Callable[[], Dict[str, _T]]) -> None:
+        self._loader = loader
+
+    def _data(self) -> Dict[str, _T]:
+        return self._loader()
+
+    def __getitem__(self, key: str) -> _T:
+        return self._data()[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._data())
+
+    def __len__(self) -> int:
+        return len(self._data())
+
+    def __repr__(self) -> str:
+        return repr(self._data())
+
+    def __eq__(self, other: object) -> bool:
+        return self._data() == other
 
 
 @dataclass(frozen=True)
@@ -117,9 +144,20 @@ PORTAL_HTML_TEMPLATE_TOKENS = {
 }
 
 
-def _load_portal_asset_manifest() -> Dict[str, PortalAssetSpec]:
+def _load_portal_asset_manifest(
+    *,
+    manifest_path: Path | None = None,
+    repo_root: Path | None = None,
+    assets_dir_real: Path | None = None,
+    assets_dir: Path | None = None,
+) -> Dict[str, PortalAssetSpec]:
+    manifest_path = PORTAL_ASSET_MANIFEST_PATH if manifest_path is None else manifest_path
+    repo_root = REPO_ROOT if repo_root is None else repo_root
+    assets_dir_real = PORTAL_ASSETS_DIR_REAL if assets_dir_real is None else assets_dir_real
+    assets_dir = PORTAL_ASSETS_DIR if assets_dir is None else assets_dir
+
     try:
-        raw_manifest = json.loads(PORTAL_ASSET_MANIFEST_PATH.read_text(encoding="utf-8"))
+        raw_manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
         raise RuntimeError(f"Unable to load portal asset manifest: {exc}") from exc
 
@@ -139,20 +177,56 @@ def _load_portal_asset_manifest() -> Dict[str, PortalAssetSpec]:
         if not repo_path or not media_type:
             raise RuntimeError(f"Portal asset manifest entry for {asset_name!r} is incomplete")
 
-        resolved_path = Path(os.path.realpath(REPO_ROOT / repo_path))
+        resolved_path = Path(os.path.realpath(repo_root / repo_path))
         try:
-            resolved_path.relative_to(PORTAL_ASSETS_DIR_REAL)
+            resolved_path.relative_to(assets_dir_real)
         except ValueError as exc:
-            raise RuntimeError(f"Portal asset manifest entry for {asset_name!r} points outside {PORTAL_ASSETS_DIR}") from exc
+            raise RuntimeError(f"Portal asset manifest entry for {asset_name!r} points outside {assets_dir}") from exc
 
         manifest[asset_name] = PortalAssetSpec(path=resolved_path, media_type=media_type)
 
     return manifest
 
 
-PORTAL_ASSET_MANIFEST = _load_portal_asset_manifest()
-PORTAL_ASSET_PATHS = {name: asset.path for name, asset in PORTAL_ASSET_MANIFEST.items()}
-PORTAL_ASSET_MEDIA_TYPES = {name: asset.media_type for name, asset in PORTAL_ASSET_MANIFEST.items()}
+def _portal_asset_manifest_cache_key() -> Tuple[str, str, str, str]:
+    return (
+        str(PORTAL_ASSET_MANIFEST_PATH),
+        str(REPO_ROOT),
+        str(PORTAL_ASSETS_DIR_REAL),
+        str(PORTAL_ASSETS_DIR),
+    )
+
+
+@lru_cache(maxsize=8)
+def _load_portal_asset_manifest_cached(
+    manifest_path: str,
+    repo_root: str,
+    assets_dir_real: str,
+    assets_dir: str,
+) -> Dict[str, PortalAssetSpec]:
+    return _load_portal_asset_manifest(
+        manifest_path=Path(manifest_path),
+        repo_root=Path(repo_root),
+        assets_dir_real=Path(assets_dir_real),
+        assets_dir=Path(assets_dir),
+    )
+
+
+def _get_portal_asset_manifest() -> Dict[str, PortalAssetSpec]:
+    return _load_portal_asset_manifest_cached(*_portal_asset_manifest_cache_key())
+
+
+def _get_portal_asset_paths() -> Dict[str, Path]:
+    return {name: asset.path for name, asset in _get_portal_asset_manifest().items()}
+
+
+def _get_portal_asset_media_types() -> Dict[str, str]:
+    return {name: asset.media_type for name, asset in _get_portal_asset_manifest().items()}
+
+
+PORTAL_ASSET_MANIFEST = _LazyPortalAssetMapping(_get_portal_asset_manifest)
+PORTAL_ASSET_PATHS = _LazyPortalAssetMapping(_get_portal_asset_paths)
+PORTAL_ASSET_MEDIA_TYPES = _LazyPortalAssetMapping(_get_portal_asset_media_types)
 
 
 def _portal_asset_signature(path: Path) -> Tuple[str, int, int]:

--- a/tests/portal/test_asset_bundle.py
+++ b/tests/portal/test_asset_bundle.py
@@ -1,0 +1,116 @@
+"""Unit tests for portal asset bundle helpers."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from starlette.requests import Request
+
+from transformation_portal.portal import asset_bundle
+
+pytestmark = pytest.mark.unit
+
+
+def _request(
+    *,
+    query_string: bytes = b"",
+    headers: list[tuple[bytes, bytes]] | None = None,
+) -> Request:
+    return Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/portal/assets/portal.css",
+            "query_string": query_string,
+            "headers": headers or [],
+        }
+    )
+
+
+def test_load_portal_asset_manifest_rejects_paths_outside_assets_dir(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest_path = tmp_path / "portal-asset-manifest.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "assets": {
+                    "portal.css": {
+                        "repo_path": "../portal.html",
+                        "media_type": "text/css; charset=utf-8",
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(asset_bundle, "PORTAL_ASSET_MANIFEST_PATH", manifest_path)
+
+    with pytest.raises(RuntimeError, match="points outside"):
+        asset_bundle._load_portal_asset_manifest()
+
+
+def test_render_portal_template_rejects_missing_required_token() -> None:
+    with pytest.raises(RuntimeError, match="missing required token __PORTAL_JS_URL__"):
+        asset_bundle._render_portal_template(
+            "<html></html>",
+            {"__PORTAL_JS_URL__": "/portal/assets/portal.js?v=abc123"},
+            template_name="portal.html",
+        )
+
+
+def test_render_portal_template_rejects_unresolved_portal_tokens() -> None:
+    with pytest.raises(RuntimeError, match="unresolved tokens: __PORTAL_UNKNOWN_URL__"):
+        asset_bundle._render_portal_template(
+            "<html>__PORTAL_UNKNOWN_URL__</html>",
+            {},
+            template_name="portal.html",
+        )
+
+
+def test_portal_asset_bundle_emits_versioned_asset_urls() -> None:
+    bundle = asset_bundle._get_portal_asset_bundle()
+
+    assert bundle.urls["portal.css"].startswith("/portal/assets/portal.css?v=")
+    assert bundle.urls["portal.js"].startswith("/portal/assets/portal.js?v=")
+    assert bundle.urls["fonts/portal-sans.woff2"].startswith("/portal/assets/fonts/portal-sans.woff2?v=")
+    assert bundle.urls["portal.css"] in bundle.html
+    assert bundle.urls["fonts/portal-sans.woff2"] in bundle.css
+    assert len(bundle.fingerprints["portal.css"]) == asset_bundle.PORTAL_ASSET_FINGERPRINT_LENGTH
+    assert len(bundle.html_bytes) == len(bundle.html.encode("utf-8"))
+    assert len(bundle.css_bytes) == len(bundle.css.encode("utf-8"))
+
+
+def test_portal_asset_cache_control_preserves_legacy_unversioned_and_stale_requests() -> None:
+    assert asset_bundle._portal_asset_cache_control("abc123", "") == asset_bundle.PORTAL_ASSET_CACHE_CONTROL
+    assert asset_bundle._portal_asset_cache_control("abc123", "stale") == asset_bundle.PORTAL_ASSET_CACHE_CONTROL
+    assert asset_bundle._portal_asset_cache_control("abc123", "abc123") == asset_bundle.PORTAL_IMMUTABLE_ASSET_CACHE_CONTROL
+
+
+def test_requested_portal_asset_fingerprint_reads_version_query_param() -> None:
+    request = _request(query_string=b"v=abc123")
+
+    assert asset_bundle._requested_portal_asset_fingerprint(request) == "abc123"
+
+
+def test_portal_asset_etag_matching_accepts_exact_match_and_wildcard() -> None:
+    exact_request = _request(headers=[(b"if-none-match", b'"abc123"')])
+    wildcard_request = _request(headers=[(b"if-none-match", b"*")])
+    stale_request = _request(headers=[(b"if-none-match", b'"stale"')])
+
+    assert asset_bundle._portal_asset_request_etag_matches(exact_request, '"abc123"') is True
+    assert asset_bundle._portal_asset_request_etag_matches(wildcard_request, '"abc123"') is True
+    assert asset_bundle._portal_asset_request_etag_matches(stale_request, '"abc123"') is False
+
+
+def test_portal_asset_not_modified_response_sets_cache_headers() -> None:
+    response = asset_bundle._portal_asset_not_modified_response(
+        etag='"abc123"',
+        cache_control=asset_bundle.PORTAL_IMMUTABLE_ASSET_CACHE_CONTROL,
+    )
+
+    assert response.status_code == 304
+    assert response.headers["Cache-Control"] == asset_bundle.PORTAL_IMMUTABLE_ASSET_CACHE_CONTROL
+    assert response.headers["ETag"] == '"abc123"'

--- a/tests/portal/test_asset_bundle.py
+++ b/tests/portal/test_asset_bundle.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
 
 import pytest
 from starlette.requests import Request
@@ -50,6 +51,18 @@ def test_load_portal_asset_manifest_rejects_paths_outside_assets_dir(
 
     with pytest.raises(RuntimeError, match="points outside"):
         asset_bundle._load_portal_asset_manifest()
+
+
+def test_portal_asset_manifest_exports_load_lazily_until_access(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(asset_bundle, "PORTAL_ASSET_MANIFEST_PATH", tmp_path / "missing-manifest.json")
+    asset_bundle._load_portal_asset_manifest_cached.cache_clear()
+
+    assert isinstance(asset_bundle.PORTAL_ASSET_MANIFEST, Mapping)
+    with pytest.raises(RuntimeError, match="Unable to load portal asset manifest"):
+        len(asset_bundle.PORTAL_ASSET_MANIFEST)
 
 
 def test_render_portal_template_rejects_missing_required_token() -> None:

--- a/tests/test_app_orchestrator_runtime.py
+++ b/tests/test_app_orchestrator_runtime.py
@@ -738,10 +738,11 @@ def test_portal_asset_manifest_rejects_paths_outside_portal_assets_dir(
         encoding="utf-8",
     )
     monkeypatch.setattr(orchestrator_app, "PORTAL_ASSET_MANIFEST_PATH", manifest_path)
-    monkeypatch.setattr(portal_asset_bundle, "PORTAL_ASSET_MANIFEST_PATH", manifest_path)
 
     with pytest.raises(RuntimeError, match="points outside"):
         orchestrator_app._load_portal_asset_manifest()
+
+    assert portal_asset_bundle.PORTAL_ASSET_MANIFEST_PATH != manifest_path
 
 
 def test_portal_html_asset_references_are_covered_by_manifest() -> None:

--- a/tests/test_app_orchestrator_runtime.py
+++ b/tests/test_app_orchestrator_runtime.py
@@ -28,6 +28,7 @@ from starlette.requests import Request as StarletteRequest
 pytestmark = pytest.mark.unit
 
 orchestrator_app = importlib.import_module("app")
+portal_asset_bundle = importlib.import_module("transformation_portal.portal.asset_bundle")
 upload_staging = importlib.import_module("transformation_portal.ingest.upload_staging")
 PORTAL_HTML_PATH = Path(__file__).resolve().parents[1] / "portal.html"
 PORTAL_ASSET_ROOT = PORTAL_HTML_PATH.parent / "public" / "portal-assets"
@@ -737,6 +738,7 @@ def test_portal_asset_manifest_rejects_paths_outside_portal_assets_dir(
         encoding="utf-8",
     )
     monkeypatch.setattr(orchestrator_app, "PORTAL_ASSET_MANIFEST_PATH", manifest_path)
+    monkeypatch.setattr(portal_asset_bundle, "PORTAL_ASSET_MANIFEST_PATH", manifest_path)
 
     with pytest.raises(RuntimeError, match="points outside"):
         orchestrator_app._load_portal_asset_manifest()


### PR DESCRIPTION
## Summary
- Completes Phase 2 Target 2A by extracting portal asset bundle rendering, fingerprints, ETag helpers, and cache semantics from app.py into transformation_portal.portal.asset_bundle.
- Keeps FastAPI route ownership and app.py private compatibility names intact through explicit imports.
- Updates the stale portal asset budget ceilings needed for the current checked-in portal.js and portal-review.js bundles; no generated assets were rebuilt or changed.

## Changes
- Added src/transformation_portal/portal/asset_bundle.py and the portal package initializer.
- Moved portal asset dataclasses, constants, manifest loading, template rendering, fingerprint caches, cache-control, ETag, and 304 helpers into the new module.
- Re-exported the moved private app names from app.py so existing orchestrator_app callers continue to resolve.
- Added focused module tests for manifest path rejection, unresolved template tokens, versioned URLs, cache-control semantics, requested fingerprints, ETag matching, and 304 headers.
- Updated app-level manifest monkeypatch coverage to point at the new module owner.
- Marked Target 2A as Landed in the monolith decomposition ledger.
- Raised only the three stale portal asset budget ceilings required for the current checked-in bundles: portal.js gzip, portal-review.js raw, and portal-review.js gzip.

No route, schema, selector, env var, CLI flag, or public HTTP contract changes are intended.

## Validation
Proven green:
- .venv/bin/pytest tests/portal/test_asset_bundle.py -v
- .venv/bin/pytest tests/test_app_orchestrator_runtime.py -k "portal_asset or portal_html_signature or portal_css_signature" -v
- .venv/bin/pytest tests/test_app_orchestrator_contract_http.py -k "portal_asset or root_ui_response" -v
- .venv/bin/pytest tests/validation/test_check_portal_asset_budgets.py -v
- make check-portal-asset-budgets
- make test-portal-contract
- PATH=/Users/richardcheetham/.nvm/versions/node/v22.22.2/bin:/usr/bin:/bin:/usr/sbin:/sbin make validate-portal-css-layer-parity
- make check-doc-heading-links
- .venv/bin/python scripts/validation/scan_todo_inventory.py --check-governance
- python3 scripts/governance/check_docs_structure.py --all
- make check-json-serialization check-yaml-governance check-python-headers
- .venv/bin/python -m json.tool config/portal_asset_budgets.json >/dev/null
- .venv/bin/python -c "import app; import transformation_portal.portal.asset_bundle as ab; print(app.PORTAL_HTML == ab.PORTAL_HTML, app.PORTAL_ASSETS_DIR == ab.PORTAL_ASSETS_DIR, app._portal_asset_versioned_url('portal.js', 'abc') == ab._portal_asset_versioned_url('portal.js', 'abc'))"
- git diff --check

Still failing:
- None from the validation commands run.

Failure classification:
- The initial asset-budget gate exposed stale budget ceilings for the current checked-in bundles; this PR updates that budget contract without rebuilding assets.
- Initial CSS parity attempts failed due Node 25 selection and sandbox temp-dir permissions; rerunning with Node 22 and the same parity target succeeded.

## Risk
- Compatibility risk is bounded by explicit app.py re-exports and unchanged FastAPI route ownership.
- Cache semantics and fingerprints remain covered through both module tests and existing app HTTP/runtime contract tests.
- The budget update is limited to current shipped assets and is revert-safe with the extraction if needed.