### PR TITLE
refactor(rendering): extract 4k pipeline types

### DIFF
--- a/docs/architecture/MONOLITH_DECOMPOSITION_TARGETS.md
+++ b/docs/architecture/MONOLITH_DECOMPOSITION_TARGETS.md
@@ -178,6 +178,7 @@ This table is the canonical progress ledger for extraction PRs that draw from th
 | Target 3D — SAM2 backend | `lux_depth_v3/segmentation_backend.py` | `lux_depth_v3/segmentation/sam2.py` | Landed | This PR: SAM2 backend extracted |
 | Target 3E — SAM ViT-H backend | `lux_depth_v3/segmentation_backend.py` | `lux_depth_v3/segmentation/sam_vit_h.py` | Landed | This PR: SAM ViT-H backend extracted |
 | Target 3F — Segmentation registry | `lux_depth_v3/segmentation_backend.py` | `lux_depth_v3/segmentation/registry.py` | Landed | This PR: segmentation registry extracted |
+| Target 4A — Rendering config/result types | `pipelines/rendering_4k_pipeline.py` | `pipelines/rendering_4k/types.py` | Landed | This PR: rendering config/result types extracted; ranking unchanged pending governance refresh |
 
 ---
 

--- a/src/transformation_portal/pipelines/rendering_4k/__init__.py
+++ b/src/transformation_portal/pipelines/rendering_4k/__init__.py
@@ -1,0 +1,39 @@
+"""Internal modules for the 4K rendering pipeline decomposition."""
+
+from .types import (
+    STAGE_NAMES,
+    AIEnhancementConfig,
+    ColorGradingConfig,
+    DepthConfig,
+    DeviceType,
+    MaterialResponseConfig,
+    OutputConfig,
+    PipelineConfig,
+    ProcessingResult,
+    QualityFeedbackConfig,
+    QualityLevel,
+    QualityMetrics,
+    StageMetrics,
+    ToneMappingConfig,
+    ToneMappingMethod,
+    UpscalingConfig,
+)
+
+__all__ = [
+    "AIEnhancementConfig",
+    "ColorGradingConfig",
+    "DepthConfig",
+    "DeviceType",
+    "MaterialResponseConfig",
+    "OutputConfig",
+    "PipelineConfig",
+    "ProcessingResult",
+    "QualityFeedbackConfig",
+    "QualityLevel",
+    "QualityMetrics",
+    "STAGE_NAMES",
+    "StageMetrics",
+    "ToneMappingConfig",
+    "ToneMappingMethod",
+    "UpscalingConfig",
+]

--- a/src/transformation_portal/pipelines/rendering_4k/types.py
+++ b/src/transformation_portal/pipelines/rendering_4k/types.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Type, configuration, and result models for the 4K rendering pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+from PIL import Image
+
+
+class ToneMappingMethod(Enum):
+    """Supported HDR tone mapping methods."""
+
+    AGX = "agx"
+    FILMIC = "filmic"
+    REINHARD = "reinhard"
+    ACES = "aces"
+
+
+class QualityLevel(Enum):
+    """Quality presets for processing."""
+
+    PREVIEW = "preview"  # Fast, lower resolution
+    STANDARD = "standard"  # Balanced quality/speed
+    HIGH = "high"  # High quality
+    ULTRA = "ultra"  # Maximum quality, 4K output
+
+
+class DeviceType(Enum):
+    """Compute device types."""
+
+    CPU = "cpu"
+    CUDA = "cuda"
+    MPS = "mps"  # Apple Metal
+
+
+# Processing stage names for metrics and feedback
+STAGE_NAMES = [
+    "input_validation",
+    "depth_estimation",
+    "tone_mapping",
+    "material_response",
+    "color_grading",
+    "ai_enhancement",
+    "upscaling",
+    "quality_assessment",
+    "output_generation",
+]
+
+
+@dataclass
+class DepthConfig:
+    """Depth estimation configuration."""
+
+    enabled: bool = True
+    model_variant: str = "small"  # small, base, large
+    backend: str = "auto"  # auto, pytorch_mps, pytorch_cpu, coreml
+    num_zones: int = 3  # Foreground, midground, background
+    cache_enabled: bool = True
+    cache_max_size: int = 50
+
+
+@dataclass
+class ToneMappingConfig:
+    """HDR tone mapping configuration."""
+
+    enabled: bool = True
+    method: ToneMappingMethod = ToneMappingMethod.AGX
+    exposure: float = 0.0
+    contrast: float = 1.0
+    white_point: float = 11.2
+    preserve_highlights: bool = True
+
+
+@dataclass
+class MaterialResponseConfig:
+    """Material Response Technology configuration."""
+
+    enabled: bool = True
+    strength: float = 0.7
+    texture_boost: float = 0.25
+    surface_types: List[str] = field(default_factory=lambda: ["wood", "metal", "glass", "stone", "fabric"])
+    preserve_highlights: bool = True
+    micro_contrast: float = 0.15
+
+
+@dataclass
+class ColorGradingConfig:
+    """Color grading and LUT configuration."""
+
+    enabled: bool = True
+    lut_paths: List[str] = field(default_factory=list)
+    lut_strengths: List[float] = field(default_factory=list)
+    saturation: float = 1.05
+    vibrance: float = 1.08
+    temperature_shift: Tuple[float, float, float] = (1.0, 1.0, 1.0)
+
+
+@dataclass
+class AIEnhancementConfig:
+    """AI enhancement configuration (ControlNet guidance)."""
+
+    enabled: bool = False  # Requires optional ML dependencies
+    use_controlnet: bool = True
+    use_depth_guidance: bool = True
+    prompt: str = "photorealistic luxury architectural rendering, professional lighting"
+    negative_prompt: str = "blurry, artifacts, cartoon, oversaturated"
+    strength: float = 0.3
+    guidance_scale: float = 7.5
+    num_steps: int = 25
+    seed: int = 42  # For reproducibility
+
+
+@dataclass
+class UpscalingConfig:
+    """Upscaling configuration."""
+
+    enabled: bool = True
+    target_resolution: Tuple[int, int] = (3840, 2160)  # 4K UHD
+    method: str = "lanczos"  # lanczos, esrgan (requires optional deps)
+    scale_factor: int = 4
+    preserve_sharpness: bool = True
+
+
+@dataclass
+class QualityFeedbackConfig:
+    """RAG-based quality feedback loop configuration."""
+
+    enabled: bool = True
+    min_quality_threshold: float = 0.75
+    max_iterations: int = 3
+    metrics: List[str] = field(default_factory=lambda: ["sharpness", "contrast", "colorfulness", "exposure"])
+    auto_adjust: bool = True
+    # LPIPS integration settings
+    use_lpips: bool = False  # Enable LPIPS perceptual scoring (requires torch/lpips)
+    lpips_network: str = "alex"  # Network for LPIPS ('alex', 'vgg', 'squeeze')
+    perceptual_percentile_target: float = 95.0  # Target percentile for perceptual quality
+    material_fidelity_target: float = 0.98  # 98% material fidelity target
+    # Hybrid mode settings
+    hybrid_mode: bool = True  # Compute both LPIPS and heuristic metrics simultaneously
+    enable_material_fidelity: bool = True  # Compute per-material fidelity scores
+    # RAG indexing settings
+    rag_indexing_enabled: bool = False  # Enable RAG quality metric indexing
+    rag_index_path: Optional[str] = None  # Path to RAG index (if None, uses default)
+
+
+@dataclass
+class OutputConfig:
+    """Output configuration."""
+
+    master_tiff_16bit: bool = True
+    delivery_jpeg: bool = True
+    jpeg_quality: int = 95
+    jpeg_progressive: bool = True
+    save_intermediate: bool = False
+    save_depth_visualization: bool = True
+    save_quality_report: bool = True
+    preserve_metadata: bool = True
+
+
+@dataclass
+class PipelineConfig:
+    """Complete pipeline configuration."""
+
+    name: str = "default"
+    description: str = ""
+    quality_level: QualityLevel = QualityLevel.HIGH
+    depth: DepthConfig = field(default_factory=DepthConfig)
+    tone_mapping: ToneMappingConfig = field(default_factory=ToneMappingConfig)
+    material_response: MaterialResponseConfig = field(default_factory=MaterialResponseConfig)
+    color_grading: ColorGradingConfig = field(default_factory=ColorGradingConfig)
+    ai_enhancement: AIEnhancementConfig = field(default_factory=AIEnhancementConfig)
+    upscaling: UpscalingConfig = field(default_factory=UpscalingConfig)
+    quality_feedback: QualityFeedbackConfig = field(default_factory=QualityFeedbackConfig)
+    output: OutputConfig = field(default_factory=OutputConfig)
+
+
+@dataclass
+class StageMetrics:
+    """Metrics for a single processing stage."""
+
+    name: str
+    duration_ms: float
+    success: bool
+    quality_delta: float = 0.0
+    notes: str = ""
+
+
+@dataclass
+class QualityMetrics:
+    """Image quality assessment metrics."""
+
+    sharpness: float = 0.0  # 0-1
+    contrast: float = 0.0  # 0-1
+    colorfulness: float = 0.0  # 0-1
+    exposure_balance: float = 0.0  # 0-1
+    noise_level: float = 0.0  # 0-1 (lower is better)
+    overall_score: float = 0.0  # 0-1
+    # LPIPS perceptual metrics (when available)
+    lpips_score: float = 0.0  # 0-1 (lower is better, 0 = identical)
+    lpips_percentile: float = 0.0  # Percentile rank against benchmark
+    material_fidelity: float = 0.0  # 0-1 (higher is better)
+    perceptual_quality: float = 0.0  # Composite perceptual score (0-100)
+
+    def to_dict(self) -> Dict[str, float]:
+        """Convert to dictionary."""
+        return asdict(self)
+
+
+@dataclass
+class ProcessingResult:
+    """Complete processing result with image and metadata."""
+
+    image: Image.Image
+    depth_map: Optional[np.ndarray] = None
+    quality_metrics: Optional[QualityMetrics] = None
+    stage_metrics: List[StageMetrics] = field(default_factory=list)
+    total_duration_ms: float = 0.0
+    iterations: int = 1
+    output_paths: Dict[str, Path] = field(default_factory=dict)
+    config_used: Optional[PipelineConfig] = None
+
+    @property
+    def quality_score(self) -> float:
+        """Get overall quality score."""
+        if self.quality_metrics:
+            return self.quality_metrics.overall_score
+        return 0.0
+
+
+__all__ = [
+    "AIEnhancementConfig",
+    "ColorGradingConfig",
+    "DepthConfig",
+    "DeviceType",
+    "MaterialResponseConfig",
+    "OutputConfig",
+    "PipelineConfig",
+    "ProcessingResult",
+    "QualityFeedbackConfig",
+    "QualityLevel",
+    "QualityMetrics",
+    "STAGE_NAMES",
+    "StageMetrics",
+    "ToneMappingConfig",
+    "ToneMappingMethod",
+    "UpscalingConfig",
+]

--- a/src/transformation_portal/pipelines/rendering_4k_pipeline.py
+++ b/src/transformation_portal/pipelines/rendering_4k_pipeline.py
@@ -40,8 +40,7 @@ import json
 import logging
 import time
 from collections import OrderedDict
-from dataclasses import asdict, dataclass, field
-from enum import Enum
+from dataclasses import asdict
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Union
 
@@ -128,6 +127,24 @@ except ImportError:
 # Import internal utilities
 from ..core.security.model_lock import resolve_model_lock_revision
 from ..utils.image_utils import load_image, np_to_pil, pil_to_np
+from .rendering_4k.types import (
+    STAGE_NAMES,
+    AIEnhancementConfig,
+    ColorGradingConfig,
+    DepthConfig,
+    DeviceType,
+    MaterialResponseConfig,
+    OutputConfig,
+    PipelineConfig,
+    ProcessingResult,
+    QualityFeedbackConfig,
+    QualityLevel,
+    QualityMetrics,
+    StageMetrics,
+    ToneMappingConfig,
+    ToneMappingMethod,
+    UpscalingConfig,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -145,241 +162,6 @@ def _json_default(obj: object) -> object:
             return obj.item() if obj.ndim == 0 else obj.detach().cpu().tolist()
 
     return str(obj)
-
-
-# =============================================================================
-# Enums and Constants
-# =============================================================================
-
-
-class ToneMappingMethod(Enum):
-    """Supported HDR tone mapping methods."""
-
-    AGX = "agx"
-    FILMIC = "filmic"
-    REINHARD = "reinhard"
-    ACES = "aces"
-
-
-class QualityLevel(Enum):
-    """Quality presets for processing."""
-
-    PREVIEW = "preview"  # Fast, lower resolution
-    STANDARD = "standard"  # Balanced quality/speed
-    HIGH = "high"  # High quality
-    ULTRA = "ultra"  # Maximum quality, 4K output
-
-
-class DeviceType(Enum):
-    """Compute device types."""
-
-    CPU = "cpu"
-    CUDA = "cuda"
-    MPS = "mps"  # Apple Metal
-
-
-# Processing stage names for metrics and feedback
-STAGE_NAMES = [
-    "input_validation",
-    "depth_estimation",
-    "tone_mapping",
-    "material_response",
-    "color_grading",
-    "ai_enhancement",
-    "upscaling",
-    "quality_assessment",
-    "output_generation",
-]
-
-
-# =============================================================================
-# Configuration Dataclasses
-# =============================================================================
-
-
-@dataclass
-class DepthConfig:
-    """Depth estimation configuration."""
-
-    enabled: bool = True
-    model_variant: str = "small"  # small, base, large
-    backend: str = "auto"  # auto, pytorch_mps, pytorch_cpu, coreml
-    num_zones: int = 3  # Foreground, midground, background
-    cache_enabled: bool = True
-    cache_max_size: int = 50
-
-
-@dataclass
-class ToneMappingConfig:
-    """HDR tone mapping configuration."""
-
-    enabled: bool = True
-    method: ToneMappingMethod = ToneMappingMethod.AGX
-    exposure: float = 0.0
-    contrast: float = 1.0
-    white_point: float = 11.2
-    preserve_highlights: bool = True
-
-
-@dataclass
-class MaterialResponseConfig:
-    """Material Response Technology configuration."""
-
-    enabled: bool = True
-    strength: float = 0.7
-    texture_boost: float = 0.25
-    surface_types: List[str] = field(default_factory=lambda: ["wood", "metal", "glass", "stone", "fabric"])
-    preserve_highlights: bool = True
-    micro_contrast: float = 0.15
-
-
-@dataclass
-class ColorGradingConfig:
-    """Color grading and LUT configuration."""
-
-    enabled: bool = True
-    lut_paths: List[str] = field(default_factory=list)
-    lut_strengths: List[float] = field(default_factory=list)
-    saturation: float = 1.05
-    vibrance: float = 1.08
-    temperature_shift: Tuple[float, float, float] = (1.0, 1.0, 1.0)
-
-
-@dataclass
-class AIEnhancementConfig:
-    """AI enhancement configuration (ControlNet guidance)."""
-
-    enabled: bool = False  # Requires optional ML dependencies
-    use_controlnet: bool = True
-    use_depth_guidance: bool = True
-    prompt: str = "photorealistic luxury architectural rendering, professional lighting"
-    negative_prompt: str = "blurry, artifacts, cartoon, oversaturated"
-    strength: float = 0.3
-    guidance_scale: float = 7.5
-    num_steps: int = 25
-    seed: int = 42  # For reproducibility
-
-
-@dataclass
-class UpscalingConfig:
-    """Upscaling configuration."""
-
-    enabled: bool = True
-    target_resolution: Tuple[int, int] = (3840, 2160)  # 4K UHD
-    method: str = "lanczos"  # lanczos, esrgan (requires optional deps)
-    scale_factor: int = 4
-    preserve_sharpness: bool = True
-
-
-@dataclass
-class QualityFeedbackConfig:
-    """RAG-based quality feedback loop configuration."""
-
-    enabled: bool = True
-    min_quality_threshold: float = 0.75
-    max_iterations: int = 3
-    metrics: List[str] = field(default_factory=lambda: ["sharpness", "contrast", "colorfulness", "exposure"])
-    auto_adjust: bool = True
-    # LPIPS integration settings
-    use_lpips: bool = False  # Enable LPIPS perceptual scoring (requires torch/lpips)
-    lpips_network: str = "alex"  # Network for LPIPS ('alex', 'vgg', 'squeeze')
-    perceptual_percentile_target: float = 95.0  # Target percentile for perceptual quality
-    material_fidelity_target: float = 0.98  # 98% material fidelity target
-    # Hybrid mode settings
-    hybrid_mode: bool = True  # Compute both LPIPS and heuristic metrics simultaneously
-    enable_material_fidelity: bool = True  # Compute per-material fidelity scores
-    # RAG indexing settings
-    rag_indexing_enabled: bool = False  # Enable RAG quality metric indexing
-    rag_index_path: Optional[str] = None  # Path to RAG index (if None, uses default)
-
-
-@dataclass
-class OutputConfig:
-    """Output configuration."""
-
-    master_tiff_16bit: bool = True
-    delivery_jpeg: bool = True
-    jpeg_quality: int = 95
-    jpeg_progressive: bool = True
-    save_intermediate: bool = False
-    save_depth_visualization: bool = True
-    save_quality_report: bool = True
-    preserve_metadata: bool = True
-
-
-@dataclass
-class PipelineConfig:
-    """Complete pipeline configuration."""
-
-    name: str = "default"
-    description: str = ""
-    quality_level: QualityLevel = QualityLevel.HIGH
-    depth: DepthConfig = field(default_factory=DepthConfig)
-    tone_mapping: ToneMappingConfig = field(default_factory=ToneMappingConfig)
-    material_response: MaterialResponseConfig = field(default_factory=MaterialResponseConfig)
-    color_grading: ColorGradingConfig = field(default_factory=ColorGradingConfig)
-    ai_enhancement: AIEnhancementConfig = field(default_factory=AIEnhancementConfig)
-    upscaling: UpscalingConfig = field(default_factory=UpscalingConfig)
-    quality_feedback: QualityFeedbackConfig = field(default_factory=QualityFeedbackConfig)
-    output: OutputConfig = field(default_factory=OutputConfig)
-
-
-# =============================================================================
-# Processing Result Classes
-# =============================================================================
-
-
-@dataclass
-class StageMetrics:
-    """Metrics for a single processing stage."""
-
-    name: str
-    duration_ms: float
-    success: bool
-    quality_delta: float = 0.0
-    notes: str = ""
-
-
-@dataclass
-class QualityMetrics:
-    """Image quality assessment metrics."""
-
-    sharpness: float = 0.0  # 0-1
-    contrast: float = 0.0  # 0-1
-    colorfulness: float = 0.0  # 0-1
-    exposure_balance: float = 0.0  # 0-1
-    noise_level: float = 0.0  # 0-1 (lower is better)
-    overall_score: float = 0.0  # 0-1
-    # LPIPS perceptual metrics (when available)
-    lpips_score: float = 0.0  # 0-1 (lower is better, 0 = identical)
-    lpips_percentile: float = 0.0  # Percentile rank against benchmark
-    material_fidelity: float = 0.0  # 0-1 (higher is better)
-    perceptual_quality: float = 0.0  # Composite perceptual score (0-100)
-
-    def to_dict(self) -> Dict[str, float]:
-        """Convert to dictionary."""
-        return asdict(self)
-
-
-@dataclass
-class ProcessingResult:
-    """Complete processing result with image and metadata."""
-
-    image: Image.Image
-    depth_map: Optional[np.ndarray] = None
-    quality_metrics: Optional[QualityMetrics] = None
-    stage_metrics: List[StageMetrics] = field(default_factory=list)
-    total_duration_ms: float = 0.0
-    iterations: int = 1
-    output_paths: Dict[str, Path] = field(default_factory=dict)
-    config_used: Optional[PipelineConfig] = None
-
-    @property
-    def quality_score(self) -> float:
-        """Get overall quality score."""
-        if self.quality_metrics:
-            return self.quality_metrics.overall_score
-        return 0.0
 
 
 # =============================================================================

--- a/tests/test_pipeline_unified.py
+++ b/tests/test_pipeline_unified.py
@@ -644,7 +644,7 @@ class TestStageExecution:
 
         assert result.success is True
 
-    def test_upscaling_fallback(self, pipeline_module, sample_input_image):
+    def test_upscaling_4k_fallback(self, pipeline_module, sample_input_image):
         """Test 4K upscaling fallback to Lanczos."""
         recipe = {
             "name": "Upscale Test",

--- a/tests/test_property_based_algorithms.py
+++ b/tests/test_property_based_algorithms.py
@@ -87,6 +87,21 @@ class TestAtmosphericPhysicalInvariants:
 
 
 class TestToneMappingOutputRange:
+    @classmethod
+    def setup_class(cls):
+        import numpy as np
+
+        from transformation_portal.pipelines.rendering_4k_pipeline import (
+            ToneMappingConfig,
+            ToneMappingMethod,
+            apply_tone_mapping,
+        )
+
+        cls.np = np
+        cls.ToneMappingConfig = ToneMappingConfig
+        cls.ToneMappingMethod = ToneMappingMethod
+        cls.apply_tone_mapping = staticmethod(apply_tone_mapping)
+
     @given(
         values=st.lists(
             st.floats(min_value=0.0, max_value=20.0, allow_nan=False, allow_infinity=False),
@@ -97,18 +112,10 @@ class TestToneMappingOutputRange:
         exposure=st.floats(min_value=-3.0, max_value=3.0, allow_nan=False, allow_infinity=False),
     )
     @settings(max_examples=60)
-    def test_output_always_in_unit_range(self, values, method, exposure):
-        import numpy as np
-
-        from transformation_portal.pipelines.rendering_4k_pipeline import (
-            ToneMappingConfig,
-            ToneMappingMethod,
-            apply_tone_mapping,
-        )
-
-        image = np.array(values, dtype=np.float32).reshape((1, 3, 3))
-        config = ToneMappingConfig(method=ToneMappingMethod(method), exposure=exposure)
-        result = apply_tone_mapping(image, config)
+    def test_tone_mapping_output_always_in_unit_range(self, values, method, exposure):
+        image = self.np.array(values, dtype=self.np.float32).reshape((1, 3, 3))
+        config = self.ToneMappingConfig(method=self.ToneMappingMethod(method), exposure=exposure)
+        result = self.apply_tone_mapping(image, config)
         assert result.min() >= -1e-5
         assert result.max() <= 1.0 + 1e-5
 
@@ -117,14 +124,10 @@ class TestToneMappingOutputRange:
         w=st.integers(min_value=4, max_value=32),
     )
     @settings(max_examples=30)
-    def test_output_shape_matches_input_shape(self, h, w):
-        import numpy as np
-
-        from transformation_portal.pipelines.rendering_4k_pipeline import ToneMappingConfig, apply_tone_mapping
-
-        rng = np.random.default_rng(0)
-        image = rng.random((h, w, 3), dtype=np.float32).astype(np.float32)
-        result = apply_tone_mapping(image, ToneMappingConfig())
+    def test_tone_mapping_output_shape_matches_input_shape(self, h, w):
+        rng = self.np.random.default_rng(0)
+        image = rng.random((h, w, 3), dtype=self.np.float32).astype(self.np.float32)
+        result = self.apply_tone_mapping(image, self.ToneMappingConfig())
         assert result.shape == (h, w, 3)
 
 

--- a/tests/unit/pipelines/test_rendering_4k_type_exports.py
+++ b/tests/unit/pipelines/test_rendering_4k_type_exports.py
@@ -1,0 +1,75 @@
+"""Compatibility tests for the Phase 4A rendering_4k type extraction."""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from PIL import Image
+
+pytestmark = [pytest.mark.unit]
+
+
+PHASE_4A_SYMBOLS = (
+    "AIEnhancementConfig",
+    "ColorGradingConfig",
+    "DepthConfig",
+    "DeviceType",
+    "MaterialResponseConfig",
+    "OutputConfig",
+    "PipelineConfig",
+    "ProcessingResult",
+    "QualityFeedbackConfig",
+    "QualityLevel",
+    "QualityMetrics",
+    "STAGE_NAMES",
+    "StageMetrics",
+    "ToneMappingConfig",
+    "ToneMappingMethod",
+    "UpscalingConfig",
+)
+
+
+def test_legacy_rendering_module_reexports_phase_4a_types() -> None:
+    legacy = importlib.import_module("transformation_portal.pipelines.rendering_4k_pipeline")
+    extracted = importlib.import_module("transformation_portal.pipelines.rendering_4k.types")
+
+    for symbol in PHASE_4A_SYMBOLS:
+        assert getattr(legacy, symbol) is getattr(extracted, symbol)
+
+
+def test_rendering_4k_package_reexports_phase_4a_types() -> None:
+    package = importlib.import_module("transformation_portal.pipelines.rendering_4k")
+    extracted = importlib.import_module("transformation_portal.pipelines.rendering_4k.types")
+
+    for symbol in PHASE_4A_SYMBOLS:
+        assert getattr(package, symbol) is getattr(extracted, symbol)
+
+
+def test_extracted_pipeline_config_preserves_default_contract() -> None:
+    from transformation_portal.pipelines.rendering_4k.types import (
+        PipelineConfig,
+        QualityLevel,
+        ToneMappingConfig,
+        ToneMappingMethod,
+        UpscalingConfig,
+    )
+
+    config = PipelineConfig()
+
+    assert config.quality_level is QualityLevel.HIGH
+    assert isinstance(config.tone_mapping, ToneMappingConfig)
+    assert config.tone_mapping.method is ToneMappingMethod.AGX
+    assert isinstance(config.upscaling, UpscalingConfig)
+    assert config.upscaling.target_resolution == (3840, 2160)
+
+
+def test_extracted_processing_result_quality_score_matches_legacy_contract() -> None:
+    from transformation_portal.pipelines.rendering_4k.types import ProcessingResult, QualityMetrics
+
+    image = Image.new("RGB", (2, 2))
+
+    assert ProcessingResult(image=image).quality_score == pytest.approx(0.0)
+    assert ProcessingResult(image=image, quality_metrics=QualityMetrics(overall_score=0.87)).quality_score == pytest.approx(
+        0.87
+    )


### PR DESCRIPTION
## Summary
- Implements ADR-045 Phase 4A for `src/transformation_portal/pipelines/rendering_4k_pipeline.py`.
- Extracts the rendering 4K enum/config/result dataclass surface into `src/transformation_portal/pipelines/rendering_4k/types.py` while preserving the legacy module as the compatibility import owner.

## Changes
- Added the internal `transformation_portal.pipelines.rendering_4k` package and explicit type exports.
- Re-exported Phase 4A symbols from `rendering_4k_pipeline.py` without moving stage functions, quality helpers, pipeline orchestration, or CLI ownership.
- Added compatibility tests proving legacy and extracted symbols are identical objects.
- Updated the decomposition status table to record Target 4A as landed while leaving the ranked-target list unchanged pending a separate governance refresh.
- Tightened two stale validation selectors so the documented `tone_mapping` and `upscaling_4k` checks select real tests.

No public route, API envelope, CLI flag, output filename, preset name, YAML shape, selector, or optional dependency behavior is intentionally changed.

## Validation
Proven green:
- `.venv/bin/pytest tests/unit/pipelines/test_rendering_4k_type_exports.py -v`
- `.venv/bin/pytest tests/unit/pipelines/test_rendering_4k_pipeline_stages.py -v`
- `.venv/bin/pytest tests/test_property_based_algorithms.py -k "tone_mapping" -v`
- `.venv/bin/pytest tests/test_rendering_4k_pipeline_smoke.py -v`
- `.venv/bin/pytest tests/test_pipeline_unified_smoke.py -v`
- `.venv/bin/pytest tests/test_pipeline_unified.py -k "rendering or upscaling_4k" -v`
- `.venv/bin/python scripts/validation/scan_todo_inventory.py --check-governance`
- `make check-json-serialization check-yaml-governance check-python-headers`
- `make check-doc-heading-links`
- `git diff --check`
- pre-commit hooks during `git commit --amend --no-edit`

Still failing:
- None observed.

Failure classification:
- No product, stale-test, or environment/tooling failures remain in the validation above.

## Risk
- Compatibility risk is bounded by keeping `rendering_4k_pipeline.py` as the import and CLI owner for this PR.
- Runtime risk is low because this PR moves data types only; image stage functions, quality/memory helpers, pipeline flow, lazy optional dependency checks, and output writing remain in place.
- Governance risk is bounded by keeping ranking changes out of this implementation PR; only the shipped 4A status-table row is updated.
- Revert is straightforward: the extracted package and legacy imports are isolated to Phase 4A.