### PR TITLE
fix(dev): reuse local env keys across quote formats

### DIFF
--- a/scripts/dev/write_local_env.sh
+++ b/scripts/dev/write_local_env.sh
@@ -54,9 +54,12 @@ ensure_writable_dir "${SESSION_DB}"
 
 resolve_existing_key() {
   if [[ -f "${ENV_FILE}" ]]; then
-    # Match: export TP_API_KEY="<value>"
+    # Match generated single-quoted keys, plus legacy double-quoted keys.
     # Use sed so trailing '=' in base64 keys is preserved (awk -F= would drop it).
-    sed -n 's/^export TP_API_KEY="\(.*\)"$/\1/p' "${ENV_FILE}" | head -n 1
+    sed -n \
+      -e "s/^export TP_API_KEY='\(.*\)'$/\1/p" \
+      -e 's/^export TP_API_KEY="\(.*\)"$/\1/p' \
+      "${ENV_FILE}" | head -n 1 | sed "s/'\\\\''/'/g"
   fi
 }
 

--- a/scripts/dev/write_local_env.sh
+++ b/scripts/dev/write_local_env.sh
@@ -52,15 +52,118 @@ ensure_writable_dir "${ENV_FILE}"
 ensure_writable_dir "${USERS_FILE}"
 ensure_writable_dir "${SESSION_DB}"
 
-resolve_existing_key() {
-  if [[ -f "${ENV_FILE}" ]]; then
-    # Match generated single-quoted keys, plus legacy double-quoted keys.
-    # Use sed so trailing '=' in base64 keys is preserved (awk -F= would drop it).
-    sed -n \
-      -e "s/^export TP_API_KEY='\(.*\)'$/\1/p" \
-      -e 's/^export TP_API_KEY="\(.*\)"$/\1/p' \
-      "${ENV_FILE}" | head -n 1 | sed "s/'\\\\''/'/g"
+decode_single_quoted_export_value() {
+  local token="$1"
+  local value=""
+  local idx=0
+  local len=${#token}
+  local char
+  local closed
+  local next_idx
+
+  while ((idx < len)); do
+    char="${token:idx:1}"
+    if [[ "${char}" == "'" ]]; then
+      idx=$((idx + 1))
+      closed=0
+      while ((idx < len)); do
+        char="${token:idx:1}"
+        if [[ "${char}" == "'" ]]; then
+          closed=1
+          idx=$((idx + 1))
+          break
+        fi
+        value+="${char}"
+        idx=$((idx + 1))
+      done
+      if [[ "${closed}" -ne 1 ]]; then
+        return 1
+      fi
+    elif [[ "${char}" == "\\" ]]; then
+      next_idx=$((idx + 1))
+      if ((next_idx >= len)) || [[ "${token:next_idx:1}" != "'" ]]; then
+        return 1
+      fi
+      value+="'"
+      idx=$((idx + 2))
+    else
+      return 1
+    fi
+  done
+
+  printf '%s\n' "${value}"
+}
+
+decode_double_quoted_export_value() {
+  local token="$1"
+  local len=${#token}
+  if ((len < 2)) || [[ "${token:0:1}" != '"' || "${token:len - 1:1}" != '"' ]]; then
+    return 1
   fi
+
+  local content_len=$((len - 2))
+  local content="${token:1:content_len}"
+  local value=""
+  local idx=0
+  local char
+  local next
+  local next_idx
+
+  while ((idx < content_len)); do
+    char="${content:idx:1}"
+    if [[ "${char}" == '"' ]]; then
+      return 1
+    fi
+    if [[ "${char}" == "\\" ]]; then
+      next_idx=$((idx + 1))
+      if ((next_idx >= content_len)); then
+        return 1
+      fi
+      next="${content:next_idx:1}"
+      case "${next}" in
+        '$' | '"' | '`' | '\')
+          value+="${next}"
+          idx=$((idx + 2))
+          ;;
+        *)
+          value+="\\"
+          idx=$((idx + 1))
+          ;;
+      esac
+    else
+      value+="${char}"
+      idx=$((idx + 1))
+    fi
+  done
+
+  printf '%s\n' "${value}"
+}
+
+resolve_existing_key() {
+  local line
+  local token
+  local parsed
+
+  if [[ ! -f "${ENV_FILE}" ]]; then
+    return 0
+  fi
+
+  while IFS= read -r line; do
+    case "${line}" in
+      export\ TP_API_KEY=*)
+        token="${line#export TP_API_KEY=}"
+        if parsed="$(decode_single_quoted_export_value "${token}")"; then
+          printf '%s\n' "${parsed}"
+          return 0
+        fi
+        if parsed="$(decode_double_quoted_export_value "${token}")"; then
+          printf '%s\n' "${parsed}"
+          return 0
+        fi
+        return 0
+        ;;
+    esac
+  done < "${ENV_FILE}"
 }
 
 EXISTING_KEY="$(resolve_existing_key || true)"

--- a/tests/validation/test_local_dev_scripts.py
+++ b/tests/validation/test_local_dev_scripts.py
@@ -56,6 +56,87 @@ def test_write_local_env_shell_quotes_caller_supplied_values(tmp_path: Path) -> 
 
 
 @pytest.mark.unit
+def test_write_local_env_reuses_generated_single_quoted_key(tmp_path: Path) -> None:
+    env_file = tmp_path / "local.env"
+    users_file = tmp_path / "users.json"
+    session_db = tmp_path / "sessions.db"
+    key = "idempotent'key-with-trailing=="
+
+    env = dict(os.environ)
+    env.update(
+        {
+            "TP_LOCAL_ENV_FILE": str(env_file),
+            "TP_FRONTDOOR_USERS_FILE": str(users_file),
+            "TP_FRONTDOOR_SESSION_DB": str(session_db),
+            "TP_LOCAL_API_KEY": key,
+        }
+    )
+
+    subprocess.run(["bash", str(WRITE_LOCAL_ENV_SCRIPT)], check=True, env=env)
+
+    env.pop("TP_LOCAL_API_KEY")
+    result = subprocess.run(
+        ["bash", str(WRITE_LOCAL_ENV_SCRIPT)],
+        check=True,
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+
+    assert "Reused existing key" in result.stdout
+    sourced = subprocess.run(
+        [
+            "bash",
+            "-lc",
+            f'source {shlex.quote(str(env_file))}; printf \'%s\\n%s\' "$TP_API_KEY" "$TP_BACKEND_API_KEY"',
+        ],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    assert sourced.stdout.splitlines() == [key, key]
+
+
+@pytest.mark.unit
+def test_write_local_env_reuses_legacy_double_quoted_key(tmp_path: Path) -> None:
+    env_file = tmp_path / "local.env"
+    users_file = tmp_path / "users.json"
+    session_db = tmp_path / "sessions.db"
+    key = "legacy-key-with-trailing=="
+    env_file.write_text(f'export TP_API_KEY="{key}"\n', encoding="utf-8")
+
+    env = dict(os.environ)
+    env.update(
+        {
+            "TP_LOCAL_ENV_FILE": str(env_file),
+            "TP_FRONTDOOR_USERS_FILE": str(users_file),
+            "TP_FRONTDOOR_SESSION_DB": str(session_db),
+        }
+    )
+
+    result = subprocess.run(
+        ["bash", str(WRITE_LOCAL_ENV_SCRIPT)],
+        check=True,
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+
+    assert "Reused existing key" in result.stdout
+    sourced = subprocess.run(
+        [
+            "bash",
+            "-lc",
+            f'source {shlex.quote(str(env_file))}; printf \'%s\\n%s\' "$TP_API_KEY" "$TP_BACKEND_API_KEY"',
+        ],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    assert sourced.stdout.splitlines() == [key, key]
+
+
+@pytest.mark.unit
 def test_stop_local_stack_uses_portable_pid_joining() -> None:
     content = STOP_LOCAL_STACK_SCRIPT.read_text(encoding="utf-8")
 

--- a/tests/validation/test_local_dev_scripts.py
+++ b/tests/validation/test_local_dev_scripts.py
@@ -13,6 +13,20 @@ STOP_LOCAL_STACK_SCRIPT = REPO_ROOT / "scripts" / "dev" / "stop_local_stack.sh"
 RUN_CLOUDFLARED_SCRIPT = REPO_ROOT / "scripts" / "dev" / "run_cloudflared.sh"
 
 
+def _source_local_env_key_pair(env_file: Path) -> list[str]:
+    result = subprocess.run(
+        [
+            "bash",
+            "-lc",
+            f'source {shlex.quote(str(env_file))}; printf \'%s\\n%s\' "$TP_API_KEY" "$TP_BACKEND_API_KEY"',
+        ],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return result.stdout.splitlines()
+
+
 @pytest.mark.unit
 def test_write_local_env_shell_quotes_caller_supplied_values(tmp_path: Path) -> None:
     env_file = tmp_path / "local.env"
@@ -60,7 +74,8 @@ def test_write_local_env_reuses_generated_single_quoted_key(tmp_path: Path) -> N
     env_file = tmp_path / "local.env"
     users_file = tmp_path / "users.json"
     session_db = tmp_path / "sessions.db"
-    key = "idempotent'key-with-trailing=="
+    shell_single_quote_escape_fragment = "'\\''"
+    key = f"idempotent{shell_single_quote_escape_fragment}key-with-trailing=="
 
     env = dict(os.environ)
     env.update(
@@ -84,17 +99,7 @@ def test_write_local_env_reuses_generated_single_quoted_key(tmp_path: Path) -> N
     )
 
     assert "Reused existing key" in result.stdout
-    sourced = subprocess.run(
-        [
-            "bash",
-            "-lc",
-            f'source {shlex.quote(str(env_file))}; printf \'%s\\n%s\' "$TP_API_KEY" "$TP_BACKEND_API_KEY"',
-        ],
-        check=True,
-        text=True,
-        capture_output=True,
-    )
-    assert sourced.stdout.splitlines() == [key, key]
+    assert _source_local_env_key_pair(env_file) == [key, key]
 
 
 @pytest.mark.unit
@@ -102,8 +107,11 @@ def test_write_local_env_reuses_legacy_double_quoted_key(tmp_path: Path) -> None
     env_file = tmp_path / "local.env"
     users_file = tmp_path / "users.json"
     session_db = tmp_path / "sessions.db"
-    key = "legacy-key-with-trailing=="
-    env_file.write_text(f'export TP_API_KEY="{key}"\n', encoding="utf-8")
+    key = 'legacy"key\\with$dollar`tick=='
+    env_file.write_text(
+        'export TP_API_KEY="legacy\\"key\\\\with\\$dollar\\`tick=="\n',
+        encoding="utf-8",
+    )
 
     env = dict(os.environ)
     env.update(
@@ -123,17 +131,7 @@ def test_write_local_env_reuses_legacy_double_quoted_key(tmp_path: Path) -> None
     )
 
     assert "Reused existing key" in result.stdout
-    sourced = subprocess.run(
-        [
-            "bash",
-            "-lc",
-            f'source {shlex.quote(str(env_file))}; printf \'%s\\n%s\' "$TP_API_KEY" "$TP_BACKEND_API_KEY"',
-        ],
-        check=True,
-        text=True,
-        capture_output=True,
-    )
-    assert sourced.stdout.splitlines() == [key, key]
+    assert _source_local_env_key_pair(env_file) == [key, key]
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- `scripts/dev/write_local_env.sh` wrote shell-safe single-quoted keys but only detected legacy double-quoted keys on later runs.
- The parser now accepts generated single-quoted keys and legacy double-quoted keys while preserving trailing `=` characters.

## Changes
- Update local env key reuse parsing for generated single-quoted exports.
- Preserve legacy double-quoted `TP_API_KEY` reuse compatibility.
- Add focused local-dev script regression tests for generated single-quoted and legacy double-quoted env files.

## Validation
Proven green:
- `git diff --check`
- `bash -n scripts/dev/write_local_env.sh`
- `.venv/bin/pytest tests/validation/test_local_dev_scripts.py`
- pre-commit hooks during `git commit`

Still failing:
- None observed.

Failure classification:
- No product logic, stale test, or environment/tooling failures remain. Initial commit attempt stopped because Black reformatted the new test, then passed after restaging.

## Risk
- No public API, route, selector, CLI flag, or env-var contract changes.
- Revert-safe and bounded to local dev env-file idempotency plus regression coverage.