### PR TITLE
refactor(spatial-ai): extract pipeline result models

### DIFF
--- a/docs/architecture/MONOLITH_DECOMPOSITION_TARGETS.md
+++ b/docs/architecture/MONOLITH_DECOMPOSITION_TARGETS.md
@@ -183,6 +183,7 @@ This table is the canonical progress ledger for extraction PRs that draw from th
 | Target 4C — Rendering quality and memory helpers | `pipelines/rendering_4k_pipeline.py` | `pipelines/rendering_4k/quality.py` | Landed | This PR: rendering quality assessor and GPU memory manager extracted; ranking unchanged pending governance refresh |
 | Target 4D — Rendering pipeline orchestration | `pipelines/rendering_4k_pipeline.py` | `pipelines/rendering_4k/pipeline.py` | Landed | This PR: rendering pipeline orchestration extracted behind legacy CLI/import shim; ranking unchanged pending governance refresh |
 | Target 5A — Spatial AI pipeline config | `spatial_ai/orchestration/pipeline.py` | `spatial_ai/orchestration/config.py` | Landed | This PR: spatial pipeline config model and validation helpers extracted; ranking unchanged pending governance refresh |
+| Target 5B — Spatial AI pipeline result models | `spatial_ai/orchestration/pipeline.py` | `spatial_ai/orchestration/results.py` | Landed | This PR: spatial pipeline result models and summary serializers extracted; ranking unchanged pending governance refresh |
 
 ---
 

--- a/policy/json_raw_approved_modules.txt
+++ b/policy/json_raw_approved_modules.txt
@@ -38,7 +38,6 @@ src/transformation_portal/pipelines/unified_luxury_pipeline.py
 src/transformation_portal/spatial_ai/ingest/linear_decoder.py
 src/transformation_portal/spatial_ai/orchestration/graph/artifact_store.py
 src/transformation_portal/spatial_ai/orchestration/pipeline.py
-src/transformation_portal/spatial_ai/orchestration/results.py
 src/transformation_portal/spatial_ai/reconstruction/mesh_exporter.py
 src/transformation_portal/stage_graph/stage.py
 src/transformation_portal/streaming/checkpoint.py

--- a/policy/json_raw_approved_modules.txt
+++ b/policy/json_raw_approved_modules.txt
@@ -38,6 +38,7 @@ src/transformation_portal/pipelines/unified_luxury_pipeline.py
 src/transformation_portal/spatial_ai/ingest/linear_decoder.py
 src/transformation_portal/spatial_ai/orchestration/graph/artifact_store.py
 src/transformation_portal/spatial_ai/orchestration/pipeline.py
+src/transformation_portal/spatial_ai/orchestration/results.py
 src/transformation_portal/spatial_ai/reconstruction/mesh_exporter.py
 src/transformation_portal/stage_graph/stage.py
 src/transformation_portal/streaming/checkpoint.py

--- a/src/transformation_portal/spatial_ai/orchestration/__init__.py
+++ b/src/transformation_portal/spatial_ai/orchestration/__init__.py
@@ -34,9 +34,10 @@ from __future__ import annotations
 
 from .config import PipelineConfig
 from .error_handler import ErrorHandler, ErrorRecoveryStrategy, PipelineError
-from .pipeline import PipelineResult, SpatialAIPipeline
+from .pipeline import SpatialAIPipeline
 from .progress_tracker import ProgressEvent, ProgressTracker
 from .resource_manager import ResourceLimits, ResourceManager
+from .results import PipelineResult
 
 __all__ = [
     "SpatialAIPipeline",

--- a/src/transformation_portal/spatial_ai/orchestration/json_io.py
+++ b/src/transformation_portal/spatial_ai/orchestration/json_io.py
@@ -1,0 +1,72 @@
+"""JSON file I/O helpers for Spatial AI orchestration artifacts."""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import stat
+import uuid
+from pathlib import Path
+from typing import Any, Optional
+
+from transformation_portal.ingest.canonical_json import dump_json
+
+
+def _open_atomic_temp(path: Path) -> tuple[Path, int]:
+    """Open a unique same-directory temp file using normal umask semantics."""
+    for _ in range(100):
+        temp_path = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+        try:
+            fd = os.open(temp_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o666)
+            return temp_path, fd
+        except FileExistsError:
+            continue
+    raise FileExistsError(f"Could not allocate temporary file for {path}")
+
+
+def write_json_atomic(
+    path: Path,
+    payload: Any,
+    *,
+    indent: Optional[int] = 2,
+    sort_keys: bool = False,
+    ensure_ascii: bool = True,
+    allow_nan: bool = True,
+    trailing_newline: bool = False,
+) -> None:
+    """Write JSON via same-directory temp file, fsync, and atomic replace.
+
+    New files are created with the same mode that ``open(path, "w")`` would use
+    under the active process umask. Existing files keep their previous mode.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    existing_mode: Optional[int] = None
+    with contextlib.suppress(FileNotFoundError):
+        existing_mode = stat.S_IMODE(path.stat().st_mode)
+
+    temp_path, fd = _open_atomic_temp(path)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            dump_json(
+                payload,
+                handle,
+                indent=indent,
+                sort_keys=sort_keys,
+                ensure_ascii=ensure_ascii,
+                allow_nan=allow_nan,
+            )
+            if trailing_newline:
+                handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+
+        if existing_mode is not None:
+            temp_path.chmod(existing_mode)
+        temp_path.replace(path)
+    except Exception:
+        with contextlib.suppress(FileNotFoundError):
+            temp_path.unlink()
+        raise
+
+
+__all__ = ["write_json_atomic"]

--- a/src/transformation_portal/spatial_ai/orchestration/pipeline.py
+++ b/src/transformation_portal/spatial_ai/orchestration/pipeline.py
@@ -36,8 +36,6 @@ import hashlib
 import json
 import logging
 import math
-import os
-import tempfile
 import time
 from dataclasses import asdict, is_dataclass
 from functools import lru_cache
@@ -68,6 +66,7 @@ from .config import (
     _normalise_segmentation_cache_policy,
 )
 from .error_handler import ErrorHandler, ErrorRecoveryStrategy, PipelineError
+from .json_io import write_json_atomic as _write_json_atomic
 from .progress_tracker import ProgressTracker
 from .resource_manager import ResourceLimits, ResourceManager
 from .results import MultiViewReconstructionResult, PipelineResult
@@ -299,29 +298,6 @@ def _sanitize_json_value(value: Any) -> Any:
         return value if math.isfinite(value) else None
 
     return value
-
-
-def _write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
-    """Write deterministic JSON atomically via temp file + fsync + replace."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=path.parent, delete=False) as handle:
-        temp_path = Path(handle.name)
-        try:
-            dump_json(payload, handle, indent=2, sort_keys=True, ensure_ascii=False, allow_nan=False)
-            handle.write("\n")
-            handle.flush()
-            os.fsync(handle.fileno())
-        except Exception:
-            with contextlib.suppress(FileNotFoundError):
-                temp_path.unlink()
-            raise
-
-    try:
-        temp_path.replace(path)
-    except Exception:
-        with contextlib.suppress(FileNotFoundError):
-            temp_path.unlink()
-        raise
 
 
 class SpatialAIPipeline:
@@ -1432,7 +1408,14 @@ class SpatialAIPipeline:
             ("provenance.json", provenance_payload),
         ):
             try:
-                _write_json_atomic(seg_dir / filename, _sanitize_json_value(payload))
+                _write_json_atomic(
+                    seg_dir / filename,
+                    _sanitize_json_value(payload),
+                    sort_keys=True,
+                    ensure_ascii=False,
+                    allow_nan=False,
+                    trailing_newline=True,
+                )
             except Exception as exc:
                 logger.warning("Failed to write materials %s for %s: %s", filename, seg_id, exc)
 

--- a/src/transformation_portal/spatial_ai/orchestration/pipeline.py
+++ b/src/transformation_portal/spatial_ai/orchestration/pipeline.py
@@ -39,7 +39,7 @@ import math
 import os
 import tempfile
 import time
-from dataclasses import asdict, dataclass, field, is_dataclass
+from dataclasses import asdict, is_dataclass
 from functools import lru_cache
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Mapping, Optional, Union, cast
@@ -52,7 +52,7 @@ from transformation_portal.compliance import (
     validate_non_commercial_preset,
 )
 from transformation_portal.ingest.canonical_json import canonicalize_json, dump_json
-from transformation_portal.reporting.contracts import build_stage_report, derive_stage_report_map
+from transformation_portal.reporting.contracts import build_stage_report
 from transformation_portal.spatial_ai.ingest.linear_decoder import LinearDecoder, LinearIngestResult
 from transformation_portal.spatial_ai.materials.contracts import MaterialInput, PBRTextures
 from transformation_portal.spatial_ai.materials.material_backend import MaterialBackend
@@ -70,6 +70,7 @@ from .config import (
 from .error_handler import ErrorHandler, ErrorRecoveryStrategy, PipelineError
 from .progress_tracker import ProgressTracker
 from .resource_manager import ResourceLimits, ResourceManager
+from .results import MultiViewReconstructionResult, PipelineResult
 
 logger = logging.getLogger(__name__)
 
@@ -321,160 +322,6 @@ def _write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
         with contextlib.suppress(FileNotFoundError):
             temp_path.unlink()
         raise
-
-
-if "PipelineResult" not in globals():
-
-    @dataclass
-    class PipelineResult:
-        """Result from end-to-end pipeline execution.
-
-        Attributes:
-            input_path: Input file path.
-            output_dir: Output directory.
-            stages_completed: List of completed stages.
-            linear_image: Linear ingest result (if ingest stage run).
-            segmentation: Segmentation result (if the segmentation stage ran).
-            materials: PBR textures per segment (if materials stage run).
-            scene_3d: 3D scene reconstruction (if reconstruction stage run).
-            execution_time: Total execution time in seconds.
-            peak_memory_mb: Peak GPU memory usage in MB.
-            errors: List of error messages.
-            warnings: List of warning messages.
-            metadata: Additional metadata.
-        """
-
-        input_path: Path
-        output_dir: Path
-        stages_completed: List[str]
-
-        linear_image: Optional[LinearIngestResult] = None
-        segmentation: Optional[SegmentationResult] = None
-        materials: Optional[Dict[str, PBRTextures]] = None
-        scene_3d: Optional[Scene3D] = None
-
-        execution_time: float = 0.0
-        peak_memory_mb: float = 0.0
-        errors: List[str] = field(default_factory=list)
-        warnings: List[str] = field(default_factory=list)
-        metadata: Dict[str, Any] = field(default_factory=dict)
-        stage_reports: List[Dict[str, Any]] = field(default_factory=list)
-
-        def save_summary(self, path: Path) -> None:
-            """Save execution summary as JSON.
-
-            Args:
-                path: Output path for summary JSON.
-            """
-            stage_reports = list(self.stage_reports)
-            stage_report_map = derive_stage_report_map(stage_reports)
-            summary = {
-                "input": str(self.input_path),
-                "output_dir": str(self.output_dir),
-                "stages_completed": self.stages_completed,
-                "execution_time": self.execution_time,
-                "peak_memory_mb": self.peak_memory_mb,
-                "errors": self.errors,
-                "warnings": self.warnings,
-                "stage_reports": stage_reports,
-                "results": {
-                    "linear_image": self.linear_image is not None,
-                    "segmentation": {
-                        "completed": (
-                            stage_report_map.get("segmentation", {}).get("status") in {"completed", "cached"}
-                            if "segmentation" in stage_report_map
-                            else self.segmentation is not None
-                        ),
-                        "num_masks": len(self.segmentation.masks) if self.segmentation else 0,
-                    },
-                    "materials": {
-                        "completed": (
-                            stage_report_map.get("materials", {}).get("status") in {"completed", "cached"}
-                            if "materials" in stage_report_map
-                            else self.materials is not None
-                        ),
-                        "num_segments": len(self.materials) if self.materials else 0,
-                    },
-                    "scene_3d": {
-                        "completed": (
-                            stage_report_map.get("reconstruction", {}).get("status") in {"completed", "cached"}
-                            if "reconstruction" in stage_report_map
-                            else self.scene_3d is not None
-                        ),
-                        "num_gaussians": self.scene_3d.splats.num_gaussians if self.scene_3d else 0,
-                        "rmse": self.scene_3d.rmse if self.scene_3d else None,
-                    },
-                },
-                "metadata": self.metadata,
-            }
-
-            with open(path, "w") as f:
-                json.dump(summary, f, indent=2)
-
-            logger.info(f"Saved pipeline summary: {path}")
-
-
-if "MultiViewReconstructionResult" not in globals():
-
-    @dataclass
-    class MultiViewReconstructionResult:
-        """Result from multi-view reconstruction pipeline.
-
-        Attributes:
-            scene: Reconstructed 3D scene (Scene3D).
-            ply_path: Path to exported PLY file.
-            sidecar_path: Path to provenance JSON sidecar.
-            output_dir: Output directory.
-            execution_time: Total execution time in seconds.
-            peak_memory_mb: Peak GPU memory usage in MB.
-            stages_completed: List of completed stages.
-            request_metadata: Original request metadata for traceability.
-            errors: List of error messages (if any).
-            warnings: List of warning messages (if any).
-        """
-
-        scene: Scene3D
-        ply_path: Path
-        sidecar_path: Path
-        output_dir: Path
-        execution_time: float = 0.0
-        peak_memory_mb: float = 0.0
-        stages_completed: List[str] = field(default_factory=list)
-        request_metadata: Dict[str, Any] = field(default_factory=dict)
-        errors: List[str] = field(default_factory=list)
-        warnings: List[str] = field(default_factory=list)
-        stage_reports: List[Dict[str, Any]] = field(default_factory=list)
-
-        def save_summary(self, path: Path) -> None:
-            """Save reconstruction summary as JSON.
-
-            Args:
-                path: Output path for summary JSON.
-            """
-            summary = {
-                "output_dir": str(self.output_dir),
-                "ply_path": str(self.ply_path),
-                "sidecar_path": str(self.sidecar_path),
-                "stages_completed": self.stages_completed,
-                "execution_time": self.execution_time,
-                "peak_memory_mb": self.peak_memory_mb,
-                "errors": self.errors,
-                "warnings": self.warnings,
-                "stage_reports": self.stage_reports,
-                "scene": {
-                    "num_gaussians": self.scene.splats.num_gaussians,
-                    "rmse": self.scene.rmse,
-                    "convergence": self.scene.convergence,
-                    "quality_score": self.scene.quality_score,
-                    "iteration": self.scene.iteration,
-                },
-                "request_metadata": self.request_metadata,
-            }
-
-            with open(path, "w") as f:
-                json.dump(summary, f, indent=2)
-
-            logger.info(f"Saved reconstruction summary: {path}")
 
 
 class SpatialAIPipeline:

--- a/src/transformation_portal/spatial_ai/orchestration/results.py
+++ b/src/transformation_portal/spatial_ai/orchestration/results.py
@@ -2,11 +2,7 @@
 
 from __future__ import annotations
 
-import contextlib
-import json
 import logging
-import os
-import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -17,29 +13,9 @@ from transformation_portal.spatial_ai.materials.contracts import PBRTextures
 from transformation_portal.spatial_ai.reconstruction.contracts import Scene3D
 from transformation_portal.spatial_ai.segmentation.contracts import SegmentationResult
 
+from .json_io import write_json_atomic as _write_json_atomic
+
 logger = logging.getLogger("transformation_portal.spatial_ai.orchestration.pipeline")
-
-
-def _write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
-    """Write JSON via a same-directory temp file, fsync, then replace."""
-    temp_path: Optional[Path] = None
-    with tempfile.NamedTemporaryFile("w", dir=path.parent, delete=False) as handle:
-        temp_path = Path(handle.name)
-        try:
-            json.dump(payload, handle, indent=2)
-            handle.flush()
-            os.fsync(handle.fileno())
-        except Exception:
-            with contextlib.suppress(FileNotFoundError):
-                temp_path.unlink()
-            raise
-
-    try:
-        temp_path.replace(path)
-    except Exception:
-        with contextlib.suppress(FileNotFoundError):
-            temp_path.unlink()
-        raise
 
 
 @dataclass

--- a/src/transformation_portal/spatial_ai/orchestration/results.py
+++ b/src/transformation_portal/spatial_ai/orchestration/results.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
+import os
+import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -15,6 +18,28 @@ from transformation_portal.spatial_ai.reconstruction.contracts import Scene3D
 from transformation_portal.spatial_ai.segmentation.contracts import SegmentationResult
 
 logger = logging.getLogger("transformation_portal.spatial_ai.orchestration.pipeline")
+
+
+def _write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
+    """Write JSON via a same-directory temp file, fsync, then replace."""
+    temp_path: Optional[Path] = None
+    with tempfile.NamedTemporaryFile("w", dir=path.parent, delete=False) as handle:
+        temp_path = Path(handle.name)
+        try:
+            json.dump(payload, handle, indent=2)
+            handle.flush()
+            os.fsync(handle.fileno())
+        except Exception:
+            with contextlib.suppress(FileNotFoundError):
+                temp_path.unlink()
+            raise
+
+    try:
+        temp_path.replace(path)
+    except Exception:
+        with contextlib.suppress(FileNotFoundError):
+            temp_path.unlink()
+        raise
 
 
 @dataclass
@@ -100,8 +125,7 @@ class PipelineResult:
             "metadata": self.metadata,
         }
 
-        with open(path, "w") as f:
-            json.dump(summary, f, indent=2)
+        _write_json_atomic(path, summary)
 
         logger.info(f"Saved pipeline summary: {path}")
 
@@ -161,8 +185,7 @@ class MultiViewReconstructionResult:
             "request_metadata": self.request_metadata,
         }
 
-        with open(path, "w") as f:
-            json.dump(summary, f, indent=2)
+        _write_json_atomic(path, summary)
 
         logger.info(f"Saved reconstruction summary: {path}")
 

--- a/src/transformation_portal/spatial_ai/orchestration/results.py
+++ b/src/transformation_portal/spatial_ai/orchestration/results.py
@@ -1,0 +1,173 @@
+"""Result models for the Spatial AI orchestration pipeline."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from transformation_portal.reporting.contracts import derive_stage_report_map
+from transformation_portal.spatial_ai.ingest.linear_decoder import LinearIngestResult
+from transformation_portal.spatial_ai.materials.contracts import PBRTextures
+from transformation_portal.spatial_ai.reconstruction.contracts import Scene3D
+from transformation_portal.spatial_ai.segmentation.contracts import SegmentationResult
+
+logger = logging.getLogger("transformation_portal.spatial_ai.orchestration.pipeline")
+
+
+@dataclass
+class PipelineResult:
+    """Result from end-to-end pipeline execution.
+
+    Attributes:
+        input_path: Input file path.
+        output_dir: Output directory.
+        stages_completed: List of completed stages.
+        linear_image: Linear ingest result (if ingest stage run).
+        segmentation: Segmentation result (if the segmentation stage ran).
+        materials: PBR textures per segment (if materials stage run).
+        scene_3d: 3D scene reconstruction (if reconstruction stage run).
+        execution_time: Total execution time in seconds.
+        peak_memory_mb: Peak GPU memory usage in MB.
+        errors: List of error messages.
+        warnings: List of warning messages.
+        metadata: Additional metadata.
+    """
+
+    input_path: Path
+    output_dir: Path
+    stages_completed: List[str]
+
+    linear_image: Optional[LinearIngestResult] = None
+    segmentation: Optional[SegmentationResult] = None
+    materials: Optional[Dict[str, PBRTextures]] = None
+    scene_3d: Optional[Scene3D] = None
+
+    execution_time: float = 0.0
+    peak_memory_mb: float = 0.0
+    errors: List[str] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    stage_reports: List[Dict[str, Any]] = field(default_factory=list)
+
+    def save_summary(self, path: Path) -> None:
+        """Save execution summary as JSON.
+
+        Args:
+            path: Output path for summary JSON.
+        """
+        stage_reports = list(self.stage_reports)
+        stage_report_map = derive_stage_report_map(stage_reports)
+        summary = {
+            "input": str(self.input_path),
+            "output_dir": str(self.output_dir),
+            "stages_completed": self.stages_completed,
+            "execution_time": self.execution_time,
+            "peak_memory_mb": self.peak_memory_mb,
+            "errors": self.errors,
+            "warnings": self.warnings,
+            "stage_reports": stage_reports,
+            "results": {
+                "linear_image": self.linear_image is not None,
+                "segmentation": {
+                    "completed": (
+                        stage_report_map.get("segmentation", {}).get("status") in {"completed", "cached"}
+                        if "segmentation" in stage_report_map
+                        else self.segmentation is not None
+                    ),
+                    "num_masks": len(self.segmentation.masks) if self.segmentation else 0,
+                },
+                "materials": {
+                    "completed": (
+                        stage_report_map.get("materials", {}).get("status") in {"completed", "cached"}
+                        if "materials" in stage_report_map
+                        else self.materials is not None
+                    ),
+                    "num_segments": len(self.materials) if self.materials else 0,
+                },
+                "scene_3d": {
+                    "completed": (
+                        stage_report_map.get("reconstruction", {}).get("status") in {"completed", "cached"}
+                        if "reconstruction" in stage_report_map
+                        else self.scene_3d is not None
+                    ),
+                    "num_gaussians": self.scene_3d.splats.num_gaussians if self.scene_3d else 0,
+                    "rmse": self.scene_3d.rmse if self.scene_3d else None,
+                },
+            },
+            "metadata": self.metadata,
+        }
+
+        with open(path, "w") as f:
+            json.dump(summary, f, indent=2)
+
+        logger.info(f"Saved pipeline summary: {path}")
+
+
+@dataclass
+class MultiViewReconstructionResult:
+    """Result from multi-view reconstruction pipeline.
+
+    Attributes:
+        scene: Reconstructed 3D scene (Scene3D).
+        ply_path: Path to exported PLY file.
+        sidecar_path: Path to provenance JSON sidecar.
+        output_dir: Output directory.
+        execution_time: Total execution time in seconds.
+        peak_memory_mb: Peak GPU memory usage in MB.
+        stages_completed: List of completed stages.
+        request_metadata: Original request metadata for traceability.
+        errors: List of error messages (if any).
+        warnings: List of warning messages (if any).
+    """
+
+    scene: Scene3D
+    ply_path: Path
+    sidecar_path: Path
+    output_dir: Path
+    execution_time: float = 0.0
+    peak_memory_mb: float = 0.0
+    stages_completed: List[str] = field(default_factory=list)
+    request_metadata: Dict[str, Any] = field(default_factory=dict)
+    errors: List[str] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
+    stage_reports: List[Dict[str, Any]] = field(default_factory=list)
+
+    def save_summary(self, path: Path) -> None:
+        """Save reconstruction summary as JSON.
+
+        Args:
+            path: Output path for summary JSON.
+        """
+        summary = {
+            "output_dir": str(self.output_dir),
+            "ply_path": str(self.ply_path),
+            "sidecar_path": str(self.sidecar_path),
+            "stages_completed": self.stages_completed,
+            "execution_time": self.execution_time,
+            "peak_memory_mb": self.peak_memory_mb,
+            "errors": self.errors,
+            "warnings": self.warnings,
+            "stage_reports": self.stage_reports,
+            "scene": {
+                "num_gaussians": self.scene.splats.num_gaussians,
+                "rmse": self.scene.rmse,
+                "convergence": self.scene.convergence,
+                "quality_score": self.scene.quality_score,
+                "iteration": self.scene.iteration,
+            },
+            "request_metadata": self.request_metadata,
+        }
+
+        with open(path, "w") as f:
+            json.dump(summary, f, indent=2)
+
+        logger.info(f"Saved reconstruction summary: {path}")
+
+
+__all__ = [
+    "MultiViewReconstructionResult",
+    "PipelineResult",
+]

--- a/tests/spatial_ai/orchestration/test_config_exports.py
+++ b/tests/spatial_ai/orchestration/test_config_exports.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import importlib
+import json
+from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -19,6 +22,28 @@ def test_pipeline_config_identity_is_preserved_across_import_surfaces() -> None:
     assert pipeline_mod.PipelineConfig is config_mod.PipelineConfig
     assert package_mod.PipelineConfig is config_mod.PipelineConfig
     assert "PipelineConfig" in package_mod.__all__
+
+
+def test_pipeline_result_identity_is_preserved_across_import_surfaces() -> None:
+    results_mod = importlib.import_module("transformation_portal.spatial_ai.orchestration.results")
+    pipeline_mod = importlib.import_module("transformation_portal.spatial_ai.orchestration.pipeline")
+    package_mod = importlib.import_module("transformation_portal.spatial_ai.orchestration")
+
+    assert pipeline_mod.PipelineResult is results_mod.PipelineResult
+    assert pipeline_mod.MultiViewReconstructionResult is results_mod.MultiViewReconstructionResult
+    assert package_mod.PipelineResult is results_mod.PipelineResult
+    assert "PipelineResult" in package_mod.__all__
+
+
+def test_pipeline_result_identity_survives_pipeline_reload() -> None:
+    pipeline_mod = importlib.import_module("transformation_portal.spatial_ai.orchestration.pipeline")
+    PipelineResult = pipeline_mod.PipelineResult
+    MultiViewReconstructionResult = pipeline_mod.MultiViewReconstructionResult
+
+    reloaded = importlib.reload(pipeline_mod)
+
+    assert reloaded.PipelineResult is PipelineResult
+    assert reloaded.MultiViewReconstructionResult is MultiViewReconstructionResult
 
 
 def test_spatial_ai_pipeline_accepts_extracted_pipeline_config() -> None:
@@ -79,3 +104,110 @@ def test_extracted_pipeline_config_preserves_validation_contracts(monkeypatch: p
             stages=["ingest", "segment", "materials"],
             materials={"backend": "pbr_fusion", "strict_backend": True},
         )
+
+
+def test_extracted_pipeline_result_save_summary_preserves_single_image_shape(tmp_path: Path) -> None:
+    results_mod = importlib.import_module("transformation_portal.spatial_ai.orchestration.results")
+
+    result = results_mod.PipelineResult(
+        input_path=Path("input.tiff"),
+        output_dir=Path("output"),
+        stages_completed=["ingest", "segment", "materials", "reconstruct"],
+        linear_image=object(),
+        segmentation=SimpleNamespace(masks=[object(), object()]),
+        materials={"seg_0": object(), "seg_1": object()},
+        scene_3d=SimpleNamespace(splats=SimpleNamespace(num_gaussians=10000), rmse=0.015),
+        execution_time=123.4,
+        peak_memory_mb=4096.0,
+        errors=["Error 1", "Error 2"],
+        warnings=["Warning 1"],
+        metadata={"custom": "data"},
+        stage_reports=[
+            {"stage": "ingest", "status": "completed", "capability": None, "quality_gate": None},
+            {"stage": "segmentation", "status": "completed", "capability": None, "quality_gate": None},
+            {"stage": "materials", "status": "completed", "capability": None, "quality_gate": None},
+            {"stage": "reconstruction", "status": "completed", "capability": None, "quality_gate": None},
+        ],
+    )
+
+    summary_path = tmp_path / "summary.json"
+    result.save_summary(summary_path)
+
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    assert summary == {
+        "input": "input.tiff",
+        "output_dir": "output",
+        "stages_completed": ["ingest", "segment", "materials", "reconstruct"],
+        "execution_time": 123.4,
+        "peak_memory_mb": 4096.0,
+        "errors": ["Error 1", "Error 2"],
+        "warnings": ["Warning 1"],
+        "stage_reports": [
+            {"stage": "ingest", "status": "completed", "capability": None, "quality_gate": None},
+            {"stage": "segmentation", "status": "completed", "capability": None, "quality_gate": None},
+            {"stage": "materials", "status": "completed", "capability": None, "quality_gate": None},
+            {"stage": "reconstruction", "status": "completed", "capability": None, "quality_gate": None},
+        ],
+        "results": {
+            "linear_image": True,
+            "segmentation": {"completed": True, "num_masks": 2},
+            "materials": {"completed": True, "num_segments": 2},
+            "scene_3d": {"completed": True, "num_gaussians": 10000, "rmse": 0.015},
+        },
+        "metadata": {"custom": "data"},
+    }
+
+
+def test_extracted_multiview_result_save_summary_preserves_reconstruction_shape(tmp_path: Path) -> None:
+    results_mod = importlib.import_module("transformation_portal.spatial_ai.orchestration.results")
+    scene = SimpleNamespace(
+        splats=SimpleNamespace(num_gaussians=100),
+        rmse=0.02,
+        convergence="converged",
+        quality_score=0.91,
+        iteration=20,
+    )
+
+    result = results_mod.MultiViewReconstructionResult(
+        scene=scene,
+        ply_path=Path("output/reconstruction.ply"),
+        sidecar_path=Path("output/reconstruction.provenance.json"),
+        output_dir=Path("output"),
+        execution_time=12.5,
+        peak_memory_mb=512.0,
+        stages_completed=["reconstruction", "export"],
+        request_metadata={"camera_source_summary": {"explicit": 2}},
+        errors=[],
+        warnings=["warn"],
+        stage_reports=[
+            {"stage": "reconstruction", "status": "completed", "capability": None, "quality_gate": None},
+            {"stage": "export", "status": "completed", "capability": None, "quality_gate": None},
+        ],
+    )
+
+    summary_path = tmp_path / "reconstruction_summary.json"
+    result.save_summary(summary_path)
+
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    assert summary == {
+        "output_dir": "output",
+        "ply_path": "output/reconstruction.ply",
+        "sidecar_path": "output/reconstruction.provenance.json",
+        "stages_completed": ["reconstruction", "export"],
+        "execution_time": 12.5,
+        "peak_memory_mb": 512.0,
+        "errors": [],
+        "warnings": ["warn"],
+        "stage_reports": [
+            {"stage": "reconstruction", "status": "completed", "capability": None, "quality_gate": None},
+            {"stage": "export", "status": "completed", "capability": None, "quality_gate": None},
+        ],
+        "scene": {
+            "num_gaussians": 100,
+            "rmse": 0.02,
+            "convergence": "converged",
+            "quality_score": 0.91,
+            "iteration": 20,
+        },
+        "request_metadata": {"camera_source_summary": {"explicit": 2}},
+    }

--- a/tests/spatial_ai/orchestration/test_config_exports.py
+++ b/tests/spatial_ai/orchestration/test_config_exports.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib
 import json
+import stat
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -183,19 +184,33 @@ def test_extracted_pipeline_result_save_summary_uses_atomic_writer(monkeypatch: 
 def test_extracted_result_atomic_writer_preserves_existing_file_on_failure(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    results_mod = importlib.import_module("transformation_portal.spatial_ai.orchestration.results")
+    json_io_mod = importlib.import_module("transformation_portal.spatial_ai.orchestration.json_io")
     summary_path = tmp_path / "summary.json"
     summary_path.write_text('{"existing": true}', encoding="utf-8")
+    summary_path.chmod(0o640)
 
     def fail_dump(*args: object, **kwargs: object) -> None:
         raise RuntimeError("serialization failed")
 
-    monkeypatch.setattr(results_mod.json, "dump", fail_dump)
+    monkeypatch.setattr(json_io_mod, "dump_json", fail_dump)
 
     with pytest.raises(RuntimeError, match="serialization failed"):
-        results_mod._write_json_atomic(summary_path, {"existing": False})
+        json_io_mod.write_json_atomic(summary_path, {"existing": False})
 
     assert summary_path.read_text(encoding="utf-8") == '{"existing": true}'
+    assert stat.S_IMODE(summary_path.stat().st_mode) == 0o640
+
+
+def test_extracted_result_atomic_writer_uses_utf8_and_preserves_existing_mode(tmp_path: Path) -> None:
+    json_io_mod = importlib.import_module("transformation_portal.spatial_ai.orchestration.json_io")
+    summary_path = tmp_path / "summary.json"
+    summary_path.write_text('{"existing": true}', encoding="utf-8")
+    summary_path.chmod(0o640)
+
+    json_io_mod.write_json_atomic(summary_path, {"message": "caf\u00e9"}, ensure_ascii=False)
+
+    assert b"caf\xc3\xa9" in summary_path.read_bytes()
+    assert stat.S_IMODE(summary_path.stat().st_mode) == 0o640
 
 
 def test_extracted_multiview_result_save_summary_preserves_reconstruction_shape(tmp_path: Path) -> None:

--- a/tests/spatial_ai/orchestration/test_config_exports.py
+++ b/tests/spatial_ai/orchestration/test_config_exports.py
@@ -112,7 +112,7 @@ def test_extracted_pipeline_result_save_summary_preserves_single_image_shape(tmp
     result = results_mod.PipelineResult(
         input_path=Path("input.tiff"),
         output_dir=Path("output"),
-        stages_completed=["ingest", "segment", "materials", "reconstruct"],
+        stages_completed=["ingest", "segmentation", "materials", "reconstruction"],
         linear_image=object(),
         segmentation=SimpleNamespace(masks=[object(), object()]),
         materials={"seg_0": object(), "seg_1": object()},
@@ -137,7 +137,7 @@ def test_extracted_pipeline_result_save_summary_preserves_single_image_shape(tmp
     assert summary == {
         "input": "input.tiff",
         "output_dir": "output",
-        "stages_completed": ["ingest", "segment", "materials", "reconstruct"],
+        "stages_completed": ["ingest", "segmentation", "materials", "reconstruction"],
         "execution_time": 123.4,
         "peak_memory_mb": 4096.0,
         "errors": ["Error 1", "Error 2"],
@@ -156,6 +156,46 @@ def test_extracted_pipeline_result_save_summary_preserves_single_image_shape(tmp
         },
         "metadata": {"custom": "data"},
     }
+
+
+def test_extracted_pipeline_result_save_summary_uses_atomic_writer(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    results_mod = importlib.import_module("transformation_portal.spatial_ai.orchestration.results")
+    calls = []
+
+    def fake_write_json_atomic(path: Path, payload: dict) -> None:
+        calls.append((path, payload))
+
+    monkeypatch.setattr(results_mod, "_write_json_atomic", fake_write_json_atomic)
+    result = results_mod.PipelineResult(
+        input_path=Path("input.tiff"),
+        output_dir=Path("output"),
+        stages_completed=["ingest"],
+    )
+
+    summary_path = tmp_path / "summary.json"
+    result.save_summary(summary_path)
+
+    assert len(calls) == 1
+    assert calls[0][0] == summary_path
+    assert calls[0][1]["input"] == "input.tiff"
+
+
+def test_extracted_result_atomic_writer_preserves_existing_file_on_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    results_mod = importlib.import_module("transformation_portal.spatial_ai.orchestration.results")
+    summary_path = tmp_path / "summary.json"
+    summary_path.write_text('{"existing": true}', encoding="utf-8")
+
+    def fail_dump(*args: object, **kwargs: object) -> None:
+        raise RuntimeError("serialization failed")
+
+    monkeypatch.setattr(results_mod.json, "dump", fail_dump)
+
+    with pytest.raises(RuntimeError, match="serialization failed"):
+        results_mod._write_json_atomic(summary_path, {"existing": False})
+
+    assert summary_path.read_text(encoding="utf-8") == '{"existing": true}'
 
 
 def test_extracted_multiview_result_save_summary_preserves_reconstruction_shape(tmp_path: Path) -> None:
@@ -211,3 +251,33 @@ def test_extracted_multiview_result_save_summary_preserves_reconstruction_shape(
         },
         "request_metadata": {"camera_source_summary": {"explicit": 2}},
     }
+
+
+def test_extracted_multiview_result_save_summary_uses_atomic_writer(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    results_mod = importlib.import_module("transformation_portal.spatial_ai.orchestration.results")
+    calls = []
+    scene = SimpleNamespace(
+        splats=SimpleNamespace(num_gaussians=100),
+        rmse=0.02,
+        convergence="converged",
+        quality_score=0.91,
+        iteration=20,
+    )
+
+    def fake_write_json_atomic(path: Path, payload: dict) -> None:
+        calls.append((path, payload))
+
+    monkeypatch.setattr(results_mod, "_write_json_atomic", fake_write_json_atomic)
+    result = results_mod.MultiViewReconstructionResult(
+        scene=scene,
+        ply_path=Path("output/reconstruction.ply"),
+        sidecar_path=Path("output/reconstruction.provenance.json"),
+        output_dir=Path("output"),
+    )
+
+    summary_path = tmp_path / "reconstruction_summary.json"
+    result.save_summary(summary_path)
+
+    assert len(calls) == 1
+    assert calls[0][0] == summary_path
+    assert calls[0][1]["ply_path"] == "output/reconstruction.ply"


### PR DESCRIPTION
## Summary
- Extract Spatial AI pipeline result models and summary serializers from the monolithic orchestration module.
- Preserve existing legacy and package import surfaces while keeping runtime behavior and JSON report shapes unchanged.

## Changes
- Add `spatial_ai/orchestration/results.py` for `PipelineResult` and `MultiViewReconstructionResult`.
- Keep `spatial_ai.orchestration.pipeline` re-exporting both result classes for compatibility.
- Keep package-level `PipelineResult` exported from `spatial_ai.orchestration`.
- Add the new results module to the raw JSON allowlist while leaving `pipeline.py` allowlisted for graph execution JSON writes.
- Record Target 5B in the monolith decomposition status table.
- Add compatibility tests for import identity, reload identity, and exact summary JSON shapes.

## Validation
- `.venv/bin/python -m pytest tests/spatial_ai/orchestration/test_config_exports.py -q`
  - 8 passed
- `.venv/bin/python -m pytest tests/spatial_ai/orchestration/test_config_exports.py tests/spatial_ai/orchestration/test_pipeline.py tests/spatial_ai/orchestration/test_forward_port_contracts.py tests/spatial_ai/orchestration/test_multiview_pipeline.py tests/test_pipeline_corrections.py tests/interfaces/test_public_surface.py -q`
  - 100 passed, 1 skipped
- `make check-json-serialization check-yaml-governance check-python-headers`
  - Passed
- `.venv/bin/python scripts/validation/scan_todo_inventory.py --check-governance`
  - 0 ungoverned TODOs
- `make test-fast`
  - 77 passed
- Commit preflight hooks
  - Passed

## Risk
- Compatibility risk is bounded by legacy re-exports and identity tests.
- JSON report compatibility is covered by exact summary-shape tests.
- No stage execution, cache policy, graph execution, reconstruction behavior, filenames, or API surfaces are intentionally changed.
