### PR TITLE
refactor(spatial-ai): extract segmentation cache helpers

### DIFF
--- a/docs/architecture/MONOLITH_DECOMPOSITION_TARGETS.md
+++ b/docs/architecture/MONOLITH_DECOMPOSITION_TARGETS.md
@@ -184,6 +184,7 @@ This table is the canonical progress ledger for extraction PRs that draw from th
 | Target 4D — Rendering pipeline orchestration | `pipelines/rendering_4k_pipeline.py` | `pipelines/rendering_4k/pipeline.py` | Landed | This PR: rendering pipeline orchestration extracted behind legacy CLI/import shim; ranking unchanged pending governance refresh |
 | Target 5A — Spatial AI pipeline config | `spatial_ai/orchestration/pipeline.py` | `spatial_ai/orchestration/config.py` | Landed | This PR: spatial pipeline config model and validation helpers extracted; ranking unchanged pending governance refresh |
 | Target 5B — Spatial AI pipeline result models | `spatial_ai/orchestration/pipeline.py` | `spatial_ai/orchestration/results.py` | Landed | This PR: spatial pipeline result models and summary serializers extracted; ranking unchanged pending governance refresh |
+| Target 5C — Spatial AI segmentation cache helpers | `spatial_ai/orchestration/pipeline.py` | `spatial_ai/orchestration/segmentation_cache.py` | Landed | This PR: segmentation cache helpers extracted; ranking unchanged pending governance refresh |
 
 ---
 

--- a/src/transformation_portal/spatial_ai/orchestration/artifact_utils.py
+++ b/src/transformation_portal/spatial_ai/orchestration/artifact_utils.py
@@ -1,0 +1,45 @@
+"""Shared artifact payload helpers for Spatial AI orchestration."""
+
+from __future__ import annotations
+
+import hashlib
+import math
+from dataclasses import asdict, is_dataclass
+from typing import Any
+
+import numpy as np
+
+
+def _sha256_array(array: np.ndarray) -> str:
+    """Return a deterministic SHA-256 for a numpy array payload."""
+    contiguous = array if array.flags["C_CONTIGUOUS"] else np.ascontiguousarray(array)
+    return hashlib.sha256(memoryview(contiguous.view(np.uint8).ravel())).hexdigest()
+
+
+def _sanitize_json_value(value: Any) -> Any:
+    """Convert values into canonical-JSON-safe primitives."""
+    if is_dataclass(value):
+        return _sanitize_json_value(asdict(value))
+
+    if isinstance(value, dict):
+        return {str(key): _sanitize_json_value(inner) for key, inner in value.items()}
+
+    if isinstance(value, (list, tuple)):
+        return [_sanitize_json_value(inner) for inner in value]
+
+    if isinstance(value, np.ndarray):
+        return _sanitize_json_value(value.tolist())
+
+    if isinstance(value, np.generic):
+        return _sanitize_json_value(value.item())
+
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+
+    return value
+
+
+__all__ = [
+    "_sanitize_json_value",
+    "_sha256_array",
+]

--- a/src/transformation_portal/spatial_ai/orchestration/pipeline.py
+++ b/src/transformation_portal/spatial_ai/orchestration/pipeline.py
@@ -31,16 +31,11 @@ Example:
 
 from __future__ import annotations
 
-import contextlib
-import hashlib
 import json
 import logging
-import math
 import time
-from dataclasses import asdict, is_dataclass
-from functools import lru_cache
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Mapping, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Union, cast
 
 import numpy as np
 
@@ -49,7 +44,6 @@ from transformation_portal.compliance import (
     validate_materials_preset,
     validate_non_commercial_preset,
 )
-from transformation_portal.ingest.canonical_json import canonicalize_json, dump_json
 from transformation_portal.reporting.contracts import build_stage_report
 from transformation_portal.spatial_ai.ingest.linear_decoder import LinearDecoder, LinearIngestResult
 from transformation_portal.spatial_ai.materials.contracts import MaterialInput, PBRTextures
@@ -59,6 +53,7 @@ from transformation_portal.spatial_ai.segmentation.contracts import MaskMetadata
 from transformation_portal.spatial_ai.segmentation.sam2_backend import SAM2Backend
 from transformation_portal.spatial_ai.segmentation.tiling.config import SegmentationTilingConfig
 
+from .artifact_utils import _sanitize_json_value, _sha256_array
 from .config import (
     PipelineConfig,
     _extract_materials_governance_overrides,
@@ -70,234 +65,25 @@ from .json_io import write_json_atomic as _write_json_atomic
 from .progress_tracker import ProgressTracker
 from .resource_manager import ResourceLimits, ResourceManager
 from .results import MultiViewReconstructionResult, PipelineResult
+from .segmentation_cache import (
+    _SEGMENTATION_CACHE_SCHEMA_VERSION,
+    _build_segmentation_cache_key,
+    _file_identity,
+    _metadata_from_cache_dict,
+    _metadata_to_cache_dict,
+    _read_segmentation_cache,
+    _segmentation_cache_paths,
+    _segmentation_mask_count,
+    _segmentation_result_checksum,
+    _sha256_file,
+    _sha256_file_cached,
+    _write_segmentation_cache,
+)
 
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from transformation_portal.core.geometry import MultiViewReconstructionRequest
-
-
-def _sha256_array(array: np.ndarray) -> str:
-    """Return a deterministic SHA-256 for a numpy array payload."""
-    contiguous = array if array.flags["C_CONTIGUOUS"] else np.ascontiguousarray(array)
-    return hashlib.sha256(memoryview(contiguous.view(np.uint8).ravel())).hexdigest()
-
-
-_SEGMENTATION_CACHE_SCHEMA_VERSION = "spatial-ai-segmentation-cache.v1"
-
-
-def _segmentation_cache_paths(cache_dir: Path, cache_key: str) -> tuple[Path, Path]:
-    root = cache_dir / cache_key[:2]
-    return root / f"{cache_key}.npz", root / f"{cache_key}.json"
-
-
-def _file_identity(path_value: Any) -> Optional[dict[str, Any]]:
-    if not path_value:
-        return None
-    path = Path(str(path_value))
-    if not path.is_file():
-        return {
-            "path": str(path),
-            "exists": False,
-            "sha256": None,
-            "size": None,
-            "mtime_ns": None,
-        }
-    try:
-        stat = path.stat()
-        return {
-            "path": str(path),
-            "exists": True,
-            "sha256": _sha256_file_cached(str(path), int(stat.st_size), int(stat.st_mtime_ns)),
-            "size": int(stat.st_size),
-            "mtime_ns": int(stat.st_mtime_ns),
-        }
-    except OSError:
-        return {
-            "path": str(path),
-            "exists": False,
-            "sha256": None,
-            "size": None,
-            "mtime_ns": None,
-        }
-
-
-@lru_cache(maxsize=8)
-def _sha256_file_cached(path: str, size: int, mtime_ns: int) -> str:
-    del size, mtime_ns
-    return _sha256_file(Path(path))
-
-
-def _sha256_file(path: Path) -> str:
-    digest = hashlib.sha256()
-    with path.open("rb") as handle:
-        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
-            digest.update(chunk)
-    return digest.hexdigest()
-
-
-def _metadata_to_cache_dict(metadata: MaskMetadata) -> dict[str, Any]:
-    return {
-        "area": int(metadata.area),
-        "bbox": list(metadata.bbox),
-        "stability_score": float(metadata.stability_score),
-        "material_label": metadata.material_label,
-        "material_confidence": metadata.material_confidence,
-        "is_empty": bool(metadata.is_empty),
-    }
-
-
-def _metadata_from_cache_dict(data: Mapping[str, Any]) -> MaskMetadata:
-    return MaskMetadata(
-        area=int(data["area"]),
-        bbox=tuple(int(value) for value in data["bbox"]),
-        stability_score=float(data["stability_score"]),
-        material_label=data.get("material_label"),
-        material_confidence=(float(data["material_confidence"]) if data.get("material_confidence") is not None else None),
-        is_empty=bool(data.get("is_empty", False)),
-    )
-
-
-def _segmentation_result_checksum(result: SegmentationResult) -> str:
-    digest = hashlib.sha256()
-    for array in (result.masks, result.scores):
-        contiguous = array if array.flags["C_CONTIGUOUS"] else np.ascontiguousarray(array)
-        digest.update(str(contiguous.shape).encode("utf-8"))
-        digest.update(str(contiguous.dtype).encode("utf-8"))
-        digest.update(memoryview(contiguous.view(np.uint8).ravel()))
-    digest.update(canonicalize_json([_metadata_to_cache_dict(item) for item in result.metadata]))
-    return digest.hexdigest()
-
-
-def _segmentation_mask_count(result: Any) -> int:
-    masks = getattr(result, "masks", None)
-    if masks is None:
-        return 0
-    shape = getattr(masks, "shape", None)
-    if shape:
-        return int(shape[0])
-    try:
-        return len(masks)
-    except TypeError:
-        return 0
-
-
-def _build_segmentation_cache_key(
-    *,
-    image: np.ndarray,
-    segmentation_cfg: Mapping[str, Any],
-    device: str,
-) -> tuple[str, dict[str, Any]]:
-    model_cfg = segmentation_cfg.get("model", {}) if isinstance(segmentation_cfg.get("model"), Mapping) else {}
-    sanitized_model_cfg = dict(model_cfg)
-    checkpoint_path = sanitized_model_cfg.get("checkpoint_path")
-    sanitized_model_cfg["checkpoint"] = _file_identity(checkpoint_path)
-    sanitized_model_cfg.pop("checkpoint_path", None)
-    payload = {
-        "schema_version": _SEGMENTATION_CACHE_SCHEMA_VERSION,
-        "image_hash": _sha256_array(image),
-        "image_shape": list(image.shape),
-        "image_dtype": str(image.dtype),
-        "backend": segmentation_cfg.get("backend", "sam2"),
-        "device": device,
-        "model": _sanitize_json_value(sanitized_model_cfg),
-        "generator": dict(segmentation_cfg.get("generator", {}) or {}),
-        "material_classification": bool(segmentation_cfg.get("material_classification", False)),
-        "material_confidence_threshold": float(segmentation_cfg.get("material_confidence_threshold", 0.3)),
-        "tiling": _sanitize_json_value(segmentation_cfg.get("tiling", {}) or {}),
-    }
-    cache_key = hashlib.sha256(canonicalize_json(payload)).hexdigest()
-    return cache_key, payload
-
-
-def _read_segmentation_cache(
-    *,
-    cache_dir: Path,
-    cache_key: str,
-    key_payload: Mapping[str, Any],
-) -> Optional[SegmentationResult]:
-    masks_path, metadata_path = _segmentation_cache_paths(cache_dir, cache_key)
-    if not masks_path.is_file() or not metadata_path.is_file():
-        return None
-    try:
-        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
-        if metadata.get("schema_version") != _SEGMENTATION_CACHE_SCHEMA_VERSION:
-            return None
-        if metadata.get("cache_key") != cache_key or metadata.get("key_payload") != dict(key_payload):
-            return None
-        with np.load(masks_path, allow_pickle=False) as data:
-            masks = np.asarray(data["masks"])
-            scores = np.asarray(data["scores"])
-        mask_metadata = [_metadata_from_cache_dict(item) for item in metadata.get("metadata", [])]
-        result = SegmentationResult(
-            masks=masks.astype(bool, copy=False), scores=scores.astype(np.float32), metadata=mask_metadata
-        )
-        if _segmentation_result_checksum(result) != metadata.get("result_sha256"):
-            return None
-        return result
-    except Exception as exc:
-        logger.debug("Ignoring invalid spatial segmentation cache entry %s: %s", cache_key, exc)
-        return None
-
-
-def _write_segmentation_cache(
-    *,
-    cache_dir: Path,
-    cache_key: str,
-    key_payload: Mapping[str, Any],
-    result: SegmentationResult,
-) -> None:
-    if _segmentation_mask_count(result) == 0:
-        return
-    if not isinstance(result.masks, np.ndarray) or not isinstance(result.scores, np.ndarray):
-        return
-    masks_path, metadata_path = _segmentation_cache_paths(cache_dir, cache_key)
-    masks_path.parent.mkdir(parents=True, exist_ok=True)
-    temp_npz = masks_path.with_suffix(".npz.tmp")
-    temp_json = metadata_path.with_suffix(".json.tmp")
-    try:
-        with temp_npz.open("wb") as handle:
-            np.savez_compressed(handle, masks=result.masks, scores=result.scores)
-        metadata = {
-            "schema_version": _SEGMENTATION_CACHE_SCHEMA_VERSION,
-            "cache_key": cache_key,
-            "key_payload": dict(key_payload),
-            "metadata": [_metadata_to_cache_dict(item) for item in result.metadata],
-            "result_sha256": _segmentation_result_checksum(result),
-        }
-        with temp_json.open("w", encoding="utf-8") as handle:
-            dump_json(metadata, handle, indent=2, sort_keys=True, ensure_ascii=False, allow_nan=False)
-            handle.write("\n")
-        temp_npz.replace(masks_path)
-        temp_json.replace(metadata_path)
-    finally:
-        for temp_path in (temp_npz, temp_json):
-            if temp_path.exists():
-                with contextlib.suppress(OSError):
-                    temp_path.unlink()
-
-
-def _sanitize_json_value(value: Any) -> Any:
-    """Convert values into canonical-JSON-safe primitives."""
-    if is_dataclass(value):
-        return _sanitize_json_value(asdict(value))
-
-    if isinstance(value, dict):
-        return {str(key): _sanitize_json_value(inner) for key, inner in value.items()}
-
-    if isinstance(value, (list, tuple)):
-        return [_sanitize_json_value(inner) for inner in value]
-
-    if isinstance(value, np.ndarray):
-        return _sanitize_json_value(value.tolist())
-
-    if isinstance(value, np.generic):
-        return _sanitize_json_value(value.item())
-
-    if isinstance(value, float):
-        return value if math.isfinite(value) else None
-
-    return value
 
 
 class SpatialAIPipeline:

--- a/src/transformation_portal/spatial_ai/orchestration/segmentation_cache.py
+++ b/src/transformation_portal/spatial_ai/orchestration/segmentation_cache.py
@@ -1,0 +1,229 @@
+"""Segmentation cache helpers for Spatial AI orchestration."""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import json
+import logging
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+import numpy as np
+
+from transformation_portal.ingest.canonical_json import canonicalize_json, dump_json
+from transformation_portal.spatial_ai.segmentation.contracts import MaskMetadata, SegmentationResult
+
+from .artifact_utils import _sanitize_json_value, _sha256_array
+
+logger = logging.getLogger("transformation_portal.spatial_ai.orchestration.pipeline")
+
+_SEGMENTATION_CACHE_SCHEMA_VERSION = "spatial-ai-segmentation-cache.v1"
+
+
+def _segmentation_cache_paths(cache_dir: Path, cache_key: str) -> tuple[Path, Path]:
+    root = cache_dir / cache_key[:2]
+    return root / f"{cache_key}.npz", root / f"{cache_key}.json"
+
+
+def _file_identity(path_value: Any) -> Optional[dict[str, Any]]:
+    if not path_value:
+        return None
+    path = Path(str(path_value))
+    if not path.is_file():
+        return {
+            "path": str(path),
+            "exists": False,
+            "sha256": None,
+            "size": None,
+            "mtime_ns": None,
+        }
+    try:
+        stat = path.stat()
+        return {
+            "path": str(path),
+            "exists": True,
+            "sha256": _sha256_file_cached(str(path), int(stat.st_size), int(stat.st_mtime_ns)),
+            "size": int(stat.st_size),
+            "mtime_ns": int(stat.st_mtime_ns),
+        }
+    except OSError:
+        return {
+            "path": str(path),
+            "exists": False,
+            "sha256": None,
+            "size": None,
+            "mtime_ns": None,
+        }
+
+
+@lru_cache(maxsize=8)
+def _sha256_file_cached(path: str, size: int, mtime_ns: int) -> str:
+    del size, mtime_ns
+    return _sha256_file(Path(path))
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _metadata_to_cache_dict(metadata: MaskMetadata) -> dict[str, Any]:
+    return {
+        "area": int(metadata.area),
+        "bbox": list(metadata.bbox),
+        "stability_score": float(metadata.stability_score),
+        "material_label": metadata.material_label,
+        "material_confidence": metadata.material_confidence,
+        "is_empty": bool(metadata.is_empty),
+    }
+
+
+def _metadata_from_cache_dict(data: Mapping[str, Any]) -> MaskMetadata:
+    return MaskMetadata(
+        area=int(data["area"]),
+        bbox=tuple(int(value) for value in data["bbox"]),
+        stability_score=float(data["stability_score"]),
+        material_label=data.get("material_label"),
+        material_confidence=(float(data["material_confidence"]) if data.get("material_confidence") is not None else None),
+        is_empty=bool(data.get("is_empty", False)),
+    )
+
+
+def _segmentation_result_checksum(result: SegmentationResult) -> str:
+    digest = hashlib.sha256()
+    for array in (result.masks, result.scores):
+        contiguous = array if array.flags["C_CONTIGUOUS"] else np.ascontiguousarray(array)
+        digest.update(str(contiguous.shape).encode("utf-8"))
+        digest.update(str(contiguous.dtype).encode("utf-8"))
+        digest.update(memoryview(contiguous.view(np.uint8).ravel()))
+    digest.update(canonicalize_json([_metadata_to_cache_dict(item) for item in result.metadata]))
+    return digest.hexdigest()
+
+
+def _segmentation_mask_count(result: Any) -> int:
+    masks = getattr(result, "masks", None)
+    if masks is None:
+        return 0
+    shape = getattr(masks, "shape", None)
+    if shape:
+        return int(shape[0])
+    try:
+        return len(masks)
+    except TypeError:
+        return 0
+
+
+def _build_segmentation_cache_key(
+    *,
+    image: np.ndarray,
+    segmentation_cfg: Mapping[str, Any],
+    device: str,
+) -> tuple[str, dict[str, Any]]:
+    model_cfg = segmentation_cfg.get("model", {}) if isinstance(segmentation_cfg.get("model"), Mapping) else {}
+    sanitized_model_cfg = dict(model_cfg)
+    checkpoint_path = sanitized_model_cfg.get("checkpoint_path")
+    sanitized_model_cfg["checkpoint"] = _file_identity(checkpoint_path)
+    sanitized_model_cfg.pop("checkpoint_path", None)
+    payload = {
+        "schema_version": _SEGMENTATION_CACHE_SCHEMA_VERSION,
+        "image_hash": _sha256_array(image),
+        "image_shape": list(image.shape),
+        "image_dtype": str(image.dtype),
+        "backend": segmentation_cfg.get("backend", "sam2"),
+        "device": device,
+        "model": _sanitize_json_value(sanitized_model_cfg),
+        "generator": dict(segmentation_cfg.get("generator", {}) or {}),
+        "material_classification": bool(segmentation_cfg.get("material_classification", False)),
+        "material_confidence_threshold": float(segmentation_cfg.get("material_confidence_threshold", 0.3)),
+        "tiling": _sanitize_json_value(segmentation_cfg.get("tiling", {}) or {}),
+    }
+    cache_key = hashlib.sha256(canonicalize_json(payload)).hexdigest()
+    return cache_key, payload
+
+
+def _read_segmentation_cache(
+    *,
+    cache_dir: Path,
+    cache_key: str,
+    key_payload: Mapping[str, Any],
+) -> Optional[SegmentationResult]:
+    masks_path, metadata_path = _segmentation_cache_paths(cache_dir, cache_key)
+    if not masks_path.is_file() or not metadata_path.is_file():
+        return None
+    try:
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        if metadata.get("schema_version") != _SEGMENTATION_CACHE_SCHEMA_VERSION:
+            return None
+        if metadata.get("cache_key") != cache_key or metadata.get("key_payload") != dict(key_payload):
+            return None
+        with np.load(masks_path, allow_pickle=False) as data:
+            masks = np.asarray(data["masks"])
+            scores = np.asarray(data["scores"])
+        mask_metadata = [_metadata_from_cache_dict(item) for item in metadata.get("metadata", [])]
+        result = SegmentationResult(
+            masks=masks.astype(bool, copy=False), scores=scores.astype(np.float32), metadata=mask_metadata
+        )
+        if _segmentation_result_checksum(result) != metadata.get("result_sha256"):
+            return None
+        return result
+    except Exception as exc:
+        logger.debug("Ignoring invalid spatial segmentation cache entry %s: %s", cache_key, exc)
+        return None
+
+
+def _write_segmentation_cache(
+    *,
+    cache_dir: Path,
+    cache_key: str,
+    key_payload: Mapping[str, Any],
+    result: SegmentationResult,
+) -> None:
+    if _segmentation_mask_count(result) == 0:
+        return
+    if not isinstance(result.masks, np.ndarray) or not isinstance(result.scores, np.ndarray):
+        return
+    masks_path, metadata_path = _segmentation_cache_paths(cache_dir, cache_key)
+    masks_path.parent.mkdir(parents=True, exist_ok=True)
+    temp_npz = masks_path.with_suffix(".npz.tmp")
+    temp_json = metadata_path.with_suffix(".json.tmp")
+    try:
+        with temp_npz.open("wb") as handle:
+            np.savez_compressed(handle, masks=result.masks, scores=result.scores)
+        metadata = {
+            "schema_version": _SEGMENTATION_CACHE_SCHEMA_VERSION,
+            "cache_key": cache_key,
+            "key_payload": dict(key_payload),
+            "metadata": [_metadata_to_cache_dict(item) for item in result.metadata],
+            "result_sha256": _segmentation_result_checksum(result),
+        }
+        with temp_json.open("w", encoding="utf-8") as handle:
+            dump_json(metadata, handle, indent=2, sort_keys=True, ensure_ascii=False, allow_nan=False)
+            handle.write("\n")
+        temp_npz.replace(masks_path)
+        temp_json.replace(metadata_path)
+    finally:
+        for temp_path in (temp_npz, temp_json):
+            if temp_path.exists():
+                with contextlib.suppress(OSError):
+                    temp_path.unlink()
+
+
+__all__ = [
+    "_SEGMENTATION_CACHE_SCHEMA_VERSION",
+    "_build_segmentation_cache_key",
+    "_file_identity",
+    "_metadata_from_cache_dict",
+    "_metadata_to_cache_dict",
+    "_read_segmentation_cache",
+    "_segmentation_cache_paths",
+    "_segmentation_mask_count",
+    "_segmentation_result_checksum",
+    "_sha256_file",
+    "_sha256_file_cached",
+    "_write_segmentation_cache",
+]

--- a/tests/spatial_ai/orchestration/test_segmentation_cache_exports.py
+++ b/tests/spatial_ai/orchestration/test_segmentation_cache_exports.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import importlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Callable
+
+import numpy as np
+import pytest
+
+from transformation_portal.spatial_ai.segmentation.contracts import MaskMetadata, SegmentationResult
+
+pytestmark = pytest.mark.unit
+
+
+def _import_modules() -> tuple[ModuleType, ModuleType, ModuleType]:
+    pipeline_mod = importlib.import_module("transformation_portal.spatial_ai.orchestration.pipeline")
+    cache_mod = importlib.import_module("transformation_portal.spatial_ai.orchestration.segmentation_cache")
+    artifact_utils_mod = importlib.import_module("transformation_portal.spatial_ai.orchestration.artifact_utils")
+    return pipeline_mod, cache_mod, artifact_utils_mod
+
+
+def _make_image() -> np.ndarray:
+    return np.arange(12, dtype=np.float32).reshape(2, 2, 3)
+
+
+def _make_config(checkpoint_path: Path | None = None) -> dict[str, Any]:
+    model: dict[str, Any] = {
+        "size": "large",
+        "repo_id": "facebook/sam2.1-hiera-large",
+        "revision": "a" * 40,
+        "prefer_hf_pipeline": True,
+    }
+    if checkpoint_path is not None:
+        model["checkpoint_path"] = str(checkpoint_path)
+    return {
+        "backend": "sam2",
+        "model": model,
+        "generator": {"points_per_side": np.int64(8)},
+        "material_classification": True,
+        "material_confidence_threshold": np.float32(0.35),
+        "tiling": {"enabled": True, "tile_size": np.int64(512)},
+    }
+
+
+def _make_result() -> SegmentationResult:
+    masks = np.zeros((2, 2, 2), dtype=bool)
+    masks[0, 0, 0] = True
+    masks[1, :, 1] = True
+    return SegmentationResult(
+        masks=masks,
+        scores=np.array([0.95, 0.55], dtype=np.float32),
+        metadata=[
+            MaskMetadata(
+                area=1,
+                bbox=(0, 0, 1, 1),
+                stability_score=0.91,
+                material_label="glass",
+                material_confidence=0.82,
+            ),
+            MaskMetadata(
+                area=2,
+                bbox=(1, 0, 1, 2),
+                stability_score=0.73,
+                material_label="stone",
+                material_confidence=0.64,
+                is_empty=False,
+            ),
+        ],
+    )
+
+
+def _write_cache_entry(cache_mod: ModuleType, tmp_path: Path) -> tuple[Path, str, dict[str, Any], SegmentationResult]:
+    checkpoint_path = tmp_path / "sam2.pt"
+    checkpoint_path.write_bytes(b"checkpoint")
+    cache_key, key_payload = cache_mod._build_segmentation_cache_key(
+        image=_make_image(),
+        segmentation_cfg=_make_config(checkpoint_path),
+        device="cpu",
+    )
+    result = _make_result()
+    cache_dir = tmp_path / ".cache" / "spatial_ai" / "segmentation"
+    cache_mod._write_segmentation_cache(
+        cache_dir=cache_dir,
+        cache_key=cache_key,
+        key_payload=key_payload,
+        result=result,
+    )
+    return cache_dir, cache_key, key_payload, result
+
+
+def test_segmentation_cache_helper_identity_is_preserved_across_import_surfaces() -> None:
+    pipeline_mod, cache_mod, artifact_utils_mod = _import_modules()
+
+    for helper_name in (
+        "_build_segmentation_cache_key",
+        "_read_segmentation_cache",
+        "_write_segmentation_cache",
+        "_segmentation_mask_count",
+        "_segmentation_cache_paths",
+        "_segmentation_result_checksum",
+        "_metadata_to_cache_dict",
+        "_metadata_from_cache_dict",
+        "_file_identity",
+        "_sha256_file",
+        "_sha256_file_cached",
+    ):
+        assert getattr(pipeline_mod, helper_name) is getattr(cache_mod, helper_name)
+
+    assert pipeline_mod._sha256_array is artifact_utils_mod._sha256_array
+    assert pipeline_mod._sanitize_json_value is artifact_utils_mod._sanitize_json_value
+    assert pipeline_mod._SEGMENTATION_CACHE_SCHEMA_VERSION == cache_mod._SEGMENTATION_CACHE_SCHEMA_VERSION
+
+
+def test_direct_segmentation_cache_roundtrip_preserves_payload(tmp_path: Path) -> None:
+    _, cache_mod, _ = _import_modules()
+    cache_dir, cache_key, key_payload, result = _write_cache_entry(cache_mod, tmp_path)
+    masks_path, metadata_path = cache_mod._segmentation_cache_paths(cache_dir, cache_key)
+
+    assert masks_path == cache_dir / cache_key[:2] / f"{cache_key}.npz"
+    assert metadata_path == cache_dir / cache_key[:2] / f"{cache_key}.json"
+    assert masks_path.is_file()
+    assert metadata_path.is_file()
+
+    cached = cache_mod._read_segmentation_cache(
+        cache_dir=cache_dir,
+        cache_key=cache_key,
+        key_payload=key_payload,
+    )
+
+    assert cached is not None
+    assert np.array_equal(cached.masks, result.masks)
+    assert np.allclose(cached.scores, result.scores)
+    assert [cache_mod._metadata_to_cache_dict(item) for item in cached.metadata] == [
+        cache_mod._metadata_to_cache_dict(item) for item in result.metadata
+    ]
+    assert cache_mod._segmentation_result_checksum(cached) == cache_mod._segmentation_result_checksum(result)
+
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    assert metadata["schema_version"] == cache_mod._SEGMENTATION_CACHE_SCHEMA_VERSION
+    assert metadata["cache_key"] == cache_key
+    assert metadata["key_payload"] == key_payload
+    assert metadata["result_sha256"] == cache_mod._segmentation_result_checksum(result)
+
+
+@pytest.mark.parametrize(
+    "mutate_metadata",
+    [
+        lambda metadata, cache_key, key_payload: metadata.update({"schema_version": "invalid"}),
+        lambda metadata, cache_key, key_payload: metadata.update({"cache_key": f"{cache_key}-stale"}),
+        lambda metadata, cache_key, key_payload: metadata.update({"result_sha256": "0" * 64}),
+    ],
+)
+def test_direct_segmentation_cache_invalid_entries_return_none_without_raising(
+    mutate_metadata: Callable[[dict[str, Any], str, dict[str, Any]], None],
+    tmp_path: Path,
+) -> None:
+    _, cache_mod, _ = _import_modules()
+    cache_dir, cache_key, key_payload, _ = _write_cache_entry(cache_mod, tmp_path)
+    _, metadata_path = cache_mod._segmentation_cache_paths(cache_dir, cache_key)
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    mutate_metadata(metadata, cache_key, key_payload)
+    metadata_path.write_text(json.dumps(metadata), encoding="utf-8")
+
+    assert (
+        cache_mod._read_segmentation_cache(
+            cache_dir=cache_dir,
+            cache_key=cache_key,
+            key_payload=key_payload,
+        )
+        is None
+    )
+
+
+def test_artifact_utils_preserve_array_hash_and_sanitizer_behavior() -> None:
+    _, _, artifact_utils_mod = _import_modules()
+    array = np.arange(24, dtype=np.float32).reshape(2, 3, 4)
+    non_contiguous = array[:, ::-1, :]
+
+    assert artifact_utils_mod._sha256_array(non_contiguous) == artifact_utils_mod._sha256_array(
+        np.ascontiguousarray(non_contiguous)
+    )
+
+    @dataclass
+    class Payload:
+        values: Any
+        nested: Any
+        non_finite: float
+
+    assert artifact_utils_mod._sanitize_json_value(
+        Payload(
+            values=np.array([np.float32(1.5), np.float32(2.5)]),
+            nested={1: (np.int64(7),)},
+            non_finite=float("nan"),
+        )
+    ) == {
+        "values": [1.5, 2.5],
+        "nested": {"1": [7]},
+        "non_finite": None,
+    }


### PR DESCRIPTION
## Summary
- Extract Spatial AI segmentation cache helpers out of the orchestration monolith.
- Preserve the existing private `pipeline.py` helper aliases and segmentation cache behavior.

## Changes
- Add `artifact_utils.py` for shared array hashing and JSON-safe payload normalization used by cache and material artifacts.
- Add `segmentation_cache.py` for cache key/path building, metadata serialization, checksum validation, and cache read/write.
- Slim `pipeline.py` to import the extracted helpers while keeping legacy private access through the pipeline module.
- Add focused cache export, roundtrip, invalid-entry, and artifact utility tests.
- Update the monolith decomposition status table with Target 5C only.

## Validation
- `.venv/bin/python -m pytest tests/spatial_ai/orchestration/test_segmentation_cache_exports.py -q`
- `.venv/bin/python -m pytest tests/spatial_ai/orchestration/test_segmentation_cache_exports.py tests/spatial_ai/orchestration/test_forward_port_contracts.py tests/spatial_ai/orchestration/test_pipeline.py tests/spatial_ai/orchestration/test_config_exports.py tests/test_pipeline_corrections.py tests/interfaces/test_public_surface.py -q`
- `make check-json-serialization check-yaml-governance check-python-headers`
- `.venv/bin/python scripts/validation/scan_todo_inventory.py --check-governance`
- `make test-fast`
- commit pre-commit hooks, including gitleaks parity

## Risk
- Extraction-only: no cache policy, graph execution, stage behavior, summary/report schema, or output filename changes are intended.
- `pipeline.py` remains on the raw JSON allowlist because graph execution still owns `graph_execution.json`.
- Revert-safe because callers continue through the existing pipeline compatibility surface.
