### PR TITLE
docs(architecture): gate app path security extraction

### DIFF
--- a/docs/architecture/ADR-046-app-path-security-helper-extraction.md
+++ b/docs/architecture/ADR-046-app-path-security-helper-extraction.md
@@ -1,0 +1,94 @@
+# ADR-046: App Path Security Helper Extraction Contract
+
+**Status:** Proposed
+**Date:** 2026-05-06
+**Decision Makers:** Architect (review) + Specialist (implementation)
+**Replaces:** None
+**Supersedes:** None
+**Related:** [ADR-045 Monolith Decomposition Residuals](ADR-045-monolith-decomposition-residuals.md), [Monolith Decomposition Targets](MONOLITH_DECOMPOSITION_TARGETS.md), [Portal Edge Hardening Implementation Standard](PORTAL_EDGE_HARDENING_IMPLEMENTATION_STANDARD.md)
+
+---
+
+## Executive Summary
+
+Target 2B may extract `app.py` path resolution and filesystem trust helpers only after this security contract is reviewed. The destination module is `src/transformation_portal/portal/path_security.py`. The extraction must be compatibility-only: no behavior changes to allowed-root resolution, symlink handling, trusted entry walking, upload-root resolution, typed validation reasons, or public error envelopes.
+
+`app.py` remains the legacy compatibility surface. Existing private helper access through `app.py` must continue to work for tests and internal callers.
+
+---
+
+## Context
+
+`app.py` is still the largest monolith and contains security-sensitive path handling used by upload staging, archive dispatch, FastVLM runtime validation, artifact lookup, and job-output resolution. Target 2A moved the pure portal asset bundle seam. Target 2B is higher risk because these helpers decide what paths the service may read, write, create, or serve.
+
+ADR-045 provides the general decomposition pattern, but it explicitly does not override module-specific app hardening. This ADR is the module-specific gate for Target 2B.
+
+---
+
+## Decision
+
+Phase 2B extraction is allowed only under these constraints:
+
+1. `src/transformation_portal/portal/path_security.py` owns pure path-security helpers and must not import `app.py`.
+2. `app.py` re-exports or wraps the legacy private helper names so existing imports and monkeypatch-based tests continue to work.
+3. `_PortalValidationReasonError` stays in `app.py` for Phase 2B. Moving it requires a later ADR/update that covers the full app validation-reason surface.
+4. `PORTAL_UPLOAD_ROOT`, `ALLOWED_INPUT_ROOTS`, `ALLOWED_OUTPUT_ROOTS`, and `ALLOWED_PATH_ROOTS` remain app-owned runtime configuration for Phase 2B.
+5. No call-site rewrites outside `app.py` are allowed in the extraction PR unless a compatibility test proves an existing public contract already imports the new module directly.
+
+The extraction surface approved for Phase 2B is:
+
+- `_normalize_root_path`
+- `_default_allowed_path_roots`
+- `_env_path_roots`
+- `_resolve_untrusted_request_path`
+- `_validate_path_against_roots`
+- `_resolve_allowed_request_path`
+- `_path_is_within_root`
+- `_trusted_allowed_entry`
+- `_trusted_existing_dir`
+- `_trusted_creatable_dir`
+- `_ensure_safe_regular_file_path`
+
+`_resolved_portal_upload_root` remains an `app.py` compatibility wrapper that uses app-owned runtime configuration and the extracted resolver.
+
+---
+
+## Security Review Checklist
+
+The Phase 2B extraction PR must show explicit review evidence for:
+
+- Traversal rejection: empty values, tilde shorthand, NUL bytes, and outside-root escapes.
+- Symlink escape rejection for existing files, existing directories, runtime paths, and artifact paths.
+- Missing path behavior for required existing files/directories versus creatable output directories.
+- Creatable output directory behavior, including no pre-admission directory creation.
+- Archive path callers: archive index, archive root, manifests, reports, policy files, bag directories, and rights sidecars.
+- Upload path callers: portal upload root resolution and staged upload input directories.
+- FastVLM path callers: runtime root, Python executable, model selector paths, and non-blocking missing-runtime status.
+- Artifact-serving callers: job output directory resolution, artifact lookup, preview proxy paths, and attachment filenames.
+- Typed error compatibility: invalid-path and outside-root reasons remain stable in internal exceptions and public envelopes.
+
+---
+
+## Implementation Plan
+
+1. Prep PR: land this ADR, update the Target 2B readiness row, and add extraction-readiness tests that still import through `app.py`.
+2. Extraction PR: add `portal/path_security.py`, import helpers into `app.py`, keep `_PortalValidationReasonError` and runtime config in `app.py`, and preserve all helper names.
+3. Follow-up only if needed: evaluate whether broader validation-reason objects can move without changing app-wide typed error behavior.
+
+---
+
+## Success Metrics
+
+- Existing `app.py` path/security tests stay green before and after extraction.
+- `app.py` remains the compatibility import surface for all listed private helper names.
+- No route shape, selector, API envelope, CLI argument, output filename, or public error-code behavior changes.
+- The extraction PR cites this ADR and passes ADR-045 governance gates.
+
+---
+
+## References
+
+- `app.py` path helper region and callers.
+- `tests/test_app_security.py`
+- `tests/test_portal_backend_hardening.py`
+- `docs/architecture/MONOLITH_DECOMPOSITION_TARGETS.md`

--- a/docs/architecture/MONOLITH_DECOMPOSITION_TARGETS.md
+++ b/docs/architecture/MONOLITH_DECOMPOSITION_TARGETS.md
@@ -127,7 +127,7 @@ Approx LOC: ~415. Re-export from `app.py` as `from transformation_portal.portal.
 **Verification:** `make check-portal-asset-budgets`, `make validate-portal-css-layer-parity`, `pytest tests/test_app_orchestrator_contract_http.py -v`, `pytest tests/validation/test_portal_smoke_scripts.py -v`.
 
 **Deferred slices (track here, do not promote until 2A lands):**
-- *2B — Path resolution & security helpers* (`app.py:516–700`). High risk: hardening surface; allowed-roots, symlink safety, untrusted-path validation. Needs its own ADR addendum and security-review skill pass.
+- *2B — Path resolution & security helpers* (`app.py:428–667` -> `src/transformation_portal/portal/path_security.py`). High risk: hardening surface; allowed-roots, symlink safety, untrusted-path validation. Ready only after ADR-046/security contract review.
 - *2C — SAM2 checksum cache* (`app.py:773–827, 1336–1440`). Medium risk: model-lock semantics and bounded cache eviction. Defer until SAM2 model-lock manifest migration is settled.
 
 ---
@@ -172,6 +172,7 @@ This table is the canonical progress ledger for extraction PRs that draw from th
 | Target 1B — Artifact reload / coercion helpers | `lux_depth_v3/orchestrator.py` | `lux_depth_v3/artifact_manager.py` | Landed | This PR: manifest reload/coercion helpers extracted |
 | Target 1C — Backend resolution & state | `lux_depth_v3/orchestrator.py` | `lux_depth_v3/pipeline_coordinator.py` | Landed | This PR: backend initialization and runtime attempt-state helpers extracted |
 | Target 2A — Portal asset bundle | `app.py` | `src/transformation_portal/portal/asset_bundle.py` | Landed | This PR: portal asset bundle helpers extracted |
+| Target 2B — Path resolution & security helpers | `app.py` | `src/transformation_portal/portal/path_security.py` | Ready after ADR-046/security contract | Prep PR: ADR and readiness harness only; no helper extraction |
 | Target 3A — Segmentation cache helpers | `lux_depth_v3/segmentation_backend.py` | `lux_depth_v3/segmentation/_cache.py` | Landed | This PR: segmentation cache helpers extracted |
 | Target 3B — Stub backend | `lux_depth_v3/segmentation_backend.py` | `lux_depth_v3/segmentation/stub.py` | Landed | This PR: stub backend extracted |
 | Target 3C — EfficientSAM backend | `lux_depth_v3/segmentation_backend.py` | `lux_depth_v3/segmentation/efficient_sam.py` | Landed | This PR: EfficientSAM backend extracted |

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -30,6 +30,7 @@ ADRs are **binding decisions** that define the repository's architecture, securi
 | [ADR-020](ADR-020-drop-python-3.10.md) | Drop Python 3.10 Support | Accepted | 2026 | Architect |
 | [ADR-021](ADR-021-huggingface-revision-policy.md) | HuggingFace Revision Pinning | Accepted | 2026-02-03 | Architect |
 | [ADR-024](ADR-024-apache-iceberg-ban.md) | Apache Iceberg Ban | Accepted | 2026 | Architect |
+| [ADR-046](ADR-046-app-path-security-helper-extraction.md) | App Path Security Helper Extraction Contract | Proposed | 2026-05-06 | Architect |
 
 ### Tier & Licensing
 

--- a/tests/test_app_path_security_extraction_contract.py
+++ b/tests/test_app_path_security_extraction_contract.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Phase 2B extraction-readiness contract for app path security helpers."""
+
+from __future__ import annotations
+
+import importlib
+import os
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.security]
+
+orchestrator_app = importlib.import_module("app")
+
+
+_PHASE_2B_LEGACY_HELPERS = (
+    "_normalize_root_path",
+    "_default_allowed_path_roots",
+    "_env_path_roots",
+    "_resolve_untrusted_request_path",
+    "_validate_path_against_roots",
+    "_resolve_allowed_request_path",
+    "_path_is_within_root",
+    "_trusted_allowed_entry",
+    "_trusted_existing_dir",
+    "_trusted_creatable_dir",
+    "_ensure_safe_regular_file_path",
+    "_resolved_portal_upload_root",
+)
+
+
+def test_phase_2b_legacy_path_security_helpers_remain_available_from_app() -> None:
+    for helper_name in _PHASE_2B_LEGACY_HELPERS:
+        assert callable(getattr(orchestrator_app, helper_name))
+
+
+def test_phase_2b_path_reason_codes_stay_distinct(tmp_path: Path) -> None:
+    allowed_root = tmp_path / "allowed"
+    allowed_root.mkdir()
+
+    with pytest.raises(orchestrator_app._PortalValidationReasonError) as invalid_exc:
+        orchestrator_app._resolve_allowed_request_path("bad\x00path", [allowed_root])
+
+    outside_path = tmp_path / "outside" / "asset.txt"
+    with pytest.raises(orchestrator_app._PortalValidationReasonError) as outside_exc:
+        orchestrator_app._resolve_allowed_request_path(str(outside_path), [allowed_root])
+
+    assert invalid_exc.value.reason == "invalid_path_value"
+    assert outside_exc.value.reason == "path_outside_allowed_roots"
+
+
+def test_phase_2b_symlink_escape_is_rejected_for_existing_dir(tmp_path: Path) -> None:
+    allowed_root = tmp_path / "allowed"
+    outside_root = tmp_path / "outside"
+    allowed_root.mkdir()
+    outside_root.mkdir()
+    outside_dir = outside_root / "data"
+    outside_dir.mkdir()
+    symlink_path = allowed_root / "linked-data"
+    symlink_path.symlink_to(outside_dir, target_is_directory=True)
+
+    with pytest.raises(orchestrator_app._PortalValidationReasonError) as exc_info:
+        orchestrator_app._resolve_allowed_request_path(str(symlink_path), [allowed_root])
+
+    assert exc_info.value.reason == "path_outside_allowed_roots"
+    assert orchestrator_app._trusted_existing_dir(str(symlink_path), [allowed_root]) is None
+
+
+def test_phase_2b_trusted_creatable_dir_returns_path_without_creating_it(tmp_path: Path) -> None:
+    allowed_root = tmp_path / "allowed"
+    allowed_root.mkdir()
+    output_dir = allowed_root / "new-output"
+
+    trusted = orchestrator_app._trusted_creatable_dir(str(output_dir), [allowed_root])
+
+    assert trusted == output_dir
+    assert not output_dir.exists()
+
+
+def test_phase_2b_path_is_within_root_uses_realpath(tmp_path: Path) -> None:
+    allowed_root = tmp_path / "allowed"
+    outside_root = tmp_path / "outside"
+    allowed_root.mkdir()
+    outside_root.mkdir()
+
+    inside = Path(os.path.realpath(allowed_root / "child"))
+    outside = Path(os.path.realpath(outside_root / "child"))
+
+    assert orchestrator_app._path_is_within_root(inside, allowed_root) is True
+    assert orchestrator_app._path_is_within_root(outside, allowed_root) is False
+
+
+def test_phase_2b_resolved_portal_upload_root_uses_allowed_input_roots(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    allowed_root = tmp_path / "allowed-input"
+    allowed_root.mkdir()
+    upload_root = allowed_root / "uploads"
+
+    monkeypatch.setattr(orchestrator_app, "ALLOWED_INPUT_ROOTS", [allowed_root])
+    monkeypatch.setattr(orchestrator_app, "PORTAL_UPLOAD_ROOT", upload_root)
+
+    resolved = orchestrator_app._resolved_portal_upload_root()
+
+    assert resolved == Path(os.path.realpath(upload_root))


### PR DESCRIPTION
## Summary
- Add ADR-046 as the security contract that gates the future Target 2B `app.py` path-security helper extraction.
- Pin extraction-sensitive app path helper behavior through a focused compatibility test harness before moving any production code.

## Changes
- Document the approved future destination module, `src/transformation_portal/portal/path_security.py`, and the compatibility requirement that `app.py` remains the legacy helper surface.
- Keep `_PortalValidationReasonError` and app-owned runtime path configuration explicitly out of the Phase 2B extraction scope.
- Update the monolith decomposition target ledger for Target 2B readiness only.
- Add tests for legacy helper availability, path reason-code stability, symlink escape rejection, creatable-directory no-create behavior, realpath root checks, and upload-root resolution.

## Validation
- Proven green: `.venv/bin/python -m pytest tests/test_app_path_security_extraction_contract.py tests/test_app_security.py tests/test_portal_backend_hardening.py -q`
- Proven green: `.venv/bin/python -m pytest tests/test_app_orchestrator_contract_http.py tests/test_app_orchestrator_runtime.py -k "path or upload or archive or fastvlm or artifact" -q`
- Proven green: `make check-json-serialization check-yaml-governance check-python-headers`
- Proven green: `.venv/bin/python scripts/validation/scan_todo_inventory.py --check-governance`
- Proven green: commit pre-checks, including Black, isort, root-file placement, ADR-031/ADR-044 checks, tautological assertion ban, and gitleaks parity.

## Risk
- Prep-only PR: no production helper extraction and no route, selector, API envelope, CLI flag, output filename, allowed-root, symlink, or public error-code behavior changes.
- Future extraction remains gated on ADR-046 review and the pinned compatibility tests.
- Bounded and revert-safe: changes are limited to documentation plus tests.
