### PR TITLE
refactor(portal): extract path security helpers

### DIFF
--- a/app.py
+++ b/app.py
@@ -68,6 +68,7 @@ from transformation_portal.ingest.upload_staging import (
 from transformation_portal.lux_depth_v3.model_registry import resolve_model_spec, resolve_registry_key, visible_cli_model_specs
 from transformation_portal.lux_depth_v3.run_card_contract import infer_run_card_version
 from transformation_portal.portal import asset_bundle as _portal_asset_bundle
+from transformation_portal.portal import path_security as _portal_path_security
 from transformation_portal.portal.asset_bundle import (
     PORTAL_ASSETS_DIR,
     PORTAL_ASSETS_DIR_REAL,
@@ -426,60 +427,15 @@ APP_VERSION = "0.3.0"
 
 
 def _normalize_root_path(value: str | Path) -> Path:
-    raw = str(value or "").strip()
-    if not raw or raw.startswith("~") or "\x00" in raw:
-        raise ValueError("Invalid path root")
-    candidate = Path(raw)
-    if not candidate.is_absolute():
-        candidate = REPO_ROOT / candidate
-    return Path(os.path.realpath(candidate))
+    return _portal_path_security._normalize_root_path(value, repo_root=REPO_ROOT)
 
 
 def _default_allowed_path_roots() -> List[Path]:
-    roots: List[Path] = [REPO_ROOT]
-    candidate_paths: List[Path] = [Path(tempfile.gettempdir()).resolve()]
-    if os.name != "nt":
-        # Accept the common POSIX temp aliases used by operators and local tooling.
-        candidate_paths.extend([Path("/tmp"), Path("/private/tmp")])
-
-    for candidate in candidate_paths:
-        try:
-            normalized = _normalize_root_path(candidate)
-        except (OSError, RuntimeError, ValueError):
-            continue
-        if normalized not in roots:
-            roots.append(normalized)
-    return roots
+    return _portal_path_security._default_allowed_path_roots(repo_root=REPO_ROOT)
 
 
 def _env_path_roots(name: str, default: List[Path]) -> List[Path]:
-    raw = os.getenv(name)
-    if raw is None:
-        values = [str(path) for path in default]
-    else:
-        values = [item.strip() for item in raw.split(",") if item.strip()]
-
-    roots: List[Path] = []
-    invalid_values: List[str] = []
-    for value in values:
-        try:
-            root = _normalize_root_path(value)
-        except (OSError, RuntimeError, ValueError):
-            invalid_values.append(value)
-            continue
-        if root not in roots:
-            roots.append(root)
-    if invalid_values:
-        LOGGER.warning(
-            "%s ignored invalid roots: %s",
-            name,
-            ", ".join(sorted(set(invalid_values))),
-        )
-    if raw is not None and not roots:
-        raise RuntimeError(f"{name} is set but contains no valid roots")
-    if not roots:
-        raise RuntimeError(f"{name} resolved to an empty root allowlist")
-    return roots
+    return _portal_path_security._env_path_roots(name, default, repo_root=REPO_ROOT, logger=LOGGER)
 
 
 def _lux_depth_runner_command() -> List[str]:
@@ -499,13 +455,11 @@ def _lux_depth_runner_available() -> bool:
 
 
 def _resolve_untrusted_request_path(path_value: str) -> Path:
-    raw = str(path_value or "").strip()
-    if not raw or raw.startswith("~") or "\x00" in raw:
-        raise ValueError("Invalid path value")
-    candidate = Path(raw)
-    if not candidate.is_absolute():
-        candidate = REPO_ROOT / candidate
-    return Path(os.path.realpath(candidate))
+    return _portal_path_security._resolve_untrusted_request_path(path_value, repo_root=REPO_ROOT)
+
+
+def _portal_path_security_error(exc: _portal_path_security.PathSecurityValidationError) -> "_PortalValidationReasonError":
+    return _PortalValidationReasonError(str(exc), reason=exc.reason)
 
 
 def _validate_path_against_roots(
@@ -519,27 +473,10 @@ def _resolve_allowed_request_path(
     path_value: str,
     allowed_roots: List[Path],
 ) -> Path:
-    if not allowed_roots:
-        raise _PortalValidationReasonError("No allowed roots configured", reason="invalid_path_value")
-
     try:
-        resolved = _resolve_untrusted_request_path(path_value)
-    except (OSError, RuntimeError, ValueError):
-        raise _PortalValidationReasonError("Invalid path value", reason="invalid_path_value") from None
-
-    for root in allowed_roots:
-        try:
-            root_real = Path(os.path.realpath(root))
-        except (OSError, RuntimeError, ValueError):
-            continue
-        try:
-            resolved.relative_to(root_real)
-        except ValueError:
-            continue
-        else:
-            return resolved
-
-    raise _PortalValidationReasonError("Path outside allowed roots", reason="path_outside_allowed_roots")
+        return _portal_path_security._resolve_allowed_request_path(path_value, allowed_roots, repo_root=REPO_ROOT)
+    except _portal_path_security.PathSecurityValidationError as exc:
+        raise _portal_path_security_error(exc) from None
 
 
 def _resolved_portal_upload_root() -> Path:
@@ -547,41 +484,17 @@ def _resolved_portal_upload_root() -> Path:
 
 
 def _path_is_within_root(resolved_path: Path, root: Path) -> bool:
-    try:
-        resolved_path.relative_to(Path(os.path.realpath(root)))
-    except ValueError:
-        return False
-    return True
+    return _portal_path_security._path_is_within_root(resolved_path, root)
 
 
 def _trusted_allowed_entry(
     resolved_path: Path,
     allowed_roots: List[Path],
 ) -> Optional[Path]:
-    for root in allowed_roots:
-        try:
-            root_real = Path(os.path.realpath(root))
-            relative_parts = resolved_path.relative_to(root_real).parts
-        except (OSError, RuntimeError, ValueError):
-            continue
-        current = root_real
-        if not relative_parts:
-            return current
-        for part in relative_parts:
-            if part in {"", ".", ".."}:
-                return None
-            try:
-                next_path = next((child for child in current.iterdir() if child.name == part), None)
-            except (NotADirectoryError, FileNotFoundError, OSError, RuntimeError, ValueError):
-                return None
-            if next_path is None:
-                return None
-            current = next_path
-        return current
-    return None
+    return _portal_path_security._trusted_allowed_entry(resolved_path, allowed_roots)
 
 
-_UNSAFE_PATH_SEGMENT_RE = re.compile(r"[\x00/\\]")
+_UNSAFE_PATH_SEGMENT_RE = _portal_path_security._UNSAFE_PATH_SEGMENT_RE
 
 
 def _trusted_existing_dir(value: str, allowed_roots: List[Path]) -> Optional[Path]:
@@ -594,19 +507,7 @@ def _trusted_existing_dir(value: str, allowed_roots: List[Path]) -> Optional[Pat
     string to subsequent filesystem APIs.
     """
 
-    try:
-        resolved = _resolve_allowed_request_path(value, allowed_roots)
-    except _PortalValidationReasonError:
-        return None
-    trusted = _trusted_allowed_entry(resolved, allowed_roots)
-    if trusted is None:
-        return None
-    try:
-        if not trusted.is_dir():
-            return None
-    except OSError:
-        return None
-    return trusted
+    return _portal_path_security._trusted_existing_dir(value, allowed_roots, repo_root=REPO_ROOT)
 
 
 def _trusted_creatable_dir(value: str, allowed_roots: List[Path]) -> Optional[Path]:
@@ -618,53 +519,14 @@ def _trusted_creatable_dir(value: str, allowed_roots: List[Path]) -> Optional[Pa
     against :data:`_UNSAFE_PATH_SEGMENT_RE` to defeat traversal injection.
     """
 
-    try:
-        resolved = _resolve_allowed_request_path(value, allowed_roots)
-    except _PortalValidationReasonError:
-        return None
-    for root in allowed_roots:
-        try:
-            root_real = Path(os.path.realpath(root))
-            relative_parts = resolved.relative_to(root_real).parts
-        except (OSError, RuntimeError, ValueError):
-            continue
-        current = root_real
-        creating = False
-        for part in relative_parts:
-            if part in {"", ".", ".."} or _UNSAFE_PATH_SEGMENT_RE.search(part):
-                return None
-            if creating:
-                current = current / part
-                continue
-            try:
-                next_path = next((child for child in current.iterdir() if child.name == part), None)
-            except (NotADirectoryError, FileNotFoundError, OSError, RuntimeError, ValueError):
-                return None
-            if next_path is None:
-                creating = True
-                current = current / part
-            else:
-                current = next_path
-        return current
-    return None
+    return _portal_path_security._trusted_creatable_dir(value, allowed_roots, repo_root=REPO_ROOT)
 
 
 def _ensure_safe_regular_file_path(path_value: Path, allowed_roots: List[Path]) -> Path:
     try:
-        candidate_real = _resolve_allowed_request_path(str(path_value), allowed_roots)
-    except _PortalValidationReasonError:
-        raise
-    except (OSError, RuntimeError, ValueError) as exc:
-        raise _PortalValidationReasonError("Invalid path value", reason="invalid_path_value") from exc
-    trusted_entry = _trusted_allowed_entry(candidate_real, allowed_roots)
-    if trusted_entry is None:
-        raise _PortalValidationReasonError("Invalid path value", reason="invalid_path_value")
-    try:
-        if not trusted_entry.is_file():
-            raise _PortalValidationReasonError("Invalid path value", reason="invalid_path_value")
-    except OSError as exc:
-        raise _PortalValidationReasonError("Invalid path value", reason="invalid_path_value") from exc
-    return trusted_entry
+        return _portal_path_security._ensure_safe_regular_file_path(path_value, allowed_roots, repo_root=REPO_ROOT)
+    except _portal_path_security.PathSecurityValidationError as exc:
+        raise _portal_path_security_error(exc) from exc.__cause__
 
 
 _MANAGED_SAM2_REASON_MESSAGES = {

--- a/docs/architecture/MONOLITH_DECOMPOSITION_TARGETS.md
+++ b/docs/architecture/MONOLITH_DECOMPOSITION_TARGETS.md
@@ -127,7 +127,7 @@ Approx LOC: ~415. Re-export from `app.py` as `from transformation_portal.portal.
 **Verification:** `make check-portal-asset-budgets`, `make validate-portal-css-layer-parity`, `pytest tests/test_app_orchestrator_contract_http.py -v`, `pytest tests/validation/test_portal_smoke_scripts.py -v`.
 
 **Deferred slices (track here, do not promote until 2A lands):**
-- *2B — Path resolution & security helpers* (`app.py:428–667` -> `src/transformation_portal/portal/path_security.py`). High risk: hardening surface; allowed-roots, symlink safety, untrusted-path validation. Ready only after ADR-046/security contract review.
+- *2B — Path resolution & security helpers* (`app.py:428–667` -> `src/transformation_portal/portal/path_security.py`). High risk: hardening surface; allowed-roots, symlink safety, untrusted-path validation. Landed behind the ADR-046 compatibility contract.
 - *2C — SAM2 checksum cache* (`app.py:773–827, 1336–1440`). Medium risk: model-lock semantics and bounded cache eviction. Defer until SAM2 model-lock manifest migration is settled.
 
 ---
@@ -172,7 +172,7 @@ This table is the canonical progress ledger for extraction PRs that draw from th
 | Target 1B — Artifact reload / coercion helpers | `lux_depth_v3/orchestrator.py` | `lux_depth_v3/artifact_manager.py` | Landed | This PR: manifest reload/coercion helpers extracted |
 | Target 1C — Backend resolution & state | `lux_depth_v3/orchestrator.py` | `lux_depth_v3/pipeline_coordinator.py` | Landed | This PR: backend initialization and runtime attempt-state helpers extracted |
 | Target 2A — Portal asset bundle | `app.py` | `src/transformation_portal/portal/asset_bundle.py` | Landed | This PR: portal asset bundle helpers extracted |
-| Target 2B — Path resolution & security helpers | `app.py` | `src/transformation_portal/portal/path_security.py` | Ready after ADR-046/security contract | Prep PR: ADR and readiness harness only; no helper extraction |
+| Target 2B — Path resolution & security helpers | `app.py` | `src/transformation_portal/portal/path_security.py` | Landed | This PR: path security helpers extracted behind ADR-046 app compatibility wrappers |
 | Target 3A — Segmentation cache helpers | `lux_depth_v3/segmentation_backend.py` | `lux_depth_v3/segmentation/_cache.py` | Landed | This PR: segmentation cache helpers extracted |
 | Target 3B — Stub backend | `lux_depth_v3/segmentation_backend.py` | `lux_depth_v3/segmentation/stub.py` | Landed | This PR: stub backend extracted |
 | Target 3C — EfficientSAM backend | `lux_depth_v3/segmentation_backend.py` | `lux_depth_v3/segmentation/efficient_sam.py` | Landed | This PR: EfficientSAM backend extracted |

--- a/src/transformation_portal/portal/path_security.py
+++ b/src/transformation_portal/portal/path_security.py
@@ -1,0 +1,247 @@
+"""Portal path resolution and filesystem trust helpers."""
+
+from __future__ import annotations
+
+import os
+import re
+import tempfile
+from pathlib import Path
+from typing import Any, List, Optional
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+_UNSAFE_PATH_SEGMENT_RE = re.compile(r"[\x00/\\]")
+
+
+class PathSecurityValidationError(ValueError):
+    """Validation error raised by app-independent path security helpers."""
+
+    def __init__(self, message: str, *, reason: str = "invalid_path_value") -> None:
+        cleaned_message = str(message or "").strip() or "invalid request"
+        self.reason = str(reason or "invalid_path_value").strip() or "invalid_path_value"
+        super().__init__(cleaned_message)
+
+
+def _repo_root(repo_root: Path | None = None) -> Path:
+    return Path(os.path.realpath(REPO_ROOT if repo_root is None else repo_root))
+
+
+def _normalize_root_path(value: str | Path, *, repo_root: Path | None = None) -> Path:
+    raw = str(value or "").strip()
+    if not raw or raw.startswith("~") or "\x00" in raw:
+        raise ValueError("Invalid path root")
+    candidate = Path(raw)
+    if not candidate.is_absolute():
+        candidate = _repo_root(repo_root) / candidate
+    return Path(os.path.realpath(candidate))
+
+
+def _default_allowed_path_roots(*, repo_root: Path | None = None) -> List[Path]:
+    root = _repo_root(repo_root)
+    roots: List[Path] = [root]
+    candidate_paths: List[Path] = [Path(tempfile.gettempdir()).resolve()]
+    if os.name != "nt":
+        # Accept the common POSIX temp aliases used by operators and local tooling.
+        candidate_paths.extend([Path("/tmp"), Path("/private/tmp")])
+
+    for candidate in candidate_paths:
+        try:
+            normalized = _normalize_root_path(candidate, repo_root=root)
+        except (OSError, RuntimeError, ValueError):
+            continue
+        if normalized not in roots:
+            roots.append(normalized)
+    return roots
+
+
+def _env_path_roots(
+    name: str,
+    default: List[Path],
+    *,
+    repo_root: Path | None = None,
+    logger: Any | None = None,
+) -> List[Path]:
+    raw = os.getenv(name)
+    if raw is None:
+        values = [str(path) for path in default]
+    else:
+        values = [item.strip() for item in raw.split(",") if item.strip()]
+
+    roots: List[Path] = []
+    invalid_values: List[str] = []
+    for value in values:
+        try:
+            root = _normalize_root_path(value, repo_root=repo_root)
+        except (OSError, RuntimeError, ValueError):
+            invalid_values.append(value)
+            continue
+        if root not in roots:
+            roots.append(root)
+    if invalid_values and logger is not None:
+        logger.warning(
+            "%s ignored invalid roots: %s",
+            name,
+            ", ".join(sorted(set(invalid_values))),
+        )
+    if raw is not None and not roots:
+        raise RuntimeError(f"{name} is set but contains no valid roots")
+    if not roots:
+        raise RuntimeError(f"{name} resolved to an empty root allowlist")
+    return roots
+
+
+def _resolve_untrusted_request_path(path_value: str, *, repo_root: Path | None = None) -> Path:
+    raw = str(path_value or "").strip()
+    if not raw or raw.startswith("~") or "\x00" in raw:
+        raise ValueError("Invalid path value")
+    candidate = Path(raw)
+    if not candidate.is_absolute():
+        candidate = _repo_root(repo_root) / candidate
+    return Path(os.path.realpath(candidate))
+
+
+def _validate_path_against_roots(
+    path_value: str,
+    allowed_roots: List[Path],
+    *,
+    repo_root: Path | None = None,
+) -> str:
+    return str(_resolve_allowed_request_path(path_value, allowed_roots, repo_root=repo_root))
+
+
+def _resolve_allowed_request_path(
+    path_value: str,
+    allowed_roots: List[Path],
+    *,
+    repo_root: Path | None = None,
+) -> Path:
+    if not allowed_roots:
+        raise PathSecurityValidationError("No allowed roots configured", reason="invalid_path_value")
+
+    try:
+        resolved = _resolve_untrusted_request_path(path_value, repo_root=repo_root)
+    except (OSError, RuntimeError, ValueError):
+        raise PathSecurityValidationError("Invalid path value", reason="invalid_path_value") from None
+
+    for root in allowed_roots:
+        try:
+            root_real = Path(os.path.realpath(root))
+        except (OSError, RuntimeError, ValueError):
+            continue
+        try:
+            resolved.relative_to(root_real)
+        except ValueError:
+            continue
+        else:
+            return resolved
+
+    raise PathSecurityValidationError("Path outside allowed roots", reason="path_outside_allowed_roots")
+
+
+def _path_is_within_root(resolved_path: Path, root: Path) -> bool:
+    try:
+        resolved_path.relative_to(Path(os.path.realpath(root)))
+    except ValueError:
+        return False
+    return True
+
+
+def _trusted_allowed_entry(
+    resolved_path: Path,
+    allowed_roots: List[Path],
+) -> Optional[Path]:
+    for root in allowed_roots:
+        try:
+            root_real = Path(os.path.realpath(root))
+            relative_parts = resolved_path.relative_to(root_real).parts
+        except (OSError, RuntimeError, ValueError):
+            continue
+        current = root_real
+        if not relative_parts:
+            return current
+        for part in relative_parts:
+            if part in {"", ".", ".."}:
+                return None
+            try:
+                next_path = next((child for child in current.iterdir() if child.name == part), None)
+            except (NotADirectoryError, FileNotFoundError, OSError, RuntimeError, ValueError):
+                return None
+            if next_path is None:
+                return None
+            current = next_path
+        return current
+    return None
+
+
+def _trusted_existing_dir(value: str, allowed_roots: List[Path], *, repo_root: Path | None = None) -> Optional[Path]:
+    """Return ``value`` as a trusted existing directory inside an allowed root."""
+
+    try:
+        resolved = _resolve_allowed_request_path(value, allowed_roots, repo_root=repo_root)
+    except PathSecurityValidationError:
+        return None
+    trusted = _trusted_allowed_entry(resolved, allowed_roots)
+    if trusted is None:
+        return None
+    try:
+        if not trusted.is_dir():
+            return None
+    except OSError:
+        return None
+    return trusted
+
+
+def _trusted_creatable_dir(value: str, allowed_roots: List[Path], *, repo_root: Path | None = None) -> Optional[Path]:
+    """Return ``value`` as a trusted directory path safe to ``mkdir`` later."""
+
+    try:
+        resolved = _resolve_allowed_request_path(value, allowed_roots, repo_root=repo_root)
+    except PathSecurityValidationError:
+        return None
+    for root in allowed_roots:
+        try:
+            root_real = Path(os.path.realpath(root))
+            relative_parts = resolved.relative_to(root_real).parts
+        except (OSError, RuntimeError, ValueError):
+            continue
+        current = root_real
+        creating = False
+        for part in relative_parts:
+            if part in {"", ".", ".."} or _UNSAFE_PATH_SEGMENT_RE.search(part):
+                return None
+            if creating:
+                current = current / part
+                continue
+            try:
+                next_path = next((child for child in current.iterdir() if child.name == part), None)
+            except (NotADirectoryError, FileNotFoundError, OSError, RuntimeError, ValueError):
+                return None
+            if next_path is None:
+                creating = True
+                current = current / part
+            else:
+                current = next_path
+        return current
+    return None
+
+
+def _ensure_safe_regular_file_path(
+    path_value: Path,
+    allowed_roots: List[Path],
+    *,
+    repo_root: Path | None = None,
+) -> Path:
+    try:
+        candidate_real = _resolve_allowed_request_path(str(path_value), allowed_roots, repo_root=repo_root)
+    except PathSecurityValidationError:
+        raise
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise PathSecurityValidationError("Invalid path value", reason="invalid_path_value") from exc
+    trusted_entry = _trusted_allowed_entry(candidate_real, allowed_roots)
+    if trusted_entry is None:
+        raise PathSecurityValidationError("Invalid path value", reason="invalid_path_value")
+    try:
+        if not trusted_entry.is_file():
+            raise PathSecurityValidationError("Invalid path value", reason="invalid_path_value")
+    except OSError as exc:
+        raise PathSecurityValidationError("Invalid path value", reason="invalid_path_value") from exc
+    return trusted_entry

--- a/tests/portal/test_path_security.py
+++ b/tests/portal/test_path_security.py
@@ -1,0 +1,111 @@
+"""Unit tests for portal path security helpers."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from transformation_portal.portal import path_security
+from transformation_portal.portal.path_security import PathSecurityValidationError, _resolve_allowed_request_path
+
+pytestmark = [pytest.mark.unit, pytest.mark.security]
+
+
+def test_path_security_import_does_not_import_app() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sys; from transformation_portal.portal import path_security; print('app' in sys.modules)",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.stdout.strip() == "False"
+
+
+def test_direct_helper_import_resolves_allowed_path(tmp_path: Path) -> None:
+    target = tmp_path / "asset.png"
+    target.write_bytes(b"x")
+
+    assert _resolve_allowed_request_path(str(target), [tmp_path]) == Path(os.path.realpath(target))
+
+
+def test_path_security_error_reasons_stay_distinct(tmp_path: Path) -> None:
+    allowed_root = tmp_path / "allowed"
+    allowed_root.mkdir()
+
+    with pytest.raises(PathSecurityValidationError) as invalid_exc:
+        path_security._resolve_allowed_request_path("bad\x00path", [allowed_root])
+
+    outside_path = tmp_path / "outside" / "asset.txt"
+    with pytest.raises(PathSecurityValidationError) as outside_exc:
+        path_security._resolve_allowed_request_path(str(outside_path), [allowed_root])
+
+    assert invalid_exc.value.reason == "invalid_path_value"
+    assert outside_exc.value.reason == "path_outside_allowed_roots"
+
+
+def test_path_security_rejects_symlink_escape_for_existing_dir(tmp_path: Path) -> None:
+    allowed_root = tmp_path / "allowed"
+    outside_root = tmp_path / "outside"
+    allowed_root.mkdir()
+    outside_root.mkdir()
+    outside_dir = outside_root / "data"
+    outside_dir.mkdir()
+    symlink_path = allowed_root / "linked-data"
+    symlink_path.symlink_to(outside_dir, target_is_directory=True)
+
+    with pytest.raises(PathSecurityValidationError) as exc_info:
+        path_security._resolve_allowed_request_path(str(symlink_path), [allowed_root])
+
+    assert exc_info.value.reason == "path_outside_allowed_roots"
+    assert path_security._trusted_existing_dir(str(symlink_path), [allowed_root]) is None
+
+
+def test_path_security_existing_dir_checks_match_app_contract(tmp_path: Path) -> None:
+    existing_dir = tmp_path / "dir"
+    existing_dir.mkdir()
+    existing_file = tmp_path / "file.txt"
+    existing_file.write_text("x", encoding="utf-8")
+
+    assert path_security._trusted_existing_dir(str(existing_dir), [tmp_path]) == existing_dir
+    assert path_security._trusted_existing_dir(str(existing_file), [tmp_path]) is None
+    assert path_security._trusted_existing_dir(str(tmp_path.parent), [tmp_path]) is None
+
+
+def test_path_security_creatable_dir_returns_path_without_creating_it(tmp_path: Path) -> None:
+    output_dir = tmp_path / "new-output"
+
+    trusted = path_security._trusted_creatable_dir(str(output_dir), [tmp_path])
+
+    assert trusted == output_dir
+    assert not output_dir.exists()
+
+
+def test_path_security_safe_regular_file_validation(tmp_path: Path) -> None:
+    target = tmp_path / "good.png"
+    target.write_bytes(b"\x89PNG")
+    subdir = tmp_path / "dir"
+    subdir.mkdir()
+    missing = tmp_path / "missing.png"
+    outside = tmp_path.parent / "outside.png"
+
+    assert path_security._ensure_safe_regular_file_path(target, [tmp_path]) == target
+
+    with pytest.raises(PathSecurityValidationError) as dir_exc:
+        path_security._ensure_safe_regular_file_path(subdir, [tmp_path])
+    with pytest.raises(PathSecurityValidationError) as missing_exc:
+        path_security._ensure_safe_regular_file_path(missing, [tmp_path])
+    with pytest.raises(PathSecurityValidationError) as outside_exc:
+        path_security._ensure_safe_regular_file_path(outside, [tmp_path])
+
+    assert dir_exc.value.reason == "invalid_path_value"
+    assert missing_exc.value.reason == "invalid_path_value"
+    assert outside_exc.value.reason == "path_outside_allowed_roots"

--- a/tests/test_app_path_security_extraction_contract.py
+++ b/tests/test_app_path_security_extraction_contract.py
@@ -67,6 +67,20 @@ def test_phase_2b_symlink_escape_is_rejected_for_existing_dir(tmp_path: Path) ->
     assert orchestrator_app._trusted_existing_dir(str(symlink_path), [allowed_root]) is None
 
 
+def test_phase_2b_safe_regular_file_preserves_outside_root_reason(tmp_path: Path) -> None:
+    allowed_root = tmp_path / "allowed"
+    outside_root = tmp_path / "outside"
+    allowed_root.mkdir()
+    outside_root.mkdir()
+    outside_file = outside_root / "asset.png"
+    outside_file.write_bytes(b"x")
+
+    with pytest.raises(orchestrator_app._PortalValidationReasonError) as exc_info:
+        orchestrator_app._ensure_safe_regular_file_path(outside_file, [allowed_root])
+
+    assert exc_info.value.reason == "path_outside_allowed_roots"
+
+
 def test_phase_2b_trusted_creatable_dir_returns_path_without_creating_it(tmp_path: Path) -> None:
     allowed_root = tmp_path / "allowed"
     allowed_root.mkdir()


### PR DESCRIPTION
## Summary
- Extract the ADR-046 app path-security helper seam into `transformation_portal.portal.path_security` without changing route behavior or public error envelopes.
- Keep `app.py` as the compatibility surface for existing private helper access and `_PortalValidationReasonError` translation.

## Changes
- Add `src/transformation_portal/portal/path_security.py` with app-independent path root normalization, allowlist parsing, untrusted path resolution, trusted entry walking, existing/creatable directory checks, safe regular-file validation, and `_path_is_within_root`.
- Convert the matching `app.py` helper definitions to wrappers that delegate to the extracted module and translate `PathSecurityValidationError` back to `_PortalValidationReasonError`.
- Preserve app-owned runtime config in `app.py`, including allowed roots, upload root resolution, and public validation-reason behavior.
- Add direct module and legacy compatibility tests for reason codes, symlink escape rejection, creatable directory behavior, upload-root resolution, and safe-file validation.
- Mark Target 2B as landed in the monolith decomposition ledger.

## Validation
Proven green:
- `.venv/bin/python -m pytest tests/portal/test_path_security.py tests/test_app_path_security_extraction_contract.py tests/test_app_security.py tests/test_portal_backend_hardening.py -q` -> 81 passed
- `.venv/bin/python -m pytest tests/test_app_orchestrator_contract_http.py tests/test_app_orchestrator_runtime.py -k "path or upload or archive or fastvlm or artifact" -q` -> 164 passed, 218 deselected
- `make check-json-serialization check-yaml-governance check-python-headers`
- `.venv/bin/python scripts/validation/scan_todo_inventory.py --check-governance` -> 25 tracked TODOs, 0 ungoverned
- `make test-fast` -> 77 passed
- pre-commit on commit, including Black, isort, test marker checks, and gitleaks parity

Still failing:
- None observed.

## Risk
- Security-sensitive path behavior is preserved behind compatibility wrappers; the extracted module does not import `app.py`.
- `_PortalValidationReasonError`, runtime config, upload-root ownership, and public error-envelope logic remain in `app.py`.
- The change is bounded and revert-safe: existing callers continue importing private helpers through `app.py`, while internal callers can now import `transformation_portal.portal.path_security` directly.
