### PR TITLE
fix(portal): suppress intentional temp-root bandit finding

### DIFF
--- a/src/transformation_portal/portal/path_security.py
+++ b/src/transformation_portal/portal/path_security.py
@@ -41,7 +41,7 @@ def _default_allowed_path_roots(*, repo_root: Path | None = None) -> List[Path]:
     candidate_paths: List[Path] = [Path(tempfile.gettempdir()).resolve()]
     if os.name != "nt":
         # Accept the common POSIX temp aliases used by operators and local tooling.
-        candidate_paths.extend([Path("/tmp"), Path("/private/tmp")])
+        candidate_paths.extend([Path("/tmp"), Path("/private/tmp")])  # nosec B108 - allowed-root aliases only.
 
     for candidate in candidate_paths:
         try:


### PR DESCRIPTION
## Summary
- Security Scans failed after #1659 because the extracted `portal.path_security` module now lives under `src/`, where Bandit scans the existing POSIX temp-root aliases.
- Add a scoped `# nosec B108` annotation to the intentional allowed-root alias line without changing path-security behavior.

## Changes
- Annotate the `Path("/tmp")` and `Path("/private/tmp")` default allowed-root aliases with a targeted `B108` suppression.
- Preserve root normalization, symlink handling, upload-root behavior, and reason-code semantics exactly.

## Validation
Proven green:
- `.venv/bin/python -m pip install -r requirements/security.txt`
- `.venv/bin/python -m bandit -r src/ -ll -ii -f screen`
- `.venv/bin/python -m pytest tests/portal/test_path_security.py tests/test_app_path_security_extraction_contract.py tests/test_app_security.py tests/test_portal_backend_hardening.py -q` -> 81 passed
- `make check-json-serialization check-yaml-governance check-python-headers`
- `.venv/bin/python scripts/validation/scan_todo_inventory.py --check-governance` -> 25 tracked TODOs, 0 ungoverned
- pre-commit on commit, including Black, isort, and gitleaks parity

Still failing:
- None observed locally.

## Risk
- This is a security-scan annotation only; runtime behavior is unchanged.
- The exception is narrow and tied to the existing allowed-root aliases, which are normalized through `realpath` and are not temp file creation.
- Revert-safe: removing this commit restores the exact #1659 source line.
