### PR TITLE
docs(portal): gate sam2 checkpoint extraction

### DIFF
--- a/docs/architecture/ADR-047-managed-sam2-checkpoint-security-extraction.md
+++ b/docs/architecture/ADR-047-managed-sam2-checkpoint-security-extraction.md
@@ -1,0 +1,93 @@
+# ADR-047: Managed SAM2 Checkpoint Security Extraction Contract
+
+**Status:** Proposed
+**Date:** 2026-05-06
+**Decision Makers:** Architect (review) + Specialist (implementation)
+**Replaces:** None
+**Supersedes:** None
+**Related:** [ADR-045 Monolith Decomposition Residuals](ADR-045-monolith-decomposition-residuals.md), [ADR-046 App Path Security Helper Extraction Contract](ADR-046-app-path-security-helper-extraction.md), [Monolith Decomposition Targets](MONOLITH_DECOMPOSITION_TARGETS.md), [Dependency ML Alert Triage](../governance/DEPENDABOT_ML_ALERT_TRIAGE_2026-04-16.md)
+
+---
+
+## Executive Summary
+
+Target 2C may extract managed SAM2 checkpoint validation and checksum-cache helpers only after this contract is reviewed. The future destination module is `src/transformation_portal/portal/sam2_checkpoint_security.py`. The extraction must be compatibility-only: no behavior changes to repo-controlled missing checkpoint acceptance, external checksum trust, bounded cache eviction, reason codes, preview errors, dispatch errors, or SAM2 backend semantics.
+
+`app.py` remains the legacy compatibility surface. Existing private helper access through `app.py` must continue to work for tests and internal callers.
+
+---
+
+## Context
+
+Managed portal/orchestrator SAM2 paths are security-sensitive because they admit model checkpoint files into a server-side execution path. Current behavior deliberately accepts repo-controlled SAM2 paths before the artifact exists locally, but external checkpoint files are accepted only when their SHA-256 digest appears in the app-owned trusted SHA set.
+
+Target 2B extracted pure path-security helpers behind ADR-046. Target 2C is the next adjacent app decomposition slice, but its trust-source boundary must be explicit before extraction because the runtime currently keeps SAM2 trusted checkpoint digests in app-owned constants rather than loading them from `config/model_lock_manifest.yaml`.
+
+---
+
+## Decision
+
+Target 2C extraction is allowed only under these constraints:
+
+1. `src/transformation_portal/portal/sam2_checkpoint_security.py` owns pure SAM2 checkpoint validation and checksum-cache helper logic and must not import `app.py`.
+2. `app.py` wraps or re-exports the legacy private helper and model names so existing imports and monkeypatch-based tests continue to work.
+3. `_PortalValidationReasonError` stays in `app.py`; the extracted module must use its own private validation error carrying a stable `reason`.
+4. `ALLOWED_INPUT_ROOTS`, `MANAGED_SAM2_TRUSTED_ROOTS`, `MANAGED_SAM2_TRUSTED_SHA256`, `MANAGED_SAM2_CHECKSUM_MAX_BYTES`, `_MANAGED_SAM2_CHECKSUM_CACHE_LOCK`, and public error-envelope mapping remain app-owned runtime configuration for Target 2C.
+5. The extracted module must accept app-owned trust/config values by parameter or wrapper injection.
+6. The current app-owned trusted SHA semantics are the Target 2C extraction contract. Migrating SAM2 checkpoint trust into `config/model_lock_manifest.yaml` requires a separate ADR/update and migration PR.
+7. No call-site rewrites outside `app.py` are allowed in the extraction PR unless a compatibility test proves an existing public contract already imports the new module directly.
+
+The extraction surface approved for Target 2C is:
+
+- `ManagedSam2CheckpointValidationResult`
+- `_ManagedSam2ChecksumCacheEntry`
+- `_Sam2CacheKey`
+- `_ManagedSam2BoundedChecksumCache`
+- `_managed_sam2_reason_message`
+- `_managed_sam2_checksum_cache_key`
+- `_clear_managed_sam2_checksum_cache`
+- `_hash_file_sha256`
+- `_cached_managed_sam2_checksum_result`
+- `_resolve_managed_sam2_checkpoint_validation`
+- `_validate_managed_sam2_checkpoint_path`
+
+---
+
+## Security Review Checklist
+
+The Target 2C extraction PR must show explicit review evidence for:
+
+- Repo-controlled missing checkpoint paths remain accepted only under trusted SAM2 roots.
+- External checkpoint files remain rejected unless their SHA-256 digest is trusted.
+- Oversized external checkpoint files fail before hashing with `checkpoint_file_too_large`.
+- Invalid path values, outside-root escapes, and non-file paths preserve existing reason codes.
+- Preview and dispatch paths preserve matching `sam2_checkpoint_path` error codes.
+- The bounded checksum cache preserves key fields, hash reuse, cache clearing, and FIFO eviction behavior.
+- The extracted module does not import `app.py` and cannot silently read app globals.
+- Any future model-lock manifest migration is reviewed separately and does not ride along with the extraction PR.
+
+---
+
+## Implementation Plan
+
+1. Prep PR: land this ADR, update the Target 2C readiness row, and add extraction-readiness tests that still import through `app.py`.
+2. Extraction PR: add `portal/sam2_checkpoint_security.py`, delegate from `app.py`, keep app-owned runtime configuration and `_PortalValidationReasonError` in `app.py`, and preserve all listed helper names.
+3. Follow-up only if approved: migrate SAM2 checkpoint trust into a governed manifest source with explicit tests for manifest loading, fallback behavior, and error semantics.
+
+---
+
+## Success Metrics
+
+- Existing SAM2 checkpoint preview, dispatch, and app runtime tests stay green before and after extraction.
+- `app.py` remains the compatibility import surface for all listed private helper and model names.
+- No route shape, selector, API envelope, CLI argument, output filename, reason code, or public error-message behavior changes.
+- The extraction PR cites this ADR and passes ADR-045 governance gates.
+
+---
+
+## References
+
+- `app.py` managed SAM2 checkpoint validation helpers and callers.
+- `tests/test_app_orchestrator_runtime.py`
+- `tests/test_app_orchestrator_contract_http.py`
+- `docs/governance/DEPENDABOT_ML_ALERT_TRIAGE_2026-04-16.md`

--- a/docs/architecture/MONOLITH_DECOMPOSITION_TARGETS.md
+++ b/docs/architecture/MONOLITH_DECOMPOSITION_TARGETS.md
@@ -128,7 +128,7 @@ Approx LOC: ~415. Re-export from `app.py` as `from transformation_portal.portal.
 
 **Deferred slices (track here, do not promote until 2A lands):**
 - *2B — Path resolution & security helpers* (`app.py:428–667` -> `src/transformation_portal/portal/path_security.py`). High risk: hardening surface; allowed-roots, symlink safety, untrusted-path validation. Landed behind the ADR-046 compatibility contract.
-- *2C — SAM2 checksum cache* (`app.py:773–827, 1336–1440`). Medium risk: model-lock semantics and bounded cache eviction. Defer until SAM2 model-lock manifest migration is settled.
+- *2C — SAM2 checkpoint security helpers* (`app.py` -> `src/transformation_portal/portal/sam2_checkpoint_security.py`). Medium risk: model-lock semantics and bounded cache eviction. Ready after ADR-047/SAM2 checkpoint trust contract; manifest migration remains a separate future decision.
 
 ---
 
@@ -173,6 +173,7 @@ This table is the canonical progress ledger for extraction PRs that draw from th
 | Target 1C — Backend resolution & state | `lux_depth_v3/orchestrator.py` | `lux_depth_v3/pipeline_coordinator.py` | Landed | This PR: backend initialization and runtime attempt-state helpers extracted |
 | Target 2A — Portal asset bundle | `app.py` | `src/transformation_portal/portal/asset_bundle.py` | Landed | This PR: portal asset bundle helpers extracted |
 | Target 2B — Path resolution & security helpers | `app.py` | `src/transformation_portal/portal/path_security.py` | Landed | This PR: path security helpers extracted behind ADR-046 app compatibility wrappers |
+| Target 2C — SAM2 checkpoint security helpers | `app.py` | `src/transformation_portal/portal/sam2_checkpoint_security.py` | Ready after ADR-047 | This PR: prep contract pins app-owned SAM2 trust semantics and extraction-sensitive cache behavior |
 | Target 3A — Segmentation cache helpers | `lux_depth_v3/segmentation_backend.py` | `lux_depth_v3/segmentation/_cache.py` | Landed | This PR: segmentation cache helpers extracted |
 | Target 3B — Stub backend | `lux_depth_v3/segmentation_backend.py` | `lux_depth_v3/segmentation/stub.py` | Landed | This PR: stub backend extracted |
 | Target 3C — EfficientSAM backend | `lux_depth_v3/segmentation_backend.py` | `lux_depth_v3/segmentation/efficient_sam.py` | Landed | This PR: EfficientSAM backend extracted |

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -31,6 +31,7 @@ ADRs are **binding decisions** that define the repository's architecture, securi
 | [ADR-021](ADR-021-huggingface-revision-policy.md) | HuggingFace Revision Pinning | Accepted | 2026-02-03 | Architect |
 | [ADR-024](ADR-024-apache-iceberg-ban.md) | Apache Iceberg Ban | Accepted | 2026 | Architect |
 | [ADR-046](ADR-046-app-path-security-helper-extraction.md) | App Path Security Helper Extraction Contract | Proposed | 2026-05-06 | Architect |
+| [ADR-047](ADR-047-managed-sam2-checkpoint-security-extraction.md) | Managed SAM2 Checkpoint Security Extraction Contract | Proposed | 2026-05-06 | Architect |
 
 ### Tier & Licensing
 

--- a/tests/test_app_sam2_checkpoint_extraction_contract.py
+++ b/tests/test_app_sam2_checkpoint_extraction_contract.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Phase 2C extraction-readiness contract for app SAM2 checkpoint helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import os
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.security]
+
+orchestrator_app = importlib.import_module("app")
+
+
+_PHASE_2C_LEGACY_NAMES = (
+    "ManagedSam2CheckpointValidationResult",
+    "_ManagedSam2ChecksumCacheEntry",
+    "_Sam2CacheKey",
+    "_ManagedSam2BoundedChecksumCache",
+    "_managed_sam2_reason_message",
+    "_managed_sam2_checksum_cache_key",
+    "_clear_managed_sam2_checksum_cache",
+    "_hash_file_sha256",
+    "_cached_managed_sam2_checksum_result",
+    "_resolve_managed_sam2_checkpoint_validation",
+    "_validate_managed_sam2_checkpoint_path",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_managed_sam2_checksum_cache() -> None:
+    orchestrator_app._clear_managed_sam2_checksum_cache()
+    yield
+    orchestrator_app._clear_managed_sam2_checksum_cache()
+
+
+def _realpath(path: Path) -> Path:
+    return Path(os.path.realpath(path))
+
+
+def test_phase_2c_legacy_sam2_checkpoint_helpers_remain_available_from_app() -> None:
+    for helper_name in _PHASE_2C_LEGACY_NAMES:
+        assert getattr(orchestrator_app, helper_name) is not None
+
+
+def test_phase_2c_managed_sam2_reason_messages_preserve_codes() -> None:
+    assert (
+        orchestrator_app._managed_sam2_reason_message("checkpoint_file_too_large")
+        == "SAM2 checkpoint path exceeds checksum verification size limit"
+    )
+    assert orchestrator_app._managed_sam2_reason_message("invalid_path_value") == "Invalid path value"
+    assert orchestrator_app._managed_sam2_reason_message("path_outside_allowed_roots") == "Path outside allowed roots"
+    assert orchestrator_app._managed_sam2_reason_message("untrusted_checkpoint_path") == "SAM2 checkpoint path is not trusted"
+    assert orchestrator_app._managed_sam2_reason_message("unknown_reason") == "Invalid path value"
+
+
+def test_phase_2c_repo_controlled_missing_checkpoint_path_remains_accepted() -> None:
+    validation = orchestrator_app._resolve_managed_sam2_checkpoint_validation("./models/sam2/sam2.1_hiera_large.pt")
+
+    assert validation.reason is None
+    assert validation.normalized_path is not None
+    assert validation.normalized_path.endswith("models/sam2/sam2.1_hiera_large.pt")
+
+
+def test_phase_2c_invalid_path_reason_is_preserved(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(orchestrator_app, "ALLOWED_INPUT_ROOTS", [_realpath(tmp_path)])
+
+    validation = orchestrator_app._resolve_managed_sam2_checkpoint_validation("bad\x00path")
+
+    assert validation.normalized_path is None
+    assert validation.reason == "invalid_path_value"
+    with pytest.raises(orchestrator_app._PortalValidationReasonError) as exc_info:
+        orchestrator_app._validate_managed_sam2_checkpoint_path("bad\x00path")
+    assert exc_info.value.reason == "invalid_path_value"
+
+
+def test_phase_2c_outside_root_reason_is_preserved(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    allowed_root = _realpath(tmp_path / "allowed")
+    outside_root = _realpath(tmp_path / "outside")
+    allowed_root.mkdir()
+    outside_root.mkdir()
+    checkpoint_path = outside_root / "sam2-outside.pt"
+    checkpoint_path.write_bytes(b"outside")
+    monkeypatch.setattr(orchestrator_app, "ALLOWED_INPUT_ROOTS", [allowed_root])
+
+    validation = orchestrator_app._resolve_managed_sam2_checkpoint_validation(str(checkpoint_path))
+
+    assert validation.normalized_path is None
+    assert validation.reason == "path_outside_allowed_roots"
+
+
+def test_phase_2c_external_checkpoint_requires_trusted_digest(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    input_root = _realpath(tmp_path)
+    checkpoint_path = input_root / "sam2-governed.pt"
+    checkpoint_bytes = b"trusted checkpoint bytes"
+    checkpoint_path.write_bytes(checkpoint_bytes)
+    digest = hashlib.sha256(checkpoint_bytes).hexdigest()
+    monkeypatch.setattr(orchestrator_app, "ALLOWED_INPUT_ROOTS", [input_root])
+    monkeypatch.setattr(orchestrator_app, "MANAGED_SAM2_TRUSTED_SHA256", {digest})
+
+    trusted = orchestrator_app._resolve_managed_sam2_checkpoint_validation(str(checkpoint_path))
+
+    assert trusted.reason is None
+    assert trusted.normalized_path == str(checkpoint_path)
+
+    orchestrator_app._clear_managed_sam2_checksum_cache()
+    monkeypatch.setattr(orchestrator_app, "MANAGED_SAM2_TRUSTED_SHA256", set())
+
+    untrusted = orchestrator_app._resolve_managed_sam2_checkpoint_validation(str(checkpoint_path))
+
+    assert untrusted.normalized_path is None
+    assert untrusted.reason == "untrusted_checkpoint_path"
+
+
+def test_phase_2c_oversized_checkpoint_reason_is_preserved(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    input_root = _realpath(tmp_path)
+    checkpoint_path = input_root / "sam2-oversized.pt"
+    checkpoint_path.write_bytes(b"oversized")
+    monkeypatch.setattr(orchestrator_app, "ALLOWED_INPUT_ROOTS", [input_root])
+    monkeypatch.setattr(orchestrator_app, "MANAGED_SAM2_CHECKSUM_MAX_BYTES", 1)
+
+    validation = orchestrator_app._resolve_managed_sam2_checkpoint_validation(str(checkpoint_path))
+
+    assert validation.normalized_path is None
+    assert validation.reason == "checkpoint_file_too_large"
+    with pytest.raises(orchestrator_app._PortalValidationReasonError) as exc_info:
+        orchestrator_app._validate_managed_sam2_checkpoint_path(str(checkpoint_path))
+    assert exc_info.value.reason == "checkpoint_file_too_large"
+
+
+def test_phase_2c_checksum_cache_key_shape_tracks_file_identity(tmp_path: Path) -> None:
+    checkpoint_path = _realpath(tmp_path / "sam2-keyed.pt")
+    checkpoint_path.write_bytes(b"checkpoint")
+
+    cache_key = orchestrator_app._managed_sam2_checksum_cache_key(checkpoint_path)
+
+    assert isinstance(cache_key, orchestrator_app._Sam2CacheKey)
+    assert cache_key.path == str(checkpoint_path)
+    assert cache_key.size == len(b"checkpoint")
+    assert isinstance(cache_key.mtime_ns, int)
+    assert isinstance(cache_key.dev, int)
+    assert isinstance(cache_key.ino, int)
+    assert isinstance(cache_key.ctime_ns, int)
+
+
+def test_phase_2c_checksum_cache_reuses_hash_results_and_clear_resets_state(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    input_root = _realpath(tmp_path)
+    checkpoint_path = input_root / "sam2-cached.pt"
+    checkpoint_bytes = b"cached checkpoint bytes"
+    checkpoint_path.write_bytes(checkpoint_bytes)
+    digest = hashlib.sha256(checkpoint_bytes).hexdigest()
+    monkeypatch.setattr(orchestrator_app, "ALLOWED_INPUT_ROOTS", [input_root])
+    monkeypatch.setattr(orchestrator_app, "MANAGED_SAM2_TRUSTED_SHA256", {digest})
+
+    hash_calls: list[Path] = []
+    original_hash = orchestrator_app._hash_file_sha256
+
+    def _counting_hash(path: Path, chunk_size: int = 1024 * 1024) -> str:
+        hash_calls.append(path)
+        return original_hash(path, chunk_size)
+
+    monkeypatch.setattr(orchestrator_app, "_hash_file_sha256", _counting_hash)
+
+    first = orchestrator_app._validate_managed_sam2_checkpoint_path(str(checkpoint_path))
+    second = orchestrator_app._validate_managed_sam2_checkpoint_path(str(checkpoint_path))
+
+    assert first == str(checkpoint_path)
+    assert second == str(checkpoint_path)
+    assert hash_calls == [checkpoint_path]
+    assert len(orchestrator_app._MANAGED_SAM2_CHECKSUM_CACHE) == 1
+
+    orchestrator_app._clear_managed_sam2_checksum_cache()
+
+    assert len(orchestrator_app._MANAGED_SAM2_CHECKSUM_CACHE) == 0
+
+
+def test_phase_2c_bounded_checksum_cache_preserves_fifo_eviction() -> None:
+    cache = orchestrator_app._ManagedSam2BoundedChecksumCache(max_entries=2)
+    entry = orchestrator_app._ManagedSam2ChecksumCacheEntry(digest="abc", reason=None)
+    key1 = orchestrator_app._Sam2CacheKey("/path/a.pt", 100, 1000, 1, 1001, 2000)
+    key2 = orchestrator_app._Sam2CacheKey("/path/b.pt", 200, 1000, 1, 1002, 2000)
+    key3 = orchestrator_app._Sam2CacheKey("/path/c.pt", 300, 1000, 1, 1003, 2000)
+
+    cache[key1] = entry
+    cache[key2] = entry
+    cache[key3] = entry
+
+    assert key1 not in cache
+    assert key2 in cache
+    assert key3 in cache
+    assert len(cache) == 2
+
+    cache[key2] = orchestrator_app._ManagedSam2ChecksumCacheEntry(digest="updated", reason=None)
+    assert len(cache) == 2
+    assert cache[key2].digest == "updated"
+
+    cache.clear()
+
+    assert len(cache) == 0
+    assert len(cache._insertion_order) == 0


### PR DESCRIPTION
## Summary
- Locks the Target 2C SAM2 checkpoint-security extraction contract before moving production helpers.
- Keeps current app-owned trusted SHA semantics explicit so later extraction can be compatibility-only.

## Changes
- Adds ADR-047 for the future `portal/sam2_checkpoint_security.py` extraction boundary.
- Updates the architecture ADR index and Target 2C decomposition status without re-ranking unrelated targets.
- Adds app-level contract tests for legacy SAM2 helper availability, reason-code preservation, repo-controlled missing checkpoint acceptance, trusted external digest behavior, checksum cache keying, hash reuse, cache clearing, and FIFO eviction.
- No production helper extraction, route, selector, API envelope, CLI, model-lock manifest, or runtime behavior changes.

## Validation
Proven green:
- `git diff --check`
- `.venv/bin/python -m pytest tests/test_app_sam2_checkpoint_extraction_contract.py tests/test_app_orchestrator_runtime.py tests/test_app_orchestrator_contract_http.py tests/validation/test_portal_smoke_scripts.py -k "sam2_checkpoint or managed_sam2 or sam2" -q`
- `.venv/bin/python -m pytest tests/test_app_security.py tests/test_portal_backend_hardening.py -q`
- `make check-json-serialization check-yaml-governance check-python-headers`
- `.venv/bin/python scripts/validation/scan_todo_inventory.py --check-governance`
- Commit pre-commit hook suite

Still failing:
- None observed.

## Risk
- Prep-only docs/test change; no production code moves in this PR.
- Revert-safe because it only adds the contract harness and readiness documentation.
- The future extraction remains bounded: `app.py` stays the compatibility surface, and any SAM2 model-lock manifest migration is explicitly deferred to a separate ADR/update.
