### PR TITLE
refactor(portal): extract sam2 checkpoint security helpers

### DIFF
--- a/app.py
+++ b/app.py
@@ -29,7 +29,7 @@ from email.policy import default as email_policy
 from functools import lru_cache
 from importlib.util import find_spec
 from pathlib import Path, PurePosixPath
-from typing import Any, AsyncGenerator, Callable, Deque, Dict, Iterable, List, Mapping, NamedTuple, Optional, Tuple
+from typing import Any, AsyncGenerator, Callable, Deque, Dict, Iterable, List, Mapping, Optional, Tuple
 from urllib.parse import quote
 
 from fastapi import FastAPI, HTTPException, Request
@@ -69,6 +69,7 @@ from transformation_portal.lux_depth_v3.model_registry import resolve_model_spec
 from transformation_portal.lux_depth_v3.run_card_contract import infer_run_card_version
 from transformation_portal.portal import asset_bundle as _portal_asset_bundle
 from transformation_portal.portal import path_security as _portal_path_security
+from transformation_portal.portal import sam2_checkpoint_security as _portal_sam2_checkpoint_security
 from transformation_portal.portal.asset_bundle import (
     PORTAL_ASSETS_DIR,
     PORTAL_ASSETS_DIR_REAL,
@@ -88,6 +89,12 @@ from transformation_portal.portal.asset_bundle import (
     PortalAssetBundle,
     PortalAssetSpec,
     PortalRenderedTextAsset,
+)
+from transformation_portal.portal.sam2_checkpoint_security import (
+    ManagedSam2CheckpointValidationResult,
+    _ManagedSam2BoundedChecksumCache,
+    _ManagedSam2ChecksumCacheEntry,
+    _Sam2CacheKey,
 )
 from transformation_portal.vlm_captioning.fastvlm_runtime import (
     FASTVLM_CHECKPOINT_DIRS,
@@ -116,57 +123,7 @@ except Exception:  # pragma: no cover - observability never blocks startup
     LOGGER.debug("healthcheck log filter unavailable", exc_info=True)
 
 
-@dataclass(frozen=True)
-class ManagedSam2CheckpointValidationResult:
-    normalized_path: Optional[str]
-    reason: Optional[str] = None
-
-
-@dataclass(frozen=True)
-class _ManagedSam2ChecksumCacheEntry:
-    digest: Optional[str]
-    reason: Optional[str]
-
-
-class _Sam2CacheKey(NamedTuple):
-    """Cache key for SAM2 checkpoint trust results."""
-
-    path: str
-    size: int
-    mtime_ns: int
-    dev: int
-    ino: int
-    ctime_ns: int
-
-
-_MANAGED_SAM2_CHECKSUM_CACHE_MAX_ENTRIES = 128
-
-
-class _ManagedSam2BoundedChecksumCache(Dict[_Sam2CacheKey, _ManagedSam2ChecksumCacheEntry]):
-    """Bounded FIFO cache for SAM2 checkpoint trust results."""
-
-    def __init__(self, max_entries: int = _MANAGED_SAM2_CHECKSUM_CACHE_MAX_ENTRIES) -> None:
-        super().__init__()
-        if max_entries < 1:
-            raise ValueError("max_entries must be at least 1")
-        self._max_entries = max_entries
-        self._insertion_order: Deque[_Sam2CacheKey] = deque()
-
-    def __setitem__(
-        self,
-        key: _Sam2CacheKey,
-        value: _ManagedSam2ChecksumCacheEntry,
-    ) -> None:
-        if key not in self:
-            self._insertion_order.append(key)
-            if len(self._insertion_order) > self._max_entries:
-                oldest = self._insertion_order.popleft()
-                super().pop(oldest, None)
-        super().__setitem__(key, value)
-
-    def clear(self) -> None:
-        super().clear()
-        self._insertion_order.clear()
+_MANAGED_SAM2_CHECKSUM_CACHE_MAX_ENTRIES = _portal_sam2_checkpoint_security._MANAGED_SAM2_CHECKSUM_CACHE_MAX_ENTRIES
 
 
 def _env_csv(name: str, default: List[str]) -> List[str]:
@@ -529,111 +486,72 @@ def _ensure_safe_regular_file_path(path_value: Path, allowed_roots: List[Path]) 
         raise _portal_path_security_error(exc) from exc.__cause__
 
 
-_MANAGED_SAM2_REASON_MESSAGES = {
-    "checkpoint_file_too_large": "SAM2 checkpoint path exceeds checksum verification size limit",
-    "invalid_path_value": "Invalid path value",
-    "path_outside_allowed_roots": "Path outside allowed roots",
-    "path_shorthand_traversal_disallowed": "Path shorthand traversal disallowed",
-    "untrusted_checkpoint_path": "SAM2 checkpoint path is not trusted",
-}
+_MANAGED_SAM2_REASON_MESSAGES = _portal_sam2_checkpoint_security._MANAGED_SAM2_REASON_MESSAGES
 _MANAGED_SAM2_CHECKSUM_CACHE: _ManagedSam2BoundedChecksumCache = _ManagedSam2BoundedChecksumCache()
 
 
 def _managed_sam2_reason_message(reason: str) -> str:
-    """Return the canonical internal validation message for a SAM2 reason code."""
-    return _MANAGED_SAM2_REASON_MESSAGES.get(reason, "Invalid path value")
+    return _portal_sam2_checkpoint_security._managed_sam2_reason_message(reason)
 
 
 def _managed_sam2_checksum_cache_key(path: Path) -> _Sam2CacheKey:
-    """Build the checksum cache key for a trusted SAM2 checkpoint path."""
-    stat_result = path.stat()
-    return _Sam2CacheKey(
-        path=str(path),
-        size=stat_result.st_size,
-        mtime_ns=stat_result.st_mtime_ns,
-        dev=stat_result.st_dev,
-        ino=stat_result.st_ino,
-        ctime_ns=stat_result.st_ctime_ns,
-    )
+    return _portal_sam2_checkpoint_security._managed_sam2_checksum_cache_key(path)
 
 
 def _clear_managed_sam2_checksum_cache() -> None:
-    """Clear the in-process SAM2 checksum cache."""
-    with _MANAGED_SAM2_CHECKSUM_CACHE_LOCK:
-        _MANAGED_SAM2_CHECKSUM_CACHE.clear()
+    _portal_sam2_checkpoint_security._clear_managed_sam2_checksum_cache(
+        _MANAGED_SAM2_CHECKSUM_CACHE,
+        _MANAGED_SAM2_CHECKSUM_CACHE_LOCK,
+    )
 
 
 def _hash_file_sha256(path: Path, chunk_size: int = 1024 * 1024) -> str:
-    """Return the SHA-256 digest for a local file."""
-    digest = hashlib.sha256()
-    with path.open("rb") as handle:
-        for chunk in iter(lambda: handle.read(chunk_size), b""):
-            digest.update(chunk)
-    return digest.hexdigest()
+    return _portal_sam2_checkpoint_security._hash_file_sha256(path, chunk_size)
 
 
 def _cached_managed_sam2_checksum_result(path: Path) -> _ManagedSam2ChecksumCacheEntry:
-    """Return the cached or newly computed trust result for an external SAM2 checkpoint."""
     try:
-        cache_key = _managed_sam2_checksum_cache_key(path)
-    except OSError as exc:
-        raise _PortalValidationReasonError("Invalid path value", reason="invalid_path_value") from exc
-
-    with _MANAGED_SAM2_CHECKSUM_CACHE_LOCK:
-        cached = _MANAGED_SAM2_CHECKSUM_CACHE.get(cache_key)
-    if cached is not None:
-        return cached
-
-    if cache_key.size > MANAGED_SAM2_CHECKSUM_MAX_BYTES:
-        entry = _ManagedSam2ChecksumCacheEntry(digest=None, reason="checkpoint_file_too_large")
-    else:
-        digest = _hash_file_sha256(path)
-        reason = None if digest in MANAGED_SAM2_TRUSTED_SHA256 else "untrusted_checkpoint_path"
-        entry = _ManagedSam2ChecksumCacheEntry(digest=digest, reason=reason)
-
-    with _MANAGED_SAM2_CHECKSUM_CACHE_LOCK:
-        _MANAGED_SAM2_CHECKSUM_CACHE[cache_key] = entry
-    return entry
+        return _portal_sam2_checkpoint_security._cached_managed_sam2_checksum_result(
+            path,
+            trusted_sha256=MANAGED_SAM2_TRUSTED_SHA256,
+            checksum_max_bytes=MANAGED_SAM2_CHECKSUM_MAX_BYTES,
+            checksum_cache=_MANAGED_SAM2_CHECKSUM_CACHE,
+            checksum_cache_lock=_MANAGED_SAM2_CHECKSUM_CACHE_LOCK,
+            hash_file_sha256=_hash_file_sha256,
+        )
+    except _portal_sam2_checkpoint_security.Sam2CheckpointValidationError as exc:
+        raise _PortalValidationReasonError(str(exc), reason=exc.reason) from exc.__cause__
 
 
 def _resolve_managed_sam2_checkpoint_validation(path_value: str) -> ManagedSam2CheckpointValidationResult:
-    """Resolve a managed SAM2 checkpoint path and preserve the exact failure reason."""
-    try:
-        resolved = _resolve_allowed_request_path(path_value, ALLOWED_INPUT_ROOTS)
-    except _PortalValidationReasonError as exc:
-        return ManagedSam2CheckpointValidationResult(
-            normalized_path=None,
-            reason=_portal_reason_from_exception(exc, default="invalid_path_value"),
-        )
-    except (OSError, RuntimeError, ValueError):
-        return ManagedSam2CheckpointValidationResult(normalized_path=None, reason="invalid_path_value")
-
-    # Repo-controlled checkpoints remain valid even before the artifact exists locally.
-    if any(_path_is_within_root(resolved, root) for root in MANAGED_SAM2_TRUSTED_ROOTS):
-        return ManagedSam2CheckpointValidationResult(normalized_path=str(resolved), reason=None)
-
-    try:
-        safe_file = _ensure_safe_regular_file_path(resolved, ALLOWED_INPUT_ROOTS)
-    except _PortalValidationReasonError as exc:
-        return ManagedSam2CheckpointValidationResult(
-            normalized_path=None,
-            reason=_portal_reason_from_exception(exc, default="invalid_path_value"),
-        )
-
-    checksum_result = _cached_managed_sam2_checksum_result(safe_file)
-    if checksum_result.reason is not None:
-        return ManagedSam2CheckpointValidationResult(normalized_path=None, reason=checksum_result.reason)
-    return ManagedSam2CheckpointValidationResult(normalized_path=str(safe_file), reason=None)
+    return _portal_sam2_checkpoint_security._resolve_managed_sam2_checkpoint_validation(
+        path_value,
+        allowed_input_roots=ALLOWED_INPUT_ROOTS,
+        trusted_roots=MANAGED_SAM2_TRUSTED_ROOTS,
+        trusted_sha256=MANAGED_SAM2_TRUSTED_SHA256,
+        checksum_max_bytes=MANAGED_SAM2_CHECKSUM_MAX_BYTES,
+        checksum_cache=_MANAGED_SAM2_CHECKSUM_CACHE,
+        checksum_cache_lock=_MANAGED_SAM2_CHECKSUM_CACHE_LOCK,
+        repo_root=REPO_ROOT,
+        hash_file_sha256=_hash_file_sha256,
+    )
 
 
 def _validate_managed_sam2_checkpoint_path(path_value: str) -> str:
-    validation = _resolve_managed_sam2_checkpoint_validation(path_value)
-    if validation.reason is not None:
-        raise _PortalValidationReasonError(
-            _managed_sam2_reason_message(validation.reason),
-            reason=validation.reason,
+    try:
+        return _portal_sam2_checkpoint_security._validate_managed_sam2_checkpoint_path(
+            path_value,
+            allowed_input_roots=ALLOWED_INPUT_ROOTS,
+            trusted_roots=MANAGED_SAM2_TRUSTED_ROOTS,
+            trusted_sha256=MANAGED_SAM2_TRUSTED_SHA256,
+            checksum_max_bytes=MANAGED_SAM2_CHECKSUM_MAX_BYTES,
+            checksum_cache=_MANAGED_SAM2_CHECKSUM_CACHE,
+            checksum_cache_lock=_MANAGED_SAM2_CHECKSUM_CACHE_LOCK,
+            repo_root=REPO_ROOT,
+            hash_file_sha256=_hash_file_sha256,
         )
-    return str(validation.normalized_path or "")
+    except _portal_sam2_checkpoint_security.Sam2CheckpointValidationError as exc:
+        raise _PortalValidationReasonError(str(exc), reason=exc.reason) from exc.__cause__
 
 
 LOG_TAIL_LIMIT = 2000
@@ -6507,9 +6425,7 @@ def _serialize_indexed_artifact(
     sha256_hex, fingerprint_status = _artifact_fingerprint(path, size_bytes)
     download_url = _artifact_url(job_id, relative_path)
     proxy_path = _artifact_preview_proxy_path(path)
-    proxy_relative = (
-        f"{relative_path}.preview.png" if proxy_path is not None else None
-    )
+    proxy_relative = f"{relative_path}.preview.png" if proxy_path is not None else None
     browser_previewable = _artifact_is_browser_previewable(path) or proxy_path is not None
     payload: Dict[str, Any] = {
         "artifact_type": _infer_artifact_type(path),

--- a/app.py
+++ b/app.py
@@ -123,9 +123,6 @@ except Exception:  # pragma: no cover - observability never blocks startup
     LOGGER.debug("healthcheck log filter unavailable", exc_info=True)
 
 
-_MANAGED_SAM2_CHECKSUM_CACHE_MAX_ENTRIES = _portal_sam2_checkpoint_security._MANAGED_SAM2_CHECKSUM_CACHE_MAX_ENTRIES
-
-
 def _env_csv(name: str, default: List[str]) -> List[str]:
     raw = os.getenv(name)
     if raw is None:

--- a/docs/architecture/MONOLITH_DECOMPOSITION_TARGETS.md
+++ b/docs/architecture/MONOLITH_DECOMPOSITION_TARGETS.md
@@ -128,7 +128,7 @@ Approx LOC: ~415. Re-export from `app.py` as `from transformation_portal.portal.
 
 **Deferred slices (track here, do not promote until 2A lands):**
 - *2B — Path resolution & security helpers* (`app.py:428–667` -> `src/transformation_portal/portal/path_security.py`). High risk: hardening surface; allowed-roots, symlink safety, untrusted-path validation. Landed behind the ADR-046 compatibility contract.
-- *2C — SAM2 checkpoint security helpers* (`app.py` -> `src/transformation_portal/portal/sam2_checkpoint_security.py`). Medium risk: model-lock semantics and bounded cache eviction. Ready after ADR-047/SAM2 checkpoint trust contract; manifest migration remains a separate future decision.
+- *2C — SAM2 checkpoint security helpers* (`app.py` -> `src/transformation_portal/portal/sam2_checkpoint_security.py`). Medium risk: model-lock semantics and bounded cache eviction. Landed behind the ADR-047 SAM2 checkpoint trust contract; manifest migration remains a separate future decision.
 
 ---
 
@@ -173,7 +173,7 @@ This table is the canonical progress ledger for extraction PRs that draw from th
 | Target 1C — Backend resolution & state | `lux_depth_v3/orchestrator.py` | `lux_depth_v3/pipeline_coordinator.py` | Landed | This PR: backend initialization and runtime attempt-state helpers extracted |
 | Target 2A — Portal asset bundle | `app.py` | `src/transformation_portal/portal/asset_bundle.py` | Landed | This PR: portal asset bundle helpers extracted |
 | Target 2B — Path resolution & security helpers | `app.py` | `src/transformation_portal/portal/path_security.py` | Landed | This PR: path security helpers extracted behind ADR-046 app compatibility wrappers |
-| Target 2C — SAM2 checkpoint security helpers | `app.py` | `src/transformation_portal/portal/sam2_checkpoint_security.py` | Ready after ADR-047 | This PR: prep contract pins app-owned SAM2 trust semantics and extraction-sensitive cache behavior |
+| Target 2C — SAM2 checkpoint security helpers | `app.py` | `src/transformation_portal/portal/sam2_checkpoint_security.py` | Landed | This PR: SAM2 checkpoint security helpers extracted behind ADR-047 app compatibility wrappers |
 | Target 3A — Segmentation cache helpers | `lux_depth_v3/segmentation_backend.py` | `lux_depth_v3/segmentation/_cache.py` | Landed | This PR: segmentation cache helpers extracted |
 | Target 3B — Stub backend | `lux_depth_v3/segmentation_backend.py` | `lux_depth_v3/segmentation/stub.py` | Landed | This PR: stub backend extracted |
 | Target 3C — EfficientSAM backend | `lux_depth_v3/segmentation_backend.py` | `lux_depth_v3/segmentation/efficient_sam.py` | Landed | This PR: EfficientSAM backend extracted |

--- a/src/transformation_portal/portal/sam2_checkpoint_security.py
+++ b/src/transformation_portal/portal/sam2_checkpoint_security.py
@@ -1,0 +1,230 @@
+"""Managed SAM2 checkpoint validation and checksum cache helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import threading
+from collections import deque
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Deque, Dict, Iterable, List, NamedTuple, Optional
+
+from transformation_portal.portal import path_security
+
+
+class Sam2CheckpointValidationError(ValueError):
+    """Validation error raised by app-independent SAM2 checkpoint helpers."""
+
+    def __init__(self, message: str, *, reason: str = "invalid_path_value") -> None:
+        cleaned_message = str(message or "").strip() or "Invalid path value"
+        self.reason = str(reason or "invalid_path_value").strip() or "invalid_path_value"
+        super().__init__(cleaned_message)
+
+
+@dataclass(frozen=True)
+class ManagedSam2CheckpointValidationResult:
+    normalized_path: Optional[str]
+    reason: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class _ManagedSam2ChecksumCacheEntry:
+    digest: Optional[str]
+    reason: Optional[str]
+
+
+class _Sam2CacheKey(NamedTuple):
+    """Cache key for SAM2 checkpoint trust results."""
+
+    path: str
+    size: int
+    mtime_ns: int
+    dev: int
+    ino: int
+    ctime_ns: int
+
+
+_MANAGED_SAM2_CHECKSUM_CACHE_MAX_ENTRIES = 128
+
+_MANAGED_SAM2_REASON_MESSAGES = {
+    "checkpoint_file_too_large": "SAM2 checkpoint path exceeds checksum verification size limit",
+    "invalid_path_value": "Invalid path value",
+    "path_outside_allowed_roots": "Path outside allowed roots",
+    "path_shorthand_traversal_disallowed": "Path shorthand traversal disallowed",
+    "untrusted_checkpoint_path": "SAM2 checkpoint path is not trusted",
+}
+
+
+class _ManagedSam2BoundedChecksumCache(Dict[_Sam2CacheKey, _ManagedSam2ChecksumCacheEntry]):
+    """Bounded FIFO cache for SAM2 checkpoint trust results."""
+
+    def __init__(self, max_entries: int = _MANAGED_SAM2_CHECKSUM_CACHE_MAX_ENTRIES) -> None:
+        super().__init__()
+        if max_entries < 1:
+            raise ValueError("max_entries must be at least 1")
+        self._max_entries = max_entries
+        self._insertion_order: Deque[_Sam2CacheKey] = deque()
+
+    def __setitem__(
+        self,
+        key: _Sam2CacheKey,
+        value: _ManagedSam2ChecksumCacheEntry,
+    ) -> None:
+        if key not in self:
+            self._insertion_order.append(key)
+            if len(self._insertion_order) > self._max_entries:
+                oldest = self._insertion_order.popleft()
+                super().pop(oldest, None)
+        super().__setitem__(key, value)
+
+    def clear(self) -> None:
+        super().clear()
+        self._insertion_order.clear()
+
+
+def _managed_sam2_reason_message(reason: str) -> str:
+    """Return the canonical internal validation message for a SAM2 reason code."""
+
+    return _MANAGED_SAM2_REASON_MESSAGES.get(reason, "Invalid path value")
+
+
+def _managed_sam2_checksum_cache_key(path: Path) -> _Sam2CacheKey:
+    """Build the checksum cache key for a trusted SAM2 checkpoint path."""
+
+    stat_result = path.stat()
+    return _Sam2CacheKey(
+        path=str(path),
+        size=stat_result.st_size,
+        mtime_ns=stat_result.st_mtime_ns,
+        dev=stat_result.st_dev,
+        ino=stat_result.st_ino,
+        ctime_ns=stat_result.st_ctime_ns,
+    )
+
+
+def _clear_managed_sam2_checksum_cache(
+    checksum_cache: _ManagedSam2BoundedChecksumCache,
+    checksum_cache_lock: threading.Lock,
+) -> None:
+    """Clear an in-process SAM2 checksum cache."""
+
+    with checksum_cache_lock:
+        checksum_cache.clear()
+
+
+def _hash_file_sha256(path: Path, chunk_size: int = 1024 * 1024) -> str:
+    """Return the SHA-256 digest for a local file."""
+
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(chunk_size), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _cached_managed_sam2_checksum_result(
+    path: Path,
+    *,
+    trusted_sha256: Iterable[str],
+    checksum_max_bytes: int,
+    checksum_cache: _ManagedSam2BoundedChecksumCache,
+    checksum_cache_lock: threading.Lock,
+    hash_file_sha256: Callable[[Path], str] = _hash_file_sha256,
+) -> _ManagedSam2ChecksumCacheEntry:
+    """Return the cached or newly computed trust result for an external SAM2 checkpoint."""
+
+    try:
+        cache_key = _managed_sam2_checksum_cache_key(path)
+    except OSError as exc:
+        raise Sam2CheckpointValidationError("Invalid path value", reason="invalid_path_value") from exc
+
+    with checksum_cache_lock:
+        cached = checksum_cache.get(cache_key)
+    if cached is not None:
+        return cached
+
+    if cache_key.size > checksum_max_bytes:
+        entry = _ManagedSam2ChecksumCacheEntry(digest=None, reason="checkpoint_file_too_large")
+    else:
+        digest = hash_file_sha256(path)
+        reason = None if digest in trusted_sha256 else "untrusted_checkpoint_path"
+        entry = _ManagedSam2ChecksumCacheEntry(digest=digest, reason=reason)
+
+    with checksum_cache_lock:
+        checksum_cache[cache_key] = entry
+    return entry
+
+
+def _resolve_managed_sam2_checkpoint_validation(
+    path_value: str,
+    *,
+    allowed_input_roots: List[Path],
+    trusted_roots: Iterable[Path],
+    trusted_sha256: Iterable[str],
+    checksum_max_bytes: int,
+    checksum_cache: _ManagedSam2BoundedChecksumCache,
+    checksum_cache_lock: threading.Lock,
+    repo_root: Path | None = None,
+    hash_file_sha256: Callable[[Path], str] = _hash_file_sha256,
+) -> ManagedSam2CheckpointValidationResult:
+    """Resolve a managed SAM2 checkpoint path and preserve the exact failure reason."""
+
+    try:
+        resolved = path_security._resolve_allowed_request_path(path_value, allowed_input_roots, repo_root=repo_root)
+    except path_security.PathSecurityValidationError as exc:
+        return ManagedSam2CheckpointValidationResult(normalized_path=None, reason=exc.reason)
+    except (OSError, RuntimeError, ValueError):
+        return ManagedSam2CheckpointValidationResult(normalized_path=None, reason="invalid_path_value")
+
+    # Repo-controlled checkpoints remain valid even before the artifact exists locally.
+    if any(path_security._path_is_within_root(resolved, Path(os.path.realpath(root))) for root in trusted_roots):
+        return ManagedSam2CheckpointValidationResult(normalized_path=str(resolved), reason=None)
+
+    try:
+        safe_file = path_security._ensure_safe_regular_file_path(resolved, allowed_input_roots, repo_root=repo_root)
+    except path_security.PathSecurityValidationError as exc:
+        return ManagedSam2CheckpointValidationResult(normalized_path=None, reason=exc.reason)
+
+    checksum_result = _cached_managed_sam2_checksum_result(
+        safe_file,
+        trusted_sha256=trusted_sha256,
+        checksum_max_bytes=checksum_max_bytes,
+        checksum_cache=checksum_cache,
+        checksum_cache_lock=checksum_cache_lock,
+        hash_file_sha256=hash_file_sha256,
+    )
+    if checksum_result.reason is not None:
+        return ManagedSam2CheckpointValidationResult(normalized_path=None, reason=checksum_result.reason)
+    return ManagedSam2CheckpointValidationResult(normalized_path=str(safe_file), reason=None)
+
+
+def _validate_managed_sam2_checkpoint_path(
+    path_value: str,
+    *,
+    allowed_input_roots: List[Path],
+    trusted_roots: Iterable[Path],
+    trusted_sha256: Iterable[str],
+    checksum_max_bytes: int,
+    checksum_cache: _ManagedSam2BoundedChecksumCache,
+    checksum_cache_lock: threading.Lock,
+    repo_root: Path | None = None,
+    hash_file_sha256: Callable[[Path], str] = _hash_file_sha256,
+) -> str:
+    validation = _resolve_managed_sam2_checkpoint_validation(
+        path_value,
+        allowed_input_roots=allowed_input_roots,
+        trusted_roots=trusted_roots,
+        trusted_sha256=trusted_sha256,
+        checksum_max_bytes=checksum_max_bytes,
+        checksum_cache=checksum_cache,
+        checksum_cache_lock=checksum_cache_lock,
+        repo_root=repo_root,
+        hash_file_sha256=hash_file_sha256,
+    )
+    if validation.reason is not None:
+        raise Sam2CheckpointValidationError(
+            _managed_sam2_reason_message(validation.reason),
+            reason=validation.reason,
+        )
+    return str(validation.normalized_path or "")

--- a/tests/portal/test_sam2_checkpoint_security.py
+++ b/tests/portal/test_sam2_checkpoint_security.py
@@ -1,0 +1,262 @@
+"""Unit tests for portal SAM2 checkpoint security helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import subprocess
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+from transformation_portal.portal import sam2_checkpoint_security
+from transformation_portal.portal.sam2_checkpoint_security import (
+    Sam2CheckpointValidationError,
+    _ManagedSam2BoundedChecksumCache,
+    _ManagedSam2ChecksumCacheEntry,
+    _resolve_managed_sam2_checkpoint_validation,
+    _Sam2CacheKey,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.security]
+
+
+def _realpath(path: Path) -> Path:
+    return Path(os.path.realpath(path))
+
+
+def _cache() -> _ManagedSam2BoundedChecksumCache:
+    return _ManagedSam2BoundedChecksumCache()
+
+
+def _lock() -> threading.Lock:
+    return threading.Lock()
+
+
+def test_sam2_checkpoint_security_import_does_not_import_app() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sys; from transformation_portal.portal import sam2_checkpoint_security; print('app' in sys.modules)",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.stdout.strip() == "False"
+
+
+def test_direct_helper_import_resolves_repo_controlled_missing_checkpoint(tmp_path: Path) -> None:
+    repo_root = _realpath(tmp_path / "repo")
+    trusted_root = repo_root / "models" / "sam2"
+    allowed_roots = [repo_root]
+    checkpoint_path = "./models/sam2/sam2.1_hiera_large.pt"
+
+    validation = _resolve_managed_sam2_checkpoint_validation(
+        checkpoint_path,
+        allowed_input_roots=allowed_roots,
+        trusted_roots=[trusted_root],
+        trusted_sha256=set(),
+        checksum_max_bytes=1024,
+        checksum_cache=_cache(),
+        checksum_cache_lock=_lock(),
+        repo_root=repo_root,
+    )
+
+    assert validation.reason is None
+    assert validation.normalized_path == str(trusted_root / "sam2.1_hiera_large.pt")
+
+
+def test_sam2_checkpoint_security_error_reasons_stay_distinct(tmp_path: Path) -> None:
+    allowed_root = _realpath(tmp_path / "allowed")
+    outside_root = _realpath(tmp_path / "outside")
+    allowed_root.mkdir()
+    outside_root.mkdir()
+    outside_checkpoint = outside_root / "sam2-outside.pt"
+    outside_checkpoint.write_bytes(b"outside")
+    cache = _cache()
+    lock = _lock()
+
+    invalid = sam2_checkpoint_security._resolve_managed_sam2_checkpoint_validation(
+        "bad\x00path",
+        allowed_input_roots=[allowed_root],
+        trusted_roots=[],
+        trusted_sha256=set(),
+        checksum_max_bytes=1024,
+        checksum_cache=cache,
+        checksum_cache_lock=lock,
+    )
+    outside = sam2_checkpoint_security._resolve_managed_sam2_checkpoint_validation(
+        str(outside_checkpoint),
+        allowed_input_roots=[allowed_root],
+        trusted_roots=[],
+        trusted_sha256=set(),
+        checksum_max_bytes=1024,
+        checksum_cache=cache,
+        checksum_cache_lock=lock,
+    )
+
+    assert invalid.reason == "invalid_path_value"
+    assert outside.reason == "path_outside_allowed_roots"
+
+
+def test_sam2_checkpoint_security_external_checkpoint_requires_trusted_digest(tmp_path: Path) -> None:
+    input_root = _realpath(tmp_path)
+    checkpoint_path = input_root / "sam2-governed.pt"
+    checkpoint_bytes = b"trusted checkpoint bytes"
+    checkpoint_path.write_bytes(checkpoint_bytes)
+    digest = hashlib.sha256(checkpoint_bytes).hexdigest()
+    cache = _cache()
+    lock = _lock()
+
+    trusted = sam2_checkpoint_security._resolve_managed_sam2_checkpoint_validation(
+        str(checkpoint_path),
+        allowed_input_roots=[input_root],
+        trusted_roots=[],
+        trusted_sha256={digest},
+        checksum_max_bytes=1024,
+        checksum_cache=cache,
+        checksum_cache_lock=lock,
+    )
+
+    assert trusted.reason is None
+    assert trusted.normalized_path == str(checkpoint_path)
+
+    sam2_checkpoint_security._clear_managed_sam2_checksum_cache(cache, lock)
+    untrusted = sam2_checkpoint_security._resolve_managed_sam2_checkpoint_validation(
+        str(checkpoint_path),
+        allowed_input_roots=[input_root],
+        trusted_roots=[],
+        trusted_sha256=set(),
+        checksum_max_bytes=1024,
+        checksum_cache=cache,
+        checksum_cache_lock=lock,
+    )
+
+    assert untrusted.normalized_path is None
+    assert untrusted.reason == "untrusted_checkpoint_path"
+
+
+def test_sam2_checkpoint_security_oversized_checkpoint_fails_before_hashing(tmp_path: Path) -> None:
+    input_root = _realpath(tmp_path)
+    checkpoint_path = input_root / "sam2-oversized.pt"
+    checkpoint_path.write_bytes(b"oversized")
+
+    validation = sam2_checkpoint_security._resolve_managed_sam2_checkpoint_validation(
+        str(checkpoint_path),
+        allowed_input_roots=[input_root],
+        trusted_roots=[],
+        trusted_sha256=set(),
+        checksum_max_bytes=1,
+        checksum_cache=_cache(),
+        checksum_cache_lock=_lock(),
+        hash_file_sha256=lambda path: pytest.fail(f"unexpected hash for {path}"),
+    )
+
+    assert validation.normalized_path is None
+    assert validation.reason == "checkpoint_file_too_large"
+
+
+def test_sam2_checkpoint_security_validate_raises_reasoned_error(tmp_path: Path) -> None:
+    input_root = _realpath(tmp_path)
+    checkpoint_path = input_root / "sam2-untrusted.pt"
+    checkpoint_path.write_bytes(b"untrusted")
+
+    with pytest.raises(Sam2CheckpointValidationError) as exc_info:
+        sam2_checkpoint_security._validate_managed_sam2_checkpoint_path(
+            str(checkpoint_path),
+            allowed_input_roots=[input_root],
+            trusted_roots=[],
+            trusted_sha256=set(),
+            checksum_max_bytes=1024,
+            checksum_cache=_cache(),
+            checksum_cache_lock=_lock(),
+        )
+
+    assert exc_info.value.reason == "untrusted_checkpoint_path"
+    assert str(exc_info.value) == "SAM2 checkpoint path is not trusted"
+
+
+def test_sam2_checkpoint_security_checksum_cache_key_shape_tracks_file_identity(tmp_path: Path) -> None:
+    checkpoint_path = _realpath(tmp_path / "sam2-keyed.pt")
+    checkpoint_path.write_bytes(b"checkpoint")
+
+    cache_key = sam2_checkpoint_security._managed_sam2_checksum_cache_key(checkpoint_path)
+
+    assert isinstance(cache_key, _Sam2CacheKey)
+    assert cache_key.path == str(checkpoint_path)
+    assert cache_key.size == len(b"checkpoint")
+    assert isinstance(cache_key.mtime_ns, int)
+    assert isinstance(cache_key.dev, int)
+    assert isinstance(cache_key.ino, int)
+    assert isinstance(cache_key.ctime_ns, int)
+
+
+def test_sam2_checkpoint_security_checksum_cache_reuses_hash_results_and_clear_resets_state(tmp_path: Path) -> None:
+    checkpoint_path = _realpath(tmp_path / "sam2-cached.pt")
+    checkpoint_bytes = b"cached checkpoint bytes"
+    checkpoint_path.write_bytes(checkpoint_bytes)
+    digest = hashlib.sha256(checkpoint_bytes).hexdigest()
+    cache = _cache()
+    lock = _lock()
+    hash_calls: list[Path] = []
+
+    def _counting_hash(path: Path) -> str:
+        hash_calls.append(path)
+        return digest
+
+    first = sam2_checkpoint_security._cached_managed_sam2_checksum_result(
+        checkpoint_path,
+        trusted_sha256={digest},
+        checksum_max_bytes=1024,
+        checksum_cache=cache,
+        checksum_cache_lock=lock,
+        hash_file_sha256=_counting_hash,
+    )
+    second = sam2_checkpoint_security._cached_managed_sam2_checksum_result(
+        checkpoint_path,
+        trusted_sha256={digest},
+        checksum_max_bytes=1024,
+        checksum_cache=cache,
+        checksum_cache_lock=lock,
+        hash_file_sha256=_counting_hash,
+    )
+
+    assert first == _ManagedSam2ChecksumCacheEntry(digest=digest, reason=None)
+    assert second == first
+    assert hash_calls == [checkpoint_path]
+    assert len(cache) == 1
+
+    sam2_checkpoint_security._clear_managed_sam2_checksum_cache(cache, lock)
+
+    assert len(cache) == 0
+
+
+def test_sam2_checkpoint_security_bounded_checksum_cache_preserves_fifo_eviction() -> None:
+    cache = _ManagedSam2BoundedChecksumCache(max_entries=2)
+    entry = _ManagedSam2ChecksumCacheEntry(digest="abc", reason=None)
+    key1 = _Sam2CacheKey("/path/a.pt", 100, 1000, 1, 1001, 2000)
+    key2 = _Sam2CacheKey("/path/b.pt", 200, 1000, 1, 1002, 2000)
+    key3 = _Sam2CacheKey("/path/c.pt", 300, 1000, 1, 1003, 2000)
+
+    cache[key1] = entry
+    cache[key2] = entry
+    cache[key3] = entry
+
+    assert key1 not in cache
+    assert key2 in cache
+    assert key3 in cache
+    assert len(cache) == 2
+
+    cache[key2] = _ManagedSam2ChecksumCacheEntry(digest="updated", reason=None)
+    assert len(cache) == 2
+    assert cache[key2].digest == "updated"
+
+    cache.clear()
+
+    assert len(cache) == 0
+    assert len(cache._insertion_order) == 0

--- a/tests/test_app_sam2_checkpoint_extraction_contract.py
+++ b/tests/test_app_sam2_checkpoint_extraction_contract.py
@@ -10,6 +10,8 @@ from pathlib import Path
 
 import pytest
 
+from transformation_portal.portal import sam2_checkpoint_security
+
 pytestmark = [pytest.mark.unit, pytest.mark.security]
 
 orchestrator_app = importlib.import_module("app")
@@ -44,6 +46,15 @@ def _realpath(path: Path) -> Path:
 def test_phase_2c_legacy_sam2_checkpoint_helpers_remain_available_from_app() -> None:
     for helper_name in _PHASE_2C_LEGACY_NAMES:
         assert getattr(orchestrator_app, helper_name) is not None
+
+
+def test_phase_2c_app_models_are_extracted_module_models() -> None:
+    assert orchestrator_app.ManagedSam2CheckpointValidationResult is (
+        sam2_checkpoint_security.ManagedSam2CheckpointValidationResult
+    )
+    assert orchestrator_app._ManagedSam2ChecksumCacheEntry is sam2_checkpoint_security._ManagedSam2ChecksumCacheEntry
+    assert orchestrator_app._Sam2CacheKey is sam2_checkpoint_security._Sam2CacheKey
+    assert orchestrator_app._ManagedSam2BoundedChecksumCache is (sam2_checkpoint_security._ManagedSam2BoundedChecksumCache)
 
 
 def test_phase_2c_managed_sam2_reason_messages_preserve_codes() -> None:
@@ -135,6 +146,15 @@ def test_phase_2c_oversized_checkpoint_reason_is_preserved(
     with pytest.raises(orchestrator_app._PortalValidationReasonError) as exc_info:
         orchestrator_app._validate_managed_sam2_checkpoint_path(str(checkpoint_path))
     assert exc_info.value.reason == "checkpoint_file_too_large"
+
+
+def test_phase_2c_app_cached_checksum_wrapper_translates_module_error(tmp_path: Path) -> None:
+    missing_path = tmp_path / "missing.pt"
+
+    with pytest.raises(orchestrator_app._PortalValidationReasonError) as exc_info:
+        orchestrator_app._cached_managed_sam2_checksum_result(missing_path)
+
+    assert exc_info.value.reason == "invalid_path_value"
 
 
 def test_phase_2c_checksum_cache_key_shape_tracks_file_identity(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Extract managed SAM2 checkpoint validation and checksum-cache helpers from `app.py` into `portal/sam2_checkpoint_security.py`.
- Preserve app-owned trusted SHA semantics, allowed roots, checksum limit, cache lock, and `_PortalValidationReasonError` compatibility wrappers.

## Changes
- Adds `src/transformation_portal/portal/sam2_checkpoint_security.py` with app-independent SAM2 checkpoint validation, cache keying, SHA-256 hashing, bounded FIFO cache behavior, and reasoned module errors.
- Keeps `app.py` as the legacy compatibility surface by re-exporting the existing helper/model names and delegating through wrappers that inject app-owned config and cache state.
- Adds direct-module tests for import independence, reason preservation, trusted digest behavior, oversized rejection, hash reuse, cache clearing, and FIFO eviction.
- Extends the app extraction contract tests to prove class identity and wrapper error translation.
- Marks Target 2C as landed behind ADR-047 without changing routes, selectors, API envelopes, CLI flags, model-lock manifest contents, or SAM2 backend semantics.

## Validation
Proven green:
- `git diff --check`
- `.venv/bin/python -m black --check app.py src/transformation_portal/portal/sam2_checkpoint_security.py tests/portal/test_sam2_checkpoint_security.py tests/test_app_sam2_checkpoint_extraction_contract.py`
- `.venv/bin/python -m pytest tests/portal/test_sam2_checkpoint_security.py tests/test_app_sam2_checkpoint_extraction_contract.py tests/test_app_orchestrator_runtime.py tests/test_app_orchestrator_contract_http.py tests/validation/test_portal_smoke_scripts.py -k "sam2_checkpoint or managed_sam2 or sam2" -q`
- `.venv/bin/python -m pytest tests/test_app_security.py tests/test_portal_backend_hardening.py -q`
- `make check-json-serialization check-yaml-governance check-python-headers`
- `.venv/bin/python scripts/validation/scan_todo_inventory.py --check-governance`
- `make test-fast`
- Commit pre-commit hook suite

Still failing:
- None observed.

## Risk
- Bounded extraction behind existing `app.py` compatibility wrappers.
- No model-lock manifest migration is included; ADR-047 keeps trusted SAM2 SHA values app-owned for this slice.
- Revert-safe because all runtime callers continue through existing `app.py` helper names and the new module is covered by direct plus compatibility tests.
