### PR TITLE
chore(deps): update FastVLM runtime pins

### DIFF
--- a/config/fastvlm_runtime_requirements.txt
+++ b/config/fastvlm_runtime_requirements.txt
@@ -1,4 +1,4 @@
-pip==26.1
+pip==26.1.1
 aiohappyeyeballs==2.6.1
 aiohttp==3.13.5
 aiosignal==1.4.0
@@ -29,12 +29,12 @@ httpx==0.28.1
 huggingface_hub==1.13.0
 idna==3.13
 Jinja2==3.1.6
-markdown-it-py==4.0.0
+markdown-it-py==4.1.0
 MarkupSafe==3.0.3
 mdurl==0.1.2
 mlx==0.31.2
 mlx-metal==0.31.2
-mpmath==1.3.0
+mpmath==1.4.1
 multidict==6.7.1
 multiprocess==0.70.19
 networkx==3.6.1
@@ -73,7 +73,7 @@ tomlkit==0.14.0
 torch==2.11.0
 torchvision==0.26.0
 tqdm==4.67.3
-transformers==5.7.0
+transformers==5.8.0
 typer==0.25.1
 typing-inspection==0.4.2
 typing_extensions==4.15.0

--- a/config/fastvlm_runtime_requirements.txt
+++ b/config/fastvlm_runtime_requirements.txt
@@ -34,7 +34,7 @@ MarkupSafe==3.0.3
 mdurl==0.1.2
 mlx==0.31.2
 mlx-metal==0.31.2
-mpmath==1.4.1
+mpmath==1.3.0
 multidict==6.7.1
 multiprocess==0.70.19
 networkx==3.6.1


### PR DESCRIPTION
## Summary
- Replace the overlapping FastVLM Dependabot pin bumps with one runtime-only dependency update.
- Keep the governed core Transformers baseline untouched while updating only the FastVLM runtime manifest.
- Leave mpmath at 1.3.0 because SymPy 1.14.0 requires mpmath<1.4 and no newer SymPy release is available.

## Changes
- Update config/fastvlm_runtime_requirements.txt pins for pip, markdown-it-py, and transformers.
- Keep mpmath pinned at 1.3.0 to preserve fresh resolver compatibility with sympy==1.14.0.
- No changes to pyproject.toml, requirements/ml-core.in, or requirements/ml-core-darwin-arm64.in.

## Validation
Proven green:
- .venv/bin/python -m pytest tests/vlm_captioning/test_fastvlm_runtime_manifest.py tests/vlm_captioning/test_fastvlm_runtime.py tests/test_app_orchestrator_contract_http.py -k "fastvlm" -q
- ./scripts/setup/install_fastvlm_runtime.sh --dry-run --models smoke,default
- make check-json-serialization check-yaml-governance check-python-headers
- make check-fastvlm-runtime
- /private/tmp/tp-fastvlm-resolve/bin/python -m pip install --dry-run -r config/fastvlm_runtime_requirements.txt

## Risk
- Runtime-only manifest change; no route, selector, API envelope, lockfile, or governed ML baseline changes.
- Bounded replacement is revert-safe and supersedes the overlapping Dependabot runtime pin PRs, except the unsafe mpmath bump which remains closed out by preserving the compatible pin.