### PR TITLE
chore(deps): bump tox lock to 4.53.1

### DIFF
--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -310,7 +310,7 @@ tomli-w==1.2.0
     # via tox
 tomlkit==0.14.0
     # via pylint
-tox==4.53.0
+tox==4.53.1
     # via -r ci.in
 tqdm==4.67.3
     # via -r base.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -185,7 +185,7 @@ tomli-w==1.2.0
     # via
     #   -c all.txt
     #   tox
-tox==4.53.0
+tox==4.53.1
     # via
     #   -c all.txt
     #   -r ci.in


### PR DESCRIPTION
## Summary
- Replace the invalid Dependabot tox lock PR with a governed lock refresh.
- Keep the change limited to the tox pin in the generic checked-in lockfiles.

## Changes
- Update tox from 4.53.0 to 4.53.1 in requirements/all.txt and requirements/ci.txt.
- Preserve ADR-032 OpenCV platform-marker runtime pins in requirements/all.txt and requirements/base.txt.
- Do not broaden or regenerate unrelated dependency lanes.

## Validation
Proven green:
- PIP_TOOLS_CACHE_DIR=/private/tmp/tp-pip-tools-cache /private/tmp/tp-piptools-311/bin/pip-compile -q --resolver=backtracking --upgrade-package tox all.in -o all.txt
- PIP_TOOLS_CACHE_DIR=/private/tmp/tp-pip-tools-cache /private/tmp/tp-piptools-311/bin/pip-compile -q --resolver=backtracking --upgrade-package tox -c all.txt ci.in -o ci.txt
- .venv/bin/python scripts/validation/check_dependency_pinning.py
- .venv/bin/python scripts/validation/check_requirements_lock_contract.py
- .venv/bin/python scripts/validation/check_dependency_update_workflow.py
- make check-requirements-lock-contract
- rg -n "tox==4\.53\.1" requirements/all.txt requirements/ci.txt
- rg -n "opencv-python==.*platform_system != \"Linux\"|opencv-python-headless==.*platform_system == \"Linux\"" requirements/all.txt requirements/base.txt

Environment note:
- The repository .venv does not expose pip-compile, and .venv-lint has pip 26.x which is incompatible with pip-tools 7.5.2. The lock regeneration used an isolated Python 3.11 pip-tools 7.5.2 environment under /private/tmp to preserve the Python 3.11 lock header contract.

## Risk
- Lock-only patch with no runtime code, route, selector, API envelope, or dependency baseline policy changes.
- Bounded replacement is revert-safe and supersedes the invalid Dependabot tox PR that dropped governed OpenCV markers.