### PR TITLE
refactor(portal): extract archive index preflight helpers

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import copy
-import csv
-import gzip
 import hashlib
 import hmac
 import json
@@ -67,6 +64,7 @@ from transformation_portal.ingest.upload_staging import (
 )
 from transformation_portal.lux_depth_v3.model_registry import resolve_model_spec, resolve_registry_key, visible_cli_model_specs
 from transformation_portal.lux_depth_v3.run_card_contract import infer_run_card_version
+from transformation_portal.portal import archive_index_preflight as _portal_archive_index_preflight
 from transformation_portal.portal import asset_bundle as _portal_asset_bundle
 from transformation_portal.portal import path_security as _portal_path_security
 from transformation_portal.portal import sam2_checkpoint_security as _portal_sam2_checkpoint_security
@@ -1015,13 +1013,13 @@ ARCHIVE_GATE_ALLOWED_COMMANDS = {
     "archive-gate-b": {"bag-build", "bag-validate", "dedup-plan"},
     "archive-gate-c": {"mets-export", "prov-export", "stac-export"},
 }
-ARCHIVE_INDEX_REQUIRED_COLUMNS = {"origin_drive", "partition", "relpath"}
-ARCHIVE_INDEX_PREFLIGHT_EXAMPLE_LIMIT = 5
-ARCHIVE_INDEX_PREFLIGHT_PREVIEW_ROW_LIMIT = 256
-ARCHIVE_INDEX_PREFLIGHT_CACHE_MAX = 64
-ARCHIVE_INDEX_PREFLIGHT_SCAN_MODES = {"preview", "full"}
-_ARCHIVE_INDEX_PREFLIGHT_CACHE_LOCK = threading.Lock()
-_ARCHIVE_INDEX_PREFLIGHT_CACHE: Dict[Tuple[str, int, int, str, str], Dict[str, Any]] = {}
+ARCHIVE_INDEX_REQUIRED_COLUMNS = _portal_archive_index_preflight.ARCHIVE_INDEX_REQUIRED_COLUMNS
+ARCHIVE_INDEX_PREFLIGHT_EXAMPLE_LIMIT = _portal_archive_index_preflight.ARCHIVE_INDEX_PREFLIGHT_EXAMPLE_LIMIT
+ARCHIVE_INDEX_PREFLIGHT_PREVIEW_ROW_LIMIT = _portal_archive_index_preflight.ARCHIVE_INDEX_PREFLIGHT_PREVIEW_ROW_LIMIT
+ARCHIVE_INDEX_PREFLIGHT_CACHE_MAX = _portal_archive_index_preflight.ARCHIVE_INDEX_PREFLIGHT_CACHE_MAX
+ARCHIVE_INDEX_PREFLIGHT_SCAN_MODES = _portal_archive_index_preflight.ARCHIVE_INDEX_PREFLIGHT_SCAN_MODES
+_ARCHIVE_INDEX_PREFLIGHT_CACHE_LOCK = _portal_archive_index_preflight._ARCHIVE_INDEX_PREFLIGHT_CACHE_LOCK
+_ARCHIVE_INDEX_PREFLIGHT_CACHE = _portal_archive_index_preflight._ARCHIVE_INDEX_PREFLIGHT_CACHE
 ALLOWED_QUALITY = {"standard", "premium", "apex"}
 ALLOWED_BACKENDS = {"da3", "depth_pro"}
 ALLOWED_DEPTH_DEVICES = {"cpu", "cuda", "mps"}
@@ -1598,196 +1596,30 @@ def _validate_existing_path(
     return resolved, None
 
 
-def _archive_index_preflight_example(
-    *,
-    row: int,
-    relpath: str,
-    reason: str,
-) -> Dict[str, Any]:
-    return {
-        "row": row,
-        "relpath": relpath,
-        "reason": reason,
-    }
-
-
-def _archive_index_preflight_result(
-    *,
-    rows_total: int,
-    blocked_rows: int,
-    examples: List[Dict[str, Any]],
-    scan_mode: str = "full",
-    truncated: bool = False,
-) -> Dict[str, Any]:
-    return {
-        "ok": blocked_rows == 0 and rows_total > 0,
-        "rows_total": rows_total,
-        "blocked_rows": blocked_rows,
-        "examples": examples[:ARCHIVE_INDEX_PREFLIGHT_EXAMPLE_LIMIT],
-        "scan_mode": scan_mode,
-        "truncated": bool(truncated),
-    }
-
-
-def _archive_index_preflight_message(result: Mapping[str, Any]) -> str:
-    rows_total = int(result.get("rows_total") or 0)
-    blocked_rows = int(result.get("blocked_rows") or 0)
-    examples = result.get("examples") if isinstance(result.get("examples"), list) else []
-    example_text = "; ".join(
-        f"row {item.get('row')}: {item.get('relpath')!r} ({item.get('reason')})"
-        for item in examples[:ARCHIVE_INDEX_PREFLIGHT_EXAMPLE_LIMIT]
-        if isinstance(item, Mapping)
-    )
-    if not example_text:
-        example_text = "no valid archive index rows found"
-    if rows_total == 0:
-        return (
-            "Archive index does not match the selected archive root: "
-            f"{blocked_rows} blocking issue before row validation. Examples: {example_text}."
-        )
-    return (
-        "Archive index does not match the selected archive root: "
-        f"{blocked_rows}/{rows_total} rows blocked. Examples: {example_text}."
-    )
-
-
-def _archive_index_preflight_primary_reason(result: Mapping[str, Any]) -> str:
-    examples = result.get("examples") if isinstance(result.get("examples"), list) else []
-    first = examples[0] if examples and isinstance(examples[0], Mapping) else {}
-    return str(first.get("reason") or "").strip()
-
-
-def _archive_index_preflight_root_reason(result: Mapping[str, Any]) -> Optional[str]:
-    reason = _archive_index_preflight_primary_reason(result)
-    if reason.startswith("archive_root_"):
-        return reason
-    return None
-
-
-def _is_drive_prefixed_relpath(raw_relpath: str) -> bool:
-    return bool(re.match(r"^[A-Za-z]:", raw_relpath))
-
-
-def _archive_index_preflight_scan_mode(scan_mode: str) -> str:
-    normalized = str(scan_mode or "full").strip().lower()
-    return normalized if normalized in ARCHIVE_INDEX_PREFLIGHT_SCAN_MODES else "full"
-
-
-def _archive_index_preflight_row_limit(scan_mode: str) -> Optional[int]:
-    if _archive_index_preflight_scan_mode(scan_mode) == "preview":
-        return ARCHIVE_INDEX_PREFLIGHT_PREVIEW_ROW_LIMIT
-    return None
-
-
-def _copy_archive_index_preflight_result(result: Mapping[str, Any]) -> Dict[str, Any]:
-    return copy.deepcopy(dict(result))
-
-
-def _archive_index_preflight_cache_key(
-    archive_index: Path,
-    archive_root: Path,
-    *,
-    scan_mode: str,
-) -> Tuple[str, int, int, str, str]:
-    stat_result = archive_index.stat()
-    return (
-        str(archive_index),
-        int(stat_result.st_mtime_ns),
-        int(stat_result.st_size),
-        str(archive_root),
-        _archive_index_preflight_scan_mode(scan_mode),
-    )
+_archive_index_preflight_example = _portal_archive_index_preflight._archive_index_preflight_example
+_archive_index_preflight_result = _portal_archive_index_preflight._archive_index_preflight_result
+_archive_index_preflight_message = _portal_archive_index_preflight._archive_index_preflight_message
+_archive_index_preflight_primary_reason = _portal_archive_index_preflight._archive_index_preflight_primary_reason
+_archive_index_preflight_root_reason = _portal_archive_index_preflight._archive_index_preflight_root_reason
+_is_drive_prefixed_relpath = _portal_archive_index_preflight._is_drive_prefixed_relpath
+_archive_index_preflight_scan_mode = _portal_archive_index_preflight._archive_index_preflight_scan_mode
+_archive_index_preflight_row_limit = _portal_archive_index_preflight._archive_index_preflight_row_limit
+_copy_archive_index_preflight_result = _portal_archive_index_preflight._copy_archive_index_preflight_result
+_archive_index_preflight_cache_key = _portal_archive_index_preflight._archive_index_preflight_cache_key
 
 
 def _trusted_existing_entry_without_realpath(
     path_value: Any,
     allowed_roots: List[Path],
 ) -> Optional[Path]:
-    raw = str(path_value or "").strip()
-    if not raw or raw.startswith("~") or "\x00" in raw:
-        return None
-    try:
-        candidate = Path(raw)
-    except (OSError, RuntimeError, ValueError):
-        return None
-    if not candidate.is_absolute():
-        candidate = REPO_ROOT / candidate
-    try:
-        candidate_absolute = Path(os.path.abspath(candidate))
-    except (OSError, RuntimeError, ValueError):
-        return None
-
-    for root in allowed_roots:
-        try:
-            root_real = Path(os.path.realpath(root))
-            relative_parts = candidate_absolute.relative_to(root_real).parts
-        except (OSError, RuntimeError, ValueError):
-            continue
-        current = root_real
-        if not relative_parts:
-            return current
-        for part in relative_parts:
-            if part in {"", ".", ".."} or _UNSAFE_PATH_SEGMENT_RE.search(part):
-                return None
-            try:
-                next_path = next((child for child in current.iterdir() if child.name == part), None)
-            except (NotADirectoryError, FileNotFoundError, OSError, RuntimeError, ValueError):
-                return None
-            if next_path is None:
-                return None
-            current = next_path
-        return current
-    return None
+    return _portal_archive_index_preflight._trusted_existing_entry_without_realpath(
+        path_value,
+        allowed_roots,
+        repo_root=REPO_ROOT,
+    )
 
 
-def _validate_archive_index_relpath(
-    raw_relpath: Any,
-    *,
-    archive_root: Path,
-) -> Tuple[bool, str, str]:
-    relpath = str(raw_relpath or "").strip()
-    if not relpath:
-        return False, relpath, "empty_relpath"
-    if "\x00" in relpath:
-        return False, relpath, "nul_relpath"
-    if relpath.startswith(("/", "\\")):
-        return False, relpath, "absolute_relpath"
-    if _is_drive_prefixed_relpath(relpath):
-        return False, relpath, "drive_prefixed_relpath"
-
-    normalized = relpath.replace("\\", "/")
-    parts = tuple(part for part in normalized.split("/") if part and part != ".")
-    if not parts:
-        return False, relpath, "empty_relpath"
-    if any(part == ".." for part in parts):
-        return False, relpath, "parent_traversal"
-
-    current = archive_root
-    for part in parts:
-        try:
-            next_path = next((child for child in current.iterdir() if child.name == part), None)
-        except FileNotFoundError:
-            return False, relpath, "missing"
-        except (NotADirectoryError, OSError, RuntimeError, ValueError):
-            return False, relpath, "unreadable"
-        if next_path is None:
-            return False, relpath, "missing"
-        try:
-            if next_path.is_symlink():
-                return False, relpath, "symlink_traversal"
-        except (OSError, RuntimeError):
-            return False, relpath, "unreadable"
-        current = next_path
-
-    try:
-        if current.is_dir():
-            return False, relpath, "directory"
-        if not current.is_file():
-            return False, relpath, "not_regular_file"
-    except (OSError, RuntimeError):
-        return False, relpath, "unreadable"
-
-    return True, relpath, "ok"
+_validate_archive_index_relpath = _portal_archive_index_preflight._validate_archive_index_relpath
 
 
 def _validate_archive_index_against_root(
@@ -1796,193 +1628,18 @@ def _validate_archive_index_against_root(
     *,
     scan_mode: str = "full",
 ) -> Dict[str, Any]:
-    scan_mode = _archive_index_preflight_scan_mode(scan_mode)
-    try:
-        trusted_archive_index = _ensure_safe_regular_file_path(archive_index, ALLOWED_PATH_ROOTS)
-    except (OSError, RuntimeError, ValueError, _PortalValidationReasonError):
-        return _archive_index_preflight_result(
-            rows_total=0,
-            blocked_rows=1,
-            examples=[
-                _archive_index_preflight_example(
-                    row=0,
-                    relpath=str(archive_index),
-                    reason="archive_index_unreadable",
-                )
-            ],
-            scan_mode=scan_mode,
-        )
-
-    trusted_archive_root = _trusted_existing_entry_without_realpath(archive_root, ALLOWED_INPUT_ROOTS)
-    if trusted_archive_root is None:
-        return _archive_index_preflight_result(
-            rows_total=0,
-            blocked_rows=1,
-            examples=[
-                _archive_index_preflight_example(
-                    row=0,
-                    relpath=str(archive_root),
-                    reason="archive_root_not_directory",
-                )
-            ],
-            scan_mode=scan_mode,
-        )
-    try:
-        if trusted_archive_root.is_symlink():
-            return _archive_index_preflight_result(
-                rows_total=0,
-                blocked_rows=1,
-                examples=[
-                    _archive_index_preflight_example(
-                        row=0,
-                        relpath=str(archive_root),
-                        reason="archive_root_symlink",
-                    )
-                ],
-                scan_mode=scan_mode,
-            )
-        if not trusted_archive_root.is_dir():
-            return _archive_index_preflight_result(
-                rows_total=0,
-                blocked_rows=1,
-                examples=[
-                    _archive_index_preflight_example(
-                        row=0,
-                        relpath=str(archive_root),
-                        reason="archive_root_not_directory",
-                    )
-                ],
-                scan_mode=scan_mode,
-            )
-        archive_root_real = Path(os.path.realpath(trusted_archive_root))
-    except (OSError, RuntimeError):
-        return _archive_index_preflight_result(
-            rows_total=0,
-            blocked_rows=1,
-            examples=[
-                _archive_index_preflight_example(
-                    row=0,
-                    relpath=str(archive_root),
-                    reason="archive_root_unreadable",
-                )
-            ],
-            scan_mode=scan_mode,
-        )
-
-    try:
-        cache_key = _archive_index_preflight_cache_key(
-            trusted_archive_index,
-            archive_root_real,
-            scan_mode=scan_mode,
-        )
-    except OSError:
-        return _archive_index_preflight_result(
-            rows_total=0,
-            blocked_rows=1,
-            examples=[
-                _archive_index_preflight_example(
-                    row=0,
-                    relpath=str(archive_index),
-                    reason="archive_index_unreadable",
-                )
-            ],
-            scan_mode=scan_mode,
-        )
-
-    with _ARCHIVE_INDEX_PREFLIGHT_CACHE_LOCK:
-        cached = _ARCHIVE_INDEX_PREFLIGHT_CACHE.get(cache_key)
-    if cached is not None:
-        return _copy_archive_index_preflight_result(cached)
-
-    rows_total = 0
-    blocked_rows = 0
-    examples: List[Dict[str, Any]] = []
-    row_limit = _archive_index_preflight_row_limit(scan_mode)
-    truncated = False
-
-    try:
-        opener: Callable[..., Any] = gzip.open if trusted_archive_index.name.endswith(".gz") else Path.open
-        with opener(trusted_archive_index, "rt", encoding="utf-8", newline="") as handle:
-            reader = csv.DictReader(handle)
-            fieldnames = set(reader.fieldnames or [])
-            missing_columns = sorted(ARCHIVE_INDEX_REQUIRED_COLUMNS - fieldnames)
-            if missing_columns:
-                return _archive_index_preflight_result(
-                    rows_total=0,
-                    blocked_rows=1,
-                    examples=[
-                        _archive_index_preflight_example(
-                            row=1,
-                            relpath="",
-                            reason=f"missing_columns:{','.join(missing_columns)}",
-                        )
-                    ],
-                    scan_mode=scan_mode,
-                )
-
-            for row_number, row in enumerate(reader, start=2):
-                rows_total += 1
-                ok, relpath, reason = _validate_archive_index_relpath(
-                    row.get("relpath"),
-                    archive_root=archive_root_real,
-                )
-                if row_limit is not None and rows_total >= row_limit:
-                    truncated = True
-                if ok:
-                    if truncated:
-                        break
-                    continue
-                blocked_rows += 1
-                if len(examples) < ARCHIVE_INDEX_PREFLIGHT_EXAMPLE_LIMIT:
-                    examples.append(
-                        _archive_index_preflight_example(
-                            row=row_number,
-                            relpath=relpath,
-                            reason=reason,
-                        )
-                    )
-                if truncated:
-                    break
-    except (csv.Error, gzip.BadGzipFile, OSError, RuntimeError, UnicodeDecodeError) as exc:
-        return _archive_index_preflight_result(
-            rows_total=rows_total,
-            blocked_rows=max(1, blocked_rows),
-            examples=[
-                _archive_index_preflight_example(
-                    row=max(1, rows_total + 1),
-                    relpath=str(trusted_archive_index),
-                    reason=f"archive_index_unreadable:{type(exc).__name__}",
-                )
-            ],
-            scan_mode=scan_mode,
-        )
-
-    if rows_total == 0:
-        return _archive_index_preflight_result(
-            rows_total=0,
-            blocked_rows=1,
-            examples=[
-                _archive_index_preflight_example(
-                    row=1,
-                    relpath="",
-                    reason="empty_archive_index",
-                )
-            ],
-            scan_mode=scan_mode,
-        )
-
-    result = _archive_index_preflight_result(
-        rows_total=rows_total,
-        blocked_rows=blocked_rows,
-        examples=examples,
+    return _portal_archive_index_preflight._validate_archive_index_against_root(
+        archive_index,
+        archive_root,
         scan_mode=scan_mode,
-        truncated=truncated,
+        allowed_path_roots=ALLOWED_PATH_ROOTS,
+        allowed_input_roots=ALLOWED_INPUT_ROOTS,
+        repo_root=REPO_ROOT,
+        cache=_ARCHIVE_INDEX_PREFLIGHT_CACHE,
+        cache_lock=_ARCHIVE_INDEX_PREFLIGHT_CACHE_LOCK,
+        cache_max_entries=ARCHIVE_INDEX_PREFLIGHT_CACHE_MAX,
+        relpath_validator=_validate_archive_index_relpath,
     )
-    with _ARCHIVE_INDEX_PREFLIGHT_CACHE_LOCK:
-        if len(_ARCHIVE_INDEX_PREFLIGHT_CACHE) >= ARCHIVE_INDEX_PREFLIGHT_CACHE_MAX:
-            _ARCHIVE_INDEX_PREFLIGHT_CACHE.pop(next(iter(_ARCHIVE_INDEX_PREFLIGHT_CACHE)), None)
-        _ARCHIVE_INDEX_PREFLIGHT_CACHE[cache_key] = _copy_archive_index_preflight_result(result)
-    return result
 
 
 def _lux_depth_readiness(args: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:

--- a/docs/architecture/MONOLITH_DECOMPOSITION_TARGETS.md
+++ b/docs/architecture/MONOLITH_DECOMPOSITION_TARGETS.md
@@ -174,6 +174,7 @@ This table is the canonical progress ledger for extraction PRs that draw from th
 | Target 2A — Portal asset bundle | `app.py` | `src/transformation_portal/portal/asset_bundle.py` | Landed | This PR: portal asset bundle helpers extracted |
 | Target 2B — Path resolution & security helpers | `app.py` | `src/transformation_portal/portal/path_security.py` | Landed | This PR: path security helpers extracted behind ADR-046 app compatibility wrappers |
 | Target 2C — SAM2 checkpoint security helpers | `app.py` | `src/transformation_portal/portal/sam2_checkpoint_security.py` | Landed | This PR: SAM2 checkpoint security helpers extracted behind ADR-047 app compatibility wrappers |
+| Target 2D — Archive index preflight helpers | `app.py` | `src/transformation_portal/portal/archive_index_preflight.py` | Landed | This PR: archive index preflight helpers extracted behind app compatibility wrappers |
 | Target 3A — Segmentation cache helpers | `lux_depth_v3/segmentation_backend.py` | `lux_depth_v3/segmentation/_cache.py` | Landed | This PR: segmentation cache helpers extracted |
 | Target 3B — Stub backend | `lux_depth_v3/segmentation_backend.py` | `lux_depth_v3/segmentation/stub.py` | Landed | This PR: stub backend extracted |
 | Target 3C — EfficientSAM backend | `lux_depth_v3/segmentation_backend.py` | `lux_depth_v3/segmentation/efficient_sam.py` | Landed | This PR: EfficientSAM backend extracted |

--- a/src/transformation_portal/portal/archive_index_preflight.py
+++ b/src/transformation_portal/portal/archive_index_preflight.py
@@ -1,0 +1,449 @@
+"""Archive index preflight helpers for portal archive-gate readiness."""
+
+from __future__ import annotations
+
+import copy
+import csv
+import gzip
+import os
+import re
+import threading
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Mapping, MutableMapping, Optional, Tuple
+
+from transformation_portal.portal import path_security
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+ARCHIVE_INDEX_REQUIRED_COLUMNS = {"origin_drive", "partition", "relpath"}
+ARCHIVE_INDEX_PREFLIGHT_EXAMPLE_LIMIT = 5
+ARCHIVE_INDEX_PREFLIGHT_PREVIEW_ROW_LIMIT = 256
+ARCHIVE_INDEX_PREFLIGHT_CACHE_MAX = 64
+ARCHIVE_INDEX_PREFLIGHT_SCAN_MODES = {"preview", "full"}
+_ARCHIVE_INDEX_PREFLIGHT_CACHE_LOCK = threading.Lock()
+_ARCHIVE_INDEX_PREFLIGHT_CACHE: Dict[Tuple[str, int, int, str, str], Dict[str, Any]] = {}
+
+
+def _repo_root(repo_root: Path | None = None) -> Path:
+    return Path(os.path.realpath(REPO_ROOT if repo_root is None else repo_root))
+
+
+def _archive_index_preflight_example(
+    *,
+    row: int,
+    relpath: str,
+    reason: str,
+) -> Dict[str, Any]:
+    return {
+        "row": row,
+        "relpath": relpath,
+        "reason": reason,
+    }
+
+
+def _archive_index_preflight_result(
+    *,
+    rows_total: int,
+    blocked_rows: int,
+    examples: List[Dict[str, Any]],
+    scan_mode: str = "full",
+    truncated: bool = False,
+) -> Dict[str, Any]:
+    return {
+        "ok": blocked_rows == 0 and rows_total > 0,
+        "rows_total": rows_total,
+        "blocked_rows": blocked_rows,
+        "examples": examples[:ARCHIVE_INDEX_PREFLIGHT_EXAMPLE_LIMIT],
+        "scan_mode": scan_mode,
+        "truncated": bool(truncated),
+    }
+
+
+def _archive_index_preflight_message(result: Mapping[str, Any]) -> str:
+    rows_total = int(result.get("rows_total") or 0)
+    blocked_rows = int(result.get("blocked_rows") or 0)
+    examples = result.get("examples") if isinstance(result.get("examples"), list) else []
+    example_text = "; ".join(
+        f"row {item.get('row')}: {item.get('relpath')!r} ({item.get('reason')})"
+        for item in examples[:ARCHIVE_INDEX_PREFLIGHT_EXAMPLE_LIMIT]
+        if isinstance(item, Mapping)
+    )
+    if not example_text:
+        example_text = "no valid archive index rows found"
+    if rows_total == 0:
+        return (
+            "Archive index does not match the selected archive root: "
+            f"{blocked_rows} blocking issue before row validation. Examples: {example_text}."
+        )
+    return (
+        "Archive index does not match the selected archive root: "
+        f"{blocked_rows}/{rows_total} rows blocked. Examples: {example_text}."
+    )
+
+
+def _archive_index_preflight_primary_reason(result: Mapping[str, Any]) -> str:
+    examples = result.get("examples") if isinstance(result.get("examples"), list) else []
+    first = examples[0] if examples and isinstance(examples[0], Mapping) else {}
+    return str(first.get("reason") or "").strip()
+
+
+def _archive_index_preflight_root_reason(result: Mapping[str, Any]) -> Optional[str]:
+    reason = _archive_index_preflight_primary_reason(result)
+    if reason.startswith("archive_root_"):
+        return reason
+    return None
+
+
+def _is_drive_prefixed_relpath(raw_relpath: str) -> bool:
+    return bool(re.match(r"^[A-Za-z]:", raw_relpath))
+
+
+def _archive_index_preflight_scan_mode(scan_mode: str) -> str:
+    normalized = str(scan_mode or "full").strip().lower()
+    return normalized if normalized in ARCHIVE_INDEX_PREFLIGHT_SCAN_MODES else "full"
+
+
+def _archive_index_preflight_row_limit(scan_mode: str) -> Optional[int]:
+    if _archive_index_preflight_scan_mode(scan_mode) == "preview":
+        return ARCHIVE_INDEX_PREFLIGHT_PREVIEW_ROW_LIMIT
+    return None
+
+
+def _copy_archive_index_preflight_result(result: Mapping[str, Any]) -> Dict[str, Any]:
+    return copy.deepcopy(dict(result))
+
+
+def _archive_index_preflight_cache_key(
+    archive_index: Path,
+    archive_root: Path,
+    *,
+    scan_mode: str,
+) -> Tuple[str, int, int, str, str]:
+    stat_result = archive_index.stat()
+    return (
+        str(archive_index),
+        int(stat_result.st_mtime_ns),
+        int(stat_result.st_size),
+        str(archive_root),
+        _archive_index_preflight_scan_mode(scan_mode),
+    )
+
+
+def _trusted_existing_entry_without_realpath(
+    path_value: Any,
+    allowed_roots: List[Path],
+    *,
+    repo_root: Path | None = None,
+) -> Optional[Path]:
+    raw = str(path_value or "").strip()
+    if not raw or raw.startswith("~") or "\x00" in raw:
+        return None
+    try:
+        candidate = Path(raw)
+    except (OSError, RuntimeError, ValueError):
+        return None
+    if not candidate.is_absolute():
+        candidate = _repo_root(repo_root) / candidate
+    try:
+        candidate_absolute = Path(os.path.abspath(candidate))
+    except (OSError, RuntimeError, ValueError):
+        return None
+
+    for root in allowed_roots:
+        try:
+            root_real = Path(os.path.realpath(root))
+            relative_parts = candidate_absolute.relative_to(root_real).parts
+        except (OSError, RuntimeError, ValueError):
+            continue
+        current = root_real
+        if not relative_parts:
+            return current
+        for index, part in enumerate(relative_parts):
+            if part in {"", ".", ".."} or path_security._UNSAFE_PATH_SEGMENT_RE.search(part):
+                return None
+            try:
+                next_path = next((child for child in current.iterdir() if child.name == part), None)
+            except (NotADirectoryError, FileNotFoundError, OSError, RuntimeError, ValueError):
+                return None
+            if next_path is None:
+                return None
+            try:
+                if index < len(relative_parts) - 1 and next_path.is_symlink():
+                    return None
+            except (OSError, RuntimeError):
+                return None
+            current = next_path
+        return current
+    return None
+
+
+def _validate_archive_index_relpath(
+    raw_relpath: Any,
+    *,
+    archive_root: Path,
+) -> Tuple[bool, str, str]:
+    relpath = str(raw_relpath or "").strip()
+    if not relpath:
+        return False, relpath, "empty_relpath"
+    if "\x00" in relpath:
+        return False, relpath, "nul_relpath"
+    if relpath.startswith(("/", "\\")):
+        return False, relpath, "absolute_relpath"
+    if _is_drive_prefixed_relpath(relpath):
+        return False, relpath, "drive_prefixed_relpath"
+
+    normalized = relpath.replace("\\", "/")
+    parts = tuple(part for part in normalized.split("/") if part and part != ".")
+    if not parts:
+        return False, relpath, "empty_relpath"
+    if any(part == ".." for part in parts):
+        return False, relpath, "parent_traversal"
+
+    current = archive_root
+    for part in parts:
+        try:
+            next_path = next((child for child in current.iterdir() if child.name == part), None)
+        except FileNotFoundError:
+            return False, relpath, "missing"
+        except (NotADirectoryError, OSError, RuntimeError, ValueError):
+            return False, relpath, "unreadable"
+        if next_path is None:
+            return False, relpath, "missing"
+        try:
+            if next_path.is_symlink():
+                return False, relpath, "symlink_traversal"
+        except (OSError, RuntimeError):
+            return False, relpath, "unreadable"
+        current = next_path
+
+    try:
+        if current.is_dir():
+            return False, relpath, "directory"
+        if not current.is_file():
+            return False, relpath, "not_regular_file"
+    except (OSError, RuntimeError):
+        return False, relpath, "unreadable"
+
+    return True, relpath, "ok"
+
+
+def _default_allowed_roots(repo_root: Path | None) -> List[Path]:
+    return path_security._default_allowed_path_roots(repo_root=_repo_root(repo_root))
+
+
+def _validate_archive_index_against_root(
+    archive_index: Path,
+    archive_root: Path,
+    *,
+    scan_mode: str = "full",
+    allowed_path_roots: Optional[List[Path]] = None,
+    allowed_input_roots: Optional[List[Path]] = None,
+    repo_root: Path | None = None,
+    cache: MutableMapping[Tuple[str, int, int, str, str], Dict[str, Any]] | None = None,
+    cache_lock: Any | None = None,
+    cache_max_entries: int = ARCHIVE_INDEX_PREFLIGHT_CACHE_MAX,
+    relpath_validator: Callable[..., Tuple[bool, str, str]] = _validate_archive_index_relpath,
+) -> Dict[str, Any]:
+    scan_mode = _archive_index_preflight_scan_mode(scan_mode)
+    if cache_max_entries < 1:
+        raise ValueError("cache_max_entries must be at least 1")
+    resolved_repo_root = _repo_root(repo_root)
+    path_roots = allowed_path_roots if allowed_path_roots is not None else _default_allowed_roots(resolved_repo_root)
+    input_roots = allowed_input_roots if allowed_input_roots is not None else _default_allowed_roots(resolved_repo_root)
+    preflight_cache = cache if cache is not None else _ARCHIVE_INDEX_PREFLIGHT_CACHE
+    preflight_cache_lock = cache_lock if cache_lock is not None else _ARCHIVE_INDEX_PREFLIGHT_CACHE_LOCK
+
+    try:
+        trusted_archive_index = path_security._ensure_safe_regular_file_path(
+            archive_index,
+            path_roots,
+            repo_root=resolved_repo_root,
+        )
+    except (OSError, RuntimeError, ValueError, path_security.PathSecurityValidationError):
+        return _archive_index_preflight_result(
+            rows_total=0,
+            blocked_rows=1,
+            examples=[
+                _archive_index_preflight_example(
+                    row=0,
+                    relpath=str(archive_index),
+                    reason="archive_index_unreadable",
+                )
+            ],
+            scan_mode=scan_mode,
+        )
+
+    trusted_archive_root = _trusted_existing_entry_without_realpath(
+        archive_root,
+        input_roots,
+        repo_root=resolved_repo_root,
+    )
+    if trusted_archive_root is None:
+        return _archive_index_preflight_result(
+            rows_total=0,
+            blocked_rows=1,
+            examples=[
+                _archive_index_preflight_example(
+                    row=0,
+                    relpath=str(archive_root),
+                    reason="archive_root_not_directory",
+                )
+            ],
+            scan_mode=scan_mode,
+        )
+    try:
+        if trusted_archive_root.is_symlink():
+            return _archive_index_preflight_result(
+                rows_total=0,
+                blocked_rows=1,
+                examples=[
+                    _archive_index_preflight_example(
+                        row=0,
+                        relpath=str(archive_root),
+                        reason="archive_root_symlink",
+                    )
+                ],
+                scan_mode=scan_mode,
+            )
+        if not trusted_archive_root.is_dir():
+            return _archive_index_preflight_result(
+                rows_total=0,
+                blocked_rows=1,
+                examples=[
+                    _archive_index_preflight_example(
+                        row=0,
+                        relpath=str(archive_root),
+                        reason="archive_root_not_directory",
+                    )
+                ],
+                scan_mode=scan_mode,
+            )
+        archive_root_real = Path(os.path.realpath(trusted_archive_root))
+    except (OSError, RuntimeError):
+        return _archive_index_preflight_result(
+            rows_total=0,
+            blocked_rows=1,
+            examples=[
+                _archive_index_preflight_example(
+                    row=0,
+                    relpath=str(archive_root),
+                    reason="archive_root_unreadable",
+                )
+            ],
+            scan_mode=scan_mode,
+        )
+
+    try:
+        cache_key = _archive_index_preflight_cache_key(
+            trusted_archive_index,
+            archive_root_real,
+            scan_mode=scan_mode,
+        )
+    except OSError:
+        return _archive_index_preflight_result(
+            rows_total=0,
+            blocked_rows=1,
+            examples=[
+                _archive_index_preflight_example(
+                    row=0,
+                    relpath=str(archive_index),
+                    reason="archive_index_unreadable",
+                )
+            ],
+            scan_mode=scan_mode,
+        )
+
+    with preflight_cache_lock:
+        cached = preflight_cache.get(cache_key)
+    if cached is not None:
+        return _copy_archive_index_preflight_result(cached)
+
+    rows_total = 0
+    blocked_rows = 0
+    examples: List[Dict[str, Any]] = []
+    row_limit = _archive_index_preflight_row_limit(scan_mode)
+    truncated = False
+
+    try:
+        opener: Callable[..., Any] = gzip.open if trusted_archive_index.name.endswith(".gz") else Path.open
+        with opener(trusted_archive_index, "rt", encoding="utf-8", newline="") as handle:
+            reader = csv.DictReader(handle)
+            fieldnames = set(reader.fieldnames or [])
+            missing_columns = sorted(ARCHIVE_INDEX_REQUIRED_COLUMNS - fieldnames)
+            if missing_columns:
+                return _archive_index_preflight_result(
+                    rows_total=0,
+                    blocked_rows=1,
+                    examples=[
+                        _archive_index_preflight_example(
+                            row=1,
+                            relpath="",
+                            reason=f"missing_columns:{','.join(missing_columns)}",
+                        )
+                    ],
+                    scan_mode=scan_mode,
+                )
+
+            for row_number, row in enumerate(reader, start=2):
+                rows_total += 1
+                ok, relpath, reason = relpath_validator(
+                    row.get("relpath"),
+                    archive_root=archive_root_real,
+                )
+                if row_limit is not None and rows_total >= row_limit:
+                    truncated = True
+                if ok:
+                    if truncated:
+                        break
+                    continue
+                blocked_rows += 1
+                if len(examples) < ARCHIVE_INDEX_PREFLIGHT_EXAMPLE_LIMIT:
+                    examples.append(
+                        _archive_index_preflight_example(
+                            row=row_number,
+                            relpath=relpath,
+                            reason=reason,
+                        )
+                    )
+                if truncated:
+                    break
+    except (csv.Error, gzip.BadGzipFile, OSError, RuntimeError, UnicodeDecodeError) as exc:
+        return _archive_index_preflight_result(
+            rows_total=rows_total,
+            blocked_rows=max(1, blocked_rows),
+            examples=[
+                _archive_index_preflight_example(
+                    row=max(1, rows_total + 1),
+                    relpath=str(trusted_archive_index),
+                    reason=f"archive_index_unreadable:{type(exc).__name__}",
+                )
+            ],
+            scan_mode=scan_mode,
+        )
+
+    if rows_total == 0:
+        return _archive_index_preflight_result(
+            rows_total=0,
+            blocked_rows=1,
+            examples=[
+                _archive_index_preflight_example(
+                    row=1,
+                    relpath="",
+                    reason="empty_archive_index",
+                )
+            ],
+            scan_mode=scan_mode,
+        )
+
+    result = _archive_index_preflight_result(
+        rows_total=rows_total,
+        blocked_rows=blocked_rows,
+        examples=examples,
+        scan_mode=scan_mode,
+        truncated=truncated,
+    )
+    with preflight_cache_lock:
+        if len(preflight_cache) >= cache_max_entries:
+            preflight_cache.pop(next(iter(preflight_cache)), None)
+        preflight_cache[cache_key] = _copy_archive_index_preflight_result(result)
+    return result

--- a/tests/portal/test_archive_index_preflight.py
+++ b/tests/portal/test_archive_index_preflight.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Archive index preflight extraction contract tests."""
+
+from __future__ import annotations
+
+import csv
+import gzip
+import importlib
+import subprocess
+import sys
+import threading
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _write_archive_index(path: Path, relpaths: list[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    opener = gzip.open if path.name.endswith(".gz") else open
+    with opener(path, "wt", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=["origin_drive", "partition", "relpath"],
+            lineterminator="\n",
+        )
+        writer.writeheader()
+        for relpath in relpaths:
+            writer.writerow(
+                {
+                    "origin_drive": "local",
+                    "partition": "test",
+                    "relpath": relpath,
+                }
+            )
+
+
+def _validate_direct(
+    module: Any,
+    archive_index: Path,
+    archive_root: Path,
+    *,
+    scan_mode: str = "full",
+    cache: dict[tuple[str, int, int, str, str], dict[str, Any]] | None = None,
+    cache_lock: threading.Lock | None = None,
+    cache_max_entries: int | None = None,
+    relpath_validator: Any | None = None,
+) -> dict[str, Any]:
+    kwargs: dict[str, Any] = {
+        "scan_mode": scan_mode,
+        "allowed_path_roots": [archive_index.parent],
+        "allowed_input_roots": [archive_root.parent],
+        "repo_root": REPO_ROOT,
+    }
+    if cache is not None:
+        kwargs["cache"] = cache
+    if cache_lock is not None:
+        kwargs["cache_lock"] = cache_lock
+    if cache_max_entries is not None:
+        kwargs["cache_max_entries"] = cache_max_entries
+    if relpath_validator is not None:
+        kwargs["relpath_validator"] = relpath_validator
+    return module._validate_archive_index_against_root(archive_index, archive_root, **kwargs)
+
+
+def test_direct_module_import_does_not_import_app() -> None:
+    code = (
+        "import sys; "
+        f"sys.path.insert(0, {str(REPO_ROOT / 'src')!r}); "
+        "import transformation_portal.portal.archive_index_preflight; "
+        "raise SystemExit(1 if 'app' in sys.modules else 0)"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=REPO_ROOT,
+        check=False,
+    )
+
+    assert result.returncode == 0
+
+
+def test_app_legacy_archive_index_helpers_remain_available() -> None:
+    module = importlib.import_module("transformation_portal.portal.archive_index_preflight")
+    orchestrator_app = importlib.import_module("app")
+
+    assert orchestrator_app.ARCHIVE_INDEX_PREFLIGHT_PREVIEW_ROW_LIMIT == module.ARCHIVE_INDEX_PREFLIGHT_PREVIEW_ROW_LIMIT
+    assert orchestrator_app._ARCHIVE_INDEX_PREFLIGHT_CACHE is module._ARCHIVE_INDEX_PREFLIGHT_CACHE
+    assert orchestrator_app._ARCHIVE_INDEX_PREFLIGHT_CACHE_LOCK is module._ARCHIVE_INDEX_PREFLIGHT_CACHE_LOCK
+    assert orchestrator_app._archive_index_preflight_message is module._archive_index_preflight_message
+    assert orchestrator_app._archive_index_preflight_root_reason is module._archive_index_preflight_root_reason
+    assert orchestrator_app._validate_archive_index_relpath is module._validate_archive_index_relpath
+    assert callable(orchestrator_app._validate_archive_index_against_root)
+
+
+def test_app_wrapper_matches_direct_module_result(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = importlib.import_module("transformation_portal.portal.archive_index_preflight")
+    orchestrator_app = importlib.import_module("app")
+    archive_root = tmp_path / "archive_root"
+    archive_root.mkdir()
+    (archive_root / "asset-001.dng").write_bytes(b"raw")
+    archive_index = tmp_path / "archive_index_normalized.csv.gz"
+    _write_archive_index(archive_index, ["asset-001.dng"])
+
+    monkeypatch.setattr(orchestrator_app, "ALLOWED_PATH_ROOTS", [tmp_path])
+    monkeypatch.setattr(orchestrator_app, "ALLOWED_INPUT_ROOTS", [tmp_path])
+    with orchestrator_app._ARCHIVE_INDEX_PREFLIGHT_CACHE_LOCK:
+        orchestrator_app._ARCHIVE_INDEX_PREFLIGHT_CACHE.clear()
+
+    direct = _validate_direct(module, archive_index, archive_root)
+    with orchestrator_app._ARCHIVE_INDEX_PREFLIGHT_CACHE_LOCK:
+        orchestrator_app._ARCHIVE_INDEX_PREFLIGHT_CACHE.clear()
+    legacy = orchestrator_app._validate_archive_index_against_root(archive_index, archive_root)
+
+    assert legacy == direct
+    assert legacy == {
+        "ok": True,
+        "rows_total": 1,
+        "blocked_rows": 0,
+        "examples": [],
+        "scan_mode": "full",
+        "truncated": False,
+    }
+
+
+@pytest.mark.parametrize(
+    ("relpath", "reason"),
+    [
+        ("../escape.dng", "parent_traversal"),
+        ("/absolute.dng", "absolute_relpath"),
+        ("C:/absolute.dng", "drive_prefixed_relpath"),
+        ("", "empty_relpath"),
+        ("missing.dng", "missing"),
+        ("folder", "directory"),
+    ],
+)
+def test_direct_validation_preserves_invalid_relpath_reasons(
+    tmp_path: Path,
+    relpath: str,
+    reason: str,
+) -> None:
+    module = importlib.import_module("transformation_portal.portal.archive_index_preflight")
+    archive_root = tmp_path / "archive_root"
+    archive_root.mkdir()
+    (archive_root / "folder").mkdir()
+    archive_index = tmp_path / f"archive_index_{reason}.csv.gz"
+    _write_archive_index(archive_index, [relpath])
+
+    result = _validate_direct(module, archive_index, archive_root)
+
+    assert result["ok"] is False
+    assert result["blocked_rows"] == 1
+    assert result["examples"][0]["reason"] == reason
+
+
+def test_direct_validation_rejects_symlink_escape(tmp_path: Path) -> None:
+    module = importlib.import_module("transformation_portal.portal.archive_index_preflight")
+    archive_root = tmp_path / "archive_root"
+    archive_root.mkdir()
+    outside = tmp_path / "outside.dng"
+    outside.write_bytes(b"outside")
+    link_path = archive_root / "asset-link.dng"
+    try:
+        link_path.symlink_to(outside)
+    except OSError as exc:
+        pytest.skip(f"symlink creation unavailable: {exc}")
+    archive_index = tmp_path / "archive_index_symlink.csv.gz"
+    _write_archive_index(archive_index, ["asset-link.dng"])
+
+    result = _validate_direct(module, archive_index, archive_root)
+
+    assert result["ok"] is False
+    assert result["examples"][0]["reason"] == "symlink_traversal"
+
+
+def test_direct_validation_rejects_intermediate_symlink_archive_root(tmp_path: Path) -> None:
+    module = importlib.import_module("transformation_portal.portal.archive_index_preflight")
+    allowed_root = tmp_path / "allowed"
+    allowed_root.mkdir()
+    archive_index = allowed_root / "archive_index.csv.gz"
+    _write_archive_index(archive_index, ["asset-001.dng"])
+    outside = tmp_path / "outside"
+    outside_archive_root = outside / "archive_root"
+    outside_archive_root.mkdir(parents=True)
+    (outside_archive_root / "asset-001.dng").write_bytes(b"raw")
+    link_path = allowed_root / "link-outside"
+    try:
+        link_path.symlink_to(outside, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"symlink creation unavailable: {exc}")
+
+    result = module._validate_archive_index_against_root(
+        archive_index,
+        link_path / "archive_root",
+        allowed_path_roots=[allowed_root],
+        allowed_input_roots=[allowed_root],
+        repo_root=REPO_ROOT,
+    )
+
+    assert result["ok"] is False
+    assert result["examples"][0]["reason"] == "archive_root_not_directory"
+
+
+def test_direct_validation_preserves_final_symlink_archive_root_reason(tmp_path: Path) -> None:
+    module = importlib.import_module("transformation_portal.portal.archive_index_preflight")
+    archive_index = tmp_path / "archive_index.csv.gz"
+    _write_archive_index(archive_index, ["asset-001.dng"])
+    real_root = tmp_path / "real_root"
+    real_root.mkdir()
+    (real_root / "asset-001.dng").write_bytes(b"raw")
+    link_root = tmp_path / "link_root"
+    try:
+        link_root.symlink_to(real_root, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"symlink creation unavailable: {exc}")
+
+    result = _validate_direct(module, archive_index, link_root)
+
+    assert result["ok"] is False
+    assert result["examples"][0]["reason"] == "archive_root_symlink"
+
+
+def test_direct_validation_rejects_missing_columns_and_bad_gzip(tmp_path: Path) -> None:
+    module = importlib.import_module("transformation_portal.portal.archive_index_preflight")
+    archive_root = tmp_path / "archive_root"
+    archive_root.mkdir()
+    missing_columns = tmp_path / "archive_index_missing_columns.csv"
+    missing_columns.write_text("relpath\nasset-001.dng\n", encoding="utf-8")
+    bad_gzip = tmp_path / "archive_index_bad.csv.gz"
+    bad_gzip.write_bytes(b"not a gzip stream")
+
+    missing_columns_result = _validate_direct(module, missing_columns, archive_root)
+    bad_gzip_result = _validate_direct(module, bad_gzip, archive_root)
+
+    assert missing_columns_result["ok"] is False
+    assert missing_columns_result["examples"][0]["reason"].startswith("missing_columns:")
+    assert bad_gzip_result["ok"] is False
+    assert bad_gzip_result["examples"][0]["reason"] == "archive_index_unreadable:BadGzipFile"
+
+
+def test_direct_preview_scan_is_bounded_deep_copied_and_cached(tmp_path: Path) -> None:
+    module = importlib.import_module("transformation_portal.portal.archive_index_preflight")
+    archive_root = tmp_path / "archive_root"
+    archive_root.mkdir()
+    existing_relpaths = [f"asset-{idx:03d}.dng" for idx in range(module.ARCHIVE_INDEX_PREFLIGHT_PREVIEW_ROW_LIMIT)]
+    for relpath in existing_relpaths:
+        (archive_root / relpath).write_bytes(b"raw")
+    archive_index = tmp_path / "archive_index_bounded.csv.gz"
+    _write_archive_index(archive_index, [*existing_relpaths, "late-missing.dng"])
+    cache: dict[tuple[str, int, int, str, str], dict[str, Any]] = {}
+    cache_lock = threading.Lock()
+
+    preview_result = _validate_direct(
+        module,
+        archive_index,
+        archive_root,
+        scan_mode="preview",
+        cache=cache,
+        cache_lock=cache_lock,
+    )
+    preview_result["ok"] = False
+
+    def fail_if_rescanned(*_args: Any, **_kwargs: Any) -> tuple[bool, str, str]:
+        raise AssertionError("cached preview result should avoid rescanning rows")
+
+    cached_preview = _validate_direct(
+        module,
+        archive_index,
+        archive_root,
+        scan_mode="preview",
+        cache=cache,
+        cache_lock=cache_lock,
+        relpath_validator=fail_if_rescanned,
+    )
+
+    assert cached_preview["ok"] is True
+    assert cached_preview["truncated"] is True
+    assert cached_preview["rows_total"] == module.ARCHIVE_INDEX_PREFLIGHT_PREVIEW_ROW_LIMIT
+
+
+def test_direct_cache_uses_fifo_eviction(tmp_path: Path) -> None:
+    module = importlib.import_module("transformation_portal.portal.archive_index_preflight")
+    archive_root = tmp_path / "archive_root"
+    archive_root.mkdir()
+    (archive_root / "asset-001.dng").write_bytes(b"raw")
+    cache: dict[tuple[str, int, int, str, str], dict[str, Any]] = {}
+    cache_lock = threading.Lock()
+    indexes = []
+    for idx in range(3):
+        archive_index = tmp_path / f"archive_index_{idx}.csv.gz"
+        _write_archive_index(archive_index, ["asset-001.dng"])
+        indexes.append(archive_index)
+        _validate_direct(
+            module,
+            archive_index,
+            archive_root,
+            cache=cache,
+            cache_lock=cache_lock,
+            cache_max_entries=2,
+        )
+
+    cached_paths = {key[0] for key in cache}
+    assert len(cache) == 2
+    assert str(indexes[0]) not in cached_paths
+    assert str(indexes[1]) in cached_paths
+    assert str(indexes[2]) in cached_paths
+
+
+def test_direct_validation_rejects_invalid_cache_max_entries(tmp_path: Path) -> None:
+    module = importlib.import_module("transformation_portal.portal.archive_index_preflight")
+    archive_root = tmp_path / "archive_root"
+    archive_root.mkdir()
+    (archive_root / "asset-001.dng").write_bytes(b"raw")
+    archive_index = tmp_path / "archive_index.csv.gz"
+    _write_archive_index(archive_index, ["asset-001.dng"])
+
+    with pytest.raises(ValueError, match="cache_max_entries must be at least 1"):
+        _validate_direct(
+            module,
+            archive_index,
+            archive_root,
+            cache={},
+            cache_lock=threading.Lock(),
+            cache_max_entries=0,
+        )
+
+
+def test_app_wrapper_uses_monkeypatched_relpath_validator(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    orchestrator_app = importlib.import_module("app")
+    archive_root = tmp_path / "archive_root"
+    archive_root.mkdir()
+    (archive_root / "asset-001.dng").write_bytes(b"raw")
+    archive_index = tmp_path / "archive_index_normalized.csv.gz"
+    _write_archive_index(archive_index, ["asset-001.dng"])
+
+    monkeypatch.setattr(orchestrator_app, "ALLOWED_PATH_ROOTS", [tmp_path])
+    monkeypatch.setattr(orchestrator_app, "ALLOWED_INPUT_ROOTS", [tmp_path])
+
+    def forced_failure(*_args: Any, **_kwargs: Any) -> tuple[bool, str, str]:
+        return False, "forced.dng", "forced_failure"
+
+    monkeypatch.setattr(orchestrator_app, "_validate_archive_index_relpath", forced_failure)
+    with orchestrator_app._ARCHIVE_INDEX_PREFLIGHT_CACHE_LOCK:
+        orchestrator_app._ARCHIVE_INDEX_PREFLIGHT_CACHE.clear()
+
+    result = orchestrator_app._validate_archive_index_against_root(archive_index, archive_root)
+
+    assert result["ok"] is False
+    assert result["examples"][0] == {
+        "row": 2,
+        "relpath": "forced.dng",
+        "reason": "forced_failure",
+    }


### PR DESCRIPTION
## Summary
- Extract the archive-index preflight helper seam from `app.py` into `transformation_portal.portal.archive_index_preflight`.
- Preserve `app.py` as the compatibility surface for existing private helper access and monkeypatch-based tests.

## Changes
- Add `portal/archive_index_preflight.py` with archive index result helpers, scan-mode normalization, trusted archive-root walking, relpath validation, cache keying, bounded cache behavior, and index/root validation.
- Replace the in-module `app.py` helper bodies with aliases and a wrapper that injects app-owned roots/cache and the app-level relpath validator.
- Add direct-module and compatibility tests covering import isolation, legacy helper availability, direct/app parity, reason preservation, symlink rejection, missing-column/bad-gzip handling, preview cache behavior, FIFO eviction, and app monkeypatch compatibility.
- Update the monolith decomposition status table with Target 2D only.

## Validation
- `.venv/bin/python -m pytest tests/portal/test_archive_index_preflight.py tests/test_app_orchestrator_runtime.py -k "archive_index_preflight or archive_gate_a_readiness or archive_index_root_mismatch" -q`
- `.venv/bin/python -m pytest tests/test_app_orchestrator_contract_http.py tests/test_app_security.py tests/test_portal_backend_hardening.py -k "archive or artifact or path" -q`
- `make check-json-serialization check-yaml-governance check-python-headers`
- `.venv/bin/python scripts/validation/scan_todo_inventory.py --check-governance`
- `make test-fast`
- `git diff --check`
- pre-commit hooks during commit

## Risk
- Compatibility wrappers preserve existing `app.py` private helper names and cache objects.
- No archive route, readiness envelope, preview error, reason-code, row-scan, symlink, or artifact-indexing behavior is intended to change.
- The change is bounded and revert-safe because archive-gate callers continue to go through the existing `app.py` surface.
