### PR TITLE
refactor(meta-pipeline): enforce WorkflowExecutor abstract contract via ABC

### DIFF
--- a/scripts/pipelines/unified_meta_pipeline.py
+++ b/scripts/pipelines/unified_meta_pipeline.py
@@ -170,7 +170,7 @@ class WorkflowExecutor(ABC):
     @abstractmethod
     def execute(self) -> bool:
         """Execute the workflow. Returns success status."""
-        pass
+        raise NotImplementedError("WorkflowExecutor subclasses must implement execute()")
 
 
 class ArchHeroWorkflow(WorkflowExecutor):

--- a/scripts/pipelines/unified_meta_pipeline.py
+++ b/scripts/pipelines/unified_meta_pipeline.py
@@ -170,7 +170,7 @@ class WorkflowExecutor(ABC):
     @abstractmethod
     def execute(self) -> bool:
         """Execute the workflow. Returns success status."""
-        raise NotImplementedError
+        pass
 
 
 class ArchHeroWorkflow(WorkflowExecutor):

--- a/scripts/pipelines/unified_meta_pipeline.py
+++ b/scripts/pipelines/unified_meta_pipeline.py
@@ -44,6 +44,7 @@ import shutil
 import subprocess
 import sys
 import time
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, List, Optional
@@ -109,7 +110,7 @@ class MetaPipelineConfig:
         (self.output_dir / "final").mkdir(exist_ok=True)
 
 
-class WorkflowExecutor:
+class WorkflowExecutor(ABC):
     """Base class for workflow execution strategies."""
 
     def __init__(self, config: MetaPipelineConfig):
@@ -166,6 +167,7 @@ class WorkflowExecutor:
             log.error(f"Manifest path: {manifest_path}")
             return None
 
+    @abstractmethod
     def execute(self) -> bool:
         """Execute the workflow. Returns success status."""
         raise NotImplementedError


### PR DESCRIPTION
WorkflowExecutor.execute() previously documented "must be overridden by
subclasses" but used a bare `raise NotImplementedError`, leaving the
abstract intent unenforced at instantiation time. Apply the same
ABC + @abstractmethod pattern documented in QW-1 (ComfyUI BaseNode) so
the contract is checked when the class is constructed rather than only
when execute() is reached. All four concrete subclasses (ArchHero,
VideoEnhance, FullStack, EnhancementOnly) already override execute()
and continue to instantiate cleanly.