### PR TITLE
refactor(portal): extract job artifact catalog helpers

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,7 +6,6 @@ import hmac
 import json
 import logging
 import math
-import mimetypes
 import os
 import re
 import shlex
@@ -16,7 +15,6 @@ import tempfile
 import threading
 import time
 import uuid
-from bisect import bisect_left
 from collections import deque
 from contextlib import asynccontextmanager, contextmanager, suppress
 from dataclasses import dataclass
@@ -25,9 +23,8 @@ from email.parser import BytesParser
 from email.policy import default as email_policy
 from functools import lru_cache
 from importlib.util import find_spec
-from pathlib import Path, PurePosixPath
-from typing import Any, AsyncGenerator, Callable, Deque, Dict, Iterable, List, Mapping, Optional, Tuple
-from urllib.parse import quote
+from pathlib import Path
+from typing import Any, AsyncGenerator, Callable, Deque, Dict, List, Mapping, Optional, Tuple
 
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.exception_handlers import request_validation_exception_handler as fastapi_request_validation_exception_handler
@@ -63,9 +60,9 @@ from transformation_portal.ingest.upload_staging import (
     stage_upload_batch,
 )
 from transformation_portal.lux_depth_v3.model_registry import resolve_model_spec, resolve_registry_key, visible_cli_model_specs
-from transformation_portal.lux_depth_v3.run_card_contract import infer_run_card_version
 from transformation_portal.portal import archive_index_preflight as _portal_archive_index_preflight
 from transformation_portal.portal import asset_bundle as _portal_asset_bundle
+from transformation_portal.portal import job_artifacts as _portal_job_artifacts
 from transformation_portal.portal import path_security as _portal_path_security
 from transformation_portal.portal import sam2_checkpoint_security as _portal_sam2_checkpoint_security
 from transformation_portal.portal.asset_bundle import (
@@ -87,6 +84,13 @@ from transformation_portal.portal.asset_bundle import (
     PortalAssetBundle,
     PortalAssetSpec,
     PortalRenderedTextAsset,
+)
+from transformation_portal.portal.job_artifacts import (
+    AbsoluteArtifactPathError,
+    ArtifactPathOutsideJobOutputDirError,
+    ArtifactPathValidationError,
+    InvalidArtifactPathError,
+    JobRunMetadata,
 )
 from transformation_portal.portal.sam2_checkpoint_security import (
     ManagedSam2CheckpointValidationResult,
@@ -977,15 +981,6 @@ class Job:
         self.logs_tail.append(line)
         if len(self.logs_tail) > limit:
             self.logs_tail = self.logs_tail[-limit:]
-
-
-@dataclass(frozen=True)
-class JobRunMetadata:
-    output_dir: Path
-    run_card_path: Optional[Path] = None
-    run_card_payload: Optional[Dict[str, Any]] = None
-    batch_manifest_path: Optional[Path] = None
-    batch_manifest_payload: Optional[Dict[str, Any]] = None
 
 
 JOBS: Dict[str, Job] = {}
@@ -5788,38 +5783,6 @@ def _job_output_dir(job: Job) -> Optional[Path]:
         return None
 
 
-def _infer_artifact_type(path: Path) -> str:
-    suffix = path.suffix.lower()
-    if suffix in {
-        ".json",
-        ".yaml",
-        ".yml",
-        ".txt",
-        ".md",
-        ".log",
-        ".csv",
-    }:
-        return "metadata"
-    if suffix in {
-        ".png",
-        ".jpg",
-        ".jpeg",
-        ".tif",
-        ".tiff",
-        ".webp",
-        ".exr",
-    }:
-        return "image"
-    if suffix in {".zip", ".tar", ".gz", ".tgz", ".bag"}:
-        return "archive"
-    return "file"
-
-
-def _artifact_content_type(path: Path) -> str:
-    guessed, _ = mimetypes.guess_type(str(path))
-    return guessed or "application/octet-stream"
-
-
 def _resolve_portal_asset(asset_path: str) -> PortalAssetSpec:
     normalized = str(asset_path or "").strip()
     if not normalized:
@@ -5835,233 +5798,37 @@ def _resolve_portal_asset(asset_path: str) -> PortalAssetSpec:
     return candidate
 
 
-def _artifact_media_kind(path: Path) -> str:
-    artifact_type = _infer_artifact_type(path)
-    if artifact_type == "image":
-        return "image"
-    if artifact_type == "metadata":
-        return "metadata"
-    if artifact_type == "archive":
-        return "archive"
-    return "file"
-
-
-def _artifact_is_previewable(path: Path) -> bool:
-    return _artifact_media_kind(path) == "image" and _artifact_content_type(path).startswith("image/")
-
-
-# MIME types browsers reliably render via <img> / <picture>. TIFF, EXR, and
-# similar formats are excluded so the portal never asks the browser to decode
-# them; previewing those goes through a sibling PNG proxy when available.
-_BROWSER_PREVIEWABLE_MIME_TYPES = frozenset(
-    {
-        "image/png",
-        "image/jpeg",
-        "image/webp",
-        "image/gif",
-        "image/avif",
-        "image/svg+xml",
-    }
-)
-
-
-def _artifact_is_browser_previewable(path: Path) -> bool:
-    return _artifact_content_type(path).lower() in _BROWSER_PREVIEWABLE_MIME_TYPES
-
-
-def _artifact_preview_proxy_path(path: Path) -> Optional[Path]:
-    """Return a sibling PNG proxy for browser-unfriendly image artifacts.
-
-    The naming convention is ``<original>.preview.png`` adjacent to the source
-    file. Pipelines that emit TIFF/EXR outputs are responsible for writing this
-    sidecar; the serializer only surfaces what already exists on disk so the
-    HTTP API never speculates about files it cannot deliver.
-    """
-
-    if _artifact_is_browser_previewable(path):
-        return None
-    if _artifact_media_kind(path) != "image":
-        return None
-    candidate = path.with_name(path.name + ".preview.png")
-    try:
-        if candidate.is_file():
-            return candidate
-    except OSError:
-        return None
-    return None
-
-
-def _add_artifact_preview_proxy_lookup(
-    lookup: Dict[str, Path],
-    *,
-    output_dir: Path,
-    artifact_path: Path,
-) -> None:
-    proxy_path = _artifact_preview_proxy_path(artifact_path)
-    if proxy_path is None:
-        return
-    try:
-        resolved_output_dir = Path(os.path.realpath(output_dir.expanduser()))
-        resolved_proxy_path = Path(os.path.realpath(proxy_path))
-        proxy_relative_path = str(resolved_proxy_path.relative_to(resolved_output_dir))
-    except (OSError, ValueError):
-        return
-    lookup.setdefault(proxy_relative_path, resolved_proxy_path)
-
-
-def _safe_artifact_attachment_filename(path: Path) -> str:
-    """Return an ASCII-safe filename for Content-Disposition attachments.
-
-    Limits the character set to avoid injection of CR/LF or quote characters
-    into the response header; falls back to ``download`` when the resulting
-    string is empty.
-    """
-
-    candidate = re.sub(r"[^A-Za-z0-9._-]", "_", path.name or "")
-    return candidate or "download"
-
-
-def _artifact_response_headers(path: Path) -> Dict[str, str]:
-    """Build response headers for a job artifact download.
-
-    Previewable media is served inline (so the browser can render it in the
-    artifact viewer); everything else is returned as an attachment to prevent
-    stored HTML/SVG/JS from executing in the portal origin.
-    """
-
-    headers: Dict[str, str] = {"Cache-Control": "no-store"}
-    if not _artifact_is_previewable(path):
-        filename = _safe_artifact_attachment_filename(path)
-        headers["Content-Disposition"] = f'attachment; filename="{filename}"'
-    return headers
-
-
-def _artifact_display_label(role: str) -> str:
-    return {
-        "primary_preview": "Primary Preview",
-        "review_preview": "Review Preview",
-        "supporting_preview": "Supporting Preview",
-        "run_card": "Run Card",
-        "report": "Report",
-        "manifest": "Manifest",
-        "vlm_caption": "Advisory Caption",
-        "archive": "Archive",
-        "log": "Log",
-        "metadata": "Metadata",
-    }.get(role, "File")
-
-
-_STEM_NOISE_RE = re.compile(
-    r"(master16|upscaled16|final|result|render|beauty|marketing|depth|preview"
-    r"|thumb|debug|segmentation|overlay|mask|albedo|normal|roughness|metallic|ao)"
-)
-
-
-def _artifact_compare_group(relative_path: str, path: Path) -> str:
-    if not _artifact_is_previewable(path):
-        return ""
-    artifact_path = PurePosixPath(relative_path)
-    parent = artifact_path.parent.as_posix()
-    if parent == ".":
-        parent = ""
-    raw_stem = artifact_path.stem.lower()
-    simplified_stem = _STEM_NOISE_RE.sub(" ", raw_stem)
-    normalized_stem = re.sub(r"[^a-z0-9]+", "-", simplified_stem).strip("-")
-    if not normalized_stem:
-        normalized_stem = re.sub(r"[^a-z0-9]+", "-", raw_stem).strip("-")
-    batch_hint = _artifact_batch_hint(relative_path)
-    return "|".join(part for part in (batch_hint, parent, normalized_stem) if part)
-
-
-def _artifact_display_hint(relative_path: str, path: Path) -> Dict[str, Any]:
-    lower_name = relative_path.lower()
-    stem_lower = PurePosixPath(relative_path).stem.lower()
-    artifact_type = _infer_artifact_type(path)
-    if _artifact_is_previewable(path):
-        if re.search(r"(mask|matte|thumb|preview|debug|overlay|segmentation|albedo|normal|roughness|metallic|ao)", lower_name):
-            role = "supporting_preview"
-            priority = 700
-        elif re.search(r"(master16|upscaled16|final|result|render|beauty|marketing|depth)", lower_name):
-            role = "primary_preview"
-            priority = 1000
-        else:
-            role = "review_preview"
-            priority = 850
-    elif lower_name.endswith(".vlm_captioning.sidecar.json"):
-        role = "vlm_caption"
-        priority = 300
-    elif lower_name.endswith(".vlm_captioning.raw.txt"):
-        role = "log"
-        priority = 160
-    elif "/captioning/" in f"/{lower_name}":
-        role = "metadata"
-        priority = 120
-    elif "run_card" in lower_name:
-        role = "run_card"
-        priority = 320
-    elif "report" in lower_name:
-        role = "report"
-        priority = 280
-    elif "manifest" in lower_name:
-        role = "manifest"
-        priority = 240
-    elif artifact_type == "archive":
-        role = "archive"
-        priority = 180
-    elif lower_name.endswith(".log") or "/logs/" in lower_name or re.search(r"(^|[._\-\s])log($|[._\-\s])", stem_lower):
-        role = "log"
-        priority = 160
-    elif artifact_type == "metadata":
-        role = "metadata"
-        priority = 120
-    else:
-        role = "file"
-        priority = 100
-
-    hint: Dict[str, Any] = {
-        "role": role,
-        "priority": priority,
-        "label": _artifact_display_label(role),
-    }
-    compare_group = _artifact_compare_group(relative_path, path)
-    if compare_group:
-        hint["compare_group"] = compare_group
-    return hint
-
-
-def _artifact_url(job_id: str, relative_path: str) -> str:
-    return f"/v1/jobs/{quote(str(job_id), safe='')}" f"/artifacts/{quote(relative_path, safe='/')}"
+_infer_artifact_type = _portal_job_artifacts._infer_artifact_type
+_artifact_content_type = _portal_job_artifacts._artifact_content_type
+_artifact_media_kind = _portal_job_artifacts._artifact_media_kind
+_artifact_is_previewable = _portal_job_artifacts._artifact_is_previewable
+_BROWSER_PREVIEWABLE_MIME_TYPES = _portal_job_artifacts._BROWSER_PREVIEWABLE_MIME_TYPES
+_artifact_is_browser_previewable = _portal_job_artifacts._artifact_is_browser_previewable
+_artifact_preview_proxy_path = _portal_job_artifacts._artifact_preview_proxy_path
+_add_artifact_preview_proxy_lookup = _portal_job_artifacts._add_artifact_preview_proxy_lookup
+_safe_artifact_attachment_filename = _portal_job_artifacts._safe_artifact_attachment_filename
+_artifact_response_headers = _portal_job_artifacts._artifact_response_headers
+_artifact_display_label = _portal_job_artifacts._artifact_display_label
+_STEM_NOISE_RE = _portal_job_artifacts._STEM_NOISE_RE
+_artifact_compare_group = _portal_job_artifacts._artifact_compare_group
+_artifact_display_hint = _portal_job_artifacts._artifact_display_hint
+_artifact_url = _portal_job_artifacts._artifact_url
+_coerce_nonnegative_int = _portal_job_artifacts._coerce_nonnegative_int
+_captioning_artifact_counts_from_paths = _portal_job_artifacts._captioning_artifact_counts_from_paths
+_captioning_artifact_counts_from_run_card = _portal_job_artifacts._captioning_artifact_counts_from_run_card
+_captioning_artifact_counts_from_job_artifacts = _portal_job_artifacts._captioning_artifact_counts_from_job_artifacts
 
 
 def _artifact_fingerprint(
     path: Path,
     size_bytes: Optional[int],
 ) -> Tuple[Optional[str], str]:
-    """Return ``(sha256_hex, status)`` for an artifact.
-
-    * ``status == "ok"`` and ``sha256_hex`` populated when the file fits under
-      ``ARTIFACT_FINGERPRINT_MAX_BYTES``.
-    * ``status == "skipped_size"`` when the file exceeds the cap (the portal
-      UI renders this as "fingerprint unavailable" rather than a broken copy
-      button).
-    * ``status == "unavailable"`` when the file cannot be read.
-    """
-
-    if size_bytes is None:
-        return None, "unavailable"
-    if size_bytes > ARTIFACT_FINGERPRINT_MAX_BYTES:
-        return None, "skipped_size"
-    digest = hashlib.sha256()
-    try:
-        with path.open("rb") as handle:
-            while True:
-                chunk = handle.read(_ARTIFACT_FINGERPRINT_CHUNK_BYTES)
-                if not chunk:
-                    break
-                digest.update(chunk)
-    except OSError:
-        return None, "unavailable"
-    return digest.hexdigest(), "ok"
+    return _portal_job_artifacts._artifact_fingerprint(
+        path,
+        size_bytes,
+        max_bytes=ARTIFACT_FINGERPRINT_MAX_BYTES,
+        chunk_bytes=_ARTIFACT_FINGERPRINT_CHUNK_BYTES,
+    )
 
 
 def _serialize_indexed_artifact(
@@ -6070,89 +5837,12 @@ def _serialize_indexed_artifact(
     relative_path: str,
     path: Path,
 ) -> Dict[str, Any]:
-    try:
-        size_bytes = path.stat().st_size
-    except OSError:
-        size_bytes = None
-
-    content_type = _artifact_content_type(path)
-    sha256_hex, fingerprint_status = _artifact_fingerprint(path, size_bytes)
-    download_url = _artifact_url(job_id, relative_path)
-    proxy_path = _artifact_preview_proxy_path(path)
-    proxy_relative = f"{relative_path}.preview.png" if proxy_path is not None else None
-    browser_previewable = _artifact_is_browser_previewable(path) or proxy_path is not None
-    payload: Dict[str, Any] = {
-        "artifact_type": _infer_artifact_type(path),
-        "media_kind": _artifact_media_kind(path),
-        "previewable": _artifact_is_previewable(path),
-        # Narrower than `previewable`: excludes TIFF/EXR which browsers cannot
-        # render via <img>. The portal review surface uses this flag to decide
-        # whether to inline-preview an artifact or render a download-only card.
-        "browser_previewable": browser_previewable,
-        "content_type": content_type,
-        "mime_type": content_type,
-        "display_hint": _artifact_display_hint(relative_path, path),
-        # `url` retained as the canonical download URL for backward compat.
-        "url": download_url,
-        "download_url": download_url,
-        # Do not expose absolute server paths in API/SSE payloads.
-        "path": relative_path,
-        "relative_path": relative_path,
-        "size_bytes": size_bytes,
-        "fingerprint_status": fingerprint_status,
-    }
-    if proxy_relative is not None:
-        payload["preview_url"] = _artifact_url(job_id, proxy_relative)
-        payload["preview_mime_type"] = "image/png"
-    if sha256_hex is not None:
-        payload["sha256"] = sha256_hex
-    return payload
-
-
-def _coerce_nonnegative_int(value: Any) -> Optional[int]:
-    if isinstance(value, bool):
-        return None
-    try:
-        parsed = int(value)
-    except (TypeError, ValueError):
-        return None
-    if parsed < 0:
-        return None
-    return parsed
-
-
-def _captioning_artifact_counts_from_paths(paths: Iterable[str]) -> Dict[str, int]:
-    counts = {"sidecar_count": 0, "raw_count": 0, "proxy_count": 0}
-    for raw_path in paths:
-        lower_path = str(raw_path or "").replace("\\", "/").strip().lower()
-        if not lower_path:
-            continue
-        if lower_path.endswith(".vlm_captioning.sidecar.json"):
-            counts["sidecar_count"] += 1
-        elif lower_path.endswith(".vlm_captioning.raw.txt"):
-            counts["raw_count"] += 1
-        elif "/captioning/" in f"/{lower_path}" and re.search(r"_proxy\.(?:png|jpe?g)$", lower_path):
-            counts["proxy_count"] += 1
-    return counts
-
-
-def _captioning_artifact_counts_from_run_card(payload: Mapping[str, Any]) -> Dict[str, int]:
-    artifact_index = payload.get("artifact_index")
-    if not isinstance(artifact_index, list):
-        return {"sidecar_count": 0, "raw_count": 0, "proxy_count": 0}
-    return _captioning_artifact_counts_from_paths(
-        str(artifact.get("relative_path") or artifact.get("path") or "")
-        for artifact in artifact_index
-        if isinstance(artifact, Mapping)
-    )
-
-
-def _captioning_artifact_counts_from_job_artifacts(artifacts: Mapping[str, Any]) -> Dict[str, int]:
-    items = artifacts.get("items") if isinstance(artifacts, Mapping) else None
-    if not isinstance(items, list):
-        return {"sidecar_count": 0, "raw_count": 0, "proxy_count": 0}
-    return _captioning_artifact_counts_from_paths(
-        str(item.get("relative_path") or item.get("path") or "") for item in items if isinstance(item, Mapping)
+    return _portal_job_artifacts._serialize_indexed_artifact(
+        job_id=job_id,
+        relative_path=relative_path,
+        path=path,
+        fingerprint_max_bytes=ARTIFACT_FINGERPRINT_MAX_BYTES,
+        fingerprint_chunk_bytes=_ARTIFACT_FINGERPRINT_CHUNK_BYTES,
     )
 
 
@@ -6265,54 +5955,14 @@ def _requested_fastvlm_captioning_status(job: Job) -> Optional[Dict[str, Any]]:
 
 
 def _load_bounded_json_object(path: Path, *, max_bytes: int = JOB_RUN_SUMMARY_MAX_BYTES) -> Optional[Dict[str, Any]]:
-    try:
-        size_bytes = path.stat().st_size
-    except OSError:
-        return None
-    if size_bytes <= 0 or size_bytes > max_bytes:
-        return None
-    try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
-        return None
-    return payload if isinstance(payload, dict) else None
+    return _portal_job_artifacts._load_bounded_json_object(path, max_bytes=max_bytes)
 
 
 def _load_bounded_run_card_payload(path: Optional[Path]) -> Optional[Dict[str, Any]]:
-    if path is None:
-        return None
-    payload = _load_bounded_json_object(path)
-    if payload is None:
-        return None
-
-    batch_id = str(payload.get("batch_id") or "").strip()
-    artifact_index = payload.get("artifact_index")
-    if not batch_id:
-        return None
-    try:
-        infer_run_card_version(payload)
-    except ValueError:
-        return None
-    if artifact_index is None:
-        total_images = _coerce_nonnegative_int(payload.get("total_images"))
-        success_count = _coerce_nonnegative_int(payload.get("success_count"))
-        error_count = _coerce_nonnegative_int(payload.get("error_count"))
-        if total_images is None and (success_count is None or error_count is None):
-            return None
-        return payload
-    if not isinstance(artifact_index, list) or not artifact_index:
-        return None
-    for artifact in artifact_index:
-        if not isinstance(artifact, Mapping):
-            return None
-        candidate_path = artifact.get("relative_path") or artifact.get("path")
-        if not isinstance(candidate_path, str) or not candidate_path.strip():
-            return None
-        try:
-            _normalize_artifact_relative_path(candidate_path)
-        except ArtifactPathValidationError:
-            return None
-    return payload
+    return _portal_job_artifacts._load_bounded_run_card_payload(
+        path,
+        max_bytes=JOB_RUN_SUMMARY_MAX_BYTES,
+    )
 
 
 def _summarize_run_card_payload(payload: Mapping[str, Any]) -> Dict[str, Any]:
@@ -6386,125 +6036,16 @@ def _summarize_batch_manifest_payload(payload: Mapping[str, Any]) -> Dict[str, A
     return summary
 
 
-def _artifact_batch_hint(relative_path: str) -> str:
-    match = re.search(r"\d{4}-\d{2}-\d{2}_\d{6}", PurePosixPath(relative_path).stem)
-    return match.group(0) if match else ""
-
-
-def _artifact_recency_key(relative_path: str, artifact_path: Path) -> Tuple[str, float, str]:
-    batch_hint = _artifact_batch_hint(relative_path)
-    try:
-        modified_time = artifact_path.stat().st_mtime
-    except OSError:
-        modified_time = -1.0
-    return (batch_hint, modified_time, relative_path)
-
-
-def _find_newest_artifact_path(output_dir: Path, candidates: List[Path]) -> Optional[Path]:
-    normalized_candidates: List[Tuple[str, Path]] = []
-    for candidate in candidates:
-        try:
-            resolved = Path(os.path.realpath(candidate))
-        except OSError:
-            continue
-        if not resolved.exists() or not resolved.is_file():
-            continue
-        try:
-            relative_path = str(resolved.relative_to(output_dir))
-        except ValueError:
-            continue
-        normalized_candidates.append((relative_path, resolved))
-    if not normalized_candidates:
-        return None
-    _, artifact_path = max(
-        normalized_candidates,
-        key=lambda item: _artifact_recency_key(item[0], item[1]),
-    )
-    return artifact_path
-
-
-def _resolve_artifact_path_within_output_dir(
-    output_dir: Path,
-    relative_path: str,
-) -> Optional[Tuple[str, Path]]:
-    try:
-        normalized_relative_path = _normalize_artifact_relative_path(relative_path)
-    except ArtifactPathValidationError:
-        return None
-    resolved_candidate = Path(
-        os.path.realpath(
-            output_dir / Path(*PurePosixPath(normalized_relative_path).parts),
-        )
-    )
-    try:
-        canonical_relative_path = str(resolved_candidate.relative_to(output_dir))
-    except ValueError:
-        return None
-    if not resolved_candidate.exists() or not resolved_candidate.is_file():
-        return None
-    return canonical_relative_path, resolved_candidate
+_artifact_batch_hint = _portal_job_artifacts._artifact_batch_hint
+_artifact_recency_key = _portal_job_artifacts._artifact_recency_key
+_find_newest_artifact_path = _portal_job_artifacts._find_newest_artifact_path
+_resolve_artifact_path_within_output_dir = _portal_job_artifacts._resolve_artifact_path_within_output_dir
 
 
 def _resolve_job_run_metadata(job: Job) -> Optional[JobRunMetadata]:
-    output_dir = _job_output_dir(job)
-    if output_dir is None:
-        return None
-    output_dir = Path(os.path.realpath(output_dir.expanduser()))
-    if not output_dir.exists() or not output_dir.is_dir():
-        return None
-
-    batch_manifest_dir = output_dir / "manifests"
-    run_card_candidates: List[Tuple[int, Tuple[str, float, str], Path, Dict[str, Any], Optional[Path]]] = []
-    for candidate in output_dir.glob("run_card_*.json"):
-        try:
-            resolved_candidate = Path(os.path.realpath(candidate))
-            relative_path = str(resolved_candidate.relative_to(output_dir))
-        except (OSError, ValueError):
-            continue
-        run_card_payload = _load_bounded_run_card_payload(resolved_candidate)
-        if run_card_payload is None:
-            continue
-        batch_id = str(run_card_payload.get("batch_id") or "").strip()
-        matching_manifest_path: Optional[Path] = None
-        if batch_id:
-            manifest_candidate = batch_manifest_dir / f"batch_{batch_id}.json"
-            if manifest_candidate.exists() and manifest_candidate.is_file():
-                matching_manifest_path = Path(os.path.realpath(manifest_candidate))
-        run_card_candidates.append(
-            (
-                1 if matching_manifest_path is not None else 0,
-                _artifact_recency_key(relative_path, resolved_candidate),
-                resolved_candidate,
-                run_card_payload,
-                matching_manifest_path,
-            )
-        )
-
-    run_card_path: Optional[Path] = None
-    run_card_payload: Optional[Dict[str, Any]] = None
-    batch_manifest_path: Optional[Path] = None
-    batch_manifest_payload: Optional[Dict[str, Any]] = None
-    if run_card_candidates:
-        _, _, run_card_path, run_card_payload, batch_manifest_path = max(
-            run_card_candidates,
-            key=lambda item: (item[0], item[1]),
-        )
-        if batch_manifest_path is not None:
-            batch_manifest_payload = _load_bounded_json_object(batch_manifest_path)
-    elif batch_manifest_dir.exists() and batch_manifest_dir.is_dir():
-        batch_manifest_path = _find_newest_artifact_path(
-            output_dir,
-            list(batch_manifest_dir.glob("batch_*.json")),
-        )
-        if batch_manifest_path is not None:
-            batch_manifest_payload = _load_bounded_json_object(batch_manifest_path)
-
-    return JobRunMetadata(
-        output_dir=output_dir,
-        run_card_path=run_card_path,
-        run_card_payload=run_card_payload,
-        batch_manifest_path=batch_manifest_path,
-        batch_manifest_payload=batch_manifest_payload,
+    return _portal_job_artifacts._resolve_job_run_metadata(
+        _job_output_dir(job),
+        max_bytes=JOB_RUN_SUMMARY_MAX_BYTES,
     )
 
 
@@ -6514,86 +6055,27 @@ def _build_scoped_job_artifacts(
     output_dir: Path,
     candidate_paths: List[Path],
 ) -> Tuple[List[Dict[str, Any]], Dict[str, Path], bool]:
-    discovered: Dict[str, Path] = {}
-    for candidate_path in candidate_paths:
-        try:
-            resolved_path = Path(os.path.realpath(candidate_path))
-        except OSError:
-            continue
-        if not resolved_path.exists() or not resolved_path.is_file():
-            continue
-        try:
-            relative_path = str(resolved_path.relative_to(output_dir))
-        except ValueError:
-            continue
-        discovered[relative_path] = resolved_path
-
-    ordered_candidates = sorted(
-        discovered.items(),
-        key=lambda item: (item[0].casefold(), item[0]),
+    return _portal_job_artifacts._build_scoped_job_artifacts(
+        job_id=job.id,
+        output_dir=output_dir,
+        candidate_paths=candidate_paths,
+        max_indexed_artifacts=MAX_INDEXED_ARTIFACTS,
+        fingerprint_max_bytes=ARTIFACT_FINGERPRINT_MAX_BYTES,
+        fingerprint_chunk_bytes=_ARTIFACT_FINGERPRINT_CHUNK_BYTES,
     )
-    truncated = len(ordered_candidates) > MAX_INDEXED_ARTIFACTS
-    selected_candidates = ordered_candidates[:MAX_INDEXED_ARTIFACTS]
-
-    items = [
-        _serialize_indexed_artifact(
-            job_id=job.id,
-            relative_path=relative_path,
-            path=path,
-        )
-        for relative_path, path in selected_candidates
-    ]
-    selected_lookup = {relative_path: path for relative_path, path in selected_candidates}
-    for relative_path, path in selected_candidates:
-        _add_artifact_preview_proxy_lookup(
-            selected_lookup,
-            output_dir=output_dir,
-            artifact_path=path,
-        )
-    return items, selected_lookup, truncated
 
 
 def _build_scoped_job_artifacts_from_run_metadata(
     job: Job,
     metadata: JobRunMetadata,
 ) -> Optional[Tuple[List[Dict[str, Any]], Dict[str, Path], bool]]:
-    artifact_index = None
-    if metadata.run_card_path is not None and metadata.run_card_payload is not None:
-        artifact_index = metadata.run_card_payload.get("artifact_index")
-        if isinstance(artifact_index, list):
-            candidate_paths: List[Path] = [metadata.run_card_path]
-            for artifact_entry in artifact_index:
-                if not isinstance(artifact_entry, dict):
-                    continue
-                artifact_relative_path = artifact_entry.get("relative_path") or artifact_entry.get("path")
-                if not isinstance(artifact_relative_path, str) or not artifact_relative_path.strip():
-                    continue
-                resolved = _resolve_artifact_path_within_output_dir(
-                    metadata.output_dir,
-                    artifact_relative_path,
-                )
-                if resolved is None:
-                    continue
-                _, resolved_path = resolved
-                candidate_paths.append(resolved_path)
-            if len(candidate_paths) > 1:
-                return _build_scoped_job_artifacts(
-                    job=job,
-                    output_dir=metadata.output_dir,
-                    candidate_paths=candidate_paths,
-                )
-
-    if metadata.batch_manifest_path is not None:
-        candidate_paths = [metadata.batch_manifest_path]
-        if metadata.run_card_path is not None and isinstance(artifact_index, list) and artifact_index:
-            candidate_paths.insert(0, metadata.run_card_path)
-        return _build_scoped_job_artifacts(
-            job=job,
-            output_dir=metadata.output_dir,
-            candidate_paths=candidate_paths,
-        )
-
-    return None
+    return _portal_job_artifacts._build_scoped_job_artifacts_from_run_metadata(
+        job_id=job.id,
+        metadata=metadata,
+        max_indexed_artifacts=MAX_INDEXED_ARTIFACTS,
+        fingerprint_max_bytes=ARTIFACT_FINGERPRINT_MAX_BYTES,
+        fingerprint_chunk_bytes=_ARTIFACT_FINGERPRINT_CHUNK_BYTES,
+    )
 
 
 def _refresh_job_run_summary(job: Job) -> Dict[str, Any]:
@@ -6686,59 +6168,17 @@ def _serialized_job_run_summary(job: Job) -> Optional[Dict[str, Any]]:
     return summary or None
 
 
-class ArtifactPathValidationError(ValueError):
-    """Base class for bounded artifact-path validation failures."""
-
-
-class InvalidArtifactPathError(ArtifactPathValidationError):
-    """Artifact path is empty or malformed."""
-
-
-class AbsoluteArtifactPathError(ArtifactPathValidationError):
-    """Artifact path attempted to use an absolute path."""
-
-
-class ArtifactPathOutsideJobOutputDirError(ArtifactPathValidationError):
-    """Artifact path attempted to escape the job output directory."""
-
-
 def _validate_resolved_job_artifact_path(
     job: Job,
     resolved_artifact: Path,
 ) -> tuple[Path, Path, str]:
-    output_dir = _job_output_dir(job)
-    if output_dir is None:
-        raise FileNotFoundError("job_output_dir_missing")
-
-    output_dir = Path(os.path.realpath(output_dir.expanduser()))
-    if not output_dir.exists() or not output_dir.is_dir():
-        raise FileNotFoundError("job_output_dir_missing")
-
-    resolved = Path(os.path.realpath(resolved_artifact))
-    try:
-        relative_path = str(resolved.relative_to(output_dir))
-    except ValueError as exc:
-        raise ArtifactPathOutsideJobOutputDirError from exc
-
-    return output_dir, resolved, relative_path
+    return _portal_job_artifacts._validate_resolved_job_artifact_path(
+        _job_output_dir(job),
+        resolved_artifact,
+    )
 
 
-def _normalize_artifact_relative_path(artifact_path: str) -> str:
-    raw = str(artifact_path or "").strip()
-    if not raw or raw.startswith("~") or "\x00" in raw or "\\" in raw:
-        raise InvalidArtifactPathError
-
-    candidate = PurePosixPath(raw)
-    if candidate.is_absolute():
-        raise AbsoluteArtifactPathError
-
-    normalized = candidate.as_posix()
-    if normalized in {"", "."}:
-        raise InvalidArtifactPathError
-    if any(part == ".." for part in candidate.parts):
-        raise ArtifactPathOutsideJobOutputDirError
-
-    return normalized
+_normalize_artifact_relative_path = _portal_job_artifacts._normalize_artifact_relative_path
 
 
 def _hydrate_artifact_lookup_from_items(job: Job) -> Dict[str, Path]:
@@ -6750,130 +6190,26 @@ def _hydrate_artifact_lookup_from_items(job: Job) -> Dict[str, Path]:
     if output_dir is None:
         return {}
 
-    lookup: Dict[str, Path] = {}
-    for item in items:
-        if not isinstance(item, dict):
-            continue
-        candidate_path = item.get("relative_path") or item.get("path")
-        try:
-            normalized = _normalize_artifact_relative_path(str(candidate_path or ""))
-        except ValueError:
-            continue
-        resolved_candidate = Path(output_dir) / Path(*PurePosixPath(normalized).parts)
-        try:
-            _, resolved, canonical_relative_path = _validate_resolved_job_artifact_path(job, resolved_candidate)
-        except (ValueError, FileNotFoundError):
-            continue
-        if not resolved.exists() or not resolved.is_file():
-            continue
-        lookup[canonical_relative_path] = resolved
-        _add_artifact_preview_proxy_lookup(
-            lookup,
-            output_dir=output_dir,
-            artifact_path=resolved,
-        )
+    lookup = _portal_job_artifacts._hydrate_artifact_lookup_from_items(
+        items=items,
+        output_dir=output_dir,
+    )
     job.artifact_lookup = lookup
     return lookup
 
 
 def _index_job_artifacts(job: Job) -> List[Dict[str, Any]]:
-    output_dir = _job_output_dir(job)
-    if output_dir is None:
-        job.artifact_lookup = {}
-        job.artifacts = {
-            "output_dir": None,
-            "items": [],
-            "indexed_count": 0,
-            "truncated": False,
-        }
-        return []
-    if not output_dir.exists() or not output_dir.is_dir():
-        job.artifact_lookup = {}
-        job.artifacts = {
-            "output_dir": str(output_dir),
-            "items": [],
-            "indexed_count": 0,
-            "truncated": False,
-        }
-        return []
-
-    output_dir = Path(os.path.realpath(output_dir.expanduser()))
-    metadata = _resolve_job_run_metadata(job)
-    if metadata is not None:
-        scoped_artifacts = _build_scoped_job_artifacts_from_run_metadata(job, metadata)
-        if scoped_artifacts is not None:
-            items, artifact_lookup, truncated = scoped_artifacts
-            job.artifacts = {
-                "output_dir": str(output_dir),
-                "items": items,
-                "indexed_count": len(items),
-                "truncated": truncated,
-            }
-            job.artifact_lookup = artifact_lookup
-            return items
-
-    selected: List[tuple[tuple[str, str], str, Path]] = []
-    selected_keys: List[tuple[str, str]] = []
-    total_files = 0
-    for path in output_dir.rglob("*"):
-        if not path.is_file():
-            continue
-        total_files += 1
-        try:
-            relative_path = str(path.relative_to(output_dir))
-        except Exception:
-            relative_path = path.name
-
-        resolved_path = Path(os.path.realpath(path))
-        try:
-            resolved_path.relative_to(output_dir)
-        except ValueError:
-            continue
-
-        key = (relative_path.casefold(), relative_path)
-
-        if len(selected) < MAX_INDEXED_ARTIFACTS:
-            insert_at = bisect_left(selected_keys, key)
-            selected_keys.insert(insert_at, key)
-            selected.insert(insert_at, (key, relative_path, resolved_path))
-            continue
-
-        if key >= selected_keys[-1]:
-            continue
-
-        insert_at = bisect_left(selected_keys, key)
-        selected_keys.insert(insert_at, key)
-        selected.insert(insert_at, (key, relative_path, resolved_path))
-        selected_keys.pop()
-        selected.pop()
-
-    truncated = total_files > MAX_INDEXED_ARTIFACTS
-
-    items: List[Dict[str, Any]] = []
-    selected_lookup: Dict[str, Path] = {}
-    for _, relative_path, path in selected:
-        items.append(
-            _serialize_indexed_artifact(
-                job_id=job.id,
-                relative_path=relative_path,
-                path=path,
-            )
-        )
-        selected_lookup[relative_path] = path
-        _add_artifact_preview_proxy_lookup(
-            selected_lookup,
-            output_dir=output_dir,
-            artifact_path=path,
-        )
-
-    job.artifacts = {
-        "output_dir": str(output_dir),
-        "items": items,
-        "indexed_count": len(items),
-        "truncated": truncated,
-    }
-    job.artifact_lookup = selected_lookup
-    return items
+    result = _portal_job_artifacts._index_job_artifacts(
+        job_id=job.id,
+        output_dir=_job_output_dir(job),
+        max_indexed_artifacts=MAX_INDEXED_ARTIFACTS,
+        fingerprint_max_bytes=ARTIFACT_FINGERPRINT_MAX_BYTES,
+        fingerprint_chunk_bytes=_ARTIFACT_FINGERPRINT_CHUNK_BYTES,
+        run_summary_max_bytes=JOB_RUN_SUMMARY_MAX_BYTES,
+    )
+    job.artifacts = result.artifacts
+    job.artifact_lookup = result.artifact_lookup
+    return result.items
 
 
 def _job_api_prefix(api_version: str = "v1") -> str:

--- a/docs/architecture/MONOLITH_DECOMPOSITION_TARGETS.md
+++ b/docs/architecture/MONOLITH_DECOMPOSITION_TARGETS.md
@@ -175,6 +175,7 @@ This table is the canonical progress ledger for extraction PRs that draw from th
 | Target 2B — Path resolution & security helpers | `app.py` | `src/transformation_portal/portal/path_security.py` | Landed | This PR: path security helpers extracted behind ADR-046 app compatibility wrappers |
 | Target 2C — SAM2 checkpoint security helpers | `app.py` | `src/transformation_portal/portal/sam2_checkpoint_security.py` | Landed | This PR: SAM2 checkpoint security helpers extracted behind ADR-047 app compatibility wrappers |
 | Target 2D — Archive index preflight helpers | `app.py` | `src/transformation_portal/portal/archive_index_preflight.py` | Landed | This PR: archive index preflight helpers extracted behind app compatibility wrappers |
+| Target 2E — Job artifact catalog helpers | `app.py` | `src/transformation_portal/portal/job_artifacts.py` | Landed | This PR: job artifact catalog and indexing helpers extracted behind app compatibility wrappers |
 | Target 3A — Segmentation cache helpers | `lux_depth_v3/segmentation_backend.py` | `lux_depth_v3/segmentation/_cache.py` | Landed | This PR: segmentation cache helpers extracted |
 | Target 3B — Stub backend | `lux_depth_v3/segmentation_backend.py` | `lux_depth_v3/segmentation/stub.py` | Landed | This PR: stub backend extracted |
 | Target 3C — EfficientSAM backend | `lux_depth_v3/segmentation_backend.py` | `lux_depth_v3/segmentation/efficient_sam.py` | Landed | This PR: EfficientSAM backend extracted |

--- a/src/transformation_portal/portal/job_artifacts.py
+++ b/src/transformation_portal/portal/job_artifacts.py
@@ -1,4 +1,9 @@
-"""Portal job artifact cataloging and response metadata helpers."""
+"""Portal job artifact cataloging and response metadata helpers.
+
+This app-independent module validates, indexes, and serializes job artifacts
+while preserving the legacy app.py payload contract through injected runtime
+limits and compatibility wrappers.
+"""
 
 from __future__ import annotations
 

--- a/src/transformation_portal/portal/job_artifacts.py
+++ b/src/transformation_portal/portal/job_artifacts.py
@@ -77,6 +77,8 @@ def _infer_artifact_type(path: Path) -> str:
         ".tif",
         ".tiff",
         ".webp",
+        ".gif",
+        ".avif",
         ".exr",
     }:
         return "image"

--- a/src/transformation_portal/portal/job_artifacts.py
+++ b/src/transformation_portal/portal/job_artifacts.py
@@ -1,3 +1,5 @@
+"""Portal job artifact cataloging and response metadata helpers."""
+
 from __future__ import annotations
 
 import hashlib

--- a/src/transformation_portal/portal/job_artifacts.py
+++ b/src/transformation_portal/portal/job_artifacts.py
@@ -1,0 +1,859 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import mimetypes
+import os
+import re
+from bisect import bisect_left
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
+from urllib.parse import quote
+
+from transformation_portal.lux_depth_v3.run_card_contract import infer_run_card_version
+
+MAX_INDEXED_ARTIFACTS = 200
+ARTIFACT_FINGERPRINT_MAX_BYTES = 8 * 1024 * 1024
+_ARTIFACT_FINGERPRINT_CHUNK_BYTES = 1024 * 1024
+JOB_RUN_SUMMARY_MAX_BYTES = 1024 * 1024
+
+
+@dataclass(frozen=True)
+class JobRunMetadata:
+    output_dir: Path
+    run_card_path: Optional[Path] = None
+    run_card_payload: Optional[Dict[str, Any]] = None
+    batch_manifest_path: Optional[Path] = None
+    batch_manifest_payload: Optional[Dict[str, Any]] = None
+
+
+@dataclass(frozen=True)
+class JobArtifactIndexResult:
+    items: List[Dict[str, Any]]
+    artifact_lookup: Dict[str, Path]
+    artifacts: Dict[str, Any]
+
+
+class ArtifactPathValidationError(ValueError):
+    """Base class for bounded artifact-path validation failures."""
+
+
+class InvalidArtifactPathError(ArtifactPathValidationError):
+    """Artifact path is empty or malformed."""
+
+
+class AbsoluteArtifactPathError(ArtifactPathValidationError):
+    """Artifact path attempted to use an absolute path."""
+
+
+class ArtifactPathOutsideJobOutputDirError(ArtifactPathValidationError):
+    """Artifact path attempted to escape the job output directory."""
+
+
+def _infer_artifact_type(path: Path) -> str:
+    suffix = path.suffix.lower()
+    if suffix in {
+        ".json",
+        ".yaml",
+        ".yml",
+        ".txt",
+        ".md",
+        ".log",
+        ".csv",
+    }:
+        return "metadata"
+    if suffix in {
+        ".png",
+        ".jpg",
+        ".jpeg",
+        ".tif",
+        ".tiff",
+        ".webp",
+        ".exr",
+    }:
+        return "image"
+    if suffix in {".zip", ".tar", ".gz", ".tgz", ".bag"}:
+        return "archive"
+    return "file"
+
+
+def _artifact_content_type(path: Path) -> str:
+    guessed, _ = mimetypes.guess_type(str(path))
+    return guessed or "application/octet-stream"
+
+
+def _artifact_media_kind(path: Path) -> str:
+    artifact_type = _infer_artifact_type(path)
+    if artifact_type == "image":
+        return "image"
+    if artifact_type == "metadata":
+        return "metadata"
+    if artifact_type == "archive":
+        return "archive"
+    return "file"
+
+
+def _artifact_is_previewable(path: Path) -> bool:
+    return _artifact_media_kind(path) == "image" and _artifact_content_type(path).startswith("image/")
+
+
+# MIME types browsers reliably render via <img> / <picture>. TIFF, EXR, and
+# similar formats are excluded so the portal never asks the browser to decode
+# them; previewing those goes through a sibling PNG proxy when available.
+_BROWSER_PREVIEWABLE_MIME_TYPES = frozenset(
+    {
+        "image/png",
+        "image/jpeg",
+        "image/webp",
+        "image/gif",
+        "image/avif",
+        "image/svg+xml",
+    }
+)
+
+
+def _artifact_is_browser_previewable(path: Path) -> bool:
+    return _artifact_content_type(path).lower() in _BROWSER_PREVIEWABLE_MIME_TYPES
+
+
+def _artifact_preview_proxy_path(path: Path) -> Optional[Path]:
+    """Return a sibling PNG proxy for browser-unfriendly image artifacts."""
+
+    if _artifact_is_browser_previewable(path):
+        return None
+    if _artifact_media_kind(path) != "image":
+        return None
+    candidate = path.with_name(path.name + ".preview.png")
+    try:
+        if candidate.is_file():
+            return candidate
+    except OSError:
+        return None
+    return None
+
+
+def _add_artifact_preview_proxy_lookup(
+    lookup: Dict[str, Path],
+    *,
+    output_dir: Path,
+    artifact_path: Path,
+) -> None:
+    proxy_path = _artifact_preview_proxy_path(artifact_path)
+    if proxy_path is None:
+        return
+    try:
+        resolved_output_dir = Path(os.path.realpath(output_dir.expanduser()))
+        resolved_proxy_path = Path(os.path.realpath(proxy_path))
+        proxy_relative_path = str(resolved_proxy_path.relative_to(resolved_output_dir))
+    except (OSError, ValueError):
+        return
+    lookup.setdefault(proxy_relative_path, resolved_proxy_path)
+
+
+def _safe_artifact_attachment_filename(path: Path) -> str:
+    """Return an ASCII-safe filename for Content-Disposition attachments."""
+
+    candidate = re.sub(r"[^A-Za-z0-9._-]", "_", path.name or "")
+    return candidate or "download"
+
+
+def _artifact_response_headers(path: Path) -> Dict[str, str]:
+    """Build response headers for a job artifact download."""
+
+    headers: Dict[str, str] = {"Cache-Control": "no-store"}
+    if not _artifact_is_previewable(path):
+        filename = _safe_artifact_attachment_filename(path)
+        headers["Content-Disposition"] = f'attachment; filename="{filename}"'
+    return headers
+
+
+def _artifact_display_label(role: str) -> str:
+    return {
+        "primary_preview": "Primary Preview",
+        "review_preview": "Review Preview",
+        "supporting_preview": "Supporting Preview",
+        "run_card": "Run Card",
+        "report": "Report",
+        "manifest": "Manifest",
+        "vlm_caption": "Advisory Caption",
+        "archive": "Archive",
+        "log": "Log",
+        "metadata": "Metadata",
+    }.get(role, "File")
+
+
+_STEM_NOISE_RE = re.compile(
+    r"(master16|upscaled16|final|result|render|beauty|marketing|depth|preview"
+    r"|thumb|debug|segmentation|overlay|mask|albedo|normal|roughness|metallic|ao)"
+)
+
+
+def _artifact_compare_group(relative_path: str, path: Path) -> str:
+    if not _artifact_is_previewable(path):
+        return ""
+    artifact_path = PurePosixPath(relative_path)
+    parent = artifact_path.parent.as_posix()
+    if parent == ".":
+        parent = ""
+    raw_stem = artifact_path.stem.lower()
+    simplified_stem = _STEM_NOISE_RE.sub(" ", raw_stem)
+    normalized_stem = re.sub(r"[^a-z0-9]+", "-", simplified_stem).strip("-")
+    if not normalized_stem:
+        normalized_stem = re.sub(r"[^a-z0-9]+", "-", raw_stem).strip("-")
+    batch_hint = _artifact_batch_hint(relative_path)
+    return "|".join(part for part in (batch_hint, parent, normalized_stem) if part)
+
+
+def _artifact_display_hint(relative_path: str, path: Path) -> Dict[str, Any]:
+    lower_name = relative_path.lower()
+    stem_lower = PurePosixPath(relative_path).stem.lower()
+    artifact_type = _infer_artifact_type(path)
+    if _artifact_is_previewable(path):
+        if re.search(
+            r"(mask|matte|thumb|preview|debug|overlay|segmentation|albedo|normal|roughness|metallic|ao)",
+            lower_name,
+        ):
+            role = "supporting_preview"
+            priority = 700
+        elif re.search(r"(master16|upscaled16|final|result|render|beauty|marketing|depth)", lower_name):
+            role = "primary_preview"
+            priority = 1000
+        else:
+            role = "review_preview"
+            priority = 850
+    elif lower_name.endswith(".vlm_captioning.sidecar.json"):
+        role = "vlm_caption"
+        priority = 300
+    elif lower_name.endswith(".vlm_captioning.raw.txt"):
+        role = "log"
+        priority = 160
+    elif "/captioning/" in f"/{lower_name}":
+        role = "metadata"
+        priority = 120
+    elif "run_card" in lower_name:
+        role = "run_card"
+        priority = 320
+    elif "report" in lower_name:
+        role = "report"
+        priority = 280
+    elif "manifest" in lower_name:
+        role = "manifest"
+        priority = 240
+    elif artifact_type == "archive":
+        role = "archive"
+        priority = 180
+    elif lower_name.endswith(".log") or "/logs/" in lower_name or re.search(r"(^|[._\-\s])log($|[._\-\s])", stem_lower):
+        role = "log"
+        priority = 160
+    elif artifact_type == "metadata":
+        role = "metadata"
+        priority = 120
+    else:
+        role = "file"
+        priority = 100
+
+    hint: Dict[str, Any] = {
+        "role": role,
+        "priority": priority,
+        "label": _artifact_display_label(role),
+    }
+    compare_group = _artifact_compare_group(relative_path, path)
+    if compare_group:
+        hint["compare_group"] = compare_group
+    return hint
+
+
+def _artifact_url(job_id: str, relative_path: str) -> str:
+    return f"/v1/jobs/{quote(str(job_id), safe='')}" f"/artifacts/{quote(relative_path, safe='/')}"
+
+
+def _artifact_fingerprint(
+    path: Path,
+    size_bytes: Optional[int],
+    *,
+    max_bytes: int = ARTIFACT_FINGERPRINT_MAX_BYTES,
+    chunk_bytes: int = _ARTIFACT_FINGERPRINT_CHUNK_BYTES,
+) -> Tuple[Optional[str], str]:
+    """Return ``(sha256_hex, status)`` for an artifact."""
+
+    if size_bytes is None:
+        return None, "unavailable"
+    if size_bytes > max_bytes:
+        return None, "skipped_size"
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as handle:
+            while True:
+                chunk = handle.read(chunk_bytes)
+                if not chunk:
+                    break
+                digest.update(chunk)
+    except OSError:
+        return None, "unavailable"
+    return digest.hexdigest(), "ok"
+
+
+def _serialize_indexed_artifact(
+    *,
+    job_id: str,
+    relative_path: str,
+    path: Path,
+    fingerprint_max_bytes: int = ARTIFACT_FINGERPRINT_MAX_BYTES,
+    fingerprint_chunk_bytes: int = _ARTIFACT_FINGERPRINT_CHUNK_BYTES,
+) -> Dict[str, Any]:
+    try:
+        size_bytes = path.stat().st_size
+    except OSError:
+        size_bytes = None
+
+    content_type = _artifact_content_type(path)
+    sha256_hex, fingerprint_status = _artifact_fingerprint(
+        path,
+        size_bytes,
+        max_bytes=fingerprint_max_bytes,
+        chunk_bytes=fingerprint_chunk_bytes,
+    )
+    download_url = _artifact_url(job_id, relative_path)
+    proxy_path = _artifact_preview_proxy_path(path)
+    proxy_relative = f"{relative_path}.preview.png" if proxy_path is not None else None
+    browser_previewable = _artifact_is_browser_previewable(path) or proxy_path is not None
+    payload: Dict[str, Any] = {
+        "artifact_type": _infer_artifact_type(path),
+        "media_kind": _artifact_media_kind(path),
+        "previewable": _artifact_is_previewable(path),
+        "browser_previewable": browser_previewable,
+        "content_type": content_type,
+        "mime_type": content_type,
+        "display_hint": _artifact_display_hint(relative_path, path),
+        "url": download_url,
+        "download_url": download_url,
+        "path": relative_path,
+        "relative_path": relative_path,
+        "size_bytes": size_bytes,
+        "fingerprint_status": fingerprint_status,
+    }
+    if proxy_relative is not None:
+        payload["preview_url"] = _artifact_url(job_id, proxy_relative)
+        payload["preview_mime_type"] = "image/png"
+    if sha256_hex is not None:
+        payload["sha256"] = sha256_hex
+    return payload
+
+
+def _coerce_nonnegative_int(value: Any) -> Optional[int]:
+    if isinstance(value, bool):
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    if parsed < 0:
+        return None
+    return parsed
+
+
+def _captioning_artifact_counts_from_paths(paths: Iterable[str]) -> Dict[str, int]:
+    counts = {"sidecar_count": 0, "raw_count": 0, "proxy_count": 0}
+    for raw_path in paths:
+        lower_path = str(raw_path or "").replace("\\", "/").strip().lower()
+        if not lower_path:
+            continue
+        if lower_path.endswith(".vlm_captioning.sidecar.json"):
+            counts["sidecar_count"] += 1
+        elif lower_path.endswith(".vlm_captioning.raw.txt"):
+            counts["raw_count"] += 1
+        elif "/captioning/" in f"/{lower_path}" and re.search(r"_proxy\.(?:png|jpe?g)$", lower_path):
+            counts["proxy_count"] += 1
+    return counts
+
+
+def _captioning_artifact_counts_from_run_card(payload: Mapping[str, Any]) -> Dict[str, int]:
+    artifact_index = payload.get("artifact_index")
+    if not isinstance(artifact_index, list):
+        return {"sidecar_count": 0, "raw_count": 0, "proxy_count": 0}
+    return _captioning_artifact_counts_from_paths(
+        str(artifact.get("relative_path") or artifact.get("path") or "")
+        for artifact in artifact_index
+        if isinstance(artifact, Mapping)
+    )
+
+
+def _captioning_artifact_counts_from_job_artifacts(artifacts: Mapping[str, Any]) -> Dict[str, int]:
+    items = artifacts.get("items") if isinstance(artifacts, Mapping) else None
+    if not isinstance(items, list):
+        return {"sidecar_count": 0, "raw_count": 0, "proxy_count": 0}
+    return _captioning_artifact_counts_from_paths(
+        str(item.get("relative_path") or item.get("path") or "") for item in items if isinstance(item, Mapping)
+    )
+
+
+def _load_bounded_json_object(
+    path: Path,
+    *,
+    max_bytes: int = JOB_RUN_SUMMARY_MAX_BYTES,
+) -> Optional[Dict[str, Any]]:
+    try:
+        size_bytes = path.stat().st_size
+    except OSError:
+        return None
+    if size_bytes <= 0 or size_bytes > max_bytes:
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _normalize_artifact_relative_path(artifact_path: str) -> str:
+    raw = str(artifact_path or "").strip()
+    if not raw or raw.startswith("~") or "\x00" in raw or "\\" in raw:
+        raise InvalidArtifactPathError
+
+    candidate = PurePosixPath(raw)
+    if candidate.is_absolute():
+        raise AbsoluteArtifactPathError
+
+    normalized = candidate.as_posix()
+    if normalized in {"", "."}:
+        raise InvalidArtifactPathError
+    if any(part == ".." for part in candidate.parts):
+        raise ArtifactPathOutsideJobOutputDirError
+
+    return normalized
+
+
+def _load_bounded_run_card_payload(
+    path: Optional[Path],
+    *,
+    max_bytes: int = JOB_RUN_SUMMARY_MAX_BYTES,
+) -> Optional[Dict[str, Any]]:
+    if path is None:
+        return None
+    payload = _load_bounded_json_object(path, max_bytes=max_bytes)
+    if payload is None:
+        return None
+
+    batch_id = str(payload.get("batch_id") or "").strip()
+    artifact_index = payload.get("artifact_index")
+    if not batch_id:
+        return None
+    try:
+        infer_run_card_version(payload)
+    except ValueError:
+        return None
+    if artifact_index is None:
+        total_images = _coerce_nonnegative_int(payload.get("total_images"))
+        success_count = _coerce_nonnegative_int(payload.get("success_count"))
+        error_count = _coerce_nonnegative_int(payload.get("error_count"))
+        if total_images is None and (success_count is None or error_count is None):
+            return None
+        return payload
+    if not isinstance(artifact_index, list) or not artifact_index:
+        return None
+    for artifact in artifact_index:
+        if not isinstance(artifact, Mapping):
+            return None
+        candidate_path = artifact.get("relative_path") or artifact.get("path")
+        if not isinstance(candidate_path, str) or not candidate_path.strip():
+            return None
+        try:
+            _normalize_artifact_relative_path(candidate_path)
+        except ArtifactPathValidationError:
+            return None
+    return payload
+
+
+def _artifact_batch_hint(relative_path: str) -> str:
+    match = re.search(r"\d{4}-\d{2}-\d{2}_\d{6}", PurePosixPath(relative_path).stem)
+    return match.group(0) if match else ""
+
+
+def _artifact_recency_key(relative_path: str, artifact_path: Path) -> Tuple[str, float, str]:
+    batch_hint = _artifact_batch_hint(relative_path)
+    try:
+        modified_time = artifact_path.stat().st_mtime
+    except OSError:
+        modified_time = -1.0
+    return (batch_hint, modified_time, relative_path)
+
+
+def _find_newest_artifact_path(output_dir: Path, candidates: List[Path]) -> Optional[Path]:
+    normalized_candidates: List[Tuple[str, Path]] = []
+    for candidate in candidates:
+        try:
+            resolved = Path(os.path.realpath(candidate))
+        except OSError:
+            continue
+        if not resolved.exists() or not resolved.is_file():
+            continue
+        try:
+            relative_path = str(resolved.relative_to(output_dir))
+        except ValueError:
+            continue
+        normalized_candidates.append((relative_path, resolved))
+    if not normalized_candidates:
+        return None
+    _, artifact_path = max(
+        normalized_candidates,
+        key=lambda item: _artifact_recency_key(item[0], item[1]),
+    )
+    return artifact_path
+
+
+def _resolve_artifact_path_within_output_dir(
+    output_dir: Path,
+    relative_path: str,
+) -> Optional[Tuple[str, Path]]:
+    try:
+        normalized_relative_path = _normalize_artifact_relative_path(relative_path)
+    except ArtifactPathValidationError:
+        return None
+    resolved_candidate = Path(
+        os.path.realpath(
+            output_dir / Path(*PurePosixPath(normalized_relative_path).parts),
+        )
+    )
+    try:
+        canonical_relative_path = str(resolved_candidate.relative_to(output_dir))
+    except ValueError:
+        return None
+    if not resolved_candidate.exists() or not resolved_candidate.is_file():
+        return None
+    return canonical_relative_path, resolved_candidate
+
+
+def _resolve_job_run_metadata(
+    output_dir: Optional[Path],
+    *,
+    max_bytes: int = JOB_RUN_SUMMARY_MAX_BYTES,
+) -> Optional[JobRunMetadata]:
+    if output_dir is None:
+        return None
+    output_dir = Path(os.path.realpath(output_dir.expanduser()))
+    if not output_dir.exists() or not output_dir.is_dir():
+        return None
+
+    batch_manifest_dir = output_dir / "manifests"
+    run_card_candidates: List[Tuple[int, Tuple[str, float, str], Path, Dict[str, Any], Optional[Path]]] = []
+    for candidate in output_dir.glob("run_card_*.json"):
+        try:
+            resolved_candidate = Path(os.path.realpath(candidate))
+            relative_path = str(resolved_candidate.relative_to(output_dir))
+        except (OSError, ValueError):
+            continue
+        run_card_payload = _load_bounded_run_card_payload(resolved_candidate, max_bytes=max_bytes)
+        if run_card_payload is None:
+            continue
+        batch_id = str(run_card_payload.get("batch_id") or "").strip()
+        matching_manifest_path: Optional[Path] = None
+        if batch_id:
+            manifest_candidate = batch_manifest_dir / f"batch_{batch_id}.json"
+            if manifest_candidate.exists() and manifest_candidate.is_file():
+                matching_manifest_path = Path(os.path.realpath(manifest_candidate))
+        run_card_candidates.append(
+            (
+                1 if matching_manifest_path is not None else 0,
+                _artifact_recency_key(relative_path, resolved_candidate),
+                resolved_candidate,
+                run_card_payload,
+                matching_manifest_path,
+            )
+        )
+
+    run_card_path: Optional[Path] = None
+    run_card_payload: Optional[Dict[str, Any]] = None
+    batch_manifest_path: Optional[Path] = None
+    batch_manifest_payload: Optional[Dict[str, Any]] = None
+    if run_card_candidates:
+        _, _, run_card_path, run_card_payload, batch_manifest_path = max(
+            run_card_candidates,
+            key=lambda item: (item[0], item[1]),
+        )
+        if batch_manifest_path is not None:
+            batch_manifest_payload = _load_bounded_json_object(batch_manifest_path, max_bytes=max_bytes)
+    elif batch_manifest_dir.exists() and batch_manifest_dir.is_dir():
+        batch_manifest_path = _find_newest_artifact_path(
+            output_dir,
+            list(batch_manifest_dir.glob("batch_*.json")),
+        )
+        if batch_manifest_path is not None:
+            batch_manifest_payload = _load_bounded_json_object(batch_manifest_path, max_bytes=max_bytes)
+
+    return JobRunMetadata(
+        output_dir=output_dir,
+        run_card_path=run_card_path,
+        run_card_payload=run_card_payload,
+        batch_manifest_path=batch_manifest_path,
+        batch_manifest_payload=batch_manifest_payload,
+    )
+
+
+def _build_scoped_job_artifacts(
+    *,
+    job_id: str,
+    output_dir: Path,
+    candidate_paths: List[Path],
+    max_indexed_artifacts: int = MAX_INDEXED_ARTIFACTS,
+    fingerprint_max_bytes: int = ARTIFACT_FINGERPRINT_MAX_BYTES,
+    fingerprint_chunk_bytes: int = _ARTIFACT_FINGERPRINT_CHUNK_BYTES,
+) -> Tuple[List[Dict[str, Any]], Dict[str, Path], bool]:
+    discovered: Dict[str, Path] = {}
+    for candidate_path in candidate_paths:
+        try:
+            resolved_path = Path(os.path.realpath(candidate_path))
+        except OSError:
+            continue
+        if not resolved_path.exists() or not resolved_path.is_file():
+            continue
+        try:
+            relative_path = str(resolved_path.relative_to(output_dir))
+        except ValueError:
+            continue
+        discovered[relative_path] = resolved_path
+
+    ordered_candidates = sorted(
+        discovered.items(),
+        key=lambda item: (item[0].casefold(), item[0]),
+    )
+    truncated = len(ordered_candidates) > max_indexed_artifacts
+    selected_candidates = ordered_candidates[:max_indexed_artifacts]
+
+    items = [
+        _serialize_indexed_artifact(
+            job_id=job_id,
+            relative_path=relative_path,
+            path=path,
+            fingerprint_max_bytes=fingerprint_max_bytes,
+            fingerprint_chunk_bytes=fingerprint_chunk_bytes,
+        )
+        for relative_path, path in selected_candidates
+    ]
+    selected_lookup = {relative_path: path for relative_path, path in selected_candidates}
+    for relative_path, path in selected_candidates:
+        _add_artifact_preview_proxy_lookup(
+            selected_lookup,
+            output_dir=output_dir,
+            artifact_path=path,
+        )
+    return items, selected_lookup, truncated
+
+
+def _build_scoped_job_artifacts_from_run_metadata(
+    *,
+    job_id: str,
+    metadata: JobRunMetadata,
+    max_indexed_artifacts: int = MAX_INDEXED_ARTIFACTS,
+    fingerprint_max_bytes: int = ARTIFACT_FINGERPRINT_MAX_BYTES,
+    fingerprint_chunk_bytes: int = _ARTIFACT_FINGERPRINT_CHUNK_BYTES,
+) -> Optional[Tuple[List[Dict[str, Any]], Dict[str, Path], bool]]:
+    artifact_index = None
+    if metadata.run_card_path is not None and metadata.run_card_payload is not None:
+        artifact_index = metadata.run_card_payload.get("artifact_index")
+        if isinstance(artifact_index, list):
+            candidate_paths: List[Path] = [metadata.run_card_path]
+            for artifact_entry in artifact_index:
+                if not isinstance(artifact_entry, dict):
+                    continue
+                artifact_relative_path = artifact_entry.get("relative_path") or artifact_entry.get("path")
+                if not isinstance(artifact_relative_path, str) or not artifact_relative_path.strip():
+                    continue
+                resolved = _resolve_artifact_path_within_output_dir(
+                    metadata.output_dir,
+                    artifact_relative_path,
+                )
+                if resolved is None:
+                    continue
+                _, resolved_path = resolved
+                candidate_paths.append(resolved_path)
+            if len(candidate_paths) > 1:
+                return _build_scoped_job_artifacts(
+                    job_id=job_id,
+                    output_dir=metadata.output_dir,
+                    candidate_paths=candidate_paths,
+                    max_indexed_artifacts=max_indexed_artifacts,
+                    fingerprint_max_bytes=fingerprint_max_bytes,
+                    fingerprint_chunk_bytes=fingerprint_chunk_bytes,
+                )
+
+    if metadata.batch_manifest_path is not None:
+        candidate_paths = [metadata.batch_manifest_path]
+        if metadata.run_card_path is not None and isinstance(artifact_index, list) and artifact_index:
+            candidate_paths.insert(0, metadata.run_card_path)
+        return _build_scoped_job_artifacts(
+            job_id=job_id,
+            output_dir=metadata.output_dir,
+            candidate_paths=candidate_paths,
+            max_indexed_artifacts=max_indexed_artifacts,
+            fingerprint_max_bytes=fingerprint_max_bytes,
+            fingerprint_chunk_bytes=fingerprint_chunk_bytes,
+        )
+
+    return None
+
+
+def _validate_resolved_job_artifact_path(
+    output_dir: Optional[Path],
+    resolved_artifact: Path,
+) -> tuple[Path, Path, str]:
+    if output_dir is None:
+        raise FileNotFoundError("job_output_dir_missing")
+
+    output_dir = Path(os.path.realpath(output_dir.expanduser()))
+    if not output_dir.exists() or not output_dir.is_dir():
+        raise FileNotFoundError("job_output_dir_missing")
+
+    resolved = Path(os.path.realpath(resolved_artifact))
+    try:
+        relative_path = str(resolved.relative_to(output_dir))
+    except ValueError as exc:
+        raise ArtifactPathOutsideJobOutputDirError from exc
+
+    return output_dir, resolved, relative_path
+
+
+def _hydrate_artifact_lookup_from_items(
+    *,
+    items: Any,
+    output_dir: Optional[Path],
+) -> Dict[str, Path]:
+    if not isinstance(items, list) or not items:
+        return {}
+    if output_dir is None:
+        return {}
+
+    lookup: Dict[str, Path] = {}
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        candidate_path = item.get("relative_path") or item.get("path")
+        try:
+            normalized = _normalize_artifact_relative_path(str(candidate_path or ""))
+        except ValueError:
+            continue
+        resolved_candidate = Path(output_dir) / Path(*PurePosixPath(normalized).parts)
+        try:
+            _, resolved, canonical_relative_path = _validate_resolved_job_artifact_path(output_dir, resolved_candidate)
+        except (ValueError, FileNotFoundError):
+            continue
+        if not resolved.exists() or not resolved.is_file():
+            continue
+        lookup[canonical_relative_path] = resolved
+        _add_artifact_preview_proxy_lookup(
+            lookup,
+            output_dir=output_dir,
+            artifact_path=resolved,
+        )
+    return lookup
+
+
+def _index_job_artifacts(
+    *,
+    job_id: str,
+    output_dir: Optional[Path],
+    max_indexed_artifacts: int = MAX_INDEXED_ARTIFACTS,
+    fingerprint_max_bytes: int = ARTIFACT_FINGERPRINT_MAX_BYTES,
+    fingerprint_chunk_bytes: int = _ARTIFACT_FINGERPRINT_CHUNK_BYTES,
+    run_summary_max_bytes: int = JOB_RUN_SUMMARY_MAX_BYTES,
+) -> JobArtifactIndexResult:
+    if output_dir is None:
+        artifacts = {
+            "output_dir": None,
+            "items": [],
+            "indexed_count": 0,
+            "truncated": False,
+        }
+        return JobArtifactIndexResult(items=[], artifact_lookup={}, artifacts=artifacts)
+    if not output_dir.exists() or not output_dir.is_dir():
+        artifacts = {
+            "output_dir": str(output_dir),
+            "items": [],
+            "indexed_count": 0,
+            "truncated": False,
+        }
+        return JobArtifactIndexResult(items=[], artifact_lookup={}, artifacts=artifacts)
+
+    output_dir = Path(os.path.realpath(output_dir.expanduser()))
+    metadata = _resolve_job_run_metadata(output_dir, max_bytes=run_summary_max_bytes)
+    if metadata is not None:
+        scoped_artifacts = _build_scoped_job_artifacts_from_run_metadata(
+            job_id=job_id,
+            metadata=metadata,
+            max_indexed_artifacts=max_indexed_artifacts,
+            fingerprint_max_bytes=fingerprint_max_bytes,
+            fingerprint_chunk_bytes=fingerprint_chunk_bytes,
+        )
+        if scoped_artifacts is not None:
+            items, artifact_lookup, truncated = scoped_artifacts
+            artifacts = {
+                "output_dir": str(output_dir),
+                "items": items,
+                "indexed_count": len(items),
+                "truncated": truncated,
+            }
+            return JobArtifactIndexResult(items=items, artifact_lookup=artifact_lookup, artifacts=artifacts)
+
+    selected: List[tuple[tuple[str, str], str, Path]] = []
+    selected_keys: List[tuple[str, str]] = []
+    total_files = 0
+    for path in output_dir.rglob("*"):
+        if not path.is_file():
+            continue
+        total_files += 1
+        try:
+            relative_path = str(path.relative_to(output_dir))
+        except Exception:
+            relative_path = path.name
+
+        resolved_path = Path(os.path.realpath(path))
+        try:
+            resolved_path.relative_to(output_dir)
+        except ValueError:
+            continue
+
+        key = (relative_path.casefold(), relative_path)
+
+        if len(selected) < max_indexed_artifacts:
+            insert_at = bisect_left(selected_keys, key)
+            selected_keys.insert(insert_at, key)
+            selected.insert(insert_at, (key, relative_path, resolved_path))
+            continue
+
+        if key >= selected_keys[-1]:
+            continue
+
+        insert_at = bisect_left(selected_keys, key)
+        selected_keys.insert(insert_at, key)
+        selected.insert(insert_at, (key, relative_path, resolved_path))
+        selected_keys.pop()
+        selected.pop()
+
+    truncated = total_files > max_indexed_artifacts
+
+    items: List[Dict[str, Any]] = []
+    selected_lookup: Dict[str, Path] = {}
+    for _, relative_path, path in selected:
+        items.append(
+            _serialize_indexed_artifact(
+                job_id=job_id,
+                relative_path=relative_path,
+                path=path,
+                fingerprint_max_bytes=fingerprint_max_bytes,
+                fingerprint_chunk_bytes=fingerprint_chunk_bytes,
+            )
+        )
+        selected_lookup[relative_path] = path
+        _add_artifact_preview_proxy_lookup(
+            selected_lookup,
+            output_dir=output_dir,
+            artifact_path=path,
+        )
+
+    artifacts = {
+        "output_dir": str(output_dir),
+        "items": items,
+        "indexed_count": len(items),
+        "truncated": truncated,
+    }
+    return JobArtifactIndexResult(items=items, artifact_lookup=selected_lookup, artifacts=artifacts)

--- a/src/transformation_portal/portal/job_artifacts.py
+++ b/src/transformation_portal/portal/job_artifacts.py
@@ -8,7 +8,7 @@ import re
 from bisect import bisect_left
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
-from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
+from typing import Any, Dict, Iterable, Iterator, List, Mapping, Optional, Tuple
 from urllib.parse import quote
 
 from transformation_portal.lux_depth_v3.run_card_contract import infer_run_card_version
@@ -108,13 +108,16 @@ _BROWSER_PREVIEWABLE_MIME_TYPES = frozenset(
         "image/webp",
         "image/gif",
         "image/avif",
-        "image/svg+xml",
     }
 )
 
 
 def _artifact_is_browser_previewable(path: Path) -> bool:
     return _artifact_content_type(path).lower() in _BROWSER_PREVIEWABLE_MIME_TYPES
+
+
+def _relative_artifact_path(path: Path, output_dir: Path) -> str:
+    return path.relative_to(output_dir).as_posix()
 
 
 def _artifact_preview_proxy_path(path: Path) -> Optional[Path]:
@@ -145,7 +148,7 @@ def _add_artifact_preview_proxy_lookup(
     try:
         resolved_output_dir = Path(os.path.realpath(output_dir.expanduser()))
         resolved_proxy_path = Path(os.path.realpath(proxy_path))
-        proxy_relative_path = str(resolved_proxy_path.relative_to(resolved_output_dir))
+        proxy_relative_path = _relative_artifact_path(resolved_proxy_path, resolved_output_dir)
     except (OSError, ValueError):
         return
     lookup.setdefault(proxy_relative_path, resolved_proxy_path)
@@ -161,7 +164,10 @@ def _safe_artifact_attachment_filename(path: Path) -> str:
 def _artifact_response_headers(path: Path) -> Dict[str, str]:
     """Build response headers for a job artifact download."""
 
-    headers: Dict[str, str] = {"Cache-Control": "no-store"}
+    headers: Dict[str, str] = {
+        "Cache-Control": "no-store",
+        "X-Content-Type-Options": "nosniff",
+    }
     if not _artifact_is_previewable(path):
         filename = _safe_artifact_attachment_filename(path)
         headers["Content-Disposition"] = f'attachment; filename="{filename}"'
@@ -489,7 +495,7 @@ def _find_newest_artifact_path(output_dir: Path, candidates: List[Path]) -> Opti
         if not resolved.exists() or not resolved.is_file():
             continue
         try:
-            relative_path = str(resolved.relative_to(output_dir))
+            relative_path = _relative_artifact_path(resolved, output_dir)
         except ValueError:
             continue
         normalized_candidates.append((relative_path, resolved))
@@ -516,7 +522,7 @@ def _resolve_artifact_path_within_output_dir(
         )
     )
     try:
-        canonical_relative_path = str(resolved_candidate.relative_to(output_dir))
+        canonical_relative_path = _relative_artifact_path(resolved_candidate, output_dir)
     except ValueError:
         return None
     if not resolved_candidate.exists() or not resolved_candidate.is_file():
@@ -540,7 +546,7 @@ def _resolve_job_run_metadata(
     for candidate in output_dir.glob("run_card_*.json"):
         try:
             resolved_candidate = Path(os.path.realpath(candidate))
-            relative_path = str(resolved_candidate.relative_to(output_dir))
+            relative_path = _relative_artifact_path(resolved_candidate, output_dir)
         except (OSError, ValueError):
             continue
         run_card_payload = _load_bounded_run_card_payload(resolved_candidate, max_bytes=max_bytes)
@@ -608,7 +614,7 @@ def _build_scoped_job_artifacts(
         if not resolved_path.exists() or not resolved_path.is_file():
             continue
         try:
-            relative_path = str(resolved_path.relative_to(output_dir))
+            relative_path = _relative_artifact_path(resolved_path, output_dir)
         except ValueError:
             continue
         discovered[relative_path] = resolved_path
@@ -706,7 +712,7 @@ def _validate_resolved_job_artifact_path(
 
     resolved = Path(os.path.realpath(resolved_artifact))
     try:
-        relative_path = str(resolved.relative_to(output_dir))
+        relative_path = _relative_artifact_path(resolved, output_dir)
     except ValueError as exc:
         raise ArtifactPathOutsideJobOutputDirError from exc
 
@@ -746,6 +752,14 @@ def _hydrate_artifact_lookup_from_items(
             artifact_path=resolved,
         )
     return lookup
+
+
+def _iter_job_artifact_files(output_dir: Path) -> Iterator[Path]:
+    for root, dirnames, filenames in os.walk(output_dir, followlinks=False):
+        root_path = Path(root)
+        dirnames[:] = sorted(dirname for dirname in dirnames if not (root_path / dirname).is_symlink())
+        for filename in sorted(filenames):
+            yield root_path / filename
 
 
 def _index_job_artifacts(
@@ -797,20 +811,20 @@ def _index_job_artifacts(
     selected: List[tuple[tuple[str, str], str, Path]] = []
     selected_keys: List[tuple[str, str]] = []
     total_files = 0
-    for path in output_dir.rglob("*"):
+    for path in _iter_job_artifact_files(output_dir):
         if not path.is_file():
             continue
-        total_files += 1
-        try:
-            relative_path = str(path.relative_to(output_dir))
-        except Exception:
-            relative_path = path.name
 
         resolved_path = Path(os.path.realpath(path))
         try:
             resolved_path.relative_to(output_dir)
         except ValueError:
             continue
+        total_files += 1
+        try:
+            relative_path = _relative_artifact_path(path, output_dir)
+        except ValueError:
+            relative_path = path.name
 
         key = (relative_path.casefold(), relative_path)
 

--- a/tests/portal/test_job_artifacts.py
+++ b/tests/portal/test_job_artifacts.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Portal job artifact catalog extraction contract tests."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_direct_module_import_does_not_import_app() -> None:
+    code = (
+        "import sys; "
+        f"sys.path.insert(0, {str(REPO_ROOT / 'src')!r}); "
+        "from transformation_portal.portal import job_artifacts; "
+        "raise SystemExit(1 if 'app' in sys.modules else 0)"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=REPO_ROOT,
+        check=False,
+    )
+
+    assert result.returncode == 0
+
+
+def test_app_legacy_artifact_helpers_remain_available() -> None:
+    module = importlib.import_module("transformation_portal.portal.job_artifacts")
+    orchestrator_app = importlib.import_module("app")
+
+    assert orchestrator_app.JobRunMetadata is module.JobRunMetadata
+    assert orchestrator_app.ArtifactPathValidationError is module.ArtifactPathValidationError
+    assert orchestrator_app.InvalidArtifactPathError is module.InvalidArtifactPathError
+    assert orchestrator_app.AbsoluteArtifactPathError is module.AbsoluteArtifactPathError
+    assert orchestrator_app.ArtifactPathOutsideJobOutputDirError is module.ArtifactPathOutsideJobOutputDirError
+    assert orchestrator_app._infer_artifact_type is module._infer_artifact_type
+    assert orchestrator_app._artifact_content_type is module._artifact_content_type
+    assert orchestrator_app._artifact_media_kind is module._artifact_media_kind
+    assert orchestrator_app._artifact_is_previewable is module._artifact_is_previewable
+    assert orchestrator_app._artifact_is_browser_previewable is module._artifact_is_browser_previewable
+    assert orchestrator_app._artifact_preview_proxy_path is module._artifact_preview_proxy_path
+    assert orchestrator_app._add_artifact_preview_proxy_lookup is module._add_artifact_preview_proxy_lookup
+    assert orchestrator_app._artifact_response_headers is module._artifact_response_headers
+    assert orchestrator_app._artifact_display_hint is module._artifact_display_hint
+    assert callable(orchestrator_app._artifact_fingerprint)
+    assert callable(orchestrator_app._serialize_indexed_artifact)
+    assert callable(orchestrator_app._normalize_artifact_relative_path)
+    assert callable(orchestrator_app._hydrate_artifact_lookup_from_items)
+    assert callable(orchestrator_app._resolve_job_run_metadata)
+    assert callable(orchestrator_app._index_job_artifacts)
+
+
+def test_direct_and_app_index_payloads_match_for_preview_proxy(tmp_path: Path) -> None:
+    module = importlib.import_module("transformation_portal.portal.job_artifacts")
+    orchestrator_app = importlib.import_module("app")
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+    (output_dir / "manifest.json").write_text("{}", encoding="utf-8")
+    (output_dir / "render.tif").write_bytes(b"II*\x00")
+    (output_dir / "render.tif.preview.png").write_bytes(b"\x89PNG")
+
+    direct = module._index_job_artifacts(job_id="job_artifacts", output_dir=output_dir)
+    job = orchestrator_app.Job(
+        id="job_artifacts",
+        created_at=orchestrator_app._now(),
+        request={"pipeline": "lux-depth-v3", "args": {"output_dir": str(output_dir)}},
+    )
+    legacy_items = orchestrator_app._index_job_artifacts(job)
+
+    assert legacy_items == direct.items
+    assert job.artifacts == direct.artifacts
+    assert job.artifact_lookup == direct.artifact_lookup
+    tiff_item = next(item for item in legacy_items if item["path"] == "render.tif")
+    assert tiff_item["preview_url"] == "/v1/jobs/job_artifacts/artifacts/render.tif.preview.png"
+    assert tiff_item["download_url"] == "/v1/jobs/job_artifacts/artifacts/render.tif"
+    assert tiff_item["browser_previewable"] is True
+    assert job.artifact_lookup["render.tif.preview.png"] == (output_dir / "render.tif.preview.png").resolve()
+
+
+def test_app_wrapper_injects_current_artifact_limits(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = importlib.import_module("transformation_portal.portal.job_artifacts")
+    orchestrator_app = importlib.import_module("app")
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+    large = output_dir / "large.txt"
+    large.write_bytes(b"12345")
+    (output_dir / "small.txt").write_text("ok", encoding="utf-8")
+    job = orchestrator_app.Job(
+        id="job_artifacts_limits",
+        created_at=orchestrator_app._now(),
+        request={"pipeline": "lux-depth-v3", "args": {"output_dir": str(output_dir)}},
+    )
+
+    monkeypatch.setattr(orchestrator_app, "MAX_INDEXED_ARTIFACTS", 1)
+    monkeypatch.setattr(orchestrator_app, "ARTIFACT_FINGERPRINT_MAX_BYTES", 4)
+
+    indexed = orchestrator_app._index_job_artifacts(job)
+
+    assert [item["path"] for item in indexed] == ["large.txt"]
+    assert indexed[0]["fingerprint_status"] == "skipped_size"
+    assert module._artifact_fingerprint(large, large.stat().st_size)[1] == "ok"
+    assert job.artifacts["truncated"] is True
+
+
+def test_app_index_wrapper_honors_job_output_dir_monkeypatch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    orchestrator_app = importlib.import_module("app")
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+    (output_dir / "manifest.json").write_text("{}", encoding="utf-8")
+    job = orchestrator_app.Job(
+        id="job_artifacts_output_dir_patch",
+        created_at=orchestrator_app._now(),
+        request={"pipeline": "lux-depth-v3", "args": {}},
+    )
+
+    monkeypatch.setattr(orchestrator_app, "_job_output_dir", lambda _: output_dir)
+
+    indexed = orchestrator_app._index_job_artifacts(job)
+
+    assert [item["path"] for item in indexed] == ["manifest.json"]
+    assert job.artifacts["output_dir"] == str(output_dir.resolve())
+
+
+@pytest.mark.parametrize(
+    ("artifact_path", "error_type"),
+    [
+        ("", "InvalidArtifactPathError"),
+        ("~/.ssh/id_rsa", "InvalidArtifactPathError"),
+        ("/tmp/secret.txt", "AbsoluteArtifactPathError"),
+        ("../secret.txt", "ArtifactPathOutsideJobOutputDirError"),
+        ("folder\\secret.txt", "InvalidArtifactPathError"),
+    ],
+)
+def test_direct_relative_path_validation_preserves_error_types(
+    artifact_path: str,
+    error_type: str,
+) -> None:
+    module = importlib.import_module("transformation_portal.portal.job_artifacts")
+
+    with pytest.raises(getattr(module, error_type)):
+        module._normalize_artifact_relative_path(artifact_path)
+
+
+def test_direct_index_skips_symlink_escape(tmp_path: Path) -> None:
+    module = importlib.import_module("transformation_portal.portal.job_artifacts")
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+    outside = tmp_path / "secret.png"
+    outside.write_bytes(b"secret")
+    link = output_dir / "escape.png"
+    try:
+        link.symlink_to(outside)
+    except OSError as exc:
+        pytest.skip(f"symlink creation unavailable: {exc}")
+
+    result = module._index_job_artifacts(job_id="job_artifacts_symlink", output_dir=output_dir)
+
+    assert result.items == []
+    assert result.artifacts["items"] == []
+    assert result.artifact_lookup == {}
+
+
+def test_direct_hydration_registers_preview_proxy(tmp_path: Path) -> None:
+    module = importlib.import_module("transformation_portal.portal.job_artifacts")
+    output_dir = tmp_path / "out"
+    artifact_path = output_dir / "renders" / "hero.tif"
+    artifact_path.parent.mkdir(parents=True)
+    artifact_path.write_bytes(b"II*\x00")
+    proxy_path = output_dir / "renders" / "hero.tif.preview.png"
+    proxy_path.write_bytes(b"\x89PNG")
+
+    lookup = module._hydrate_artifact_lookup_from_items(
+        items=[{"path": "renders/hero.tif", "relative_path": "renders/hero.tif"}],
+        output_dir=output_dir,
+    )
+
+    assert lookup["renders/hero.tif"] == artifact_path.resolve()
+    assert lookup["renders/hero.tif.preview.png"] == proxy_path.resolve()
+
+
+def test_direct_index_prefers_run_card_scoped_artifacts(tmp_path: Path) -> None:
+    module = importlib.import_module("transformation_portal.portal.job_artifacts")
+    output_dir = tmp_path / "out"
+    depth_dir = output_dir / "depth"
+    manifests_dir = output_dir / "manifests"
+    depth_dir.mkdir(parents=True)
+    manifests_dir.mkdir(parents=True)
+    current_depth = depth_dir / "current_depth.png"
+    current_depth.write_bytes(b"current")
+    (depth_dir / "stale_depth.png").write_bytes(b"stale")
+    batch_manifest = manifests_dir / "batch_2026-05-06_120000.json"
+    batch_manifest.write_text(json.dumps({"batch_id": "2026-05-06_120000", "results": []}), encoding="utf-8")
+    run_card = output_dir / "run_card_2026-05-06_120000.json"
+    run_card.write_text(
+        json.dumps(
+            {
+                "batch_id": "2026-05-06_120000",
+                "success_count": 1,
+                "error_count": 0,
+                "artifact_index": [{"relative_path": "depth/current_depth.png"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = module._index_job_artifacts(job_id="job_artifacts_scoped", output_dir=output_dir)
+
+    assert {item["path"] for item in result.items} == {
+        "depth/current_depth.png",
+        "run_card_2026-05-06_120000.json",
+    }
+    assert "depth/stale_depth.png" not in result.artifact_lookup
+
+
+def test_direct_index_uses_batch_manifest_when_run_card_has_no_artifact_index(
+    tmp_path: Path,
+) -> None:
+    module = importlib.import_module("transformation_portal.portal.job_artifacts")
+    output_dir = tmp_path / "out"
+    manifests_dir = output_dir / "manifests"
+    manifests_dir.mkdir(parents=True)
+    batch_manifest = manifests_dir / "batch_2026-05-06_120000.json"
+    batch_manifest.write_text(
+        json.dumps(
+            {
+                "batch_id": "2026-05-06_120000",
+                "results": [{"status": "error"}],
+                "stats": {"total_images": 1},
+            }
+        ),
+        encoding="utf-8",
+    )
+    run_card = output_dir / "run_card_2026-05-06_120000.json"
+    run_card.write_text(
+        json.dumps(
+            {
+                "batch_id": "2026-05-06_120000",
+                "success_count": 0,
+                "error_count": 1,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = module._index_job_artifacts(job_id="job_artifacts_manifest", output_dir=output_dir)
+
+    assert [item["path"] for item in result.items] == ["manifests/batch_2026-05-06_120000.json"]

--- a/tests/portal/test_job_artifacts.py
+++ b/tests/portal/test_job_artifacts.py
@@ -119,6 +119,39 @@ def test_svg_artifacts_are_not_browser_previewable_and_are_served_as_attachments
     assert headers["X-Content-Type-Options"] == "nosniff"
 
 
+@pytest.mark.parametrize(
+    ("filename", "content_type"),
+    [
+        ("animated.gif", "image/gif"),
+        ("modern.avif", "image/avif"),
+    ],
+)
+def test_browser_previewable_image_formats_are_served_inline(
+    tmp_path: Path,
+    filename: str,
+    content_type: str,
+) -> None:
+    module = importlib.import_module("transformation_portal.portal.job_artifacts")
+    artifact_path = tmp_path / filename
+    artifact_path.write_bytes(b"image")
+
+    payload = module._serialize_indexed_artifact(
+        job_id="job_artifacts_browser_image",
+        relative_path=filename,
+        path=artifact_path,
+    )
+    headers = module._artifact_response_headers(artifact_path)
+
+    assert module._infer_artifact_type(artifact_path) == "image"
+    assert module._artifact_content_type(artifact_path) == content_type
+    assert module._artifact_is_previewable(artifact_path) is True
+    assert module._artifact_is_browser_previewable(artifact_path) is True
+    assert payload["previewable"] is True
+    assert payload["browser_previewable"] is True
+    assert "Content-Disposition" not in headers
+    assert headers["X-Content-Type-Options"] == "nosniff"
+
+
 def test_app_wrapper_injects_current_artifact_limits(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/portal/test_job_artifacts.py
+++ b/tests/portal/test_job_artifacts.py
@@ -8,7 +8,7 @@ import importlib
 import json
 import subprocess
 import sys
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 
 import pytest
 
@@ -86,6 +86,39 @@ def test_direct_and_app_index_payloads_match_for_preview_proxy(tmp_path: Path) -
     assert job.artifact_lookup["render.tif.preview.png"] == (output_dir / "render.tif.preview.png").resolve()
 
 
+def test_direct_module_serializes_artifact_relative_paths_as_posix() -> None:
+    module = importlib.import_module("transformation_portal.portal.job_artifacts")
+
+    assert (
+        module._relative_artifact_path(
+            PureWindowsPath("C:/job-output/renders/hero.png"),
+            PureWindowsPath("C:/job-output"),
+        )
+        == "renders/hero.png"
+    )
+
+
+def test_svg_artifacts_are_not_browser_previewable_and_are_served_as_attachments(
+    tmp_path: Path,
+) -> None:
+    module = importlib.import_module("transformation_portal.portal.job_artifacts")
+    artifact_path = tmp_path / "active.svg"
+    artifact_path.write_text('<svg onload="alert(1)"></svg>', encoding="utf-8")
+
+    payload = module._serialize_indexed_artifact(
+        job_id="job_artifacts_svg",
+        relative_path="active.svg",
+        path=artifact_path,
+    )
+    headers = module._artifact_response_headers(artifact_path)
+
+    assert module._artifact_content_type(artifact_path) == "image/svg+xml"
+    assert module._artifact_is_browser_previewable(artifact_path) is False
+    assert payload["browser_previewable"] is False
+    assert "attachment" in headers["Content-Disposition"]
+    assert headers["X-Content-Type-Options"] == "nosniff"
+
+
 def test_app_wrapper_injects_current_artifact_limits(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -160,18 +193,52 @@ def test_direct_index_skips_symlink_escape(tmp_path: Path) -> None:
     module = importlib.import_module("transformation_portal.portal.job_artifacts")
     output_dir = tmp_path / "out"
     output_dir.mkdir()
-    outside = tmp_path / "secret.png"
-    outside.write_bytes(b"secret")
-    link = output_dir / "escape.png"
+    outside_a = tmp_path / "secret-a.png"
+    outside_b = tmp_path / "secret-b.png"
+    outside_a.write_bytes(b"secret-a")
+    outside_b.write_bytes(b"secret-b")
+    link_a = output_dir / "escape-a.png"
+    link_b = output_dir / "escape-b.png"
     try:
-        link.symlink_to(outside)
+        link_a.symlink_to(outside_a)
+        link_b.symlink_to(outside_b)
     except OSError as exc:
         pytest.skip(f"symlink creation unavailable: {exc}")
 
-    result = module._index_job_artifacts(job_id="job_artifacts_symlink", output_dir=output_dir)
+    result = module._index_job_artifacts(
+        job_id="job_artifacts_symlink",
+        output_dir=output_dir,
+        max_indexed_artifacts=1,
+    )
 
     assert result.items == []
     assert result.artifacts["items"] == []
+    assert result.artifacts["truncated"] is False
+    assert result.artifact_lookup == {}
+
+
+def test_direct_index_does_not_descend_into_symlinked_directories(tmp_path: Path) -> None:
+    module = importlib.import_module("transformation_portal.portal.job_artifacts")
+    output_dir = tmp_path / "out"
+    outside_dir = tmp_path / "outside"
+    output_dir.mkdir()
+    outside_dir.mkdir()
+    for index in range(3):
+        (outside_dir / f"secret-{index}.txt").write_text("secret", encoding="utf-8")
+    link = output_dir / "linked"
+    try:
+        link.symlink_to(outside_dir, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"symlink creation unavailable: {exc}")
+
+    result = module._index_job_artifacts(
+        job_id="job_artifacts_symlink_dir",
+        output_dir=output_dir,
+        max_indexed_artifacts=1,
+    )
+
+    assert result.items == []
+    assert result.artifacts["truncated"] is False
     assert result.artifact_lookup == {}
 
 

--- a/tests/test_portal_backend_hardening.py
+++ b/tests/test_portal_backend_hardening.py
@@ -283,6 +283,7 @@ def test_artifact_endpoint_attaches_non_previewable(client: TestClient, tmp_path
     disposition = response.headers.get("content-disposition", "")
     assert "attachment" in disposition
     assert 'filename="report.html"' in disposition
+    assert response.headers["X-Content-Type-Options"] == "nosniff"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Extract the portal job artifact catalog and indexing helpers from `app.py` into `src/transformation_portal/portal/job_artifacts.py`.
- Keep `app.py` as the compatibility and mutation surface for job-owned state, output-root resolution, route handlers, SSE publishing, and run-summary mutation.
- Include review-thread hardening for artifact preview safety: active SVG content is served as an attachment with `nosniff` instead of being marked browser-previewable.

## Changes
- Add `portal/job_artifacts.py` with artifact classification, content/media metadata, preview proxy lookup, display hints, fingerprinting, artifact serialization, bounded run-card/batch-manifest metadata discovery, artifact path validation, lookup hydration, and catalog indexing.
- Re-export legacy artifact helper names and validation classes through `app.py`, using wrappers where app-owned constants or `Job` mutation must be injected.
- Preserve artifact payload shape, URLs, preview proxy naming, fingerprint caps, relative-path validation, and indexed artifact lookup behavior, except for the intentional SVG hardening above.
- Align GIF and AVIF artifact classification with the existing browser-previewable MIME allowlist so those image artifacts are served inline consistently.
- Update the monolith decomposition status table for Target 2E only.
- Add focused extraction contract tests for direct module behavior, app compatibility, direct/app parity, path validation, symlink escape skipping, hydration, scoped run-card indexing, batch-manifest fallback, monkeypatched app limits, SVG attachment handling, and GIF/AVIF preview consistency.

## Validation
- `.venv/bin/python -m pytest tests/portal/test_job_artifacts.py tests/test_app_orchestrator_runtime.py -k "artifact or run_summary or captioning" -q`
- `.venv/bin/python -m pytest tests/test_portal_backend_hardening.py tests/test_app_orchestrator_contract_http.py -k "artifact or path or job" -q`
- `make check-json-serialization`
- `make check-yaml-governance`
- `make check-python-headers`
- `.venv/bin/python scripts/validation/scan_todo_inventory.py --check-governance`
- `make test-fast`
- `git diff --check`

## Risk
- Compatibility wrappers preserve existing private imports from `app.py`.
- Public job routes, API envelopes, SSE events, selectors, artifact URLs, auth behavior, and run-summary mutation remain in `app.py`.
- SVG browser preview behavior is intentionally narrowed: SVG artifacts are no longer browser-previewable and are served as attachments with `X-Content-Type-Options: nosniff` to avoid active SVG execution under the portal origin.
- The change is bounded and revert-safe because the new module is reached through the existing app compatibility surface.
