### PR TITLE
fix(requirements): rotate diffusers ml lock floor

### DIFF
--- a/docs/architecture/ML_CI_OPTIMIZATION_CHECKLIST.md
+++ b/docs/architecture/ML_CI_OPTIMIZATION_CHECKLIST.md
@@ -117,7 +117,7 @@
   # ML dependencies with range pins
   -c constraints.txt  # Enforce banned packages (ADR-032)
   transformers>=4.57.0,<6
-  diffusers>=0.36.0,<1
+  diffusers>=0.38.0,<1
   sentence-transformers>=3.1.0,<6  # CVE-73169 minimum (ADR-032)
   controlnet-aux>=0.0.6,<1
   huggingface-hub>=0.19.0,<2

--- a/docs/architecture/ML_CI_OPTIMIZATION_QUICKREF.md
+++ b/docs/architecture/ML_CI_OPTIMIZATION_QUICKREF.md
@@ -85,7 +85,7 @@ torchvision==0.25.0+cpu
 # Standard ML dependencies with range pins
 -c constraints.txt  # Banned package enforcement
 transformers>=4.57.0,<6
-diffusers>=0.36.0,<1
+diffusers>=0.38.0,<1
 sentence-transformers>=3.1.0,<6  # CVE-73169 minimum
 controlnet-aux>=0.0.6,<1
 huggingface-hub>=0.19.0,<2

--- a/docs/architecture/ML_CI_OPTIMIZATION_STRATEGIC_REVIEW.md
+++ b/docs/architecture/ML_CI_OPTIMIZATION_STRATEGIC_REVIEW.md
@@ -85,7 +85,7 @@ torchvision==0.25.0+cpu # Strict pin: CI reproducibility
 # Include base ML deps but skip heavy optional deps
 -c constraints.txt      # Enforce banned packages
 transformers>=4.57.0,<6
-diffusers>=0.36.0,<1
+diffusers>=0.38.0,<1
 sentence-transformers>=3.1.0,<6  # CVE-73169 minimum
 controlnet-aux>=0.0.6,<1
 huggingface-hub>=0.19.0,<2

--- a/docs/guides/FLUX_INTEGRATION.md
+++ b/docs/guides/FLUX_INTEGRATION.md
@@ -26,7 +26,7 @@ FLUX.1 represents the state-of-the-art for architectural image enhancement with 
 
 ```bash
 # Update diffusers and transformers
-pip install diffusers>=0.30.0 transformers>=4.38.0 accelerate
+python -m pip install "diffusers>=0.38.0" "transformers>=4.38.0" accelerate
 
 # Optional: ControlNet auxiliary models
 pip install controlnet-aux

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ classifiers = [
 ml-core = [
     "torch>=2.8.0",
     "torchvision>=0.23.0",
-    "diffusers>=0.30",
+    "diffusers>=0.38.0,<1",
     "transformers>=5.0.0,<5.1",
     "huggingface-hub>=0.19",
     "accelerate>=0.20",
@@ -88,7 +88,7 @@ raw = [
 ml = [
     "torch>=2.8.0",
     "torchvision>=0.23.0",
-    "diffusers>=0.30",
+    "diffusers>=0.38.0,<1",
     "transformers>=5.0.0,<5.1",
     "rawpy>=0.18.0",
 ]

--- a/requirements/README.md
+++ b/requirements/README.md
@@ -67,10 +67,10 @@ To ensure deterministic builds, the checked-in ML contract is limited to the sup
 
 | Target | Lockfile | Governed baseline |
 |----------|----------|-------------------|
-| macOS Apple Silicon (`darwin-arm64`) | `ml-core-darwin-arm64.txt` | `torch==2.8.0` + `torchvision==0.23.0` + `transformers==5.0.0` + pinned `coremltools` |
+| macOS Apple Silicon (`darwin-arm64`) | `ml-core-darwin-arm64.txt` | `torch==2.8.0` + `torchvision==0.23.0` + `diffusers>=0.38.0` + `transformers==5.0.0` + pinned `coremltools` |
 
 **Contract notes:**
-- Supported target-owned core locks anchor on torch 2.8.0 / torchvision 0.23.0 and Transformers 5.x.
+- Supported target-owned core locks anchor on torch 2.8.0 / torchvision 0.23.0, Diffusers 0.38.0+, and Transformers 5.x.
 - The Apple Silicon Darwin lock must keep pinned `coremltools` and must remain free of Linux/CUDA-only packages.
 - Darwin target-owned lockfiles must never contain `nvidia-*` or `triton`.
 - Linux and macOS Intel ML lanes are retired unsupported lanes and are not kept as installable `requirements/*.in` or `requirements/*.txt` manifests.

--- a/requirements/ml-core-darwin-arm64.in
+++ b/requirements/ml-core-darwin-arm64.in
@@ -28,7 +28,7 @@ torch==2.8.0  # Supported security baseline
 torchvision==0.23.0  # Paired Apple Silicon baseline
 
 # Diffusion / HuggingFace ecosystem
-diffusers>=0.36.0,<1
+diffusers>=0.38.0,<1
 transformers>=5.0.0,<5.1
 huggingface-hub>=0.19.0,<2
 accelerate>=0.20.0,<2

--- a/requirements/ml-core-darwin-arm64.txt
+++ b/requirements/ml-core-darwin-arm64.txt
@@ -40,7 +40,7 @@ controlnet-aux==0.0.10
     # via -r ml-core-darwin-arm64.in
 coremltools==9.0
     # via -r ml-core-darwin-arm64.in
-diffusers==0.37.1
+diffusers==0.38.0
     # via -r ml-core-darwin-arm64.in
 efficientsam==1.0.0
     # via -r ml-core-darwin-arm64.in
@@ -193,7 +193,7 @@ rich==15.0.0
     # via
     #   -c base.txt
     #   typer
-safetensors==0.7.0
+safetensors==0.8.0rc0
     # via
     #   accelerate
     #   diffusers

--- a/requirements/ml-core.in
+++ b/requirements/ml-core.in
@@ -30,7 +30,7 @@ torch>=2.8.0
 torchvision>=0.23.0
 
 # Diffusion / HuggingFace ecosystem
-diffusers>=0.36.0,<1
+diffusers>=0.38.0,<1
 transformers>=5.0.0,<5.1
 huggingface-hub>=0.19.0,<2
 accelerate>=0.20.0,<2

--- a/scripts/validation/check_requirements_lock_contract.py
+++ b/scripts/validation/check_requirements_lock_contract.py
@@ -116,6 +116,8 @@ GENERIC_BASE_RUNTIME_LOCKS = ("all.txt", "base.txt")
 
 SUPPORTED_TORCH_PIN = "2.8.0"
 SUPPORTED_TORCHVISION_PIN = "0.23.0"
+SUPPORTED_DIFFUSERS_MIN = "0.38.0"
+SUPPORTED_DIFFUSERS_INPUT_RANGE = "diffusers>=0.38.0,<1"
 SUPPORTED_TRANSFORMERS_MIN = "5.0.0"
 SUPPORTED_TRANSFORMERS_INPUT_RANGE = "transformers>=5.0.0,<5.1"
 
@@ -420,6 +422,10 @@ def validate_darwin_input_guards() -> list[str]:
         errors.append(
             f"{darwin_arm64_input} must pin torchvision=={SUPPORTED_TORCHVISION_PIN} alongside the supported Apple Silicon torch baseline."
         )
+    if SUPPORTED_DIFFUSERS_INPUT_RANGE not in arm64_non_comment_lines:
+        errors.append(
+            f"{darwin_arm64_input} must declare {SUPPORTED_DIFFUSERS_INPUT_RANGE!r} for the supported Diffusers security baseline."
+        )
     if SUPPORTED_TRANSFORMERS_INPUT_RANGE not in arm64_non_comment_lines:
         errors.append(
             f"{darwin_arm64_input} must declare {SUPPORTED_TRANSFORMERS_INPUT_RANGE!r} for the supported Transformers security baseline."
@@ -449,12 +455,18 @@ def validate_platform_lock_runtime_compatibility() -> list[str]:
         packages = _read_pinned_packages(lock_path)
         torch_version = packages.get("torch")
         torchvision_version = packages.get("torchvision")
+        diffusers_version = packages.get("diffusers")
         transformers_version = packages.get("transformers")
 
         if lock_name == "ml-core-darwin-arm64.txt" and "coremltools" not in packages:
             errors.append(
                 f"{lock_path} must include a pinned coremltools dependency so Apple Silicon "
                 "CoreML support remains part of the checked-in arm64 contract."
+            )
+        if lock_name == "ml-core-darwin-arm64.txt" and "diffusers" not in packages:
+            errors.append(
+                f"{lock_path} must include a pinned diffusers dependency so the supported Diffusers "
+                "security baseline remains part of the checked-in arm64 contract."
             )
 
         if (
@@ -472,6 +484,14 @@ def validate_platform_lock_runtime_compatibility() -> list[str]:
         ):
             errors.append(
                 f"{lock_path} must rotate to torchvision=={SUPPORTED_TORCHVISION_PIN} for the supported Apple Silicon security baseline."
+            )
+        if (
+            lock_name == "ml-core-darwin-arm64.txt"
+            and diffusers_version is not None
+            and _parse_numeric_version(diffusers_version) < _parse_numeric_version(SUPPORTED_DIFFUSERS_MIN)
+        ):
+            errors.append(
+                f"{lock_path} must rotate to diffusers>={SUPPORTED_DIFFUSERS_MIN} for the supported Diffusers security baseline."
             )
         if (
             lock_name == "ml-core-darwin-arm64.txt"

--- a/scripts/verification/verify_ml_deps.py
+++ b/scripts/verification/verify_ml_deps.py
@@ -53,7 +53,7 @@ def check_dependencies():
             ("torch", "PyTorch", "2.8.0"),
             ("torchvision", "TorchVision", "0.23.0"),
             ("transformers", "Transformers", "4.57.6"),
-            ("diffusers", "Diffusers", "0.36.0"),
+            ("diffusers", "Diffusers", "0.38.0"),
         ],
         "Depth": [
             ("depth_pro", "Apple Depth Pro", "0.1"),

--- a/tests/smoke/test_ml_stack_smoke.py
+++ b/tests/smoke/test_ml_stack_smoke.py
@@ -326,7 +326,7 @@ def test_ml_stack_imports(monkeypatch: pytest.MonkeyPatch):
 
     # Check sklearn (if available)
     assert_importable_if_installed("scikit-learn", "sklearn", "1.8.0")
-    assert_importable_if_installed("diffusers", "diffusers", "0.36.0")
+    assert_importable_if_installed("diffusers", "diffusers", "0.38.0")
     assert_importable_if_installed("transformers", "transformers", "4.57.0")
     assert_importable_if_installed("torchvision", "torchvision", "0.17.2")
     assert_importable_if_installed("timm", "timm")

--- a/tests/test_check_requirements_lock_contract.py
+++ b/tests/test_check_requirements_lock_contract.py
@@ -111,7 +111,7 @@ def fixture_isolated_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Pa
         tmp_path,
         "ml-core-darwin-arm64.txt",
         "3.11",
-        body="torch==2.8.0\ntorchvision==0.23.0\ntransformers==5.0.0\ncoremltools==9.0\n",
+        body="torch==2.8.0\ntorchvision==0.23.0\ndiffusers==0.38.0\ntransformers==5.0.0\ncoremltools==9.0\n",
     )
     return tmp_path
 
@@ -350,7 +350,7 @@ def test_retired_darwin_x86_input_is_reported(isolated_repo: Path) -> None:
 
 def test_darwin_arm64_input_requires_coremltools(isolated_repo: Path) -> None:
     (isolated_repo / "requirements" / "ml-core-darwin-arm64.in").write_text(
-        "torch==2.8.0\ntorchvision==0.23.0\ntransformers>=5.0.0,<5.1\n",
+        "torch==2.8.0\ntorchvision==0.23.0\ndiffusers>=0.38.0,<1\ntransformers>=5.0.0,<5.1\n",
         encoding="utf-8",
     )
 
@@ -364,7 +364,7 @@ def test_darwin_arm64_input_requires_coremltools(isolated_repo: Path) -> None:
 
 def test_darwin_arm64_input_requires_supported_torch_pin(isolated_repo: Path) -> None:
     (isolated_repo / "requirements" / "ml-core-darwin-arm64.in").write_text(
-        "torch==2.7.0\ntorchvision==0.23.0\ntransformers>=5.0.0,<5.1\ncoremltools>=7.0\n",
+        "torch==2.7.0\ntorchvision==0.23.0\ndiffusers>=0.38.0,<1\ntransformers>=5.0.0,<5.1\ncoremltools>=7.0\n",
         encoding="utf-8",
     )
 
@@ -377,7 +377,7 @@ def test_darwin_arm64_input_requires_supported_torch_pin(isolated_repo: Path) ->
 
 def test_darwin_arm64_input_requires_supported_torchvision_pin(isolated_repo: Path) -> None:
     (isolated_repo / "requirements" / "ml-core-darwin-arm64.in").write_text(
-        "torch==2.8.0\ntorchvision==0.22.0\ntransformers>=5.0.0,<5.1\ncoremltools>=7.0\n",
+        "torch==2.8.0\ntorchvision==0.22.0\ndiffusers>=0.38.0,<1\ntransformers>=5.0.0,<5.1\ncoremltools>=7.0\n",
         encoding="utf-8",
     )
 
@@ -390,7 +390,7 @@ def test_darwin_arm64_input_requires_supported_torchvision_pin(isolated_repo: Pa
 
 def test_darwin_arm64_input_requires_supported_transformers_range(isolated_repo: Path) -> None:
     (isolated_repo / "requirements" / "ml-core-darwin-arm64.in").write_text(
-        "torch==2.8.0\ntorchvision==0.23.0\ntransformers>=4.57.0,<5\ncoremltools>=7.0\n",
+        "torch==2.8.0\ntorchvision==0.23.0\ndiffusers>=0.38.0,<1\ntransformers>=4.57.0,<5\ncoremltools>=7.0\n",
         encoding="utf-8",
     )
 
@@ -402,12 +402,26 @@ def test_darwin_arm64_input_requires_supported_transformers_range(isolated_repo:
     ]
 
 
+def test_darwin_arm64_input_requires_supported_diffusers_range(isolated_repo: Path) -> None:
+    (isolated_repo / "requirements" / "ml-core-darwin-arm64.in").write_text(
+        "torch==2.8.0\ntorchvision==0.23.0\ndiffusers>=0.36.0,<1\ntransformers>=5.0.0,<5.1\ncoremltools>=7.0\n",
+        encoding="utf-8",
+    )
+
+    errors = contract.validate_darwin_input_guards()
+
+    assert errors == [
+        f"{isolated_repo / 'requirements' / 'ml-core-darwin-arm64.in'} must declare 'diffusers>=0.38.0,<1' "
+        "for the supported Diffusers security baseline."
+    ]
+
+
 def test_platform_lock_runtime_compatibility_requires_arm64_coremltools(isolated_repo: Path) -> None:
     write_lockfile(
         isolated_repo,
         "ml-core-darwin-arm64.txt",
         "3.11",
-        body="torch==2.8.0\ntorchvision==0.23.0\ntransformers==5.0.0\nnumpy==2.4.3\n",
+        body="torch==2.8.0\ntorchvision==0.23.0\ndiffusers==0.38.0\ntransformers==5.0.0\nnumpy==2.4.3\n",
     )
 
     errors = contract.validate_platform_lock_runtime_compatibility()
@@ -418,12 +432,28 @@ def test_platform_lock_runtime_compatibility_requires_arm64_coremltools(isolated
     ]
 
 
+def test_platform_lock_runtime_compatibility_requires_arm64_diffusers(isolated_repo: Path) -> None:
+    write_lockfile(
+        isolated_repo,
+        "ml-core-darwin-arm64.txt",
+        "3.11",
+        body="torch==2.8.0\ntorchvision==0.23.0\ntransformers==5.0.0\nnumpy==2.4.3\ncoremltools==9.0\n",
+    )
+
+    errors = contract.validate_platform_lock_runtime_compatibility()
+
+    assert errors == [
+        f"{isolated_repo / 'requirements' / 'ml-core-darwin-arm64.txt'} must include a pinned diffusers dependency so the supported Diffusers "
+        "security baseline remains part of the checked-in arm64 contract."
+    ]
+
+
 def test_platform_lock_runtime_compatibility_requires_supported_arm64_torch_rotation(isolated_repo: Path) -> None:
     write_lockfile(
         isolated_repo,
         "ml-core-darwin-arm64.txt",
         "3.11",
-        body="torch==2.2.2\ntorchvision==0.17.2\ntransformers==5.0.0\nnumpy==2.4.3\ncoremltools==9.0\n",
+        body="torch==2.2.2\ntorchvision==0.17.2\ndiffusers==0.38.0\ntransformers==5.0.0\nnumpy==2.4.3\ncoremltools==9.0\n",
     )
 
     errors = contract.validate_platform_lock_runtime_compatibility()
@@ -439,7 +469,7 @@ def test_platform_lock_runtime_compatibility_requires_supported_transformers_rot
         isolated_repo,
         "ml-core-darwin-arm64.txt",
         "3.11",
-        body="torch==2.8.0\ntorchvision==0.23.0\ntransformers==4.57.6\nnumpy==2.4.4\ncoremltools==9.0\n",
+        body="torch==2.8.0\ntorchvision==0.23.0\ndiffusers==0.38.0\ntransformers==4.57.6\nnumpy==2.4.4\ncoremltools==9.0\n",
     )
 
     errors = contract.validate_platform_lock_runtime_compatibility()
@@ -447,6 +477,22 @@ def test_platform_lock_runtime_compatibility_requires_supported_transformers_rot
     assert errors == [
         f"{isolated_repo / 'requirements' / 'ml-core-darwin-arm64.txt'} must rotate to transformers>=5.0.0 "
         "for the supported Transformers security baseline."
+    ]
+
+
+def test_platform_lock_runtime_compatibility_requires_supported_diffusers_rotation(isolated_repo: Path) -> None:
+    write_lockfile(
+        isolated_repo,
+        "ml-core-darwin-arm64.txt",
+        "3.11",
+        body="torch==2.8.0\ntorchvision==0.23.0\ndiffusers==0.37.1\ntransformers==5.0.0\nnumpy==2.4.4\ncoremltools==9.0\n",
+    )
+
+    errors = contract.validate_platform_lock_runtime_compatibility()
+
+    assert errors == [
+        f"{isolated_repo / 'requirements' / 'ml-core-darwin-arm64.txt'} must rotate to diffusers>=0.38.0 "
+        "for the supported Diffusers security baseline."
     ]
 
 


### PR DESCRIPTION
## Summary
- Dependabot alert #175 identifies `diffusers<0.38.0` in `requirements/ml-core-darwin-arm64.txt` as vulnerable to GHSA-j7w6-vpvq-j3gm.
- Rotate the supported Apple Silicon ML lock/input to the first patched Diffusers baseline and add contract coverage so the vulnerable floor cannot re-enter the governed lock.

## Changes
- Raise Diffusers requirements to `diffusers>=0.38.0,<1` in `pyproject.toml`, `requirements/ml-core.in`, and `requirements/ml-core-darwin-arm64.in`.
- Regenerate `requirements/ml-core-darwin-arm64.txt` on the target-owned Darwin arm64 lane, pinning `diffusers==0.38.0`; `safetensors` moves to `0.8.0rc0` because Diffusers 0.38.0 requires `safetensors>=0.8.0-rc.0`.
- Extend `scripts/validation/check_requirements_lock_contract.py` and focused tests to require the supported Diffusers input range and a pinned, non-vulnerable Diffusers lock entry.
- Update ML smoke/version verification and related dependency docs to match the new security floor.

## Validation
Proven green:
- `.venv/bin/pytest tests/test_check_requirements_lock_contract.py`
- `python3 scripts/validation/check_requirements_lock_contract.py`
- `python3 scripts/validation/check_dependency_pinning.py`
- `python3 scripts/validation/check_dependency_update_workflow.py`
- `.venv/bin/python scripts/validation/check_dependabot_config.py`
- `make -C requirements check-ml-darwin-arm64 PIP_COMPILE_BIN=/private/tmp/tp-piptools-311/bin/pip-compile LOCK_PYTHON_VERSION=3.11 PIP_TOOLS_CACHE_DIR=/private/tmp/tp-piptools-cache`
- `.venv/bin/pip-audit -r requirements/ml-core-darwin-arm64.txt --desc`
- `git diff --check`
- pre-commit hooks during `git commit`

Still failing:
- None observed.

Environment/tooling notes:
- `.venv/bin/pytest tests/smoke/test_ml_stack_smoke.py::test_ml_stack_imports` skipped because the local `.venv` does not have the optional ML stack installed.
- `pip-audit` reported no known vulnerabilities for `requirements/ml-core-darwin-arm64.txt`; it also warned that its local cache directory was not writable, which only affects audit cache performance.

## Risk
- Scope is limited to the supported target-owned Darwin arm64 ML lane and matching version-contract surfaces.
- The `safetensors` pre-release pin is resolver-required by Diffusers 0.38.0 metadata, not an unrelated broad refresh.
- Generic lockfiles, route shapes, selectors, auth behavior, and browser/frontdoor contracts are untouched; the change is revert-safe by restoring the prior ML input/lock pins and guard constants.