### PR TITLE
fix(pipelines): stabilize unified luxury compatibility pipeline

### DIFF
--- a/docs/guides/UNIFIED_LUXURY_PIPELINE.md
+++ b/docs/guides/UNIFIED_LUXURY_PIPELINE.md
@@ -1,10 +1,12 @@
-# Unified Luxury Pipeline
+# Unified Luxury Pipeline (Compatibility)
 
-**Production-grade unified image processing pipeline for luxury real estate rendering, architectural visualization, and editorial post-production.**
+**Compatibility/convenience image-finishing facade for luxury real estate rendering, architectural visualization, and editorial post-production.**
+
+For governed production depth, PBR, Materials V3, APEX, run-card, and portal/orchestrator workflows, use `lux-depth-v3` and the `transformation_portal.lux_depth_v3` package. This pipeline remains available for legacy callers and lightweight multi-format finishing workflows.
 
 ## Overview
 
-The Unified Luxury Pipeline combines the best aspects of all previous pipeline implementations into a single, cohesive, production-ready system:
+The Unified Luxury Pipeline combines the best aspects of earlier image-finishing pipeline implementations into a single compatibility surface:
 
 - **Multi-format output generation** with proper bit-depth handling (from `premium_pipeline_fixed.py`)
 - **Modular stage-based architecture** with graceful failure handling (from `pro_pipeline.py`)

--- a/src/transformation_portal/pipelines/unified_luxury_pipeline.py
+++ b/src/transformation_portal/pipelines/unified_luxury_pipeline.py
@@ -379,14 +379,15 @@ class UnifiedLuxuryPipeline:
         # Apply overrides to temporary config
         temp_config = self._apply_overrides(overrides)
         temp_config.output_dir.mkdir(parents=True, exist_ok=True)
+        self._configure_stage_state(temp_config)
 
         try:
             # Stage 1: Load & Validate
             image, metadata = self._execute_stage("load", self._load_image, input_path)
 
             # Stage 2: Scene Detection (if AUTO)
-            if temp_config.scene_type == SceneType.AUTO:
-                scene_type = self._execute_stage("scene_detect", self._detect_scene_type, image, enabled=True)
+            if self.stages["scene_detect"].enabled:
+                scene_type = self._execute_stage("scene_detect", self._detect_scene_type, image)
                 temp_config.scene_type = scene_type
                 log.info(f"  Detected scene type: {scene_type.value}")
 
@@ -394,33 +395,31 @@ class UnifiedLuxuryPipeline:
             params = self._optimize_parameters(temp_config)
 
             # Stage 3: Depth Processing
-            if temp_config.enable_depth:
-                image = self._execute_stage("depth", self._apply_depth_processing, image, params, temp_config, enabled=True)
+            if self.stages["depth"].enabled:
+                image = self._execute_stage("depth", self._apply_depth_processing, image, params, temp_config)
 
             # Stage 4: Material Response
-            if temp_config.enable_material_response:
+            if self.stages["material"].enabled:
                 image = self._execute_stage(
                     "material",
                     self._apply_material_response,
                     image,
                     params,
                     temp_config.scene_type,
-                    enabled=True,
                 )
 
             # Stage 5: VFX Effects
-            if temp_config.enable_vfx:
-                image = self._execute_stage("vfx", self._apply_vfx_effects, image, params, enabled=True)
+            if self.stages["vfx"].enabled:
+                image = self._execute_stage("vfx", self._apply_vfx_effects, image, params)
 
             # Stage 6: Color Grading
-            if temp_config.enable_color_grading:
+            if self.stages["color_grade"].enabled:
                 image = self._execute_stage(
                     "color_grade",
                     self._apply_color_grading,
                     image,
                     params,
                     temp_config,
-                    enabled=True,
                 )
 
             # Stage 7: Generate Outputs
@@ -524,7 +523,26 @@ class UnifiedLuxuryPipeline:
         temp_config.__post_init__()
         return temp_config
 
-    def _execute_stage(self, stage_name: str, func, *args, enabled: Optional[bool] = None, **kwargs):
+    def _configure_stage_state(self, config: UnifiedPipelineConfig) -> None:
+        """Reset per-call stage state from the active configuration."""
+        enabled_by_stage = {
+            "load": True,
+            "scene_detect": config.scene_type == SceneType.AUTO,
+            "depth": config.enable_depth,
+            "material": config.enable_material_response,
+            "vfx": config.enable_vfx,
+            "color_grade": config.enable_color_grading,
+            "output": True,
+        }
+
+        self.stats.stage_times.clear()
+        for stage_name, stage in self.stages.items():
+            stage.enabled = enabled_by_stage[stage_name]
+            stage.elapsed_time = 0.0
+            stage.success = False
+            stage.error_message = None
+
+    def _execute_stage(self, stage_name: str, func, *args, **kwargs):
         """
         Execute pipeline stage with timing and error handling.
 
@@ -541,8 +559,7 @@ class UnifiedLuxuryPipeline:
         """
         stage = self.stages[stage_name]
 
-        should_run = stage.enabled if enabled is None else enabled
-        if not should_run:
+        if not stage.enabled:
             return args[0] if args else None
 
         start = time.time()
@@ -1498,12 +1515,30 @@ def process_luxury_render(
 
 def _expand_brace_pattern(pattern: str) -> List[str]:
     """Expand one simple glob brace group, e.g. ``*.{jpg,png}``."""
-    if "{" not in pattern or "}" not in pattern:
+    open_count = pattern.count("{")
+    close_count = pattern.count("}")
+    if open_count == 0 and close_count == 0:
         return [pattern]
 
-    prefix, remainder = pattern.split("{", 1)
-    choices, suffix = remainder.split("}", 1)
-    return [f"{prefix}{choice.strip()}{suffix}" for choice in choices.split(",") if choice.strip()]
+    if open_count != 1 or close_count != 1:
+        raise ValueError(f"Invalid brace glob pattern {pattern!r}; expected one '{{...}}' group such as '*." "{jpg,png}'")
+
+    open_index = pattern.index("{")
+    close_index = pattern.index("}")
+    if close_index < open_index:
+        raise ValueError(f"Invalid brace glob pattern {pattern!r}; closing brace must appear after opening brace")
+
+    prefix = pattern[:open_index]
+    choices = pattern[open_index + 1 : close_index]
+    suffix = pattern[close_index + 1 :]
+    if not choices.strip():
+        raise ValueError(f"Invalid brace glob pattern {pattern!r}; brace group must contain at least one choice")
+
+    expanded_choices = [choice.strip() for choice in choices.split(",")]
+    if any(not choice for choice in expanded_choices):
+        raise ValueError(f"Invalid brace glob pattern {pattern!r}; brace choices must be non-empty")
+
+    return [f"{prefix}{choice}{suffix}" for choice in expanded_choices]
 
 
 def batch_process_luxury_renders(

--- a/src/transformation_portal/pipelines/unified_luxury_pipeline.py
+++ b/src/transformation_portal/pipelines/unified_luxury_pipeline.py
@@ -4,7 +4,12 @@
 Unified Luxury Pipeline - Transformation Portal
 ===============================================
 
-Production-grade unified pipeline combining the best aspects of:
+Compatibility image-finishing facade for legacy luxury-render workflows.
+For governed production depth, PBR, Materials V3, APEX, run-card, and
+portal/orchestrator workflows, use the `lux-depth-v3` CLI and
+`transformation_portal.lux_depth_v3` package.
+
+This compatibility pipeline combines the best aspects of:
 - premium_pipeline_fixed.py: Multi-format output system with proper bit-depth handling
 - pro_pipeline.py: Modular PipelineStage architecture with graceful failure handling
 - context_aware_pro_pipeline.py: Architectural context intelligence
@@ -103,6 +108,9 @@ class OutputFormat(Enum):
     PRINT_8K = "print"  # 8K print JPEG (7680px)
     SOCIAL = "social"  # 1080p Instagram/social (1080px)
     MAGAZINE = "magazine"  # 2K magazine layout (2048px)
+
+
+DEFAULT_BATCH_PATTERN = "*.{jpg,jpeg,png,tif,tiff,exr}"
 
 
 @dataclass
@@ -370,14 +378,15 @@ class UnifiedLuxuryPipeline:
 
         # Apply overrides to temporary config
         temp_config = self._apply_overrides(overrides)
+        temp_config.output_dir.mkdir(parents=True, exist_ok=True)
 
         try:
             # Stage 1: Load & Validate
             image, metadata = self._execute_stage("load", self._load_image, input_path)
 
             # Stage 2: Scene Detection (if AUTO)
-            if self.stages["scene_detect"].enabled:
-                scene_type = self._execute_stage("scene_detect", self._detect_scene_type, image)
+            if temp_config.scene_type == SceneType.AUTO:
+                scene_type = self._execute_stage("scene_detect", self._detect_scene_type, image, enabled=True)
                 temp_config.scene_type = scene_type
                 log.info(f"  Detected scene type: {scene_type.value}")
 
@@ -385,26 +394,34 @@ class UnifiedLuxuryPipeline:
             params = self._optimize_parameters(temp_config)
 
             # Stage 3: Depth Processing
-            if self.stages["depth"].enabled:
-                image = self._execute_stage("depth", self._apply_depth_processing, image, params)
+            if temp_config.enable_depth:
+                image = self._execute_stage("depth", self._apply_depth_processing, image, params, temp_config, enabled=True)
 
             # Stage 4: Material Response
-            if self.stages["material"].enabled:
+            if temp_config.enable_material_response:
                 image = self._execute_stage(
                     "material",
                     self._apply_material_response,
                     image,
                     params,
                     temp_config.scene_type,
+                    enabled=True,
                 )
 
             # Stage 5: VFX Effects
-            if self.stages["vfx"].enabled:
-                image = self._execute_stage("vfx", self._apply_vfx_effects, image, params)
+            if temp_config.enable_vfx:
+                image = self._execute_stage("vfx", self._apply_vfx_effects, image, params, enabled=True)
 
             # Stage 6: Color Grading
-            if self.stages["color_grade"].enabled:
-                image = self._execute_stage("color_grade", self._apply_color_grading, image, params)
+            if temp_config.enable_color_grading:
+                image = self._execute_stage(
+                    "color_grade",
+                    self._apply_color_grading,
+                    image,
+                    params,
+                    temp_config,
+                    enabled=True,
+                )
 
             # Stage 7: Generate Outputs
             outputs = self._execute_stage(
@@ -504,9 +521,10 @@ class UnifiedLuxuryPipeline:
             if hasattr(temp_config, key):
                 setattr(temp_config, key, value)
 
+        temp_config.__post_init__()
         return temp_config
 
-    def _execute_stage(self, stage_name: str, func, *args, **kwargs):
+    def _execute_stage(self, stage_name: str, func, *args, enabled: Optional[bool] = None, **kwargs):
         """
         Execute pipeline stage with timing and error handling.
 
@@ -523,7 +541,8 @@ class UnifiedLuxuryPipeline:
         """
         stage = self.stages[stage_name]
 
-        if not stage.enabled:
+        should_run = stage.enabled if enabled is None else enabled
+        if not should_run:
             return args[0] if args else None
 
         start = time.time()
@@ -668,7 +687,12 @@ class UnifiedLuxuryPipeline:
 
         return params
 
-    def _apply_depth_processing(self, image: Image.Image, params: Dict[str, Any]) -> Image.Image:
+    def _apply_depth_processing(
+        self,
+        image: Image.Image,
+        params: Dict[str, Any],
+        config: Optional[UnifiedPipelineConfig] = None,
+    ) -> Image.Image:
         """
         Apply depth-aware processing using Depth Anything V2.
 
@@ -680,6 +704,7 @@ class UnifiedLuxuryPipeline:
             Depth-processed PIL Image
         """
         log.info("  Applying depth-aware processing...")
+        active_config = config or self.config
 
         # Lazy load depth pipeline
         if self._depth_pipeline is None:
@@ -712,14 +737,14 @@ class UnifiedLuxuryPipeline:
         # Process image through depth pipeline
         try:
             # Create temporary file for depth processing
-            temp_path = self.config.output_dir / "temp_for_depth.jpg"
+            temp_path = active_config.output_dir / "temp_for_depth.jpg"
             image.save(temp_path, quality=95)
 
             # Process through depth pipeline
             result = self._depth_pipeline.process_render(str(temp_path))
 
             # Clean up temporary file
-            if not self.config.save_intermediates:
+            if not active_config.save_intermediates:
                 temp_path.unlink()
 
             # Handle different result types from depth pipeline
@@ -1011,7 +1036,12 @@ class UnifiedLuxuryPipeline:
 
         return image
 
-    def _apply_color_grading(self, image: Image.Image, params: Dict[str, Any]) -> Image.Image:
+    def _apply_color_grading(
+        self,
+        image: Image.Image,
+        params: Dict[str, Any],
+        config: Optional[UnifiedPipelineConfig] = None,
+    ) -> Image.Image:
         """
         Apply professional color grading with optional LUT.
 
@@ -1023,6 +1053,7 @@ class UnifiedLuxuryPipeline:
             Color-graded PIL Image
         """
         log.info("  Applying color grading...")
+        active_config = config or self.config
 
         arr = np.array(image).astype(np.float32) / 255.0
 
@@ -1049,10 +1080,10 @@ class UnifiedLuxuryPipeline:
             log.info(f"    Saturation: {saturation:.2f}x")
 
         # Apply LUT if specified
-        if self.config.lut_path is not None:
+        if active_config.lut_path is not None:
             try:
-                arr = self._apply_lut(arr, self.config.lut_path, self.config.lut_strength)
-                log.info(f"    LUT: {self.config.lut_path.name} @ {self.config.lut_strength:.0%}")
+                arr = self._apply_lut(arr, active_config.lut_path, active_config.lut_strength)
+                log.info(f"    LUT: {active_config.lut_path.name} @ {active_config.lut_strength:.0%}")
             except Exception as e:
                 log.warning(f"    LUT application failed: {e}")
 
@@ -1099,6 +1130,7 @@ class UnifiedLuxuryPipeline:
 
         basename = input_path.stem
         outputs = {}
+        failures: List[Tuple[OutputFormat, Exception]] = []
 
         # Extract ICC profile if available
         icc_profile = metadata.get("info", {}).get("icc_profile")
@@ -1115,6 +1147,7 @@ class UnifiedLuxuryPipeline:
                         fmt,
                         icc_profile,
                         metadata,
+                        config,
                     )
                     futures[future] = fmt
 
@@ -1125,15 +1158,24 @@ class UnifiedLuxuryPipeline:
                         outputs[fmt.value] = path
                     except Exception as e:
                         log.error(f"    Failed to generate {fmt.value}: {e}")
+                        failures.append((fmt, e))
         else:
             for fmt in config.output_formats:
                 try:
-                    path = self._generate_single_output(image, basename, fmt, icc_profile, metadata)
+                    path = self._generate_single_output(image, basename, fmt, icc_profile, metadata, config)
                     outputs[fmt.value] = path
                 except Exception as e:
                     log.error(f"    Failed to generate {fmt.value}: {e}")
+                    failures.append((fmt, e))
 
         log.info(f"    Generated {len(outputs)} outputs")
+
+        if failures:
+            details = "; ".join(f"{fmt.value}: {exc}" for fmt, exc in failures)
+            raise RuntimeError(f"Failed to generate requested output format(s): {details}")
+
+        if config.output_formats and not outputs:
+            raise RuntimeError("No outputs generated for requested output formats")
 
         return outputs
 
@@ -1144,6 +1186,7 @@ class UnifiedLuxuryPipeline:
         fmt: OutputFormat,
         icc_profile: Optional[bytes],
         metadata: Dict[str, Any],
+        config: Optional[UnifiedPipelineConfig] = None,
     ) -> Path:
         """
         Generate single output format.
@@ -1158,22 +1201,29 @@ class UnifiedLuxuryPipeline:
         Returns:
             Path to generated output file
         """
+        active_config = config or self.config
         if fmt == OutputFormat.MASTER_TIFF:
-            return self._save_master_tiff(image, basename, metadata)
+            return self._save_master_tiff(image, basename, metadata, active_config.output_dir)
         elif fmt == OutputFormat.WEB_4K:
-            return self._save_web_4k(image, basename, icc_profile)
+            return self._save_web_4k(image, basename, icc_profile, active_config.output_dir)
         elif fmt == OutputFormat.PRINT_8K:
-            return self._save_print_8k(image, basename, icc_profile)
+            return self._save_print_8k(image, basename, icc_profile, active_config.output_dir)
         elif fmt == OutputFormat.SOCIAL:
-            return self._save_social(image, basename, icc_profile)
+            return self._save_social(image, basename, icc_profile, active_config.output_dir)
         elif fmt == OutputFormat.MAGAZINE:
-            return self._save_magazine(image, basename, icc_profile)
+            return self._save_magazine(image, basename, icc_profile, active_config.output_dir)
         else:
             raise ValueError(f"Unknown output format: {fmt}")
 
-    def _save_master_tiff(self, image: Image.Image, basename: str, metadata: Dict) -> Path:
+    def _save_master_tiff(
+        self,
+        image: Image.Image,
+        basename: str,
+        metadata: Dict,
+        output_dir: Optional[Path] = None,
+    ) -> Path:
         """Save 16-bit TIFF master with full resolution."""
-        output_path = self.config.output_dir / f"{basename}_MASTER.tif"
+        output_path = (output_dir or self.config.output_dir) / f"{basename}_MASTER.tif"
 
         if HAS_TIFFFILE:
             # Handle both PIL Images and numpy arrays
@@ -1199,6 +1249,7 @@ class UnifiedLuxuryPipeline:
             # CRITICAL: Always clip to [0,1] before converting to 16-bit
             # This prevents float32 TIFFs with values outside [0,1] range
             arr_16bit = (np.clip(arr_float, 0.0, 1.0) * 65535).astype(np.uint16)
+            height, width = arr_16bit.shape[:2]
 
             # Extract ICC profile if available
             icc_profile = metadata.get("info", {}).get("icc_profile")
@@ -1214,9 +1265,7 @@ class UnifiedLuxuryPipeline:
                 compression="lzw",
                 extratags=extratags if extratags else None,
             )
-            log.info(
-                f"    Master TIFF: {image.size[0]}x{image.size[1]}, 16-bit, {output_path.stat().st_size / (1024**2):.1f} MB"
-            )
+            log.info(f"    Master TIFF: {width}x{height}, 16-bit, {output_path.stat().st_size / (1024**2):.1f} MB")
         else:
             # Fallback to PIL (8-bit only)
             log.warning("    tifffile not available - saving 8-bit TIFF (install tifffile for 16-bit)")
@@ -1227,9 +1276,15 @@ class UnifiedLuxuryPipeline:
 
         return output_path
 
-    def _save_web_4k(self, image: Image.Image, basename: str, icc_profile: Optional[bytes]) -> Path:
+    def _save_web_4k(
+        self,
+        image: Image.Image,
+        basename: str,
+        icc_profile: Optional[bytes],
+        output_dir: Optional[Path] = None,
+    ) -> Path:
         """Save 4K web-optimized JPEG."""
-        output_path = self.config.output_dir / f"{basename}_WEB_4K.jpg"
+        output_path = (output_dir or self.config.output_dir) / f"{basename}_WEB_4K.jpg"
 
         # Resize to 4K
         max_dim = 3840
@@ -1258,9 +1313,15 @@ class UnifiedLuxuryPipeline:
 
         return output_path
 
-    def _save_print_8k(self, image: Image.Image, basename: str, icc_profile: Optional[bytes]) -> Path:
+    def _save_print_8k(
+        self,
+        image: Image.Image,
+        basename: str,
+        icc_profile: Optional[bytes],
+        output_dir: Optional[Path] = None,
+    ) -> Path:
         """Save 8K print-quality JPEG."""
-        output_path = self.config.output_dir / f"{basename}_PRINT_8K.jpg"
+        output_path = (output_dir or self.config.output_dir) / f"{basename}_PRINT_8K.jpg"
 
         # Resize to 8K
         max_dim = 7680
@@ -1289,9 +1350,15 @@ class UnifiedLuxuryPipeline:
 
         return output_path
 
-    def _save_social(self, image: Image.Image, basename: str, icc_profile: Optional[bytes]) -> Path:
+    def _save_social(
+        self,
+        image: Image.Image,
+        basename: str,
+        icc_profile: Optional[bytes],
+        output_dir: Optional[Path] = None,
+    ) -> Path:
         """Save 1080p social media optimized JPEG."""
-        output_path = self.config.output_dir / f"{basename}_SOCIAL_1080p.jpg"
+        output_path = (output_dir or self.config.output_dir) / f"{basename}_SOCIAL_1080p.jpg"
 
         # Resize to 1080p
         max_dim = 1080
@@ -1317,9 +1384,15 @@ class UnifiedLuxuryPipeline:
 
         return output_path
 
-    def _save_magazine(self, image: Image.Image, basename: str, icc_profile: Optional[bytes]) -> Path:
+    def _save_magazine(
+        self,
+        image: Image.Image,
+        basename: str,
+        icc_profile: Optional[bytes],
+        output_dir: Optional[Path] = None,
+    ) -> Path:
         """Save 2K magazine layout JPEG."""
-        output_path = self.config.output_dir / f"{basename}_MAGAZINE_2K.jpg"
+        output_path = (output_dir or self.config.output_dir) / f"{basename}_MAGAZINE_2K.jpg"
 
         # Resize to 2K
         max_dim = 2048
@@ -1423,11 +1496,21 @@ def process_luxury_render(
     return pipeline.process(input_path)
 
 
+def _expand_brace_pattern(pattern: str) -> List[str]:
+    """Expand one simple glob brace group, e.g. ``*.{jpg,png}``."""
+    if "{" not in pattern or "}" not in pattern:
+        return [pattern]
+
+    prefix, remainder = pattern.split("{", 1)
+    choices, suffix = remainder.split("}", 1)
+    return [f"{prefix}{choice.strip()}{suffix}" for choice in choices.split(",") if choice.strip()]
+
+
 def batch_process_luxury_renders(
     input_dir: Path,
     output_dir: Path = Path("output"),
     profile: ProcessingProfile = ProcessingProfile.BALANCED,
-    pattern: str = "*.{jpg,jpeg,png,tiff,exr}",
+    pattern: str = DEFAULT_BATCH_PATTERN,
 ) -> Dict[Path, Dict[str, Path]]:
     """
     Convenience function for batch processing luxury renders.
@@ -1447,9 +1530,15 @@ def batch_process_luxury_renders(
             profile=ProcessingProfile.PREMIUM
         )
     """
+    input_root = Path(input_dir)
     input_paths = []
-    for ext in ["jpg", "jpeg", "png", "tif", "ti", "exr"]:
-        input_paths.extend(Path(input_dir).glob(f"*.{ext}"))
+    seen = set()
+    for expanded_pattern in _expand_brace_pattern(pattern):
+        for input_path in sorted(input_root.glob(expanded_pattern)):
+            if not input_path.is_file() or input_path in seen:
+                continue
+            seen.add(input_path)
+            input_paths.append(input_path)
 
     config = UnifiedPipelineConfig(
         scene_type=SceneType.AUTO,

--- a/tests/test_unified_luxury_pipeline.py
+++ b/tests/test_unified_luxury_pipeline.py
@@ -506,6 +506,40 @@ class TestPerCallOverrides:
         assert results["master"].exists()
         mock_depth.assert_not_called()
         assert pipeline.config.enable_depth is True
+        assert pipeline.stages["depth"].enabled is False
+        assert pipeline.stages["depth"].success is False
+        assert pipeline.stages["depth"].elapsed_time == 0.0
+        assert "Depth Processing" not in pipeline.stats.stage_times
+
+    def test_process_override_resets_stage_state_between_calls(self, sample_image_file, sample_image, temp_dir):
+        """Test skipped per-call stages do not retain previous success/timing state."""
+        config = UnifiedPipelineConfig(
+            scene_type=SceneType.INTERIOR,
+            output_dir=temp_dir,
+            output_formats=[OutputFormat.MASTER_TIFF],
+            enable_depth=True,
+            enable_material_response=False,
+            enable_color_grading=False,
+        )
+        pipeline = UnifiedLuxuryPipeline(config)
+
+        with patch.object(pipeline, "_apply_depth_processing", return_value=sample_image):
+            first_results = pipeline.process(sample_image_file)
+
+        assert first_results["master"].exists()
+        assert pipeline.stages["depth"].enabled is True
+        assert pipeline.stages["depth"].success is True
+        assert pipeline.stages["depth"].elapsed_time > 0.0
+        assert "Depth Processing" in pipeline.stats.stage_times
+
+        second_results = pipeline.process(sample_image_file, enable_depth=False)
+
+        assert second_results["master"].exists()
+        assert pipeline.stages["depth"].enabled is False
+        assert pipeline.stages["depth"].success is False
+        assert pipeline.stages["depth"].elapsed_time == 0.0
+        assert pipeline.stages["depth"].error_message is None
+        assert "Depth Processing" not in pipeline.stats.stage_times
 
     def test_process_override_can_enable_vfx_for_current_call(self, sample_image_file, temp_dir):
         """Test enable_vfx override can activate a constructor-disabled stage."""
@@ -526,6 +560,8 @@ class TestPerCallOverrides:
         assert results["master"].exists()
         mock_vfx.assert_called_once()
         assert pipeline.config.enable_vfx is False
+        assert pipeline.stages["vfx"].enabled is True
+        assert pipeline.stages["vfx"].success is True
 
     def test_process_override_can_enable_material_response_for_current_call(self, sample_image_file, temp_dir):
         """Test enable_material_response override can activate a constructor-disabled stage."""
@@ -549,6 +585,8 @@ class TestPerCallOverrides:
         assert results["master"].exists()
         mock_material.assert_called_once()
         assert pipeline.config.enable_material_response is False
+        assert pipeline.stages["material"].enabled is True
+        assert pipeline.stages["material"].success is True
 
     def test_process_override_uses_output_dir_for_current_call(self, sample_image_file, temp_dir):
         """Test output_dir override does not mutate constructor config."""
@@ -720,6 +758,18 @@ class TestConvenienceFunctions:
 
         input_paths = mock_instance.batch_process.call_args.args[0]
         assert input_paths == [input_dir / "keep.png"]
+
+    @pytest.mark.parametrize("pattern", ["*.{jpg,png", "*.}jpg{", "*.{jpg,}", "*.{}"])
+    @patch("transformation_portal.pipelines.unified_luxury_pipeline.UnifiedLuxuryPipeline")
+    def test_batch_process_luxury_renders_rejects_malformed_brace_pattern(self, mock_pipeline_class, pattern, temp_dir):
+        """Test malformed public brace patterns fail predictably."""
+        input_dir = temp_dir / "inputs"
+        input_dir.mkdir()
+
+        with pytest.raises(ValueError, match="Invalid brace glob pattern"):
+            batch_process_luxury_renders(input_dir, output_dir=temp_dir / "output", pattern=pattern)
+
+        mock_pipeline_class.assert_not_called()
 
 
 class TestDeviceDetection:

--- a/tests/test_unified_luxury_pipeline.py
+++ b/tests/test_unified_luxury_pipeline.py
@@ -26,6 +26,7 @@ import pytest
 from PIL import Image
 
 from transformation_portal.pipelines.unified_luxury_pipeline import (
+    HAS_TIFFFILE,
     OutputFormat,
     PipelineStage,
     PipelineStatistics,
@@ -389,6 +390,42 @@ class TestOutputGeneration:
         for path in results.values():
             assert path.exists()
 
+    def test_requested_output_failure_raises_and_does_not_count_success(self, sample_image_file, temp_dir):
+        """Test requested output failures fail the required output stage."""
+        config = UnifiedPipelineConfig(
+            scene_type=SceneType.INTERIOR,
+            output_dir=temp_dir,
+            output_formats=[OutputFormat.WEB_4K],
+            enable_depth=False,
+            enable_material_response=False,
+            enable_color_grading=False,
+        )
+        pipeline = UnifiedLuxuryPipeline(config)
+
+        with patch.object(pipeline, "_save_web_4k", side_effect=RuntimeError("encoder failed")):
+            with pytest.raises(RuntimeError, match="Failed to generate requested output format"):
+                pipeline.process(sample_image_file)
+
+        assert pipeline.stats.images_processed == 0
+        assert pipeline.stats.images_failed == 1
+
+    @pytest.mark.skipif(not HAS_TIFFFILE, reason="ndarray TIFF path requires tifffile")
+    def test_master_tiff_generation_accepts_ndarray(self, temp_dir):
+        """Test ndarray master TIFF generation logs dimensions without raising."""
+        arr = np.zeros((12, 16, 3), dtype=np.float32)
+        arr[..., 0] = 0.25
+        arr[..., 1] = 0.5
+        arr[..., 2] = 0.75
+
+        config = UnifiedPipelineConfig(output_dir=temp_dir, output_formats=[OutputFormat.MASTER_TIFF])
+        pipeline = UnifiedLuxuryPipeline(config)
+
+        output_path = pipeline._save_master_tiff(arr, "array_input", {})
+
+        assert output_path.exists()
+        loaded = Image.open(output_path)
+        assert loaded.size == (16, 12)
+
 
 class TestMetadataPreservation:
     """Test metadata preservation through pipeline."""
@@ -446,6 +483,93 @@ class TestGracefulDegradation:
         # Should raise exception for non-existent file
         with pytest.raises(FileNotFoundError):
             pipeline.process(Path("nonexistent_file.jpg"))
+
+
+class TestPerCallOverrides:
+    """Test per-call override behavior."""
+
+    def test_process_override_can_disable_depth_for_current_call(self, sample_image_file, temp_dir):
+        """Test enable_depth override gates the current call only."""
+        config = UnifiedPipelineConfig(
+            scene_type=SceneType.INTERIOR,
+            output_dir=temp_dir,
+            output_formats=[OutputFormat.MASTER_TIFF],
+            enable_depth=True,
+            enable_material_response=False,
+            enable_color_grading=False,
+        )
+        pipeline = UnifiedLuxuryPipeline(config)
+
+        with patch.object(pipeline, "_apply_depth_processing", wraps=pipeline._apply_depth_processing) as mock_depth:
+            results = pipeline.process(sample_image_file, enable_depth=False)
+
+        assert results["master"].exists()
+        mock_depth.assert_not_called()
+        assert pipeline.config.enable_depth is True
+
+    def test_process_override_can_enable_vfx_for_current_call(self, sample_image_file, temp_dir):
+        """Test enable_vfx override can activate a constructor-disabled stage."""
+        config = UnifiedPipelineConfig(
+            scene_type=SceneType.INTERIOR,
+            output_dir=temp_dir,
+            output_formats=[OutputFormat.MASTER_TIFF],
+            enable_depth=False,
+            enable_material_response=False,
+            enable_vfx=False,
+            enable_color_grading=False,
+        )
+        pipeline = UnifiedLuxuryPipeline(config)
+
+        with patch.object(pipeline, "_apply_vfx_effects", wraps=pipeline._apply_vfx_effects) as mock_vfx:
+            results = pipeline.process(sample_image_file, enable_vfx=True)
+
+        assert results["master"].exists()
+        mock_vfx.assert_called_once()
+        assert pipeline.config.enable_vfx is False
+
+    def test_process_override_can_enable_material_response_for_current_call(self, sample_image_file, temp_dir):
+        """Test enable_material_response override can activate a constructor-disabled stage."""
+        config = UnifiedPipelineConfig(
+            scene_type=SceneType.INTERIOR,
+            output_dir=temp_dir,
+            output_formats=[OutputFormat.MASTER_TIFF],
+            enable_depth=False,
+            enable_material_response=False,
+            enable_color_grading=False,
+        )
+        pipeline = UnifiedLuxuryPipeline(config)
+
+        with patch.object(
+            pipeline,
+            "_apply_material_response",
+            wraps=pipeline._apply_material_response,
+        ) as mock_material:
+            results = pipeline.process(sample_image_file, enable_material_response=True)
+
+        assert results["master"].exists()
+        mock_material.assert_called_once()
+        assert pipeline.config.enable_material_response is False
+
+    def test_process_override_uses_output_dir_for_current_call(self, sample_image_file, temp_dir):
+        """Test output_dir override does not mutate constructor config."""
+        default_output_dir = temp_dir / "default"
+        override_output_dir = temp_dir / "override"
+        config = UnifiedPipelineConfig(
+            scene_type=SceneType.INTERIOR,
+            output_dir=default_output_dir,
+            output_formats=[OutputFormat.MASTER_TIFF],
+            enable_depth=False,
+            enable_material_response=False,
+            enable_color_grading=False,
+        )
+        pipeline = UnifiedLuxuryPipeline(config)
+
+        results = pipeline.process(sample_image_file, output_dir=override_output_dir)
+
+        assert results["master"].parent == override_output_dir
+        assert results["master"].exists()
+        assert not (default_output_dir / f"{sample_image_file.stem}_MASTER.tif").exists()
+        assert pipeline.config.output_dir == default_output_dir
 
 
 class TestBatchProcessing:
@@ -557,6 +681,45 @@ class TestConvenienceFunctions:
         # Should create pipeline and call process
         assert mock_pipeline_class.called
         assert mock_instance.process.called
+
+    @patch("transformation_portal.pipelines.unified_luxury_pipeline.UnifiedLuxuryPipeline")
+    def test_batch_process_luxury_renders_default_includes_tiff(self, mock_pipeline_class, sample_image, temp_dir):
+        """Test default batch discovery includes .tif and .tiff but not typo extensions."""
+        input_dir = temp_dir / "inputs"
+        input_dir.mkdir()
+        sample_image.save(input_dir / "a.tiff")
+        sample_image.save(input_dir / "b.tif")
+        sample_image.save(input_dir / "c.jpg")
+        (input_dir / "skip.ti").write_text("not an image")
+
+        mock_instance = MagicMock()
+        mock_instance.batch_process.return_value = {}
+        mock_pipeline_class.return_value = mock_instance
+
+        batch_process_luxury_renders(input_dir, output_dir=temp_dir / "output")
+
+        input_paths = mock_instance.batch_process.call_args.args[0]
+        assert input_dir / "a.tiff" in input_paths
+        assert input_dir / "b.tif" in input_paths
+        assert input_dir / "c.jpg" in input_paths
+        assert input_dir / "skip.ti" not in input_paths
+
+    @patch("transformation_portal.pipelines.unified_luxury_pipeline.UnifiedLuxuryPipeline")
+    def test_batch_process_luxury_renders_respects_custom_pattern(self, mock_pipeline_class, sample_image, temp_dir):
+        """Test custom batch discovery pattern is honored."""
+        input_dir = temp_dir / "inputs"
+        input_dir.mkdir()
+        sample_image.save(input_dir / "keep.png")
+        sample_image.save(input_dir / "skip.jpg")
+
+        mock_instance = MagicMock()
+        mock_instance.batch_process.return_value = {}
+        mock_pipeline_class.return_value = mock_instance
+
+        batch_process_luxury_renders(input_dir, output_dir=temp_dir / "output", pattern="*.png")
+
+        input_paths = mock_instance.batch_process.call_args.args[0]
+        assert input_paths == [input_dir / "keep.png"]
 
 
 class TestDeviceDetection:


### PR DESCRIPTION
## Summary
- UnifiedLuxuryPipeline was still positioned as production-grade while retaining compatibility-pipeline behavior and several unsafe edge cases.
- This PR keeps the surface exported, but makes requested outputs fail closed, honors per-call overrides, fixes batch discovery, and clarifies production guidance.

## Changes
- Fail closed when any requested output format fails, or when a non-empty output request produces no files.
- Apply per-call config for stage gates, output directories, LUT settings, and depth temporary files without mutating constructor config.
- Fix batch input discovery to respect the pattern argument and include jpg, jpeg, png, tif, tiff, and exr by default.
- Fix ndarray master TIFF logging to use normalized array dimensions after 16-bit conversion.
- Add focused regression coverage for output failure accounting, per-call overrides, TIFF discovery, custom patterns, and ndarray TIFF writes.
- Update the Unified Luxury Pipeline guide to mark this as a compatibility/convenience facade and route governed production depth/PBR/Materials/APEX workflows to lux-depth-v3.

## Validation
Proven green:
- .venv/bin/pytest tests/test_unified_luxury_pipeline.py
- .venv/bin/python -m py_compile src/transformation_portal/pipelines/unified_luxury_pipeline.py tests/test_unified_luxury_pipeline.py
- make check-json-serialization
- git diff --check
- make check-worktree
- pre-commit hooks run by git commit, including Black, isort, root-file placement, dependency constraints, test markers, tautological assertions, and gitleaks.

Still failing:
- None observed.

Failure classification:
- No product, stale-test, or environment/tooling failures remain on the validated path.

## Risk
- Compatibility risk is bounded to UnifiedLuxuryPipeline and its focused guide/test surface.
- The production portal/orchestrator and lux-depth-v3 paths are not routed through this change.
- Revert is safe because the patch is isolated to one compatibility module, one guide, and focused tests.