### PR TITLE
Lazy-load hidden portal artifact preview images

### DIFF
--- a/portal.html
+++ b/portal.html
@@ -1683,15 +1683,15 @@ Contract notes:
                     <div id="artifactPreviewStage" class="artifact-review-stage rounded-xl border border-slate-200 dark:border-slate-800 bg-slate-50/80 dark:bg-slate-900/50">
                         <div id="artifactCompareStage" class="hidden grid grid-cols-1 md:grid-cols-2 gap-4">
                             <figure class="space-y-3">
-                                <img id="artifactPreviewImage" alt="Selected artifact preview" class="hidden w-full rounded-2xl border border-slate-200 dark:border-slate-800 bg-slate-900/60 object-contain max-h-[320px]" />
+                                <img id="artifactPreviewImage" alt="Selected artifact preview" class="hidden w-full rounded-2xl border border-slate-200 dark:border-slate-800 bg-slate-900/60 object-contain max-h-[320px]" loading="lazy" decoding="async" />
                                 <figcaption id="artifactPreviewPrimaryCaption" class="text-[11px] font-mono text-slate-500 dark:text-slate-400 break-all"></figcaption>
                             </figure>
                             <figure class="space-y-3">
-                                <img id="artifactCompareImage" alt="Comparison artifact preview" class="hidden w-full rounded-2xl border border-slate-200 dark:border-slate-800 bg-slate-900/60 object-contain max-h-[320px]" />
+                                <img id="artifactCompareImage" alt="Comparison artifact preview" class="hidden w-full rounded-2xl border border-slate-200 dark:border-slate-800 bg-slate-900/60 object-contain max-h-[320px]" loading="lazy" decoding="async" />
                                 <figcaption id="artifactCompareCaption" class="text-[11px] font-mono text-slate-500 dark:text-slate-400 break-all"></figcaption>
                             </figure>
                         </div>
-                        <img id="artifactPreviewSoloImage" alt="Artifact preview" class="hidden w-full rounded-2xl border border-slate-200 dark:border-slate-800 bg-slate-900/60 object-contain max-h-[320px]" />
+                        <img id="artifactPreviewSoloImage" alt="Artifact preview" class="hidden w-full rounded-2xl border border-slate-200 dark:border-slate-800 bg-slate-900/60 object-contain max-h-[320px]" loading="lazy" decoding="async" />
                         <div id="artifactMetadataCard" class="rounded-2xl border border-dashed border-slate-200 dark:border-slate-700 bg-white/80 dark:bg-slate-900/70 p-5 text-[12px] leading-6 text-slate-600 dark:text-slate-300">
                             Select a completed run to bring the primary review artifact, provenance context, and next actions into focus here.
                         </div>
@@ -1889,7 +1889,7 @@ Contract notes:
                 </div>
             </div>
             <div id="artifactViewerStage" class="artifact-viewer-stage mt-5">
-                <img id="artifactViewerImage" alt="Artifact viewer preview" class="artifact-viewer-image hidden" />
+                <img id="artifactViewerImage" alt="Artifact viewer preview" class="artifact-viewer-image hidden" loading="lazy" decoding="async" />
                 <div id="artifactViewerFallback" class="artifact-viewer-fallback hidden">
                     <p id="artifactViewerFallbackTitle" class="artifact-viewer-fallback-title">Inline preview unavailable</p>
                     <p id="artifactViewerFallbackDetail" class="artifact-viewer-fallback-detail">This artifact stays reviewable through its retained metadata and the managed raw asset link.</p>

--- a/tests/test_app_orchestrator_runtime.py
+++ b/tests/test_app_orchestrator_runtime.py
@@ -1726,6 +1726,33 @@ def test_portal_artifact_viewer_modal_is_feature_flagged_and_keyboard_complete()
     assert "if (key === '0')" in content
 
 
+def test_portal_artifact_previews_lazy_load_and_decode_async() -> None:
+    # The four artifact preview <img> tags start hidden and live behind the
+    # lazy-loaded Review surface bundle. They must carry loading="lazy" and
+    # decoding="async" so assigning .src never blocks the bootstrap path
+    # decoding artifact bytes synchronously. Brand <img> tags above the
+    # fold keep their existing attributes; this test guards both contracts.
+    html = _portal_html_content()
+    for img_id in (
+        "artifactPreviewImage",
+        "artifactCompareImage",
+        "artifactPreviewSoloImage",
+        "artifactViewerImage",
+    ):
+        marker = f'id="{img_id}"'
+        assert marker in html, f"{img_id} not found in portal.html"
+        marker_index = html.index(marker)
+        start = html.rindex("<img", 0, marker_index)
+        end = html.index(">", marker_index)
+        tag = html[start:end + 1]
+        assert 'loading="lazy"' in tag, f'{img_id} missing loading="lazy"'
+        assert 'decoding="async"' in tag, f'{img_id} missing decoding="async"'
+
+    # fetchpriority="high" is reserved for the above-fold light brand logo.
+    # Adding it to lazy previews would defeat the lazy-load contract above.
+    assert html.count('fetchpriority="high"') == 1
+
+
 def test_portal_review_surface_supports_compare_summary_and_keyboard_selection() -> None:
     content = _portal_bundle_content()
     review_content = _portal_review_source_content()

--- a/tests/test_app_orchestrator_runtime.py
+++ b/tests/test_app_orchestrator_runtime.py
@@ -1744,7 +1744,7 @@ def test_portal_artifact_previews_lazy_load_and_decode_async() -> None:
         marker_index = html.index(marker)
         start = html.rindex("<img", 0, marker_index)
         end = html.index(">", marker_index)
-        tag = html[start:end + 1]
+        tag = html[start : end + 1]
         assert 'loading="lazy"' in tag, f'{img_id} missing loading="lazy"'
         assert 'decoding="async"' in tag, f'{img_id} missing decoding="async"'
 


### PR DESCRIPTION
## Summary

- Adds `loading="lazy"` and `decoding="async"` to the four hidden / off-screen artifact preview `<img>` tags in `portal.html` (`artifactPreviewImage`, `artifactCompareImage`, `artifactPreviewSoloImage`, `artifactViewerImage`). They start `class="hidden"` and live behind the lazy-loaded Review surface bundle, so without these attributes assigning `.src` decoded artifact bytes synchronously and contended with the bootstrap critical path.
- Does not extend `fetchpriority="high"` to any of these hidden previews. The new test asserts `fetchpriority="high"` appears exactly once across `portal.html` (the above-fold light brand logo) so accidental high-priority loading on hidden previews is caught.
- Above-the-fold brand `<img>` tags at `portal.html:60-78` are unchanged. Both already carry `decoding="async"`; the light variant correctly carries `fetchpriority="high"` because it paints in the visible header on initial load.
- Adds focused runtime coverage in `tests/test_app_orchestrator_runtime.py::test_portal_artifact_previews_lazy_load_and_decode_async` that pins the four IDs, asserts both attributes on each, and asserts the singular `fetchpriority="high"` count.
- Does **not** change JS, CSS, the portal asset manifest (`config/portal_asset_manifest.json`), asset budgets, backend routes, the asset-bundle schema, or the build pipeline. All five JS bundles plus CSS rebuild byte-identical (`portal bundle unchanged`).

### Scope exclusions (intentional)

- No WebP/AVIF generation.
- No `<picture>` / `srcset` conversion.
- No portal-asset-manifest schema extension to multi-variant entries.
- No backend image-transform or content-negotiation handler.
- No RUM, Playwright, deferred-surface, or rate-limit changes.

### Files changed

- `portal.html` (4 `<img>` tags; +`loading="lazy"` + `decoding="async"` on each)
- `tests/test_app_orchestrator_runtime.py` (one new test, +27 lines)

Commit: `3de6b25`

### Reviewer note

This intentionally implements lazy-loading only. Brand assets are already SVG, and dynamic artifact previews do not currently have backend image-transform / content-negotiation support. Adding `<picture>`, WebP/AVIF variants, or manifest multi-variant schema would be a separate asset-contract / backend change rather than a low-risk markup optimization, and it has been explicitly deferred until a backend transform endpoint exists.

## Verification

- `cd web/secure-landing && npm run build:portal` — clean. All 5 JS bundles + CSS rebuild byte-identical (`portal bundle unchanged: public/portal-assets/portal.js (400021 bytes)`, `review surface bundle unchanged`, `operate surface bundle unchanged`, `build surface bundle unchanged`, `overview surface bundle unchanged`, `portal css unchanged`).
- `python3 scripts/validation/check_portal_asset_budgets.py` — `portal asset budgets: OK` across all 12 tracked assets (`portal.js` stays 400,021 raw / 91,547 gzip, well under 405,000 / 92,000 budget).
- Focused runtime image-loading test (`tests/test_app_orchestrator_runtime.py::test_portal_artifact_previews_lazy_load_and_decode_async`) — `1 passed`.
- `pytest tests/test_app_orchestrator_runtime.py` — **250 passed, 2 failed**. The 2 failures are the same sandbox-only `scipy`-missing tests (`test_lux_ui_backend_and_direct_cli_paths_share_config_fingerprint`, `test_importing_lux_depth_main_does_not_eagerly_import_depth_models`) that pre-date this work and reproduce on `origin/main`; net **+1 passing** vs prior baseline (the test this PR adds).
- `pytest tests/test_app_rejection_paths.py tests/test_app_orchestrator_contract_http.py tests/portal/test_asset_bundle.py` — `155 passed`.
- `cd web/secure-landing && npm test` — `156/156 pass`. Portal-utility-ownership map unchanged (no new utility classes used).
- `make test-frontdoor-contract` — `156/156 pass` + Next build pass.
- `make test-orchestrator-http-contract` — not runnable in the agent sandbox (project venv not provisioned for `make`). Equivalent direct invocation `pytest tests/test_app_orchestrator_contract_http.py` passes (132/132).
- `make validate-portal-browser` — not runnable in the agent sandbox for the Chromium-as-root reason already documented in PR #1680 (`validate_portal_browser_smoke.py` does not pass `--no-sandbox`). Backend portion confirmed healthy under the smoke harness: uvicorn ready, `GET /ready 200`, `POST /v1/config-preview 200`. Smoke gate runs unchanged in CI / any non-root environment.

https://claude.ai/code/session_013U4w5a7j1iN2v7t8w9MD3D

---
_Generated by [Claude Code](https://claude.ai/code/session_013U4w5a7j1iN2v7t8w9MD3D)_