### PR TITLE
extend RUM coverage to landing and login pages

### DIFF
--- a/app.py
+++ b/app.py
@@ -1256,9 +1256,18 @@ PORTAL_ALLOWED_RUM_EVENT_TYPES = {
     "core_web_vital",
     "queue_request",
     "sse_reconnect",
+    "landing_rendered",
+    "login_rendered",
 }
-PORTAL_ALLOWED_RUM_ROUTES = {"/portal"}
-PORTAL_ALLOWED_RUM_VIEWS = {"overview", "build", "operate", "review"}
+PORTAL_ALLOWED_RUM_ROUTES = {"/portal", "/", "/login"}
+PORTAL_ALLOWED_RUM_VIEWS = {
+    "overview",
+    "build",
+    "operate",
+    "review",
+    "landing",
+    "login",
+}
 PORTAL_ALLOWED_RUM_UNITS = {"ms", "score", "count"}
 PORTAL_ALLOWED_RUM_METRICS = {
     "bootstrap_ready": {"duration"},
@@ -1267,6 +1276,8 @@ PORTAL_ALLOWED_RUM_METRICS = {
     "portal_shell_rendered": {"duration"},
     "queue_request": {"cancel", "submit"},
     "sse_reconnect": set(),
+    "landing_rendered": {"duration"},
+    "login_rendered": {"duration"},
 }
 PATH_SCOPE_INPUT = "input"
 PATH_SCOPE_OUTPUT = "output"

--- a/tests/test_app_orchestrator_contract_http.py
+++ b/tests/test_app_orchestrator_contract_http.py
@@ -2043,6 +2043,121 @@ def test_portal_rum_invalid_payload_returns_sanitized_reason(
     assert body["error"]["details"] == {"field": "payload", "reason": reason}
 
 
+def test_portal_rum_contract_accepts_landing_rendered_event(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TP_PORTAL_RUM_ENABLED", "1")
+    monkeypatch.setenv("TP_PORTAL_RUM_ROLLOUT_PERCENT", "100")
+
+    response = client.post(
+        "/v1/portal/rum",
+        json={
+            "event_type": "landing_rendered",
+            "route": "/",
+            "view": "landing",
+            "metric": "duration",
+            "value": 142.5,
+            "unit": "ms",
+        },
+    )
+    body = response.json()
+
+    assert response.status_code == 200
+    assert body["success"] is True
+    assert body["data"]["accepted"] is True
+    event = body["data"]["event"]
+    assert event["event_type"] == "landing_rendered"
+    assert event["route"] == "/"
+    assert event["view"] == "landing"
+    assert event["metric"] == "duration"
+    assert event["value"] == 142.5
+    assert event["unit"] == "ms"
+
+
+def test_portal_rum_contract_accepts_login_rendered_event(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TP_PORTAL_RUM_ENABLED", "1")
+    monkeypatch.setenv("TP_PORTAL_RUM_ROLLOUT_PERCENT", "100")
+
+    response = client.post(
+        "/v1/portal/rum",
+        json={
+            "event_type": "login_rendered",
+            "route": "/login",
+            "view": "login",
+            "metric": "duration",
+            "value": 87.25,
+            "unit": "ms",
+        },
+    )
+    body = response.json()
+
+    assert response.status_code == 200
+    assert body["success"] is True
+    assert body["data"]["accepted"] is True
+    event = body["data"]["event"]
+    assert event["event_type"] == "login_rendered"
+    assert event["route"] == "/login"
+    assert event["view"] == "login"
+
+
+def test_portal_rum_contract_accepts_core_web_vital_from_root_route(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TP_PORTAL_RUM_ENABLED", "1")
+    monkeypatch.setenv("TP_PORTAL_RUM_ROLLOUT_PERCENT", "100")
+
+    response = client.post(
+        "/v1/portal/rum",
+        json={
+            "event_type": "core_web_vital",
+            "route": "/",
+            "view": "landing",
+            "metric": "lcp",
+            "value": 1820.5,
+            "unit": "ms",
+        },
+    )
+    body = response.json()
+
+    assert response.status_code == 200
+    assert body["data"]["accepted"] is True
+    assert body["data"]["event"]["route"] == "/"
+    assert body["data"]["event"]["view"] == "landing"
+    assert body["data"]["event"]["metric"] == "lcp"
+
+
+def test_portal_rum_contract_accepts_core_web_vital_from_login_route(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TP_PORTAL_RUM_ENABLED", "1")
+    monkeypatch.setenv("TP_PORTAL_RUM_ROLLOUT_PERCENT", "100")
+
+    response = client.post(
+        "/v1/portal/rum",
+        json={
+            "event_type": "core_web_vital",
+            "route": "/login",
+            "view": "login",
+            "metric": "cls",
+            "value": 0.0125,
+            "unit": "score",
+        },
+    )
+    body = response.json()
+
+    assert response.status_code == 200
+    assert body["data"]["accepted"] is True
+    assert body["data"]["event"]["route"] == "/login"
+    assert body["data"]["event"]["view"] == "login"
+    assert body["data"]["event"]["metric"] == "cls"
+
+
 def test_readiness_contract_reports_pipeline_status_matrix(
     client: TestClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_app_orchestrator_runtime.py
+++ b/tests/test_app_orchestrator_runtime.py
@@ -707,6 +707,21 @@ def test_advisory_caption_panel_uses_bounded_payload_cache() -> None:
     assert "requestId !== advisoryCaptionRenderRequestId" in panel_body
 
 
+def test_portal_rum_allowlists_cover_landing_and_login_surfaces() -> None:
+    assert "/portal" in orchestrator_app.PORTAL_ALLOWED_RUM_ROUTES
+    assert "/" in orchestrator_app.PORTAL_ALLOWED_RUM_ROUTES
+    assert "/login" in orchestrator_app.PORTAL_ALLOWED_RUM_ROUTES
+
+    assert "landing_rendered" in orchestrator_app.PORTAL_ALLOWED_RUM_EVENT_TYPES
+    assert "login_rendered" in orchestrator_app.PORTAL_ALLOWED_RUM_EVENT_TYPES
+
+    assert "landing" in orchestrator_app.PORTAL_ALLOWED_RUM_VIEWS
+    assert "login" in orchestrator_app.PORTAL_ALLOWED_RUM_VIEWS
+
+    assert orchestrator_app.PORTAL_ALLOWED_RUM_METRICS["landing_rendered"] == {"duration"}
+    assert orchestrator_app.PORTAL_ALLOWED_RUM_METRICS["login_rendered"] == {"duration"}
+
+
 def test_portal_rum_rollout_reuses_shared_rollout_helper(monkeypatch: pytest.MonkeyPatch) -> None:
     actor = {"username": "portal-admin"}
     captured: list[tuple[str, dict[str, str]]] = []

--- a/web/secure-landing/app/login/route.js
+++ b/web/secure-landing/app/login/route.js
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server.js";
 import { resolveAccessContext, resolveAuthenticatedAccessSession, revokeSessionOnAccessFailure } from "../../lib/access.js";
 import { escapeHtml, FRONTDOOR_ASSETS, renderBrandAsset } from "../../lib/brand.js";
 import { audit } from "../../lib/audit.js";
+import { isPortalRumEnabled } from "../../lib/config.js";
 import { applySecurityHeaders, buildRequestUrl, FRONTDOOR_CSP, generateScriptNonce } from "../../lib/http.js";
 import { applyPortalReturnTo, resolvePortalReturnTo, validatePortalReturnTo } from "../../lib/return-to.js";
 import { renderRumClientScript } from "../../lib/rum-client.js";
@@ -23,10 +24,6 @@ import { validateOriginAndReferrer } from "../../lib/request-security.js";
 import { verifyUserCredentials } from "../../lib/users.js";
 
 export const runtime = "nodejs";
-
-function _isRumEnabled() {
-  return String(process.env.TP_PORTAL_RUM_ENABLED || "").trim().toLowerCase() === "true";
-}
 
 function resolveLoginMessage(code) {
   if (code === "access") return "Access verification is required before sign-in can continue. Refresh your Access session and try again.";
@@ -282,7 +279,7 @@ export async function GET(request) {
   // token on the login form is bound to a server-side session from the start.
   session = session || createAnonymousSession();
   const accessContext = await resolveAccessContext(request);
-  const rumEnabled = _isRumEnabled();
+  const rumEnabled = isPortalRumEnabled();
   const scriptNonce = rumEnabled ? generateScriptNonce() : null;
   const rumScript = rumEnabled
     ? renderRumClientScript({

--- a/web/secure-landing/app/login/route.js
+++ b/web/secure-landing/app/login/route.js
@@ -3,8 +3,9 @@ import { NextResponse } from "next/server.js";
 import { resolveAccessContext, resolveAuthenticatedAccessSession, revokeSessionOnAccessFailure } from "../../lib/access.js";
 import { escapeHtml, FRONTDOOR_ASSETS, renderBrandAsset } from "../../lib/brand.js";
 import { audit } from "../../lib/audit.js";
-import { applySecurityHeaders, buildRequestUrl, FRONTDOOR_CSP } from "../../lib/http.js";
+import { applySecurityHeaders, buildRequestUrl, FRONTDOOR_CSP, generateScriptNonce } from "../../lib/http.js";
 import { applyPortalReturnTo, resolvePortalReturnTo, validatePortalReturnTo } from "../../lib/return-to.js";
+import { renderRumClientScript } from "../../lib/rum-client.js";
 import {
   createAnonymousSession,
   destroySession,
@@ -17,10 +18,15 @@ import {
   validateCsrfToken
 } from "../../lib/sessions.js";
 import { getConfig } from "../../lib/config.js";
+import { generateTraceparent } from "../../lib/trace.js";
 import { validateOriginAndReferrer } from "../../lib/request-security.js";
 import { verifyUserCredentials } from "../../lib/users.js";
 
 export const runtime = "nodejs";
+
+function _isRumEnabled() {
+  return String(process.env.TP_PORTAL_RUM_ENABLED || "").trim().toLowerCase() === "true";
+}
 
 function resolveLoginMessage(code) {
   if (code === "access") return "Access verification is required before sign-in can continue. Refresh your Access session and try again.";
@@ -68,7 +74,10 @@ function resolveEntryState({ accessEmail, errorCode, bypass = false }) {
   };
 }
 
-function renderLoginPage({ csrfToken, accessEmail, errorCode, bypass = false, returnTo = "" }) {
+function renderLoginPage({ csrfToken, accessEmail, errorCode, bypass = false, returnTo = "", rumScript = "", scriptNonce = null }) {
+  const rumScriptTag = rumScript && scriptNonce
+    ? `<script nonce="${escapeHtml(scriptNonce)}">${rumScript}</script>`
+    : "";
   const errorMessage = errorCode ? resolveLoginMessage(errorCode) : "";
   const entryState = resolveEntryState({ accessEmail, errorCode, bypass });
   const hasAccessContext = Boolean(bypass || accessEmail);
@@ -236,6 +245,7 @@ function renderLoginPage({ csrfToken, accessEmail, errorCode, bypass = false, re
         </div>
       </section>
     </main>
+    ${rumScriptTag}
   </body>
 </html>`;
 }
@@ -272,12 +282,23 @@ export async function GET(request) {
   // token on the login form is bound to a server-side session from the start.
   session = session || createAnonymousSession();
   const accessContext = await resolveAccessContext(request);
+  const rumEnabled = _isRumEnabled();
+  const scriptNonce = rumEnabled ? generateScriptNonce() : null;
+  const rumScript = rumEnabled
+    ? renderRumClientScript({
+        route: "/login",
+        view: "login",
+        traceparent: generateTraceparent(),
+      })
+    : "";
   const html = renderLoginPage({
     csrfToken: session.csrfToken,
     accessEmail: accessContext.accessEmail,
     errorCode: request.nextUrl.searchParams.get("error"),
     bypass: accessContext.bypass,
-    returnTo: requestedReturnTo || ""
+    returnTo: requestedReturnTo || "",
+    rumScript,
+    scriptNonce
   });
   const response = new NextResponse(html, {
     status: 200,
@@ -287,7 +308,7 @@ export async function GET(request) {
     }
   });
   setSessionCookie(response, session.id);
-  return applySecurityHeaders(response, { csp: FRONTDOOR_CSP });
+  return applySecurityHeaders(response, { csp: FRONTDOOR_CSP, scriptNonce });
 }
 
 export async function POST(request) {

--- a/web/secure-landing/app/portal/bootstrap/route.js
+++ b/web/secure-landing/app/portal/bootstrap/route.js
@@ -4,6 +4,7 @@ import { NextResponse } from "next/server.js";
 
 import { revokeSessionOnAccessFailure, resolveAuthenticatedAccessSession } from "../../../lib/access.js";
 import { audit } from "../../../lib/audit.js";
+import { isPortalRumEnabled } from "../../../lib/config.js";
 import { applySecurityHeaders } from "../../../lib/http.js";
 import {
   auditManagedSurfaceFailure,
@@ -57,7 +58,7 @@ function resolveReviewSurfaceDeferred(session, env = process.env) {
 }
 
 function resolveRumTelemetry(session, env = process.env) {
-  if (String(env.TP_PORTAL_RUM_ENABLED || "").trim().toLowerCase() !== "1") {
+  if (!isPortalRumEnabled(env)) {
     return false;
   }
   return resolvePortalRollout(session, "TP_PORTAL_RUM_ROLLOUT_PERCENT", env);

--- a/web/secure-landing/app/route.js
+++ b/web/secure-landing/app/route.js
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server.js";
 
+import { isPortalRumEnabled } from "../lib/config.js";
 import { applySecurityHeaders, FRONTDOOR_CSP, generateScriptNonce } from "../lib/http.js";
 import { renderHomepage } from "../lib/homepage.js";
 import { renderRumClientScript } from "../lib/rum-client.js";
@@ -16,12 +17,8 @@ export const dynamic = "force-dynamic";
 const HOMEPAGE_CACHE_CONTROL_STATIC = "public, max-age=300, must-revalidate";
 const HOMEPAGE_CACHE_CONTROL_DYNAMIC = "no-store";
 
-function _isRumEnabled() {
-  return String(process.env.TP_PORTAL_RUM_ENABLED || "").trim().toLowerCase() === "true";
-}
-
 export async function GET() {
-  const rumEnabled = _isRumEnabled();
+  const rumEnabled = isPortalRumEnabled();
   const scriptNonce = rumEnabled ? generateScriptNonce() : null;
   const rumScript = rumEnabled
     ? renderRumClientScript({

--- a/web/secure-landing/app/route.js
+++ b/web/secure-landing/app/route.js
@@ -1,21 +1,42 @@
 import { NextResponse } from "next/server.js";
 
-import { applySecurityHeaders, FRONTDOOR_CSP } from "../lib/http.js";
+import { applySecurityHeaders, FRONTDOOR_CSP, generateScriptNonce } from "../lib/http.js";
 import { renderHomepage } from "../lib/homepage.js";
+import { renderRumClientScript } from "../lib/rum-client.js";
+import { generateTraceparent } from "../lib/trace.js";
 
 export const runtime = "nodejs";
-export const dynamic = "force-static";
+// force-dynamic ensures GET re-runs per request so each response carries a
+// fresh CSP nonce when RUM is enabled. When RUM is disabled the response body
+// is identical and the Cache-Control hint below still allows downstream
+// caching; when RUM is enabled the response is marked no-store so a per-user
+// nonce cannot leak across requests via shared caches.
+export const dynamic = "force-dynamic";
 
-const HOMEPAGE_CACHE_CONTROL = "public, max-age=300, must-revalidate";
+const HOMEPAGE_CACHE_CONTROL_STATIC = "public, max-age=300, must-revalidate";
+const HOMEPAGE_CACHE_CONTROL_DYNAMIC = "no-store";
+
+function _isRumEnabled() {
+  return String(process.env.TP_PORTAL_RUM_ENABLED || "").trim().toLowerCase() === "true";
+}
 
 export async function GET() {
-  const html = renderHomepage();
+  const rumEnabled = _isRumEnabled();
+  const scriptNonce = rumEnabled ? generateScriptNonce() : null;
+  const rumScript = rumEnabled
+    ? renderRumClientScript({
+        route: "/",
+        view: "landing",
+        traceparent: generateTraceparent(),
+      })
+    : "";
+  const html = renderHomepage({ rumScript, scriptNonce });
   const response = new NextResponse(html, {
     status: 200,
     headers: {
       "Content-Type": "text/html; charset=utf-8",
-      "Cache-Control": HOMEPAGE_CACHE_CONTROL
+      "Cache-Control": rumEnabled ? HOMEPAGE_CACHE_CONTROL_DYNAMIC : HOMEPAGE_CACHE_CONTROL_STATIC
     }
   });
-  return applySecurityHeaders(response, { csp: FRONTDOOR_CSP });
+  return applySecurityHeaders(response, { csp: FRONTDOOR_CSP, scriptNonce });
 }

--- a/web/secure-landing/app/v1/portal/rum/route.js
+++ b/web/secure-landing/app/v1/portal/rum/route.js
@@ -1,0 +1,174 @@
+import { NextResponse } from "next/server.js";
+
+import { getConfig, isPortalRumEnabled } from "../../../../lib/config.js";
+import { applySecurityHeaders } from "../../../../lib/http.js";
+import {
+  auditManagedSurfaceFailure,
+  buildManagedV1ErrorDetails,
+  classifyUpstreamFailureStatus,
+  getManagedFailureMessage,
+  MANAGED_FAILURE_REASON
+} from "../../../../lib/managed-failure.js";
+import { buildUpstreamHeaders, buildUpstreamUrl, copyUpstreamResponseHeaders } from "../../../../lib/proxy.js";
+import { validateOriginAndReferrer } from "../../../../lib/request-security.js";
+import { resolveRequestTraceparent, traceIdFromTraceparent, normalizeTraceparent } from "../../../../lib/trace.js";
+
+export const runtime = "nodejs";
+
+const PUBLIC_RUM_PATH = "/v1/portal/rum";
+
+function successEnvelope(data, traceparent = "") {
+  return applySecurityHeaders(
+    NextResponse.json(
+      {
+        schema: "tp.orchestrator.portal_rum_ingest.v1",
+        success: true,
+        data,
+        error: null
+      },
+      {
+        status: 200,
+        headers: {
+          "Cache-Control": "no-store",
+          ...(traceparent ? { traceparent } : {})
+        }
+      }
+    )
+  );
+}
+
+function errorEnvelope(status, code, message, details = {}, traceparent = "") {
+  return applySecurityHeaders(
+    NextResponse.json(
+      {
+        schema: "tp.orchestrator.error.v1",
+        success: false,
+        data: null,
+        error: {
+          code,
+          message,
+          details
+        }
+      },
+      {
+        status,
+        headers: {
+          "Cache-Control": "no-store",
+          ...(traceparent ? { traceparent } : {})
+        }
+      }
+    )
+  );
+}
+
+export async function POST(request) {
+  const requestTraceparent = resolveRequestTraceparent(request);
+  const traceId = traceIdFromTraceparent(requestTraceparent);
+
+  if (!validateOriginAndReferrer(request)) {
+    return errorEnvelope(
+      403,
+      "INVALID_CSRF",
+      "origin validation failed",
+      { path: PUBLIC_RUM_PATH },
+      requestTraceparent
+    );
+  }
+
+  if (!isPortalRumEnabled()) {
+    return successEnvelope({ accepted: false, disabled: true }, requestTraceparent);
+  }
+
+  const config = getConfig();
+  if (!config.backendApiKey) {
+    auditManagedSurfaceFailure("v1_proxy", {
+      extra: { env: "TP_BACKEND_API_KEY", ...(traceId ? { traceId } : {}) },
+      path: PUBLIC_RUM_PATH,
+      reason: MANAGED_FAILURE_REASON.CONFIG_FAILURE,
+      status: 503
+    });
+    return errorEnvelope(
+      503,
+      "AUTH_CONFIGURATION_ERROR",
+      "TP_BACKEND_API_KEY is not configured",
+      buildManagedV1ErrorDetails(PUBLIC_RUM_PATH, MANAGED_FAILURE_REASON.CONFIG_FAILURE, {
+        env: "TP_BACKEND_API_KEY"
+      }),
+      requestTraceparent
+    );
+  }
+
+  const upstreamHeaders = buildUpstreamHeaders(request.headers, {
+    backendApiKey: config.backendApiKey,
+    actor: null,
+    traceparent: requestTraceparent,
+    forwarding: {
+      clientIp: String(request.headers.get("cf-connecting-ip") || "").trim() || null,
+      host: request.headers.get("host") || request.nextUrl.host,
+      proto: request.nextUrl.protocol.replace(":", "")
+    }
+  });
+
+  let upstream;
+  try {
+    upstream = await fetch(buildUpstreamUrl(PUBLIC_RUM_PATH, request.nextUrl.search), {
+      method: "POST",
+      headers: upstreamHeaders,
+      body: request.body,
+      cache: "no-store",
+      redirect: "manual",
+      duplex: "half"
+    });
+  } catch (error) {
+    auditManagedSurfaceFailure("v1_proxy", {
+      message: error instanceof Error ? error.message : String(error),
+      path: PUBLIC_RUM_PATH,
+      reason: MANAGED_FAILURE_REASON.UPSTREAM_UNAVAILABLE,
+      status: 502,
+      extra: traceId ? { traceId } : {}
+    });
+    return errorEnvelope(
+      502,
+      "UPSTREAM_UNAVAILABLE",
+      getManagedFailureMessage("v1_proxy", MANAGED_FAILURE_REASON.UPSTREAM_UNAVAILABLE),
+      buildManagedV1ErrorDetails(PUBLIC_RUM_PATH, MANAGED_FAILURE_REASON.UPSTREAM_UNAVAILABLE),
+      requestTraceparent
+    );
+  }
+
+  const upstreamFailureReason = classifyUpstreamFailureStatus(upstream.status);
+  if (upstreamFailureReason) {
+    const status = upstreamFailureReason === MANAGED_FAILURE_REASON.CONFIG_FAILURE ? 503 : 502;
+    const code =
+      upstreamFailureReason === MANAGED_FAILURE_REASON.CONFIG_FAILURE
+        ? "AUTH_CONFIGURATION_ERROR"
+        : "UPSTREAM_UNAVAILABLE";
+    auditManagedSurfaceFailure("v1_proxy", {
+      path: PUBLIC_RUM_PATH,
+      reason: upstreamFailureReason,
+      status,
+      upstreamStatus: upstream.status,
+      extra: traceId ? { traceId } : {}
+    });
+    return errorEnvelope(
+      status,
+      code,
+      getManagedFailureMessage("v1_proxy", upstreamFailureReason),
+      buildManagedV1ErrorDetails(PUBLIC_RUM_PATH, upstreamFailureReason, {
+        upstreamStatus: upstream.status
+      }),
+      requestTraceparent
+    );
+  }
+
+  const responseHeaders = copyUpstreamResponseHeaders(upstream.headers);
+  responseHeaders.set("Cache-Control", "no-store");
+  responseHeaders.set("traceparent", normalizeTraceparent(upstream.headers.get("traceparent")) || requestTraceparent);
+
+  return applySecurityHeaders(
+    new Response(upstream.body, {
+      status: upstream.status,
+      headers: responseHeaders
+    })
+  );
+}

--- a/web/secure-landing/lib/config.js
+++ b/web/secure-landing/lib/config.js
@@ -11,6 +11,14 @@ export function isLocalAccessBypassEnabled(env = process.env) {
   return (env.NODE_ENV || "development") === "development" && env.TP_ALLOW_LOCAL_ACCESS_BYPASS === "1";
 }
 
+export function isTruthyEnvFlag(value) {
+  return ["1", "true", "yes", "on"].includes(String(value || "").trim().toLowerCase());
+}
+
+export function isPortalRumEnabled(env = process.env) {
+  return isTruthyEnvFlag(env.TP_PORTAL_RUM_ENABLED);
+}
+
 export function normalizeUsername(value) {
   return String(value || "").trim().toLowerCase();
 }

--- a/web/secure-landing/lib/homepage.js
+++ b/web/secure-landing/lib/homepage.js
@@ -411,7 +411,10 @@ function renderReleaseBundlePreview() {
   </section>`;
 }
 
-export function renderHomepage() {
+export function renderHomepage({ rumScript = "", scriptNonce = null } = {}) {
+  const rumScriptTag = rumScript && scriptNonce
+    ? `<script nonce="${escapeHtml(scriptNonce)}">${rumScript}</script>`
+    : "";
   return `<!DOCTYPE html>
 <html lang="en">
   <head>
@@ -653,6 +656,7 @@ export function renderHomepage() {
         <a class="site-link" href="/login" data-ui="homepage-footer-login">Operator Login</a>
       </div>
     </footer>
+    ${rumScriptTag}
   </body>
 </html>`;
 }

--- a/web/secure-landing/lib/http.js
+++ b/web/secure-landing/lib/http.js
@@ -96,14 +96,26 @@ export function buildRequestUrl(request, pathname) {
   return url;
 }
 
-export function applySecurityHeaders(response, { csp = null } = {}) {
+export function generateScriptNonce() {
+  const cryptoImpl = globalThis.crypto;
+  if (!cryptoImpl || typeof cryptoImpl.getRandomValues !== "function") {
+    throw new Error("Secure random source unavailable for script nonce generation");
+  }
+  const bytes = cryptoImpl.getRandomValues(new Uint8Array(16));
+  return Buffer.from(bytes).toString("base64");
+}
+
+export function applySecurityHeaders(response, { csp = null, scriptNonce = null } = {}) {
   for (const [name, value] of Object.entries(BASE_SECURITY_HEADERS)) {
     if (!response.headers.has(name)) {
       response.headers.set(name, value);
     }
   }
   if (csp) {
-    response.headers.set("Content-Security-Policy", csp);
+    const finalCsp = scriptNonce
+      ? csp.replace("script-src 'none'", `script-src 'nonce-${scriptNonce}'`)
+      : csp;
+    response.headers.set("Content-Security-Policy", finalCsp);
   }
   return response;
 }

--- a/web/secure-landing/lib/http.js
+++ b/web/secure-landing/lib/http.js
@@ -105,6 +105,30 @@ export function generateScriptNonce() {
   return Buffer.from(bytes).toString("base64");
 }
 
+function applyScriptNonceToCsp(csp, scriptNonce) {
+  const nonceToken = `'nonce-${scriptNonce}'`;
+  let scriptDirectiveUpdated = false;
+  const directives = String(csp || "")
+    .split(";")
+    .map((directive) => directive.trim())
+    .filter(Boolean)
+    .map((directive) => {
+      const [name, ...tokens] = directive.split(/\s+/);
+      if (String(name || "").toLowerCase() !== "script-src") {
+        return directive;
+      }
+      scriptDirectiveUpdated = true;
+      const sourceTokens = tokens.filter((token) => token !== "'none'" && token !== nonceToken);
+      return ["script-src", nonceToken, ...sourceTokens].join(" ");
+    });
+
+  if (!scriptDirectiveUpdated) {
+    throw new Error("CSP script-src directive required when scriptNonce is provided");
+  }
+
+  return directives.join("; ");
+}
+
 export function applySecurityHeaders(response, { csp = null, scriptNonce = null } = {}) {
   for (const [name, value] of Object.entries(BASE_SECURITY_HEADERS)) {
     if (!response.headers.has(name)) {
@@ -112,9 +136,7 @@ export function applySecurityHeaders(response, { csp = null, scriptNonce = null 
     }
   }
   if (csp) {
-    const finalCsp = scriptNonce
-      ? csp.replace("script-src 'none'", `script-src 'nonce-${scriptNonce}'`)
-      : csp;
+    const finalCsp = scriptNonce ? applyScriptNonceToCsp(csp, scriptNonce) : csp;
     response.headers.set("Content-Security-Policy", finalCsp);
   }
   return response;

--- a/web/secure-landing/lib/rum-client.js
+++ b/web/secure-landing/lib/rum-client.js
@@ -1,0 +1,220 @@
+// Server-side string builder that returns the JavaScript body injected into
+// the rendered HTML via <script nonce="...">. The returned string is the JS
+// body only — the calling route is responsible for the <script> wrapper and
+// the matching CSP nonce.
+//
+// Mirrors the portal RUM emitter at portal-src/portal.template.js (LCP/CLS/INP
+// observers, first_view_interactive, queued POSTs to /v1/portal/rum) so the
+// front door produces samples in the same shape that the backend validator
+// at app.py:_record_portal_rum already accepts.
+
+function _serialize(value) {
+  // JSON.stringify is safe inside a <script> body provided we escape the two
+  // sequences that can prematurely close the script tag or open an HTML
+  // comment. Both substitutions preserve JSON validity for the embedded JS
+  // parser.
+  return JSON.stringify(value)
+    .replace(/<\//g, "<\\/")
+    .replace(/<!--/g, "<\\!--");
+}
+
+export function renderRumClientScript({ route, view, traceparent }) {
+  const routeLiteral = _serialize(String(route));
+  const viewLiteral = _serialize(String(view));
+  const traceparentLiteral = _serialize(String(traceparent));
+  const eventTypeLiteral = _serialize(`${String(view)}_rendered`);
+
+  return `(function () {
+  try {
+    var ROUTE = ${routeLiteral};
+    var VIEW = ${viewLiteral};
+    var TRACEPARENT = ${traceparentLiteral};
+    var RENDERED_EVENT = ${eventTypeLiteral};
+    var ENDPOINT = "/v1/portal/rum";
+    var emitted = Object.create(null);
+    var vitals = { lcpMs: null, inpMs: null, clsScore: 0, finalized: false };
+    var queue = [];
+
+    function nowMs() {
+      try {
+        return (window.performance && typeof window.performance.now === "function")
+          ? window.performance.now()
+          : Date.now();
+      } catch (_err) {
+        return Date.now();
+      }
+    }
+
+    function postSample(sample, keepalive) {
+      try {
+        var headers = { "Content-Type": "application/json" };
+        if (TRACEPARENT) {
+          headers["traceparent"] = TRACEPARENT;
+        }
+        var body = JSON.stringify({
+          event_type: sample.event_type,
+          route: ROUTE,
+          view: VIEW,
+          metric: sample.metric,
+          value: sample.value,
+          unit: sample.unit,
+          metadata: sample.metadata || {}
+        });
+        return fetch(ENDPOINT, {
+          method: "POST",
+          headers: headers,
+          body: body,
+          keepalive: Boolean(keepalive),
+          credentials: "same-origin"
+        }).catch(function () { /* best-effort telemetry */ });
+      } catch (_err) {
+        // best-effort telemetry only
+      }
+    }
+
+    function flushQueue(keepalive) {
+      var pending = queue.splice(0, queue.length);
+      for (var i = 0; i < pending.length; i += 1) {
+        postSample(pending[i], keepalive);
+      }
+    }
+
+    function enqueue(sample, options) {
+      if (!sample || typeof sample.value !== "number" || !isFinite(sample.value) || sample.value < 0) {
+        return;
+      }
+      queue.push(sample);
+      flushQueue(Boolean(options && options.keepalive));
+    }
+
+    function emitOnce(eventType, sampleBuilder) {
+      if (emitted[eventType]) return;
+      emitted[eventType] = true;
+      enqueue(sampleBuilder());
+    }
+
+    function emitRendered() {
+      emitOnce(RENDERED_EVENT, function () {
+        return {
+          event_type: RENDERED_EVENT,
+          metric: "duration",
+          unit: "ms",
+          value: nowMs()
+        };
+      });
+    }
+
+    function scheduleFirstViewInteractive() {
+      if (emitted.first_view_interactive) return;
+      var emit = function () {
+        emitOnce("first_view_interactive", function () {
+          return {
+            event_type: "first_view_interactive",
+            metric: "duration",
+            unit: "ms",
+            value: nowMs()
+          };
+        });
+      };
+      if (typeof window.requestAnimationFrame === "function") {
+        window.requestAnimationFrame(emit);
+      } else {
+        window.setTimeout(emit, 0);
+      }
+    }
+
+    function finalizeVitals() {
+      if (vitals.finalized) return;
+      vitals.finalized = true;
+      if (typeof vitals.lcpMs === "number" && isFinite(vitals.lcpMs)) {
+        enqueue({
+          event_type: "core_web_vital",
+          metric: "lcp",
+          unit: "ms",
+          value: vitals.lcpMs
+        }, { keepalive: true });
+      }
+      if (typeof vitals.inpMs === "number" && isFinite(vitals.inpMs)) {
+        enqueue({
+          event_type: "core_web_vital",
+          metric: "inp",
+          unit: "ms",
+          value: vitals.inpMs
+        }, { keepalive: true });
+      }
+      enqueue({
+        event_type: "core_web_vital",
+        metric: "cls",
+        unit: "score",
+        value: Number(vitals.clsScore.toFixed(4))
+      }, { keepalive: true });
+    }
+
+    function startObservers() {
+      if (typeof window.PerformanceObserver !== "function") return;
+      var supported = Array.isArray(window.PerformanceObserver.supportedEntryTypes)
+        ? new Set(window.PerformanceObserver.supportedEntryTypes)
+        : new Set();
+      if (supported.has("largest-contentful-paint")) {
+        try {
+          var lcpObserver = new PerformanceObserver(function (list) {
+            var entries = list.getEntries();
+            var latest = entries[entries.length - 1];
+            if (latest) {
+              vitals.lcpMs = latest.startTime;
+            }
+          });
+          lcpObserver.observe({ type: "largest-contentful-paint", buffered: true });
+          window.addEventListener("pagehide", function () { lcpObserver.disconnect(); }, { once: true });
+        } catch (_err) { /* observer unsupported */ }
+      }
+      if (supported.has("layout-shift")) {
+        try {
+          var clsObserver = new PerformanceObserver(function (list) {
+            list.getEntries().forEach(function (entry) {
+              if (!entry.hadRecentInput) {
+                vitals.clsScore = Number((vitals.clsScore + entry.value).toFixed(4));
+              }
+            });
+          });
+          clsObserver.observe({ type: "layout-shift", buffered: true });
+          window.addEventListener("pagehide", function () { clsObserver.disconnect(); }, { once: true });
+        } catch (_err) { /* observer unsupported */ }
+      }
+      if (supported.has("event")) {
+        try {
+          var inpObserver = new PerformanceObserver(function (list) {
+            list.getEntries().forEach(function (entry) {
+              if (Number(entry.interactionId) > 0) {
+                var current = Number(vitals.inpMs) || 0;
+                vitals.inpMs = Math.max(current, entry.duration || 0);
+              }
+            });
+          });
+          inpObserver.observe({ type: "event", buffered: true, durationThreshold: 16 });
+          window.addEventListener("pagehide", function () { inpObserver.disconnect(); }, { once: true });
+        } catch (_err) { /* observer unsupported */ }
+      }
+    }
+
+    function bootstrap() {
+      startObservers();
+      emitRendered();
+      scheduleFirstViewInteractive();
+    }
+
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", bootstrap, { once: true });
+    } else {
+      bootstrap();
+    }
+
+    window.addEventListener("pagehide", function () {
+      finalizeVitals();
+      flushQueue(true);
+    }, { once: true });
+  } catch (_err) {
+    // RUM is best-effort; never block the page on telemetry errors.
+  }
+})();`;
+}

--- a/web/secure-landing/lib/rum-client.js
+++ b/web/secure-landing/lib/rum-client.js
@@ -8,6 +8,8 @@
 // front door produces samples in the same shape that the backend validator
 // at app.py:_record_portal_rum already accepts.
 
+import { normalizeTraceparent } from "./trace.js";
+
 function _serialize(value) {
   // JSON.stringify is safe inside a <script> body provided we escape the two
   // sequences that can prematurely close the script tag or open an HTML
@@ -21,7 +23,7 @@ function _serialize(value) {
 export function renderRumClientScript({ route, view, traceparent }) {
   const routeLiteral = _serialize(String(route));
   const viewLiteral = _serialize(String(view));
-  const traceparentLiteral = _serialize(String(traceparent));
+  const traceparentLiteral = _serialize(normalizeTraceparent(traceparent));
   const eventTypeLiteral = _serialize(`${String(view)}_rendered`);
 
   return `(function () {

--- a/web/secure-landing/tests/routes.test.mjs
+++ b/web/secure-landing/tests/routes.test.mjs
@@ -723,13 +723,12 @@ test("homepage GET serves the public DNA landing page instead of redirecting", a
   }
 });
 
-test("homepage route is explicitly static and ignores authenticated session hints", async () => {
+test("homepage GET is stateless and ignores authenticated session hints", async () => {
   const env = withTempEnvironment();
 
   try {
     const sessions = await importFresh("../lib/sessions.js");
     const db = getDb(env.dbPath);
-    const routeSource = readFileSync(path.resolve(process.cwd(), "app", "route.js"), "utf-8");
     const { GET } = await importFresh("../app/route.js");
     const authenticatedSession = sessions.rotateAuthenticatedSession(
       sessions.createAnonymousSession(),
@@ -755,7 +754,6 @@ test("homepage route is explicitly static and ignores authenticated session hint
       .prepare("SELECT last_seen_at, idle_expires_at FROM sessions WHERE id = ?")
       .get(authenticatedSession.id);
 
-    assert.match(routeSource, /dynamic = "force-static"/);
     assert.equal(response.status, 200);
     assert.equal(response.headers.get("set-cookie"), null);
     assert.match(html, /(?:data-ui="homepage-utility-cta"[^>]*href="\/login"|href="\/login"[^>]*data-ui="homepage-utility-cta")/);

--- a/web/secure-landing/tests/rum-client.test.mjs
+++ b/web/secure-landing/tests/rum-client.test.mjs
@@ -37,7 +37,7 @@ function restoreEnv(snapshot) {
   }
 }
 
-function withRumEnvironment({ rumEnabled = false } = {}) {
+function withRumEnvironment({ rumEnabled = false, rumFlagValue = "1" } = {}) {
   const snapshot = snapshotEnv();
   const tempDir = mkdtempSync(path.join(os.tmpdir(), "tp-frontdoor-rum-"));
   const dbPath = path.join(tempDir, "sessions.sqlite");
@@ -55,7 +55,7 @@ function withRumEnvironment({ rumEnabled = false } = {}) {
   delete process.env.TP_CF_ACCESS_AUD;
 
   if (rumEnabled) {
-    process.env.TP_PORTAL_RUM_ENABLED = "true";
+    process.env.TP_PORTAL_RUM_ENABLED = rumFlagValue;
     process.env.TP_PORTAL_RUM_ROLLOUT_PERCENT = "100";
   } else {
     delete process.env.TP_PORTAL_RUM_ENABLED;
@@ -80,6 +80,14 @@ async function importFresh(relativePath) {
 
 function buildRequest(url, options = {}) {
   return new NextRequest(url, options);
+}
+
+function withMockedFetch(handler) {
+  const originalFetch = global.fetch;
+  global.fetch = handler;
+  return () => {
+    global.fetch = originalFetch;
+  };
 }
 
 function extractScriptNonce(html) {
@@ -194,6 +202,27 @@ test("renderRumClientScript embeds caller-supplied route, view, and traceparent 
   assert.doesNotMatch(body, /\bnew\s+Function\b/);
 });
 
+test("renderRumClientScript omits invalid or missing traceparent values", async () => {
+  const { renderRumClientScript } = await importFresh("../lib/rum-client.js");
+
+  const missingTraceparentBody = renderRumClientScript({
+    route: "/",
+    view: "landing",
+    traceparent: undefined,
+  });
+  const invalidTraceparentBody = renderRumClientScript({
+    route: "/login",
+    view: "login",
+    traceparent: "undefined",
+  });
+
+  assert.match(missingTraceparentBody, /TRACEPARENT\s*=\s*""/);
+  assert.match(invalidTraceparentBody, /TRACEPARENT\s*=\s*""/);
+  assert.doesNotMatch(missingTraceparentBody, /TRACEPARENT\s*=\s*"undefined"/);
+  assert.doesNotMatch(invalidTraceparentBody, /TRACEPARENT\s*=\s*"undefined"/);
+  assert.doesNotMatch(invalidTraceparentBody, /TRACEPARENT\s*=\s*"null"/);
+});
+
 test("homepage GET mints a fresh nonce on every request when RUM is enabled", async () => {
   const env = withRumEnvironment({ rumEnabled: true });
 
@@ -209,6 +238,189 @@ test("homepage GET mints a fresh nonce on every request when RUM is enabled", as
     assert.ok(firstNonce);
     assert.ok(secondNonce);
     assert.notEqual(firstNonce, secondNonce);
+  } finally {
+    env.cleanup();
+  }
+});
+
+test("applySecurityHeaders inserts script nonces into the script-src directive", async () => {
+  const { applySecurityHeaders } = await importFresh("../lib/http.js");
+  const response = new Response("ok");
+
+  applySecurityHeaders(response, {
+    csp: "default-src 'self'; object-src 'none'; script-src 'self' https://cdn.example.test",
+    scriptNonce: "nonce-value"
+  });
+
+  assert.equal(
+    response.headers.get("content-security-policy"),
+    "default-src 'self'; object-src 'none'; script-src 'nonce-nonce-value' 'self' https://cdn.example.test"
+  );
+});
+
+test("applySecurityHeaders fails closed when a script nonce cannot be inserted", async () => {
+  const { applySecurityHeaders } = await importFresh("../lib/http.js");
+  const response = new Response("ok");
+
+  assert.throws(
+    () => applySecurityHeaders(response, {
+      csp: "default-src 'self'; object-src 'none'",
+      scriptNonce: "nonce-value"
+    }),
+    /script-src directive required/
+  );
+});
+
+test("public RUM route proxies same-origin unauthenticated samples with backend auth", async () => {
+  const env = withRumEnvironment({ rumEnabled: true });
+  const traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+  const upstreamTraceparent = "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01";
+
+  try {
+    const route = await importFresh("../app/v1/portal/rum/route.js");
+    const restoreFetch = withMockedFetch(async (url, init) => {
+      assert.equal(String(url), "http://127.0.0.1:8000/v1/portal/rum");
+      assert.equal(init.method, "POST");
+      assert.equal(init.headers.get("authorization"), "Bearer backend-secret");
+      assert.equal(init.headers.get("x-api-key"), "backend-secret");
+      assert.equal(init.headers.get("traceparent"), traceparent);
+      assert.equal(init.headers.get("x-forwarded-host"), "portal.example.com");
+      assert.equal(init.headers.get("x-forwarded-proto"), "https");
+      assert.equal(init.headers.has("cookie"), false);
+      assert.equal(init.headers.has("x-csrf-token"), false);
+      assert.equal(await new Response(init.body).text(), JSON.stringify({
+        event_type: "landing_rendered",
+        route: "/",
+        view: "landing",
+        metric: "duration",
+        value: 25,
+        unit: "ms"
+      }));
+      return Response.json(
+        {
+          schema: "tp.orchestrator.portal_rum_ingest.v1",
+          success: true,
+          data: { accepted: true },
+          error: null
+        },
+        {
+          headers: {
+            traceparent: upstreamTraceparent
+          }
+        }
+      );
+    });
+
+    try {
+      const request = buildRequest("https://portal.example.com/v1/portal/rum", {
+        method: "POST",
+        headers: new Headers({
+          cookie: "__Host-tp_session=browser-session",
+          "content-type": "application/json",
+          origin: "https://portal.example.com",
+          referer: "https://portal.example.com/",
+          traceparent,
+          "x-csrf-token": "browser-csrf-token"
+        }),
+        body: JSON.stringify({
+          event_type: "landing_rendered",
+          route: "/",
+          view: "landing",
+          metric: "duration",
+          value: 25,
+          unit: "ms"
+        })
+      });
+
+      const response = await route.POST(request);
+      const body = await response.json();
+
+      assert.equal(response.status, 200);
+      assert.equal(response.headers.get("cache-control"), "no-store");
+      assert.equal(response.headers.get("traceparent"), upstreamTraceparent);
+      assert.deepEqual(body.data, { accepted: true });
+    } finally {
+      restoreFetch();
+    }
+  } finally {
+    env.cleanup();
+  }
+});
+
+test("public RUM route rejects cross-origin samples before proxying", async () => {
+  const env = withRumEnvironment({ rumEnabled: true });
+
+  try {
+    const route = await importFresh("../app/v1/portal/rum/route.js");
+    const restoreFetch = withMockedFetch(async () => {
+      assert.fail("cross-origin public RUM requests must not reach the backend");
+    });
+
+    try {
+      const request = buildRequest("https://portal.example.com/v1/portal/rum", {
+        method: "POST",
+        headers: new Headers({
+          "content-type": "application/json",
+          origin: "https://attacker.example.com"
+        }),
+        body: JSON.stringify({
+          event_type: "landing_rendered",
+          route: "/",
+          view: "landing",
+          metric: "duration",
+          value: 25,
+          unit: "ms"
+        })
+      });
+
+      const response = await route.POST(request);
+      const body = await response.json();
+
+      assert.equal(response.status, 403);
+      assert.equal(body.error.code, "INVALID_CSRF");
+      assert.equal(body.error.details.path, "/v1/portal/rum");
+    } finally {
+      restoreFetch();
+    }
+  } finally {
+    env.cleanup();
+  }
+});
+
+test("public RUM route noops without proxying when RUM is disabled", async () => {
+  const env = withRumEnvironment({ rumEnabled: false });
+
+  try {
+    const route = await importFresh("../app/v1/portal/rum/route.js");
+    const restoreFetch = withMockedFetch(async () => {
+      assert.fail("disabled public RUM requests must not reach the backend");
+    });
+
+    try {
+      const request = buildRequest("https://portal.example.com/v1/portal/rum", {
+        method: "POST",
+        headers: new Headers({
+          "content-type": "application/json",
+          origin: "https://portal.example.com"
+        }),
+        body: JSON.stringify({
+          event_type: "landing_rendered",
+          route: "/",
+          view: "landing",
+          metric: "duration",
+          value: 25,
+          unit: "ms"
+        })
+      });
+
+      const response = await route.POST(request);
+      const body = await response.json();
+
+      assert.equal(response.status, 200);
+      assert.deepEqual(body.data, { accepted: false, disabled: true });
+    } finally {
+      restoreFetch();
+    }
   } finally {
     env.cleanup();
   }

--- a/web/secure-landing/tests/rum-client.test.mjs
+++ b/web/secure-landing/tests/rum-client.test.mjs
@@ -1,0 +1,215 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+
+import { NextRequest } from "next/server.js";
+
+import { getDb, resetDbCache } from "../lib/db.js";
+
+const ENV_KEYS = [
+  "NODE_ENV",
+  "TP_FASTAPI_ORIGIN",
+  "TP_BACKEND_API_KEY",
+  "TP_FRONTDOOR_USERS_FILE",
+  "TP_FRONTDOOR_USERS_JSON",
+  "TP_FRONTDOOR_SESSION_DB",
+  "TP_CF_ACCESS_TEAM_DOMAIN",
+  "TP_CF_ACCESS_AUD",
+  "TP_ALLOW_LOCAL_ACCESS_BYPASS",
+  "TP_PORTAL_RUM_ENABLED",
+  "TP_PORTAL_RUM_ROLLOUT_PERCENT"
+];
+
+function snapshotEnv() {
+  return new Map(ENV_KEYS.map((key) => [key, process.env[key]]));
+}
+
+function restoreEnv(snapshot) {
+  for (const key of ENV_KEYS) {
+    const previous = snapshot.get(key);
+    if (typeof previous === "string") {
+      process.env[key] = previous;
+    } else {
+      delete process.env[key];
+    }
+  }
+}
+
+function withRumEnvironment({ rumEnabled = false } = {}) {
+  const snapshot = snapshotEnv();
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), "tp-frontdoor-rum-"));
+  const dbPath = path.join(tempDir, "sessions.sqlite");
+  const usersFilePath = path.join(tempDir, "frontdoor-users.json");
+  writeFileSync(usersFilePath, JSON.stringify([]), "utf-8");
+
+  process.env.NODE_ENV = "production";
+  process.env.TP_FASTAPI_ORIGIN = "http://127.0.0.1:8000";
+  process.env.TP_BACKEND_API_KEY = "backend-secret";
+  process.env.TP_FRONTDOOR_SESSION_DB = dbPath;
+  process.env.TP_FRONTDOOR_USERS_FILE = usersFilePath;
+  process.env.TP_FRONTDOOR_USERS_JSON = "[]";
+  process.env.TP_ALLOW_LOCAL_ACCESS_BYPASS = "1";
+  delete process.env.TP_CF_ACCESS_TEAM_DOMAIN;
+  delete process.env.TP_CF_ACCESS_AUD;
+
+  if (rumEnabled) {
+    process.env.TP_PORTAL_RUM_ENABLED = "true";
+    process.env.TP_PORTAL_RUM_ROLLOUT_PERCENT = "100";
+  } else {
+    delete process.env.TP_PORTAL_RUM_ENABLED;
+    delete process.env.TP_PORTAL_RUM_ROLLOUT_PERCENT;
+  }
+
+  resetDbCache();
+
+  return {
+    dbPath,
+    cleanup() {
+      resetDbCache();
+      restoreEnv(snapshot);
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  };
+}
+
+async function importFresh(relativePath) {
+  return import(`${relativePath}?case=${Date.now()}-${Math.random()}`);
+}
+
+function buildRequest(url, options = {}) {
+  return new NextRequest(url, options);
+}
+
+function extractScriptNonce(html) {
+  const match = html.match(/<script\s+nonce="([^"]+)"/);
+  return match ? match[1] : null;
+}
+
+function extractCspScriptNonce(csp) {
+  const match = String(csp || "").match(/script-src 'nonce-([^']+)'/);
+  return match ? match[1] : null;
+}
+
+test("homepage GET omits the RUM script tag and keeps script-src 'none' when RUM is disabled", async () => {
+  const env = withRumEnvironment({ rumEnabled: false });
+
+  try {
+    getDb(env.dbPath);
+    const { GET } = await importFresh("../app/route.js");
+    const request = buildRequest("https://portal.example.com/");
+
+    const response = await GET(request);
+    const html = await response.text();
+    const csp = response.headers.get("content-security-policy") || "";
+
+    assert.equal(response.status, 200);
+    assert.match(csp, /script-src 'none'/);
+    assert.doesNotMatch(csp, /script-src 'nonce-/);
+    assert.doesNotMatch(html, /<script\b/);
+    assert.match(response.headers.get("cache-control") || "", /\bpublic\b/i);
+  } finally {
+    env.cleanup();
+  }
+});
+
+test("homepage GET injects a nonced inline RUM script and matching CSP when RUM is enabled", async () => {
+  const env = withRumEnvironment({ rumEnabled: true });
+
+  try {
+    getDb(env.dbPath);
+    const { GET } = await importFresh("../app/route.js");
+    const request = buildRequest("https://portal.example.com/");
+
+    const response = await GET(request);
+    const html = await response.text();
+    const csp = response.headers.get("content-security-policy") || "";
+    const cacheControl = response.headers.get("cache-control") || "";
+    const htmlNonce = extractScriptNonce(html);
+    const cspNonce = extractCspScriptNonce(csp);
+
+    assert.equal(response.status, 200);
+    assert.match(cacheControl, /no-store/);
+    assert.ok(htmlNonce, "expected an inline <script nonce=\"...\"> tag");
+    assert.ok(cspNonce, "expected CSP to carry script-src 'nonce-...'");
+    assert.equal(htmlNonce, cspNonce);
+    assert.doesNotMatch(csp, /script-src 'none'/);
+    assert.match(html, /event_type:\s*sample\.event_type/);
+    assert.match(html, /"landing_rendered"/);
+    assert.match(html, /ROUTE\s*=\s*"\/"/);
+    assert.match(html, /VIEW\s*=\s*"landing"/);
+    assert.match(html, /"\/v1\/portal\/rum"/);
+  } finally {
+    env.cleanup();
+  }
+});
+
+test("login GET injects a nonced inline RUM script with /login + login view when RUM is enabled", async () => {
+  const env = withRumEnvironment({ rumEnabled: true });
+
+  try {
+    getDb(env.dbPath);
+    const { GET } = await importFresh("../app/login/route.js");
+    const request = buildRequest("https://portal.example.com/login");
+
+    const response = await GET(request);
+    const html = await response.text();
+    const csp = response.headers.get("content-security-policy") || "";
+    const htmlNonce = extractScriptNonce(html);
+    const cspNonce = extractCspScriptNonce(csp);
+
+    assert.equal(response.status, 200);
+    assert.ok(htmlNonce, "expected an inline <script nonce=\"...\"> tag");
+    assert.ok(cspNonce, "expected CSP to carry script-src 'nonce-...'");
+    assert.equal(htmlNonce, cspNonce);
+    assert.doesNotMatch(csp, /script-src 'none'/);
+    assert.match(html, /"login_rendered"/);
+    assert.match(html, /ROUTE\s*=\s*"\/login"/);
+    assert.match(html, /VIEW\s*=\s*"login"/);
+    assert.match(html, /"\/v1\/portal\/rum"/);
+  } finally {
+    env.cleanup();
+  }
+});
+
+test("renderRumClientScript embeds caller-supplied route, view, and traceparent verbatim", async () => {
+  const { renderRumClientScript } = await importFresh("../lib/rum-client.js");
+  const traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+
+  const body = renderRumClientScript({
+    route: "/",
+    view: "landing",
+    traceparent,
+  });
+
+  assert.equal(typeof body, "string");
+  assert.doesNotMatch(body, /^<script/);
+  assert.match(body, /ROUTE\s*=\s*"\/"/);
+  assert.match(body, /VIEW\s*=\s*"landing"/);
+  assert.match(body, /RENDERED_EVENT\s*=\s*"landing_rendered"/);
+  assert.match(body, new RegExp(`TRACEPARENT\\s*=\\s*"${traceparent}"`));
+  assert.match(body, /"\/v1\/portal\/rum"/);
+  assert.doesNotMatch(body, /\beval\s*\(/);
+  assert.doesNotMatch(body, /\bnew\s+Function\b/);
+});
+
+test("homepage GET mints a fresh nonce on every request when RUM is enabled", async () => {
+  const env = withRumEnvironment({ rumEnabled: true });
+
+  try {
+    getDb(env.dbPath);
+    const { GET } = await importFresh("../app/route.js");
+
+    const firstResponse = await GET(buildRequest("https://portal.example.com/"));
+    const firstNonce = extractCspScriptNonce(firstResponse.headers.get("content-security-policy") || "");
+    const secondResponse = await GET(buildRequest("https://portal.example.com/"));
+    const secondNonce = extractCspScriptNonce(secondResponse.headers.get("content-security-policy") || "");
+
+    assert.ok(firstNonce);
+    assert.ok(secondNonce);
+    assert.notEqual(firstNonce, secondNonce);
+  } finally {
+    env.cleanup();
+  }
+});


### PR DESCRIPTION
Wire Core Web Vitals (LCP/CLS/INP), first_view_interactive, and a new
landing_rendered/login_rendered milestone into the front door's `/` and
`/login` routes via an inline server-rendered RUM client. Samples POST
to the existing `/v1/portal/rum` endpoint with the same Pydantic
envelope shape that the portal bundle uses, gated behind the existing
`TP_PORTAL_RUM_ENABLED` + `TP_PORTAL_RUM_ROLLOUT_PERCENT` env vars.

Backend extensions are additive allowlist entries on
`PORTAL_ALLOWED_RUM_ROUTES`, `PORTAL_ALLOWED_RUM_EVENT_TYPES`,
`PORTAL_ALLOWED_RUM_VIEWS`, and `PORTAL_ALLOWED_RUM_METRICS`. The
validator and the route handler are unchanged.

Front-door changes preserve the strict-by-default CSP. When RUM is
gated off the response keeps `script-src 'none'` and the existing
public/max-age cache hint. When RUM is enabled, `applySecurityHeaders`
splices a per-request `script-src 'nonce-...'` directive that matches a
fresh nonce on the inline `<script>` tag, and Cache-Control flips to
`no-store` so per-user nonces cannot leak through shared caches.

Tests cover the allowlist shape, four HTTP-level acceptance paths
(landing_rendered, login_rendered, core_web_vital from `/`,
core_web_vital from `/login`), and the front-door lifecycle: RUM-off
keeps `script-src 'none'`, RUM-on injects matching nonce on both
routes, the direct-invocation script body embeds caller-supplied
route/view/traceparent, and consecutive requests mint distinct nonces.