### PR TITLE
fix(frontdoor): refresh fast-uri security lock

### DIFF
--- a/web/secure-landing/package-lock.json
+++ b/web/secure-landing/package-lock.json
@@ -1909,9 +1909,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary
- Dependabot alert #177 flags fast-uri <=3.1.0 in web/secure-landing/package-lock.json via the frontdoor stylelint toolchain.
- Refresh only the transitive lock entry to fast-uri 3.1.2, above the patched 3.1.1 floor.

## Changes
- Updates web/secure-landing/package-lock.json for node_modules/fast-uri from 3.1.0 to 3.1.2.
- Leaves package.json, runtime dependencies, routes, selectors, env, and app code unchanged.

## Validation
Proven green:
- npm ls fast-uri
- npm audit --audit-level=high
- npm run lint:css
- make test-frontdoor-contract
- git diff --check

Still failing:
- None observed locally.

## Risk
- Low. This is a dev-tool transitive lock refresh only, with no frontdoor runtime contract changes.
- Revert-safe by reverting the lockfile entry.
- Dependabot alert closure depends on GitHub dependency graph reprocessing after merge.