### PR TITLE
feat(depth): add depth-aware DOF CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "transformation-portal"
-version = "0.1.0"
+version = "0.2.0"
 description = "Professional image and video processing toolkit for luxury real estate rendering and architectural visualization."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,6 +153,9 @@ transform-analyze = "transformation_portal.cli:analyze_cli"
 # Lux Depth V3 Pipeline CLI (APEX command variants)
 lux-depth-v3 = "transformation_portal.lux_depth_v3.__main__:app"
 
+# Depth-aware post-processing CLI
+depth-aware-dof = "transformation_portal.depth.depth_aware_dof:main"
+
 # Luxury TIFF Batch Processor CLI
 luxury-tiff-batch = "luxury_tiff_batch_processor.cli:main"
 

--- a/src/transformation_portal/depth/__init__.py
+++ b/src/transformation_portal/depth/__init__.py
@@ -12,12 +12,22 @@ from typing import Any, Dict, Tuple
 __version__ = "1.0.0"
 __author__ = "Transformation Portal"
 
-__all__ = ["ArchitecturalDepthPipeline", "DepthAnythingV2Model", "DepthCache"]
+__all__ = [
+    "ArchitecturalDepthPipeline",
+    "DepthAnythingV2Model",
+    "DepthCache",
+    "DepthAwareDofOptions",
+    "DepthAwareDofResult",
+    "run_depth_aware_dof",
+]
 
 _LAZY_EXPORTS: Dict[str, Tuple[str, str]] = {
     "ArchitecturalDepthPipeline": (".pipeline", "ArchitecturalDepthPipeline"),
     "DepthAnythingV2Model": (".models.depth_anything_v2", "DepthAnythingV2Model"),
     "DepthCache": (".utils.cache", "DepthCache"),
+    "DepthAwareDofOptions": (".depth_aware_dof", "DepthAwareDofOptions"),
+    "DepthAwareDofResult": (".depth_aware_dof", "DepthAwareDofResult"),
+    "run_depth_aware_dof": (".depth_aware_dof", "run_depth_aware_dof"),
 }
 
 

--- a/src/transformation_portal/depth/depth_aware_dof.py
+++ b/src/transformation_portal/depth/depth_aware_dof.py
@@ -18,6 +18,8 @@ from typing import Any, Iterable, Literal, Mapping, Optional
 import numpy as np
 from PIL import Image, ImageDraw
 
+from transformation_portal.ingest.canonical_json import dumps_json
+
 from .tools import gaussian_blur_float
 
 try:
@@ -123,8 +125,8 @@ def run_depth_aware_dof(options: DepthAwareDofOptions) -> DepthAwareDofResult:
 
     opts.out_dir.mkdir(parents=True, exist_ok=True)
     stem = opts.source.stem
-    production_tiff = opts.out_dir / f"{stem}_depth_aware_DOF_16bit.tiff"
-    preview_jpeg = opts.out_dir / f"{stem}_depth_aware_DOF_preview_2400px.jpg"
+    production_tiff = opts.out_dir / f"{stem}_depth_aware_DOF_{source.bit_depth}bit.tiff"
+    preview_jpeg = opts.out_dir / f"{stem}_depth_aware_DOF_preview_{opts.preview_long_edge}px.jpg"
     diagnostic_contact_sheet = opts.out_dir / f"{stem}_depth_dof_diagnostic_contact_sheet.jpg"
     summary_json = opts.out_dir / f"{stem}_depth_dof_summary.json"
     package_zip = opts.out_dir / f"{stem}_depth_dof_package.zip"
@@ -161,7 +163,7 @@ def run_depth_aware_dof(options: DepthAwareDofOptions) -> DepthAwareDofResult:
         },
         artifact_hashes=artifact_hashes,
     )
-    summary_json.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    summary_json.write_text(dumps_json(summary, indent=2, sort_keys=True, allow_nan=False) + "\n", encoding="utf-8")
 
     _write_package_zip(
         package_zip,
@@ -247,7 +249,7 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
         return 2
 
     print(
-        json.dumps(
+        dumps_json(
             {
                 "production_tiff": str(result.production_tiff),
                 "preview_jpeg": str(result.preview_jpeg),
@@ -258,6 +260,7 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
                 "depth_convention": result.depth_convention,
             },
             sort_keys=True,
+            allow_nan=False,
         )
     )
     return 0
@@ -272,9 +275,17 @@ def _normalize_options(options: DepthAwareDofOptions) -> DepthAwareDofOptions:
             raise FileNotFoundError(f"{field_name.replace('_', ' ')} not found: {path}")
         if not path.is_file():
             raise ValueError(f"{field_name.replace('_', ' ')} is not a file: {path}")
-    for path in (options.metadata, options.protect_mask, options.sky_mask, options.edge_mask):
+    optional_inputs = (
+        ("metadata", options.metadata),
+        ("protect mask", options.protect_mask),
+        ("sky mask", options.sky_mask),
+        ("edge mask", options.edge_mask),
+    )
+    for field_name, path in optional_inputs:
         if path is not None and not path.exists():
-            raise FileNotFoundError(f"Optional input not found: {path}")
+            raise FileNotFoundError(f"{field_name} not found: {path}")
+        if path is not None and not path.is_file():
+            raise ValueError(f"{field_name} is not a file: {path}")
     if options.focus_depth is not None and not np.isfinite(options.focus_depth):
         raise ValueError("focus_depth must be finite")
     if options.depth_convention is not None and options.depth_convention not in _VALID_CONVENTIONS:
@@ -379,6 +390,8 @@ def _load_depth_npy(depth_path: Path) -> np.ndarray:
     depth = np.load(depth_path, allow_pickle=False)
     if depth.ndim != 2:
         raise ValueError(f"Depth .npy must be a 2D array, got shape {depth.shape}")
+    if depth.shape[0] <= 0 or depth.shape[1] <= 0:
+        raise ValueError(f"Depth .npy must be non-empty with positive height and width, got shape {depth.shape}")
     if not np.issubdtype(depth.dtype, np.floating):
         raise ValueError(f"Depth .npy must use a floating dtype, got {depth.dtype}")
     depth32 = np.asarray(depth, dtype=np.float32)
@@ -651,14 +664,15 @@ def _build_summary(
             "focus_protection": float(options.focus_protection),
             "preview_long_edge": int(options.preview_long_edge),
         },
-        "outputs": {
-            key: {
-                "path": str(path),
-                "sha256": artifact_hashes.get(key),
-            }
-            for key, path in artifacts.items()
-        },
+        "outputs": {key: _artifact_summary(path, artifact_hashes.get(key)) for key, path in artifacts.items()},
     }
+
+
+def _artifact_summary(path: Path, sha256: Optional[str]) -> dict[str, str]:
+    payload = {"path": str(path)}
+    if sha256 is not None:
+        payload["sha256"] = sha256
+    return payload
 
 
 def _write_package_zip(package_zip: Path, members: Mapping[str, Path]) -> None:

--- a/src/transformation_portal/depth/depth_aware_dof.py
+++ b/src/transformation_portal/depth/depth_aware_dof.py
@@ -1,0 +1,679 @@
+"""Depth-aware architectural DOF post-processing.
+
+This module is intentionally separate from the legacy ``depth_tools`` batch
+helpers because this workflow must preserve float depth and 16-bit TIFF data.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Literal, Mapping, Optional
+
+import numpy as np
+from PIL import Image, ImageDraw
+
+from .tools import gaussian_blur_float
+
+try:
+    import tifffile
+
+    _TIFFFILE_AVAILABLE = True
+except ImportError:  # pragma: no cover - exercised only in stripped envs
+    tifffile = None  # type: ignore[assignment]
+    _TIFFFILE_AVAILABLE = False
+
+DepthConvention = Literal["higher-is-farther", "lower-is-farther"]
+
+_LOG = logging.getLogger(__name__)
+_VALID_CONVENTIONS: set[DepthConvention] = {"higher-is-farther", "lower-is-farther"}
+_TIFF_EXTENSIONS = {".tif", ".tiff"}
+_HAZE_COLOR = np.array([0.94, 0.96, 0.99], dtype=np.float32)
+
+
+@dataclass(frozen=True)
+class DepthAwareDofOptions:
+    """Options for one depth-aware DOF render."""
+
+    source: Path
+    depth_npy: Path
+    out_dir: Path
+    metadata: Optional[Path] = None
+    protect_mask: Optional[Path] = None
+    sky_mask: Optional[Path] = None
+    edge_mask: Optional[Path] = None
+    focus_depth: Optional[float] = None
+    focus_roi: Optional[tuple[int, int, int, int]] = None
+    depth_convention: Optional[DepthConvention] = None
+    preview_long_edge: int = 2400
+    near_strength: float = 0.34
+    far_strength: float = 0.24
+    haze_strength: float = 0.08
+    edge_protection: float = 0.70
+    focus_protection: float = 0.88
+
+
+@dataclass(frozen=True)
+class DepthAwareDofResult:
+    """Artifact paths and selected parameters from one DOF render."""
+
+    production_tiff: Path
+    preview_jpeg: Path
+    diagnostic_contact_sheet: Path
+    summary_json: Path
+    package_zip: Path
+    focus_depth: float
+    depth_convention: DepthConvention
+    artifact_hashes: Mapping[str, str]
+
+
+@dataclass(frozen=True)
+class _SourceImage:
+    path: Path
+    rgb01: np.ndarray
+    bit_depth: int
+    dtype: str
+
+
+@dataclass(frozen=True)
+class _DofIntermediates:
+    focus_matte: np.ndarray
+    near_matte: np.ndarray
+    far_matte: np.ndarray
+    edge_matte: np.ndarray
+    protection_matte: np.ndarray
+    blur_matte: np.ndarray
+
+
+def run_depth_aware_dof(options: DepthAwareDofOptions) -> DepthAwareDofResult:
+    """Run a single-image float-depth DOF composite."""
+
+    opts = _normalize_options(options)
+    metadata = _load_metadata(opts.metadata)
+    convention = _resolve_depth_convention(metadata, opts.depth_convention)
+    source = _load_source_image(opts.source)
+    depth = _load_depth_npy(opts.depth_npy)
+    height, width = source.rgb01.shape[:2]
+    if depth.shape != (height, width):
+        raise ValueError(
+            "Depth/source dimension mismatch: "
+            f"depth={depth.shape}, source={(height, width)} for {opts.depth_npy} and {opts.source}"
+        )
+
+    focus_depth = _select_focus_depth(depth, opts.focus_depth, opts.focus_roi)
+    sky_mask = _load_optional_mask(opts.sky_mask, (height, width))
+    explicit_edge_mask = _load_optional_mask(opts.edge_mask, (height, width))
+    explicit_protect_mask = _load_optional_mask(opts.protect_mask, (height, width))
+
+    composite, intermediates = _composite_depth_dof(
+        source.rgb01,
+        depth,
+        convention=convention,
+        focus_depth=focus_depth,
+        sky_mask=sky_mask,
+        edge_mask=explicit_edge_mask,
+        protect_mask=explicit_protect_mask,
+        options=opts,
+    )
+
+    opts.out_dir.mkdir(parents=True, exist_ok=True)
+    stem = opts.source.stem
+    production_tiff = opts.out_dir / f"{stem}_depth_aware_DOF_16bit.tiff"
+    preview_jpeg = opts.out_dir / f"{stem}_depth_aware_DOF_preview_2400px.jpg"
+    diagnostic_contact_sheet = opts.out_dir / f"{stem}_depth_dof_diagnostic_contact_sheet.jpg"
+    summary_json = opts.out_dir / f"{stem}_depth_dof_summary.json"
+    package_zip = opts.out_dir / f"{stem}_depth_dof_package.zip"
+
+    _save_tiff_preserve_depth(production_tiff, composite, bit_depth=source.bit_depth)
+    _save_preview(preview_jpeg, composite, long_edge=opts.preview_long_edge)
+    _save_contact_sheet(
+        diagnostic_contact_sheet,
+        source.rgb01,
+        depth,
+        intermediates,
+        focus_depth=focus_depth,
+        convention=convention,
+    )
+
+    artifact_hashes = {
+        "production_tiff": _sha256_file(production_tiff),
+        "preview_jpeg": _sha256_file(preview_jpeg),
+        "diagnostic_contact_sheet": _sha256_file(diagnostic_contact_sheet),
+    }
+    summary = _build_summary(
+        opts,
+        source,
+        depth,
+        metadata=metadata,
+        convention=convention,
+        focus_depth=focus_depth,
+        artifacts={
+            "production_tiff": production_tiff,
+            "preview_jpeg": preview_jpeg,
+            "diagnostic_contact_sheet": diagnostic_contact_sheet,
+            "summary_json": summary_json,
+            "package_zip": package_zip,
+        },
+        artifact_hashes=artifact_hashes,
+    )
+    summary_json.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    _write_package_zip(
+        package_zip,
+        {
+            production_tiff.name: production_tiff,
+            preview_jpeg.name: preview_jpeg,
+            diagnostic_contact_sheet.name: diagnostic_contact_sheet,
+            summary_json.name: summary_json,
+        },
+    )
+
+    artifact_hashes = {
+        **artifact_hashes,
+        "summary_json": _sha256_file(summary_json),
+        "package_zip": _sha256_file(package_zip),
+    }
+    return DepthAwareDofResult(
+        production_tiff=production_tiff,
+        preview_jpeg=preview_jpeg,
+        diagnostic_contact_sheet=diagnostic_contact_sheet,
+        summary_json=summary_json,
+        package_zip=package_zip,
+        focus_depth=focus_depth,
+        depth_convention=convention,
+        artifact_hashes=artifact_hashes,
+    )
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="depth-aware-dof",
+        description="Single-image depth-aware DOF using float .npy depth and 16-bit TIFF preservation.",
+    )
+    parser.add_argument("--source", required=True, type=Path, help="Source RGB image, preferably 16-bit TIFF.")
+    parser.add_argument("--depth-npy", required=True, type=Path, help="Float32 depth .npy aligned to the source image.")
+    parser.add_argument(
+        "--out-dir", required=True, type=Path, help="Output directory for TIFF, preview, diagnostics, JSON, ZIP."
+    )
+    parser.add_argument("--metadata", type=Path, default=None, help="Optional depth metadata JSON.")
+    parser.add_argument("--protect-mask", type=Path, default=None, help="Optional grayscale architecture protection mask.")
+    parser.add_argument("--sky-mask", type=Path, default=None, help="Optional grayscale sky/horizon mask.")
+    parser.add_argument("--edge-mask", type=Path, default=None, help="Optional grayscale edge protection mask.")
+    parser.add_argument("--focus-depth", type=float, default=None, help="Explicit focus depth in source depth units.")
+    parser.add_argument(
+        "--focus-roi",
+        type=int,
+        nargs=4,
+        metavar=("X", "Y", "W", "H"),
+        default=None,
+        help="Focus ROI used to select median focus depth when --focus-depth is omitted.",
+    )
+    parser.add_argument(
+        "--depth-convention",
+        choices=sorted(_VALID_CONVENTIONS),
+        default=None,
+        help="Required when metadata does not provide stats.convention.",
+    )
+    parser.add_argument("--preview-long-edge", type=int, default=2400)
+    parser.add_argument("--verbose", action="store_true")
+    return parser
+
+
+def main(argv: Optional[Iterable[str]] = None) -> int:
+    args = build_arg_parser().parse_args(list(argv) if argv is not None else None)
+    logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO, format="%(levelname)s: %(message)s")
+    options = DepthAwareDofOptions(
+        source=args.source,
+        depth_npy=args.depth_npy,
+        out_dir=args.out_dir,
+        metadata=args.metadata,
+        protect_mask=args.protect_mask,
+        sky_mask=args.sky_mask,
+        edge_mask=args.edge_mask,
+        focus_depth=args.focus_depth,
+        focus_roi=tuple(args.focus_roi) if args.focus_roi is not None else None,
+        depth_convention=args.depth_convention,
+        preview_long_edge=args.preview_long_edge,
+    )
+    try:
+        result = run_depth_aware_dof(options)
+    except Exception as exc:  # pragma: no cover - shell behavior
+        _LOG.error("depth-aware DOF failed: %s", exc)
+        return 2
+
+    print(
+        json.dumps(
+            {
+                "production_tiff": str(result.production_tiff),
+                "preview_jpeg": str(result.preview_jpeg),
+                "diagnostic_contact_sheet": str(result.diagnostic_contact_sheet),
+                "summary_json": str(result.summary_json),
+                "package_zip": str(result.package_zip),
+                "focus_depth": result.focus_depth,
+                "depth_convention": result.depth_convention,
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+def _normalize_options(options: DepthAwareDofOptions) -> DepthAwareDofOptions:
+    if options.preview_long_edge <= 0:
+        raise ValueError("preview_long_edge must be positive")
+    for field_name in ("source", "depth_npy"):
+        path = getattr(options, field_name)
+        if not path.exists():
+            raise FileNotFoundError(f"{field_name.replace('_', ' ')} not found: {path}")
+        if not path.is_file():
+            raise ValueError(f"{field_name.replace('_', ' ')} is not a file: {path}")
+    for path in (options.metadata, options.protect_mask, options.sky_mask, options.edge_mask):
+        if path is not None and not path.exists():
+            raise FileNotFoundError(f"Optional input not found: {path}")
+    if options.focus_depth is not None and not np.isfinite(options.focus_depth):
+        raise ValueError("focus_depth must be finite")
+    if options.depth_convention is not None and options.depth_convention not in _VALID_CONVENTIONS:
+        raise ValueError(f"Unsupported depth convention: {options.depth_convention!r}")
+    return DepthAwareDofOptions(
+        source=Path(options.source),
+        depth_npy=Path(options.depth_npy),
+        out_dir=Path(options.out_dir),
+        metadata=Path(options.metadata) if options.metadata is not None else None,
+        protect_mask=Path(options.protect_mask) if options.protect_mask is not None else None,
+        sky_mask=Path(options.sky_mask) if options.sky_mask is not None else None,
+        edge_mask=Path(options.edge_mask) if options.edge_mask is not None else None,
+        focus_depth=options.focus_depth,
+        focus_roi=options.focus_roi,
+        depth_convention=options.depth_convention,
+        preview_long_edge=options.preview_long_edge,
+        near_strength=float(options.near_strength),
+        far_strength=float(options.far_strength),
+        haze_strength=float(options.haze_strength),
+        edge_protection=float(options.edge_protection),
+        focus_protection=float(options.focus_protection),
+    )
+
+
+def _load_metadata(metadata_path: Optional[Path]) -> dict[str, Any]:
+    if metadata_path is None:
+        return {}
+    with metadata_path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, dict):
+        raise ValueError(f"Metadata JSON must be an object: {metadata_path}")
+    return payload
+
+
+def _resolve_depth_convention(metadata: Mapping[str, Any], explicit: Optional[str]) -> DepthConvention:
+    if explicit is not None:
+        return _normalize_depth_convention(explicit)
+    raw = None
+    stats = metadata.get("stats")
+    if isinstance(stats, Mapping):
+        raw = stats.get("convention")
+    if raw is None:
+        raw = metadata.get("convention")
+    if raw is None:
+        raise ValueError("Depth convention is required when metadata does not provide stats.convention")
+    return _normalize_depth_convention(str(raw))
+
+
+def _normalize_depth_convention(value: str) -> DepthConvention:
+    normalized = value.strip().lower().replace("_", "-")
+    aliases = {
+        "higher-is-farther": "higher-is-farther",
+        "higher-farther": "higher-is-farther",
+        "farther-is-higher": "higher-is-farther",
+        "lower-is-farther": "lower-is-farther",
+        "lower-farther": "lower-is-farther",
+        "farther-is-lower": "lower-is-farther",
+    }
+    resolved = aliases.get(normalized)
+    if resolved is None:
+        raise ValueError(f"Unsupported depth convention: {value!r}")
+    return resolved  # type: ignore[return-value]
+
+
+def _load_source_image(source_path: Path) -> _SourceImage:
+    suffix = source_path.suffix.lower()
+    if suffix in _TIFF_EXTENSIONS:
+        if not _TIFFFILE_AVAILABLE:
+            raise ImportError("tifffile is required to preserve TIFF bit depth")
+        arr = np.asarray(tifffile.imread(source_path))
+    else:
+        arr = np.asarray(Image.open(source_path).convert("RGB"))
+
+    if arr.ndim == 2:
+        arr = np.stack([arr, arr, arr], axis=-1)
+    elif arr.ndim == 3 and arr.shape[2] >= 3:
+        arr = arr[..., :3]
+    else:
+        raise ValueError(f"Unsupported source image shape: {arr.shape}")
+
+    bit_depth: int
+    if np.issubdtype(arr.dtype, np.uint16):
+        bit_depth = 16
+        rgb01 = arr.astype(np.float32) / 65535.0
+    elif np.issubdtype(arr.dtype, np.uint8):
+        bit_depth = 8
+        rgb01 = arr.astype(np.float32) / 255.0
+    elif np.issubdtype(arr.dtype, np.floating):
+        bit_depth = 32
+        rgb01 = np.asarray(arr, dtype=np.float32)
+        if float(np.nanmax(rgb01)) > 1.0:
+            rgb01 = rgb01 / max(float(np.nanmax(rgb01)), 1.0)
+    else:
+        raise ValueError(f"Unsupported source image dtype: {arr.dtype}")
+
+    if not np.isfinite(rgb01).all():
+        raise ValueError(f"Source image contains non-finite values: {source_path}")
+    return _SourceImage(path=source_path, rgb01=np.clip(rgb01, 0.0, 1.0), bit_depth=bit_depth, dtype=str(arr.dtype))
+
+
+def _load_depth_npy(depth_path: Path) -> np.ndarray:
+    depth = np.load(depth_path, allow_pickle=False)
+    if depth.ndim != 2:
+        raise ValueError(f"Depth .npy must be a 2D array, got shape {depth.shape}")
+    if not np.issubdtype(depth.dtype, np.floating):
+        raise ValueError(f"Depth .npy must use a floating dtype, got {depth.dtype}")
+    depth32 = np.asarray(depth, dtype=np.float32)
+    if not np.isfinite(depth32).all():
+        raise ValueError(f"Depth .npy contains non-finite values: {depth_path}")
+    return depth32
+
+
+def _load_optional_mask(mask_path: Optional[Path], target_shape: tuple[int, int]) -> np.ndarray:
+    if mask_path is None:
+        return np.zeros(target_shape, dtype=np.float32)
+    with Image.open(mask_path) as mask_image:
+        raw = np.asarray(mask_image)
+    raw_dtype = raw.dtype
+    arr = raw
+    if arr.ndim == 3:
+        if arr.shape[2] == 4:
+            arr = arr[..., 3]
+        else:
+            arr = arr[..., :3].mean(axis=2)
+    arr = arr.astype(np.float32)
+    max_value = float(np.nanmax(arr)) if arr.size else 0.0
+    if max_value > 1.0:
+        if np.issubdtype(raw_dtype, np.integer):
+            dtype_info = np.iinfo(raw_dtype)
+            arr = arr / float(dtype_info.max)
+        else:
+            arr = arr / max_value
+    arr = np.clip(np.nan_to_num(arr, nan=0.0, posinf=1.0, neginf=0.0), 0.0, 1.0)
+    if arr.shape != target_shape:
+        arr = _resize_mask(arr, target_shape)
+    return arr.astype(np.float32, copy=False)
+
+
+def _resize_mask(mask: np.ndarray, target_shape: tuple[int, int]) -> np.ndarray:
+    height, width = target_shape
+    resized = Image.fromarray(mask.astype(np.float32), mode="F").resize((width, height), Image.Resampling.BILINEAR)
+    return np.asarray(resized, dtype=np.float32)
+
+
+def _select_focus_depth(depth: np.ndarray, explicit: Optional[float], roi: Optional[tuple[int, int, int, int]]) -> float:
+    if explicit is not None:
+        return float(explicit)
+    height, width = depth.shape
+    if roi is None:
+        roi_width = max(1, int(width * 0.38))
+        roi_height = max(1, int(height * 0.38))
+        x0 = (width - roi_width) // 2
+        y0 = (height - roi_height) // 2
+        roi = (x0, y0, roi_width, roi_height)
+    x, y, w, h = roi
+    if w <= 0 or h <= 0:
+        raise ValueError(f"focus_roi width/height must be positive: {roi}")
+    x0 = max(0, min(width, int(x)))
+    y0 = max(0, min(height, int(y)))
+    x1 = max(0, min(width, x0 + int(w)))
+    y1 = max(0, min(height, y0 + int(h)))
+    if x1 <= x0 or y1 <= y0:
+        raise ValueError(f"focus_roi does not intersect the image: {roi}")
+    return float(np.median(depth[y0:y1, x0:x1]))
+
+
+def _composite_depth_dof(
+    img: np.ndarray,
+    depth: np.ndarray,
+    *,
+    convention: DepthConvention,
+    focus_depth: float,
+    sky_mask: np.ndarray,
+    edge_mask: np.ndarray,
+    protect_mask: np.ndarray,
+    options: DepthAwareDofOptions,
+) -> tuple[np.ndarray, _DofIntermediates]:
+    oriented_depth = depth if convention == "higher-is-farther" else -depth
+    oriented_focus = focus_depth if convention == "higher-is-farther" else -focus_depth
+    p01, p99 = np.percentile(oriented_depth, [1.0, 99.0])
+    depth_span = max(float(p99 - p01), 1e-6)
+    near_span = max(float(oriented_focus - p01), depth_span * 0.12, 1e-6)
+    far_span = max(float(p99 - oriented_focus), depth_span * 0.12, 1e-6)
+    focus_band = max(depth_span * 0.13, 1e-6)
+
+    near_matte = _smoothstep(np.maximum(oriented_focus - oriented_depth, 0.0) / near_span)
+    far_matte = _smoothstep(np.maximum(oriented_depth - oriented_focus, 0.0) / far_span)
+    focus_matte = 1.0 - _smoothstep(np.abs(oriented_depth - oriented_focus) / focus_band)
+
+    generated_edge = _generate_edge_matte(img) if not np.any(edge_mask) else edge_mask
+    base_protection = np.maximum(protect_mask, focus_matte * options.focus_protection)
+    edge_protection = np.clip(generated_edge * options.edge_protection, 0.0, 1.0)
+    protection_matte = np.clip(np.maximum(base_protection, edge_protection), 0.0, 1.0)
+
+    raw_blur_matte = np.maximum(near_matte * options.near_strength, far_matte * options.far_strength)
+    raw_blur_matte *= 1.0 - protection_matte
+    blur_matte = np.clip(gaussian_blur_float(raw_blur_matte.astype(np.float32), sigma=1.2), 0.0, 1.0)
+
+    blur_small = gaussian_blur_float(img, sigma=1.2)
+    blur_medium = gaussian_blur_float(img, sigma=3.2)
+    blur_large = gaussian_blur_float(img, sigma=6.5)
+    far_selector = far_matte[..., None]
+    near_selector = near_matte[..., None]
+    blur_layer = (
+        blur_small * (1.0 - np.maximum(far_selector, near_selector) * 0.35)
+        + blur_medium * np.maximum(far_selector, near_selector) * 0.35
+    )
+    blur_layer = blur_layer * (1.0 - far_selector * 0.28) + blur_large * (far_selector * 0.28)
+
+    matte3 = blur_matte[..., None]
+    out = img * (1.0 - matte3) + blur_layer * matte3
+
+    haze_matte = np.clip(far_matte * (1.0 - protection_matte) + sky_mask * 0.18, 0.0, 1.0)[..., None]
+    haze_weight = haze_matte * float(options.haze_strength)
+    hazed = out * (1.0 - haze_weight) + _HAZE_COLOR[None, None, :] * haze_weight
+    decontrasted = 0.5 + (hazed - 0.5) * (1.0 - haze_matte * 0.055)
+    out = hazed * (1.0 - haze_matte * 0.45) + decontrasted * (haze_matte * 0.45)
+    out = np.clip(out, 0.0, 1.0).astype(np.float32, copy=False)
+
+    return out, _DofIntermediates(
+        focus_matte=focus_matte.astype(np.float32),
+        near_matte=near_matte.astype(np.float32),
+        far_matte=far_matte.astype(np.float32),
+        edge_matte=generated_edge.astype(np.float32),
+        protection_matte=protection_matte.astype(np.float32),
+        blur_matte=blur_matte.astype(np.float32),
+    )
+
+
+def _generate_edge_matte(img: np.ndarray) -> np.ndarray:
+    luminance = img[..., 0] * 0.2126 + img[..., 1] * 0.7152 + img[..., 2] * 0.0722
+    gy, gx = np.gradient(luminance.astype(np.float32))
+    magnitude = np.sqrt(gx * gx + gy * gy)
+    p95 = float(np.percentile(magnitude, 95.0))
+    if p95 <= 1e-8:
+        return np.zeros(luminance.shape, dtype=np.float32)
+    edge = _smoothstep(magnitude / p95)
+    return np.clip(gaussian_blur_float(edge.astype(np.float32), sigma=0.9), 0.0, 1.0)
+
+
+def _smoothstep(values: np.ndarray) -> np.ndarray:
+    x = np.clip(values.astype(np.float32), 0.0, 1.0)
+    return x * x * (3.0 - 2.0 * x)
+
+
+def _save_tiff_preserve_depth(path: Path, rgb01: np.ndarray, *, bit_depth: int) -> None:
+    if not _TIFFFILE_AVAILABLE:
+        raise ImportError("tifffile is required to write production TIFF output")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if bit_depth == 16:
+        payload = np.rint(np.clip(rgb01, 0.0, 1.0) * 65535.0).astype(np.uint16)
+    elif bit_depth == 32:
+        payload = np.clip(rgb01, 0.0, 1.0).astype(np.float32)
+    else:
+        payload = np.rint(np.clip(rgb01, 0.0, 1.0) * 255.0).astype(np.uint8)
+    tifffile.imwrite(path, payload, photometric="rgb", compression="deflate")
+
+
+def _save_preview(path: Path, rgb01: np.ndarray, *, long_edge: int) -> None:
+    image = _rgb01_to_pil(rgb01)
+    width, height = image.size
+    max_edge = max(width, height)
+    if max_edge > long_edge:
+        scale = long_edge / float(max_edge)
+        image = image.resize((max(1, int(width * scale)), max(1, int(height * scale))), Image.Resampling.LANCZOS)
+    image.save(path, quality=94, optimize=True)
+
+
+def _save_contact_sheet(
+    path: Path,
+    source: np.ndarray,
+    depth: np.ndarray,
+    intermediates: _DofIntermediates,
+    *,
+    focus_depth: float,
+    convention: DepthConvention,
+) -> None:
+    panels = [
+        ("source", _rgb01_to_pil(source)),
+        ("depth", _mask_to_pil(_normalize_for_display(depth))),
+        ("focus matte", _mask_to_pil(intermediates.focus_matte)),
+        ("near blur", _mask_to_pil(intermediates.near_matte)),
+        ("far blur", _mask_to_pil(intermediates.far_matte)),
+        ("edge protect", _mask_to_pil(intermediates.edge_matte)),
+        ("subject protect", _mask_to_pil(intermediates.protection_matte)),
+        ("final blur matte", _mask_to_pil(intermediates.blur_matte)),
+    ]
+    thumb_w = 320
+    thumb_h = 214
+    label_h = 28
+    cols = 4
+    rows = 2
+    sheet = Image.new("RGB", (cols * thumb_w, rows * (thumb_h + label_h) + 30), "white")
+    draw = ImageDraw.Draw(sheet)
+    title = f"depth-aware DOF diagnostics | focus={focus_depth:.4g} | {convention}"
+    draw.text((8, 6), title, fill=(20, 20, 20))
+    y_offset = 30
+    for index, (label, panel) in enumerate(panels):
+        col = index % cols
+        row = index // cols
+        x = col * thumb_w
+        y = y_offset + row * (thumb_h + label_h)
+        thumb = panel.resize((thumb_w, thumb_h), Image.Resampling.BILINEAR)
+        sheet.paste(thumb, (x, y))
+        draw.text((x + 8, y + thumb_h + 7), label, fill=(20, 20, 20))
+    sheet.save(path, quality=92, optimize=True)
+
+
+def _rgb01_to_pil(rgb01: np.ndarray) -> Image.Image:
+    payload = np.rint(np.clip(rgb01, 0.0, 1.0) * 255.0).astype(np.uint8)
+    return Image.fromarray(payload, mode="RGB")
+
+
+def _mask_to_pil(mask: np.ndarray) -> Image.Image:
+    payload = np.rint(np.clip(mask, 0.0, 1.0) * 255.0).astype(np.uint8)
+    return Image.fromarray(payload, mode="L").convert("RGB")
+
+
+def _normalize_for_display(values: np.ndarray) -> np.ndarray:
+    finite = values[np.isfinite(values)]
+    if finite.size == 0:
+        return np.zeros(values.shape, dtype=np.float32)
+    p01, p99 = np.percentile(finite, [1.0, 99.0])
+    if p99 <= p01:
+        return np.zeros(values.shape, dtype=np.float32)
+    return np.clip((values - p01) / (p99 - p01), 0.0, 1.0).astype(np.float32)
+
+
+def _build_summary(
+    options: DepthAwareDofOptions,
+    source: _SourceImage,
+    depth: np.ndarray,
+    *,
+    metadata: Mapping[str, Any],
+    convention: DepthConvention,
+    focus_depth: float,
+    artifacts: Mapping[str, Path],
+    artifact_hashes: Mapping[str, str],
+) -> dict[str, Any]:
+    finite = depth[np.isfinite(depth)]
+    return {
+        "schema": "tp.depth_aware_dof.v1",
+        "inputs": {
+            "source": str(options.source),
+            "depth_npy": str(options.depth_npy),
+            "metadata": str(options.metadata) if options.metadata else None,
+            "protect_mask": str(options.protect_mask) if options.protect_mask else None,
+            "sky_mask": str(options.sky_mask) if options.sky_mask else None,
+            "edge_mask": str(options.edge_mask) if options.edge_mask else None,
+        },
+        "source": {
+            "shape": list(source.rgb01.shape),
+            "dtype": source.dtype,
+            "bit_depth": source.bit_depth,
+        },
+        "depth": {
+            "shape": list(depth.shape),
+            "dtype": str(depth.dtype),
+            "convention": convention,
+            "min": float(np.min(finite)),
+            "median": float(np.median(finite)),
+            "max": float(np.max(finite)),
+            "percentile_1": float(np.percentile(finite, 1.0)),
+            "percentile_99": float(np.percentile(finite, 99.0)),
+            "metadata_model": metadata.get("model"),
+        },
+        "parameters": {
+            "focus_depth": float(focus_depth),
+            "focus_roi": list(options.focus_roi) if options.focus_roi else None,
+            "near_strength": float(options.near_strength),
+            "far_strength": float(options.far_strength),
+            "haze_strength": float(options.haze_strength),
+            "edge_protection": float(options.edge_protection),
+            "focus_protection": float(options.focus_protection),
+            "preview_long_edge": int(options.preview_long_edge),
+        },
+        "outputs": {
+            key: {
+                "path": str(path),
+                "sha256": artifact_hashes.get(key),
+            }
+            for key, path in artifacts.items()
+        },
+    }
+
+
+def _write_package_zip(package_zip: Path, members: Mapping[str, Path]) -> None:
+    with zipfile.ZipFile(package_zip, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for archive_name, path in members.items():
+            archive.write(path, arcname=archive_name)
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/transformation_portal/pipelines/depth_tools.py
+++ b/src/transformation_portal/pipelines/depth_tools.py
@@ -42,6 +42,8 @@ from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
 import numpy as np
 from PIL import Image, ImageFilter, ImageOps
 
+from ..depth.depth_aware_dof import DepthAwareDofOptions, DepthAwareDofResult, run_depth_aware_dof
+
 # ----- Optional accelerated libraries -----
 
 try:

--- a/tests/structural/console_scripts_snapshot.json
+++ b/tests/structural/console_scripts_snapshot.json
@@ -1,6 +1,7 @@
 {
-  "_version_marker": "0.1.0",
+  "_version_marker": "0.2.0",
   "scripts": {
+    "depth-aware-dof": "transformation_portal.depth.depth_aware_dof:main",
     "lux-depth-v3": "transformation_portal.lux_depth_v3.__main__:app",
     "lux_render": "transformation_portal.pipelines.lux_render_pipeline:main",
     "luxury-tiff-batch": "luxury_tiff_batch_processor.cli:main",

--- a/tests/test_depth_aware_dof.py
+++ b/tests/test_depth_aware_dof.py
@@ -60,6 +60,26 @@ def test_run_depth_aware_dof_uses_metadata_convention_and_writes_package(tmp_pat
     assert summary["depth"]["convention"] == "higher-is-farther"
     assert summary["depth"]["metadata_model"] == "depth_pro"
     assert summary["outputs"]["production_tiff"]["sha256"] == result.artifact_hashes["production_tiff"]
+    assert "sha256" not in summary["outputs"]["summary_json"]
+    assert "sha256" not in summary["outputs"]["package_zip"]
+
+
+def test_output_filenames_reflect_source_depth_and_preview_size(tmp_path):
+    source, depth_path, metadata = _write_fixture(tmp_path)
+
+    result = run_depth_aware_dof(
+        DepthAwareDofOptions(
+            source=source,
+            depth_npy=depth_path,
+            metadata=metadata,
+            out_dir=tmp_path / "out",
+            focus_depth=9.0,
+            preview_long_edge=512,
+        )
+    )
+
+    assert result.production_tiff.name == "source_depth_aware_DOF_16bit.tiff"
+    assert result.preview_jpeg.name == "source_depth_aware_DOF_preview_512px.jpg"
 
 
 def test_missing_metadata_convention_fails_closed(tmp_path):
@@ -91,6 +111,22 @@ def test_depth_npy_requires_float_and_disallows_pickle(tmp_path):
         )
 
 
+def test_empty_depth_npy_fails_closed(tmp_path):
+    source, _depth_path, metadata = _write_fixture(tmp_path)
+    empty_depth = tmp_path / "empty_depth.npy"
+    np.save(empty_depth, np.empty((0, 12), dtype=np.float32))
+
+    with pytest.raises(ValueError, match="non-empty with positive height and width"):
+        run_depth_aware_dof(
+            DepthAwareDofOptions(
+                source=source,
+                depth_npy=empty_depth,
+                metadata=metadata,
+                out_dir=tmp_path / "out",
+            )
+        )
+
+
 def test_depth_source_dimension_mismatch_fails(tmp_path):
     source, _depth_path, metadata = _write_fixture(tmp_path)
     mismatched_depth = tmp_path / "mismatched_depth.npy"
@@ -102,6 +138,23 @@ def test_depth_source_dimension_mismatch_fails(tmp_path):
                 source=source,
                 depth_npy=mismatched_depth,
                 metadata=metadata,
+                out_dir=tmp_path / "out",
+            )
+        )
+
+
+def test_optional_inputs_must_be_files(tmp_path):
+    source, depth_path, _metadata = _write_fixture(tmp_path)
+    metadata_dir = tmp_path / "metadata_dir"
+    metadata_dir.mkdir()
+
+    with pytest.raises(ValueError, match="metadata is not a file"):
+        run_depth_aware_dof(
+            DepthAwareDofOptions(
+                source=source,
+                depth_npy=depth_path,
+                metadata=metadata_dir,
+                depth_convention="higher-is-farther",
                 out_dir=tmp_path / "out",
             )
         )

--- a/tests/test_depth_aware_dof.py
+++ b/tests/test_depth_aware_dof.py
@@ -1,0 +1,185 @@
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from src.transformation_portal.depth.depth_aware_dof import DepthAwareDofOptions, main, run_depth_aware_dof
+
+tifffile = pytest.importorskip("tifffile")
+
+pytestmark = [pytest.mark.unit]
+
+
+def _write_fixture(tmp_path: Path, *, height: int = 40, width: int = 60) -> tuple[Path, Path, Path]:
+    yy, xx = np.indices((height, width))
+    checker = ((xx + yy) % 2).astype(np.float32)
+    gradient = xx.astype(np.float32) / max(width - 1, 1)
+    rgb01 = np.stack(
+        [
+            0.20 + checker * 0.45,
+            0.25 + gradient * 0.50,
+            0.30 + (1.0 - gradient) * 0.35,
+        ],
+        axis=-1,
+    )
+    source = tmp_path / "source.tiff"
+    tifffile.imwrite(source, np.rint(rgb01 * 65535.0).astype(np.uint16), photometric="rgb")
+
+    depth = np.tile(np.linspace(2.0, 30.0, width, dtype=np.float32), (height, 1))
+    depth_path = tmp_path / "source_depth.npy"
+    np.save(depth_path, depth)
+
+    metadata = tmp_path / "source_depth_metadata.json"
+    metadata.write_text(json.dumps({"model": "depth_pro", "stats": {"convention": "higher_is_farther"}}), encoding="utf-8")
+    return source, depth_path, metadata
+
+
+def test_run_depth_aware_dof_uses_metadata_convention_and_writes_package(tmp_path):
+    source, depth_path, metadata = _write_fixture(tmp_path)
+
+    result = run_depth_aware_dof(
+        DepthAwareDofOptions(
+            source=source,
+            depth_npy=depth_path,
+            metadata=metadata,
+            out_dir=tmp_path / "out",
+            focus_depth=9.0,
+        )
+    )
+
+    assert result.depth_convention == "higher-is-farther"
+    assert result.production_tiff.exists()
+    assert result.preview_jpeg.exists()
+    assert result.diagnostic_contact_sheet.exists()
+    assert result.summary_json.exists()
+    assert result.package_zip.exists()
+
+    summary = json.loads(result.summary_json.read_text(encoding="utf-8"))
+    assert summary["depth"]["convention"] == "higher-is-farther"
+    assert summary["depth"]["metadata_model"] == "depth_pro"
+    assert summary["outputs"]["production_tiff"]["sha256"] == result.artifact_hashes["production_tiff"]
+
+
+def test_missing_metadata_convention_fails_closed(tmp_path):
+    source, depth_path, _metadata = _write_fixture(tmp_path)
+
+    with pytest.raises(ValueError, match="Depth convention is required"):
+        run_depth_aware_dof(
+            DepthAwareDofOptions(
+                source=source,
+                depth_npy=depth_path,
+                out_dir=tmp_path / "out",
+            )
+        )
+
+
+def test_depth_npy_requires_float_and_disallows_pickle(tmp_path):
+    source, _depth_path, metadata = _write_fixture(tmp_path)
+    object_depth = tmp_path / "object_depth.npy"
+    np.save(object_depth, np.array([[{"not": "safe"}]], dtype=object))
+
+    with pytest.raises(ValueError, match="Object arrays|pickle"):
+        run_depth_aware_dof(
+            DepthAwareDofOptions(
+                source=source,
+                depth_npy=object_depth,
+                metadata=metadata,
+                out_dir=tmp_path / "out",
+            )
+        )
+
+
+def test_depth_source_dimension_mismatch_fails(tmp_path):
+    source, _depth_path, metadata = _write_fixture(tmp_path)
+    mismatched_depth = tmp_path / "mismatched_depth.npy"
+    np.save(mismatched_depth, np.ones((12, 12), dtype=np.float32))
+
+    with pytest.raises(ValueError, match="dimension mismatch"):
+        run_depth_aware_dof(
+            DepthAwareDofOptions(
+                source=source,
+                depth_npy=mismatched_depth,
+                metadata=metadata,
+                out_dir=tmp_path / "out",
+            )
+        )
+
+
+def test_16bit_tiff_output_preserves_uint16(tmp_path):
+    source, depth_path, metadata = _write_fixture(tmp_path)
+
+    result = run_depth_aware_dof(
+        DepthAwareDofOptions(
+            source=source,
+            depth_npy=depth_path,
+            metadata=metadata,
+            out_dir=tmp_path / "out",
+            focus_depth=9.0,
+        )
+    )
+
+    output = tifffile.imread(result.production_tiff)
+    assert output.dtype == np.uint16
+    assert output.shape == (40, 60, 3)
+
+
+def test_protection_mask_keeps_architecture_region_stable(tmp_path):
+    source, depth_path, metadata = _write_fixture(tmp_path)
+    protect_mask = tmp_path / "protect.png"
+    mask = np.zeros((40, 60), dtype=np.uint8)
+    mask[12:28, 18:38] = 255
+    Image.fromarray(mask, mode="L").save(protect_mask)
+
+    result = run_depth_aware_dof(
+        DepthAwareDofOptions(
+            source=source,
+            depth_npy=depth_path,
+            metadata=metadata,
+            protect_mask=protect_mask,
+            out_dir=tmp_path / "out",
+            focus_depth=12.0,
+        )
+    )
+
+    before = tifffile.imread(source).astype(np.float32) / 65535.0
+    after = tifffile.imread(result.production_tiff).astype(np.float32) / 65535.0
+    protected_delta = np.abs(after[12:28, 18:38] - before[12:28, 18:38]).mean()
+    far_delta = np.abs(after[:, 48:58] - before[:, 48:58]).mean()
+    assert protected_delta < far_delta * 0.5
+
+
+def test_cli_writes_expected_outputs(tmp_path, capsys):
+    source, depth_path, metadata = _write_fixture(tmp_path)
+    out_dir = tmp_path / "out"
+
+    exit_code = main(
+        [
+            "--source",
+            str(source),
+            "--depth-npy",
+            str(depth_path),
+            "--metadata",
+            str(metadata),
+            "--out-dir",
+            str(out_dir),
+            "--focus-depth",
+            "9.0",
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert Path(payload["production_tiff"]).exists()
+    assert Path(payload["preview_jpeg"]).exists()
+    assert Path(payload["diagnostic_contact_sheet"]).exists()
+    assert Path(payload["summary_json"]).exists()
+    assert Path(payload["package_zip"]).exists()
+
+
+def test_legacy_pipeline_depth_tools_reexports_depth_aware_api():
+    from src.transformation_portal.pipelines import depth_tools
+
+    assert depth_tools.DepthAwareDofOptions is DepthAwareDofOptions
+    assert depth_tools.run_depth_aware_dof is run_depth_aware_dof


### PR DESCRIPTION
## Summary
- The existing depth-tools DOF path is built around normalized depth previews and legacy image helpers, which is not sufficient for the float-depth, 16-bit architectural DOF workflow.
- Adds a standalone single-image depth-aware DOF tool without changing portal or lux-depth-v3 runtime behavior.

## Changes
- Adds `transformation_portal.depth.depth_aware_dof` with `DepthAwareDofOptions`, `DepthAwareDofResult`, and `run_depth_aware_dof`.
- Adds `depth-aware-dof` and `python -m transformation_portal.depth.depth_aware_dof` CLI support for source TIFF, float `.npy` depth, optional metadata/masks, focus depth/ROI, and explicit convention fallback.
- Writes production TIFF, preview JPEG, diagnostic contact sheet, JSON summary, and ZIP package while preserving 16-bit TIFF output when the source is 16-bit.
- Re-exports the new API from `transformation_portal.depth` and the legacy `transformation_portal.pipelines.depth_tools` path for compatibility.
- Adds focused unit coverage for float depth loading, convention handling, dimension mismatch, 16-bit TIFF preservation, protected-region behavior, CLI artifacts, and legacy API exports.

## Validation
Proven green:
- `.venv/bin/pytest tests/test_depth_tools.py tests/test_depth_aware_dof.py -q` -> 25 passed
- `.venv/bin/python -m transformation_portal.depth.depth_aware_dof --help` -> OK
- `make test-fast` -> 77 passed
- `git diff --check` -> OK

Still failing:
- None observed.

Failure classification:
- No product logic, stale test, or environment/tooling failures observed.

## Risk
- Bounded to a new standalone CLI plus explicit API exports; portal and lux-depth-v3 job flows are unchanged.
- Fails closed on missing depth convention, non-float depth, non-finite arrays, and source/depth dimension mismatch.
- Revert-safe because the feature is isolated to the new module, console-script entry, compatibility exports, and tests.