### PR TITLE
add portal Playwright browser smoke tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,6 +94,10 @@ jobs:
               /^config\/portal_asset_manifest\.json$/,
               /^scripts\/validation\/validate_frontdoor_browser_smoke\.py$/,
               /^docs\/guides\/PORTAL_SECURE_FRONTDOOR_QUICKSTART\.md$/,
+              // The @portal-browser Playwright suite serves portal.html
+              // through the mock FastAPI origin, so changes to the
+              // portal markup template must trigger frontdoor-contract.
+              /^portal\.html$/,
             ];
 
             const runFrontdoor = names.some(name => frontdoorMatchers.some(re => re.test(name)));
@@ -416,12 +420,14 @@ jobs:
           cd web/secure-landing
           npx playwright install --with-deps chromium
 
-      - name: Run frontdoor browser smoke suite
+      - name: Run frontdoor + portal browser smoke suite
         env:
           CI: "1"
         run: |
           set -euo pipefail
           cd web/secure-landing
+          # Runs all Playwright projects in dependency order:
+          # chromium (@frontdoor-browser) + portal-setup → portal-browser.
           npm run test:browser
 
       - name: Upload Playwright report on failure

--- a/.gitignore
+++ b/.gitignore
@@ -124,6 +124,7 @@ web/secure-landing/test-results/
 web/secure-landing/playwright-report/
 web/secure-landing/blob-report/
 web/secure-landing/.playwright/
+web/secure-landing/tests/e2e/.auth/
 /node_modules/
 cloudflare/transformationportal-worker/.wrangler/
 cloudflare/transformationportal-worker/node_modules/

--- a/web/secure-landing/playwright.config.mjs
+++ b/web/secure-landing/playwright.config.mjs
@@ -1,23 +1,40 @@
-// Playwright configuration for the front-door browser smoke suite.
+// Playwright configuration for the front-door + portal browser smoke
+// suites.
 //
-// Scope (Phase-1 closeout):
-//   - Chromium only.
-//   - Three @frontdoor-browser specs covering /, /login, and the
-//     unauthenticated /portal redirect to /login.
+// Scope:
+//   - Chromium only, headless only.
+//   - @frontdoor-browser specs covering /, /login, and the
+//     unauthenticated /portal redirect to /login (#1690).
+//   - @portal-browser specs covering the signed-in /portal shell
+//     served via the front-door upstream proxy (this config). The
+//     proxy fetches from a Node mock FastAPI origin started by the
+//     second webServer entry below — no Python in CI.
 //   - Supplemental coverage that runs alongside the existing node:test
 //     unit suite. The CDP-based scripts/validation/validate_portal_browser_smoke.py
 //     and validate_frontdoor_browser_smoke.py remain the governed Make
 //     lanes; this Playwright config does NOT replace them.
 //
-// The webServer block boots the Next.js dev server with a minimal env so
-// the smoke tests can render pages without depending on a live FastAPI
-// origin.
+// The two webServer entries boot:
+//   1. The Node mock FastAPI origin on MOCK_FASTAPI_PORT (default 9999).
+//      Serves portal.html with placeholder URLs substituted to inert
+//      mock-asset stubs.
+//   2. The front-door Next.js dev server on PLAYWRIGHT_BASE_URL's port.
+//      Configured via TP_FASTAPI_ORIGIN to proxy to the mock above.
+//
+// Authentication for @portal-browser is handled by the portal-setup
+// project, which performs a real form-POST login against the seeded
+// smoke-admin user (the same credentials already pre-baked here for
+// #1690). The login flow uses production code paths verbatim — no
+// test-only auth shortcut.
 
 import { defineConfig, devices } from "@playwright/test";
 
 const isCi = Boolean(process.env.CI);
 const baseURL = process.env.PLAYWRIGHT_BASE_URL || "http://127.0.0.1:3000";
 const webServerPort = getWebServerPort(baseURL);
+const mockFastapiHost = process.env.MOCK_FASTAPI_HOST || "127.0.0.1";
+const mockFastapiPort = process.env.MOCK_FASTAPI_PORT || "9999";
+const mockFastapiOrigin = `http://${mockFastapiHost}:${mockFastapiPort}`;
 const frontdoorSmokeUsersJson = JSON.stringify([
   {
     username: "smoke-admin",
@@ -27,6 +44,7 @@ const frontdoorSmokeUsersJson = JSON.stringify([
     role: "admin",
   },
 ]);
+const portalAuthStateFile = "tests/e2e/.auth/portal-state.json";
 
 function getWebServerPort(playwrightBaseURL) {
   const url = new URL(playwrightBaseURL);
@@ -63,25 +81,67 @@ export default defineConfig({
   projects: [
     {
       name: "chromium",
+      // Default project: @frontdoor-browser specs (landing, login,
+      // unauthenticated portal redirect). Excludes the portal-setup
+      // bootstrap and the .portal.spec.mjs files which require an
+      // authenticated context.
+      testIgnore: [
+        "**/portal-setup.spec.mjs",
+        "**/*.portal.spec.mjs",
+      ],
       use: { ...devices["Desktop Chrome"] },
     },
-  ],
-  webServer: {
-    command: `npm run dev -- --port ${webServerPort}`,
-    url: baseURL,
-    reuseExistingServer: !isCi,
-    timeout: 120_000,
-    env: {
-      NODE_ENV: "development",
-      // Stub backend so the dev server boots; smoke tests do not call
-      // protected /v1/* routes that would require a real upstream. The
-      // development preflight still requires a configured user source, but
-      // allows the stub backend to be unavailable.
-      TP_FASTAPI_ORIGIN: "http://127.0.0.1:9999",
-      TP_BACKEND_API_KEY: "frontdoor-browser-smoke",
-      TP_FRONTDOOR_USERS_JSON: frontdoorSmokeUsersJson,
-      TP_ALLOW_LOCAL_ACCESS_BYPASS: "1",
-      WATCHPACK_POLLING: "true",
+    {
+      // Setup project: performs the real form-POST login against the
+      // pre-seeded smoke-admin user and persists storageState for the
+      // portal-browser project. Runs once per session.
+      name: "portal-setup",
+      testMatch: /portal-setup\.spec\.mjs/,
+      use: { ...devices["Desktop Chrome"] },
     },
-  },
+    {
+      // @portal-browser specs run against the authenticated context
+      // captured by portal-setup. Project dependency makes Playwright
+      // run portal-setup first and skip portal-browser if it fails.
+      name: "portal-browser",
+      testMatch: /\.portal\.spec\.mjs$/,
+      dependencies: ["portal-setup"],
+      use: {
+        ...devices["Desktop Chrome"],
+        storageState: portalAuthStateFile,
+      },
+    },
+  ],
+  webServer: [
+    {
+      // Node mock FastAPI origin — serves portal.html (with placeholders
+      // substituted) for the front-door's upstream proxy. No Python in CI.
+      command: `node tests/e2e/fixtures/mock-fastapi-origin.mjs`,
+      url: `${mockFastapiOrigin}/healthz`,
+      reuseExistingServer: !isCi,
+      timeout: 30_000,
+      env: {
+        MOCK_FASTAPI_HOST: mockFastapiHost,
+        MOCK_FASTAPI_PORT: mockFastapiPort,
+      },
+    },
+    {
+      // Next.js front-door dev server. Proxies /portal upstream to the
+      // mock FastAPI origin above. Auth bypass for Cloudflare Access is
+      // enabled via TP_ALLOW_LOCAL_ACCESS_BYPASS=1 +
+      // NODE_ENV=development (lib/config.js:10-12).
+      command: `npm run dev -- --port ${webServerPort}`,
+      url: baseURL,
+      reuseExistingServer: !isCi,
+      timeout: 120_000,
+      env: {
+        NODE_ENV: "development",
+        TP_FASTAPI_ORIGIN: mockFastapiOrigin,
+        TP_BACKEND_API_KEY: "frontdoor-browser-smoke",
+        TP_FRONTDOOR_USERS_JSON: frontdoorSmokeUsersJson,
+        TP_ALLOW_LOCAL_ACCESS_BYPASS: "1",
+        WATCHPACK_POLLING: "true",
+      },
+    },
+  ],
 });

--- a/web/secure-landing/tests/e2e/fixtures/mock-fastapi-origin.mjs
+++ b/web/secure-landing/tests/e2e/fixtures/mock-fastapi-origin.mjs
@@ -1,0 +1,141 @@
+// Mock FastAPI origin for the @portal-browser Playwright suite.
+//
+// The front-door's /portal route fetches GET / from the configured
+// TP_FASTAPI_ORIGIN and proxies the response body through to the
+// browser (web/secure-landing/app/portal/route.js:174). That fetch is
+// server-side from the Next.js process, so browser-level page.route()
+// cannot intercept it. This tiny Node origin stands in for FastAPI
+// and serves the real portal.html template with placeholder URLs
+// substituted to inert mock-served stubs — keeping the assertions
+// against live portal markup, not a hand-written fixture.
+//
+// Lifecycle is owned by Playwright's webServer config (no
+// globalSetup/globalTeardown). The script starts a node:http server
+// and stays alive until Playwright SIGTERMs it.
+
+import { createServer } from "node:http";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const HOST = process.env.MOCK_FASTAPI_HOST || "127.0.0.1";
+const PORT = Number(process.env.MOCK_FASTAPI_PORT || 9999);
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "..", "..");
+const PORTAL_HTML_PATH = process.env.MOCK_FASTAPI_PORTAL_HTML
+  ? path.resolve(process.env.MOCK_FASTAPI_PORTAL_HTML)
+  : path.join(REPO_ROOT, "portal.html");
+
+// Mock-served stub asset paths the placeholder substitutions point at.
+// Each stub returns a minimal valid body so the browser does not log
+// console errors that would trip the @portal-browser suite's console-error
+// gate. The portal shell's interactive JS is intentionally NOT loaded —
+// these tests assert markup contracts, not runtime behavior. Live JS/CSS
+// behavior remains the responsibility of validate_portal_browser_smoke.py.
+const STUB_ROUTES = new Map([
+  ["/__mock-portal-asset.css", { type: "text/css; charset=utf-8", body: "/* mock portal css */\n" }],
+  ["/__mock-portal-asset.js", { type: "text/javascript; charset=utf-8", body: "/* mock portal js */\n" }],
+  ["/__mock-portal-asset.svg", {
+    type: "image/svg+xml",
+    body: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1"></svg>'
+  }]
+]);
+
+// Substitution map for the __PORTAL_*_URL__ placeholders defined in
+// src/transformation_portal/portal/asset_bundle.py. CSS/JS placeholders
+// route to the inert stubs above; the brand SVG and font placeholders
+// route to a transparent SVG stub (the font is also stubbed to a tiny
+// SVG since the preload is non-essential for shell-anchor coverage).
+const PLACEHOLDER_SUBSTITUTIONS = Object.freeze({
+  __PORTAL_CSS_URL__: "/__mock-portal-asset.css",
+  __PORTAL_REVIEW_CSS_URL__: "/__mock-portal-asset.css",
+  __PORTAL_JS_URL__: "/__mock-portal-asset.js",
+  __PORTAL_BUILD_JS_URL__: "/__mock-portal-asset.js",
+  __PORTAL_OPERATE_JS_URL__: "/__mock-portal-asset.js",
+  __PORTAL_OVERVIEW_JS_URL__: "/__mock-portal-asset.js",
+  __PORTAL_REVIEW_JS_URL__: "/__mock-portal-asset.js",
+  __PORTAL_BRAND_LIGHT_URL__: "/__mock-portal-asset.svg",
+  __PORTAL_BRAND_DARK_URL__: "/__mock-portal-asset.svg",
+  __PORTAL_FONT_SANS_URL__: "/__mock-portal-asset.svg"
+});
+
+function renderPortalHtml() {
+  const template = readFileSync(PORTAL_HTML_PATH, "utf-8");
+  let rendered = template;
+  for (const [placeholder, replacement] of Object.entries(PLACEHOLDER_SUBSTITUTIONS)) {
+    rendered = rendered.split(placeholder).join(replacement);
+  }
+  // Drop the woff2 font preload — without a real font body the browser
+  // emits a console error about the preload type/cors mismatch which would
+  // trip @portal-browser console-error gates. The preload is a perf hint,
+  // not part of the markup contract.
+  rendered = rendered.replace(
+    /<link\s+rel="preload"\s+as="font"[^>]*>\s*/g,
+    ""
+  );
+  const unresolved = rendered.match(/__PORTAL_[A-Z0-9_]+__/g);
+  if (unresolved) {
+    throw new Error(`mock-fastapi-origin: unresolved portal placeholders: ${[...new Set(unresolved)].join(", ")}`);
+  }
+  return rendered;
+}
+
+let cachedPortalHtml = null;
+function getPortalHtml() {
+  if (cachedPortalHtml === null) {
+    cachedPortalHtml = renderPortalHtml();
+  }
+  return cachedPortalHtml;
+}
+
+const server = createServer((req, res) => {
+  const url = new URL(req.url || "/", `http://${HOST}:${PORT}`);
+  const pathname = url.pathname;
+
+  res.setHeader("Cache-Control", "no-store");
+
+  if (req.method === "GET" && (pathname === "/" || pathname === "/healthz" || pathname === "/ready")) {
+    if (pathname === "/healthz" || pathname === "/ready") {
+      res.writeHead(200, { "Content-Type": "text/plain; charset=utf-8" });
+      res.end("ok");
+      return;
+    }
+    try {
+      const body = getPortalHtml();
+      res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+      res.end(body);
+    } catch (error) {
+      res.writeHead(500, { "Content-Type": "text/plain; charset=utf-8" });
+      res.end(`mock-fastapi-origin: ${error?.message || String(error)}`);
+    }
+    return;
+  }
+
+  // The front-door's preflight-backend-auth.mjs probes
+  // GET /v1/config-metadata?pipeline=lux-depth-v3 on dev-server start.
+  // A 200 here lets the dev server come up; non-2xx fails closed.
+  if (req.method === "GET" && pathname === "/v1/config-metadata") {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ pipeline: url.searchParams.get("pipeline") || "" }));
+    return;
+  }
+
+  if (req.method === "GET" && STUB_ROUTES.has(pathname)) {
+    const stub = STUB_ROUTES.get(pathname);
+    res.writeHead(200, { "Content-Type": stub.type });
+    res.end(stub.body);
+    return;
+  }
+
+  res.writeHead(404, { "Content-Type": "text/plain; charset=utf-8" });
+  res.end("not found");
+});
+
+server.listen(PORT, HOST, () => {
+  process.stdout.write(`mock-fastapi-origin: listening on http://${HOST}:${PORT}\n`);
+});
+
+const shutdown = () => {
+  server.close(() => process.exit(0));
+};
+process.once("SIGTERM", shutdown);
+process.once("SIGINT", shutdown);

--- a/web/secure-landing/tests/e2e/fixtures/mock-fastapi-origin.mjs
+++ b/web/secure-landing/tests/e2e/fixtures/mock-fastapi-origin.mjs
@@ -24,13 +24,20 @@ const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..
 const PORTAL_HTML_PATH = process.env.MOCK_FASTAPI_PORTAL_HTML
   ? path.resolve(process.env.MOCK_FASTAPI_PORTAL_HTML)
   : path.join(REPO_ROOT, "portal.html");
+const PUBLIC_ORIGIN = `http://${HOST}:${PORT}`;
 
 // Mock-served stub asset paths the placeholder substitutions point at.
-// Each stub returns a minimal valid body so the browser does not log
-// console errors that would trip the @portal-browser suite's console-error
-// gate. The portal shell's interactive JS is intentionally NOT loaded —
-// these tests assert markup contracts, not runtime behavior. Live JS/CSS
-// behavior remains the responsibility of validate_portal_browser_smoke.py.
+// Asset URLs in the substituted HTML are *fully qualified* back to the
+// mock origin (PUBLIC_ORIGIN below), because the front-door serves the
+// proxied portal HTML at port 3000 — root-relative paths would resolve
+// to the front-door origin and 404 there. Cross-origin GETs to port
+// 9999 work without CORS preflight (no fetch credentials, no custom
+// headers), and the /portal route doesn't apply CSP (lib/http.js:138),
+// so cross-origin <link>/<script>/<img> loads have no policy hurdle.
+//
+// Each stub returns a minimal valid body so the browser does not raise
+// errors when loading these assets — the @portal-browser specs assert
+// `consoleErrors === []` end-to-end.
 const STUB_ROUTES = new Map([
   ["/__mock-portal-asset.css", { type: "text/css; charset=utf-8", body: "/* mock portal css */\n" }],
   ["/__mock-portal-asset.js", { type: "text/javascript; charset=utf-8", body: "/* mock portal js */\n" }],
@@ -41,21 +48,21 @@ const STUB_ROUTES = new Map([
 ]);
 
 // Substitution map for the __PORTAL_*_URL__ placeholders defined in
-// src/transformation_portal/portal/asset_bundle.py. CSS/JS placeholders
-// route to the inert stubs above; the brand SVG and font placeholders
-// route to a transparent SVG stub (the font is also stubbed to a tiny
-// SVG since the preload is non-essential for shell-anchor coverage).
+// src/transformation_portal/portal/asset_bundle.py. All placeholders
+// resolve to fully-qualified URLs at the mock origin so the browser
+// loads them from port 9999 (where the stubs are served), not from the
+// front-door at port 3000 where they would 404.
 const PLACEHOLDER_SUBSTITUTIONS = Object.freeze({
-  __PORTAL_CSS_URL__: "/__mock-portal-asset.css",
-  __PORTAL_REVIEW_CSS_URL__: "/__mock-portal-asset.css",
-  __PORTAL_JS_URL__: "/__mock-portal-asset.js",
-  __PORTAL_BUILD_JS_URL__: "/__mock-portal-asset.js",
-  __PORTAL_OPERATE_JS_URL__: "/__mock-portal-asset.js",
-  __PORTAL_OVERVIEW_JS_URL__: "/__mock-portal-asset.js",
-  __PORTAL_REVIEW_JS_URL__: "/__mock-portal-asset.js",
-  __PORTAL_BRAND_LIGHT_URL__: "/__mock-portal-asset.svg",
-  __PORTAL_BRAND_DARK_URL__: "/__mock-portal-asset.svg",
-  __PORTAL_FONT_SANS_URL__: "/__mock-portal-asset.svg"
+  __PORTAL_CSS_URL__: `${PUBLIC_ORIGIN}/__mock-portal-asset.css`,
+  __PORTAL_REVIEW_CSS_URL__: `${PUBLIC_ORIGIN}/__mock-portal-asset.css`,
+  __PORTAL_JS_URL__: `${PUBLIC_ORIGIN}/__mock-portal-asset.js`,
+  __PORTAL_BUILD_JS_URL__: `${PUBLIC_ORIGIN}/__mock-portal-asset.js`,
+  __PORTAL_OPERATE_JS_URL__: `${PUBLIC_ORIGIN}/__mock-portal-asset.js`,
+  __PORTAL_OVERVIEW_JS_URL__: `${PUBLIC_ORIGIN}/__mock-portal-asset.js`,
+  __PORTAL_REVIEW_JS_URL__: `${PUBLIC_ORIGIN}/__mock-portal-asset.js`,
+  __PORTAL_BRAND_LIGHT_URL__: `${PUBLIC_ORIGIN}/__mock-portal-asset.svg`,
+  __PORTAL_BRAND_DARK_URL__: `${PUBLIC_ORIGIN}/__mock-portal-asset.svg`,
+  __PORTAL_FONT_SANS_URL__: `${PUBLIC_ORIGIN}/__mock-portal-asset.svg`
 });
 
 function renderPortalHtml() {

--- a/web/secure-landing/tests/e2e/portal-auth.portal.spec.mjs
+++ b/web/secure-landing/tests/e2e/portal-auth.portal.spec.mjs
@@ -1,0 +1,50 @@
+// @portal-browser portal-auth/session smoke.
+//
+// Verifies the authenticated session captured by the portal-setup
+// project survives across reloads and deep-link navigations, and
+// that an unauthenticated context redirects to /login (the negative
+// path covered by portal-shell.spec.mjs's @frontdoor-browser tag is
+// inverted here against an authenticated context).
+
+import { test, expect } from "@playwright/test";
+
+test.describe(
+  "portal auth boundary (authenticated)",
+  { tag: "@portal-browser" },
+  () => {
+    test("session survives reload and deep-link navigation", async ({ page }) => {
+      await page.goto("/portal");
+      expect(page.url()).toMatch(/\/portal(\?|$)/);
+      await expect(page.locator('[data-ui="portal-topbar"]')).toBeVisible();
+
+      // Reload — session cookie must keep the user on /portal, not
+      // redirect to /login.
+      await page.reload();
+      expect(page.url()).toMatch(/\/portal(\?|$)/);
+      await expect(page.locator('[data-ui="portal-topbar"]')).toBeVisible();
+
+      // Deep link to a non-default view stays inside /portal.
+      const response = await page.goto("/portal?view=review");
+      expect(response?.status()).toBe(200);
+      expect(page.url()).toContain("/portal");
+      expect(page.url()).not.toContain("/login");
+      await expect(page.locator('[data-ui="view-switcher"]')).toBeVisible();
+    });
+
+    test("session is scoped — clearing cookies forces a redirect to /login", async ({ page, context }) => {
+      // Pre-condition: authenticated visit succeeds.
+      await page.goto("/portal");
+      await expect(page.locator('[data-ui="portal-topbar"]')).toBeVisible();
+
+      // Drop the session cookie. The next /portal hit must 302 to /login.
+      await context.clearCookies();
+
+      const response = await page.goto("/portal");
+      expect(response?.status()).toBe(200);
+      expect(page.url()).toContain("/login");
+      // Login form is rendered — same anchor #1690's @frontdoor-browser
+      // suite pins.
+      await expect(page.locator('[data-ui="login-form"]')).toBeVisible();
+    });
+  }
+);

--- a/web/secure-landing/tests/e2e/portal-auth.portal.spec.mjs
+++ b/web/secure-landing/tests/e2e/portal-auth.portal.spec.mjs
@@ -1,10 +1,16 @@
 // @portal-browser portal-auth/session smoke.
 //
 // Verifies the authenticated session captured by the portal-setup
-// project survives across reloads and deep-link navigations, and
-// that an unauthenticated context redirects to /login (the negative
-// path covered by portal-shell.spec.mjs's @frontdoor-browser tag is
-// inverted here against an authenticated context).
+// project survives across reloads and deep-link navigations.
+//
+// Suite-coverage map (intentional duplication-free pyramid layout):
+//   - Unauthenticated /portal → /login redirect: covered by
+//     tests/e2e/portal-shell.spec.mjs (tag: @frontdoor-browser, from
+//     PR #1690). NOT a .portal.spec.mjs — the suffix-less filename
+//     belongs to the @frontdoor-browser project.
+//   - Authenticated /portal positive paths: this file. Includes a
+//     scoped negative case (clearing cookies mid-test) to assert the
+//     same session boundary from the authenticated side.
 
 import { test, expect } from "@playwright/test";
 
@@ -13,6 +19,12 @@ test.describe(
   { tag: "@portal-browser" },
   () => {
     test("session survives reload and deep-link navigation", async ({ page }) => {
+      const consoleErrors = [];
+      page.on("console", (msg) => {
+        if (msg.type() === "error") consoleErrors.push(msg.text());
+      });
+      page.on("pageerror", (err) => consoleErrors.push(String(err)));
+
       await page.goto("/portal");
       expect(page.url()).toMatch(/\/portal(\?|$)/);
       await expect(page.locator('[data-ui="portal-topbar"]')).toBeVisible();
@@ -29,9 +41,20 @@ test.describe(
       expect(page.url()).toContain("/portal");
       expect(page.url()).not.toContain("/login");
       await expect(page.locator('[data-ui="view-switcher"]')).toBeVisible();
+
+      expect(
+        consoleErrors,
+        `unexpected console errors: ${consoleErrors.join("\n")}`
+      ).toEqual([]);
     });
 
     test("session is scoped — clearing cookies forces a redirect to /login", async ({ page, context }) => {
+      const consoleErrors = [];
+      page.on("console", (msg) => {
+        if (msg.type() === "error") consoleErrors.push(msg.text());
+      });
+      page.on("pageerror", (err) => consoleErrors.push(String(err)));
+
       // Pre-condition: authenticated visit succeeds.
       await page.goto("/portal");
       await expect(page.locator('[data-ui="portal-topbar"]')).toBeVisible();
@@ -45,6 +68,11 @@ test.describe(
       // Login form is rendered — same anchor #1690's @frontdoor-browser
       // suite pins.
       await expect(page.locator('[data-ui="login-form"]')).toBeVisible();
+
+      expect(
+        consoleErrors,
+        `unexpected console errors: ${consoleErrors.join("\n")}`
+      ).toEqual([]);
     });
   }
 );

--- a/web/secure-landing/tests/e2e/portal-setup.spec.mjs
+++ b/web/secure-landing/tests/e2e/portal-setup.spec.mjs
@@ -16,6 +16,9 @@
 //     code path the front-door uses in production.
 // No new env vars, no new auth code, no new password hashes.
 
+import { mkdirSync } from "node:fs";
+import path from "node:path";
+
 import { test as setup, expect } from "@playwright/test";
 
 const STORAGE_STATE_PATH = "tests/e2e/.auth/portal-state.json";
@@ -46,5 +49,9 @@ setup("authenticate the smoke-admin operator", async ({ page }) => {
   // any auth-side regressions before the @portal-browser specs run.
   await expect(page.locator('[data-ui="portal-topbar"]')).toBeVisible();
 
+  // Ensure the parent directory exists before storageState() writes —
+  // a clean checkout has no tests/e2e/.auth/ and node:fs writes do not
+  // mkdir-p, so the persist would otherwise fail with ENOENT.
+  mkdirSync(path.dirname(STORAGE_STATE_PATH), { recursive: true });
   await page.context().storageState({ path: STORAGE_STATE_PATH });
 });

--- a/web/secure-landing/tests/e2e/portal-setup.spec.mjs
+++ b/web/secure-landing/tests/e2e/portal-setup.spec.mjs
@@ -1,0 +1,50 @@
+// Playwright "setup" project for the @portal-browser suite.
+//
+// Runs once before the @portal-browser specs and persists an
+// authenticated browser context (storageState) for them to load via
+// project dependencies. The login flow is the production form-POST at
+// /login — no test-only auth path or session-mint shortcut.
+//
+// Auth fixture cost analysis:
+//   - The smoke-admin user (username/password/access_email) is already
+//     pre-seeded in playwright.config.mjs's TP_FRONTDOOR_USERS_JSON.
+//   - TP_ALLOW_LOCAL_ACCESS_BYPASS=1 + NODE_ENV=development is already
+//     set on the front-door webServer, so resolveAccessContext returns
+//     {bypass: true} (lib/access.js:13-21, lib/config.js:10-12).
+//   - The form login POST flow (app/login/route.js:316-444) calls
+//     rotateAuthenticatedSession + setSessionCookie verbatim — same
+//     code path the front-door uses in production.
+// No new env vars, no new auth code, no new password hashes.
+
+import { test as setup, expect } from "@playwright/test";
+
+const STORAGE_STATE_PATH = "tests/e2e/.auth/portal-state.json";
+const SMOKE_USERNAME = "smoke-admin";
+const SMOKE_PASSWORD = "correct horse battery staple";
+
+setup("authenticate the smoke-admin operator", async ({ page }) => {
+  // The login form lives at /login. Form selectors mirror those pinned
+  // by the @frontdoor-browser login spec (login.spec.mjs:46-50).
+  await page.goto("/login");
+  await expect(page.locator('[data-ui="login-form"]')).toBeVisible();
+
+  await page
+    .locator('[data-ui="login-username-field"] input[name="username"]')
+    .fill(SMOKE_USERNAME);
+  await page
+    .locator('[data-ui="login-password-field"] input[name="password"]')
+    .fill(SMOKE_PASSWORD);
+
+  // Submit and wait for the 303 redirect chain to land at /portal.
+  await Promise.all([
+    page.waitForURL((url) => url.pathname === "/portal"),
+    page.locator('[data-ui="login-submit"]').click()
+  ]);
+
+  // The portal shell is served upstream-proxied from the mock FastAPI
+  // origin; assert one stable anchor before persisting state to catch
+  // any auth-side regressions before the @portal-browser specs run.
+  await expect(page.locator('[data-ui="portal-topbar"]')).toBeVisible();
+
+  await page.context().storageState({ path: STORAGE_STATE_PATH });
+});

--- a/web/secure-landing/tests/e2e/portal-shell.portal.spec.mjs
+++ b/web/secure-landing/tests/e2e/portal-shell.portal.spec.mjs
@@ -1,0 +1,47 @@
+// @portal-browser portal-shell smoke.
+//
+// Verifies the signed-in /portal shell renders with the stable
+// data-ui hooks and view-switcher links the source-string tests
+// already pin (e.g., portal-css-architecture.test.mjs). This spec
+// runs through the full request chain:
+//
+//   browser → front-door /portal route → fetch upstream
+//           → mock FastAPI origin /  (serves portal.html with the
+//             __PORTAL_*_URL__ placeholders substituted)
+//
+// The mock origin keeps the live portal.html template as the source
+// of truth, so accidental removal of a stable anchor in the real
+// markup will fail this spec — same regression signal the
+// @frontdoor-browser specs provide for the login surface.
+
+import { test, expect } from "@playwright/test";
+
+test.describe(
+  "portal shell",
+  { tag: "@portal-browser" },
+  () => {
+    test("authenticated /portal renders the shell with stable view-switcher hooks", async ({ page }) => {
+      const response = await page.goto("/portal");
+      expect(response?.status()).toBe(200);
+
+      // Top-level shell anchors served via the front-door's upstream proxy.
+      await expect(page.locator('[data-ui="portal-topbar"]')).toBeVisible();
+      await expect(page.locator('[data-ui="view-switcher"]')).toBeVisible();
+
+      // All four workspace sections are rendered with stable
+      // data-view-link hooks and ?view=… hrefs. The portal JS is not
+      // executed in this mock environment, so we assert the static
+      // markup contract only.
+      for (const view of ["overview", "build", "operate", "review"]) {
+        const link = page.locator(`[data-view-link="${view}"]`);
+        await expect(link).toBeVisible();
+        await expect(link).toHaveAttribute("href", `?view=${view}`);
+      }
+
+      // Overview is the default view — aria-current pinned in markup.
+      await expect(
+        page.locator('[data-view-link="overview"]')
+      ).toHaveAttribute("aria-current", "page");
+    });
+  }
+);

--- a/web/secure-landing/tests/e2e/portal-shell.portal.spec.mjs
+++ b/web/secure-landing/tests/e2e/portal-shell.portal.spec.mjs
@@ -21,6 +21,12 @@ test.describe(
   { tag: "@portal-browser" },
   () => {
     test("authenticated /portal renders the shell with stable view-switcher hooks", async ({ page }) => {
+      const consoleErrors = [];
+      page.on("console", (msg) => {
+        if (msg.type() === "error") consoleErrors.push(msg.text());
+      });
+      page.on("pageerror", (err) => consoleErrors.push(String(err)));
+
       const response = await page.goto("/portal");
       expect(response?.status()).toBe(200);
 
@@ -42,6 +48,11 @@ test.describe(
       await expect(
         page.locator('[data-view-link="overview"]')
       ).toHaveAttribute("aria-current", "page");
+
+      expect(
+        consoleErrors,
+        `unexpected console errors: ${consoleErrors.join("\n")}`
+      ).toEqual([]);
     });
   }
 );

--- a/web/secure-landing/tests/e2e/portal-views.portal.spec.mjs
+++ b/web/secure-landing/tests/e2e/portal-views.portal.spec.mjs
@@ -1,0 +1,44 @@
+// @portal-browser portal-views smoke.
+//
+// Verifies the per-view affordances are present in the static portal
+// markup served via the front-door upstream proxy, and that the
+// shared shell anchors remain visible regardless of the ?view= deep
+// link. The portal interactivity bundle is stubbed in this mock
+// environment, so we assert the markup contract — not the JS-driven
+// view-toggling behavior, which is governed by
+// validate_portal_browser_smoke.py's live CDP suite.
+
+import { test, expect } from "@playwright/test";
+
+const SHARED_SHELL_ANCHORS = [
+  '[data-ui="portal-topbar"]',
+  '[data-ui="view-switcher"]',
+  '[data-ui="console-context-shell"]'
+];
+
+const VIEW_AFFORDANCES = {
+  build: ['[data-ui="connection-card"]', '[data-ui="build-stepper"]'],
+  operate: ['[data-ui="operate-grid"]'],
+  review: ['[data-ui="review-surface"]']
+};
+
+test.describe(
+  "portal view shells",
+  { tag: "@portal-browser" },
+  () => {
+    for (const [view, affordances] of Object.entries(VIEW_AFFORDANCES)) {
+      test(`/portal?view=${view} keeps the shared shell and reaches the ${view} affordances`, async ({ page }) => {
+        const response = await page.goto(`/portal?view=${view}`);
+        expect(response?.status()).toBe(200);
+
+        for (const sharedAnchor of SHARED_SHELL_ANCHORS) {
+          await expect(page.locator(sharedAnchor)).toBeVisible();
+        }
+
+        for (const viewAnchor of affordances) {
+          await expect(page.locator(viewAnchor).first()).toBeVisible();
+        }
+      });
+    }
+  }
+);

--- a/web/secure-landing/tests/e2e/portal-views.portal.spec.mjs
+++ b/web/secure-landing/tests/e2e/portal-views.portal.spec.mjs
@@ -28,6 +28,12 @@ test.describe(
   () => {
     for (const [view, affordances] of Object.entries(VIEW_AFFORDANCES)) {
       test(`/portal?view=${view} keeps the shared shell and reaches the ${view} affordances`, async ({ page }) => {
+        const consoleErrors = [];
+        page.on("console", (msg) => {
+          if (msg.type() === "error") consoleErrors.push(msg.text());
+        });
+        page.on("pageerror", (err) => consoleErrors.push(String(err)));
+
         const response = await page.goto(`/portal?view=${view}`);
         expect(response?.status()).toBe(200);
 
@@ -38,6 +44,11 @@ test.describe(
         for (const viewAnchor of affordances) {
           await expect(page.locator(viewAnchor).first()).toBeVisible();
         }
+
+        expect(
+          consoleErrors,
+          `unexpected console errors: ${consoleErrors.join("\n")}`
+        ).toEqual([]);
       });
     }
   }

--- a/web/secure-landing/tests/routes.test.mjs
+++ b/web/secure-landing/tests/routes.test.mjs
@@ -192,16 +192,31 @@ test("next config honors TP_NEXT_DIST_DIR for isolated local frontdoor runs", as
   }
 });
 
+function frontdoorWebServerEntry(config) {
+  // The webServer field is now an array — entry 0 is the mock FastAPI
+  // origin, entry 1 is the front-door dev server. The front-door entry
+  // is identified by its `npm run dev` command.
+  const entries = Array.isArray(config.webServer) ? config.webServer : [config.webServer];
+  return entries.find((entry) => /npm run dev/.test(entry.command));
+}
+
+function mockFastapiWebServerEntry(config) {
+  const entries = Array.isArray(config.webServer) ? config.webServer : [config.webServer];
+  return entries.find((entry) => /mock-fastapi-origin/.test(entry.command));
+}
+
 test("playwright frontdoor smoke config uses local preflight-safe fixtures", async () => {
   const previous = process.env.PLAYWRIGHT_BASE_URL;
   delete process.env.PLAYWRIGHT_BASE_URL;
 
   try {
     const configModule = await importFresh("../playwright.config.mjs");
-    const env = configModule.default.webServer.env;
+    const frontdoor = frontdoorWebServerEntry(configModule.default);
+    assert.ok(frontdoor, "front-door webServer entry must exist");
+    const env = frontdoor.env;
     const users = JSON.parse(env.TP_FRONTDOOR_USERS_JSON);
 
-    assert.equal(configModule.default.webServer.command, "npm run dev -- --port 3000");
+    assert.equal(frontdoor.command, "npm run dev -- --port 3000");
     assert.equal(env.NODE_ENV, "development");
     assert.equal(env.TP_ALLOW_LOCAL_ACCESS_BYPASS, "1");
     assert.equal(env.TP_FASTAPI_ORIGIN, "http://127.0.0.1:9999");
@@ -211,6 +226,14 @@ test("playwright frontdoor smoke config uses local preflight-safe fixtures", asy
     assert.equal(users[0].username, "smoke-admin");
     assert.equal(users[0].access_email, "smoke-admin@local.invalid");
     assert.match(users[0].password_hash, /^\$argon2/);
+
+    // The mock FastAPI origin must be wired alongside the front-door so
+    // the @portal-browser suite can serve portal.html upstream-proxied
+    // through the front-door without spawning real FastAPI.
+    const mock = mockFastapiWebServerEntry(configModule.default);
+    assert.ok(mock, "mock FastAPI origin webServer entry must exist");
+    assert.equal(mock.url, "http://127.0.0.1:9999/healthz");
+    assert.equal(mock.env.MOCK_FASTAPI_PORT, "9999");
   } finally {
     if (typeof previous === "string") {
       process.env.PLAYWRIGHT_BASE_URL = previous;
@@ -226,10 +249,11 @@ test("playwright frontdoor smoke config derives webServer port from PLAYWRIGHT_B
 
   try {
     const configModule = await importFresh("../playwright.config.mjs");
+    const frontdoor = frontdoorWebServerEntry(configModule.default);
 
     assert.equal(configModule.default.use.baseURL, "http://127.0.0.1:3017");
-    assert.equal(configModule.default.webServer.url, "http://127.0.0.1:3017");
-    assert.equal(configModule.default.webServer.command, "npm run dev -- --port 3017");
+    assert.equal(frontdoor.url, "http://127.0.0.1:3017");
+    assert.equal(frontdoor.command, "npm run dev -- --port 3017");
   } finally {
     if (typeof previous === "string") {
       process.env.PLAYWRIGHT_BASE_URL = previous;

--- a/web/secure-landing/tests/routes.test.mjs
+++ b/web/secure-landing/tests/routes.test.mjs
@@ -205,9 +205,39 @@ function mockFastapiWebServerEntry(config) {
   return entries.find((entry) => /mock-fastapi-origin/.test(entry.command));
 }
 
+// Env vars that influence playwright.config.mjs's runtime shape — the
+// config tests below pin defaults, so the caller's environment must be
+// scrubbed during the test and restored on exit.
+const PLAYWRIGHT_CONFIG_ENV_KEYS = [
+  "PLAYWRIGHT_BASE_URL",
+  "MOCK_FASTAPI_HOST",
+  "MOCK_FASTAPI_PORT"
+];
+
+function snapshotPlaywrightConfigEnv() {
+  return new Map(PLAYWRIGHT_CONFIG_ENV_KEYS.map((key) => [key, process.env[key]]));
+}
+
+function clearPlaywrightConfigEnv() {
+  for (const key of PLAYWRIGHT_CONFIG_ENV_KEYS) {
+    delete process.env[key];
+  }
+}
+
+function restorePlaywrightConfigEnv(snapshot) {
+  for (const key of PLAYWRIGHT_CONFIG_ENV_KEYS) {
+    const previous = snapshot.get(key);
+    if (typeof previous === "string") {
+      process.env[key] = previous;
+    } else {
+      delete process.env[key];
+    }
+  }
+}
+
 test("playwright frontdoor smoke config uses local preflight-safe fixtures", async () => {
-  const previous = process.env.PLAYWRIGHT_BASE_URL;
-  delete process.env.PLAYWRIGHT_BASE_URL;
+  const snapshot = snapshotPlaywrightConfigEnv();
+  clearPlaywrightConfigEnv();
 
   try {
     const configModule = await importFresh("../playwright.config.mjs");
@@ -234,17 +264,15 @@ test("playwright frontdoor smoke config uses local preflight-safe fixtures", asy
     assert.ok(mock, "mock FastAPI origin webServer entry must exist");
     assert.equal(mock.url, "http://127.0.0.1:9999/healthz");
     assert.equal(mock.env.MOCK_FASTAPI_PORT, "9999");
+    assert.equal(mock.env.MOCK_FASTAPI_HOST, "127.0.0.1");
   } finally {
-    if (typeof previous === "string") {
-      process.env.PLAYWRIGHT_BASE_URL = previous;
-    } else {
-      delete process.env.PLAYWRIGHT_BASE_URL;
-    }
+    restorePlaywrightConfigEnv(snapshot);
   }
 });
 
 test("playwright frontdoor smoke config derives webServer port from PLAYWRIGHT_BASE_URL", async () => {
-  const previous = process.env.PLAYWRIGHT_BASE_URL;
+  const snapshot = snapshotPlaywrightConfigEnv();
+  clearPlaywrightConfigEnv();
   process.env.PLAYWRIGHT_BASE_URL = "http://127.0.0.1:3017";
 
   try {
@@ -255,11 +283,7 @@ test("playwright frontdoor smoke config derives webServer port from PLAYWRIGHT_B
     assert.equal(frontdoor.url, "http://127.0.0.1:3017");
     assert.equal(frontdoor.command, "npm run dev -- --port 3017");
   } finally {
-    if (typeof previous === "string") {
-      process.env.PLAYWRIGHT_BASE_URL = previous;
-    } else {
-      delete process.env.PLAYWRIGHT_BASE_URL;
-    }
+    restorePlaywrightConfigEnv(snapshot);
   }
 });
 


### PR DESCRIPTION
Mirrors PR #1690's @frontdoor-browser foundation onto the signed-in
/portal shell with three @portal-browser specs:

  - portal-shell.portal.spec.mjs — authenticated /portal returns 200
    and renders the stable view-switcher hooks (portal-topbar,
    view-switcher, all four data-view-link anchors, overview default).
  - portal-views.portal.spec.mjs — /portal?view=build|operate|review
    each return 200 with the per-view affordance markers visible
    (connection-card + build-stepper, operate-grid, review-surface)
    while the shared shell anchors stay rendered across views.
  - portal-auth.portal.spec.mjs — session survives reload and deep-link
    navigation; clearing cookies forces a redirect back to /login.

Architecture choices, all source-verified before implementation:

  - playwright.config.mjs.webServer is now an array. Entry 1 is a Node
    mock FastAPI origin (tests/e2e/fixtures/mock-fastapi-origin.mjs)
    that serves the real portal.html template with __PORTAL_*_URL__
    placeholders substituted to inert mock-asset stubs, plus the
    /v1/config-metadata stub the front-door's preflight expects. No
    Python in CI; the frontdoor-contract job stays Node-only.
  - The portal-setup project performs a real form-POST login against
    the smoke-admin user already pre-seeded in TP_FRONTDOOR_USERS_JSON
    (web/secure-landing/scripts/seed-frontdoor-user.mjs). Cloudflare
    Access bypass is the source-verified TP_ALLOW_LOCAL_ACCESS_BYPASS=1
    env var (lib/config.js:10-12). No new auth code, no new password
    hashes, no test-only auth shortcut.
  - storageState is persisted at tests/e2e/.auth/portal-state.json
    (gitignored) and consumed by the @portal-browser project via
    Playwright's project-dependencies pattern.
  - Path-gate adds portal.html so portal markup template changes
    trigger frontdoor-contract.

The existing scripts/validation/validate_portal_browser_smoke.py
governed CDP suite remains the live-integration smoke (full FastAPI
spawn, real bootstrap, real artifact viewer); this Playwright suite is
the CI mock-backend layer of the pyramid — both stay, neither replaces
the other.