### PR TITLE
fix(frontdoor): restore managed smoke readiness

### DIFF
--- a/scripts/validation/validate_frontdoor_browser_smoke.py
+++ b/scripts/validation/validate_frontdoor_browser_smoke.py
@@ -66,6 +66,7 @@ DEFAULT_FRONTDOOR_PASSWORD = "correct horse battery staple"
 DEFAULT_FRONTDOOR_ROLE = "admin"
 FRONTDOOR_ROOT = SCRIPT_DIR.parent.parent / "web" / "secure-landing"
 FRONTDOOR_SEED_SCRIPT = FRONTDOOR_ROOT / "scripts" / "seed-frontdoor-user.mjs"
+FRONTDOOR_SMOKE_DIST_DIR_PREFIX = ".next-smoke-"
 
 
 def _request_frontdoor_health(base_url: str) -> tuple[int, dict]:
@@ -167,6 +168,15 @@ def _generate_frontdoor_users_file(username: str, password: str, runtime_root: P
     )
 
 
+def _prune_stale_frontdoor_dist_dirs(active_dist_dir: Path) -> None:
+    active_dist_dir = active_dist_dir.resolve()
+    for candidate in FRONTDOOR_ROOT.glob(f"{FRONTDOOR_SMOKE_DIST_DIR_PREFIX}*"):
+        if candidate.resolve() == active_dist_dir:
+            continue
+        if candidate.is_dir():
+            shutil.rmtree(candidate, ignore_errors=True)
+
+
 def _spawn_local_frontdoor(
     *,
     username: str,
@@ -192,13 +202,15 @@ def _spawn_local_frontdoor(
     log_path = runtime_root / "frontdoor.log"
     port = _find_free_port()
     base_url = f"http://localhost:{port}"
-    dist_dir_name = f".next-smoke-{port}"
+    dist_dir_name = f"{FRONTDOOR_SMOKE_DIST_DIR_PREFIX}{port}"
     dist_dir_path = FRONTDOOR_ROOT / dist_dir_name
+    _prune_stale_frontdoor_dist_dirs(dist_dir_path)
 
     env = os.environ.copy()
     env.update(
         {
             "NEXT_TELEMETRY_DISABLED": "1",
+            "WATCHPACK_POLLING": "true",
             "TP_FRONTDOOR_HOST": "127.0.0.1",
             "TP_FRONTDOOR_PORT": str(port),
             "TP_FRONTDOOR_USERS_FILE": str(users_file),

--- a/scripts/validation/validate_frontdoor_browser_smoke.py
+++ b/scripts/validation/validate_frontdoor_browser_smoke.py
@@ -67,6 +67,7 @@ DEFAULT_FRONTDOOR_ROLE = "admin"
 FRONTDOOR_ROOT = SCRIPT_DIR.parent.parent / "web" / "secure-landing"
 FRONTDOOR_SEED_SCRIPT = FRONTDOOR_ROOT / "scripts" / "seed-frontdoor-user.mjs"
 FRONTDOOR_SMOKE_DIST_DIR_PREFIX = ".next-smoke-"
+FRONTDOOR_STALE_DIST_DIR_MIN_AGE_SECONDS = 5 * 60
 
 
 def _request_frontdoor_health(base_url: str) -> tuple[int, dict]:
@@ -168,13 +169,38 @@ def _generate_frontdoor_users_file(username: str, password: str, runtime_root: P
     )
 
 
-def _prune_stale_frontdoor_dist_dirs(active_dist_dir: Path) -> None:
+def _prune_stale_frontdoor_dist_dirs(
+    active_dist_dir: Path,
+    *,
+    now: Optional[float] = None,
+    min_age_seconds: float = FRONTDOOR_STALE_DIST_DIR_MIN_AGE_SECONDS,
+) -> None:
     active_dist_dir = active_dist_dir.resolve()
+    current_time = time.time() if now is None else now
     for candidate in FRONTDOOR_ROOT.glob(f"{FRONTDOOR_SMOKE_DIST_DIR_PREFIX}*"):
         if candidate.resolve() == active_dist_dir:
             continue
         if candidate.is_dir():
-            shutil.rmtree(candidate, ignore_errors=True)
+            try:
+                candidate_mtime = candidate.stat().st_mtime
+            except FileNotFoundError:
+                continue
+            except OSError as exc:
+                raise SmokeFailure(
+                    f"Could not inspect front-door smoke distDir {candidate}: {exc}",
+                    kind="runtime",
+                ) from exc
+            if current_time - candidate_mtime < min_age_seconds:
+                continue
+            try:
+                shutil.rmtree(candidate)
+            except FileNotFoundError:
+                continue
+            except OSError as exc:
+                raise SmokeFailure(
+                    f"Could not remove stale front-door smoke distDir {candidate}: {exc}",
+                    kind="runtime",
+                ) from exc
 
 
 def _spawn_local_frontdoor(

--- a/tests/validation/test_portal_smoke_scripts.py
+++ b/tests/validation/test_portal_smoke_scripts.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 import sys
 import urllib.error
 from pathlib import Path
@@ -803,20 +804,50 @@ def test_frontdoor_browser_tail_text_reads_only_a_bounded_suffix(tmp_path: Path)
 
 def test_frontdoor_browser_prunes_only_stale_smoke_distdirs(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     module = _load_module(FRONTDOOR_BROWSER_SCRIPT_PATH, "tests_validate_frontdoor_browser_smoke_stale_distdirs")
+    now = 1_000_000.0
+    old_mtime = now - module.FRONTDOOR_STALE_DIST_DIR_MIN_AGE_SECONDS - 1
+    fresh_mtime = now - module.FRONTDOOR_STALE_DIST_DIR_MIN_AGE_SECONDS + 1
     active = tmp_path / ".next-smoke-3000"
     stale = tmp_path / ".next-smoke-3001"
+    fresh = tmp_path / ".next-smoke-3002"
     unrelated = tmp_path / ".next"
     active.mkdir()
     stale.mkdir()
+    fresh.mkdir()
     unrelated.mkdir()
+    for candidate in (active, stale, unrelated):
+        os.utime(candidate, (old_mtime, old_mtime))
+    os.utime(fresh, (fresh_mtime, fresh_mtime))
 
     monkeypatch.setattr(module, "FRONTDOOR_ROOT", tmp_path)
 
-    module._prune_stale_frontdoor_dist_dirs(active)
+    module._prune_stale_frontdoor_dist_dirs(active, now=now)
 
     assert active.is_dir()
     assert not stale.exists()
+    assert fresh.is_dir()
     assert unrelated.is_dir()
+
+
+def test_frontdoor_browser_prune_reports_cleanup_failures(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    module = _load_module(FRONTDOOR_BROWSER_SCRIPT_PATH, "tests_validate_frontdoor_browser_smoke_stale_failure")
+    now = 1_000_000.0
+    old_mtime = now - module.FRONTDOOR_STALE_DIST_DIR_MIN_AGE_SECONDS - 1
+    active = tmp_path / ".next-smoke-3000"
+    stale = tmp_path / ".next-smoke-3001"
+    active.mkdir()
+    stale.mkdir()
+    for candidate in (active, stale):
+        os.utime(candidate, (old_mtime, old_mtime))
+
+    def _fail_rmtree(_candidate: Path) -> None:
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(module, "FRONTDOOR_ROOT", tmp_path)
+    monkeypatch.setattr(module.shutil, "rmtree", _fail_rmtree)
+
+    with pytest.raises(module.SmokeFailure, match="Could not remove stale front-door smoke distDir.*permission denied"):
+        module._prune_stale_frontdoor_dist_dirs(active, now=now)
 
 
 def test_frontdoor_browser_main_terminates_spawned_runtimes_on_setup_failure(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):

--- a/tests/validation/test_portal_smoke_scripts.py
+++ b/tests/validation/test_portal_smoke_scripts.py
@@ -801,6 +801,24 @@ def test_frontdoor_browser_tail_text_reads_only_a_bounded_suffix(tmp_path: Path)
     assert len(tail) <= 24
 
 
+def test_frontdoor_browser_prunes_only_stale_smoke_distdirs(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    module = _load_module(FRONTDOOR_BROWSER_SCRIPT_PATH, "tests_validate_frontdoor_browser_smoke_stale_distdirs")
+    active = tmp_path / ".next-smoke-3000"
+    stale = tmp_path / ".next-smoke-3001"
+    unrelated = tmp_path / ".next"
+    active.mkdir()
+    stale.mkdir()
+    unrelated.mkdir()
+
+    monkeypatch.setattr(module, "FRONTDOOR_ROOT", tmp_path)
+
+    module._prune_stale_frontdoor_dist_dirs(active)
+
+    assert active.is_dir()
+    assert not stale.exists()
+    assert unrelated.is_dir()
+
+
 def test_frontdoor_browser_main_terminates_spawned_runtimes_on_setup_failure(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     module = _load_module(FRONTDOOR_BROWSER_SCRIPT_PATH, "tests_validate_frontdoor_browser_smoke_runtime_cleanup")
     backend_runtime = SimpleNamespace(base_url="http://127.0.0.1:8124")

--- a/web/secure-landing/next.config.js
+++ b/web/secure-landing/next.config.js
@@ -10,9 +10,6 @@ const nextConfig = {
   output: "standalone",
   distDir: requestedDistDir || ".next",
   outputFileTracingRoot: repoRoot,
-  turbopack: {
-    root: repoRoot
-  },
   outputFileTracingIncludes: {
     "/portal/assets/[...path]": ["../../config/portal_asset_manifest.json"]
   }

--- a/web/secure-landing/tests/routes.test.mjs
+++ b/web/secure-landing/tests/routes.test.mjs
@@ -4,6 +4,7 @@ import { spawnSync } from "node:child_process";
 import { createSign, generateKeyPairSync } from "node:crypto";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 
 import argon2 from "argon2";
@@ -36,6 +37,8 @@ const ENV_KEYS = [
 const TEST_CF_ACCESS_TEAM_DOMAIN = "https://tp-frontdoor-tests.cloudflareaccess.com";
 const TEST_CF_ACCESS_AUD = "tp-frontdoor-aud";
 const TEST_CF_ACCESS_KID = "tp-frontdoor-key";
+const FRONTDOOR_APP_ROOT = fileURLToPath(new URL("../", import.meta.url));
+const REPO_ROOT = path.resolve(FRONTDOOR_APP_ROOT, "../..");
 const TEST_CF_ACCESS_KEYS = generateKeyPairSync("rsa", {
   modulusLength: 2048
 });
@@ -186,7 +189,7 @@ test("next config honors TP_NEXT_DIST_DIR for isolated local frontdoor runs", as
     assert.equal(configModule.default.turbopack, undefined);
     assert.equal(
       path.resolve(configModule.default.outputFileTracingRoot),
-      path.resolve(process.cwd(), "../.."),
+      REPO_ROOT,
       "standalone tracing must still include repo-root files such as the portal asset manifest"
     );
   } finally {

--- a/web/secure-landing/tests/routes.test.mjs
+++ b/web/secure-landing/tests/routes.test.mjs
@@ -183,6 +183,12 @@ test("next config honors TP_NEXT_DIST_DIR for isolated local frontdoor runs", as
   try {
     const configModule = await importFresh("../next.config.js");
     assert.equal(configModule.default.distDir, ".next-smoke-test");
+    assert.equal(configModule.default.turbopack, undefined);
+    assert.equal(
+      path.resolve(configModule.default.outputFileTracingRoot),
+      path.resolve(process.cwd(), "../.."),
+      "standalone tracing must still include repo-root files such as the portal asset manifest"
+    );
   } finally {
     if (typeof previous === "string") {
       process.env.TP_NEXT_DIST_DIR = previous;


### PR DESCRIPTION
## Summary
- Root cause: the isolated managed-frontdoor smoke could start a Next dev server that served the custom not-found page for `/` and `/healthz`, while repeated failed smokes left `.next-smoke-*` directories that increased watcher pressure.
- Smallest safe change: let Next dev use its app cwd by removing the explicit Turbopack repo root, preserve repo-root standalone tracing, and prune stale frontdoor smoke dist directories before launch.

## Changes
- Removed explicit `turbopack.root` from `web/secure-landing/next.config.js`; `outputFileTracingRoot` still points at the repo root for standalone tracing and the portal asset manifest.
- Added stale `.next-smoke-*` cleanup and `WATCHPACK_POLLING=true` to the isolated frontdoor browser-smoke launcher.
- Added Node and Python coverage for the config contract and stale distDir pruning.
- Preserved existing `/healthz` JSON envelope, auth behavior, selectors, routes, env names, and smoke expectations.

## Validation
Proven green:
- `git diff --check`
- pre-commit hooks during `git commit -m "fix(frontdoor): restore managed smoke readiness"`
- `PATH=/Users/richardcheetham/.nvm/versions/node/v22.22.2/bin:/usr/bin:/bin:/usr/sbin:/sbin npm test -- --test-name-pattern "next config honors TP_NEXT_DIST_DIR"` from `web/secure-landing`
- `.venv/bin/pytest tests/validation/test_portal_smoke_scripts.py -k "frontdoor_browser_prunes_only_stale_smoke_distdirs or frontdoor_browser_tail_text"`
- `PATH=/Users/richardcheetham/.nvm/versions/node/v22.22.2/bin:/usr/bin:/bin:/usr/sbin:/sbin make test-frontdoor-contract`
- `PATH=/Users/richardcheetham/.nvm/versions/node/v22.22.2/bin:/usr/bin:/bin:/usr/sbin:/sbin make validate-frontdoor-browser` passed with Chrome launch outside the sandbox
- `make test-portal-contract` -> `303 passed`
- `PATH=/Users/richardcheetham/.nvm/versions/node/v22.22.2/bin:/usr/bin:/bin:/usr/sbin:/sbin make validate-portal-browser` passed with Chrome launch outside the sandbox
- `npm audit --audit-level=high` in repo root, `web/secure-landing`, and `cloudflare/transformationportal-worker` -> `0 vulnerabilities`
- `npm_config_cache=/private/tmp/npm-cache-tp-cloudflare PATH=/Users/richardcheetham/.nvm/versions/node/v22.22.2/bin:/usr/bin:/bin:/usr/sbin:/sbin npm run typecheck` from `cloudflare/transformationportal-worker`
- `npm_config_cache=/private/tmp/npm-cache-tp-cloudflare PATH=/Users/richardcheetham/.nvm/versions/node/v22.22.2/bin:/usr/bin:/bin:/usr/sbin:/sbin npm run dry-run` from `cloudflare/transformationportal-worker` passed outside the sandbox so Wrangler could write its normal log file
- GitHub `CI Quality Firewall (post-CI)` run `25586954150` completed `success` on `2048833a911a70ae9e907c9c389a36fa5646d522`

Still failing:
- None in the local or GitHub validation paths above.

Not run:
- `make validate-frontdoor-deployment-gate`; the required production `TP_FRONTDOOR_GATE_FRONTDOOR_URL` and `TP_FRONTDOOR_GATE_CF_ACCESS_TEAM_DOMAIN` were not available in env or repo docs. Current main Vercel production deployment found through Vercel is `https://transformation-portal-frontdoor-n2gnsfirf-rc219805s-projects.vercel.app`.

## Risk
- Compatibility risk is bounded to local managed-frontdoor dev/smoke startup and Next config root selection.
- Production standalone tracing remains repo-root scoped through `outputFileTracingRoot`.
- The change is revert-safe: it removes an explicit Turbopack root that caused local dev route discovery issues, and the stale distDir cleanup only targets ignored `.next-smoke-*` artifacts owned by the smoke harness.