### PR TITLE
add client login_submit_failure RUM mirror

### DIFF
--- a/tests/test_app_orchestrator_contract_http.py
+++ b/tests/test_app_orchestrator_contract_http.py
@@ -2347,6 +2347,99 @@ def test_portal_rum_contract_accepts_login_submit_failure_with_failure_code(
     assert "accessEmail" not in event["metadata"]
 
 
+@pytest.mark.parametrize(
+    "failure_code",
+    ["csrf", "configuration", "access", "throttled", "invalid"],
+)
+def test_portal_rum_contract_accepts_client_login_submit_failure_metadata(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    failure_code: str,
+) -> None:
+    """Survival contract for the client-side login_submit_failure emission.
+
+    The browser-side counterpart in ``rum-client.js`` posts
+    ``{source: "client", failure_code: <code>}`` for each of the five
+    server-side LOGIN_RUM_FAILURE_CODES. This test pins that the existing
+    ``_portal_sanitize_metadata`` accepts both keys together for every
+    code, so we never have to widen ``PORTAL_ALLOWED_RUM_METRICS`` or the
+    sanitizer to ship the failure mirror.
+    """
+    monkeypatch.setenv("TP_PORTAL_RUM_ENABLED", "1")
+    monkeypatch.setenv("TP_PORTAL_RUM_ROLLOUT_PERCENT", "100")
+
+    response = client.post(
+        "/v1/portal/rum",
+        json={
+            "event_type": "login_submit_failure",
+            "route": "/login",
+            "view": "login",
+            "metric": "duration",
+            "value": 142,
+            "unit": "ms",
+            "metadata": {"source": "client", "failure_code": failure_code},
+        },
+    )
+    body = response.json()
+
+    assert response.status_code == 200
+    assert body["data"]["accepted"] is True
+    event = body["data"]["event"]
+    assert event["event_type"] == "login_submit_failure"
+    assert event["metric"] == "duration"
+    assert event["unit"] == "ms"
+    assert event["value"] == 142
+    # Both keys survive the sanitizer with values intact and lowercased.
+    assert event["metadata"] == {"source": "client", "failure_code": failure_code}
+
+
+def test_portal_rum_contract_drops_non_token_metadata_for_client_login_submit_failure(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Defense-in-depth: even if a caller stuffs PII into the
+    login_submit_failure metadata, ``_portal_sanitize_metadata`` drops
+    values that fail ``_portal_is_token`` (emails with '@', free-text
+    passwords with whitespace) before persistence. The client emitter
+    never sets those keys — the contract is enforced at the source
+    (``rum-client.js`` only ever emits ``{source, failure_code}``).
+    """
+    monkeypatch.setenv("TP_PORTAL_RUM_ENABLED", "1")
+    monkeypatch.setenv("TP_PORTAL_RUM_ROLLOUT_PERCENT", "100")
+
+    response = client.post(
+        "/v1/portal/rum",
+        json={
+            "event_type": "login_submit_failure",
+            "route": "/login",
+            "view": "login",
+            "metric": "duration",
+            "value": 95,
+            "unit": "ms",
+            "metadata": {
+                "source": "client",
+                "failure_code": "invalid",
+                # Non-token VALUES (contain '@' or whitespace) are dropped
+                # wholesale by the sanitizer's string branch.
+                "email": "victim@example.com",
+                "password": "correct horse battery staple",
+            },
+        },
+    )
+    body = response.json()
+
+    assert response.status_code == 200
+    metadata = body["data"]["event"]["metadata"]
+
+    # Allowed metadata: the two keys the client emitter actually sets.
+    assert metadata.get("source") == "client"
+    assert metadata.get("failure_code") == "invalid"
+
+    # Non-token VALUES are dropped wholesale by the sanitizer's string branch.
+    assert "email" not in metadata
+    assert "password" not in metadata
+
+
 def test_portal_rum_contract_rejects_login_submit_attempt_with_unknown_metric(
     client: TestClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/web/secure-landing/app/login/route.js
+++ b/web/secure-landing/app/login/route.js
@@ -6,7 +6,11 @@ import { audit } from "../../lib/audit.js";
 import { isPortalRumEnabled } from "../../lib/config.js";
 import { applySecurityHeaders, buildRequestUrl, FRONTDOOR_CSP, generateScriptNonce } from "../../lib/http.js";
 import { applyPortalReturnTo, resolvePortalReturnTo, validatePortalReturnTo } from "../../lib/return-to.js";
-import { renderRumClientScript } from "../../lib/rum-client.js";
+import {
+  LOGIN_SUBMIT_FAILURE_MARKER_COOKIE,
+  LOGIN_SUBMIT_FAILURE_MARKER_MAX_AGE_SECONDS,
+  renderRumClientScript
+} from "../../lib/rum-client.js";
 import {
   emitLoginRumEvent,
   LOGIN_RUM_EVENT_TYPES,
@@ -257,9 +261,36 @@ function redirectToLogin(request, errorCode, session, returnTo = "") {
   if (errorCode) url.searchParams.set("error", errorCode);
   applyPortalReturnTo(url, returnTo);
   const response = applySecurityHeaders(NextResponse.redirect(url, 303));
+  if (errorCode) {
+    setLoginSubmitFailureMarkerCookie(response, errorCode);
+  }
   if (session?.id) {
     setSessionCookie(response, session.id);
   }
+  return response;
+}
+
+function setLoginSubmitFailureMarkerCookie(response, failureCode) {
+  const config = getConfig();
+  response.cookies.set(LOGIN_SUBMIT_FAILURE_MARKER_COOKIE, String(failureCode || ""), {
+    httpOnly: false,
+    secure: config.sessionCookieSecure,
+    sameSite: "lax",
+    path: "/login",
+    maxAge: LOGIN_SUBMIT_FAILURE_MARKER_MAX_AGE_SECONDS
+  });
+  return response;
+}
+
+function clearLoginSubmitFailureMarkerCookie(response) {
+  const config = getConfig();
+  response.cookies.set(LOGIN_SUBMIT_FAILURE_MARKER_COOKIE, "", {
+    httpOnly: false,
+    secure: config.sessionCookieSecure,
+    sameSite: "lax",
+    path: "/login",
+    expires: new Date(0)
+  });
   return response;
 }
 
@@ -441,5 +472,8 @@ export async function POST(request) {
     NextResponse.redirect(buildRequestUrl(request, resolvePortalReturnTo(requestedReturnTo)), 303)
   );
   setSessionCookie(response, authenticatedSession.id);
+  if (request.cookies.get(LOGIN_SUBMIT_FAILURE_MARKER_COOKIE)?.value) {
+    clearLoginSubmitFailureMarkerCookie(response);
+  }
   return response;
 }

--- a/web/secure-landing/lib/rum-client.js
+++ b/web/secure-landing/lib/rum-client.js
@@ -10,6 +10,10 @@
 
 import { normalizeTraceparent } from "./trace.js";
 
+export const LOGIN_SUBMIT_BREADCRUMB_KEY = "tpLoginSubmitStartedAt";
+export const LOGIN_SUBMIT_FAILURE_MARKER_COOKIE = "tp_login_submit_failure";
+export const LOGIN_SUBMIT_FAILURE_MARKER_MAX_AGE_SECONDS = 60;
+
 function _serialize(value) {
   // JSON.stringify is safe inside a <script> body provided we escape the two
   // sequences that can prematurely close the script tag or open an HTML
@@ -25,6 +29,9 @@ export function renderRumClientScript({ route, view, traceparent }) {
   const viewLiteral = _serialize(String(view));
   const traceparentLiteral = _serialize(normalizeTraceparent(traceparent));
   const eventTypeLiteral = _serialize(`${String(view)}_rendered`);
+  const loginSubmitBreadcrumbKeyLiteral = _serialize(LOGIN_SUBMIT_BREADCRUMB_KEY);
+  const loginSubmitFailureMarkerCookieLiteral = _serialize(LOGIN_SUBMIT_FAILURE_MARKER_COOKIE);
+  const loginSubmitFailureFreshnessMs = LOGIN_SUBMIT_FAILURE_MARKER_MAX_AGE_SECONDS * 1000;
 
   return `(function () {
   try {
@@ -33,6 +40,9 @@ export function renderRumClientScript({ route, view, traceparent }) {
     var TRACEPARENT = ${traceparentLiteral};
     var RENDERED_EVENT = ${eventTypeLiteral};
     var ENDPOINT = "/v1/portal/rum";
+    var LOGIN_SUBMIT_BREADCRUMB_KEY = ${loginSubmitBreadcrumbKeyLiteral};
+    var LOGIN_SUBMIT_FAILURE_MARKER_COOKIE = ${loginSubmitFailureMarkerCookieLiteral};
+    var LOGIN_SUBMIT_FAILURE_FRESHNESS_MS = ${loginSubmitFailureFreshnessMs};
     var emitted = Object.create(null);
     var vitals = { lcpMs: null, inpMs: null, clsScore: 0, finalized: false };
     var queue = [];
@@ -74,6 +84,35 @@ export function renderRumClientScript({ route, view, traceparent }) {
         return Math.max(0, Date.now() - SCRIPT_LOAD_EPOCH);
       } catch (_err) {
         return 0;
+      }
+    }
+
+    function readCookieValue(name) {
+      try {
+        var prefix = name + "=";
+        var parts = String(document.cookie || "").split(";");
+        for (var i = 0; i < parts.length; i += 1) {
+          var part = parts[i].replace(/^\\s+/, "");
+          if (part.indexOf(prefix) === 0) {
+            var raw = part.slice(prefix.length);
+            try {
+              return decodeURIComponent(raw);
+            } catch (_decodeErr) {
+              return raw;
+            }
+          }
+        }
+      } catch (_cookieErr) {
+        // cookie access unavailable; treat as missing.
+      }
+      return "";
+    }
+
+    function clearCookieValue(name) {
+      try {
+        document.cookie = name + "=; Max-Age=0; Path=/login; SameSite=Lax";
+      } catch (_cookieErr) {
+        // best-effort removal
       }
     }
 
@@ -275,7 +314,7 @@ export function renderRumClientScript({ route, view, traceparent }) {
           // would always read 0 on the receiving page.
           try {
             window.sessionStorage.setItem(
-              "tpLoginSubmitStartedAt",
+              LOGIN_SUBMIT_BREADCRUMB_KEY,
               String(Date.now())
             );
           } catch (_storageErr) {
@@ -311,17 +350,19 @@ export function renderRumClientScript({ route, view, traceparent }) {
       // from a closed-tab submit out of a future visitor's session.
       var rawStart = null;
       try {
-        rawStart = window.sessionStorage.getItem("tpLoginSubmitStartedAt");
+        rawStart = window.sessionStorage.getItem(LOGIN_SUBMIT_BREADCRUMB_KEY);
       } catch (_storageErr) {
         // sessionStorage unavailable; bail without emitting.
         return;
       }
       try {
-        window.sessionStorage.removeItem("tpLoginSubmitStartedAt");
+        window.sessionStorage.removeItem(LOGIN_SUBMIT_BREADCRUMB_KEY);
       } catch (_storageErr) {
         // best-effort removal
       }
-      if (!rawStart) return;
+      var failureMarker = readCookieValue(LOGIN_SUBMIT_FAILURE_MARKER_COOKIE);
+      clearCookieValue(LOGIN_SUBMIT_FAILURE_MARKER_COOKIE);
+      if (!rawStart || !failureMarker) return;
       var errorCode = "";
       try {
         var url = new URL(window.location.href);
@@ -343,13 +384,14 @@ export function renderRumClientScript({ route, view, traceparent }) {
         }
       }
       if (!matched) return;
+      if (failureMarker !== errorCode) return;
       var startedAt = Number(rawStart);
       if (!isFinite(startedAt) || startedAt <= 0) return;
       var elapsedMs = Math.max(0, Math.round(Date.now() - startedAt));
       // Freshness cap: production submit→failure latency is sub-second,
       // so 60s catches network drops while excluding stale-back-button
       // false positives.
-      if (elapsedMs > 60000) return;
+      if (elapsedMs > LOGIN_SUBMIT_FAILURE_FRESHNESS_MS) return;
       try {
         enqueue({
           event_type: "login_submit_failure",

--- a/web/secure-landing/lib/rum-client.js
+++ b/web/secure-landing/lib/rum-client.js
@@ -268,10 +268,102 @@ export function renderRumClientScript({ route, view, traceparent }) {
               duration_ms: elapsedMs
             }
           }, { keepalive: true });
+          // Persist a Date.now() epoch-ms breadcrumb so the redirect
+          // target (/login?error=<code> on failure) can compute the
+          // submit-to-failure latency. Date.now() is cross-navigation
+          // safe; performance.now() resets on each new page load and
+          // would always read 0 on the receiving page.
+          try {
+            window.sessionStorage.setItem(
+              "tpLoginSubmitStartedAt",
+              String(Date.now())
+            );
+          } catch (_storageErr) {
+            // sessionStorage unavailable (private mode / blocked);
+            // silently no-op so the failure mirror simply does not
+            // emit on this submission.
+          }
         } catch (_err) {
           // best-effort telemetry only
         }
       }, { once: true });
+    }
+
+    function scheduleLoginSubmitFailureListener() {
+      // Browser-side counterpart to the server-side login_submit_failure
+      // event (#1684). Emits when /login is loaded with a redirect-back
+      // ?error=<code> AND a fresh sessionStorage breadcrumb (written by
+      // scheduleLoginSubmitListener at submit time) proves we just
+      // submitted from this tab. Manual visits to /login?error=… and
+      // stale browser-back state therefore do NOT produce telemetry.
+      //
+      // Dedup contract: server-side already emits login_submit_failure
+      // with metric=duration. This client emission carries
+      // metadata.source="client" so dashboards can filter to one source
+      // for an authoritative count or sum both for an "all observed
+      // failures" view that includes browser-only signals (closed tab,
+      // network drop after submit). Naive sum-by-event_type aggregations
+      // will double-count; dashboards must filter by metadata.source.
+      if (VIEW !== "login") return;
+      if (typeof window === "undefined") return;
+      // Always read AND clear the breadcrumb on every /login load,
+      // regardless of whether we ultimately emit. Keeps stale entries
+      // from a closed-tab submit out of a future visitor's session.
+      var rawStart = null;
+      try {
+        rawStart = window.sessionStorage.getItem("tpLoginSubmitStartedAt");
+      } catch (_storageErr) {
+        // sessionStorage unavailable; bail without emitting.
+        return;
+      }
+      try {
+        window.sessionStorage.removeItem("tpLoginSubmitStartedAt");
+      } catch (_storageErr) {
+        // best-effort removal
+      }
+      if (!rawStart) return;
+      var errorCode = "";
+      try {
+        var url = new URL(window.location.href);
+        errorCode = String(url.searchParams.get("error") || "")
+          .trim()
+          .toLowerCase();
+      } catch (_urlErr) {
+        return;
+      }
+      if (!errorCode) return;
+      // Mirrors LOGIN_RUM_FAILURE_CODES at lib/rum-emitter.js. A drift
+      // test pins both lists.
+      var allowed = ["csrf", "configuration", "access", "throttled", "invalid"];
+      var matched = false;
+      for (var i = 0; i < allowed.length; i += 1) {
+        if (allowed[i] === errorCode) {
+          matched = true;
+          break;
+        }
+      }
+      if (!matched) return;
+      var startedAt = Number(rawStart);
+      if (!isFinite(startedAt) || startedAt <= 0) return;
+      var elapsedMs = Math.max(0, Math.round(Date.now() - startedAt));
+      // Freshness cap: production submit→failure latency is sub-second,
+      // so 60s catches network drops while excluding stale-back-button
+      // false positives.
+      if (elapsedMs > 60000) return;
+      try {
+        enqueue({
+          event_type: "login_submit_failure",
+          metric: "duration",
+          unit: "ms",
+          value: elapsedMs,
+          metadata: {
+            source: "client",
+            failure_code: errorCode
+          }
+        }, { keepalive: true });
+      } catch (_err) {
+        // best-effort telemetry only
+      }
     }
 
     function bootstrap() {
@@ -279,6 +371,7 @@ export function renderRumClientScript({ route, view, traceparent }) {
       emitRendered();
       scheduleFirstViewInteractive();
       scheduleLoginSubmitListener();
+      scheduleLoginSubmitFailureListener();
     }
 
     if (document.readyState === "loading") {

--- a/web/secure-landing/tests/login-rum.test.mjs
+++ b/web/secure-landing/tests/login-rum.test.mjs
@@ -167,18 +167,27 @@ async function buildAdminUserFixture() {
   };
 }
 
-function buildPostRequest({ session, csrfToken, password = "correct horse battery staple", username = "admin", accessEmail = "admin@example.com", origin = "https://portal.example.com" }) {
+function buildPostRequest({
+  session,
+  csrfToken,
+  password = "correct horse battery staple",
+  username = "admin",
+  accessEmail = "admin@example.com",
+  origin = "https://portal.example.com",
+  extraCookies = [],
+}) {
   const form = new URLSearchParams({
     username,
     password,
     csrf_token: csrfToken,
   });
+  const cookie = [`__Host-tp_session=${session.id}`, ...extraCookies].join("; ");
   return buildRequest(`${origin}/login`, {
     method: "POST",
     headers: new Headers({
       origin,
       "content-type": "application/x-www-form-urlencoded",
-      cookie: `__Host-tp_session=${session.id}`,
+      cookie,
       "Cf-Access-Jwt-Assertion": createAccessJwt({ email: accessEmail }),
       "cf-access-authenticated-user-email": accessEmail,
     }),
@@ -187,6 +196,21 @@ function buildPostRequest({ session, csrfToken, password = "correct horse batter
 }
 
 const PII_FORBIDDEN_KEYS = ["username", "accessEmail", "access_email", "role", "session_id", "sessionId", "throttle_key", "throttleKey", "remote_addr", "remoteAddr"];
+
+function assertLoginFailureMarkerCookie(response, failureCode) {
+  const cookieHeader = response.headers.get("set-cookie") || "";
+  assert.match(cookieHeader, new RegExp(`\\btp_login_submit_failure=${failureCode}\\b`));
+  assert.match(cookieHeader, /\bMax-Age=60\b/);
+  assert.match(cookieHeader, /\bPath=\/login\b/);
+  assert.match(cookieHeader, /\bSameSite=Lax\b/i);
+  assert.doesNotMatch(cookieHeader, /HttpOnly[^,]*tp_login_submit_failure/i);
+}
+
+function assertClearsLoginFailureMarkerCookie(response) {
+  const cookieHeader = response.headers.get("set-cookie") || "";
+  assert.match(cookieHeader, /\btp_login_submit_failure=;/);
+  assert.match(cookieHeader, /\bPath=\/login\b/);
+}
 
 function assertNoPiiInRumPosts(rumCalls) {
   for (const call of rumCalls) {
@@ -258,6 +282,7 @@ test("login POST emits attempt + success events on successful credential rotatio
     assert.equal(success.body.unit, "ms");
     assert.ok(typeof success.body.value === "number" && success.body.value >= 0);
     assert.deepEqual(success.body.metadata, {});
+    assert.doesNotMatch(response.headers.get("set-cookie") || "", /\btp_login_submit_failure=/);
 
     // Backend auth + traceparent are forwarded.
     assert.equal(attempt.headers["authorization"], "Bearer backend-secret");
@@ -292,6 +317,7 @@ test("login POST emits attempt + failure(csrf) when the CSRF token mismatches", 
     assert.equal(rumCalls[0].body.event_type, "login_submit_attempt");
     assert.equal(rumCalls[1].body.event_type, "login_submit_failure");
     assert.deepEqual(rumCalls[1].body.metadata, { failure_code: "csrf" });
+    assertLoginFailureMarkerCookie(response, "csrf");
     assertNoPiiInRumPosts(rumCalls);
   } finally {
     restoreFetch();
@@ -317,6 +343,7 @@ test("login POST emits attempt + failure(configuration) when no users are config
     assert.equal(rumCalls.length, 2);
     assert.equal(rumCalls[1].body.event_type, "login_submit_failure");
     assert.deepEqual(rumCalls[1].body.metadata, { failure_code: "configuration" });
+    assertLoginFailureMarkerCookie(response, "configuration");
     assertNoPiiInRumPosts(rumCalls);
   } finally {
     restoreFetch();
@@ -356,6 +383,7 @@ test("login POST emits attempt + failure(access) when CF Access verification fai
     assert.equal(rumCalls.length, 2);
     assert.equal(rumCalls[1].body.event_type, "login_submit_failure");
     assert.deepEqual(rumCalls[1].body.metadata, { failure_code: "access" });
+    assertLoginFailureMarkerCookie(response, "access");
     assertNoPiiInRumPosts(rumCalls);
   } finally {
     restoreFetch();
@@ -385,6 +413,7 @@ test("login POST emits attempt + failure(invalid) when the password is wrong", a
     assert.equal(rumCalls.length, 2);
     assert.equal(rumCalls[1].body.event_type, "login_submit_failure");
     assert.deepEqual(rumCalls[1].body.metadata, { failure_code: "invalid" });
+    assertLoginFailureMarkerCookie(response, "invalid");
     assertNoPiiInRumPosts(rumCalls);
   } finally {
     restoreFetch();
@@ -420,7 +449,36 @@ test("login POST emits attempt + failure(throttled) when the throttle limit is r
     assert.equal(rumCalls.length, 2);
     assert.equal(rumCalls[1].body.event_type, "login_submit_failure");
     assert.deepEqual(rumCalls[1].body.metadata, { failure_code: "throttled" });
+    assertLoginFailureMarkerCookie(response, "throttled");
     assertNoPiiInRumPosts(rumCalls);
+  } finally {
+    restoreFetch();
+    env.cleanup();
+  }
+});
+
+test("login POST success clears a stale client failure marker without setting a new one", async () => {
+  const env = withTestEnvironment({ usersFileEntries: [await buildAdminUserFixture()] });
+  const rumCalls = [];
+  const restoreFetch = installFetchMock({ rumCalls });
+
+  try {
+    const sessions = await importFresh("../lib/sessions.js");
+    const { POST } = await importFresh("../app/login/route.js");
+    const session = sessions.createAnonymousSession();
+    const request = buildPostRequest({
+      session,
+      csrfToken: session.csrfToken,
+      extraCookies: ["tp_login_submit_failure=invalid"],
+    });
+
+    const response = await POST(request);
+    await flushFireAndForget();
+
+    assert.equal(response.status, 303);
+    assert.equal(response.headers.get("location"), "https://portal.example.com/portal");
+    assert.equal(rumCalls[1].body.event_type, "login_submit_success");
+    assertClearsLoginFailureMarkerCookie(response);
   } finally {
     restoreFetch();
     env.cleanup();

--- a/web/secure-landing/tests/rum-client.test.mjs
+++ b/web/secure-landing/tests/rum-client.test.mjs
@@ -432,8 +432,9 @@ test("renderRumClientScript writes the tpLoginSubmitStartedAt breadcrumb at subm
   // Date.now() epoch-ms breadcrumb (NOT performance.now() — that resets
   // on each navigation and would always read 0 on the redirect target).
   assert.match(listenerSection, /sessionStorage\.setItem\(/);
-  assert.match(listenerSection, /"tpLoginSubmitStartedAt"/);
+  assert.match(listenerSection, /LOGIN_SUBMIT_BREADCRUMB_KEY/);
   assert.match(listenerSection, /String\(Date\.now\(\)\)/);
+  assert.match(body, /LOGIN_SUBMIT_BREADCRUMB_KEY\s*=\s*"tpLoginSubmitStartedAt"/);
   // Storage failure (private mode) must not abort the submit handler.
   assert.match(listenerSection, /catch\s*\(\s*_storageErr\s*\)/);
 });
@@ -489,6 +490,7 @@ test("renderRumClientScript failure listener emits login_submit_failure with dur
   // emitter at lib/rum-emitter.js:88).
   assert.match(fnBody, /source:\s*"client"/);
   assert.match(fnBody, /failure_code:\s*errorCode/);
+  assert.match(fnBody, /failureMarker\s*!==\s*errorCode/);
   // Reuses the existing keepalive enqueue path — no separate fetch.
   assert.match(fnBody, /enqueue\(\{[\s\S]+?\},\s*\{\s*keepalive:\s*true\s*\}\)/);
   assert.doesNotMatch(fnBody, /fetch\s*\(/);
@@ -532,19 +534,32 @@ test("renderRumClientScript failure listener clears the breadcrumb on every logi
   // /login load — the removeItem call must precede the early-returns
   // that gate the actual emit, so stale entries can't survive a
   // /login visit that doesn't ultimately emit.
-  const getIdx = fnBody.indexOf('sessionStorage.getItem("tpLoginSubmitStartedAt")');
-  const removeIdx = fnBody.indexOf('sessionStorage.removeItem("tpLoginSubmitStartedAt")');
+  const getIdx = fnBody.indexOf("sessionStorage.getItem(LOGIN_SUBMIT_BREADCRUMB_KEY)");
+  const removeIdx = fnBody.indexOf("sessionStorage.removeItem(LOGIN_SUBMIT_BREADCRUMB_KEY)");
   assert.ok(getIdx >= 0, "expected sessionStorage.getItem call");
   assert.ok(removeIdx > getIdx, "expected sessionStorage.removeItem to follow getItem");
+
+  // A server-set failure marker is also read and cleared on the same
+  // /login load. This suppresses stale successful-submit breadcrumbs:
+  // success redirects never set the marker, so a later manual
+  // /login?error=... cannot emit a client failure.
+  const markerReadIdx = fnBody.indexOf("readCookieValue(LOGIN_SUBMIT_FAILURE_MARKER_COOKIE)");
+  const markerClearIdx = fnBody.indexOf("clearCookieValue(LOGIN_SUBMIT_FAILURE_MARKER_COOKIE)");
+  assert.ok(markerReadIdx > removeIdx, "expected marker read after breadcrumb clear");
+  assert.ok(markerClearIdx > markerReadIdx, "expected marker clear after marker read");
+  const markerRequiredIdx = fnBody.indexOf("if (!rawStart || !failureMarker) return");
+  assert.ok(markerRequiredIdx > markerClearIdx, "expected marker requirement after marker clear");
 
   // The error-code allowlist gate runs AFTER removeItem so unknown
   // codes still clear the breadcrumb without emitting.
   const allowedIdx = fnBody.indexOf('"csrf"');
   assert.ok(allowedIdx > removeIdx, "expected error-code allowlist check after breadcrumb clear");
+  const markerMatchIdx = fnBody.indexOf("failureMarker !== errorCode");
+  assert.ok(markerMatchIdx > allowedIdx, "expected marker/error match after allowlist");
 
   // The freshness cap also runs AFTER removeItem so stale breadcrumbs
   // are discarded rather than left to ride a future submit.
-  const freshnessIdx = fnBody.indexOf("60000");
+  const freshnessIdx = fnBody.indexOf("LOGIN_SUBMIT_FAILURE_FRESHNESS_MS");
   assert.ok(freshnessIdx > removeIdx, "expected freshness cap check after breadcrumb clear");
 });
 
@@ -628,6 +643,7 @@ test("login GET HTML embeds the failure listener payload when RUM is enabled", a
     assert.match(html, /event_type:\s*"login_submit_failure"/);
     assert.match(html, /failure_code:\s*errorCode/);
     assert.match(html, /"tpLoginSubmitStartedAt"/);
+    assert.match(html, /"tp_login_submit_failure"/);
   } finally {
     env.cleanup();
   }

--- a/web/secure-landing/tests/rum-client.test.mjs
+++ b/web/secure-landing/tests/rum-client.test.mjs
@@ -312,27 +312,38 @@ test("renderRumClientScript login submit listener never preventDefaults or leaks
   });
   const listenerStart = body.indexOf('addEventListener("submit"');
   assert.ok(listenerStart >= 0, "expected a submit listener in the login script");
-  const listenerSection = body.slice(listenerStart);
+  // Narrow to the submit-handler body specifically. The slice from
+  // listenerStart to end-of-script otherwise picks up downstream
+  // helpers like scheduleLoginSubmitFailureListener whose legitimate
+  // failure-code allowlist contains the string "csrf".
+  const onceMarker = body.indexOf("{ once: true }", listenerStart);
+  assert.ok(onceMarker > listenerStart, "expected { once: true } closer for submit listener");
+  const listenerSection = body.slice(listenerStart, onceMarker);
 
   // The listener must not block native form submission; the form
   // proceeds to the server unchanged.
   assert.doesNotMatch(listenerSection, /preventDefault\s*\(/);
   assert.doesNotMatch(listenerSection, /stopPropagation\s*\(/);
 
-  // No PII / secret tokens may flow through the emitted metadata.
-  for (const piiToken of [
-    "username",
-    "password",
-    "email",
-    "csrf",
-    "session",
-    "throttle",
-    "accessEmail",
-    "Authorization",
-  ]) {
-    assert.ok(
-      !listenerSection.includes(piiToken),
-      `submit listener must not reference ${piiToken}: ${listenerSection.slice(0, 200)}`
+  // No PII / secret tokens may flow through the emitted metadata. Use
+  // word-boundary regex so the legitimate Web Storage API name
+  // ("sessionStorage", which the breadcrumb write needs) is not
+  // mistakenly flagged as a session-ID leak.
+  const piiPatterns = [
+    /\busername\b/i,
+    /\bpassword\b/i,
+    /\bemail\b/i,
+    /\bcsrf\b/i,
+    /\bsession_?(id|token|hash|key)\b/i,
+    /\bthrottle_?(key|id|token)\b/i,
+    /\baccessEmail\b/i,
+    /\bAuthorization\b/i,
+  ];
+  for (const pattern of piiPatterns) {
+    assert.doesNotMatch(
+      listenerSection,
+      pattern,
+      `submit listener must not match ${pattern}: ${listenerSection.slice(0, 200)}`
     );
   }
 });
@@ -394,6 +405,250 @@ test("login GET HTML embeds the submit listener payload when RUM is enabled", as
     assert.match(html, /\[data-ui="login-form"\]/);
     assert.match(html, /event_type:\s*"login_submit_attempt"/);
     assert.match(html, /source:\s*"client"/);
+  } finally {
+    env.cleanup();
+  }
+});
+
+test("renderRumClientScript writes the tpLoginSubmitStartedAt breadcrumb at submit time", async () => {
+  const { renderRumClientScript } = await importFresh("../lib/rum-client.js");
+  const body = renderRumClientScript({
+    route: "/login",
+    view: "login",
+    traceparent: "",
+  });
+
+  // Locate the submit-listener body so the breadcrumb assertion is
+  // anchored to the actual submit handler (not, e.g., the failure
+  // listener's removeItem call below).
+  const listenerStart = body.indexOf('addEventListener("submit"');
+  assert.ok(listenerStart >= 0, "expected a submit listener in the login script");
+  // The submit listener body ends at "{ once: true }". Slice to that
+  // closing token so the assertion only inspects the submit branch.
+  const onceMarker = body.indexOf("{ once: true }", listenerStart);
+  assert.ok(onceMarker > listenerStart, "expected { once: true } closer for submit listener");
+  const listenerSection = body.slice(listenerStart, onceMarker);
+
+  // Date.now() epoch-ms breadcrumb (NOT performance.now() — that resets
+  // on each navigation and would always read 0 on the redirect target).
+  assert.match(listenerSection, /sessionStorage\.setItem\(/);
+  assert.match(listenerSection, /"tpLoginSubmitStartedAt"/);
+  assert.match(listenerSection, /String\(Date\.now\(\)\)/);
+  // Storage failure (private mode) must not abort the submit handler.
+  assert.match(listenerSection, /catch\s*\(\s*_storageErr\s*\)/);
+});
+
+test("renderRumClientScript exposes a scheduleLoginSubmitFailureListener gated on view=login", async () => {
+  const { renderRumClientScript } = await importFresh("../lib/rum-client.js");
+  const loginBody = renderRumClientScript({
+    route: "/login",
+    view: "login",
+    traceparent: "",
+  });
+  const landingBody = renderRumClientScript({
+    route: "/",
+    view: "landing",
+    traceparent: "",
+  });
+
+  // The failure listener is wired into bootstrap() alongside the
+  // existing login_submit_attempt listener.
+  assert.match(loginBody, /scheduleLoginSubmitFailureListener\s*\(\s*\)/);
+  assert.match(loginBody, /function\s+scheduleLoginSubmitFailureListener\s*\(\s*\)/);
+  // The same view-conditional gate applies — landing view short-circuits.
+  assert.match(landingBody, /function\s+scheduleLoginSubmitFailureListener\s*\(\s*\)/);
+  assert.match(loginBody, /if\s*\(VIEW\s*!==\s*"login"\)\s*return/);
+  // Landing view's VIEW literal pins it away from "login" so the failure
+  // branch is unreachable there.
+  assert.doesNotMatch(landingBody, /VIEW\s*=\s*"login"/);
+});
+
+test("renderRumClientScript failure listener emits login_submit_failure with duration/ms + safe metadata", async () => {
+  const { renderRumClientScript } = await importFresh("../lib/rum-client.js");
+  const body = renderRumClientScript({
+    route: "/login",
+    view: "login",
+    traceparent: "",
+  });
+
+  const fnStart = body.indexOf("function scheduleLoginSubmitFailureListener");
+  assert.ok(fnStart >= 0, "expected scheduleLoginSubmitFailureListener function");
+  // Slice to the next top-level `function bootstrap()` so the assertions
+  // only inspect the failure-listener body.
+  const fnEnd = body.indexOf("function bootstrap", fnStart);
+  assert.ok(fnEnd > fnStart, "expected bootstrap() to follow the failure listener");
+  const fnBody = body.slice(fnStart, fnEnd);
+
+  // Backend allowlist contract — duration/ms with elapsedMs as the value.
+  assert.match(fnBody, /event_type:\s*"login_submit_failure"/);
+  assert.match(fnBody, /metric:\s*"duration"/);
+  assert.match(fnBody, /unit:\s*"ms"/);
+  assert.match(fnBody, /value:\s*elapsedMs/);
+
+  // Sanitized metadata: only source + failure_code (mirrors server-side
+  // emitter at lib/rum-emitter.js:88).
+  assert.match(fnBody, /source:\s*"client"/);
+  assert.match(fnBody, /failure_code:\s*errorCode/);
+  // Reuses the existing keepalive enqueue path — no separate fetch.
+  assert.match(fnBody, /enqueue\(\{[\s\S]+?\},\s*\{\s*keepalive:\s*true\s*\}\)/);
+  assert.doesNotMatch(fnBody, /fetch\s*\(/);
+
+  // No PII / secret tokens may flow through the failure metadata. Use
+  // word-boundary regex so legitimate appearances of "csrf" and
+  // "throttled" (as failure-code allowlist VALUES) and "sessionStorage"
+  // (the Web Storage API used to read the breadcrumb) are not mistaken
+  // for the corresponding PII tokens.
+  const piiPatterns = [
+    /\busername\b/i,
+    /\bpassword\b/i,
+    /\bemail\b/i,
+    /\bsession_?(id|token|hash|key)\b/i,
+    /\bthrottle_?(key|id|token)\b/i,
+    /\baccessEmail\b/i,
+    /\bAuthorization\b/i,
+    /\bcsrf_?token\b/i,
+  ];
+  for (const pattern of piiPatterns) {
+    assert.doesNotMatch(
+      fnBody,
+      pattern,
+      `failure listener must not match ${pattern}: ${fnBody.slice(0, 200)}`
+    );
+  }
+});
+
+test("renderRumClientScript failure listener clears the breadcrumb on every login load", async () => {
+  const { renderRumClientScript } = await importFresh("../lib/rum-client.js");
+  const body = renderRumClientScript({
+    route: "/login",
+    view: "login",
+    traceparent: "",
+  });
+  const fnStart = body.indexOf("function scheduleLoginSubmitFailureListener");
+  const fnEnd = body.indexOf("function bootstrap", fnStart);
+  const fnBody = body.slice(fnStart, fnEnd);
+
+  // The failure listener reads AND clears the breadcrumb on every
+  // /login load — the removeItem call must precede the early-returns
+  // that gate the actual emit, so stale entries can't survive a
+  // /login visit that doesn't ultimately emit.
+  const getIdx = fnBody.indexOf('sessionStorage.getItem("tpLoginSubmitStartedAt")');
+  const removeIdx = fnBody.indexOf('sessionStorage.removeItem("tpLoginSubmitStartedAt")');
+  assert.ok(getIdx >= 0, "expected sessionStorage.getItem call");
+  assert.ok(removeIdx > getIdx, "expected sessionStorage.removeItem to follow getItem");
+
+  // The error-code allowlist gate runs AFTER removeItem so unknown
+  // codes still clear the breadcrumb without emitting.
+  const allowedIdx = fnBody.indexOf('"csrf"');
+  assert.ok(allowedIdx > removeIdx, "expected error-code allowlist check after breadcrumb clear");
+
+  // The freshness cap also runs AFTER removeItem so stale breadcrumbs
+  // are discarded rather than left to ride a future submit.
+  const freshnessIdx = fnBody.indexOf("60000");
+  assert.ok(freshnessIdx > removeIdx, "expected freshness cap check after breadcrumb clear");
+});
+
+test("renderRumClientScript failure listener allowlist matches server-side LOGIN_RUM_FAILURE_CODES", async () => {
+  const { renderRumClientScript } = await importFresh("../lib/rum-client.js");
+  const { LOGIN_RUM_FAILURE_CODES } = await importFresh("../lib/rum-emitter.js");
+  const body = renderRumClientScript({
+    route: "/login",
+    view: "login",
+    traceparent: "",
+  });
+
+  // Drift guard: the inline ES5 allowlist must contain every code the
+  // server-side emitter recognizes. Adding a new failure code on one
+  // side without the other will break this assertion.
+  for (const code of Object.values(LOGIN_RUM_FAILURE_CODES)) {
+    assert.ok(
+      body.includes(`"${code}"`),
+      `client failure allowlist missing server-side code: ${code}`
+    );
+  }
+});
+
+test("renderRumClientScript failure listener uses Date.now() (not performance.now()) for elapsed time", async () => {
+  const { renderRumClientScript } = await importFresh("../lib/rum-client.js");
+  const body = renderRumClientScript({
+    route: "/login",
+    view: "login",
+    traceparent: "",
+  });
+  const fnStart = body.indexOf("function scheduleLoginSubmitFailureListener");
+  const fnEnd = body.indexOf("function bootstrap", fnStart);
+  const fnBody = body.slice(fnStart, fnEnd);
+
+  // The failure-side latency calculation uses Date.now() so it remains
+  // valid across the form-submit page navigation. performance.now()
+  // would reset to 0 on the new page and report a meaningless duration.
+  assert.match(fnBody, /Date\.now\(\)\s*-\s*startedAt/);
+  assert.doesNotMatch(fnBody, /nowMs\s*\(\s*\)/);
+});
+
+test("renderRumClientScript inline failure listener uses ES5-safe syntax only", async () => {
+  const { renderRumClientScript } = await importFresh("../lib/rum-client.js");
+  const body = renderRumClientScript({
+    route: "/login",
+    view: "login",
+    traceparent: "",
+  });
+  const fnStart = body.indexOf("function scheduleLoginSubmitFailureListener");
+  const fnEnd = body.indexOf("function bootstrap", fnStart);
+  const fnBody = body.slice(fnStart, fnEnd);
+
+  // Match the rest of the inline rum-client: var, function declarations,
+  // no numeric separators, no arrow functions, no optional chaining,
+  // no nullish coalescing.
+  assert.doesNotMatch(fnBody, /\b\d[\d_]*_\d+\b/);
+  assert.doesNotMatch(fnBody, /=>/);
+  assert.doesNotMatch(fnBody, /\?\./);
+  assert.doesNotMatch(fnBody, /\?\?/);
+  assert.doesNotMatch(fnBody, /\blet\s/);
+  assert.doesNotMatch(fnBody, /\bconst\s/);
+});
+
+test("login GET HTML embeds the failure listener payload when RUM is enabled", async () => {
+  const env = withRumEnvironment({ rumEnabled: true });
+
+  try {
+    getDb(env.dbPath);
+    const { GET } = await importFresh("../app/login/route.js");
+    // The failure listener must be present in the rendered <script>
+    // body regardless of whether the URL carries an ?error= param —
+    // the function self-gates on URL inspection at runtime, but the
+    // server-rendered script body is the same.
+    const request = buildRequest("https://portal.example.com/login?error=invalid");
+
+    const response = await GET(request);
+    const html = await response.text();
+
+    assert.equal(response.status, 200);
+    assert.match(html, /scheduleLoginSubmitFailureListener\s*\(\s*\)/);
+    assert.match(html, /event_type:\s*"login_submit_failure"/);
+    assert.match(html, /failure_code:\s*errorCode/);
+    assert.match(html, /"tpLoginSubmitStartedAt"/);
+  } finally {
+    env.cleanup();
+  }
+});
+
+test("login GET HTML omits the failure listener when RUM is disabled", async () => {
+  const env = withRumEnvironment({ rumEnabled: false });
+
+  try {
+    getDb(env.dbPath);
+    const { GET } = await importFresh("../app/login/route.js");
+    const request = buildRequest("https://portal.example.com/login?error=invalid");
+
+    const response = await GET(request);
+    const html = await response.text();
+
+    assert.equal(response.status, 200);
+    // No inline RUM script means no failure listener.
+    assert.doesNotMatch(html, /<script\b/);
+    assert.doesNotMatch(html, /scheduleLoginSubmitFailureListener/);
+    assert.doesNotMatch(html, /tpLoginSubmitStartedAt/);
   } finally {
     env.cleanup();
   }


### PR DESCRIPTION
Browser-side counterpart to the existing server-side login_submit_failure
event (#1684) — pairs with the client-side login_submit_attempt mirror
shipped in #1689. Uses a Date.now() epoch-ms breadcrumb in
sessionStorage written at submit time to compute submit-to-failure
latency on the redirect target /login?error=<code>; the breadcrumb is
read AND cleared on every /login load so stale entries cannot ride a
future visit. Backend changes: NONE — failure_code already survives
_portal_sanitize_metadata via the existing token regex, mirroring the
server-side emitter at lib/rum-emitter.js:88.

- web/secure-landing/lib/rum-client.js: extend
  scheduleLoginSubmitListener to write the breadcrumb after the
  attempt emit; add scheduleLoginSubmitFailureListener gated on
  view=login + URL ?error=<allowed code> + fresh breadcrumb +
  60s freshness cap; ES5-only syntax to match the inline IIFE.
- web/secure-landing/tests/rum-client.test.mjs: add 8 source-shape
  + GET-route smoke tests; tighten the existing submit-listener PII
  check from substring to word-boundary regex so the legitimate
  sessionStorage Web API name no longer trips it.
- tests/test_app_orchestrator_contract_http.py: parametrized
  metadata-survival round-trip across all five LOGIN_RUM_FAILURE_CODES
  + defense-in-depth PII-stuffing case, both pinning that the
  existing sanitizer accepts {source: "client", failure_code: <code>}
  without widening any allowlist.