### PR TITLE
add server-side logout_submit_* RUM events

### DIFF
--- a/app.py
+++ b/app.py
@@ -1261,8 +1261,11 @@ PORTAL_ALLOWED_RUM_EVENT_TYPES = {
     "login_submit_attempt",
     "login_submit_success",
     "login_submit_failure",
+    "logout_submit_attempt",
+    "logout_submit_success",
+    "logout_submit_failure",
 }
-PORTAL_ALLOWED_RUM_ROUTES = {"/portal", "/", "/login"}
+PORTAL_ALLOWED_RUM_ROUTES = {"/portal", "/", "/login", "/logout"}
 PORTAL_ALLOWED_RUM_VIEWS = {
     "overview",
     "build",
@@ -1284,6 +1287,9 @@ PORTAL_ALLOWED_RUM_METRICS = {
     "login_submit_attempt": {"count"},
     "login_submit_success": {"duration"},
     "login_submit_failure": {"duration"},
+    "logout_submit_attempt": {"count"},
+    "logout_submit_success": {"duration"},
+    "logout_submit_failure": {"duration"},
 }
 PATH_SCOPE_INPUT = "input"
 PATH_SCOPE_OUTPUT = "output"

--- a/tests/test_app_orchestrator_contract_http.py
+++ b/tests/test_app_orchestrator_contract_http.py
@@ -2528,6 +2528,144 @@ def test_portal_rum_contract_drops_non_token_metadata_for_client_login_submit_fa
     assert "password" not in metadata
 
 
+def test_portal_rum_contract_accepts_logout_submit_attempt(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Server-side logout_submit_attempt round-trip.
+
+    Mirrors the login_submit_attempt contract: the front-door's POST
+    /logout handler emits this event at handler entry to anchor the
+    paired attempt/terminal latency calculation. ``route="/logout"``
+    requires the new entry in PORTAL_ALLOWED_RUM_ROUTES; ``view="login"``
+    matches the redirect destination, paralleling how the login event
+    types report the user-facing shell.
+    """
+    monkeypatch.setenv("TP_PORTAL_RUM_ENABLED", "1")
+    monkeypatch.setenv("TP_PORTAL_RUM_ROLLOUT_PERCENT", "100")
+
+    response = client.post(
+        "/v1/portal/rum",
+        json={
+            "event_type": "logout_submit_attempt",
+            "route": "/logout",
+            "view": "login",
+            "metric": "count",
+            "value": 1,
+            "unit": "count",
+        },
+    )
+    body = response.json()
+
+    assert response.status_code == 200
+    assert body["data"]["accepted"] is True
+    event = body["data"]["event"]
+    assert event["event_type"] == "logout_submit_attempt"
+    assert event["route"] == "/logout"
+    assert event["view"] == "login"
+    assert event["metric"] == "count"
+    assert event["unit"] == "count"
+    assert event["metadata"] == {}
+
+
+def test_portal_rum_contract_accepts_logout_submit_success(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TP_PORTAL_RUM_ENABLED", "1")
+    monkeypatch.setenv("TP_PORTAL_RUM_ROLLOUT_PERCENT", "100")
+
+    response = client.post(
+        "/v1/portal/rum",
+        json={
+            "event_type": "logout_submit_success",
+            "route": "/logout",
+            "view": "login",
+            "metric": "duration",
+            "value": 73.4,
+            "unit": "ms",
+        },
+    )
+    body = response.json()
+
+    assert response.status_code == 200
+    assert body["data"]["accepted"] is True
+    event = body["data"]["event"]
+    assert event["event_type"] == "logout_submit_success"
+    assert event["route"] == "/logout"
+    assert event["view"] == "login"
+    assert event["metric"] == "duration"
+    assert event["unit"] == "ms"
+    assert event["value"] == 73.4
+    assert event["metadata"] == {}
+
+
+def test_portal_rum_contract_accepts_logout_submit_failure_with_csrf_code(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The logout route currently has only one failure surface (CSRF).
+
+    Both the Origin/Referrer mismatch path and the x-csrf-token mismatch
+    path fold into ``failure_code: "csrf"``. If a future change widens
+    the failure surface, both this test and ``ALLOWED_LOGOUT_FAILURE_CODES``
+    in ``lib/rum-emitter.js`` must be extended together.
+    """
+    monkeypatch.setenv("TP_PORTAL_RUM_ENABLED", "1")
+    monkeypatch.setenv("TP_PORTAL_RUM_ROLLOUT_PERCENT", "100")
+
+    response = client.post(
+        "/v1/portal/rum",
+        json={
+            "event_type": "logout_submit_failure",
+            "route": "/logout",
+            "view": "login",
+            "metric": "duration",
+            "value": 41.0,
+            "unit": "ms",
+            "metadata": {"failure_code": "csrf"},
+        },
+    )
+    body = response.json()
+
+    assert response.status_code == 200
+    assert body["data"]["accepted"] is True
+    event = body["data"]["event"]
+    assert event["event_type"] == "logout_submit_failure"
+    assert event["metric"] == "duration"
+    assert event["metadata"] == {"failure_code": "csrf"}
+
+
+def test_portal_rum_contract_rejects_logout_submit_attempt_with_unknown_route(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Defense-in-depth pin against accidental route-allowlist drift.
+
+    If a refactor drops ``/logout`` from PORTAL_ALLOWED_RUM_ROUTES, this
+    test will pass (200) instead of failing (400) when the value is
+    rejected. We instead verify a known-bad route still gets rejected,
+    proving the allowlist is enforced at all and the new ``/logout``
+    entry isn't a wildcard.
+    """
+    monkeypatch.setenv("TP_PORTAL_RUM_ENABLED", "1")
+    monkeypatch.setenv("TP_PORTAL_RUM_ROLLOUT_PERCENT", "100")
+
+    response = client.post(
+        "/v1/portal/rum",
+        json={
+            "event_type": "logout_submit_attempt",
+            "route": "/logout/anything-else",
+            "view": "login",
+            "metric": "count",
+            "value": 1,
+            "unit": "count",
+        },
+    )
+
+    assert response.status_code == 400
+
+
 def test_portal_rum_contract_rejects_login_submit_attempt_with_unknown_metric(
     client: TestClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_app_orchestrator_contract_http.py
+++ b/tests/test_app_orchestrator_contract_http.py
@@ -2640,13 +2640,17 @@ def test_portal_rum_contract_rejects_logout_submit_attempt_with_unknown_route(
     client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Defense-in-depth pin against accidental route-allowlist drift.
+    """Pin exact-match routing on the new ``/logout`` allowlist entry.
 
-    If a refactor drops ``/logout`` from PORTAL_ALLOWED_RUM_ROUTES, this
-    test will pass (200) instead of failing (400) when the value is
-    rejected. We instead verify a known-bad route still gets rejected,
-    proving the allowlist is enforced at all and the new ``/logout``
-    entry isn't a wildcard.
+    Paired with ``test_portal_rum_contract_accepts_logout_submit_attempt``
+    above (which pins exactly ``/logout`` returns 200), this test pins
+    that a sibling sub-path under ``/logout/...`` is rejected. Together
+    the pair encodes the invariant: ``/logout`` is allowed iff the
+    request route equals ``/logout`` exactly. If a refactor ever
+    weakens the route check from a set-membership test (``route in
+    PORTAL_ALLOWED_RUM_ROUTES``) to a prefix/glob match (e.g.
+    ``any(route.startswith(p) for p in ...)``), ``/logout/anything-else``
+    would suddenly start being accepted and this test would fail.
     """
     monkeypatch.setenv("TP_PORTAL_RUM_ENABLED", "1")
     monkeypatch.setenv("TP_PORTAL_RUM_ROLLOUT_PERCENT", "100")

--- a/web/secure-landing/app/logout/route.js
+++ b/web/secure-landing/app/logout/route.js
@@ -1,21 +1,52 @@
 import { NextResponse } from "next/server.js";
 
 import { applySecurityHeaders, buildRequestUrl } from "../../lib/http.js";
+import { isPortalRumEnabled } from "../../lib/config.js";
+import {
+  emitLogoutRumEvent,
+  LOGOUT_RUM_EVENT_TYPES,
+  LOGOUT_RUM_FAILURE_CODES
+} from "../../lib/rum-emitter.js";
 import {
   clearSessionCookie,
   destroySession,
   getSessionFromRequest,
   validateCsrfToken
 } from "../../lib/sessions.js";
+import { resolveRequestTraceparent } from "../../lib/trace.js";
 import { validateOriginAndReferrer } from "../../lib/request-security.js";
 import { audit } from "../../lib/audit.js";
 
 export const runtime = "nodejs";
 
 export async function POST(request) {
+  // Capture the RUM enable decision once at handler entry. This is the SOLE
+  // gate for paired emissions: the emitter intentionally does not re-check
+  // isPortalRumEnabled() so a flag flip mid-request cannot produce a partial
+  // attempt/terminal pair (one captured but not the other). Mirrors the
+  // /login handler's contract from #1684.
+  const rumActive = isPortalRumEnabled();
+  const attemptStart = Date.now();
+  const rumTraceparent = rumActive ? resolveRequestTraceparent(request) : "";
+  const emitLogoutRum = (eventType, failureCode = null) => {
+    if (!rumActive) return;
+    const value = eventType === LOGOUT_RUM_EVENT_TYPES.ATTEMPT
+      ? 1
+      : Math.max(0, Date.now() - attemptStart);
+    emitLogoutRumEvent({
+      eventType,
+      value,
+      failureCode,
+      traceparent: rumTraceparent
+    });
+  };
+
+  emitLogoutRum(LOGOUT_RUM_EVENT_TYPES.ATTEMPT);
+
   const session = getSessionFromRequest(request, { touch: false });
   if (!validateOriginAndReferrer(request)) {
     audit("csrf_failure", { path: "/logout" });
+    emitLogoutRum(LOGOUT_RUM_EVENT_TYPES.FAILURE, LOGOUT_RUM_FAILURE_CODES.CSRF);
     const response = applySecurityHeaders(NextResponse.redirect(buildRequestUrl(request, "/login?error=csrf"), 303));
     clearSessionCookie(response);
     return response;
@@ -24,6 +55,7 @@ export async function POST(request) {
   const csrfToken = request.headers.get("x-csrf-token") || "";
   if (session && !validateCsrfToken(session, csrfToken)) {
     audit("csrf_failure", { path: "/logout", username: session.username });
+    emitLogoutRum(LOGOUT_RUM_EVENT_TYPES.FAILURE, LOGOUT_RUM_FAILURE_CODES.CSRF);
     const response = applySecurityHeaders(NextResponse.redirect(buildRequestUrl(request, "/login?error=csrf"), 303));
     clearSessionCookie(response);
     return response;
@@ -32,6 +64,8 @@ export async function POST(request) {
   if (session?.id) {
     destroySession(session.id, "logout");
   }
+
+  emitLogoutRum(LOGOUT_RUM_EVENT_TYPES.SUCCESS);
 
   const response = applySecurityHeaders(NextResponse.redirect(buildRequestUrl(request, "/login"), 303));
   clearSessionCookie(response);

--- a/web/secure-landing/lib/rum-emitter.js
+++ b/web/secure-landing/lib/rum-emitter.js
@@ -1,4 +1,5 @@
-// Server-side RUM emitter for the front-door's POST /login handler.
+// Server-side RUM emitter for the front-door's POST /login and POST
+// /logout handlers.
 //
 // Fire-and-forget POSTs to FastAPI's /v1/portal/rum using the same proxy
 // helpers the browser-facing /v1/portal/rum proxy route uses. Bypasses the
@@ -19,8 +20,9 @@
 //   - Times out via `AbortSignal.timeout(...)`, which uses an internally
 //     `unref`'d timer so a slow upstream cannot extend Node process lifetime
 //     past the response.
-//   - Emission failure must never alter login response status, redirect,
-//     cookie, session rotation, CSRF handling, or response timing.
+//   - Emission failure must never alter login or logout response status,
+//     redirect, cookie, session rotation/destruction, CSRF handling, or
+//     response timing.
 
 import { getConfig } from "./config.js";
 import { buildUpstreamHeaders, buildUpstreamUrl } from "./proxy.js";
@@ -37,6 +39,15 @@ const ALLOWED_FAILURE_CODES = new Set([
   "invalid",
 ]);
 
+// Logout has only one failure surface today (CSRF — both Origin/Referrer
+// mismatch and x-csrf-token mismatch fold into the same code in
+// app/logout/route.js, both also auditing as "csrf_failure"). Keep the
+// allowlist narrow on purpose: widening it requires extending the audit
+// trail and contract tests in the same change.
+const ALLOWED_LOGOUT_FAILURE_CODES = new Set([
+  "csrf",
+]);
+
 const LOGIN_ATTEMPT_EVENT = "login_submit_attempt";
 const LOGIN_SUCCESS_EVENT = "login_submit_success";
 const LOGIN_FAILURE_EVENT = "login_submit_failure";
@@ -45,6 +56,16 @@ const LOGIN_EVENT_TYPES = new Set([
   LOGIN_ATTEMPT_EVENT,
   LOGIN_SUCCESS_EVENT,
   LOGIN_FAILURE_EVENT,
+]);
+
+const LOGOUT_ATTEMPT_EVENT = "logout_submit_attempt";
+const LOGOUT_SUCCESS_EVENT = "logout_submit_success";
+const LOGOUT_FAILURE_EVENT = "logout_submit_failure";
+
+const LOGOUT_EVENT_TYPES = new Set([
+  LOGOUT_ATTEMPT_EVENT,
+  LOGOUT_SUCCESS_EVENT,
+  LOGOUT_FAILURE_EVENT,
 ]);
 
 export const LOGIN_RUM_EVENT_TYPES = Object.freeze({
@@ -59,6 +80,16 @@ export const LOGIN_RUM_FAILURE_CODES = Object.freeze({
   ACCESS: "access",
   THROTTLED: "throttled",
   INVALID: "invalid",
+});
+
+export const LOGOUT_RUM_EVENT_TYPES = Object.freeze({
+  ATTEMPT: LOGOUT_ATTEMPT_EVENT,
+  SUCCESS: LOGOUT_SUCCESS_EVENT,
+  FAILURE: LOGOUT_FAILURE_EVENT,
+});
+
+export const LOGOUT_RUM_FAILURE_CODES = Object.freeze({
+  CSRF: "csrf",
 });
 
 export function emitLoginRumEvent({
@@ -110,6 +141,72 @@ export function emitLoginRumEvent({
   // the Node event loop alive past the response. Detach from the event loop
   // via Promise.resolve().then so the caller never awaits and unhandled
   // rejections cannot escape.
+  void Promise.resolve()
+    .then(() =>
+      fetch(buildUpstreamUrl(RUM_PATH), {
+        method: "POST",
+        headers,
+        body,
+        cache: "no-store",
+        keepalive: true,
+        signal: AbortSignal.timeout(RUM_EMIT_TIMEOUT_MS),
+        redirect: "manual",
+      })
+    )
+    .catch(() => {
+      // best-effort telemetry; never propagate
+    });
+}
+
+export function emitLogoutRumEvent({
+  eventType,
+  value,
+  failureCode = null,
+  traceparent = "",
+}) {
+  if (!LOGOUT_EVENT_TYPES.has(eventType)) return;
+
+  const config = getConfig();
+  if (!config.backendApiKey) return;
+
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    return;
+  }
+
+  const metric = eventType === LOGOUT_ATTEMPT_EVENT ? "count" : "duration";
+  const unit = eventType === LOGOUT_ATTEMPT_EVENT ? "count" : "ms";
+
+  const metadata = {};
+  if (
+    eventType === LOGOUT_FAILURE_EVENT
+    && typeof failureCode === "string"
+    && ALLOWED_LOGOUT_FAILURE_CODES.has(failureCode)
+  ) {
+    metadata.failure_code = failureCode;
+  }
+
+  const tp = normalizeTraceparent(traceparent) || generateTraceparent();
+  const headers = buildUpstreamHeaders(new Headers(), {
+    backendApiKey: config.backendApiKey,
+    actor: null,
+    traceparent: tp,
+  });
+  headers.set("Content-Type", "application/json");
+
+  // route="/logout" is the surface the user submitted from. view="login"
+  // is the redirect destination, mirroring the login route's view choice
+  // (the user's perceived "shell" after the response): the front-door
+  // 303 always lands them back on /login post-logout, success or fail.
+  const body = JSON.stringify({
+    event_type: eventType,
+    route: "/logout",
+    view: "login",
+    metric,
+    value,
+    unit,
+    metadata,
+  });
+
   void Promise.resolve()
     .then(() =>
       fetch(buildUpstreamUrl(RUM_PATH), {

--- a/web/secure-landing/tests/logout-rum.test.mjs
+++ b/web/secure-landing/tests/logout-rum.test.mjs
@@ -1,0 +1,423 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+
+import { NextRequest } from "next/server.js";
+
+import { resetDbCache } from "../lib/db.js";
+
+const ENV_KEYS = [
+  "NODE_ENV",
+  "TP_FASTAPI_ORIGIN",
+  "TP_BACKEND_API_KEY",
+  "TP_FRONTDOOR_USERS_FILE",
+  "TP_FRONTDOOR_USERS_JSON",
+  "TP_FRONTDOOR_SESSION_DB",
+  "TP_PORTAL_RUM_ENABLED",
+  "TP_PORTAL_RUM_ROLLOUT_PERCENT",
+];
+
+const FASTAPI_ORIGIN = "http://127.0.0.1:8000";
+
+function snapshotEnv() {
+  return new Map(ENV_KEYS.map((key) => [key, process.env[key]]));
+}
+
+function restoreEnv(snapshot) {
+  for (const key of ENV_KEYS) {
+    const previous = snapshot.get(key);
+    if (typeof previous === "string") {
+      process.env[key] = previous;
+    } else {
+      delete process.env[key];
+    }
+  }
+}
+
+function withTestEnvironment({ rumEnabled = true } = {}) {
+  const snapshot = snapshotEnv();
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), "tp-frontdoor-logout-rum-"));
+  const dbPath = path.join(tempDir, "sessions.sqlite");
+  const usersFilePath = path.join(tempDir, "frontdoor-users.json");
+  writeFileSync(usersFilePath, JSON.stringify([]), "utf-8");
+
+  process.env.NODE_ENV = "production";
+  process.env.TP_FASTAPI_ORIGIN = FASTAPI_ORIGIN;
+  process.env.TP_BACKEND_API_KEY = "backend-secret";
+  process.env.TP_FRONTDOOR_SESSION_DB = dbPath;
+  process.env.TP_FRONTDOOR_USERS_FILE = usersFilePath;
+  process.env.TP_FRONTDOOR_USERS_JSON = "[]";
+
+  if (rumEnabled) {
+    process.env.TP_PORTAL_RUM_ENABLED = "1";
+    process.env.TP_PORTAL_RUM_ROLLOUT_PERCENT = "100";
+  } else {
+    delete process.env.TP_PORTAL_RUM_ENABLED;
+    delete process.env.TP_PORTAL_RUM_ROLLOUT_PERCENT;
+  }
+
+  resetDbCache();
+  return {
+    dbPath,
+    cleanup() {
+      resetDbCache();
+      restoreEnv(snapshot);
+      rmSync(tempDir, { recursive: true, force: true });
+    },
+  };
+}
+
+async function importFresh(relativePath) {
+  return import(`${relativePath}?case=${Date.now()}-${Math.random()}`);
+}
+
+function buildRequest(url, options = {}) {
+  return new NextRequest(url, options);
+}
+
+function installFetchMock({ rumCalls, rumFetchImpl } = {}) {
+  const originalFetch = global.fetch;
+  global.fetch = async (url, init) => {
+    const target = String(url);
+    if (target === `${FASTAPI_ORIGIN}/v1/portal/rum`) {
+      const headers = init?.headers instanceof Headers ? init.headers : new Headers(init?.headers || {});
+      const headerEntries = {};
+      for (const [k, v] of headers.entries()) headerEntries[k] = v;
+      const body = init?.body ? JSON.parse(init.body) : null;
+      rumCalls?.push({ url: target, body, headers: headerEntries });
+      if (rumFetchImpl) return rumFetchImpl(url, init);
+      return Response.json(
+        {
+          schema: "tp.orchestrator.portal_rum_ingest.v1",
+          success: true,
+          data: { accepted: true, event: body },
+          error: null,
+        },
+        { status: 200 }
+      );
+    }
+    throw new Error(`unmocked fetch: ${target}`);
+  };
+  return () => {
+    global.fetch = originalFetch;
+  };
+}
+
+async function flushFireAndForget() {
+  // Drain the microtask + macrotask queue so emitter Promise.resolve().then(...)
+  // chains complete before assertions run.
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+function buildAuthenticatedSession(sessions) {
+  return sessions.rotateAuthenticatedSession(
+    sessions.createAnonymousSession(),
+    {
+      username: "admin",
+      accessEmail: "admin@example.com",
+      role: "admin",
+    }
+  );
+}
+
+function buildLogoutPostRequest({
+  session = null,
+  csrfHeader = null,
+  // The URL the route sees (validateOriginAndReferrer derives the
+  // expected origin from this URL, not from the Origin header).
+  requestUrlOrigin = "https://portal.example.com",
+  // The Origin header the route compares against the URL origin. Pass a
+  // distinct value to simulate a cross-origin POST.
+  originHeader = "https://portal.example.com",
+  extraHeaders = {},
+}) {
+  const headers = new Headers({
+    origin: originHeader,
+    "content-type": "application/x-www-form-urlencoded",
+    ...extraHeaders,
+  });
+  if (session) {
+    headers.set("cookie", `__Host-tp_session=${session.id}`);
+  }
+  if (csrfHeader !== null) {
+    headers.set("x-csrf-token", csrfHeader);
+  }
+  return buildRequest(`${requestUrlOrigin}/logout`, { method: "POST", headers });
+}
+
+const PII_FORBIDDEN_KEYS = [
+  "username",
+  "accessEmail",
+  "access_email",
+  "role",
+  "session_id",
+  "sessionId",
+  "throttle_key",
+  "throttleKey",
+  "remote_addr",
+  "remoteAddr",
+];
+
+function assertNoPiiInRumPosts(rumCalls) {
+  for (const call of rumCalls) {
+    const flat = JSON.stringify(call.body);
+    for (const key of PII_FORBIDDEN_KEYS) {
+      assert.ok(!flat.includes(`"${key}"`), `RUM body should not contain ${key}: ${flat}`);
+    }
+    assert.ok(!flat.includes("admin@example.com"), `RUM body should not contain access email: ${flat}`);
+    assert.ok(!flat.includes("admin"), `RUM body should not contain username: ${flat}`);
+    // Logout failures only carry failure_code; success/attempt carry no metadata at all.
+    if (call.body?.metadata) {
+      const allowedKeys = new Set(["failure_code"]);
+      for (const key of Object.keys(call.body.metadata)) {
+        assert.ok(allowedKeys.has(key), `RUM metadata key should be in closed enum: ${key}`);
+      }
+    }
+  }
+}
+
+test("logout POST emits no RUM events when front-door RUM is disabled", async () => {
+  const env = withTestEnvironment({ rumEnabled: false });
+  const rumCalls = [];
+  const restoreFetch = installFetchMock({ rumCalls });
+
+  try {
+    const sessions = await importFresh("../lib/sessions.js");
+    const { POST } = await importFresh("../app/logout/route.js");
+    const session = buildAuthenticatedSession(sessions);
+    const request = buildLogoutPostRequest({ session, csrfHeader: session.csrfToken });
+
+    const response = await POST(request);
+    await flushFireAndForget();
+
+    assert.equal(response.status, 303);
+    assert.equal(response.headers.get("location"), "https://portal.example.com/login");
+    assert.equal(rumCalls.length, 0, `expected zero RUM calls when disabled, got ${rumCalls.length}`);
+    // Session was destroyed even though RUM was off — RUM must never alter behavior.
+    assert.equal(sessions.getSessionById(session.id, { touch: false }), null);
+  } finally {
+    restoreFetch();
+    env.cleanup();
+  }
+});
+
+test("logout POST emits attempt + success on the happy path with an authenticated session", async () => {
+  const env = withTestEnvironment();
+  const rumCalls = [];
+  const restoreFetch = installFetchMock({ rumCalls });
+
+  try {
+    const sessions = await importFresh("../lib/sessions.js");
+    const { POST } = await importFresh("../app/logout/route.js");
+    const session = buildAuthenticatedSession(sessions);
+    const request = buildLogoutPostRequest({ session, csrfHeader: session.csrfToken });
+
+    const response = await POST(request);
+    await flushFireAndForget();
+
+    assert.equal(response.status, 303);
+    assert.equal(response.headers.get("location"), "https://portal.example.com/login");
+    assert.equal(rumCalls.length, 2, `expected attempt + success, got ${rumCalls.length}`);
+
+    const [attempt, success] = rumCalls;
+    assert.equal(attempt.body.event_type, "logout_submit_attempt");
+    assert.equal(attempt.body.route, "/logout");
+    assert.equal(attempt.body.view, "login");
+    assert.equal(attempt.body.metric, "count");
+    assert.equal(attempt.body.unit, "count");
+    assert.equal(attempt.body.value, 1);
+    assert.deepEqual(attempt.body.metadata, {});
+
+    assert.equal(success.body.event_type, "logout_submit_success");
+    assert.equal(success.body.route, "/logout");
+    assert.equal(success.body.view, "login");
+    assert.equal(success.body.metric, "duration");
+    assert.equal(success.body.unit, "ms");
+    assert.ok(typeof success.body.value === "number" && success.body.value >= 0);
+    assert.deepEqual(success.body.metadata, {});
+
+    // Session is destroyed on the success path.
+    assert.equal(sessions.getSessionById(session.id, { touch: false }), null);
+
+    // Backend auth + traceparent are forwarded.
+    assert.equal(attempt.headers["authorization"], "Bearer backend-secret");
+    assert.equal(attempt.headers["x-api-key"], "backend-secret");
+    assert.match(attempt.headers["traceparent"] || "", /^00-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}$/);
+    // Both events share the same traceparent — single decision, single trace per submission.
+    assert.equal(attempt.headers["traceparent"], success.headers["traceparent"]);
+
+    assertNoPiiInRumPosts(rumCalls);
+  } finally {
+    restoreFetch();
+    env.cleanup();
+  }
+});
+
+test("logout POST emits attempt + success even when the request carries no session", async () => {
+  // An anonymous logout (no __Host-tp_session cookie) is still a successful
+  // no-op: the route returns the same 303 to /login whether or not there was
+  // a session to destroy. RUM must capture both branches uniformly so a
+  // dashboard delta isn't biased by the cookie's presence.
+  const env = withTestEnvironment();
+  const rumCalls = [];
+  const restoreFetch = installFetchMock({ rumCalls });
+
+  try {
+    await importFresh("../lib/sessions.js");
+    const { POST } = await importFresh("../app/logout/route.js");
+    const request = buildLogoutPostRequest({ session: null, csrfHeader: null });
+
+    const response = await POST(request);
+    await flushFireAndForget();
+
+    assert.equal(response.status, 303);
+    assert.equal(response.headers.get("location"), "https://portal.example.com/login");
+    assert.equal(rumCalls.length, 2);
+    assert.equal(rumCalls[0].body.event_type, "logout_submit_attempt");
+    assert.equal(rumCalls[1].body.event_type, "logout_submit_success");
+    assert.deepEqual(rumCalls[1].body.metadata, {});
+
+    assertNoPiiInRumPosts(rumCalls);
+  } finally {
+    restoreFetch();
+    env.cleanup();
+  }
+});
+
+test("logout POST emits attempt + failure(csrf) when Origin/Referrer validation fails", async () => {
+  const env = withTestEnvironment();
+  const rumCalls = [];
+  const restoreFetch = installFetchMock({ rumCalls });
+
+  try {
+    const sessions = await importFresh("../lib/sessions.js");
+    const { POST } = await importFresh("../app/logout/route.js");
+    const session = buildAuthenticatedSession(sessions);
+    // Cross-origin POST: the route's validateOriginAndReferrer rejects
+    // this (Origin header doesn't match the URL's origin) before even
+    // looking at x-csrf-token.
+    const request = buildLogoutPostRequest({
+      session,
+      csrfHeader: session.csrfToken,
+      requestUrlOrigin: "https://portal.example.com",
+      originHeader: "https://attacker.example.com",
+    });
+
+    const response = await POST(request);
+    await flushFireAndForget();
+
+    assert.equal(response.status, 303);
+    assert.match(response.headers.get("location") || "", /\/login\?error=csrf$/);
+    assert.equal(rumCalls.length, 2);
+    assert.equal(rumCalls[1].body.event_type, "logout_submit_failure");
+    assert.deepEqual(rumCalls[1].body.metadata, { failure_code: "csrf" });
+
+    // Existing route behavior: Origin/Referrer failure does NOT destroy the
+    // session in storage, only clears the cookie. RUM emit must not change
+    // that.
+    assert.notEqual(sessions.getSessionById(session.id, { touch: false }), null);
+
+    assertNoPiiInRumPosts(rumCalls);
+  } finally {
+    restoreFetch();
+    env.cleanup();
+  }
+});
+
+test("logout POST emits attempt + failure(csrf) when the x-csrf-token header mismatches", async () => {
+  const env = withTestEnvironment();
+  const rumCalls = [];
+  const restoreFetch = installFetchMock({ rumCalls });
+
+  try {
+    const sessions = await importFresh("../lib/sessions.js");
+    const { POST } = await importFresh("../app/logout/route.js");
+    const session = buildAuthenticatedSession(sessions);
+    const request = buildLogoutPostRequest({ session, csrfHeader: "wrong-token" });
+
+    const response = await POST(request);
+    await flushFireAndForget();
+
+    assert.equal(response.status, 303);
+    assert.match(response.headers.get("location") || "", /\/login\?error=csrf$/);
+    assert.equal(rumCalls.length, 2);
+    assert.equal(rumCalls[0].body.event_type, "logout_submit_attempt");
+    assert.equal(rumCalls[1].body.event_type, "logout_submit_failure");
+    assert.deepEqual(rumCalls[1].body.metadata, { failure_code: "csrf" });
+
+    // CSRF token failure does NOT destroy the session in storage either.
+    assert.notEqual(sessions.getSessionById(session.id, { touch: false }), null);
+
+    assertNoPiiInRumPosts(rumCalls);
+  } finally {
+    restoreFetch();
+    env.cleanup();
+  }
+});
+
+test("logout POST still completes the redirect when the RUM emitter fetch rejects", async () => {
+  const env = withTestEnvironment();
+  const rumCalls = [];
+  const restoreFetch = installFetchMock({
+    rumCalls,
+    rumFetchImpl: async () => {
+      throw new Error("simulated upstream RUM outage");
+    },
+  });
+  // Track unhandled rejections — emitter must catch its own.
+  const unhandled = [];
+  const onUnhandled = (err) => unhandled.push(err);
+  process.on("unhandledRejection", onUnhandled);
+
+  try {
+    const sessions = await importFresh("../lib/sessions.js");
+    const { POST } = await importFresh("../app/logout/route.js");
+    const session = buildAuthenticatedSession(sessions);
+    const request = buildLogoutPostRequest({ session, csrfHeader: session.csrfToken });
+
+    const response = await POST(request);
+    await flushFireAndForget();
+
+    assert.equal(response.status, 303);
+    assert.equal(response.headers.get("location"), "https://portal.example.com/login");
+    // Session is still destroyed even when RUM fetches reject — RUM is
+    // strictly best-effort and cannot change the session-destruction path.
+    assert.equal(sessions.getSessionById(session.id, { touch: false }), null);
+    assert.equal(rumCalls.length, 2, "fetch was attempted for both events");
+    assert.equal(unhandled.length, 0, "emitter must catch all rejections");
+  } finally {
+    process.off("unhandledRejection", onUnhandled);
+    restoreFetch();
+    env.cleanup();
+  }
+});
+
+test("logout POST does not emit RUM events when no backend api key is configured", async () => {
+  const env = withTestEnvironment();
+  // Simulate a misconfigured deployment where TP_BACKEND_API_KEY is unset.
+  // The emitter short-circuits on missing config.backendApiKey, so no events
+  // should reach FastAPI even though the front-door RUM env flag is on.
+  delete process.env.TP_BACKEND_API_KEY;
+  const rumCalls = [];
+  const restoreFetch = installFetchMock({ rumCalls });
+
+  try {
+    const sessions = await importFresh("../lib/sessions.js");
+    const { POST } = await importFresh("../app/logout/route.js");
+    const session = buildAuthenticatedSession(sessions);
+    const request = buildLogoutPostRequest({ session, csrfHeader: session.csrfToken });
+
+    const response = await POST(request);
+    await flushFireAndForget();
+
+    assert.equal(response.status, 303);
+    assert.equal(response.headers.get("location"), "https://portal.example.com/login");
+    assert.equal(rumCalls.length, 0);
+  } finally {
+    restoreFetch();
+    env.cleanup();
+  }
+});


### PR DESCRIPTION
Mirrors the #1684 login_submit_* server emission pattern for the
logout route. The /logout handler had zero RUM coverage on either
side; this PR establishes the server-side foundation (a future PR
can layer client mirrors symmetric to #1689/#1694/#1695).

Three new event types: logout_submit_attempt (count, emitted at
handler entry), logout_submit_success (duration ms, on the destroy
path including the no-session anonymous-logout branch), and
logout_submit_failure (duration ms, with metadata.failure_code on
the only current failure surface — CSRF, covering both the
Origin/Referrer mismatch path and the x-csrf-token mismatch path).
The narrow ALLOWED_LOGOUT_FAILURE_CODES enum mirrors the audit
trail: both csrf-rejection paths in app/logout/route.js already
audit as "csrf_failure".

Same gate contract as login: route handler captures
isPortalRumEnabled() once at entry, the emitter never re-reads the
flag, so a flag flip mid-request cannot produce a partial
attempt/terminal pair. Same fire-and-forget plumbing — AbortSignal
timeout, unref'd timer, Promise.resolve().then(...).catch chain —
so emission failure (network outage, unhandled rejection in the
upstream RUM pipeline, missing TP_BACKEND_API_KEY) cannot alter
the response status, redirect, cookie clearing, or session
destruction. ``view: "login"`` matches the post-logout redirect
destination, paralleling how the login event types report the
user's perceived shell after the response.

Backend allowlists in app.py extended in the same change (no
schema migration — additive set membership): three new entries in
PORTAL_ALLOWED_RUM_EVENT_TYPES, ``/logout`` added to
PORTAL_ALLOWED_RUM_ROUTES, and three new metric mappings in
PORTAL_ALLOWED_RUM_METRICS.

Tests:
- web/secure-landing/tests/logout-rum.test.mjs (8 cases): RUM-disabled
  silence; happy-path attempt+success with session destruction +
  backend-auth/traceparent forwarding + paired-traceparent invariant;
  anonymous-logout (no session cookie) still emits attempt+success;
  Origin/Referrer mismatch emits attempt+failure(csrf) WITHOUT
  destroying the session; x-csrf-token mismatch same; emitter fetch
  rejection still completes the redirect AND destroys the session
  with no unhandled rejections; missing TP_BACKEND_API_KEY suppresses
  emissions silently; PII-safety assertions on every RUM body.
- tests/test_app_orchestrator_contract_http.py (4 cases):
  round-trips for logout_submit_attempt, logout_submit_success, and
  logout_submit_failure{failure_code: "csrf"}; defense-in-depth
  rejection of an unknown route under /logout/* to pin that the new
  ROUTES entry isn't a wildcard.