### PR TITLE
refactor(rum): consolidate marker-cookie helpers into shared rum-client primitives

### DIFF
--- a/web/secure-landing/app/login/route.js
+++ b/web/secure-landing/app/login/route.js
@@ -7,12 +7,12 @@ import { isPortalRumEnabled } from "../../lib/config.js";
 import { applySecurityHeaders, buildRequestUrl, FRONTDOOR_CSP, generateScriptNonce } from "../../lib/http.js";
 import { applyPortalReturnTo, resolvePortalReturnTo, validatePortalReturnTo } from "../../lib/return-to.js";
 import {
-  LOGIN_SUBMIT_FAILURE_MARKER_COOKIE,
-  LOGIN_SUBMIT_FAILURE_MARKER_MAX_AGE_SECONDS,
-  LOGIN_SUBMIT_SUCCESS_MARKER_COOKIE,
-  LOGIN_SUBMIT_SUCCESS_MARKER_MAX_AGE_SECONDS,
+  clearRumMarkerCookie,
+  LOGIN_SUBMIT_FAILURE_MARKER,
+  LOGIN_SUBMIT_SUCCESS_MARKER,
   LOGIN_SUBMIT_SUCCESS_MARKER_VALUE,
-  renderRumClientScript
+  renderRumClientScript,
+  setRumMarkerCookie
 } from "../../lib/rum-client.js";
 import {
   emitLoginRumEvent,
@@ -265,69 +265,17 @@ function redirectToLogin(request, errorCode, session, returnTo = "") {
   applyPortalReturnTo(url, returnTo);
   const response = applySecurityHeaders(NextResponse.redirect(url, 303));
   if (errorCode) {
-    setLoginSubmitFailureMarkerCookie(response, errorCode);
+    setRumMarkerCookie(response, LOGIN_SUBMIT_FAILURE_MARKER, errorCode);
     // A failure path must not leave behind a stale success marker —
     // clearing here mirrors the success path's failure-marker clear
     // so the two markers can never both be live for the same submit.
-    if (request.cookies.get(LOGIN_SUBMIT_SUCCESS_MARKER_COOKIE)?.value) {
-      clearLoginSubmitSuccessMarkerCookie(response);
+    if (request.cookies.get(LOGIN_SUBMIT_SUCCESS_MARKER.name)?.value) {
+      clearRumMarkerCookie(response, LOGIN_SUBMIT_SUCCESS_MARKER);
     }
   }
   if (session?.id) {
     setSessionCookie(response, session.id);
   }
-  return response;
-}
-
-function setLoginSubmitFailureMarkerCookie(response, failureCode) {
-  const config = getConfig();
-  response.cookies.set(LOGIN_SUBMIT_FAILURE_MARKER_COOKIE, String(failureCode || ""), {
-    httpOnly: false,
-    secure: config.sessionCookieSecure,
-    sameSite: "lax",
-    path: "/login",
-    maxAge: LOGIN_SUBMIT_FAILURE_MARKER_MAX_AGE_SECONDS
-  });
-  return response;
-}
-
-function clearLoginSubmitFailureMarkerCookie(response) {
-  const config = getConfig();
-  response.cookies.set(LOGIN_SUBMIT_FAILURE_MARKER_COOKIE, "", {
-    httpOnly: false,
-    secure: config.sessionCookieSecure,
-    sameSite: "lax",
-    path: "/login",
-    expires: new Date(0)
-  });
-  return response;
-}
-
-function setLoginSubmitSuccessMarkerCookie(response) {
-  // Path=/ (NOT /login) so the portal bundle on /portal can read it.
-  // The cookie value is a fixed presence marker; the portal-side
-  // emitter computes elapsed time from the sessionStorage breadcrumb,
-  // never from this cookie.
-  const config = getConfig();
-  response.cookies.set(LOGIN_SUBMIT_SUCCESS_MARKER_COOKIE, LOGIN_SUBMIT_SUCCESS_MARKER_VALUE, {
-    httpOnly: false,
-    secure: config.sessionCookieSecure,
-    sameSite: "lax",
-    path: "/",
-    maxAge: LOGIN_SUBMIT_SUCCESS_MARKER_MAX_AGE_SECONDS
-  });
-  return response;
-}
-
-function clearLoginSubmitSuccessMarkerCookie(response) {
-  const config = getConfig();
-  response.cookies.set(LOGIN_SUBMIT_SUCCESS_MARKER_COOKIE, "", {
-    httpOnly: false,
-    secure: config.sessionCookieSecure,
-    sameSite: "lax",
-    path: "/",
-    expires: new Date(0)
-  });
   return response;
 }
 
@@ -509,9 +457,9 @@ export async function POST(request) {
     NextResponse.redirect(buildRequestUrl(request, resolvePortalReturnTo(requestedReturnTo)), 303)
   );
   setSessionCookie(response, authenticatedSession.id);
-  setLoginSubmitSuccessMarkerCookie(response);
-  if (request.cookies.get(LOGIN_SUBMIT_FAILURE_MARKER_COOKIE)?.value) {
-    clearLoginSubmitFailureMarkerCookie(response);
+  setRumMarkerCookie(response, LOGIN_SUBMIT_SUCCESS_MARKER, LOGIN_SUBMIT_SUCCESS_MARKER_VALUE);
+  if (request.cookies.get(LOGIN_SUBMIT_FAILURE_MARKER.name)?.value) {
+    clearRumMarkerCookie(response, LOGIN_SUBMIT_FAILURE_MARKER);
   }
   return response;
 }

--- a/web/secure-landing/lib/rum-client.js
+++ b/web/secure-landing/lib/rum-client.js
@@ -9,6 +9,7 @@
 // at app.py:_record_portal_rum already accepts.
 
 import { normalizeTraceparent } from "./trace.js";
+import { getConfig } from "./config.js";
 
 export const LOGIN_SUBMIT_BREADCRUMB_KEY = "tpLoginSubmitStartedAt";
 export const LOGIN_SUBMIT_FAILURE_MARKER_COOKIE = "tp_login_submit_failure";
@@ -22,6 +23,64 @@ export const LOGIN_SUBMIT_FAILURE_MARKER_MAX_AGE_SECONDS = 60;
 export const LOGIN_SUBMIT_SUCCESS_MARKER_COOKIE = "tp_login_submit_success";
 export const LOGIN_SUBMIT_SUCCESS_MARKER_VALUE = "1";
 export const LOGIN_SUBMIT_SUCCESS_MARKER_MAX_AGE_SECONDS = 60;
+
+// Marker descriptors that pin every variant of the RUM cookie pair to a
+// single shape: { name, path, maxAgeSeconds }. The setRumMarkerCookie /
+// clearRumMarkerCookie primitives below consume these descriptors so a
+// future logout client-mirror lands by adding two more constants
+// (LOGOUT_SUBMIT_FAILURE_MARKER, LOGOUT_SUBMIT_SUCCESS_MARKER) instead
+// of duplicating four near-identical helpers.
+//
+// The failure marker is scoped to Path=/login so it never reaches
+// /portal; the success marker is scoped to Path=/ so the portal bundle
+// can read and clear it on first load.
+export const LOGIN_SUBMIT_FAILURE_MARKER = Object.freeze({
+  name: LOGIN_SUBMIT_FAILURE_MARKER_COOKIE,
+  path: "/login",
+  maxAgeSeconds: LOGIN_SUBMIT_FAILURE_MARKER_MAX_AGE_SECONDS,
+});
+export const LOGIN_SUBMIT_SUCCESS_MARKER = Object.freeze({
+  name: LOGIN_SUBMIT_SUCCESS_MARKER_COOKIE,
+  path: "/",
+  maxAgeSeconds: LOGIN_SUBMIT_SUCCESS_MARKER_MAX_AGE_SECONDS,
+});
+
+// Set a server-set RUM marker cookie. httpOnly=false because the
+// portal bundle and the inline rum-client.js script both need to read
+// these from JS; secure tracks config.sessionCookieSecure so local-dev
+// HTTP loopbacks don't strip the cookie; sameSite="lax" lets the
+// cookie ride the same-origin 303 redirect from POST /login (or
+// future /logout) to the GET landing page. ``value`` is coerced to a
+// non-empty string defensively so a caller passing null/undefined
+// doesn't end up with the literal strings "null" / "undefined" as the
+// cookie value.
+export function setRumMarkerCookie(response, marker, value) {
+  const config = getConfig();
+  response.cookies.set(marker.name, String(value || ""), {
+    httpOnly: false,
+    secure: config.sessionCookieSecure,
+    sameSite: "lax",
+    path: marker.path,
+    maxAge: marker.maxAgeSeconds,
+  });
+  return response;
+}
+
+// Clear a server-set RUM marker cookie by writing an empty value with
+// expires=epoch on the same path the set helper uses. Path discipline
+// matters: clearing has to match the original Path attribute or the
+// browser keeps the prior cookie alive.
+export function clearRumMarkerCookie(response, marker) {
+  const config = getConfig();
+  response.cookies.set(marker.name, "", {
+    httpOnly: false,
+    secure: config.sessionCookieSecure,
+    sameSite: "lax",
+    path: marker.path,
+    expires: new Date(0),
+  });
+  return response;
+}
 
 function _serialize(value) {
   // JSON.stringify is safe inside a <script> body provided we escape the two

--- a/web/secure-landing/lib/rum-client.js
+++ b/web/secure-landing/lib/rum-client.js
@@ -50,13 +50,14 @@ export const LOGIN_SUBMIT_SUCCESS_MARKER = Object.freeze({
 // these from JS; secure tracks config.sessionCookieSecure so local-dev
 // HTTP loopbacks don't strip the cookie; sameSite="lax" lets the
 // cookie ride the same-origin 303 redirect from POST /login (or
-// future /logout) to the GET landing page. ``value`` is coerced to a
-// non-empty string defensively so a caller passing null/undefined
+// future /logout) to the GET landing page. Nullish values are coerced
+// to an empty string defensively so a caller passing null/undefined
 // doesn't end up with the literal strings "null" / "undefined" as the
-// cookie value.
+// cookie value, while explicit falsy marker values like 0/false remain
+// observable.
 export function setRumMarkerCookie(response, marker, value) {
   const config = getConfig();
-  response.cookies.set(marker.name, String(value || ""), {
+  response.cookies.set(marker.name, String(value ?? ""), {
     httpOnly: false,
     secure: config.sessionCookieSecure,
     sameSite: "lax",

--- a/web/secure-landing/tests/rum-client.test.mjs
+++ b/web/secure-landing/tests/rum-client.test.mjs
@@ -5,7 +5,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 
-import { NextRequest } from "next/server.js";
+import { NextRequest, NextResponse } from "next/server.js";
 
 import { getDb, resetDbCache } from "../lib/db.js";
 
@@ -689,6 +689,42 @@ test("portal bundle source clears login_submit_success marker state when session
   assert.ok(markerReadIdx > removeIdx, "expected marker read after breadcrumb removal");
   assert.ok(markerClearIdx > markerReadIdx, "expected marker clear after marker read");
   assert.ok(markerRequiredIdx > markerClearIdx, "expected marker requirement after marker clear");
+});
+
+test("setRumMarkerCookie preserves explicit falsy marker values", async () => {
+  const env = withRumEnvironment();
+
+  try {
+    const { setRumMarkerCookie } = await importFresh("../lib/rum-client.js");
+    const marker = Object.freeze({
+      name: "tp_test_marker",
+      path: "/test-marker",
+      maxAgeSeconds: 60,
+    });
+    const cases = [
+      { value: 0, expected: "0" },
+      { value: false, expected: "false" },
+      { value: null, expected: "" },
+      { value: undefined, expected: "" },
+    ];
+
+    for (const { value, expected } of cases) {
+      const response = NextResponse.next();
+      setRumMarkerCookie(response, marker, value);
+      const cookieHeader = response.headers.get("set-cookie") || "";
+      if (expected) {
+        assert.match(cookieHeader, new RegExp(`\\btp_test_marker=${expected}\\b`));
+      } else {
+        assert.match(cookieHeader, /\btp_test_marker=;/);
+      }
+      assert.match(cookieHeader, /\bPath=\/test-marker\b/);
+      assert.match(cookieHeader, /\bMax-Age=60\b/);
+      assert.match(cookieHeader, /\bSameSite=Lax\b/i);
+      assert.doesNotMatch(cookieHeader, /HttpOnly/i);
+    }
+  } finally {
+    env.cleanup();
+  }
 });
 
 test("renderRumClientScript failure listener uses Date.now() (not performance.now()) for elapsed time", async () => {


### PR DESCRIPTION
DRY cleanup of the four near-identical setLoginSubmit*MarkerCookie /
clearLoginSubmit*MarkerCookie helpers introduced across #1684, #1694,
and #1695. The four helpers shared the same shape — httpOnly=false,
secure tracking config.sessionCookieSecure, sameSite="lax", different
only in cookie name, path, and TTL — so a future logout client-mirror
PR would have to add two more near-duplicates.

Replaces the four specialized helpers in app/login/route.js with two
generic primitives in lib/rum-client.js, parameterized by descriptor
objects:

  setRumMarkerCookie(response, marker, value) — set
  clearRumMarkerCookie(response, marker)       — clear by expiring

Two new descriptor exports pin the per-marker shape:

  LOGIN_SUBMIT_FAILURE_MARKER = { name, path: "/login", maxAgeSeconds: 60 }
  LOGIN_SUBMIT_SUCCESS_MARKER = { name, path: "/",      maxAgeSeconds: 60 }

A future logout client-mirror PR adds two more entries (LOGOUT_*
markers) without duplicating helper bodies.

No behavior change — the helpers preserve the prior cookie shape
exactly: same attributes, same path discipline, same defensive
String(value || "") coercion against null/undefined cookie values.
The four call sites in app/login/route.js (redirectToLogin set +
cross-marker clear, success set + cross-marker clear) now route
through the generic primitives. Net delta: +70/-63 LOC across two
files; the route file alone shrinks by 51 lines.

Verified:
- web/secure-landing tests: 215/215 pass (login-rum 13, logout-rum 8, rum-client 28, plus the broader suite)
- pytest tests/test_app_orchestrator_contract_http.py + tests/test_app_rejection_paths.py: 168/168 pass
- npm run build: 11-route Next.js production build clean
- check_portal_asset_budgets.py: all assets under budget (no portal bundle change)
- pre-commit hooks against changed files: all pass