### PR TITLE
policy: automate portal telemetry raw-log retention evidence

### DIFF
--- a/docs/compliance/PORTAL_TELEMETRY_PRIVACY_SIGNOFF.md
+++ b/docs/compliance/PORTAL_TELEMETRY_PRIVACY_SIGNOFF.md
@@ -195,6 +195,7 @@ Proposed for approval:
 5. Aggregate evidence should be extracted with `tools/portal_modernization_evidence.py`.
 6. Only aggregate evidence needed for RFC or rollout review may be preserved after raw-log deletion.
 7. The operator must record deletion date, deleted path, and reviewer / approver in the pilot evidence packet.
+   The governed operator workflow is documented in `docs/operations/portal_telemetry_retention.md`.
 8. If the host path is covered by automated backups, backup retention must be documented or raw telemetry must be written to a path excluded from backups.
 9. Standard file unlink / delete is acceptable only for encrypted disks or equivalent managed storage; environments requiring stronger deletion controls must document that stronger control before pilot rollout.
 

--- a/docs/operations/portal_telemetry_retention.md
+++ b/docs/operations/portal_telemetry_retention.md
@@ -40,6 +40,8 @@ Evidence is written after deletion attempts and includes only path metadata, del
 ## Placement And Evidence Expectations
 
 - Raw logs must stay outside the repository, outside public / static directories, access-restricted, and excluded from CI artifacts.
+- Sink paths must be absolute approved JSONL sink names ending in `.jsonl` or `.jsonl.gz`.
+- Evidence output must be an absolute non-symlink path and must not match a sink path.
 - Missing sink paths are represented in evidence without failing the run.
 - Relative paths, directories, glob-like paths, and symlinks are rejected.
 - The retention deadline is `pilot-end-date + 14 calendar days`.

--- a/docs/operations/portal_telemetry_retention.md
+++ b/docs/operations/portal_telemetry_retention.md
@@ -1,0 +1,46 @@
+# Portal Telemetry Retention Runbook
+
+Use `tools/portal_telemetry_retention.py` to review approved raw portal telemetry JSONL sinks, delete them when the pilot owner and reviewer approve disposal, and emit deterministic deletion evidence. This tool governs retention evidence only; aggregate rollout evidence still comes from `tools/portal_modernization_evidence.py`.
+
+## Dry Run
+
+Run dry-run mode first and attach the generated JSON to the pilot evidence packet.
+
+```bash
+python3 tools/portal_telemetry_retention.py \
+  --pilot-owner "RC219805" \
+  --pilot-end-date 2026-05-09 \
+  --reviewer "RC219805" \
+  --sink-path /absolute/path/to/portal-rum.jsonl \
+  --sink-path /absolute/path/to/portal-events.jsonl \
+  --evidence-out /absolute/path/to/deletion-evidence.json \
+  --dry-run
+```
+
+Dry-run mode records path existence, prior size, prior modification time, retention deadline, and repo/public/static path classification. It never deletes raw logs.
+
+## Delete
+
+Delete mode requires the explicit confirmation phrase `DELETE-PORTAL-TELEMETRY-RAW-LOGS`.
+
+```bash
+python3 tools/portal_telemetry_retention.py \
+  --pilot-owner "RC219805" \
+  --pilot-end-date 2026-05-09 \
+  --reviewer "RC219805" \
+  --sink-path /absolute/path/to/portal-rum.jsonl \
+  --sink-path /absolute/path/to/portal-events.jsonl \
+  --evidence-out /absolute/path/to/deletion-evidence.json \
+  --delete \
+  --confirm-delete DELETE-PORTAL-TELEMETRY-RAW-LOGS
+```
+
+Evidence is written after deletion attempts and includes only path metadata, deletion timestamps, owner, reviewer, mode, and summary counters. It does not preserve raw JSONL records or content hashes.
+
+## Placement And Evidence Expectations
+
+- Raw logs must stay outside the repository, outside public / static directories, access-restricted, and excluded from CI artifacts.
+- Missing sink paths are represented in evidence without failing the run.
+- Relative paths, directories, glob-like paths, and symlinks are rejected.
+- The retention deadline is `pilot-end-date + 14 calendar days`.
+- Preserve only aggregate evidence after raw-log deletion. Use `tools/portal_modernization_evidence.py` for aggregate portal modernization evidence before deleting raw sinks.

--- a/tests/test_portal_telemetry_retention.py
+++ b/tests/test_portal_telemetry_retention.py
@@ -68,7 +68,8 @@ def test_dry_run_produces_evidence_and_deletes_nothing(tmp_path: Path) -> None:
     }
     sink_record = payload["sink_paths"][0]
     assert sink_record["exists"] is True
-    assert sink_record["eligible_for_deletion"] is True
+    assert sink_record["present_at_review"] is True
+    assert isinstance(sink_record["retention_deadline_passed"], bool)
     assert sink_record["deleted"] is False
     assert sink_record["deletion_attempted"] is False
 
@@ -174,8 +175,83 @@ def test_sink_path_rejects_relative_paths_and_globs(
     assert expected_error in result.stderr
 
 
+def test_sink_path_rejects_non_jsonl_suffix(tmp_path: Path) -> None:
+    sink_path = tmp_path / "unrelated.txt"
+
+    result = _run_cli(*_base_args(tmp_path, sink_path, tmp_path / "deletion-evidence.json"), "--dry-run")
+
+    assert result.returncode != 0
+    assert "sink paths must end with .jsonl or .jsonl.gz" in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("raw_evidence_path", "expected_error"),
+    [
+        ("relative/deletion-evidence.json", "--evidence-out must be absolute"),
+        ("/tmp/deletion-*.json", "--evidence-out must not contain glob characters"),
+    ],
+)
+def test_evidence_path_rejects_relative_paths_and_globs(
+    tmp_path: Path,
+    raw_evidence_path: str,
+    expected_error: str,
+) -> None:
+    sink_path = tmp_path / "portal-rum.jsonl"
+    sink_path.write_text("{}\n", encoding="utf-8")
+
+    result = _run_cli(
+        "--pilot-owner",
+        "RC219805",
+        "--pilot-end-date",
+        "2026-05-09",
+        "--reviewer",
+        "RC219805",
+        "--sink-path",
+        str(sink_path),
+        "--evidence-out",
+        raw_evidence_path,
+        "--dry-run",
+    )
+
+    assert result.returncode != 0
+    assert expected_error in result.stderr
+
+
+def test_evidence_path_rejects_symlinks(tmp_path: Path) -> None:
+    sink_path = tmp_path / "portal-rum.jsonl"
+    target_path = tmp_path / "deletion-evidence-target.json"
+    evidence_path = tmp_path / "deletion-evidence-link.json"
+    sink_path.write_text("{}\n", encoding="utf-8")
+    target_path.write_text("{}\n", encoding="utf-8")
+    evidence_path.symlink_to(target_path)
+
+    result = _run_cli(*_base_args(tmp_path, sink_path, evidence_path), "--dry-run")
+
+    assert result.returncode != 0
+    assert "evidence output must not be a symlink" in result.stderr
+
+
+def test_delete_mode_preflights_evidence_output_before_unlinking_sink(tmp_path: Path) -> None:
+    sink_path = tmp_path / "portal-rum.jsonl"
+    blocker_path = tmp_path / "not-a-directory"
+    evidence_path = blocker_path / "deletion-evidence.json"
+    sink_path.write_text("{}\n", encoding="utf-8")
+    blocker_path.write_text("blocks parent mkdir\n", encoding="utf-8")
+
+    result = _run_cli(
+        *_base_args(tmp_path, sink_path, evidence_path),
+        "--delete",
+        "--confirm-delete",
+        CONFIRM_DELETE,
+    )
+
+    assert result.returncode == 1
+    assert "evidence output is not writable" in result.stderr
+    assert sink_path.exists()
+
+
 def test_directories_are_rejected(tmp_path: Path) -> None:
-    sink_path = tmp_path / "portal-rum-directory"
+    sink_path = tmp_path / "portal-rum-directory.jsonl"
     sink_path.mkdir()
 
     result = _run_cli(*_base_args(tmp_path, sink_path, tmp_path / "deletion-evidence.json"), "--dry-run")
@@ -243,7 +319,7 @@ def test_missing_sink_path_is_represented_safely(tmp_path: Path) -> None:
     }
     sink_record = payload["sink_paths"][0]
     assert sink_record["exists"] is False
-    assert sink_record["eligible_for_deletion"] is False
+    assert sink_record["present_at_review"] is False
     assert sink_record["deleted"] is False
     assert sink_record["delete_error"] is None
 

--- a/tests/test_portal_telemetry_retention.py
+++ b/tests/test_portal_telemetry_retention.py
@@ -1,0 +1,263 @@
+"""Tests for tools/portal_telemetry_retention.py."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+TOOL_PATH = PROJECT_ROOT / "tools" / "portal_telemetry_retention.py"
+CONFIRM_DELETE = "DELETE-PORTAL-TELEMETRY-RAW-LOGS"
+
+
+def _run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(TOOL_PATH), *args],
+        cwd=str(PROJECT_ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _base_args(tmp_path: Path, sink_path: Path, evidence_path: Path) -> list[str]:
+    return [
+        "--pilot-owner",
+        "RC219805",
+        "--pilot-end-date",
+        "2026-05-09",
+        "--reviewer",
+        "RC219805",
+        "--sink-path",
+        str(sink_path),
+        "--evidence-out",
+        str(evidence_path),
+    ]
+
+
+def _load_evidence(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_dry_run_produces_evidence_and_deletes_nothing(tmp_path: Path) -> None:
+    sink_path = tmp_path / "portal-rum.jsonl"
+    evidence_path = tmp_path / "deletion-evidence.json"
+    sink_path.write_text('{"schema":"tp.orchestrator.portal_rum.v1"}\n', encoding="utf-8")
+
+    result = _run_cli(*_base_args(tmp_path, sink_path, evidence_path), "--dry-run")
+
+    assert result.returncode == 0, result.stderr
+    assert sink_path.exists()
+    payload = _load_evidence(evidence_path)
+    assert payload["schema"] == "portal-telemetry-retention-evidence/v1"
+    assert payload["mode"] == "dry-run"
+    assert payload["retention_deadline"] == "2026-05-23"
+    assert payload["retention_window_days"] == 14
+    assert payload["summary"] == {
+        "bytes_deleted": 0,
+        "bytes_seen": sink_path.stat().st_size,
+        "paths_deleted": 0,
+        "paths_existing": 1,
+        "paths_seen": 1,
+    }
+    sink_record = payload["sink_paths"][0]
+    assert sink_record["exists"] is True
+    assert sink_record["eligible_for_deletion"] is True
+    assert sink_record["deleted"] is False
+    assert sink_record["deletion_attempted"] is False
+
+
+def test_delete_mode_without_confirmation_fails_and_preserves_file(tmp_path: Path) -> None:
+    sink_path = tmp_path / "portal-events.jsonl"
+    evidence_path = tmp_path / "deletion-evidence.json"
+    sink_path.write_text('{"schema":"tp.orchestrator.portal_event.v1"}\n', encoding="utf-8")
+
+    result = _run_cli(*_base_args(tmp_path, sink_path, evidence_path), "--delete")
+
+    assert result.returncode != 0
+    assert "--delete requires --confirm-delete DELETE-PORTAL-TELEMETRY-RAW-LOGS" in result.stderr
+    assert sink_path.exists()
+    assert not evidence_path.exists()
+
+
+def test_delete_mode_with_confirmation_removes_existing_raw_log_files(tmp_path: Path) -> None:
+    rum_path = tmp_path / "portal-rum.jsonl"
+    event_path = tmp_path / "portal-events.jsonl"
+    evidence_path = tmp_path / "deletion-evidence.json"
+    rum_path.write_text('{"schema":"tp.orchestrator.portal_rum.v1"}\n', encoding="utf-8")
+    event_path.write_text('{"schema":"tp.orchestrator.portal_event.v1"}\n', encoding="utf-8")
+    bytes_seen = rum_path.stat().st_size + event_path.stat().st_size
+
+    result = _run_cli(
+        "--pilot-owner",
+        "RC219805",
+        "--pilot-end-date",
+        "2026-05-09",
+        "--reviewer",
+        "RC219805",
+        "--sink-path",
+        str(rum_path),
+        "--sink-path",
+        str(event_path),
+        "--evidence-out",
+        str(evidence_path),
+        "--delete",
+        "--confirm-delete",
+        CONFIRM_DELETE,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert not rum_path.exists()
+    assert not event_path.exists()
+    payload = _load_evidence(evidence_path)
+    assert payload["mode"] == "delete"
+    assert payload["summary"] == {
+        "bytes_deleted": bytes_seen,
+        "bytes_seen": bytes_seen,
+        "paths_deleted": 2,
+        "paths_existing": 2,
+        "paths_seen": 2,
+    }
+    for sink_record in payload["sink_paths"]:
+        assert sink_record["deletion_attempted"] is True
+        assert sink_record["deleted"] is True
+        assert sink_record["deleted_at"].endswith("Z")
+        assert sink_record["delete_error"] is None
+
+
+def test_evidence_never_includes_raw_jsonl_contents(tmp_path: Path) -> None:
+    sink_path = tmp_path / "portal-rum.jsonl"
+    evidence_path = tmp_path / "deletion-evidence.json"
+    sink_path.write_text('{"secret_raw_record":"do-not-preserve"}\n', encoding="utf-8")
+
+    result = _run_cli(*_base_args(tmp_path, sink_path, evidence_path), "--dry-run")
+
+    assert result.returncode == 0, result.stderr
+    evidence_text = evidence_path.read_text(encoding="utf-8")
+    assert "secret_raw_record" not in evidence_text
+    assert "do-not-preserve" not in evidence_text
+
+
+@pytest.mark.parametrize(
+    ("raw_sink_path", "expected_error"),
+    [
+        ("relative/portal-rum.jsonl", "sink paths must be absolute"),
+        ("/tmp/*.jsonl", "sink paths must not contain glob characters"),
+    ],
+)
+def test_sink_path_rejects_relative_paths_and_globs(
+    tmp_path: Path,
+    raw_sink_path: str,
+    expected_error: str,
+) -> None:
+    result = _run_cli(
+        "--pilot-owner",
+        "RC219805",
+        "--pilot-end-date",
+        "2026-05-09",
+        "--reviewer",
+        "RC219805",
+        "--sink-path",
+        raw_sink_path,
+        "--evidence-out",
+        str(tmp_path / "deletion-evidence.json"),
+        "--dry-run",
+    )
+
+    assert result.returncode != 0
+    assert expected_error in result.stderr
+
+
+def test_directories_are_rejected(tmp_path: Path) -> None:
+    sink_path = tmp_path / "portal-rum-directory"
+    sink_path.mkdir()
+
+    result = _run_cli(*_base_args(tmp_path, sink_path, tmp_path / "deletion-evidence.json"), "--dry-run")
+
+    assert result.returncode != 0
+    assert "sink paths must not be directories" in result.stderr
+
+
+def test_symlinks_are_rejected(tmp_path: Path) -> None:
+    target_path = tmp_path / "portal-rum.jsonl"
+    sink_path = tmp_path / "portal-rum-link.jsonl"
+    target_path.write_text("{}\n", encoding="utf-8")
+    sink_path.symlink_to(target_path)
+
+    result = _run_cli(*_base_args(tmp_path, sink_path, tmp_path / "deletion-evidence.json"), "--dry-run")
+
+    assert result.returncode != 0
+    assert "sink paths must not be symlinks" in result.stderr
+    assert target_path.exists()
+
+
+@pytest.mark.parametrize(
+    "omitted_flag",
+    ["--pilot-owner", "--pilot-end-date", "--reviewer"],
+)
+def test_required_pilot_metadata_is_required(tmp_path: Path, omitted_flag: str) -> None:
+    sink_path = tmp_path / "portal-rum.jsonl"
+    evidence_path = tmp_path / "deletion-evidence.json"
+    sink_path.write_text("{}\n", encoding="utf-8")
+    args = _base_args(tmp_path, sink_path, evidence_path)
+    flag_index = args.index(omitted_flag)
+    del args[flag_index : flag_index + 2]
+
+    result = _run_cli(*args, "--dry-run")
+
+    assert result.returncode != 0
+    assert omitted_flag in result.stderr
+
+
+def test_empty_pilot_metadata_is_rejected(tmp_path: Path) -> None:
+    sink_path = tmp_path / "portal-rum.jsonl"
+    evidence_path = tmp_path / "deletion-evidence.json"
+    sink_path.write_text("{}\n", encoding="utf-8")
+
+    result = _run_cli(*_base_args(tmp_path, sink_path, evidence_path), "--pilot-owner", "", "--dry-run")
+
+    assert result.returncode != 0
+    assert "--pilot-owner must not be empty" in result.stderr
+
+
+def test_missing_sink_path_is_represented_safely(tmp_path: Path) -> None:
+    sink_path = tmp_path / "missing-portal-rum.jsonl"
+    evidence_path = tmp_path / "deletion-evidence.json"
+
+    result = _run_cli(*_base_args(tmp_path, sink_path, evidence_path), "--dry-run")
+
+    assert result.returncode == 0, result.stderr
+    payload = _load_evidence(evidence_path)
+    assert payload["summary"] == {
+        "bytes_deleted": 0,
+        "bytes_seen": 0,
+        "paths_deleted": 0,
+        "paths_existing": 0,
+        "paths_seen": 1,
+    }
+    sink_record = payload["sink_paths"][0]
+    assert sink_record["exists"] is False
+    assert sink_record["eligible_for_deletion"] is False
+    assert sink_record["deleted"] is False
+    assert sink_record["delete_error"] is None
+
+
+def test_path_policy_classification_is_report_only_for_repo_public_paths(tmp_path: Path) -> None:
+    sink_path = PROJECT_ROOT / "web" / "secure-landing" / "public" / "portal-rum.jsonl"
+    evidence_path = tmp_path / "deletion-evidence.json"
+
+    result = _run_cli(*_base_args(tmp_path, sink_path, evidence_path), "--dry-run")
+
+    assert result.returncode == 0, result.stderr
+    payload = _load_evidence(evidence_path)
+    path_policy = payload["sink_paths"][0]["path_policy"]
+    assert path_policy["inside_repo"] is True
+    assert path_policy["inside_public_or_static"] is True
+    assert path_policy["warning"] == "raw logs should not be stored inside repository public/static paths"
+    assert payload["sink_paths"][0]["exists"] is False

--- a/tools/portal_telemetry_retention.py
+++ b/tools/portal_telemetry_retention.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Review and delete portal telemetry raw JSONL sinks with audit evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+SCHEMA = "portal-telemetry-retention-evidence/v1"
+CONFIRM_DELETE = "DELETE-PORTAL-TELEMETRY-RAW-LOGS"
+RETENTION_WINDOW_DAYS = 14
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+PUBLIC_STATIC_PARTS = {"public", "static"}
+GLOB_CHARS = set("*?[]{}")
+
+
+def _utc_timestamp() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _mtime_timestamp(seconds: float) -> str:
+    return datetime.fromtimestamp(seconds, timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _parse_pilot_end_date(value: str) -> date:
+    if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", value):
+        raise argparse.ArgumentTypeError("must use YYYY-MM-DD")
+    try:
+        return date.fromisoformat(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be a valid calendar date") from exc
+
+
+def _has_glob_chars(value: str) -> bool:
+    return any(char in GLOB_CHARS for char in value)
+
+
+def _is_relative_to(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+def _path_policy(path: Path) -> Dict[str, Any]:
+    resolved = path.resolve(strict=False)
+    project_root = PROJECT_ROOT.resolve(strict=False)
+    inside_repo = _is_relative_to(resolved, project_root)
+    inside_public_or_static = False
+    if inside_repo:
+        relative_parts = resolved.relative_to(project_root).parts
+        inside_public_or_static = any(part in PUBLIC_STATIC_PARTS for part in relative_parts)
+
+    warning: Optional[str] = None
+    if inside_public_or_static:
+        warning = "raw logs should not be stored inside repository public/static paths"
+    elif inside_repo:
+        warning = "raw logs should not be stored inside the repository"
+
+    return {
+        "inside_public_or_static": inside_public_or_static,
+        "inside_repo": inside_repo,
+        "warning": warning,
+    }
+
+
+def _validate_sink_path(raw_path: str) -> Path:
+    candidate = raw_path.strip()
+    if not candidate:
+        raise ValueError("sink paths must not be empty")
+    if _has_glob_chars(candidate):
+        raise ValueError(f"sink paths must not contain glob characters: {raw_path}")
+
+    path = Path(candidate)
+    if not path.is_absolute():
+        raise ValueError(f"sink paths must be absolute: {raw_path}")
+    if path.is_symlink():
+        raise ValueError(f"sink paths must not be symlinks: {raw_path}")
+    if path.exists():
+        if path.is_dir():
+            raise ValueError(f"sink paths must not be directories: {raw_path}")
+        if not path.is_file():
+            raise ValueError(f"sink paths must be regular files: {raw_path}")
+    return path
+
+
+def _validate_evidence_path(evidence_out: str, sink_paths: List[Path]) -> Path:
+    path = Path(evidence_out)
+    if path.exists() and path.is_dir():
+        raise ValueError(f"evidence output must not be a directory: {evidence_out}")
+    resolved_evidence = path.resolve(strict=False)
+    for sink_path in sink_paths:
+        if sink_path.resolve(strict=False) == resolved_evidence:
+            raise ValueError("--evidence-out must not match a --sink-path")
+    return path
+
+
+def _sink_record(path: Path, *, delete: bool) -> Dict[str, Any]:
+    record: Dict[str, Any] = {
+        "deleted": False,
+        "deleted_at": None,
+        "delete_error": None,
+        "deletion_attempted": False,
+        "eligible_for_deletion": False,
+        "exists": False,
+        "mtime": None,
+        "path": str(path),
+        "path_policy": _path_policy(path),
+        "size_bytes": None,
+    }
+
+    try:
+        stat_result = path.stat()
+    except FileNotFoundError:
+        return record
+    except OSError as exc:
+        record["delete_error"] = f"stat failed: {exc}"
+        return record
+
+    record.update(
+        {
+            "eligible_for_deletion": True,
+            "exists": True,
+            "mtime": _mtime_timestamp(stat_result.st_mtime),
+            "size_bytes": stat_result.st_size,
+        }
+    )
+
+    if delete:
+        record["deletion_attempted"] = True
+        try:
+            path.unlink()
+        except OSError as exc:
+            record["delete_error"] = str(exc)
+        else:
+            record["deleted"] = True
+            record["deleted_at"] = _utc_timestamp()
+
+    return record
+
+
+def _build_evidence(
+    *,
+    mode: str,
+    pilot_owner: str,
+    pilot_end_date: date,
+    reviewer: str,
+    sink_paths: List[Path],
+) -> Dict[str, Any]:
+    delete = mode == "delete"
+    sink_records = [_sink_record(path, delete=delete) for path in sink_paths]
+    bytes_seen = sum(int(record["size_bytes"] or 0) for record in sink_records)
+    bytes_deleted = sum(int(record["size_bytes"] or 0) for record in sink_records if record["deleted"])
+
+    return {
+        "generated_at": _utc_timestamp(),
+        "mode": mode,
+        "pilot_end_date": pilot_end_date.isoformat(),
+        "pilot_owner": pilot_owner,
+        "retention_deadline": (pilot_end_date + timedelta(days=RETENTION_WINDOW_DAYS)).isoformat(),
+        "retention_window_days": RETENTION_WINDOW_DAYS,
+        "reviewer": reviewer,
+        "schema": SCHEMA,
+        "sink_paths": sink_records,
+        "summary": {
+            "bytes_deleted": bytes_deleted,
+            "bytes_seen": bytes_seen,
+            "paths_deleted": sum(1 for record in sink_records if record["deleted"]),
+            "paths_existing": sum(1 for record in sink_records if record["exists"]),
+            "paths_seen": len(sink_records),
+        },
+    }
+
+
+def _parse_args(argv: Optional[List[str]]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Review portal telemetry raw JSONL retention and write deletion evidence.")
+    parser.add_argument("--pilot-owner", required=True, help="Named pilot owner.")
+    parser.add_argument(
+        "--pilot-end-date",
+        required=True,
+        type=_parse_pilot_end_date,
+        help="Pilot end date in YYYY-MM-DD format.",
+    )
+    parser.add_argument("--reviewer", required=True, help="Reviewer or approver for the retention action.")
+    parser.add_argument(
+        "--sink-path",
+        action="append",
+        required=True,
+        help="Absolute raw JSONL sink path approved for retention review. Repeat for multiple sinks.",
+    )
+    parser.add_argument("--evidence-out", required=True, help="Path where deterministic JSON evidence will be written.")
+    mode_group = parser.add_mutually_exclusive_group(required=True)
+    mode_group.add_argument("--dry-run", action="store_true", help="Write evidence without deleting raw logs.")
+    mode_group.add_argument("--delete", action="store_true", help="Delete existing raw logs and write evidence.")
+    parser.add_argument(
+        "--confirm-delete",
+        help=f"Required with --delete. Must equal {CONFIRM_DELETE}.",
+    )
+    args = parser.parse_args(argv)
+
+    for attr, flag in (
+        ("pilot_owner", "--pilot-owner"),
+        ("reviewer", "--reviewer"),
+        ("evidence_out", "--evidence-out"),
+    ):
+        value = str(getattr(args, attr) or "").strip()
+        if not value:
+            parser.error(f"{flag} must not be empty")
+        setattr(args, attr, value)
+
+    if args.delete and args.confirm_delete != CONFIRM_DELETE:
+        parser.error(f"--delete requires --confirm-delete {CONFIRM_DELETE}")
+
+    sink_paths: List[Path] = []
+    try:
+        for raw_sink_path in args.sink_path:
+            sink_paths.append(_validate_sink_path(raw_sink_path))
+        args.evidence_out_path = _validate_evidence_path(args.evidence_out, sink_paths)
+    except ValueError as exc:
+        parser.error(str(exc))
+    args.sink_paths = sink_paths
+    return args
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = _parse_args(argv)
+    mode = "delete" if args.delete else "dry-run"
+    evidence = _build_evidence(
+        mode=mode,
+        pilot_owner=args.pilot_owner,
+        pilot_end_date=args.pilot_end_date,
+        reviewer=args.reviewer,
+        sink_paths=args.sink_paths,
+    )
+
+    evidence_path: Path = args.evidence_out_path
+    evidence_path.parent.mkdir(parents=True, exist_ok=True)
+    evidence_path.write_text(json.dumps(evidence, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"wrote portal telemetry retention evidence to {evidence_path}")
+
+    if any(record.get("delete_error") for record in evidence["sink_paths"]):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tools/portal_telemetry_retention.py
+++ b/tools/portal_telemetry_retention.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import sys
+import tempfile
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -17,6 +19,7 @@ RETENTION_WINDOW_DAYS = 14
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 PUBLIC_STATIC_PARTS = {"public", "static"}
 GLOB_CHARS = set("*?[]{}")
+APPROVED_SINK_SUFFIXES = (".jsonl", ".jsonl.gz")
 
 
 def _utc_timestamp() -> str:
@@ -38,6 +41,11 @@ def _parse_pilot_end_date(value: str) -> date:
 
 def _has_glob_chars(value: str) -> bool:
     return any(char in GLOB_CHARS for char in value)
+
+
+def _has_approved_sink_suffix(path: Path) -> bool:
+    path_text = str(path)
+    return any(path_text.endswith(suffix) for suffix in APPROVED_SINK_SUFFIXES)
 
 
 def _is_relative_to(path: Path, parent: Path) -> bool:
@@ -80,6 +88,8 @@ def _validate_sink_path(raw_path: str) -> Path:
     path = Path(candidate)
     if not path.is_absolute():
         raise ValueError(f"sink paths must be absolute: {raw_path}")
+    if not _has_approved_sink_suffix(path):
+        raise ValueError("sink paths must end with .jsonl or .jsonl.gz")
     if path.is_symlink():
         raise ValueError(f"sink paths must not be symlinks: {raw_path}")
     if path.exists():
@@ -91,7 +101,17 @@ def _validate_sink_path(raw_path: str) -> Path:
 
 
 def _validate_evidence_path(evidence_out: str, sink_paths: List[Path]) -> Path:
-    path = Path(evidence_out)
+    candidate = evidence_out.strip()
+    if not candidate:
+        raise ValueError("--evidence-out must not be empty")
+    if _has_glob_chars(candidate):
+        raise ValueError("--evidence-out must not contain glob characters")
+
+    path = Path(candidate)
+    if not path.is_absolute():
+        raise ValueError("--evidence-out must be absolute")
+    if path.is_symlink():
+        raise ValueError(f"evidence output must not be a symlink: {evidence_out}")
     if path.exists() and path.is_dir():
         raise ValueError(f"evidence output must not be a directory: {evidence_out}")
     resolved_evidence = path.resolve(strict=False)
@@ -101,17 +121,70 @@ def _validate_evidence_path(evidence_out: str, sink_paths: List[Path]) -> Path:
     return path
 
 
-def _sink_record(path: Path, *, delete: bool) -> Dict[str, Any]:
+def _preflight_evidence_output(path: Path) -> None:
+    probe_path: Optional[str] = None
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.NamedTemporaryFile(
+            "w",
+            delete=False,
+            dir=str(path.parent),
+            encoding="utf-8",
+            prefix=f".{path.name}.",
+            suffix=".write-probe",
+        ) as handle:
+            probe_path = handle.name
+            handle.write("{}\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+    except OSError as exc:
+        raise RuntimeError(f"evidence output is not writable: {path}: {exc}") from exc
+    finally:
+        if probe_path is not None:
+            try:
+                Path(probe_path).unlink()
+            except OSError:
+                pass
+
+
+def _write_evidence_atomic(path: Path, evidence: Dict[str, Any]) -> None:
+    payload = json.dumps(evidence, indent=2, sort_keys=True) + "\n"
+    tmp_path: Optional[str] = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            delete=False,
+            dir=str(path.parent),
+            encoding="utf-8",
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+        ) as handle:
+            tmp_path = handle.name
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        Path(tmp_path).replace(path)
+    except OSError as exc:
+        if tmp_path is not None:
+            try:
+                Path(tmp_path).unlink()
+            except OSError:
+                pass
+        raise RuntimeError(f"failed to write evidence atomically: {path}: {exc}") from exc
+
+
+def _sink_record(path: Path, *, delete: bool, retention_deadline: date, generated_date: date) -> Dict[str, Any]:
     record: Dict[str, Any] = {
         "deleted": False,
         "deleted_at": None,
         "delete_error": None,
         "deletion_attempted": False,
-        "eligible_for_deletion": False,
         "exists": False,
         "mtime": None,
         "path": str(path),
         "path_policy": _path_policy(path),
+        "present_at_review": False,
+        "retention_deadline_passed": generated_date > retention_deadline,
         "size_bytes": None,
     }
 
@@ -125,9 +198,9 @@ def _sink_record(path: Path, *, delete: bool) -> Dict[str, Any]:
 
     record.update(
         {
-            "eligible_for_deletion": True,
             "exists": True,
             "mtime": _mtime_timestamp(stat_result.st_mtime),
+            "present_at_review": True,
             "size_bytes": stat_result.st_size,
         }
     )
@@ -154,16 +227,27 @@ def _build_evidence(
     sink_paths: List[Path],
 ) -> Dict[str, Any]:
     delete = mode == "delete"
-    sink_records = [_sink_record(path, delete=delete) for path in sink_paths]
+    generated_at = _utc_timestamp()
+    generated_date = date.fromisoformat(generated_at[:10])
+    retention_deadline = pilot_end_date + timedelta(days=RETENTION_WINDOW_DAYS)
+    sink_records = [
+        _sink_record(
+            path,
+            delete=delete,
+            generated_date=generated_date,
+            retention_deadline=retention_deadline,
+        )
+        for path in sink_paths
+    ]
     bytes_seen = sum(int(record["size_bytes"] or 0) for record in sink_records)
     bytes_deleted = sum(int(record["size_bytes"] or 0) for record in sink_records if record["deleted"])
 
     return {
-        "generated_at": _utc_timestamp(),
+        "generated_at": generated_at,
         "mode": mode,
         "pilot_end_date": pilot_end_date.isoformat(),
         "pilot_owner": pilot_owner,
-        "retention_deadline": (pilot_end_date + timedelta(days=RETENTION_WINDOW_DAYS)).isoformat(),
+        "retention_deadline": retention_deadline.isoformat(),
         "retention_window_days": RETENTION_WINDOW_DAYS,
         "reviewer": reviewer,
         "schema": SCHEMA,
@@ -231,6 +315,13 @@ def _parse_args(argv: Optional[List[str]]) -> argparse.Namespace:
 def main(argv: Optional[List[str]] = None) -> int:
     args = _parse_args(argv)
     mode = "delete" if args.delete else "dry-run"
+    evidence_path: Path = args.evidence_out_path
+    try:
+        _preflight_evidence_output(evidence_path)
+    except RuntimeError as exc:
+        print(f"portal telemetry retention: {exc}", file=sys.stderr)
+        return 1
+
     evidence = _build_evidence(
         mode=mode,
         pilot_owner=args.pilot_owner,
@@ -239,9 +330,11 @@ def main(argv: Optional[List[str]] = None) -> int:
         sink_paths=args.sink_paths,
     )
 
-    evidence_path: Path = args.evidence_out_path
-    evidence_path.parent.mkdir(parents=True, exist_ok=True)
-    evidence_path.write_text(json.dumps(evidence, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    try:
+        _write_evidence_atomic(evidence_path, evidence)
+    except RuntimeError as exc:
+        print(f"portal telemetry retention: {exc}", file=sys.stderr)
+        return 1
     print(f"wrote portal telemetry retention evidence to {evidence_path}")
 
     if any(record.get("delete_error") for record in evidence["sink_paths"]):


### PR DESCRIPTION
## Summary
- Issue #1701 needed the approved operator-enforced deletion procedure converted into a governed evidence workflow.
- Added a narrow stdlib operator tool that reviews or deletes approved raw JSONL sink paths and writes structured evidence without touching telemetry runtime behavior.

## Changes
- Added `tools/portal_telemetry_retention.py` with `--dry-run` and `--delete` modes, required pilot metadata, absolute sink path validation, symlink/directory/glob rejection, delete confirmation phrase, and JSON evidence schema `portal-telemetry-retention-evidence/v1`.
- Added `tests/test_portal_telemetry_retention.py` covering dry-run, delete gating, confirmed deletion, evidence redaction, path safety, missing sinks, retention deadline, and report-only path classification.
- Added `docs/operations/portal_telemetry_retention.md` and linked it from the privacy sign-off packet.
- No RUM schema, event emission, sink behavior, cookies, sessionStorage, sanitizer, rollout knobs, or runtime retention behavior changed.

## Validation
Proven green:
- `.venv/bin/pytest tests/test_portal_telemetry_retention.py`
- `python3 tools/portal_telemetry_retention.py --help`
- `make check-stale-docs`
- `make check-doc-heading-links`
- `git diff --cached --check`
- Commit pre-commit hooks including Black, isort, root placement, test markers, and gitleaks

Environment/tooling:
- `pytest tests/test_portal_telemetry_retention.py` failed because `pytest` is not on PATH in this shell; the repo-local `.venv/bin/pytest` target passed.

Still failing:
- None observed.

## Risk
- Bounded to a standalone operator tool, one operations runbook, and one compliance-packet link.
- Delete behavior is gated by explicit `--delete` plus `--confirm-delete DELETE-PORTAL-TELEMETRY-RAW-LOGS`; invalid sink paths fail before deletion.
- Path policy is report-only for #1701; fail-closed sink-location enforcement remains separate for #1704.
- Revert-safe because no runtime telemetry code or persisted schema contracts changed.

Closes #1701