### PR TITLE
policy: enforce portal telemetry sink path policy

### DIFF
--- a/app.py
+++ b/app.py
@@ -5401,18 +5401,26 @@ def _persist_portal_event_record(record: Dict[str, Any], log_path: Optional[Path
     encoded_record = (json.dumps(record, sort_keys=True) + "\n").encode("utf-8")
     try:
         log_path = _portal_path_security.validate_portal_telemetry_sink_path(str(log_path), repo_root=REPO_ROOT)
-        open_flags = os.O_APPEND | os.O_CREAT | os.O_WRONLY | getattr(os, "O_NOFOLLOW", 0)
+        if os.open not in os.supports_dir_fd:
+            raise OSError("dir_fd is required for portal telemetry sink writes")
+        no_follow_flag = getattr(os, "O_NOFOLLOW", 0)
+        parent_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | no_follow_flag
+        file_flags = os.O_APPEND | os.O_CREAT | os.O_WRONLY | no_follow_flag
         with _PORTAL_EVENT_LOG_WRITE_LOCK:
-            fd = os.open(log_path, open_flags, 0o600)
+            parent_fd = os.open(log_path.parent, parent_flags)
             try:
-                bytes_written = 0
-                while bytes_written < len(encoded_record):
-                    chunk_size = os.write(fd, encoded_record[bytes_written:])
-                    if chunk_size <= 0:
-                        raise OSError("short write while appending portal telemetry")
-                    bytes_written += chunk_size
+                fd = os.open(log_path.name, file_flags, 0o600, dir_fd=parent_fd)
+                try:
+                    bytes_written = 0
+                    while bytes_written < len(encoded_record):
+                        chunk_size = os.write(fd, encoded_record[bytes_written:])
+                        if chunk_size <= 0:
+                            raise OSError("short write while appending portal telemetry")
+                        bytes_written += chunk_size
+                finally:
+                    os.close(fd)
             finally:
-                os.close(fd)
+                os.close(parent_fd)
     except (OSError, _portal_path_security.PathSecurityValidationError):
         LOGGER.warning(
             "failed to persist portal event telemetry to %s",

--- a/app.py
+++ b/app.py
@@ -5400,9 +5400,10 @@ def _persist_portal_event_record(record: Dict[str, Any], log_path: Optional[Path
         return
     encoded_record = (json.dumps(record, sort_keys=True) + "\n").encode("utf-8")
     try:
-        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_path = _portal_path_security.validate_portal_telemetry_sink_path(str(log_path), repo_root=REPO_ROOT)
+        open_flags = os.O_APPEND | os.O_CREAT | os.O_WRONLY | getattr(os, "O_NOFOLLOW", 0)
         with _PORTAL_EVENT_LOG_WRITE_LOCK:
-            fd = os.open(log_path, os.O_APPEND | os.O_CREAT | os.O_WRONLY, 0o600)
+            fd = os.open(log_path, open_flags, 0o600)
             try:
                 bytes_written = 0
                 while bytes_written < len(encoded_record):
@@ -5412,7 +5413,7 @@ def _persist_portal_event_record(record: Dict[str, Any], log_path: Optional[Path
                     bytes_written += chunk_size
             finally:
                 os.close(fd)
-    except OSError:
+    except (OSError, _portal_path_security.PathSecurityValidationError):
         LOGGER.warning(
             "failed to persist portal event telemetry to %s",
             log_path,

--- a/app.py
+++ b/app.py
@@ -394,6 +394,16 @@ def _env_path_roots(name: str, default: List[Path]) -> List[Path]:
     return _portal_path_security._env_path_roots(name, default, repo_root=REPO_ROOT, logger=LOGGER)
 
 
+def _portal_telemetry_sink_path_from_env(name: str) -> Optional[Path]:
+    raw_value = os.getenv(name, "").strip()
+    if not raw_value:
+        return None
+    try:
+        return _portal_path_security.validate_portal_telemetry_sink_path(raw_value, repo_root=REPO_ROOT)
+    except _portal_path_security.PathSecurityValidationError as exc:
+        raise RuntimeError(f"{name} violates portal telemetry sink path policy: {exc}") from exc
+
+
 def _lux_depth_runner_command() -> List[str]:
     return [sys.executable, "-m", LUX_DEPTH_MODULE]
 
@@ -1398,19 +1408,8 @@ LUX_RECONSTRUCTION_FIELD_ALIASES: Dict[str, Tuple[str, ...]] = {
 }
 LUX_DEBUG_BUNDLE_DESTINATION_TEMPLATE = "reconstruction/<scene-fingerprint>/debug"
 
-_portal_event_log_path_raw = os.getenv("TP_PORTAL_EVENT_LOG_PATH", "").strip()
-try:
-    PORTAL_EVENT_LOG_PATH = _normalize_root_path(_portal_event_log_path_raw) if _portal_event_log_path_raw else None
-except (OSError, RuntimeError, ValueError):
-    LOGGER.warning("TP_PORTAL_EVENT_LOG_PATH ignored invalid path: %s", _portal_event_log_path_raw)
-    PORTAL_EVENT_LOG_PATH = None
-
-_portal_rum_log_path_raw = os.getenv("TP_PORTAL_RUM_LOG_PATH", "").strip()
-try:
-    PORTAL_RUM_LOG_PATH = _normalize_root_path(_portal_rum_log_path_raw) if _portal_rum_log_path_raw else None
-except (OSError, RuntimeError, ValueError):
-    LOGGER.warning("TP_PORTAL_RUM_LOG_PATH ignored invalid path: %s", _portal_rum_log_path_raw)
-    PORTAL_RUM_LOG_PATH = None
+PORTAL_EVENT_LOG_PATH = _portal_telemetry_sink_path_from_env("TP_PORTAL_EVENT_LOG_PATH")
+PORTAL_RUM_LOG_PATH = _portal_telemetry_sink_path_from_env("TP_PORTAL_RUM_LOG_PATH")
 
 
 class JobPreflightError(RuntimeError):

--- a/app.py
+++ b/app.py
@@ -10,6 +10,7 @@ import os
 import re
 import shlex
 import signal
+import stat
 import sys
 import tempfile
 import threading
@@ -5406,11 +5407,21 @@ def _persist_portal_event_record(record: Dict[str, Any], log_path: Optional[Path
         no_follow_flag = getattr(os, "O_NOFOLLOW", 0)
         parent_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | no_follow_flag
         file_flags = os.O_APPEND | os.O_CREAT | os.O_WRONLY | no_follow_flag
+        expected_parent_stat = os.stat(log_path.parent, follow_symlinks=False)
         with _PORTAL_EVENT_LOG_WRITE_LOCK:
             parent_fd = os.open(log_path.parent, parent_flags)
             try:
+                actual_parent_stat = os.fstat(parent_fd)
+                if (
+                    actual_parent_stat.st_dev != expected_parent_stat.st_dev
+                    or actual_parent_stat.st_ino != expected_parent_stat.st_ino
+                ):
+                    raise OSError("portal telemetry sink parent changed before open")
                 fd = os.open(log_path.name, file_flags, 0o600, dir_fd=parent_fd)
                 try:
+                    opened_file_stat = os.fstat(fd)
+                    if not stat.S_ISREG(opened_file_stat.st_mode):
+                        raise OSError("portal telemetry sink is not a regular file")
                     bytes_written = 0
                     while bytes_written < len(encoded_record):
                         chunk_size = os.write(fd, encoded_record[bytes_written:])

--- a/app.py
+++ b/app.py
@@ -5406,7 +5406,7 @@ def _persist_portal_event_record(record: Dict[str, Any], log_path: Optional[Path
             raise OSError("dir_fd is required for portal telemetry sink writes")
         no_follow_flag = getattr(os, "O_NOFOLLOW", 0)
         parent_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | no_follow_flag
-        file_flags = os.O_APPEND | os.O_CREAT | os.O_WRONLY | no_follow_flag
+        file_flags = os.O_APPEND | os.O_CREAT | os.O_WRONLY | no_follow_flag | getattr(os, "O_NONBLOCK", 0)
         expected_parent_stat = os.stat(log_path.parent, follow_symlinks=False)
         with _PORTAL_EVENT_LOG_WRITE_LOCK:
             parent_fd = os.open(log_path.parent, parent_flags)
@@ -5417,6 +5417,12 @@ def _persist_portal_event_record(record: Dict[str, Any], log_path: Optional[Path
                     or actual_parent_stat.st_ino != expected_parent_stat.st_ino
                 ):
                     raise OSError("portal telemetry sink parent changed before open")
+                try:
+                    existing_file_stat = os.stat(log_path.name, dir_fd=parent_fd, follow_symlinks=False)
+                except FileNotFoundError:
+                    existing_file_stat = None
+                if existing_file_stat is not None and not stat.S_ISREG(existing_file_stat.st_mode):
+                    raise OSError("portal telemetry sink target is not a regular file")
                 fd = os.open(log_path.name, file_flags, 0o600, dir_fd=parent_fd)
                 try:
                     opened_file_stat = os.fstat(fd)

--- a/docs/operations/portal_telemetry_retention.md
+++ b/docs/operations/portal_telemetry_retention.md
@@ -39,6 +39,7 @@ Evidence is written after deletion attempts and includes only path metadata, del
 
 ## Placement And Evidence Expectations
 
+- Configured telemetry sinks fail closed if they point inside the repository, public / static asset surfaces, or detected CI workspace / artifact paths.
 - Raw logs must stay outside the repository, outside public / static directories, access-restricted, and excluded from CI artifacts.
 - Sink paths must be absolute approved JSONL sink names ending in `.jsonl` or `.jsonl.gz`.
 - Evidence output must be an absolute non-symlink path and must not match a sink path.

--- a/docs/operations/portal_telemetry_retention.md
+++ b/docs/operations/portal_telemetry_retention.md
@@ -42,6 +42,7 @@ Evidence is written after deletion attempts and includes only path metadata, del
 - Configured telemetry sinks fail closed if they point inside the repository, public / static asset surfaces, or detected CI workspace / artifact paths.
 - Raw logs must stay outside the repository, outside public / static directories, access-restricted, and excluded from CI artifacts.
 - Sink paths must be absolute approved JSONL sink names ending in `.jsonl` or `.jsonl.gz`.
+- Configured sink parent directories must already exist and must not be symlinks.
 - Evidence output must be an absolute non-symlink path and must not match a sink path.
 - Missing sink paths are represented in evidence without failing the run.
 - Relative paths, directories, glob-like paths, and symlinks are rejected.

--- a/src/transformation_portal/portal/path_security.py
+++ b/src/transformation_portal/portal/path_security.py
@@ -6,10 +6,27 @@ import os
 import re
 import tempfile
 from pathlib import Path
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Sequence
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 _UNSAFE_PATH_SEGMENT_RE = re.compile(r"[\x00/\\]")
+_GLOB_PATH_CHARS = set("*?[]{}")
+_PORTAL_TELEMETRY_SINK_SUFFIXES = (".jsonl", ".jsonl.gz")
+_CI_ROOT_ENV_VARS = (
+    "GITHUB_WORKSPACE",
+    "RUNNER_TEMP",
+    "RUNNER_TOOL_CACHE",
+    "CI_ARTIFACTS_DIR",
+    "ARTIFACTS_DIR",
+    "ARTIFACT_DIR",
+    "CI_OUTPUT_DIR",
+)
+_CI_FILE_ENV_VARS = (
+    "GITHUB_ENV",
+    "GITHUB_OUTPUT",
+    "GITHUB_PATH",
+    "GITHUB_STEP_SUMMARY",
+)
 
 
 class PathSecurityValidationError(ValueError):
@@ -143,6 +160,148 @@ def _path_is_within_root(resolved_path: Path, root: Path) -> bool:
     except ValueError:
         return False
     return True
+
+
+def _portal_telemetry_public_roots(repo_root: Path) -> List[Path]:
+    return [
+        repo_root / "public",
+        repo_root / "static",
+        repo_root / "web" / "secure-landing" / "public",
+        repo_root / "web" / "secure-landing" / "static",
+    ]
+
+
+def _portal_telemetry_ci_roots() -> List[Path]:
+    roots: List[Path] = []
+    for env_var in _CI_ROOT_ENV_VARS:
+        raw_value = str(os.getenv(env_var) or "").strip()
+        if raw_value:
+            roots.append(Path(raw_value))
+    for env_var in _CI_FILE_ENV_VARS:
+        raw_value = str(os.getenv(env_var) or "").strip()
+        if raw_value:
+            roots.append(Path(raw_value).parent)
+    return roots
+
+
+def _has_glob_chars(value: str) -> bool:
+    return any(char in _GLOB_PATH_CHARS for char in value)
+
+
+def _has_portal_telemetry_sink_suffix(path: Path) -> bool:
+    path_text = str(path)
+    return any(path_text.endswith(suffix) for suffix in _PORTAL_TELEMETRY_SINK_SUFFIXES)
+
+
+def _normalized_roots(roots: Sequence[Path]) -> List[Path]:
+    normalized: List[Path] = []
+    for root in roots:
+        try:
+            normalized_root = Path(os.path.realpath(root))
+        except (OSError, RuntimeError, ValueError):
+            continue
+        if normalized_root not in normalized:
+            normalized.append(normalized_root)
+    return normalized
+
+
+def validate_portal_telemetry_sink_path(
+    path: str,
+    *,
+    repo_root: Path | None = None,
+    public_roots: Sequence[Path] | None = None,
+    ci_roots: Sequence[Path] | None = None,
+) -> Path:
+    """Validate a configured portal telemetry raw JSONL sink path."""
+
+    raw_path = str(path or "").strip()
+    if not raw_path:
+        raise PathSecurityValidationError(
+            "Portal telemetry sink path must not be empty",
+            reason="empty_portal_telemetry_sink_path",
+        )
+    if raw_path.startswith("~") or "\x00" in raw_path:
+        raise PathSecurityValidationError(
+            "Portal telemetry sink path is invalid",
+            reason="invalid_portal_telemetry_sink_path",
+        )
+    if _has_glob_chars(raw_path):
+        raise PathSecurityValidationError(
+            "Portal telemetry sink path must not contain glob characters",
+            reason="glob_portal_telemetry_sink_path",
+        )
+
+    candidate = Path(raw_path)
+    if not candidate.is_absolute():
+        raise PathSecurityValidationError(
+            "Portal telemetry sink path must be absolute",
+            reason="relative_portal_telemetry_sink_path",
+        )
+    if not _has_portal_telemetry_sink_suffix(candidate):
+        raise PathSecurityValidationError(
+            "Portal telemetry sink path must end with .jsonl or .jsonl.gz",
+            reason="invalid_portal_telemetry_sink_suffix",
+        )
+    if candidate.is_symlink():
+        raise PathSecurityValidationError(
+            "Portal telemetry sink path must not be a symlink",
+            reason="symlink_portal_telemetry_sink_path",
+        )
+    try:
+        if candidate.exists() and candidate.is_dir():
+            raise PathSecurityValidationError(
+                "Portal telemetry sink path must not be a directory",
+                reason="directory_portal_telemetry_sink_path",
+            )
+        if candidate.exists() and not candidate.is_file():
+            raise PathSecurityValidationError(
+                "Portal telemetry sink path must be a regular file",
+                reason="invalid_portal_telemetry_sink_path",
+            )
+    except OSError as exc:
+        raise PathSecurityValidationError(
+            "Portal telemetry sink path is invalid",
+            reason="invalid_portal_telemetry_sink_path",
+        ) from exc
+
+    parent = candidate.parent
+    try:
+        if parent.exists() and not parent.is_dir():
+            raise PathSecurityValidationError(
+                "Portal telemetry sink parent must be a directory",
+                reason="invalid_portal_telemetry_sink_parent",
+            )
+    except OSError as exc:
+        raise PathSecurityValidationError(
+            "Portal telemetry sink parent is invalid",
+            reason="invalid_portal_telemetry_sink_parent",
+        ) from exc
+
+    resolved = Path(os.path.realpath(candidate))
+    resolved_repo_root = _repo_root(repo_root)
+    resolved_public_roots = _normalized_roots(
+        _portal_telemetry_public_roots(resolved_repo_root) if public_roots is None else public_roots
+    )
+    resolved_ci_roots = _normalized_roots(_portal_telemetry_ci_roots() if ci_roots is None else ci_roots)
+
+    for public_root in resolved_public_roots:
+        if _path_is_within_root(resolved, public_root):
+            raise PathSecurityValidationError(
+                "Portal telemetry sink path must not be inside public/static asset surfaces",
+                reason="public_static_portal_telemetry_sink_path",
+            )
+    if _path_is_within_root(resolved, resolved_repo_root):
+        raise PathSecurityValidationError(
+            "Portal telemetry sink path must not be inside the repository",
+            reason="repo_portal_telemetry_sink_path",
+        )
+    for ci_root in resolved_ci_roots:
+        if _path_is_within_root(resolved, ci_root):
+            raise PathSecurityValidationError(
+                "Portal telemetry sink path must not be inside CI workspace or artifact paths",
+                reason="ci_portal_telemetry_sink_path",
+            )
+    return resolved
 
 
 def _trusted_allowed_entry(

--- a/src/transformation_portal/portal/path_security.py
+++ b/src/transformation_portal/portal/path_security.py
@@ -205,6 +205,26 @@ def _normalized_roots(roots: Sequence[Path]) -> List[Path]:
     return normalized
 
 
+def _absolute_roots(roots: Sequence[Path]) -> List[Path]:
+    absolute: List[Path] = []
+    for root in roots:
+        try:
+            absolute_root = Path(os.path.abspath(root))
+        except (OSError, RuntimeError, ValueError):
+            continue
+        if absolute_root not in absolute:
+            absolute.append(absolute_root)
+    return absolute
+
+
+def _path_is_lexically_within_root(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
 def validate_portal_telemetry_sink_path(
     path: str,
     *,
@@ -277,26 +297,42 @@ def validate_portal_telemetry_sink_path(
             reason="invalid_portal_telemetry_sink_parent",
         ) from exc
 
+    lexical = Path(os.path.abspath(candidate))
     resolved = Path(os.path.realpath(candidate))
     resolved_repo_root = _repo_root(repo_root)
-    resolved_public_roots = _normalized_roots(
-        _portal_telemetry_public_roots(resolved_repo_root) if public_roots is None else public_roots
-    )
-    resolved_ci_roots = _normalized_roots(_portal_telemetry_ci_roots() if ci_roots is None else ci_roots)
+    lexical_repo_root = Path(os.path.abspath(resolved_repo_root))
+    portal_public_roots = _portal_telemetry_public_roots(resolved_repo_root) if public_roots is None else public_roots
+    portal_ci_roots = _portal_telemetry_ci_roots() if ci_roots is None else ci_roots
+    lexical_public_roots = _absolute_roots(portal_public_roots)
+    resolved_public_roots = _normalized_roots(portal_public_roots)
+    lexical_ci_roots = _absolute_roots(portal_ci_roots)
+    resolved_ci_roots = _normalized_roots(portal_ci_roots)
 
-    for public_root in resolved_public_roots:
-        if _path_is_within_root(resolved, public_root):
+    for lexical_public_root in lexical_public_roots:
+        if _path_is_lexically_within_root(lexical, lexical_public_root):
             raise PathSecurityValidationError(
                 "Portal telemetry sink path must not be inside public/static asset surfaces",
                 reason="public_static_portal_telemetry_sink_path",
             )
-    if _path_is_within_root(resolved, resolved_repo_root):
+    for resolved_public_root in resolved_public_roots:
+        if _path_is_within_root(resolved, resolved_public_root):
+            raise PathSecurityValidationError(
+                "Portal telemetry sink path must not be inside public/static asset surfaces",
+                reason="public_static_portal_telemetry_sink_path",
+            )
+    if _path_is_lexically_within_root(lexical, lexical_repo_root) or _path_is_within_root(resolved, resolved_repo_root):
         raise PathSecurityValidationError(
             "Portal telemetry sink path must not be inside the repository",
             reason="repo_portal_telemetry_sink_path",
         )
-    for ci_root in resolved_ci_roots:
-        if _path_is_within_root(resolved, ci_root):
+    for lexical_ci_root in lexical_ci_roots:
+        if _path_is_lexically_within_root(lexical, lexical_ci_root):
+            raise PathSecurityValidationError(
+                "Portal telemetry sink path must not be inside CI workspace or artifact paths",
+                reason="ci_portal_telemetry_sink_path",
+            )
+    for resolved_ci_root in resolved_ci_roots:
+        if _path_is_within_root(resolved, resolved_ci_root):
             raise PathSecurityValidationError(
                 "Portal telemetry sink path must not be inside CI workspace or artifact paths",
                 reason="ci_portal_telemetry_sink_path",

--- a/src/transformation_portal/portal/path_security.py
+++ b/src/transformation_portal/portal/path_security.py
@@ -284,19 +284,6 @@ def validate_portal_telemetry_sink_path(
             reason="invalid_portal_telemetry_sink_path",
         ) from exc
 
-    parent = candidate.parent
-    try:
-        if parent.exists() and not parent.is_dir():
-            raise PathSecurityValidationError(
-                "Portal telemetry sink parent must be a directory",
-                reason="invalid_portal_telemetry_sink_parent",
-            )
-    except OSError as exc:
-        raise PathSecurityValidationError(
-            "Portal telemetry sink parent is invalid",
-            reason="invalid_portal_telemetry_sink_parent",
-        ) from exc
-
     lexical = Path(os.path.abspath(candidate))
     resolved = Path(os.path.realpath(candidate))
     resolved_repo_root = _repo_root(repo_root)
@@ -337,6 +324,29 @@ def validate_portal_telemetry_sink_path(
                 "Portal telemetry sink path must not be inside CI workspace or artifact paths",
                 reason="ci_portal_telemetry_sink_path",
             )
+
+    parent = candidate.parent
+    try:
+        if not parent.exists():
+            raise PathSecurityValidationError(
+                "Portal telemetry sink parent must already exist",
+                reason="missing_portal_telemetry_sink_parent",
+            )
+        if parent.is_symlink():
+            raise PathSecurityValidationError(
+                "Portal telemetry sink parent must not be a symlink",
+                reason="symlink_portal_telemetry_sink_parent",
+            )
+        if not parent.is_dir():
+            raise PathSecurityValidationError(
+                "Portal telemetry sink parent must be a directory",
+                reason="invalid_portal_telemetry_sink_parent",
+            )
+    except OSError as exc:
+        raise PathSecurityValidationError(
+            "Portal telemetry sink parent is invalid",
+            reason="invalid_portal_telemetry_sink_parent",
+        ) from exc
     return resolved
 
 

--- a/tests/test_portal_telemetry_sink_policy.py
+++ b/tests/test_portal_telemetry_sink_policy.py
@@ -46,6 +46,47 @@ def test_unset_sink_path_remains_noop_at_config_layer(monkeypatch: pytest.Monkey
     assert orchestrator_app._portal_telemetry_sink_path_from_env("TP_PORTAL_EVENT_LOG_PATH") is None
 
 
+def test_persist_portal_event_record_opens_sink_relative_to_parent_dir_fd(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    orchestrator_app = importlib.import_module("app")
+    sink_path = _external_sink(tmp_path)
+    open_calls = []
+    closed_fds = []
+    next_fd = iter([101, 102])
+
+    def fake_open(path, flags, mode=0o777, *, dir_fd=None):
+        fd = next(next_fd)
+        open_calls.append(
+            {
+                "path": path,
+                "flags": flags,
+                "mode": mode,
+                "dir_fd": dir_fd,
+                "fd": fd,
+            }
+        )
+        return fd
+
+    monkeypatch.setattr(orchestrator_app.os, "open", fake_open)
+    monkeypatch.setattr(orchestrator_app.os, "supports_dir_fd", {*orchestrator_app.os.supports_dir_fd, fake_open})
+    monkeypatch.setattr(orchestrator_app.os, "write", lambda _fd, data: len(data))
+    monkeypatch.setattr(orchestrator_app.os, "close", lambda fd: closed_fds.append(fd))
+
+    orchestrator_app._persist_portal_event_record({"schema": "test"}, sink_path)
+
+    assert open_calls[0]["path"] == Path(os.path.realpath(sink_path)).parent
+    assert open_calls[0]["dir_fd"] is None
+    assert open_calls[1]["path"] == sink_path.name
+    assert open_calls[1]["dir_fd"] == open_calls[0]["fd"]
+    no_follow_flag = getattr(orchestrator_app.os, "O_NOFOLLOW", 0)
+    if no_follow_flag:
+        assert open_calls[0]["flags"] & no_follow_flag
+        assert open_calls[1]["flags"] & no_follow_flag
+    assert closed_fds == [open_calls[1]["fd"], open_calls[0]["fd"]]
+
+
 def test_external_jsonl_sink_path_is_accepted(tmp_path: Path) -> None:
     repo_root = _repo_root(tmp_path)
     sink_path = _external_sink(tmp_path)

--- a/tests/test_portal_telemetry_sink_policy.py
+++ b/tests/test_portal_telemetry_sink_policy.py
@@ -118,11 +118,41 @@ def test_nested_repo_sink_path_is_rejected(tmp_path: Path) -> None:
     )
 
 
+def test_repo_symlink_parent_to_external_sink_is_rejected(tmp_path: Path) -> None:
+    repo_root = _repo_root(tmp_path)
+    external_root = tmp_path / "operator-owned"
+    external_root.mkdir()
+    link_path = repo_root / "logs-link"
+    link_path.symlink_to(external_root, target_is_directory=True)
+
+    _assert_policy_reason(
+        str(link_path / "portal-rum.jsonl"),
+        "repo_portal_telemetry_sink_path",
+        repo_root=repo_root,
+    )
+
+
 def test_frontdoor_public_sink_path_is_rejected(tmp_path: Path) -> None:
     repo_root = _repo_root(tmp_path)
 
     _assert_policy_reason(
         str(repo_root / "web" / "secure-landing" / "public" / "portal-rum.jsonl"),
+        "public_static_portal_telemetry_sink_path",
+        repo_root=repo_root,
+    )
+
+
+def test_frontdoor_public_symlink_parent_to_external_sink_is_rejected(tmp_path: Path) -> None:
+    repo_root = _repo_root(tmp_path)
+    external_root = tmp_path / "operator-owned"
+    external_root.mkdir()
+    public_root = repo_root / "web" / "secure-landing" / "public"
+    public_root.mkdir(parents=True)
+    link_path = public_root / "logs-link"
+    link_path.symlink_to(external_root, target_is_directory=True)
+
+    _assert_policy_reason(
+        str(link_path / "portal-rum.jsonl"),
         "public_static_portal_telemetry_sink_path",
         repo_root=repo_root,
     )

--- a/tests/test_portal_telemetry_sink_policy.py
+++ b/tests/test_portal_telemetry_sink_policy.py
@@ -16,7 +16,6 @@ from transformation_portal.portal.path_security import PathSecurityValidationErr
 pytestmark = [pytest.mark.unit, pytest.mark.security]
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
-orchestrator_app = importlib.import_module("app")
 
 
 def _repo_root(tmp_path: Path) -> Path:
@@ -41,6 +40,7 @@ def _assert_policy_reason(path_value: str, reason: str, *, repo_root: Path) -> N
 def test_unset_sink_path_remains_noop_at_config_layer(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("TP_PORTAL_RUM_LOG_PATH", raising=False)
     monkeypatch.delenv("TP_PORTAL_EVENT_LOG_PATH", raising=False)
+    orchestrator_app = importlib.import_module("app")
 
     assert orchestrator_app._portal_telemetry_sink_path_from_env("TP_PORTAL_RUM_LOG_PATH") is None
     assert orchestrator_app._portal_telemetry_sink_path_from_env("TP_PORTAL_EVENT_LOG_PATH") is None
@@ -84,6 +84,13 @@ def test_non_jsonl_sink_suffix_is_rejected(tmp_path: Path) -> None:
     )
 
 
+def test_missing_parent_sink_path_is_rejected(tmp_path: Path) -> None:
+    repo_root = _repo_root(tmp_path)
+    sink_path = tmp_path / "operator-owned" / "missing-parent" / "portal-rum.jsonl"
+
+    _assert_policy_reason(str(sink_path), "missing_portal_telemetry_sink_parent", repo_root=repo_root)
+
+
 def test_existing_directory_sink_path_is_rejected(tmp_path: Path) -> None:
     repo_root = _repo_root(tmp_path)
     sink_path = _external_sink(tmp_path, "portal-rum.jsonl")
@@ -100,6 +107,22 @@ def test_symlink_sink_path_is_rejected(tmp_path: Path) -> None:
     symlink_path.symlink_to(target_path)
 
     _assert_policy_reason(str(symlink_path), "symlink_portal_telemetry_sink_path", repo_root=repo_root)
+
+
+def test_external_symlink_parent_sink_path_is_rejected(tmp_path: Path) -> None:
+    repo_root = _repo_root(tmp_path)
+    operator_root = tmp_path / "operator-owned"
+    operator_root.mkdir()
+    target_root = tmp_path / "operator-target"
+    target_root.mkdir()
+    link_path = operator_root / "logs-link"
+    link_path.symlink_to(target_root, target_is_directory=True)
+
+    _assert_policy_reason(
+        str(link_path / "portal-rum.jsonl"),
+        "symlink_portal_telemetry_sink_parent",
+        repo_root=repo_root,
+    )
 
 
 def test_repo_root_sink_path_is_rejected(tmp_path: Path) -> None:

--- a/tests/test_portal_telemetry_sink_policy.py
+++ b/tests/test_portal_telemetry_sink_policy.py
@@ -60,6 +60,7 @@ def test_persist_portal_event_record_opens_sink_relative_to_parent_dir_fd(
     open_calls = []
     closed_fds = []
     next_fd = iter([101, 102])
+    real_stat = orchestrator_app.os.stat
     parent_stat = orchestrator_app.os.stat(sink_path.parent, follow_symlinks=False)
 
     def fake_open(path, flags, mode=0o777, *, dir_fd=None):
@@ -80,8 +81,14 @@ def test_persist_portal_event_record_opens_sink_relative_to_parent_dir_fd(
             return parent_stat
         return _stat_result(mode=stat.S_IFREG | 0o600, dev=parent_stat.st_dev, ino=parent_stat.st_ino + 1)
 
+    def fake_stat(path, *args, follow_symlinks=True, **kwargs):
+        if path == sink_path.name and kwargs.get("dir_fd") == 101:
+            raise FileNotFoundError(path)
+        return real_stat(path, *args, follow_symlinks=follow_symlinks, **kwargs)
+
     monkeypatch.setattr(orchestrator_app.os, "open", fake_open)
     monkeypatch.setattr(orchestrator_app.os, "supports_dir_fd", {*orchestrator_app.os.supports_dir_fd, fake_open})
+    monkeypatch.setattr(orchestrator_app.os, "stat", fake_stat)
     monkeypatch.setattr(orchestrator_app.os, "fstat", fake_fstat)
     monkeypatch.setattr(orchestrator_app.os, "write", lambda _fd, data: len(data))
     monkeypatch.setattr(orchestrator_app.os, "close", lambda fd: closed_fds.append(fd))
@@ -152,6 +159,62 @@ def test_persist_portal_event_record_rejects_parent_fd_identity_mismatch(
     assert unsafe_content not in caplog.text
 
 
+def test_persist_portal_event_record_rejects_non_regular_existing_sink_before_open(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    orchestrator_app = importlib.import_module("app")
+    sink_path = _external_sink(tmp_path)
+    unsafe_content = "do-not-leak-raw-log-content"
+    open_calls = []
+    close_calls = []
+    write_calls = []
+    real_stat = orchestrator_app.os.stat
+    real_fstat = orchestrator_app.os.fstat
+    parent_stat = _stat_result(mode=stat.S_IFDIR | 0o700, dev=1, ino=10)
+    fifo_stat = _stat_result(mode=stat.S_IFIFO | 0o600, dev=1, ino=11)
+
+    monkeypatch.setattr(
+        orchestrator_app._portal_path_security,
+        "validate_portal_telemetry_sink_path",
+        lambda _path, *, repo_root=None: sink_path,
+    )
+
+    def fake_stat(path, *args, follow_symlinks=True, **kwargs):
+        if isinstance(path, (str, os.PathLike)) and Path(path) == sink_path.parent:
+            return parent_stat
+        if path == sink_path.name and kwargs.get("dir_fd") == 101:
+            return fifo_stat
+        return real_stat(path, *args, follow_symlinks=follow_symlinks, **kwargs)
+
+    def fake_fstat(fd):
+        if fd == 101:
+            return parent_stat
+        return real_fstat(fd)
+
+    def fake_open(path, flags, mode=0o777, *, dir_fd=None):
+        fd = 101 if dir_fd is None else 102
+        open_calls.append((path, flags, mode, dir_fd, fd))
+        return fd
+
+    monkeypatch.setattr(orchestrator_app.os, "stat", fake_stat)
+    monkeypatch.setattr(orchestrator_app.os, "fstat", fake_fstat)
+    monkeypatch.setattr(orchestrator_app.os, "open", fake_open)
+    monkeypatch.setattr(orchestrator_app.os, "supports_dir_fd", {*orchestrator_app.os.supports_dir_fd, fake_open})
+    monkeypatch.setattr(orchestrator_app.os, "write", lambda fd, data: write_calls.append((fd, data)) or len(data))
+    monkeypatch.setattr(orchestrator_app.os, "close", lambda fd: close_calls.append(fd))
+
+    with caplog.at_level("WARNING"):
+        orchestrator_app._persist_portal_event_record({"schema": "test", "raw": unsafe_content}, sink_path)
+
+    assert len(open_calls) == 1
+    assert write_calls == []
+    assert close_calls == [101]
+    assert "failed to persist portal event telemetry" in caplog.text
+    assert unsafe_content not in caplog.text
+
+
 def test_persist_portal_event_record_requires_regular_opened_file_fd(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -177,6 +240,8 @@ def test_persist_portal_event_record_requires_regular_opened_file_fd(
     def fake_stat(path, *args, follow_symlinks=True, **kwargs):
         if isinstance(path, (str, os.PathLike)) and Path(path) == sink_path.parent:
             return parent_stat
+        if path == sink_path.name and kwargs.get("dir_fd") == 101:
+            raise FileNotFoundError(path)
         return real_stat(path, *args, follow_symlinks=follow_symlinks, **kwargs)
 
     def fake_fstat(fd):

--- a/tests/test_portal_telemetry_sink_policy.py
+++ b/tests/test_portal_telemetry_sink_policy.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib
 import os
+import stat
 import subprocess
 import sys
 from pathlib import Path
@@ -37,6 +38,10 @@ def _assert_policy_reason(path_value: str, reason: str, *, repo_root: Path) -> N
     assert exc_info.value.reason == reason
 
 
+def _stat_result(*, mode: int, dev: int = 1, ino: int = 10) -> os.stat_result:
+    return os.stat_result((mode, ino, dev, 1, 0, 0, 0, 0, 0, 0))
+
+
 def test_unset_sink_path_remains_noop_at_config_layer(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("TP_PORTAL_RUM_LOG_PATH", raising=False)
     monkeypatch.delenv("TP_PORTAL_EVENT_LOG_PATH", raising=False)
@@ -55,6 +60,7 @@ def test_persist_portal_event_record_opens_sink_relative_to_parent_dir_fd(
     open_calls = []
     closed_fds = []
     next_fd = iter([101, 102])
+    parent_stat = orchestrator_app.os.stat(sink_path.parent, follow_symlinks=False)
 
     def fake_open(path, flags, mode=0o777, *, dir_fd=None):
         fd = next(next_fd)
@@ -69,8 +75,14 @@ def test_persist_portal_event_record_opens_sink_relative_to_parent_dir_fd(
         )
         return fd
 
+    def fake_fstat(fd):
+        if fd == 101:
+            return parent_stat
+        return _stat_result(mode=stat.S_IFREG | 0o600, dev=parent_stat.st_dev, ino=parent_stat.st_ino + 1)
+
     monkeypatch.setattr(orchestrator_app.os, "open", fake_open)
     monkeypatch.setattr(orchestrator_app.os, "supports_dir_fd", {*orchestrator_app.os.supports_dir_fd, fake_open})
+    monkeypatch.setattr(orchestrator_app.os, "fstat", fake_fstat)
     monkeypatch.setattr(orchestrator_app.os, "write", lambda _fd, data: len(data))
     monkeypatch.setattr(orchestrator_app.os, "close", lambda fd: closed_fds.append(fd))
 
@@ -85,6 +97,115 @@ def test_persist_portal_event_record_opens_sink_relative_to_parent_dir_fd(
         assert open_calls[0]["flags"] & no_follow_flag
         assert open_calls[1]["flags"] & no_follow_flag
     assert closed_fds == [open_calls[1]["fd"], open_calls[0]["fd"]]
+
+
+def test_persist_portal_event_record_rejects_parent_fd_identity_mismatch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    orchestrator_app = importlib.import_module("app")
+    sink_path = _external_sink(tmp_path)
+    unsafe_content = "do-not-leak-raw-log-content"
+    open_calls = []
+    close_calls = []
+    write_calls = []
+    real_stat = orchestrator_app.os.stat
+    real_fstat = orchestrator_app.os.fstat
+    expected_parent_stat = _stat_result(mode=stat.S_IFDIR | 0o700, dev=1, ino=10)
+    changed_parent_stat = _stat_result(mode=stat.S_IFDIR | 0o700, dev=2, ino=20)
+
+    monkeypatch.setattr(
+        orchestrator_app._portal_path_security,
+        "validate_portal_telemetry_sink_path",
+        lambda _path, *, repo_root=None: sink_path,
+    )
+
+    def fake_stat(path, *args, follow_symlinks=True, **kwargs):
+        if isinstance(path, (str, os.PathLike)) and Path(path) == sink_path.parent:
+            return expected_parent_stat
+        return real_stat(path, *args, follow_symlinks=follow_symlinks, **kwargs)
+
+    def fake_fstat(fd):
+        if fd == 101:
+            return changed_parent_stat
+        return real_fstat(fd)
+
+    def fake_open(path, flags, mode=0o777, *, dir_fd=None):
+        open_calls.append((path, flags, mode, dir_fd))
+        return 101
+
+    monkeypatch.setattr(orchestrator_app.os, "open", fake_open)
+    monkeypatch.setattr(orchestrator_app.os, "supports_dir_fd", {*orchestrator_app.os.supports_dir_fd, fake_open})
+    monkeypatch.setattr(orchestrator_app.os, "stat", fake_stat)
+    monkeypatch.setattr(orchestrator_app.os, "fstat", fake_fstat)
+    monkeypatch.setattr(orchestrator_app.os, "write", lambda fd, data: write_calls.append((fd, data)) or len(data))
+    monkeypatch.setattr(orchestrator_app.os, "close", lambda fd: close_calls.append(fd))
+
+    with caplog.at_level("WARNING"):
+        orchestrator_app._persist_portal_event_record({"schema": "test", "raw": unsafe_content}, sink_path)
+
+    assert len(open_calls) == 1
+    assert write_calls == []
+    assert close_calls == [101]
+    assert "failed to persist portal event telemetry" in caplog.text
+    assert unsafe_content not in caplog.text
+
+
+def test_persist_portal_event_record_requires_regular_opened_file_fd(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    orchestrator_app = importlib.import_module("app")
+    sink_path = _external_sink(tmp_path)
+    unsafe_content = "do-not-leak-raw-log-content"
+    open_calls = []
+    close_calls = []
+    write_calls = []
+    real_stat = orchestrator_app.os.stat
+    real_fstat = orchestrator_app.os.fstat
+    parent_stat = _stat_result(mode=stat.S_IFDIR | 0o700, dev=1, ino=10)
+    fifo_stat = _stat_result(mode=stat.S_IFIFO | 0o600, dev=1, ino=11)
+
+    monkeypatch.setattr(
+        orchestrator_app._portal_path_security,
+        "validate_portal_telemetry_sink_path",
+        lambda _path, *, repo_root=None: sink_path,
+    )
+
+    def fake_stat(path, *args, follow_symlinks=True, **kwargs):
+        if isinstance(path, (str, os.PathLike)) and Path(path) == sink_path.parent:
+            return parent_stat
+        return real_stat(path, *args, follow_symlinks=follow_symlinks, **kwargs)
+
+    def fake_fstat(fd):
+        if fd == 101:
+            return parent_stat
+        if fd == 102:
+            return fifo_stat
+        return real_fstat(fd)
+
+    def fake_open(path, flags, mode=0o777, *, dir_fd=None):
+        fd = 101 if dir_fd is None else 102
+        open_calls.append((path, flags, mode, dir_fd, fd))
+        return fd
+
+    monkeypatch.setattr(orchestrator_app.os, "fstat", fake_fstat)
+    monkeypatch.setattr(orchestrator_app.os, "stat", fake_stat)
+    monkeypatch.setattr(orchestrator_app.os, "open", fake_open)
+    monkeypatch.setattr(orchestrator_app.os, "supports_dir_fd", {*orchestrator_app.os.supports_dir_fd, fake_open})
+    monkeypatch.setattr(orchestrator_app.os, "write", lambda fd, data: write_calls.append((fd, data)) or len(data))
+    monkeypatch.setattr(orchestrator_app.os, "close", lambda fd: close_calls.append(fd))
+
+    with caplog.at_level("WARNING"):
+        orchestrator_app._persist_portal_event_record({"schema": "test", "raw": unsafe_content}, sink_path)
+
+    assert len(open_calls) == 2
+    assert write_calls == []
+    assert close_calls == [102, 101]
+    assert "failed to persist portal event telemetry" in caplog.text
+    assert unsafe_content not in caplog.text
 
 
 def test_external_jsonl_sink_path_is_accepted(tmp_path: Path) -> None:

--- a/tests/test_portal_telemetry_sink_policy.py
+++ b/tests/test_portal_telemetry_sink_policy.py
@@ -1,0 +1,194 @@
+"""Tests for portal telemetry sink path policy."""
+
+from __future__ import annotations
+
+import importlib
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from transformation_portal.portal import path_security
+from transformation_portal.portal.path_security import PathSecurityValidationError
+
+pytestmark = [pytest.mark.unit, pytest.mark.security]
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+orchestrator_app = importlib.import_module("app")
+
+
+def _repo_root(tmp_path: Path) -> Path:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    return repo_root
+
+
+def _external_sink(tmp_path: Path, name: str = "portal-rum.jsonl") -> Path:
+    sink_root = tmp_path / "operator-owned"
+    sink_root.mkdir()
+    return sink_root / name
+
+
+def _assert_policy_reason(path_value: str, reason: str, *, repo_root: Path) -> None:
+    with pytest.raises(PathSecurityValidationError) as exc_info:
+        path_security.validate_portal_telemetry_sink_path(path_value, repo_root=repo_root)
+
+    assert exc_info.value.reason == reason
+
+
+def test_unset_sink_path_remains_noop_at_config_layer(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("TP_PORTAL_RUM_LOG_PATH", raising=False)
+    monkeypatch.delenv("TP_PORTAL_EVENT_LOG_PATH", raising=False)
+
+    assert orchestrator_app._portal_telemetry_sink_path_from_env("TP_PORTAL_RUM_LOG_PATH") is None
+    assert orchestrator_app._portal_telemetry_sink_path_from_env("TP_PORTAL_EVENT_LOG_PATH") is None
+
+
+def test_external_jsonl_sink_path_is_accepted(tmp_path: Path) -> None:
+    repo_root = _repo_root(tmp_path)
+    sink_path = _external_sink(tmp_path)
+
+    assert path_security.validate_portal_telemetry_sink_path(str(sink_path), repo_root=repo_root) == Path(
+        os.path.realpath(sink_path)
+    )
+
+
+def test_external_jsonl_gz_sink_path_is_accepted(tmp_path: Path) -> None:
+    repo_root = _repo_root(tmp_path)
+    sink_path = _external_sink(tmp_path, "portal-rum.jsonl.gz")
+
+    assert path_security.validate_portal_telemetry_sink_path(str(sink_path), repo_root=repo_root) == Path(
+        os.path.realpath(sink_path)
+    )
+
+
+def test_relative_sink_path_is_rejected(tmp_path: Path) -> None:
+    _assert_policy_reason("logs/portal-rum.jsonl", "relative_portal_telemetry_sink_path", repo_root=_repo_root(tmp_path))
+
+
+def test_empty_sink_path_is_rejected(tmp_path: Path) -> None:
+    _assert_policy_reason("", "empty_portal_telemetry_sink_path", repo_root=_repo_root(tmp_path))
+
+
+def test_glob_like_sink_path_is_rejected(tmp_path: Path) -> None:
+    _assert_policy_reason("/tmp/portal-*.jsonl", "glob_portal_telemetry_sink_path", repo_root=_repo_root(tmp_path))
+
+
+def test_non_jsonl_sink_suffix_is_rejected(tmp_path: Path) -> None:
+    _assert_policy_reason(
+        str(_external_sink(tmp_path, "portal-rum.txt")),
+        "invalid_portal_telemetry_sink_suffix",
+        repo_root=_repo_root(tmp_path),
+    )
+
+
+def test_existing_directory_sink_path_is_rejected(tmp_path: Path) -> None:
+    repo_root = _repo_root(tmp_path)
+    sink_path = _external_sink(tmp_path, "portal-rum.jsonl")
+    sink_path.mkdir()
+
+    _assert_policy_reason(str(sink_path), "directory_portal_telemetry_sink_path", repo_root=repo_root)
+
+
+def test_symlink_sink_path_is_rejected(tmp_path: Path) -> None:
+    repo_root = _repo_root(tmp_path)
+    target_path = _external_sink(tmp_path, "target.jsonl")
+    target_path.write_text("{}\n", encoding="utf-8")
+    symlink_path = target_path.parent / "portal-rum.jsonl"
+    symlink_path.symlink_to(target_path)
+
+    _assert_policy_reason(str(symlink_path), "symlink_portal_telemetry_sink_path", repo_root=repo_root)
+
+
+def test_repo_root_sink_path_is_rejected(tmp_path: Path) -> None:
+    repo_root = _repo_root(tmp_path)
+
+    _assert_policy_reason(str(repo_root / "portal-rum.jsonl"), "repo_portal_telemetry_sink_path", repo_root=repo_root)
+
+
+def test_nested_repo_sink_path_is_rejected(tmp_path: Path) -> None:
+    repo_root = _repo_root(tmp_path)
+
+    _assert_policy_reason(
+        str(repo_root / "var" / "portal-rum.jsonl"),
+        "repo_portal_telemetry_sink_path",
+        repo_root=repo_root,
+    )
+
+
+def test_frontdoor_public_sink_path_is_rejected(tmp_path: Path) -> None:
+    repo_root = _repo_root(tmp_path)
+
+    _assert_policy_reason(
+        str(repo_root / "web" / "secure-landing" / "public" / "portal-rum.jsonl"),
+        "public_static_portal_telemetry_sink_path",
+        repo_root=repo_root,
+    )
+
+
+def test_static_asset_sink_path_is_rejected(tmp_path: Path) -> None:
+    repo_root = _repo_root(tmp_path)
+
+    _assert_policy_reason(
+        str(repo_root / "static" / "portal-rum.jsonl"),
+        "public_static_portal_telemetry_sink_path",
+        repo_root=repo_root,
+    )
+
+
+def test_github_workspace_sink_path_is_rejected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo_root = _repo_root(tmp_path)
+    github_workspace = tmp_path / "github-workspace"
+    github_workspace.mkdir()
+    monkeypatch.setenv("GITHUB_WORKSPACE", str(github_workspace))
+
+    _assert_policy_reason(
+        str(github_workspace / "portal-rum.jsonl"),
+        "ci_portal_telemetry_sink_path",
+        repo_root=repo_root,
+    )
+
+
+def test_runner_temp_sink_path_is_rejected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo_root = _repo_root(tmp_path)
+    runner_temp = tmp_path / "runner-temp"
+    runner_temp.mkdir()
+    monkeypatch.setenv("RUNNER_TEMP", str(runner_temp))
+
+    _assert_policy_reason(
+        str(runner_temp / "portal-events.jsonl"),
+        "ci_portal_telemetry_sink_path",
+        repo_root=repo_root,
+    )
+
+
+def test_configured_invalid_sink_fails_app_import_without_leaking_contents(tmp_path: Path) -> None:
+    unsafe_content = "do-not-leak-raw-log-content"
+    unsafe_path = tmp_path / "portal-rum.txt"
+    unsafe_path.write_text(unsafe_content, encoding="utf-8")
+    env = os.environ.copy()
+    env["TP_PORTAL_RUM_LOG_PATH"] = str(unsafe_path)
+    env.pop("TP_PORTAL_EVENT_LOG_PATH", None)
+
+    result = subprocess.run(
+        [sys.executable, "-c", "import app"],
+        cwd=str(PROJECT_ROOT),
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    combined_output = result.stdout + result.stderr
+    assert result.returncode != 0
+    assert "TP_PORTAL_RUM_LOG_PATH violates portal telemetry sink path policy" in combined_output
+    assert "must end with .jsonl or .jsonl.gz" in combined_output
+    assert unsafe_content not in combined_output


### PR DESCRIPTION
## Summary
- Issue #1704 needs configured portal telemetry raw-log sinks to fail closed before unsafe sink placement can write raw logs.
- Adds a runtime-owned sink path policy helper and applies it during app configuration ingestion and write-time persistence for the portal RUM and event sink env vars.

## Changes
- Added `validate_portal_telemetry_sink_path` in `src/transformation_portal/portal/path_security.py`.
- Guarded `TP_PORTAL_RUM_LOG_PATH` and `TP_PORTAL_EVENT_LOG_PATH` at startup/config ingestion.
- Rejects empty, relative, glob-like, directory, symlink, non-JSONL suffix, missing parent, symlink parent, repo-local, public/static asset-surface, and detected CI workspace/artifact paths.
- Checks both the lexical configured path and the realpath-resolved target against repo/public/static/CI roots.
- Revalidates sinks before appending telemetry and no longer creates sink parent directories during persistence.
- Opens the validated parent directory with no-follow directory flags and opens the sink file by basename through `dir_fd` to avoid parent-symlink redirection.
- Verifies the opened parent fd still matches the expected parent dev/inode and verifies the opened sink fd is a regular file before writing.
- Preflights an existing sink basename with `dir_fd` / `follow_symlinks=False` and uses `O_NONBLOCK` on the file open to reject FIFO or special-file swaps without blocking.
- Allows unset sink vars to remain no-op and valid absolute external `.jsonl` / `.jsonl.gz` paths with existing non-symlink parents to enable sinks.
- Added focused sink policy tests and a small retention-runbook enforcement note.

## Validation
Proven green:
- `.venv/bin/pytest tests/test_portal_telemetry_sink_policy.py`
- `.venv/bin/pytest tests/test_app_orchestrator_contract_http.py -k rum`
- `make test-orchestrator-http-contract`
- `make check-stale-docs`
- `make check-doc-heading-links`
- `git diff --check`

Still failing:
- None observed.

## Risk
- Bounded to optional telemetry sink path configuration and persistence guardrails; unset sinks continue to be disabled.
- Invalid configured sinks now fail closed instead of being silently ignored, which is intentional for governed pilots.
- No RUM schema, event emission, cookie, sessionStorage, sanitizer, rollout, or retention/deletion behavior changes.

Closes #1704