### PR TITLE
policy: add independent front-door RUM rollout control

### DIFF
--- a/docs/compliance/PORTAL_TELEMETRY_PRIVACY_SIGNOFF.md
+++ b/docs/compliance/PORTAL_TELEMETRY_PRIVACY_SIGNOFF.md
@@ -166,9 +166,19 @@ Current rollout knobs:
 ```bash
 export TP_PORTAL_RUM_ENABLED=0
 export TP_PORTAL_RUM_ROLLOUT_PERCENT=0
+export TP_FRONTDOOR_RUM_ENABLED=0
+export TP_FRONTDOOR_RUM_ROLLOUT_PERCENT=0
 ```
 
-`TP_PORTAL_RUM_ENABLED` is the shared master flag for portal and front-door RUM scripts / emitters. `TP_PORTAL_RUM_ROLLOUT_PERCENT` gates managed portal bootstrap RUM telemetry by rollout cohort. The current front-door landing, login, and logout RUM paths do not define a separate front-door rollout or sampling env var in this revision; they are controlled by the shared enabled flag.
+Portal RUM controls:
+
+- `TP_PORTAL_RUM_ENABLED` remains the shared master kill switch for portal and front-door RUM scripts / emitters.
+- `TP_PORTAL_RUM_ROLLOUT_PERCENT` gates managed portal bootstrap RUM telemetry by rollout cohort.
+
+Front-door RUM controls:
+
+- `TP_FRONTDOOR_RUM_ENABLED` independently gates landing, login, logout, and front-door RUM proxy telemetry after the shared master flag is enabled.
+- `TP_FRONTDOOR_RUM_ROLLOUT_PERCENT` independently samples front-door RUM requests; it defaults to `100` when front-door RUM is enabled, clamps to `0..100`, and treats invalid values as `0`.
 
 Current sink path knobs:
 

--- a/docs/compliance/PORTAL_TELEMETRY_PRIVACY_SIGNOFF.md
+++ b/docs/compliance/PORTAL_TELEMETRY_PRIVACY_SIGNOFF.md
@@ -177,7 +177,7 @@ Portal RUM controls:
 
 Front-door RUM controls:
 
-- `TP_FRONTDOOR_RUM_ENABLED` independently gates landing, login, logout, and front-door RUM proxy telemetry after the shared master flag is enabled.
+- `TP_FRONTDOOR_RUM_ENABLED` independently gates landing, login, logout, and front-door event-family payloads submitted through the RUM proxy after the shared master flag is enabled.
 - `TP_FRONTDOOR_RUM_ROLLOUT_PERCENT` independently samples front-door RUM requests; it defaults to `100` when front-door RUM is enabled, clamps to `0..100`, and treats invalid values as `0`.
 
 Current sink path knobs:

--- a/docs/compliance/PORTAL_TELEMETRY_PRIVACY_SIGNOFF.md
+++ b/docs/compliance/PORTAL_TELEMETRY_PRIVACY_SIGNOFF.md
@@ -177,7 +177,7 @@ Portal RUM controls:
 
 Front-door RUM controls:
 
-- `TP_FRONTDOOR_RUM_ENABLED` independently gates landing, login, logout, and front-door event-family payloads submitted through the RUM proxy after the shared master flag is enabled.
+- `TP_FRONTDOOR_RUM_ENABLED` independently gates landing, login, logout, and front-door payloads submitted through the RUM proxy after the shared master flag is enabled.
 - `TP_FRONTDOOR_RUM_ROLLOUT_PERCENT` independently samples front-door RUM requests; it defaults to `100` when front-door RUM is enabled, clamps to `0..100`, and treats invalid values as `0`.
 
 Current sink path knobs:

--- a/docs/guides/PORTAL_SECURE_FRONTDOOR_QUICKSTART.md
+++ b/docs/guides/PORTAL_SECURE_FRONTDOOR_QUICKSTART.md
@@ -83,7 +83,7 @@ export TP_PORTAL_EVENT_LOG_PATH="/absolute/path/to/portal-events.jsonl"
 Notes:
 - `TP_PORTAL_RUM_ENABLED=0` keeps `/v1/portal/rum` in success/no-op mode and keeps `features.rumTelemetry=false` on both bootstrap surfaces.
 - `TP_PORTAL_RUM_ROLLOUT_PERCENT=0` keeps managed portal/bootstrap RUM disabled even when the hard flag is on.
-- `TP_FRONTDOOR_RUM_ENABLED=0` independently disables landing, login, logout, and front-door RUM proxy telemetry after the shared hard flag is on.
+- `TP_FRONTDOOR_RUM_ENABLED=0` independently disables landing, login, logout, and front-door event-family payloads submitted through the RUM proxy after the shared hard flag is on.
 - `TP_FRONTDOOR_RUM_ROLLOUT_PERCENT=0` samples out front-door RUM even when both hard flags are on.
 - `TP_PORTAL_RUM_LOG_PATH` is optional. When set, FastAPI appends PII-free JSONL records for the pilot summary CLI.
 - `TP_PORTAL_EVENT_LOG_PATH` is optional. When set, FastAPI appends PII-free portal event JSONL for viewer, review, and stream telemetry evidence.

--- a/docs/guides/PORTAL_SECURE_FRONTDOOR_QUICKSTART.md
+++ b/docs/guides/PORTAL_SECURE_FRONTDOOR_QUICKSTART.md
@@ -74,13 +74,17 @@ and a deterministic rollout percentage.
 ```bash
 export TP_PORTAL_RUM_ENABLED=0
 export TP_PORTAL_RUM_ROLLOUT_PERCENT=0
+export TP_FRONTDOOR_RUM_ENABLED=0
+export TP_FRONTDOOR_RUM_ROLLOUT_PERCENT=0
 export TP_PORTAL_RUM_LOG_PATH="/absolute/path/to/portal-rum.jsonl"
 export TP_PORTAL_EVENT_LOG_PATH="/absolute/path/to/portal-events.jsonl"
 ```
 
 Notes:
 - `TP_PORTAL_RUM_ENABLED=0` keeps `/v1/portal/rum` in success/no-op mode and keeps `features.rumTelemetry=false` on both bootstrap surfaces.
-- `TP_PORTAL_RUM_ROLLOUT_PERCENT=0` keeps collection disabled even when the hard flag is on.
+- `TP_PORTAL_RUM_ROLLOUT_PERCENT=0` keeps managed portal/bootstrap RUM disabled even when the hard flag is on.
+- `TP_FRONTDOOR_RUM_ENABLED=0` independently disables landing, login, logout, and front-door RUM proxy telemetry after the shared hard flag is on.
+- `TP_FRONTDOOR_RUM_ROLLOUT_PERCENT=0` samples out front-door RUM even when both hard flags are on.
 - `TP_PORTAL_RUM_LOG_PATH` is optional. When set, FastAPI appends PII-free JSONL records for the pilot summary CLI.
 - `TP_PORTAL_EVENT_LOG_PATH` is optional. When set, FastAPI appends PII-free portal event JSONL for viewer, review, and stream telemetry evidence.
 - Direct-debug rollout stability reuses `TP_PORTAL_DIRECT_DEBUG_COHORT_KEY`.

--- a/docs/guides/PORTAL_SECURE_FRONTDOOR_QUICKSTART.md
+++ b/docs/guides/PORTAL_SECURE_FRONTDOOR_QUICKSTART.md
@@ -83,7 +83,7 @@ export TP_PORTAL_EVENT_LOG_PATH="/absolute/path/to/portal-events.jsonl"
 Notes:
 - `TP_PORTAL_RUM_ENABLED=0` keeps `/v1/portal/rum` in success/no-op mode and keeps `features.rumTelemetry=false` on both bootstrap surfaces.
 - `TP_PORTAL_RUM_ROLLOUT_PERCENT=0` keeps managed portal/bootstrap RUM disabled even when the hard flag is on.
-- `TP_FRONTDOOR_RUM_ENABLED=0` independently disables landing, login, logout, and front-door event-family payloads submitted through the RUM proxy after the shared hard flag is on.
+- `TP_FRONTDOOR_RUM_ENABLED=0` independently disables landing, login, logout, and front-door payloads submitted through the RUM proxy after the shared hard flag is on.
 - `TP_FRONTDOOR_RUM_ROLLOUT_PERCENT=0` samples out front-door RUM even when both hard flags are on.
 - `TP_PORTAL_RUM_LOG_PATH` is optional. When set, FastAPI appends PII-free JSONL records for the pilot summary CLI.
 - `TP_PORTAL_EVENT_LOG_PATH` is optional. When set, FastAPI appends PII-free portal event JSONL for viewer, review, and stream telemetry evidence.

--- a/docs/operations/frontdoor_vercel_env.md
+++ b/docs/operations/frontdoor_vercel_env.md
@@ -31,8 +31,8 @@ two values as one secret, set them together, rotate them together.
 | `TP_ALLOW_LOCAL_ACCESS_BYPASS` | unset | Development-only bypass for Cloudflare Access verification. **Never set in production.** |
 | `TP_NEXT_DIST_DIR` | unset | Override Next.js build output directory; rarely needed on Vercel. |
 | `TP_PORTAL_RUM_ENABLED` | unset | Shared master kill switch for managed portal/bootstrap RUM and front-door RUM. Set to a truthy value before any RUM path can emit or proxy samples. |
-| `TP_PORTAL_RUM_ROLLOUT_PERCENT` | `0` | Managed portal/bootstrap RUM rollout percentage. Does not govern landing, login, logout, or front-door RUM proxy sampling. |
-| `TP_FRONTDOOR_RUM_ENABLED` | unset | Independent flag for landing, login, logout, and front-door RUM proxy telemetry after `TP_PORTAL_RUM_ENABLED` is enabled. |
+| `TP_PORTAL_RUM_ROLLOUT_PERCENT` | `0` | Managed portal/bootstrap RUM rollout percentage. Does not govern landing, login, logout, or front-door event-family proxy sampling. |
+| `TP_FRONTDOOR_RUM_ENABLED` | unset | Independent flag for landing, login, logout, and front-door event-family payloads submitted through the RUM proxy after `TP_PORTAL_RUM_ENABLED` is enabled. |
 | `TP_FRONTDOOR_RUM_ROLLOUT_PERCENT` | `100` when front-door RUM is enabled | Independent front-door RUM sampling percentage. Values clamp to `0..100`; invalid values are treated as `0`. |
 
 ## Verification

--- a/docs/operations/frontdoor_vercel_env.md
+++ b/docs/operations/frontdoor_vercel_env.md
@@ -30,6 +30,10 @@ two values as one secret, set them together, rotate them together.
 | `TP_FRONTDOOR_PREFLIGHT_DISABLE` | `0` | Hard escape hatch for the startup preflight. Use only for emergencies; never set in production. |
 | `TP_ALLOW_LOCAL_ACCESS_BYPASS` | unset | Development-only bypass for Cloudflare Access verification. **Never set in production.** |
 | `TP_NEXT_DIST_DIR` | unset | Override Next.js build output directory; rarely needed on Vercel. |
+| `TP_PORTAL_RUM_ENABLED` | unset | Shared master kill switch for managed portal/bootstrap RUM and front-door RUM. Set to a truthy value before any RUM path can emit or proxy samples. |
+| `TP_PORTAL_RUM_ROLLOUT_PERCENT` | `0` | Managed portal/bootstrap RUM rollout percentage. Does not govern landing, login, logout, or front-door RUM proxy sampling. |
+| `TP_FRONTDOOR_RUM_ENABLED` | unset | Independent flag for landing, login, logout, and front-door RUM proxy telemetry after `TP_PORTAL_RUM_ENABLED` is enabled. |
+| `TP_FRONTDOOR_RUM_ROLLOUT_PERCENT` | `100` when front-door RUM is enabled | Independent front-door RUM sampling percentage. Values clamp to `0..100`; invalid values are treated as `0`. |
 
 ## Verification
 

--- a/docs/operations/frontdoor_vercel_env.md
+++ b/docs/operations/frontdoor_vercel_env.md
@@ -31,8 +31,8 @@ two values as one secret, set them together, rotate them together.
 | `TP_ALLOW_LOCAL_ACCESS_BYPASS` | unset | Development-only bypass for Cloudflare Access verification. **Never set in production.** |
 | `TP_NEXT_DIST_DIR` | unset | Override Next.js build output directory; rarely needed on Vercel. |
 | `TP_PORTAL_RUM_ENABLED` | unset | Shared master kill switch for managed portal/bootstrap RUM and front-door RUM. Set to a truthy value before any RUM path can emit or proxy samples. |
-| `TP_PORTAL_RUM_ROLLOUT_PERCENT` | `0` | Managed portal/bootstrap RUM rollout percentage. Does not govern landing, login, logout, or front-door event-family proxy sampling. |
-| `TP_FRONTDOOR_RUM_ENABLED` | unset | Independent flag for landing, login, logout, and front-door event-family payloads submitted through the RUM proxy after `TP_PORTAL_RUM_ENABLED` is enabled. |
+| `TP_PORTAL_RUM_ROLLOUT_PERCENT` | `0` | Managed portal/bootstrap RUM rollout percentage. Does not govern landing, login, logout, or front-door proxy sampling. |
+| `TP_FRONTDOOR_RUM_ENABLED` | unset | Independent flag for landing, login, logout, and front-door payloads submitted through the RUM proxy after `TP_PORTAL_RUM_ENABLED` is enabled. |
 | `TP_FRONTDOOR_RUM_ROLLOUT_PERCENT` | `100` when front-door RUM is enabled | Independent front-door RUM sampling percentage. Values clamp to `0..100`; invalid values are treated as `0`. |
 
 ## Verification

--- a/scripts/validation/check_frontdoor_vercel_env.py
+++ b/scripts/validation/check_frontdoor_vercel_env.py
@@ -35,6 +35,10 @@ VARIABLES: tuple[Variable, ...] = (
     Variable("TP_FRONTDOOR_SESSION_SCALING_MODE", "all", "single_instance or external-store-backed mode"),
     Variable("TP_CF_ACCESS_TEAM_DOMAIN", "production", "Cloudflare Access team domain"),
     Variable("TP_CF_ACCESS_AUD", "production", "Cloudflare Access JWT audience"),
+    Variable("TP_PORTAL_RUM_ENABLED", "optional", "Shared portal/frontdoor RUM kill switch"),
+    Variable("TP_PORTAL_RUM_ROLLOUT_PERCENT", "optional", "Managed portal/bootstrap RUM rollout percent"),
+    Variable("TP_FRONTDOOR_RUM_ENABLED", "optional", "Independent landing/login/logout RUM flag"),
+    Variable("TP_FRONTDOOR_RUM_ROLLOUT_PERCENT", "optional", "Independent front-door RUM sampling percent"),
 )
 
 SUPPORTED_SESSION_SCALING_MODES = frozenset({"single_instance"})

--- a/scripts/validation/check_frontdoor_vercel_env.py
+++ b/scripts/validation/check_frontdoor_vercel_env.py
@@ -18,13 +18,16 @@ import json
 import os
 import sys
 from dataclasses import dataclass
-from typing import Iterable, List, Optional
+from typing import Iterable, List, Literal, Optional
+
+
+RequiredScope = Literal["all", "production", "optional"]
 
 
 @dataclass(frozen=True)
 class Variable:
     name: str
-    required_in: str  # "all" | "production"
+    required_in: RequiredScope
     description: str
 
 

--- a/tests/validation/test_check_frontdoor_vercel_env.py
+++ b/tests/validation/test_check_frontdoor_vercel_env.py
@@ -48,6 +48,44 @@ def test_vercel_env_accepts_runtime_fastapi_origin_without_backend_alias() -> No
 
     assert ok is True
     assert all(row[1] != "TP_BACKEND_ORIGIN" for row in rows)
+    assert (
+        "optional",
+        "TP_FRONTDOOR_RUM_ENABLED",
+        "Independent landing/login/logout RUM flag",
+    ) in rows
+    assert (
+        "optional",
+        "TP_FRONTDOOR_RUM_ROLLOUT_PERCENT",
+        "Independent front-door RUM sampling percent",
+    ) in rows
+
+
+@pytest.mark.unit
+def test_vercel_env_reports_frontdoor_rum_knobs_when_configured() -> None:
+    module = _load_module()
+    ok, rows = module._evaluate(
+        {
+            "TP_FASTAPI_ORIGIN": "https://fastapi.example.com",
+            "TP_BACKEND_API_KEY": "secret",
+            "TP_FRONTDOOR_USERS_JSON": _valid_user_json(),
+            "TP_FRONTDOOR_SESSION_SCALING_MODE": "single_instance",
+            "TP_PORTAL_RUM_ENABLED": "1",
+            "TP_PORTAL_RUM_ROLLOUT_PERCENT": "100",
+            "TP_FRONTDOOR_RUM_ENABLED": "1",
+            "TP_FRONTDOOR_RUM_ROLLOUT_PERCENT": "25",
+        },
+        production=False,
+    )
+
+    assert ok is True
+    assert ("ok", "TP_PORTAL_RUM_ENABLED", "set via TP_PORTAL_RUM_ENABLED") in rows
+    assert ("ok", "TP_PORTAL_RUM_ROLLOUT_PERCENT", "set via TP_PORTAL_RUM_ROLLOUT_PERCENT") in rows
+    assert ("ok", "TP_FRONTDOOR_RUM_ENABLED", "set via TP_FRONTDOOR_RUM_ENABLED") in rows
+    assert (
+        "ok",
+        "TP_FRONTDOOR_RUM_ROLLOUT_PERCENT",
+        "set via TP_FRONTDOOR_RUM_ROLLOUT_PERCENT",
+    ) in rows
 
 
 @pytest.mark.unit

--- a/web/secure-landing/app/login/route.js
+++ b/web/secure-landing/app/login/route.js
@@ -3,7 +3,7 @@ import { NextResponse } from "next/server.js";
 import { resolveAccessContext, resolveAuthenticatedAccessSession, revokeSessionOnAccessFailure } from "../../lib/access.js";
 import { escapeHtml, FRONTDOOR_ASSETS, renderBrandAsset } from "../../lib/brand.js";
 import { audit } from "../../lib/audit.js";
-import { isPortalRumEnabled } from "../../lib/config.js";
+import { isFrontdoorRumTelemetryEnabled } from "../../lib/config.js";
 import { applySecurityHeaders, buildRequestUrl, FRONTDOOR_CSP, generateScriptNonce } from "../../lib/http.js";
 import { applyPortalReturnTo, resolvePortalReturnTo, validatePortalReturnTo } from "../../lib/return-to.js";
 import {
@@ -31,7 +31,7 @@ import {
   validateCsrfToken
 } from "../../lib/sessions.js";
 import { getConfig } from "../../lib/config.js";
-import { generateTraceparent, resolveRequestTraceparent } from "../../lib/trace.js";
+import { resolveRequestTraceparent } from "../../lib/trace.js";
 import { validateOriginAndReferrer } from "../../lib/request-security.js";
 import { verifyUserCredentials } from "../../lib/users.js";
 
@@ -300,13 +300,14 @@ export async function GET(request) {
   // token on the login form is bound to a server-side session from the start.
   session = session || createAnonymousSession();
   const accessContext = await resolveAccessContext(request);
-  const rumEnabled = isPortalRumEnabled();
+  const rumTraceparent = resolveRequestTraceparent(request);
+  const rumEnabled = isFrontdoorRumTelemetryEnabled({ traceparent: rumTraceparent });
   const scriptNonce = rumEnabled ? generateScriptNonce() : null;
   const rumScript = rumEnabled
     ? renderRumClientScript({
         route: "/login",
         view: "login",
-        traceparent: generateTraceparent(),
+        traceparent: rumTraceparent,
       })
     : "";
   const html = renderLoginPage({
@@ -332,11 +333,11 @@ export async function GET(request) {
 export async function POST(request) {
   // Capture the RUM enable decision once at handler entry. This is the SOLE
   // gate for paired emissions: the emitter intentionally does not re-check
-  // isPortalRumEnabled() so a flag flip mid-request cannot produce a partial
+  // isFrontdoorRumTelemetryEnabled() so a flag flip mid-request cannot produce a partial
   // attempt/terminal pair (one captured but not the other).
-  const rumActive = isPortalRumEnabled();
+  const rumTraceparent = resolveRequestTraceparent(request);
+  const rumActive = isFrontdoorRumTelemetryEnabled({ traceparent: rumTraceparent });
   const attemptStart = Date.now();
-  const rumTraceparent = rumActive ? resolveRequestTraceparent(request) : "";
   const emitLoginRum = (eventType, failureCode = null) => {
     if (!rumActive) return;
     const value = eventType === LOGIN_RUM_EVENT_TYPES.ATTEMPT

--- a/web/secure-landing/app/logout/route.js
+++ b/web/secure-landing/app/logout/route.js
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server.js";
 
 import { applySecurityHeaders, buildRequestUrl } from "../../lib/http.js";
-import { isPortalRumEnabled } from "../../lib/config.js";
+import { isFrontdoorRumTelemetryEnabled } from "../../lib/config.js";
 import {
   emitLogoutRumEvent,
   LOGOUT_RUM_EVENT_TYPES,
@@ -22,12 +22,12 @@ export const runtime = "nodejs";
 export async function POST(request) {
   // Capture the RUM enable decision once at handler entry. This is the SOLE
   // gate for paired emissions: the emitter intentionally does not re-check
-  // isPortalRumEnabled() so a flag flip mid-request cannot produce a partial
+  // isFrontdoorRumTelemetryEnabled() so a flag flip mid-request cannot produce a partial
   // attempt/terminal pair (one captured but not the other). Mirrors the
   // /login handler's contract from #1684.
-  const rumActive = isPortalRumEnabled();
+  const rumTraceparent = resolveRequestTraceparent(request);
+  const rumActive = isFrontdoorRumTelemetryEnabled({ traceparent: rumTraceparent });
   const attemptStart = Date.now();
-  const rumTraceparent = rumActive ? resolveRequestTraceparent(request) : "";
   const emitLogoutRum = (eventType, failureCode = null) => {
     if (!rumActive) return;
     const value = eventType === LOGOUT_RUM_EVENT_TYPES.ATTEMPT

--- a/web/secure-landing/app/portal/bootstrap/route.js
+++ b/web/secure-landing/app/portal/bootstrap/route.js
@@ -1,11 +1,10 @@
-import { createHash } from "node:crypto";
-
 import { NextResponse } from "next/server.js";
 
 import { revokeSessionOnAccessFailure, resolveAuthenticatedAccessSession } from "../../../lib/access.js";
 import { audit } from "../../../lib/audit.js";
 import { isPortalRumEnabled } from "../../../lib/config.js";
 import { applySecurityHeaders } from "../../../lib/http.js";
+import { stableRolloutBucket } from "../../../lib/rollout.js";
 import {
   auditManagedSurfaceFailure,
   buildManagedBootstrapFailure,
@@ -22,15 +21,6 @@ function parseRolloutPercent(rawValue) {
     return 0;
   }
   return Math.max(0, Math.min(100, parsed));
-}
-
-function stableRolloutBucket(key) {
-  const normalized = String(key || "").trim().toLowerCase();
-  if (!normalized) {
-    return 100;
-  }
-  const digest = createHash("sha256").update(normalized).digest("hex");
-  return Number.parseInt(digest.slice(0, 8), 16) % 100;
 }
 
 function resolveRolloutCohortKey(session) {

--- a/web/secure-landing/app/route.js
+++ b/web/secure-landing/app/route.js
@@ -1,6 +1,9 @@
 import { NextResponse } from "next/server.js";
 
-import { isFrontdoorRumTelemetryEnabled } from "../lib/config.js";
+import {
+  isFrontdoorRumTelemetryEnabled,
+  shouldDisableFrontdoorRumHomepageCache
+} from "../lib/config.js";
 import { applySecurityHeaders, FRONTDOOR_CSP, generateScriptNonce } from "../lib/http.js";
 import { renderHomepage } from "../lib/homepage.js";
 import { renderRumClientScript } from "../lib/rum-client.js";
@@ -8,10 +11,9 @@ import { resolveRequestTraceparent } from "../lib/trace.js";
 
 export const runtime = "nodejs";
 // force-dynamic ensures GET re-runs per request so each response carries a
-// fresh CSP nonce when RUM is enabled. When RUM is disabled the response body
-// is identical and the Cache-Control hint below still allows downstream
-// caching; when RUM is enabled the response is marked no-store so a per-user
-// nonce cannot leak across requests via shared caches.
+// fresh CSP nonce when RUM is enabled. When front-door RUM can vary by rollout
+// sampling the response is marked no-store for every request, so shared caches
+// cannot pin a sampled-out body for the same URL.
 export const dynamic = "force-dynamic";
 
 const HOMEPAGE_CACHE_CONTROL_STATIC = "public, max-age=300, must-revalidate";
@@ -20,6 +22,7 @@ const HOMEPAGE_CACHE_CONTROL_DYNAMIC = "no-store";
 export async function GET(request) {
   const rumTraceparent = resolveRequestTraceparent(request);
   const rumEnabled = isFrontdoorRumTelemetryEnabled({ traceparent: rumTraceparent });
+  const disableRumHomepageCache = shouldDisableFrontdoorRumHomepageCache();
   const scriptNonce = rumEnabled ? generateScriptNonce() : null;
   const rumScript = rumEnabled
     ? renderRumClientScript({
@@ -33,7 +36,9 @@ export async function GET(request) {
     status: 200,
     headers: {
       "Content-Type": "text/html; charset=utf-8",
-      "Cache-Control": rumEnabled ? HOMEPAGE_CACHE_CONTROL_DYNAMIC : HOMEPAGE_CACHE_CONTROL_STATIC
+      "Cache-Control": disableRumHomepageCache
+        ? HOMEPAGE_CACHE_CONTROL_DYNAMIC
+        : HOMEPAGE_CACHE_CONTROL_STATIC
     }
   });
   return applySecurityHeaders(response, { csp: FRONTDOOR_CSP, scriptNonce });

--- a/web/secure-landing/app/route.js
+++ b/web/secure-landing/app/route.js
@@ -1,10 +1,10 @@
 import { NextResponse } from "next/server.js";
 
-import { isPortalRumEnabled } from "../lib/config.js";
+import { isFrontdoorRumTelemetryEnabled } from "../lib/config.js";
 import { applySecurityHeaders, FRONTDOOR_CSP, generateScriptNonce } from "../lib/http.js";
 import { renderHomepage } from "../lib/homepage.js";
 import { renderRumClientScript } from "../lib/rum-client.js";
-import { generateTraceparent } from "../lib/trace.js";
+import { resolveRequestTraceparent } from "../lib/trace.js";
 
 export const runtime = "nodejs";
 // force-dynamic ensures GET re-runs per request so each response carries a
@@ -17,14 +17,15 @@ export const dynamic = "force-dynamic";
 const HOMEPAGE_CACHE_CONTROL_STATIC = "public, max-age=300, must-revalidate";
 const HOMEPAGE_CACHE_CONTROL_DYNAMIC = "no-store";
 
-export async function GET() {
-  const rumEnabled = isPortalRumEnabled();
+export async function GET(request) {
+  const rumTraceparent = resolveRequestTraceparent(request);
+  const rumEnabled = isFrontdoorRumTelemetryEnabled({ traceparent: rumTraceparent });
   const scriptNonce = rumEnabled ? generateScriptNonce() : null;
   const rumScript = rumEnabled
     ? renderRumClientScript({
         route: "/",
         view: "landing",
-        traceparent: generateTraceparent(),
+        traceparent: rumTraceparent,
       })
     : "";
   const html = renderHomepage({ rumScript, scriptNonce });

--- a/web/secure-landing/app/v1/portal/rum/route.js
+++ b/web/secure-landing/app/v1/portal/rum/route.js
@@ -26,6 +26,8 @@ const FRONTDOOR_RUM_EVENT_TYPES = new Set([
   "logout_submit_success",
   "logout_submit_failure",
 ]);
+const FRONTDOOR_RUM_ROUTES = new Set(["/", "/login"]);
+const FRONTDOOR_RUM_VIEWS = new Set(["landing", "login"]);
 
 function successEnvelope(data, traceparent = "") {
   return applySecurityHeaders(
@@ -74,7 +76,14 @@ function errorEnvelope(status, code, message, details = {}, traceparent = "") {
 function isFrontdoorRumPayload(bodyText) {
   try {
     const parsed = JSON.parse(bodyText || "{}");
-    return FRONTDOOR_RUM_EVENT_TYPES.has(String(parsed?.event_type || ""));
+    const eventType = String(parsed?.event_type || "").trim();
+    const route = String(parsed?.route || "").trim();
+    const view = String(parsed?.view || "").trim().toLowerCase();
+    return (
+      FRONTDOOR_RUM_EVENT_TYPES.has(eventType)
+      || FRONTDOOR_RUM_ROUTES.has(route)
+      || FRONTDOOR_RUM_VIEWS.has(view)
+    );
   } catch {
     return false;
   }

--- a/web/secure-landing/app/v1/portal/rum/route.js
+++ b/web/secure-landing/app/v1/portal/rum/route.js
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server.js";
 
-import { getConfig, isPortalRumEnabled } from "../../../../lib/config.js";
+import { getConfig, isFrontdoorRumTelemetryEnabled } from "../../../../lib/config.js";
 import { applySecurityHeaders } from "../../../../lib/http.js";
 import {
   auditManagedSurfaceFailure,
@@ -75,7 +75,7 @@ export async function POST(request) {
     );
   }
 
-  if (!isPortalRumEnabled()) {
+  if (!isFrontdoorRumTelemetryEnabled({ traceparent: requestTraceparent })) {
     return successEnvelope({ accepted: false, disabled: true }, requestTraceparent);
   }
 

--- a/web/secure-landing/app/v1/portal/rum/route.js
+++ b/web/secure-landing/app/v1/portal/rum/route.js
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server.js";
 
-import { getConfig, isFrontdoorRumTelemetryEnabled } from "../../../../lib/config.js";
+import { getConfig, isFrontdoorRumTelemetryEnabled, isPortalRumEnabled } from "../../../../lib/config.js";
 import { applySecurityHeaders } from "../../../../lib/http.js";
 import {
   auditManagedSurfaceFailure,
@@ -16,6 +16,16 @@ import { resolveRequestTraceparent, traceIdFromTraceparent, normalizeTraceparent
 export const runtime = "nodejs";
 
 const PUBLIC_RUM_PATH = "/v1/portal/rum";
+const FRONTDOOR_RUM_EVENT_TYPES = new Set([
+  "landing_rendered",
+  "login_rendered",
+  "login_submit_attempt",
+  "login_submit_success",
+  "login_submit_failure",
+  "logout_submit_attempt",
+  "logout_submit_success",
+  "logout_submit_failure",
+]);
 
 function successEnvelope(data, traceparent = "") {
   return applySecurityHeaders(
@@ -61,6 +71,15 @@ function errorEnvelope(status, code, message, details = {}, traceparent = "") {
   );
 }
 
+function isFrontdoorRumPayload(bodyText) {
+  try {
+    const parsed = JSON.parse(bodyText || "{}");
+    return FRONTDOOR_RUM_EVENT_TYPES.has(String(parsed?.event_type || ""));
+  } catch {
+    return false;
+  }
+}
+
 export async function POST(request) {
   const requestTraceparent = resolveRequestTraceparent(request);
   const traceId = traceIdFromTraceparent(requestTraceparent);
@@ -75,7 +94,15 @@ export async function POST(request) {
     );
   }
 
-  if (!isFrontdoorRumTelemetryEnabled({ traceparent: requestTraceparent })) {
+  if (!isPortalRumEnabled()) {
+    return successEnvelope({ accepted: false, disabled: true }, requestTraceparent);
+  }
+
+  const bodyText = await request.text();
+  if (
+    isFrontdoorRumPayload(bodyText)
+    && !isFrontdoorRumTelemetryEnabled({ traceparent: requestTraceparent })
+  ) {
     return successEnvelope({ accepted: false, disabled: true }, requestTraceparent);
   }
 
@@ -114,7 +141,7 @@ export async function POST(request) {
     upstream = await fetch(buildUpstreamUrl(PUBLIC_RUM_PATH, request.nextUrl.search), {
       method: "POST",
       headers: upstreamHeaders,
-      body: request.body,
+      body: bodyText,
       cache: "no-store",
       redirect: "manual",
       duplex: "half"

--- a/web/secure-landing/lib/config.js
+++ b/web/secure-landing/lib/config.js
@@ -41,6 +41,16 @@ export function resolveFrontdoorRumRolloutPercent(env = process.env) {
   return parseFrontdoorRumRolloutPercent(env.TP_FRONTDOOR_RUM_ROLLOUT_PERCENT);
 }
 
+export function shouldDisableFrontdoorRumHomepageCache(env = process.env) {
+  if (!isPortalRumEnabled(env)) {
+    return false;
+  }
+  if (!isTruthyEnvFlag(env.TP_FRONTDOOR_RUM_ENABLED)) {
+    return false;
+  }
+  return resolveFrontdoorRumRolloutPercent(env) > 0;
+}
+
 export function isFrontdoorRumTelemetryEnabled({ traceparent = "", env = process.env } = {}) {
   if (!isPortalRumEnabled(env)) {
     return false;

--- a/web/secure-landing/lib/config.js
+++ b/web/secure-landing/lib/config.js
@@ -1,5 +1,6 @@
-import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
+
+import { stableRolloutBucket } from "./rollout.js";
 
 const DEFAULT_SESSION_DB_PATH = "/tmp/transformation-portal-frontdoor-sessions.db";
 const DEFAULT_SESSION_SCALING_MODE = "single_instance";
@@ -26,20 +27,14 @@ function parseFrontdoorRumRolloutPercent(rawValue) {
   if (!raw) {
     return DEFAULT_FRONTDOOR_RUM_ROLLOUT_PERCENT;
   }
-  const parsed = Number.parseInt(raw, 10);
-  if (!Number.isFinite(parsed)) {
+  if (!/^\d+$/u.test(raw)) {
+    return 0;
+  }
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed)) {
     return 0;
   }
   return Math.max(0, Math.min(100, parsed));
-}
-
-function stableRolloutBucket(key) {
-  const normalized = String(key || "").trim().toLowerCase();
-  if (!normalized) {
-    return 100;
-  }
-  const digest = createHash("sha256").update(normalized).digest("hex");
-  return Number.parseInt(digest.slice(0, 8), 16) % 100;
 }
 
 export function resolveFrontdoorRumRolloutPercent(env = process.env) {

--- a/web/secure-landing/lib/config.js
+++ b/web/secure-landing/lib/config.js
@@ -1,7 +1,9 @@
+import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 
 const DEFAULT_SESSION_DB_PATH = "/tmp/transformation-portal-frontdoor-sessions.db";
 const DEFAULT_SESSION_SCALING_MODE = "single_instance";
+const DEFAULT_FRONTDOOR_RUM_ROLLOUT_PERCENT = 100;
 const SESSION_IDLE_TIMEOUT_MS = 8 * 60 * 60 * 1000;
 const SESSION_ABSOLUTE_TIMEOUT_MS = 24 * 60 * 60 * 1000;
 const LOGIN_WINDOW_MS = 15 * 60 * 1000;
@@ -17,6 +19,48 @@ export function isTruthyEnvFlag(value) {
 
 export function isPortalRumEnabled(env = process.env) {
   return isTruthyEnvFlag(env.TP_PORTAL_RUM_ENABLED);
+}
+
+function parseFrontdoorRumRolloutPercent(rawValue) {
+  const raw = String(rawValue ?? "").trim();
+  if (!raw) {
+    return DEFAULT_FRONTDOOR_RUM_ROLLOUT_PERCENT;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed)) {
+    return 0;
+  }
+  return Math.max(0, Math.min(100, parsed));
+}
+
+function stableRolloutBucket(key) {
+  const normalized = String(key || "").trim().toLowerCase();
+  if (!normalized) {
+    return 100;
+  }
+  const digest = createHash("sha256").update(normalized).digest("hex");
+  return Number.parseInt(digest.slice(0, 8), 16) % 100;
+}
+
+export function resolveFrontdoorRumRolloutPercent(env = process.env) {
+  return parseFrontdoorRumRolloutPercent(env.TP_FRONTDOOR_RUM_ROLLOUT_PERCENT);
+}
+
+export function isFrontdoorRumTelemetryEnabled({ traceparent = "", env = process.env } = {}) {
+  if (!isPortalRumEnabled(env)) {
+    return false;
+  }
+  if (!isTruthyEnvFlag(env.TP_FRONTDOOR_RUM_ENABLED)) {
+    return false;
+  }
+  const rolloutPercent = resolveFrontdoorRumRolloutPercent(env);
+  if (rolloutPercent <= 0) {
+    return false;
+  }
+  if (rolloutPercent >= 100) {
+    return true;
+  }
+  return stableRolloutBucket(traceparent) < rolloutPercent;
 }
 
 export function normalizeUsername(value) {

--- a/web/secure-landing/lib/rollout.js
+++ b/web/secure-landing/lib/rollout.js
@@ -1,0 +1,10 @@
+import { createHash } from "node:crypto";
+
+export function stableRolloutBucket(key) {
+  const normalized = String(key || "").trim().toLowerCase();
+  if (!normalized) {
+    return 100;
+  }
+  const digest = createHash("sha256").update(normalized).digest("hex");
+  return Number.parseInt(digest.slice(0, 8), 16) % 100;
+}

--- a/web/secure-landing/lib/rum-emitter.js
+++ b/web/secure-landing/lib/rum-emitter.js
@@ -8,9 +8,9 @@
 //
 // Gate contract:
 //   - The CALLER is the sole feature-flag gate. This emitter does NOT consult
-//     `isPortalRumEnabled()` so paired events (attempt + terminal) cannot
+//     `isFrontdoorRumTelemetryEnabled()` so paired events (attempt + terminal) cannot
 //     diverge if the env flag flips between calls. The route handler captures
-//     `isPortalRumEnabled()` once per request and short-circuits its own
+//     `isFrontdoorRumTelemetryEnabled()` once per request and short-circuits its own
 //     wrapper before reaching this function.
 //
 // Safety contract:

--- a/web/secure-landing/tests/login-rum.test.mjs
+++ b/web/secure-landing/tests/login-rum.test.mjs
@@ -22,6 +22,8 @@ const ENV_KEYS = [
   "TP_ALLOW_LOCAL_ACCESS_BYPASS",
   "TP_PORTAL_RUM_ENABLED",
   "TP_PORTAL_RUM_ROLLOUT_PERCENT",
+  "TP_FRONTDOOR_RUM_ENABLED",
+  "TP_FRONTDOOR_RUM_ROLLOUT_PERCENT",
 ];
 
 const TEST_CF_ACCESS_TEAM_DOMAIN = "https://tp-frontdoor-tests.cloudflareaccess.com";
@@ -52,7 +54,12 @@ function restoreEnv(snapshot) {
   }
 }
 
-function withTestEnvironment({ rumEnabled = true, usersFileEntries = [] } = {}) {
+function withTestEnvironment({
+  rumEnabled = true,
+  frontdoorRumEnabled = rumEnabled,
+  frontdoorRolloutPercent = "100",
+  usersFileEntries = []
+} = {}) {
   const snapshot = snapshotEnv();
   const tempDir = mkdtempSync(path.join(os.tmpdir(), "tp-frontdoor-login-rum-"));
   const dbPath = path.join(tempDir, "sessions.sqlite");
@@ -75,6 +82,14 @@ function withTestEnvironment({ rumEnabled = true, usersFileEntries = [] } = {}) 
   } else {
     delete process.env.TP_PORTAL_RUM_ENABLED;
     delete process.env.TP_PORTAL_RUM_ROLLOUT_PERCENT;
+  }
+
+  if (frontdoorRumEnabled) {
+    process.env.TP_FRONTDOOR_RUM_ENABLED = "1";
+    process.env.TP_FRONTDOOR_RUM_ROLLOUT_PERCENT = frontdoorRolloutPercent;
+  } else {
+    delete process.env.TP_FRONTDOOR_RUM_ENABLED;
+    delete process.env.TP_FRONTDOOR_RUM_ROLLOUT_PERCENT;
   }
 
   resetDbCache();
@@ -249,7 +264,7 @@ function assertNoPiiInRumPosts(rumCalls) {
   }
 }
 
-test("login POST emits no RUM events when front-door RUM is disabled", async () => {
+test("login POST emits no RUM events when the shared RUM master flag is disabled", async () => {
   const env = withTestEnvironment({ rumEnabled: false, usersFileEntries: [await buildAdminUserFixture()] });
   const rumCalls = [];
   const restoreFetch = installFetchMock({ rumCalls });
@@ -265,6 +280,59 @@ test("login POST emits no RUM events when front-door RUM is disabled", async () 
 
     assert.equal(response.status, 303);
     assert.equal(rumCalls.length, 0, `expected no RUM POSTs, got ${rumCalls.length}`);
+  } finally {
+    restoreFetch();
+    env.cleanup();
+  }
+});
+
+test("login POST emits no RUM events when the front-door RUM flag is disabled", async () => {
+  const env = withTestEnvironment({
+    rumEnabled: true,
+    frontdoorRumEnabled: false,
+    usersFileEntries: [await buildAdminUserFixture()]
+  });
+  const rumCalls = [];
+  const restoreFetch = installFetchMock({ rumCalls });
+
+  try {
+    const sessions = await importFresh("../lib/sessions.js");
+    const { POST } = await importFresh("../app/login/route.js");
+    const session = sessions.createAnonymousSession();
+    const request = buildPostRequest({ session, csrfToken: session.csrfToken });
+
+    const response = await POST(request);
+    await flushFireAndForget();
+
+    assert.equal(response.status, 303);
+    assert.equal(rumCalls.length, 0, `expected no RUM POSTs, got ${rumCalls.length}`);
+  } finally {
+    restoreFetch();
+    env.cleanup();
+  }
+});
+
+test("login POST emits no RUM events when front-door rollout percent samples out", async () => {
+  const env = withTestEnvironment({
+    rumEnabled: true,
+    frontdoorRumEnabled: true,
+    frontdoorRolloutPercent: "0",
+    usersFileEntries: [await buildAdminUserFixture()]
+  });
+  const rumCalls = [];
+  const restoreFetch = installFetchMock({ rumCalls });
+
+  try {
+    const sessions = await importFresh("../lib/sessions.js");
+    const { POST } = await importFresh("../app/login/route.js");
+    const session = sessions.createAnonymousSession();
+    const request = buildPostRequest({ session, csrfToken: session.csrfToken });
+
+    const response = await POST(request);
+    await flushFireAndForget();
+
+    assert.equal(response.status, 303);
+    assert.equal(rumCalls.length, 0, `expected sampled-out RUM POSTs, got ${rumCalls.length}`);
   } finally {
     restoreFetch();
     env.cleanup();

--- a/web/secure-landing/tests/logout-rum.test.mjs
+++ b/web/secure-landing/tests/logout-rum.test.mjs
@@ -17,6 +17,8 @@ const ENV_KEYS = [
   "TP_FRONTDOOR_SESSION_DB",
   "TP_PORTAL_RUM_ENABLED",
   "TP_PORTAL_RUM_ROLLOUT_PERCENT",
+  "TP_FRONTDOOR_RUM_ENABLED",
+  "TP_FRONTDOOR_RUM_ROLLOUT_PERCENT",
 ];
 
 const FASTAPI_ORIGIN = "http://127.0.0.1:8000";
@@ -36,7 +38,11 @@ function restoreEnv(snapshot) {
   }
 }
 
-function withTestEnvironment({ rumEnabled = true } = {}) {
+function withTestEnvironment({
+  rumEnabled = true,
+  frontdoorRumEnabled = rumEnabled,
+  frontdoorRolloutPercent = "100"
+} = {}) {
   const snapshot = snapshotEnv();
   const tempDir = mkdtempSync(path.join(os.tmpdir(), "tp-frontdoor-logout-rum-"));
   const dbPath = path.join(tempDir, "sessions.sqlite");
@@ -56,6 +62,14 @@ function withTestEnvironment({ rumEnabled = true } = {}) {
   } else {
     delete process.env.TP_PORTAL_RUM_ENABLED;
     delete process.env.TP_PORTAL_RUM_ROLLOUT_PERCENT;
+  }
+
+  if (frontdoorRumEnabled) {
+    process.env.TP_FRONTDOOR_RUM_ENABLED = "1";
+    process.env.TP_FRONTDOOR_RUM_ROLLOUT_PERCENT = frontdoorRolloutPercent;
+  } else {
+    delete process.env.TP_FRONTDOOR_RUM_ENABLED;
+    delete process.env.TP_FRONTDOOR_RUM_ROLLOUT_PERCENT;
   }
 
   resetDbCache();
@@ -179,7 +193,7 @@ function assertNoPiiInRumPosts(rumCalls) {
   }
 }
 
-test("logout POST emits no RUM events when front-door RUM is disabled", async () => {
+test("logout POST emits no RUM events when the shared RUM master flag is disabled", async () => {
   const env = withTestEnvironment({ rumEnabled: false });
   const rumCalls = [];
   const restoreFetch = installFetchMock({ rumCalls });
@@ -197,6 +211,58 @@ test("logout POST emits no RUM events when front-door RUM is disabled", async ()
     assert.equal(response.headers.get("location"), "https://portal.example.com/login");
     assert.equal(rumCalls.length, 0, `expected zero RUM calls when disabled, got ${rumCalls.length}`);
     // Session was destroyed even though RUM was off — RUM must never alter behavior.
+    assert.equal(sessions.getSessionById(session.id, { touch: false }), null);
+  } finally {
+    restoreFetch();
+    env.cleanup();
+  }
+});
+
+test("logout POST emits no RUM events when the front-door RUM flag is disabled", async () => {
+  const env = withTestEnvironment({ rumEnabled: true, frontdoorRumEnabled: false });
+  const rumCalls = [];
+  const restoreFetch = installFetchMock({ rumCalls });
+
+  try {
+    const sessions = await importFresh("../lib/sessions.js");
+    const { POST } = await importFresh("../app/logout/route.js");
+    const session = buildAuthenticatedSession(sessions);
+    const request = buildLogoutPostRequest({ session, csrfHeader: session.csrfToken });
+
+    const response = await POST(request);
+    await flushFireAndForget();
+
+    assert.equal(response.status, 303);
+    assert.equal(response.headers.get("location"), "https://portal.example.com/login");
+    assert.equal(rumCalls.length, 0, `expected zero RUM calls when disabled, got ${rumCalls.length}`);
+    assert.equal(sessions.getSessionById(session.id, { touch: false }), null);
+  } finally {
+    restoreFetch();
+    env.cleanup();
+  }
+});
+
+test("logout POST emits no RUM events when front-door rollout percent samples out", async () => {
+  const env = withTestEnvironment({
+    rumEnabled: true,
+    frontdoorRumEnabled: true,
+    frontdoorRolloutPercent: "0"
+  });
+  const rumCalls = [];
+  const restoreFetch = installFetchMock({ rumCalls });
+
+  try {
+    const sessions = await importFresh("../lib/sessions.js");
+    const { POST } = await importFresh("../app/logout/route.js");
+    const session = buildAuthenticatedSession(sessions);
+    const request = buildLogoutPostRequest({ session, csrfHeader: session.csrfToken });
+
+    const response = await POST(request);
+    await flushFireAndForget();
+
+    assert.equal(response.status, 303);
+    assert.equal(response.headers.get("location"), "https://portal.example.com/login");
+    assert.equal(rumCalls.length, 0, `expected sampled-out RUM calls, got ${rumCalls.length}`);
     assert.equal(sessions.getSessionById(session.id, { touch: false }), null);
   } finally {
     restoreFetch();

--- a/web/secure-landing/tests/routes.contract.gaps.test.mjs
+++ b/web/secure-landing/tests/routes.contract.gaps.test.mjs
@@ -19,7 +19,9 @@ const ENV_KEYS = [
   "TP_CF_ACCESS_AUD",
   "TP_ALLOW_LOCAL_ACCESS_BYPASS",
   "TP_PORTAL_RUM_ENABLED",
-  "TP_PORTAL_RUM_ROLLOUT_PERCENT"
+  "TP_PORTAL_RUM_ROLLOUT_PERCENT",
+  "TP_FRONTDOOR_RUM_ENABLED",
+  "TP_FRONTDOOR_RUM_ROLLOUT_PERCENT"
 ];
 
 const TEST_CF_ACCESS_TEAM_DOMAIN = "https://tp-frontdoor-tests.cloudflareaccess.com";
@@ -67,6 +69,11 @@ function withTempEnvironment(overrides = {}) {
   } else {
     delete process.env.TP_ALLOW_LOCAL_ACCESS_BYPASS;
   }
+
+  delete process.env.TP_PORTAL_RUM_ENABLED;
+  delete process.env.TP_PORTAL_RUM_ROLLOUT_PERCENT;
+  delete process.env.TP_FRONTDOOR_RUM_ENABLED;
+  delete process.env.TP_FRONTDOOR_RUM_ROLLOUT_PERCENT;
 
   resetDbCache();
 

--- a/web/secure-landing/tests/routes.test.mjs
+++ b/web/secure-landing/tests/routes.test.mjs
@@ -30,6 +30,8 @@ const ENV_KEYS = [
   "TP_PORTAL_REVIEW_SURFACE_DEFER_ROLLOUT_PERCENT",
   "TP_PORTAL_RUM_ENABLED",
   "TP_PORTAL_RUM_ROLLOUT_PERCENT",
+  "TP_FRONTDOOR_RUM_ENABLED",
+  "TP_FRONTDOOR_RUM_ROLLOUT_PERCENT",
   "TP_PORTAL_FASTVLM_CAPTIONING_ENABLED",
   "TP_PORTAL_FASTVLM_CAPTIONING_ROLLOUT_PERCENT"
 ];
@@ -148,6 +150,18 @@ function withTempEnvironment(overrides = {}) {
     process.env.TP_PORTAL_RUM_ROLLOUT_PERCENT = overrides.TP_PORTAL_RUM_ROLLOUT_PERCENT;
   } else {
     delete process.env.TP_PORTAL_RUM_ROLLOUT_PERCENT;
+  }
+
+  if (typeof overrides.TP_FRONTDOOR_RUM_ENABLED === "string") {
+    process.env.TP_FRONTDOOR_RUM_ENABLED = overrides.TP_FRONTDOOR_RUM_ENABLED;
+  } else {
+    delete process.env.TP_FRONTDOOR_RUM_ENABLED;
+  }
+
+  if (typeof overrides.TP_FRONTDOOR_RUM_ROLLOUT_PERCENT === "string") {
+    process.env.TP_FRONTDOOR_RUM_ROLLOUT_PERCENT = overrides.TP_FRONTDOOR_RUM_ROLLOUT_PERCENT;
+  } else {
+    delete process.env.TP_FRONTDOOR_RUM_ROLLOUT_PERCENT;
   }
 
   if (typeof overrides.TP_PORTAL_FASTVLM_CAPTIONING_ENABLED === "string") {
@@ -1667,6 +1681,44 @@ test("managed bootstrap enables rum telemetry for rollout cohorts", async () => 
   const env = withTempEnvironment({
     TP_PORTAL_RUM_ENABLED: "1",
     TP_PORTAL_RUM_ROLLOUT_PERCENT: "100"
+  });
+
+  try {
+    const sessions = await importFresh("../lib/sessions.js");
+    const { GET } = await importFresh("../app/portal/bootstrap/route.js");
+    const authenticatedSession = sessions.rotateAuthenticatedSession(
+      sessions.createAnonymousSession(),
+      {
+        username: "admin",
+        accessEmail: "admin@example.com",
+        role: "admin"
+      }
+    );
+
+    const request = buildRequest("https://portal.example.com/portal/bootstrap", {
+      method: "GET",
+      headers: new Headers({
+        cookie: `__Host-tp_session=${authenticatedSession.id}`,
+        "Cf-Access-Jwt-Assertion": createAccessJwt()
+      })
+    });
+
+    const response = await GET(request);
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(body.features.rumTelemetry, true);
+  } finally {
+    env.cleanup();
+  }
+});
+
+test("managed bootstrap rum telemetry ignores front-door RUM rollout controls", async () => {
+  const env = withTempEnvironment({
+    TP_PORTAL_RUM_ENABLED: "1",
+    TP_PORTAL_RUM_ROLLOUT_PERCENT: "100",
+    TP_FRONTDOOR_RUM_ENABLED: "0",
+    TP_FRONTDOOR_RUM_ROLLOUT_PERCENT: "0"
   });
 
   try {

--- a/web/secure-landing/tests/rum-client.test.mjs
+++ b/web/secure-landing/tests/rum-client.test.mjs
@@ -20,7 +20,9 @@ const ENV_KEYS = [
   "TP_CF_ACCESS_AUD",
   "TP_ALLOW_LOCAL_ACCESS_BYPASS",
   "TP_PORTAL_RUM_ENABLED",
-  "TP_PORTAL_RUM_ROLLOUT_PERCENT"
+  "TP_PORTAL_RUM_ROLLOUT_PERCENT",
+  "TP_FRONTDOOR_RUM_ENABLED",
+  "TP_FRONTDOOR_RUM_ROLLOUT_PERCENT"
 ];
 
 function snapshotEnv() {
@@ -38,7 +40,12 @@ function restoreEnv(snapshot) {
   }
 }
 
-function withRumEnvironment({ rumEnabled = false, rumFlagValue = "1" } = {}) {
+function withRumEnvironment({
+  rumEnabled = false,
+  rumFlagValue = "1",
+  frontdoorRumEnabled = rumEnabled,
+  frontdoorRolloutPercent = "100"
+} = {}) {
   const snapshot = snapshotEnv();
   const tempDir = mkdtempSync(path.join(os.tmpdir(), "tp-frontdoor-rum-"));
   const dbPath = path.join(tempDir, "sessions.sqlite");
@@ -61,6 +68,14 @@ function withRumEnvironment({ rumEnabled = false, rumFlagValue = "1" } = {}) {
   } else {
     delete process.env.TP_PORTAL_RUM_ENABLED;
     delete process.env.TP_PORTAL_RUM_ROLLOUT_PERCENT;
+  }
+
+  if (frontdoorRumEnabled) {
+    process.env.TP_FRONTDOOR_RUM_ENABLED = "1";
+    process.env.TP_FRONTDOOR_RUM_ROLLOUT_PERCENT = frontdoorRolloutPercent;
+  } else {
+    delete process.env.TP_FRONTDOOR_RUM_ENABLED;
+    delete process.env.TP_FRONTDOOR_RUM_ROLLOUT_PERCENT;
   }
 
   resetDbCache();
@@ -117,6 +132,77 @@ test("homepage GET omits the RUM script tag and keeps script-src 'none' when RUM
     assert.match(csp, /script-src 'none'/);
     assert.doesNotMatch(csp, /script-src 'nonce-/);
     assert.doesNotMatch(html, /<script\b/);
+    assert.match(response.headers.get("cache-control") || "", /\bpublic\b/i);
+  } finally {
+    env.cleanup();
+  }
+});
+
+test("homepage GET omits front-door RUM when only the front-door flag is disabled", async () => {
+  const env = withRumEnvironment({ rumEnabled: true, frontdoorRumEnabled: false });
+
+  try {
+    getDb(env.dbPath);
+    const { GET } = await importFresh("../app/route.js");
+    const request = buildRequest("https://portal.example.com/");
+
+    const response = await GET(request);
+    const html = await response.text();
+    const csp = response.headers.get("content-security-policy") || "";
+
+    assert.equal(response.status, 200);
+    assert.match(csp, /script-src 'none'/);
+    assert.doesNotMatch(html, /landing_rendered/);
+    assert.match(response.headers.get("cache-control") || "", /\bpublic\b/i);
+  } finally {
+    env.cleanup();
+  }
+});
+
+test("homepage GET samples out front-door RUM when rollout percent is zero", async () => {
+  const env = withRumEnvironment({
+    rumEnabled: true,
+    frontdoorRumEnabled: true,
+    frontdoorRolloutPercent: "0"
+  });
+
+  try {
+    getDb(env.dbPath);
+    const { GET } = await importFresh("../app/route.js");
+    const request = buildRequest("https://portal.example.com/");
+
+    const response = await GET(request);
+    const html = await response.text();
+    const csp = response.headers.get("content-security-policy") || "";
+
+    assert.equal(response.status, 200);
+    assert.match(csp, /script-src 'none'/);
+    assert.doesNotMatch(html, /landing_rendered/);
+    assert.match(response.headers.get("cache-control") || "", /\bpublic\b/i);
+  } finally {
+    env.cleanup();
+  }
+});
+
+test("homepage GET treats invalid front-door RUM rollout values as sampled out", async () => {
+  const env = withRumEnvironment({
+    rumEnabled: true,
+    frontdoorRumEnabled: true,
+    frontdoorRolloutPercent: "not-a-number"
+  });
+
+  try {
+    getDb(env.dbPath);
+    const { GET } = await importFresh("../app/route.js");
+    const request = buildRequest("https://portal.example.com/");
+
+    const response = await GET(request);
+    const html = await response.text();
+    const csp = response.headers.get("content-security-policy") || "";
+
+    assert.equal(response.status, 200);
+    assert.match(csp, /script-src 'none'/);
+    assert.doesNotMatch(html, /landing_rendered/);
     assert.match(response.headers.get("cache-control") || "", /\bpublic\b/i);
   } finally {
     env.cleanup();
@@ -222,6 +308,38 @@ test("renderRumClientScript omits invalid or missing traceparent values", async 
   assert.doesNotMatch(missingTraceparentBody, /TRACEPARENT\s*=\s*"undefined"/);
   assert.doesNotMatch(invalidTraceparentBody, /TRACEPARENT\s*=\s*"undefined"/);
   assert.doesNotMatch(invalidTraceparentBody, /TRACEPARENT\s*=\s*"null"/);
+});
+
+test("front-door RUM rollout config defaults, clamps, and fails closed on invalid values", async () => {
+  const {
+    isFrontdoorRumTelemetryEnabled,
+    resolveFrontdoorRumRolloutPercent
+  } = await importFresh("../lib/config.js");
+  const traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+
+  assert.equal(
+    resolveFrontdoorRumRolloutPercent({}),
+    100,
+    "front-door rollout defaults to 100 when the env value is omitted"
+  );
+  assert.equal(resolveFrontdoorRumRolloutPercent({ TP_FRONTDOOR_RUM_ROLLOUT_PERCENT: "150" }), 100);
+  assert.equal(resolveFrontdoorRumRolloutPercent({ TP_FRONTDOOR_RUM_ROLLOUT_PERCENT: "-10" }), 0);
+  assert.equal(resolveFrontdoorRumRolloutPercent({ TP_FRONTDOOR_RUM_ROLLOUT_PERCENT: "bogus" }), 0);
+
+  assert.equal(isFrontdoorRumTelemetryEnabled({
+    traceparent,
+    env: {
+      TP_PORTAL_RUM_ENABLED: "1",
+      TP_FRONTDOOR_RUM_ENABLED: "1"
+    }
+  }), true);
+  assert.equal(isFrontdoorRumTelemetryEnabled({
+    traceparent,
+    env: {
+      TP_PORTAL_RUM_ENABLED: "0",
+      TP_FRONTDOOR_RUM_ENABLED: "1"
+    }
+  }), false);
 });
 
 test("homepage GET mints a fresh nonce on every request when RUM is enabled", async () => {
@@ -950,6 +1068,45 @@ test("public RUM route rejects cross-origin samples before proxying", async () =
       assert.equal(response.status, 403);
       assert.equal(body.error.code, "INVALID_CSRF");
       assert.equal(body.error.details.path, "/v1/portal/rum");
+    } finally {
+      restoreFetch();
+    }
+  } finally {
+    env.cleanup();
+  }
+});
+
+test("public RUM route noops when only front-door RUM is disabled", async () => {
+  const env = withRumEnvironment({ rumEnabled: true, frontdoorRumEnabled: false });
+
+  try {
+    const route = await importFresh("../app/v1/portal/rum/route.js");
+    const restoreFetch = withMockedFetch(async () => {
+      assert.fail("front-door-disabled public RUM requests must not reach the backend");
+    });
+
+    try {
+      const request = buildRequest("https://portal.example.com/v1/portal/rum", {
+        method: "POST",
+        headers: new Headers({
+          "content-type": "application/json",
+          origin: "https://portal.example.com"
+        }),
+        body: JSON.stringify({
+          event_type: "landing_rendered",
+          route: "/",
+          view: "landing",
+          metric: "duration",
+          value: 25,
+          unit: "ms"
+        })
+      });
+
+      const response = await route.POST(request);
+      const body = await response.json();
+
+      assert.equal(response.status, 200);
+      assert.deepEqual(body.data, { accepted: false, disabled: true });
     } finally {
       restoreFetch();
     }

--- a/web/secure-landing/tests/rum-client.test.mjs
+++ b/web/secure-landing/tests/rum-client.test.mjs
@@ -324,6 +324,9 @@ test("front-door RUM rollout config defaults, clamps, and fails closed on invali
   );
   assert.equal(resolveFrontdoorRumRolloutPercent({ TP_FRONTDOOR_RUM_ROLLOUT_PERCENT: "150" }), 100);
   assert.equal(resolveFrontdoorRumRolloutPercent({ TP_FRONTDOOR_RUM_ROLLOUT_PERCENT: "-10" }), 0);
+  assert.equal(resolveFrontdoorRumRolloutPercent({ TP_FRONTDOOR_RUM_ROLLOUT_PERCENT: "10.5" }), 0);
+  assert.equal(resolveFrontdoorRumRolloutPercent({ TP_FRONTDOOR_RUM_ROLLOUT_PERCENT: "25%" }), 0);
+  assert.equal(resolveFrontdoorRumRolloutPercent({ TP_FRONTDOOR_RUM_ROLLOUT_PERCENT: "0x10" }), 0);
   assert.equal(resolveFrontdoorRumRolloutPercent({ TP_FRONTDOOR_RUM_ROLLOUT_PERCENT: "bogus" }), 0);
 
   assert.equal(isFrontdoorRumTelemetryEnabled({
@@ -340,6 +343,16 @@ test("front-door RUM rollout config defaults, clamps, and fails closed on invali
       TP_FRONTDOOR_RUM_ENABLED: "1"
     }
   }), false);
+});
+
+test("stableRolloutBucket preserves empty-key sentinel and case-insensitive buckets", async () => {
+  const { stableRolloutBucket } = await importFresh("../lib/rollout.js");
+
+  assert.equal(stableRolloutBucket(""), 100);
+  assert.equal(stableRolloutBucket("   "), 100);
+  assert.equal(stableRolloutBucket("Admin@Example.Com"), stableRolloutBucket("admin@example.com"));
+  assert.ok(stableRolloutBucket("admin@example.com") >= 0);
+  assert.ok(stableRolloutBucket("admin@example.com") < 100);
 });
 
 test("homepage GET mints a fresh nonce on every request when RUM is enabled", async () => {
@@ -1107,6 +1120,74 @@ test("public RUM route noops when only front-door RUM is disabled", async () => 
 
       assert.equal(response.status, 200);
       assert.deepEqual(body.data, { accepted: false, disabled: true });
+    } finally {
+      restoreFetch();
+    }
+  } finally {
+    env.cleanup();
+  }
+});
+
+test("public RUM route keeps portal-family payloads independent from front-door RUM controls", async () => {
+  const env = withRumEnvironment({ rumEnabled: true, frontdoorRumEnabled: false });
+  const traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+
+  try {
+    const route = await importFresh("../app/v1/portal/rum/route.js");
+    const restoreFetch = withMockedFetch(async (url, init) => {
+      assert.equal(String(url), "http://127.0.0.1:8000/v1/portal/rum");
+      assert.equal(init.method, "POST");
+      assert.equal(init.headers.get("authorization"), "Bearer backend-secret");
+      assert.equal(init.headers.get("x-api-key"), "backend-secret");
+      assert.equal(init.headers.get("traceparent"), traceparent);
+      assert.equal(await new Response(init.body).text(), JSON.stringify({
+        event_type: "portal_shell_rendered",
+        route: "/portal",
+        view: "portal",
+        metric: "duration",
+        value: 25,
+        unit: "ms"
+      }));
+      return Response.json(
+        {
+          schema: "tp.orchestrator.portal_rum_ingest.v1",
+          success: true,
+          data: { accepted: true },
+          error: null
+        },
+        {
+          headers: {
+            traceparent
+          }
+        }
+      );
+    });
+
+    try {
+      const request = buildRequest("https://portal.example.com/v1/portal/rum", {
+        method: "POST",
+        headers: new Headers({
+          "content-type": "application/json",
+          origin: "https://portal.example.com",
+          referer: "https://portal.example.com/portal",
+          traceparent
+        }),
+        body: JSON.stringify({
+          event_type: "portal_shell_rendered",
+          route: "/portal",
+          view: "portal",
+          metric: "duration",
+          value: 25,
+          unit: "ms"
+        })
+      });
+
+      const response = await route.POST(request);
+      const body = await response.json();
+
+      assert.equal(response.status, 200);
+      assert.equal(response.headers.get("traceparent"), traceparent);
+      assert.deepEqual(body.data, { accepted: true });
     } finally {
       restoreFetch();
     }

--- a/web/secure-landing/tests/rum-client.test.mjs
+++ b/web/secure-landing/tests/rum-client.test.mjs
@@ -209,6 +209,33 @@ test("homepage GET treats invalid front-door RUM rollout values as sampled out",
   }
 });
 
+test("homepage GET disables shared cache for nonzero rollout even when sampled out", async () => {
+  const env = withRumEnvironment({
+    rumEnabled: true,
+    frontdoorRumEnabled: true,
+    frontdoorRolloutPercent: "25"
+  });
+
+  try {
+    getDb(env.dbPath);
+    const { GET } = await importFresh("../app/route.js");
+    const request = buildRequest("https://portal.example.com/");
+
+    const response = await GET(request);
+    const html = await response.text();
+    const csp = response.headers.get("content-security-policy") || "";
+    const cacheControl = response.headers.get("cache-control") || "";
+
+    assert.equal(response.status, 200);
+    assert.match(csp, /script-src 'none'/);
+    assert.doesNotMatch(html, /landing_rendered/);
+    assert.match(cacheControl, /no-store/);
+    assert.doesNotMatch(cacheControl, /\bpublic\b/i);
+  } finally {
+    env.cleanup();
+  }
+});
+
 test("homepage GET injects a nonced inline RUM script and matching CSP when RUM is enabled", async () => {
   const env = withRumEnvironment({ rumEnabled: true });
 
@@ -313,7 +340,8 @@ test("renderRumClientScript omits invalid or missing traceparent values", async 
 test("front-door RUM rollout config defaults, clamps, and fails closed on invalid values", async () => {
   const {
     isFrontdoorRumTelemetryEnabled,
-    resolveFrontdoorRumRolloutPercent
+    resolveFrontdoorRumRolloutPercent,
+    shouldDisableFrontdoorRumHomepageCache
   } = await importFresh("../lib/config.js");
   const traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
 
@@ -342,6 +370,36 @@ test("front-door RUM rollout config defaults, clamps, and fails closed on invali
       TP_PORTAL_RUM_ENABLED: "0",
       TP_FRONTDOOR_RUM_ENABLED: "1"
     }
+  }), false);
+  assert.equal(shouldDisableFrontdoorRumHomepageCache({
+    TP_PORTAL_RUM_ENABLED: "0",
+    TP_FRONTDOOR_RUM_ENABLED: "1",
+    TP_FRONTDOOR_RUM_ROLLOUT_PERCENT: "25"
+  }), false);
+  assert.equal(shouldDisableFrontdoorRumHomepageCache({
+    TP_PORTAL_RUM_ENABLED: "1",
+    TP_FRONTDOOR_RUM_ENABLED: "0",
+    TP_FRONTDOOR_RUM_ROLLOUT_PERCENT: "25"
+  }), false);
+  assert.equal(shouldDisableFrontdoorRumHomepageCache({
+    TP_PORTAL_RUM_ENABLED: "1",
+    TP_FRONTDOOR_RUM_ENABLED: "1",
+    TP_FRONTDOOR_RUM_ROLLOUT_PERCENT: "0"
+  }), false);
+  assert.equal(shouldDisableFrontdoorRumHomepageCache({
+    TP_PORTAL_RUM_ENABLED: "1",
+    TP_FRONTDOOR_RUM_ENABLED: "1",
+    TP_FRONTDOOR_RUM_ROLLOUT_PERCENT: "25"
+  }), true);
+  assert.equal(shouldDisableFrontdoorRumHomepageCache({
+    TP_PORTAL_RUM_ENABLED: "1",
+    TP_FRONTDOOR_RUM_ENABLED: "1",
+    TP_FRONTDOOR_RUM_ROLLOUT_PERCENT: "100"
+  }), true);
+  assert.equal(shouldDisableFrontdoorRumHomepageCache({
+    TP_PORTAL_RUM_ENABLED: "1",
+    TP_FRONTDOOR_RUM_ENABLED: "1",
+    TP_FRONTDOOR_RUM_ROLLOUT_PERCENT: "invalid"
   }), false);
 });
 

--- a/web/secure-landing/tests/rum-client.test.mjs
+++ b/web/secure-landing/tests/rum-client.test.mjs
@@ -1128,6 +1128,84 @@ test("public RUM route noops when only front-door RUM is disabled", async () => 
   }
 });
 
+test("public RUM route noops front-door core web vitals when only front-door RUM is disabled", async () => {
+  const env = withRumEnvironment({ rumEnabled: true, frontdoorRumEnabled: false });
+
+  try {
+    const route = await importFresh("../app/v1/portal/rum/route.js");
+    const restoreFetch = withMockedFetch(async () => {
+      assert.fail("front-door-disabled core web vital samples must not reach the backend");
+    });
+
+    try {
+      const request = buildRequest("https://portal.example.com/v1/portal/rum", {
+        method: "POST",
+        headers: new Headers({
+          "content-type": "application/json",
+          origin: "https://portal.example.com"
+        }),
+        body: JSON.stringify({
+          event_type: "core_web_vital",
+          route: "/",
+          view: "landing",
+          metric: "lcp",
+          value: 100,
+          unit: "ms"
+        })
+      });
+
+      const response = await route.POST(request);
+      const body = await response.json();
+
+      assert.equal(response.status, 200);
+      assert.deepEqual(body.data, { accepted: false, disabled: true });
+    } finally {
+      restoreFetch();
+    }
+  } finally {
+    env.cleanup();
+  }
+});
+
+test("public RUM route noops front-door interactive metrics when only front-door RUM is disabled", async () => {
+  const env = withRumEnvironment({ rumEnabled: true, frontdoorRumEnabled: false });
+
+  try {
+    const route = await importFresh("../app/v1/portal/rum/route.js");
+    const restoreFetch = withMockedFetch(async () => {
+      assert.fail("front-door-disabled interactive samples must not reach the backend");
+    });
+
+    try {
+      const request = buildRequest("https://portal.example.com/v1/portal/rum", {
+        method: "POST",
+        headers: new Headers({
+          "content-type": "application/json",
+          origin: "https://portal.example.com"
+        }),
+        body: JSON.stringify({
+          event_type: "first_view_interactive",
+          route: "/login",
+          view: "login",
+          metric: "duration",
+          value: 100,
+          unit: "ms"
+        })
+      });
+
+      const response = await route.POST(request);
+      const body = await response.json();
+
+      assert.equal(response.status, 200);
+      assert.deepEqual(body.data, { accepted: false, disabled: true });
+    } finally {
+      restoreFetch();
+    }
+  } finally {
+    env.cleanup();
+  }
+});
+
 test("public RUM route keeps portal-family payloads independent from front-door RUM controls", async () => {
   const env = withRumEnvironment({ rumEnabled: true, frontdoorRumEnabled: false });
   const traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
@@ -1141,11 +1219,11 @@ test("public RUM route keeps portal-family payloads independent from front-door 
       assert.equal(init.headers.get("x-api-key"), "backend-secret");
       assert.equal(init.headers.get("traceparent"), traceparent);
       assert.equal(await new Response(init.body).text(), JSON.stringify({
-        event_type: "portal_shell_rendered",
+        event_type: "core_web_vital",
         route: "/portal",
-        view: "portal",
-        metric: "duration",
-        value: 25,
+        view: "overview",
+        metric: "lcp",
+        value: 100,
         unit: "ms"
       }));
       return Response.json(
@@ -1173,11 +1251,11 @@ test("public RUM route keeps portal-family payloads independent from front-door 
           traceparent
         }),
         body: JSON.stringify({
-          event_type: "portal_shell_rendered",
+          event_type: "core_web_vital",
           route: "/portal",
-          view: "portal",
-          metric: "duration",
-          value: 25,
+          view: "overview",
+          metric: "lcp",
+          value: 100,
           unit: "ms"
         })
       });


### PR DESCRIPTION
## Summary
- Adds independent front-door RUM enablement and rollout controls while preserving `TP_PORTAL_RUM_ENABLED` as the shared master kill switch.
- Keeps managed portal/bootstrap RUM governed by `TP_PORTAL_RUM_ROLLOUT_PERCENT`.

## Changes
- Adds `TP_FRONTDOOR_RUM_ENABLED` and `TP_FRONTDOOR_RUM_ROLLOUT_PERCENT` in the front-door config helper.
- Gates landing, login GET inline RUM, login POST server RUM, logout POST server RUM, and front-door-classified `/v1/portal/rum` payloads through the front-door controls.
- Classifies front-door proxy payloads by explicit front-door event families, landing/login routes, and landing/login views so shared page metric families stay independently gated by surface.
- Marks homepage responses `no-store` whenever front-door RUM is enabled with a nonzero rollout percentage, including sampled-out requests, so shared caches cannot pin a sampled-out variant.
- Leaves portal/bootstrap `features.rumTelemetry` on the existing portal rollout path.
- Documents the split controls in the privacy sign-off packet, front-door quickstart, and Vercel env checklist.
- Updates contract tests for master-off, front-door-off, rollout-zero, invalid rollout, default/clamp behavior, homepage cache behavior, public proxy no-op, route/view-aware front-door page metrics, and portal/bootstrap independence.

## Validation
Proven green:
- `PATH=/Users/richardcheetham/.nvm/versions/node/v22.22.2/bin:$PATH npm test` (231 passed)
- `PATH=/Users/richardcheetham/.nvm/versions/node/v22.22.2/bin:$PATH make test-frontdoor-contract` (231 passed + Next build)
- `make test-orchestrator-http-contract` (154 passed)
- `.venv/bin/pytest tests/validation/test_check_frontdoor_vercel_env.py` (5 passed)
- `make check-stale-docs`
- `make check-doc-heading-links`
- `git diff --check`
- GitHub checks passed on head `e92991927c1832fb5f9d24ab37b418dd2eac18a5`.

Still failing:
- None.

## Risk
- Runtime behavior is bounded to front-door RUM gating and homepage cache headers when front-door RUM can vary by sampling. No RUM schema, event family, login/logout submit semantic, marker cookie, sessionStorage, sanitizer, sink-path, rollout cohort, or retention/deletion behavior is changed.
- Revert-safe: the new front-door envs default to disabled unless the shared master and front-door flag are both enabled; invalid front-door rollout values fail closed to `0`, which preserves static public homepage caching.