### PR TITLE
test(frontdoor): make homepage rum cache test deterministic

### DIFF
--- a/web/secure-landing/tests/rum-client.test.mjs
+++ b/web/secure-landing/tests/rum-client.test.mjs
@@ -218,11 +218,21 @@ test("homepage GET disables shared cache for nonzero rollout even when sampled o
   const sampledOutTraceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
 
   try {
-    const { stableRolloutBucket } = await importFresh("../lib/rollout.js");
-    // The -01 suffix is W3C trace flags; front-door rollout hashes the full traceparent.
-    assert.equal(stableRolloutBucket(sampledOutTraceparent), 79);
-
     getDb(env.dbPath);
+    const { stableRolloutBucket } = await importFresh("../lib/rollout.js");
+    const { isFrontdoorRumTelemetryEnabled } = await importFresh("../lib/config.js");
+    // The final "-01" is the W3C trace-flags field, not the rollout decision.
+    // The assertions below pin this fixture as sampled out for 25%.
+    const bucket = stableRolloutBucket(sampledOutTraceparent);
+    assert.ok(
+      bucket >= 25,
+      `expected fixed traceparent bucket ${bucket} to be sampled out for 25% rollout`
+    );
+    assert.equal(
+      isFrontdoorRumTelemetryEnabled({ traceparent: sampledOutTraceparent }),
+      false
+    );
+
     const { GET } = await importFresh("../app/route.js");
     const request = buildRequest("https://portal.example.com/", {
       headers: {

--- a/web/secure-landing/tests/rum-client.test.mjs
+++ b/web/secure-landing/tests/rum-client.test.mjs
@@ -215,11 +215,20 @@ test("homepage GET disables shared cache for nonzero rollout even when sampled o
     frontdoorRumEnabled: true,
     frontdoorRolloutPercent: "25"
   });
+  const sampledOutTraceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
 
   try {
+    const { stableRolloutBucket } = await importFresh("../lib/rollout.js");
+    // The -01 suffix is W3C trace flags; front-door rollout hashes the full traceparent.
+    assert.equal(stableRolloutBucket(sampledOutTraceparent), 79);
+
     getDb(env.dbPath);
     const { GET } = await importFresh("../app/route.js");
-    const request = buildRequest("https://portal.example.com/");
+    const request = buildRequest("https://portal.example.com/", {
+      headers: {
+        traceparent: sampledOutTraceparent
+      }
+    });
 
     const response = await GET(request);
     const html = await response.text();


### PR DESCRIPTION
## Summary
- Fixes the post-merge `Frontdoor contract` failure on `main` after #1708.
- The failing homepage cache-control test intended to assert the sampled-out 25% rollout path, but it let the route mint a random traceparent. When that random traceparent landed inside the 25% bucket, the route correctly emitted the RUM script and CSP nonce, making the test flaky.

## Changes
- Pins the sampled-out homepage cache test to an explicit traceparent whose stable rollout bucket is outside `TP_FRONTDOOR_RUM_ROLLOUT_PERCENT=25`.
- Leaves front-door RUM cache behavior, CSP behavior, route behavior, rollout controls, RUM schema, cookies, sessionStorage, sinks, and retention behavior unchanged.

## Validation
Proven green:
- `PATH=/Users/richardcheetham/.nvm/versions/node/v22.22.2/bin:$PATH npm test` in `web/secure-landing` — 231 passed.
- `make test-frontdoor-contract` — 231 passed plus Next build.
- `PATH=/Users/richardcheetham/.nvm/versions/node/v22.22.2/bin:$PATH npm run test:coverage` in `web/secure-landing` — 231 passed, coverage gate passed.
- `git diff --check`
- pre-commit hooks during `git commit`

Still failing:
- None locally.

## Risk
- Test-only deterministic fixture change. Revert-safe and bounded to the exact flaky assertion that failed in the GitHub `Frontdoor contract` job.
- No selector, route, env var, API envelope, telemetry payload, auth, sink, or retention behavior changes.