### PR TITLE
docs(architecture): backfill TP_FRONTDOOR_RUM_* gates into the pilot collection procedure

### DIFF
--- a/docs/architecture/PORTAL_OPERATOR_CONSOLE_MODERNIZATION_EVIDENCE.md
+++ b/docs/architecture/PORTAL_OPERATOR_CONSOLE_MODERNIZATION_EVIDENCE.md
@@ -51,9 +51,13 @@ Optional review-time segmentation refinement is not part of the shipped scope ca
 ```bash
 export TP_PORTAL_RUM_ENABLED=1
 export TP_PORTAL_RUM_ROLLOUT_PERCENT=100
+export TP_FRONTDOOR_RUM_ENABLED=1
+export TP_FRONTDOOR_RUM_ROLLOUT_PERCENT=100
 export TP_PORTAL_RUM_LOG_PATH="/absolute/path/to/portal-rum.jsonl"
 export TP_PORTAL_EVENT_LOG_PATH="/absolute/path/to/portal-events.jsonl"
 ```
+
+`TP_PORTAL_RUM_ENABLED` is the shared master kill switch and `TP_PORTAL_RUM_ROLLOUT_PERCENT` only governs managed portal/bootstrap RUM. The independent `TP_FRONTDOOR_RUM_*` gates added in #1707 must also be set or `make validate-frontdoor-browser` will silently produce zero landing/login/logout samples in the JSONL log even though the pilot appears to run.
 
 2. Run the current browser validation backbone:
 


### PR DESCRIPTION
Closes a silent-failure governance gap introduced when #1707 split the
shared TP_PORTAL_RUM_ROLLOUT_PERCENT gate into a managed-portal-only
rollout knob plus an independent TP_FRONTDOOR_RUM_ENABLED /
TP_FRONTDOOR_RUM_ROLLOUT_PERCENT pair governing landing, login,
logout, and front-door proxy emissions.

The portal modernization evidence note's pilot collection procedure
predates that split: it sets only TP_PORTAL_RUM_ENABLED +
TP_PORTAL_RUM_ROLLOUT_PERCENT, then runs make validate-frontdoor-browser
+ make validate-portal-browser. After #1707 that combination produces
zero landing/login/logout RUM samples in the JSONL log, because the
new TP_FRONTDOOR_RUM_ENABLED flag defaults to disabled. The pilot
appears to run cleanly, the operator attaches the resulting summary
to the rollout notes, and the M1 visibility gate gets credit for
evidence that does not in fact exist.

Two additions, no behavior change:

- The bash export block now sets TP_FRONTDOOR_RUM_ENABLED=1 and
  TP_FRONTDOOR_RUM_ROLLOUT_PERCENT=100 alongside the existing portal
  exports so make validate-frontdoor-browser actually emits
  landing/login/logout samples.
- A one-paragraph note under the block names the master switch /
  rollout knob / front-door gate split, points reviewers at #1707 for
  the policy rationale, and calls out that omitting the front-door
  flags produces a silent zero-sample failure rather than a loud
  error.

The privacy sign-off packet
(docs/compliance/PORTAL_TELEMETRY_PRIVACY_SIGNOFF.md), the front-door
quickstart (docs/guides/PORTAL_SECURE_FRONTDOOR_QUICKSTART.md), and
the Vercel env reference (docs/operations/frontdoor_vercel_env.md)
were already updated by the parallel policy work; verified by grep
that this is the only remaining reference to the old TP_PORTAL_RUM_*-only
enablement combo paired with make validate-frontdoor-browser.

Verified:
- pre-commit run --files: all hooks pass (gitleaks etc.)
- make check-stale-docs: no stale docs path references in changed file
- make check-doc-heading-links: doc heading links OK