### PR TITLE
docs(architecture): refresh modernization evidence status

### DIFF
--- a/docs/architecture/PORTAL_OPERATOR_CONSOLE_MODERNIZATION_EVIDENCE.md
+++ b/docs/architecture/PORTAL_OPERATOR_CONSOLE_MODERNIZATION_EVIDENCE.md
@@ -83,7 +83,7 @@ python tools/portal_modernization_evidence.py \
 | Gate | Repo-Owned Input | Current State |
 | --- | --- | --- |
 | M1 visibility | `portal_rum_summary.py`, `portal_modernization_evidence.py` | Implemented, waiting for pilot capture |
-| M1 telemetry sign-off | `docs/compliance/PORTAL_TELEMETRY_PRIVACY_SIGNOFF.md` | Approved with conditions for bounded portal/front-door pilots |
+| M1 telemetry sign-off | `docs/compliance/PORTAL_TELEMETRY_PRIVACY_SIGNOFF.md` | `Approved with Conditions` for bounded portal/front-door pilots |
 | M4 pilot metrics | `portal_modernization_evidence.py` plus browser validation | Open |
 | M5 viewer evidence | `portal_modernization_evidence.py` plus browser validation | Open |
 | ADR-050 rewrite evidence | `docs/decisions/ADR-050-portal-react-migration.md` | Open |

--- a/docs/architecture/PORTAL_OPERATOR_CONSOLE_MODERNIZATION_EVIDENCE.md
+++ b/docs/architecture/PORTAL_OPERATOR_CONSOLE_MODERNIZATION_EVIDENCE.md
@@ -2,6 +2,7 @@
 
 **Status:** Working evidence register
 **Date:** 2026-04-14
+**Last revised:** 2026-05-10
 **Owner:** Frontdoor / Platform
 
 This note tracks the repo-owned evidence package for the portal modernization RFC. It does not create human approval or invent pilot results. It records what the repo can prove now, how pilot measurements should be collected, and which gates remain open.
@@ -82,13 +83,13 @@ python tools/portal_modernization_evidence.py \
 | Gate | Repo-Owned Input | Current State |
 | --- | --- | --- |
 | M1 visibility | `portal_rum_summary.py`, `portal_modernization_evidence.py` | Implemented, waiting for pilot capture |
-| M1 telemetry sign-off | `docs/compliance/PORTAL_TELEMETRY_PRIVACY_SIGNOFF.md` | Open human approval |
+| M1 telemetry sign-off | `docs/compliance/PORTAL_TELEMETRY_PRIVACY_SIGNOFF.md` | Approved with conditions for bounded portal/front-door pilots |
 | M4 pilot metrics | `portal_modernization_evidence.py` plus browser validation | Open |
 | M5 viewer evidence | `portal_modernization_evidence.py` plus browser validation | Open |
 | ADR-050 rewrite evidence | `docs/decisions/ADR-050-portal-react-migration.md` | Open |
 
 ## Remaining Open Gates
 
-- Security / Privacy approval of telemetry schema, retention, and disposal posture
 - Pilot measurements for CWV, queue latency, SSE reconnect rate, and artifact-viewer success
+- Privacy packet revision before any new RUM event family, metadata key, marker cookie, storage key, rollout knob, sink behavior, or retention posture
 - ADR-050 evidence that compares rewrite vs no-rewrite delivery, quality, and developer-experience tradeoffs

--- a/docs/architecture/PORTAL_OPERATOR_CONSOLE_MODERNIZATION_RFC.md
+++ b/docs/architecture/PORTAL_OPERATOR_CONSOLE_MODERNIZATION_RFC.md
@@ -57,7 +57,7 @@ The following sections are non-normative:
 
 ### Partial
 
-- M1 Measurement Foundation is implemented with bounded-pilot telemetry sign-off approved with conditions, but it is not formally closed until measured pilot evidence is attached.
+- M1 Measurement Foundation is implemented, and the bounded-pilot telemetry sign-off status is `Approved with Conditions`, but it is not formally closed until measured pilot evidence is attached.
 - M4 Performance and Rendering is implemented but not formally closed pending measured pilot evidence against the provisional CWV, queue-latency, and SSE targets.
 - M5 Artifact Review is implemented for deferred review loading, modal viewer behavior, metadata visibility, fingerprint copy, and explicit fallback states, but it is not formally closed pending measured pilot evidence.
 - M5's optional segmentation refinement is not counted as shipped in this RFC. Current shipped scope is the viewer and fallback path only.
@@ -544,4 +544,4 @@ These are provisional targets and should be confirmed or adjusted after pilot ca
 - `tools/portal_rum_summary.py` remains the contract-stable RUM-only summary path.
 - `tools/portal_modernization_evidence.py` is the repo-owned pilot evidence path for M1, M4, and M5.
 - `docs/architecture/PORTAL_OPERATOR_CONSOLE_MODERNIZATION_EVIDENCE.md` records the evidence collection workflow and open gates.
-- `docs/compliance/PORTAL_TELEMETRY_PRIVACY_SIGNOFF.md` is the approved-with-conditions bounded-pilot sign-off record for the current telemetry schema, retention, and disposal posture.
+- `docs/compliance/PORTAL_TELEMETRY_PRIVACY_SIGNOFF.md` is the `Approved with Conditions` bounded-pilot sign-off record for the current telemetry schema, retention, and disposal posture.

--- a/docs/architecture/PORTAL_OPERATOR_CONSOLE_MODERNIZATION_RFC.md
+++ b/docs/architecture/PORTAL_OPERATOR_CONSOLE_MODERNIZATION_RFC.md
@@ -57,15 +57,15 @@ The following sections are non-normative:
 
 ### Partial
 
-- M1 Measurement Foundation is implemented but not formally closed pending Security / Privacy schema and retention sign-off plus measured pilot evidence.
+- M1 Measurement Foundation is implemented with bounded-pilot telemetry sign-off approved with conditions, but it is not formally closed until measured pilot evidence is attached.
 - M4 Performance and Rendering is implemented but not formally closed pending measured pilot evidence against the provisional CWV, queue-latency, and SSE targets.
 - M5 Artifact Review is implemented for deferred review loading, modal viewer behavior, metadata visibility, fingerprint copy, and explicit fallback states, but it is not formally closed pending measured pilot evidence.
 - M5's optional segmentation refinement is not counted as shipped in this RFC. Current shipped scope is the viewer and fallback path only.
 
 ### Open Gate
 
-- Security / Privacy sign-off for the telemetry schema, retention posture, and disposal procedure remains open.
 - Repo-owned pilot evidence for M1, M4, and M5 remains open until measurements are captured and attached.
+- Privacy packet revision remains required before any new RUM event family, metadata key, marker cookie, storage key, rollout knob, sink behavior, or retention posture.
 - The ADR-050 rewrite evidence checklist remains open and is not resolved by this RFC.
 
 ## Decision Drivers
@@ -544,4 +544,4 @@ These are provisional targets and should be confirmed or adjusted after pilot ca
 - `tools/portal_rum_summary.py` remains the contract-stable RUM-only summary path.
 - `tools/portal_modernization_evidence.py` is the repo-owned pilot evidence path for M1, M4, and M5.
 - `docs/architecture/PORTAL_OPERATOR_CONSOLE_MODERNIZATION_EVIDENCE.md` records the evidence collection workflow and open gates.
-- `docs/compliance/PORTAL_TELEMETRY_PRIVACY_SIGNOFF.md` is the pending human approval packet for telemetry schema, retention, and disposal.
+- `docs/compliance/PORTAL_TELEMETRY_PRIVACY_SIGNOFF.md` is the approved-with-conditions bounded-pilot sign-off record for the current telemetry schema, retention, and disposal posture.

--- a/docs/guides/PORTAL_SECURE_FRONTDOOR_QUICKSTART.md
+++ b/docs/guides/PORTAL_SECURE_FRONTDOOR_QUICKSTART.md
@@ -89,7 +89,7 @@ Notes:
 - `TP_PORTAL_EVENT_LOG_PATH` is optional. When set, FastAPI appends PII-free portal event JSONL for viewer, review, and stream telemetry evidence.
 - Direct-debug rollout stability reuses `TP_PORTAL_DIRECT_DEBUG_COHORT_KEY`.
 - Managed rollout stability uses the authenticated actor identity already present on the front door; raw usernames and emails are not stored in the RUM sink.
-- Rollout expansion remains blocked until `docs/compliance/PORTAL_TELEMETRY_PRIVACY_SIGNOFF.md` has explicit Security / Privacy approval.
+- Bounded pilot rollout is approved with conditions by `docs/compliance/PORTAL_TELEMETRY_PRIVACY_SIGNOFF.md`; revise that packet before adding any new telemetry event family, metadata key, marker cookie, storage key, rollout knob, sink behavior, or retention posture.
 
 ## Optional Review Surface Pilot Knobs
 

--- a/docs/guides/PORTAL_SECURE_FRONTDOOR_QUICKSTART.md
+++ b/docs/guides/PORTAL_SECURE_FRONTDOOR_QUICKSTART.md
@@ -89,7 +89,7 @@ Notes:
 - `TP_PORTAL_EVENT_LOG_PATH` is optional. When set, FastAPI appends PII-free portal event JSONL for viewer, review, and stream telemetry evidence.
 - Direct-debug rollout stability reuses `TP_PORTAL_DIRECT_DEBUG_COHORT_KEY`.
 - Managed rollout stability uses the authenticated actor identity already present on the front door; raw usernames and emails are not stored in the RUM sink.
-- Bounded pilot rollout is approved with conditions by `docs/compliance/PORTAL_TELEMETRY_PRIVACY_SIGNOFF.md`; revise that packet before adding any new telemetry event family, metadata key, marker cookie, storage key, rollout knob, sink behavior, or retention posture.
+- Bounded pilot rollout is governed by the `Approved with Conditions` sign-off packet at `docs/compliance/PORTAL_TELEMETRY_PRIVACY_SIGNOFF.md`; revise that packet before adding any new telemetry event family, metadata key, marker cookie, storage key, rollout knob, sink behavior, or retention posture.
 
 ## Optional Review Surface Pilot Knobs
 


### PR DESCRIPTION
## Summary
- Refreshes stale modernization evidence status now that the bounded portal/front-door telemetry privacy packet is approved with conditions.
- Keeps the remaining gates focused on pilot evidence, ADR-050 evidence, and required privacy-packet revisions for any future telemetry/storage/sink/retention changes.

## Changes
- Updates `docs/architecture/PORTAL_OPERATOR_CONSOLE_MODERNIZATION_EVIDENCE.md` with a 2026-05-10 revision marker and the current approved-with-conditions M1 telemetry sign-off status.
- Updates `docs/architecture/PORTAL_OPERATOR_CONSOLE_MODERNIZATION_RFC.md` so it no longer says telemetry sign-off is open or pending human approval.
- Updates `docs/guides/PORTAL_SECURE_FRONTDOOR_QUICKSTART.md` so bounded pilot rollout points to the approved-with-conditions packet while preserving the revision requirement for new telemetry behavior.
- No runtime, route, selector, API envelope, telemetry payload, cookie, storage, rollout, sink, or retention behavior changes.

## Validation
Proven green:
- `make check-stale-docs`
- `make check-doc-heading-links`
- `python3 scripts/governance/check_docs_structure.py --all`
- `git diff --check`
- pre-commit hook stack during commit, including gitleaks

Still failing:
- None.

## Risk
- Low. This is docs-only and aligns status language with the existing approved-with-conditions privacy packet.
- Revert-safe: reverting restores only the prior wording and does not affect runtime behavior or validation contracts.
