### PR TITLE
test(frontdoor): add managed portal logout click smoke

### DIFF
--- a/scripts/validation/validate_frontdoor_browser_smoke.py
+++ b/scripts/validation/validate_frontdoor_browser_smoke.py
@@ -11,6 +11,8 @@ Coverage:
 2. Login loads with the operator form and front-door video shell.
 3. Username/password authentication succeeds.
 4. Managed portal entry honors a validated `/portal?view=build` returnTo and keeps browser-side API key input hidden.
+5. The managed-mode logout button is rendered and visible, clicking it returns the browser to /login with the login form rendered.
+6. A subsequent direct navigation to `/portal?view=build` bounces back to /login (the session cookie cleared by /logout cannot silently restore the authenticated shell).
 
 Run via:
     python scripts/validation/validate_frontdoor_browser_smoke.py
@@ -473,7 +475,10 @@ def _frontdoor_state_probe_expression() -> str:
     buildViewVisible: visibleById('build-shell'),
     overviewViewVisible: visibleById('overview-shell'),
     operateViewVisible: visibleById('jobs-shell'),
-    portalAccessStateReady: !!document.querySelector('[data-ui="portal-access-state"]')
+    portalAccessStateReady: !!document.querySelector('[data-ui="portal-access-state"]'),
+    logoutButtonPresent: !!document.querySelector('[data-ui="logout-button"]'),
+    logoutButtonVisible: visibleById('logoutBtn'),
+    logoutButtonHidden: hiddenById('logoutBtn')
   };
 })()
 """
@@ -837,10 +842,73 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
             f"Managed portal did not hide browser API key workflow cleanly: {portal_state}",
         )
 
+        # Logout click-flow smoke (#1711 follow-up): the managed-mode Sign
+        # out button was added in #1711 with structural-only Playwright
+        # coverage because the @portal-browser fixture serves an inert
+        # portal JS stub. The governed front-door smoke is the natural
+        # home for the real-bundle behavior — the real portal.js runs,
+        # the bootstrap-ready code un-hides the button, the click
+        # handler fires fetchWithTimeout('/logout'), and the session
+        # cookie is actually destroyed by the front-door route.
+        print("frontdoor-browser-smoke: validating portal logout click flow", flush=True)
+        _expect(
+            bool(portal_state.get("logoutButtonPresent")),
+            f'Managed portal did not render the [data-ui="logout-button"] control: {portal_state}',
+        )
+        _expect(
+            bool(portal_state.get("logoutButtonVisible")),
+            f"Managed portal logout button stayed hidden after bootstrap-ready (managed-mode un-hide did not fire): {portal_state}",
+        )
+        connection.evaluate(_click_expression('[data-ui="logout-button"]'))
+        logout_state = _poll(
+            connection,
+            _frontdoor_state_probe_expression(),
+            predicate=lambda value: (
+                isinstance(value, dict)
+                and str(value.get("readyState", "")) == "complete"
+                and str(value.get("pathname", "")) == "/login"
+                and bool(value.get("loginFormPresent"))
+            ),
+            timeout_seconds=args.timeout_seconds,
+            description="front-door logout to return to login",
+        )
+        _expect(
+            str(logout_state.get("pathname", "")) == "/login",
+            f"Logout click did not land the browser on /login: {logout_state}",
+        )
+        _expect(
+            bool(logout_state.get("loginFormPresent")),
+            f"Login form was not rendered after logout: {logout_state}",
+        )
+
+        # Defense-in-depth: a direct navigation to a managed deep link
+        # must not silently restore the prior authenticated shell. The
+        # session cookie was cleared by the /logout route, so the
+        # front-door /portal handler must redirect back to /login.
+        connection.evaluate(_navigate_expression("/portal?view=build"))
+        post_logout_state = _poll(
+            connection,
+            _frontdoor_state_probe_expression(),
+            predicate=lambda value: (
+                isinstance(value, dict)
+                and str(value.get("readyState", "")) == "complete"
+                and str(value.get("pathname", "")) == "/login"
+                and bool(value.get("loginFormPresent"))
+            ),
+            timeout_seconds=args.timeout_seconds,
+            description="post-logout portal access to require login",
+        )
+        _expect(
+            str(post_logout_state.get("pathname", "")) == "/login",
+            f"Post-logout /portal?view=build did not redirect to /login: {post_logout_state}",
+        )
+
         print("frontdoor-browser-smoke: ok")
         print(f"base_url: {base_url}")
         print(f"portal_path: {portal_state.get('pathname')}")
         print(f"view: {portal_state.get('currentView')}")
+        print(f"logout_path: {logout_state.get('pathname')}")
+        print(f"post_logout_path: {post_logout_state.get('pathname')}")
         return 0
     finally:
         if connection is not None:

--- a/tests/validation/test_portal_smoke_scripts.py
+++ b/tests/validation/test_portal_smoke_scripts.py
@@ -940,6 +940,41 @@ def test_frontdoor_browser_waits_for_managed_portal_bootstrap_before_passing():
     assert "--spawn-local-backend" in content
 
 
+def test_frontdoor_browser_smoke_pins_managed_logout_click_flow():
+    """Pin the #1713 governed logout click smoke against silent removal.
+
+    The smoke at scripts/validation/validate_frontdoor_browser_smoke.py
+    is the only repo-owned harness that exercises the real-bundle
+    managed logout click flow end to end (the @portal-browser
+    Playwright lane stubs portal.js so it can only assert
+    server-rendered structure). Future edits could quietly drop the
+    new probe fields, swap the click selector for the legacy id-only
+    form, rename the poll descriptions, or skip the post-logout
+    bounce check; none of those would fail a Chrome-less CI lane and
+    none would fail flake8. This content-grep pins the exact tokens
+    the smoke needs so any of those regressions trip an explicit
+    test failure with a clear name.
+    """
+    content = FRONTDOOR_BROWSER_SCRIPT_PATH.read_text(encoding="utf-8")
+
+    # Probe extension — three new fields the new poll predicates read.
+    assert "logoutButtonPresent" in content
+    assert "logoutButtonVisible" in content
+    # Click target must be the data-ui hook, not a brittle text or id
+    # selector (matches the data-ui="logout-button" attribute pinned
+    # by tests/test_app_orchestrator_runtime.py for the rendered HTML).
+    assert '[data-ui="logout-button"]' in content
+    # Both _poll descriptions must remain stable so a poll-timeout
+    # error message names the actual flow being asserted.
+    assert "front-door logout to return to login" in content
+    assert "post-logout portal access to require login" in content
+    # The defense-in-depth post-logout bounce navigates to the same
+    # managed deep link the entry block uses; keeping the literal
+    # string here pins that we still exercise the deep link, not just
+    # the bare /portal path.
+    assert "/portal?view=build" in content
+
+
 def test_frontdoor_browser_accessibility_probe_tracks_target_size_and_reduced_motion():
     module = _load_module(FRONTDOOR_BROWSER_SCRIPT_PATH, "tests_validate_frontdoor_browser_smoke_accessibility_probe")
 


### PR DESCRIPTION
#1711 added a managed-mode Sign out button to the operator console
topbar, but the @portal-browser Playwright lane could only assert
server-rendered structure: the mock-fastapi-origin fixture substitutes
__PORTAL_JS_URL__ to an inert /__mock-portal-asset.js stub, so the
real portal bundle never runs in that lane, the bootstrap-ready code
that un-hides the button never fires, and the live click → POST →
/login redirect cannot be exercised there. PR #1711 explicitly
deferred the real-bundle smoke to the governed front-door browser
lane.

This commit closes that gap. The validate_frontdoor_browser_smoke.py
script already launches a managed front door, drives a real Chrome
via CDP, completes a real form-POST login against a seeded operator,
and verifies portal entry under /portal?view=build. Three additions
turn that probe into a full logout round-trip:

1. _frontdoor_state_probe_expression() gains three fields the new
   block reads:
     - logoutButtonPresent: !!document.querySelector('[data-ui="logout-button"]')
     - logoutButtonVisible: visibleById('logoutBtn')
     - logoutButtonHidden:  hiddenById('logoutBtn')
   Both visibility helpers were already in the probe; the new
   fields just wire the logout button's id and data-ui hook into
   the same predicate vocabulary used for every other front-door
   structural assertion.

2. Immediately after the existing managed-portal-entry assertions,
   a new "validating portal logout click flow" block runs:
     - asserts the button is rendered AND visible (proves the
       bootstrap-ready managed-mode un-hide actually fired in the
       real bundle — the structural Playwright spec from #1711
       cannot reach this assertion);
     - clicks [data-ui="logout-button"] via the existing
       _click_expression helper;
     - polls the probe for readyState=complete +
       pathname=/login + loginFormPresent, with a clear
       "front-door logout to return to login" description that
       surfaces cleanly in poll-timeout error messages.

3. Defense-in-depth follow-up: a direct navigation to
   /portal?view=build must NOT silently restore the prior
   authenticated shell. The /logout route already clears the
   session cookie, so the front-door /portal handler must
   redirect back to /login. A second _poll block asserts that
   bounce.

The existing success prints are extended with the two new pathname
captures so the smoke's stdout records the full round-trip
(homepage → login → portal → logout → login → bounce).

Scope discipline (all of the following intentionally NOT touched):
- logout client-side RUM emission
- logout marker cookies
- logout sessionStorage breadcrumbs
- telemetry schema / privacy packet
- Playwright fixture / @portal-browser lane
- auth proxy mode
- IndexedDB persistence

This is a real-browser behavior smoke, not a telemetry PR. Any
future logout client-side RUM mirror remains a separate
telemetry-changing PR that will need to revise
docs/compliance/PORTAL_TELEMETRY_PRIVACY_SIGNOFF.md in the same
change per the approval-with-conditions block.

Validation:
- pytest tests/validation/test_portal_smoke_scripts.py: 50 / 50 pass
- flake8 --select=E9,F63,F7,F82 on the changed file: clean
- pre-commit run --files: all hooks pass
- python3 -c "ast.parse(open(...))": AST parses cleanly
- The CDP smoke itself (python3 scripts/validation/validate_frontdoor_browser_smoke.py
  --spawn-local-backend --spawn-local-frontdoor) requires Chromium
  which is unavailable in this sandbox, but the additions follow
  the existing _expect / _poll / _click_expression / _navigate_expression
  conventions exactly and the probe AST + content greps all
  validate.