### PR TITLE
chore(deps): bump urllib3 to 2.7.0 across Python locks

### DIFF
--- a/config/fastvlm_runtime_requirements.txt
+++ b/config/fastvlm_runtime_requirements.txt
@@ -77,7 +77,7 @@ transformers==5.8.0
 typer==0.25.1
 typing-inspection==0.4.2
 typing_extensions==4.15.0
-urllib3==2.6.3
+urllib3==2.7.0
 uvicorn==0.46.0
 xxhash==3.7.0
 yarl==1.23.0

--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -335,7 +335,7 @@ typing-inspection==0.4.2
     # via
     #   fastapi
     #   pydantic
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   id
     #   requests

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -193,7 +193,7 @@ twine==6.2.0
     # via
     #   -c all.txt
     #   -r ci.in
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c all.txt
     #   id

--- a/requirements/ml-core-darwin-arm64.txt
+++ b/requirements/ml-core-darwin-arm64.txt
@@ -283,7 +283,7 @@ typing-extensions==4.15.0
     #   huggingface-hub
     #   sentence-transformers
     #   torch
-urllib3==2.6.3
+urllib3==2.7.0
     # via requests
 wcwidth==0.6.0
     # via ftfy

--- a/requirements/security.txt
+++ b/requirements/security.txt
@@ -72,7 +72,7 @@ tomli-w==1.2.0
     # via pip-audit
 typing-extensions==4.15.0
     # via cyclonedx-python-lib
-urllib3==2.6.3
+urllib3==2.7.0
     # via requests
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
## Summary
- Resolve the urllib3 2.7.0 security remediation without accepting Dependabot-generated lockfile contract drift.
- Apply the smallest safe maintainer patch: update only governed urllib3 pins while preserving existing lockfile contracts.

## Changes
- Bump urllib3 from 2.6.3 to 2.7.0 in requirements/all.txt, requirements/ci.txt, requirements/security.txt, requirements/ml-core-darwin-arm64.txt, and config/fastvlm_runtime_requirements.txt.
- Preserve generic OpenCV platform-marker pins, the Darwin arm64 PyTorch CPU index line, and the Darwin lock purity surface with no nvidia-* or triton additions.
- No API, route, selector, CLI, workflow, package input, or Next.js/frontdoor changes are included.

## Validation
Proven green:
- python3 scripts/validation/check_requirements_lock_contract.py
- bash scripts/validate_dependency_constraints.sh --verbose
- .venv/bin/pytest -q tests/test_check_requirements_lock_contract.py tests/test_requirements_lock_lane_makefile.py
- ./scripts/setup/install_fastvlm_runtime.sh --dry-run --skip-model-download --skip-verify
- pre-commit hooks during git commit, including Validate Dependency Constraints (ADR-032) and gitleaks (CI parity)

Still failing:
- None in the planned validation path.

Environment/tooling notes:
- python3 -m pytest -q tests/test_check_requirements_lock_contract.py tests/test_requirements_lock_lane_makefile.py could not run because the system Python at /Library/Developer/CommandLineTools/usr/bin/python3 has no pytest module; reran successfully through .venv/bin/pytest.

## Risk
- Low runtime risk: this is a pin-only security update to a patched urllib3 release.
- Revert-safe and bounded to five manifest/lock surfaces; Next.js alerts remain intentionally out of scope for a separate frontdoor/npm remediation.
- Lockfile contract risk is explicitly bounded by the passing ADR-032 lock-contract and dependency-constraint checks.
