### PR TITLE
docs: refresh current codebase audit reports

### DIFF
--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,475 +1,308 @@
 # Repository Architecture
 
+**Status:** Maintained architecture overview
+**Last updated:** 2026-05-12
+**Canonical navigation:** [Documentation Map](../governance/DOCUMENTATION_MAP.md)
+
 ## Overview
 
-This document describes the architecture of the Transformation Portal after the October 2025 refactoring. It explains the design decisions, module organization, and best practices for development.
+Transformation Portal is a governed image and video processing platform for
+luxury real estate rendering and architectural visualization. The current
+architecture combines:
+
+- A FastAPI portal/orchestrator backend in `app.py`.
+- A managed Next frontdoor in `web/secure-landing`.
+- Python package modules under `src/transformation_portal/`.
+- Governed CLI and pipeline runtimes for Lux Depth V3, archive gates, APEX,
+  Materials V3, spatial AI, ingest, attestation, and optional advisory VLM
+  captioning.
+- Layered dependency locks, deterministic validation, provenance, run-card,
+  manifest, and documentation governance.
+
+This document describes the current architecture at a system-boundary level.
+Use more specific guides for operator procedures, API examples, and pipeline
+commands.
+
+## Runtime Topology
+
+The browser-facing production path is intentionally frontdoor-first:
+
+```text
+Browser
+  -> managed Next frontdoor (`web/secure-landing`)
+  -> FastAPI backend (`app.py`)
+  -> orchestrator jobs, pipeline CLIs, local runtimes, and artifacts
+```
+
+If a Cloudflare Worker is present, it is a frontdoor-only proxy. It must not
+become a direct public bypass to the FastAPI backend.
+
+Local development has two supported entrypoints:
+
+- Backend-direct debugging through FastAPI routes such as `/portal`,
+  `/portal/bootstrap`, `/healthz`, `/ready`, and versioned `/v1/*` API routes.
+- Managed frontdoor debugging through `make run-frontdoor-local`,
+  `make validate-frontdoor-browser`, and the Node 22.x guarded
+  `web/secure-landing` runtime.
 
 ## Design Principles
 
-### 1. Separation of Concerns
-Each module has a single, well-defined responsibility:
-- **Pipelines**: Orchestrate multi-step workflows
-- **Processors**: Core data transformation engines
-- **Enhancers**: Specialized improvement algorithms
-- **Analyzers**: Code and workflow analysis tools
-- **Utils**: Shared functionality with no business logic
+### Contract Preservation
 
-### 2. Explicit Over Implicit
-- Clear import paths: `from transformation_portal.processors.material_response.engine import MaterialResponseEngine`
-- Explicit dependencies listed in each module
-- No magic imports or hidden behavior
+Routes, selectors, API envelopes, CLI flags, schema names, artifact paths, and
+test semantics are treated as contracts. Behavior changes must update focused
+tests and validation paths in the same patch.
 
-### 3. Backward Compatibility
-- Root-level files maintained for existing code (v0.1.x)
-- Deprecation warnings for future removal
-- Migration tools provided
+### Fail-Closed Boundaries
 
-### 4. Performance First
-- Lazy imports to reduce startup time
-- Efficient file I/O with pathlib
-- Caching where beneficial
-- Batch processing support
+Authentication, host validation, path resolution, artifact access, dependency
+governance, and optional runtime discovery fail closed. Environment problems
+should be classified as environment problems instead of weakening product
+contracts.
 
-### 5. Developer Friendly
-- Consistent structure across modules
-- Comprehensive documentation
-- Clear error messages
-- Type hints where beneficial
+### Deterministic Execution
 
-## Module Structure
+Pipelines emit explicit metadata and avoid hidden ambient state where practical.
+Run cards, manifests, provenance records, content-addressed storage, fixity
+checks, and deterministic test fixtures are part of the architecture, not
+incidental tooling.
 
-### Top-Level Organization
+### Layered Capabilities
 
-```
-transformation_portal/              # Repository root
-├── src/                          # Installable package source
-│   ├── transformation_portal/    # Main package
-│   ├── tp/                       # Short alias package
-│   └── luxury_tiff_batch_processor/  # TIFF batch processor
-├── scripts/                      # Operational scripts and pipeline runners
-├── config/                       # YAML presets and configuration
-├── assets/                       # LUTs, branding, look assets
-├── docs/                         # Documentation
-├── tests/                        # Pytest suite
-├── tools/                        # Dev/ops tools (manifests, audits)
-├── workflows/                    # Workflow artifacts / ComfyUI workflows
-├── requirements/                 # Layered dependency sources (pip-tools)
-└── schemas/                      # JSON schemas for contracts
-```
+Core Python dependencies, development dependencies, CI dependencies, and ML
+capability layers are separated. Optional model runtimes such as DA3, Depth Pro,
+RAW ingest, SAM2, and FastVLM are installed and validated through their
+governed setup scripts and runtime manifests.
 
-### Package Organization (src/transformation_portal/)
+### Frontdoor And Backend Separation
 
-```
-transformation_portal/
-├── __init__.py                   # Package root with lazy imports
-├── lux_depth_v3/                 # 🔑 Main depth processing pipeline
-│   ├── __main__.py               # CLI entry point
-│   ├── orchestrator.py           # Pipeline orchestration
-│   ├── config.py                 # Configuration management
-│   └── ...                       # Preprocessing, postprocessing, etc.
-├── depth/                        # Depth estimation backends
-│   ├── backends/                 # DA3, Depth Pro backends
-│   └── registry.py               # Backend selection
-├── pipelines/                    # High-level workflows
-│   ├── lux_render_pipeline.py    # AI-powered render refinement
-│   └── depth_tools.py            # Depth processing utilities
-├── processors/                   # Core processing engines
-│   ├── luxury_video_master_grader.py  # Video color grading
-│   └── material_response/        # Material-aware processing
-├── enhancers/                    # Specialized enhancement
-├── analyzers/                    # Analysis & monitoring
-├── rendering/                    # Rendering workflows
-├── ingest/                       # RAW/TIFF ingest with provenance
-├── attestation/                  # Archive attestation CLI
-├── comfyui/                      # ComfyUI workflow integration
-├── spatial_ai/                   # Spatial AI features
-├── determinism/                  # Cross-ISA determinism tools
-├── utils/                        # Shared utilities
-└── cli/                          # CLI entry points
+The managed frontdoor owns browser authentication, session handling, access
+posture, public route handling, and frontdoor health checks. The FastAPI backend
+owns API contracts, pipeline readiness, job lifecycle, artifact access, and
+direct-debug portal behavior.
+
+## Repository Layout
+
+```text
+Transformation_Portal/
+├── app.py                         # FastAPI portal/orchestrator backend
+├── web/secure-landing/            # Managed Next frontdoor and portal bundle source
+├── src/transformation_portal/      # Main Python package
+├── src/luxury_tiff_batch_processor/# TIFF batch processor package
+├── scripts/                       # Setup, validation, bootstrap, and pipeline scripts
+├── tools/                         # Operator and governance tools
+├── config/                        # Runtime presets, manifests, budgets, and model locks
+├── requirements/                  # Layered dependency inputs, locks, and ownership metadata
+├── schemas/                       # JSON schema contracts
+├── tests/                         # Unit, contract, smoke, governance, and fixture tests
+├── docs/                          # Maintained and historical documentation
+├── workflows/                     # ComfyUI and workflow artifacts
+└── cloudflare/                    # Frontdoor-only Worker package when used
 ```
 
-## Module Responsibilities
+## Core Backend And API
 
-### Pipelines
-**Purpose**: Orchestrate complex, multi-step workflows
+`app.py` is the FastAPI integration surface. It wires:
 
-**Characteristics**:
-- High-level APIs
-- Coordinate multiple processors
-- Handle configuration and state
-- Provide progress tracking
-- Error handling and recovery
+- Portal HTML and assets: `/`, `/portal`, `/portal/assets/*`,
+  `/portal/bootstrap`, and portal video routes.
+- Health and readiness: `/healthz`, `/ready`, and `/v1/readiness`.
+- Operator configuration: `/v1/presets`, `/v1/config-metadata`, and
+  `/v1/config-preview`.
+- Portal event ingress: `/v1/portal/events`, `/v1/portal/rum`, and staged
+  upload routes.
+- Job lifecycle: `/v1/jobs`, `/v2/jobs`, job status, artifacts, cancellation,
+  and server-sent events.
 
-**Example**:
-```python
-# lux_render_pipeline.py
-from transformation_portal.processors.material_response.engine import MaterialResponseEngine
-from transformation_portal.utils.color_science import apply_lut
+Typed response models live under `src/transformation_portal/api/v1/`. Versioned
+API responses use the shared envelope model where applicable. The liveness and
+readiness probes deliberately preserve raw response shapes:
 
-def process_render(image_path, config):
-    """Complete render refinement pipeline."""
-    # 1. Load and preprocess
-    image = load_image(image_path)
+| Route | Shape | Owner |
+| --- | --- | --- |
+| `/healthz` | Raw JSON with `ok` and `time` | Load balancers, frontdoors, probes |
+| `/ready` | Raw JSON with `ok`, `time`, `version`, plus optional verbose fields | Backend readiness checks |
+| `/v1/readiness` | `tp.orchestrator.readiness.v1` API envelope | Operator truth for pipeline dispatch readiness |
 
-    # 2. AI enhancement
-    enhanced = ai_enhance(image, config)
+Do not wrap `/healthz` or `/ready` in the versioned API envelope unless the
+probe contract is intentionally changed and contract tests are updated.
 
-    # 3. Material response
-    if config.material_response:
-        material_engine = MaterialResponseEngine.from_config(
-            {"profile": "luxury_interior"}
-        )
-        enhanced = material_engine.apply(enhanced)
+## Managed Frontdoor
 
-    # 4. Color grading
-    result = apply_lut(enhanced, config.lut)
+`web/secure-landing` is the managed browser frontdoor. It handles:
 
-    return result
+- Login, logout, session cookies, Cloudflare Access posture, and local managed
+  smoke credentials.
+- Frontdoor `/healthz` readiness for backend connectivity, access config, user
+  source, session store, and session-scaling checks.
+- Proxying versioned backend requests while preserving auth and trace context.
+- Portal bundle generation from modular `portal-src/` sources.
+- RUM telemetry rollout controls, retry-after UX, deferred portal surfaces,
+  asset manifest checks, CSS layer parity, and browser smoke selectors.
+
+Node 22.x is the enforced runtime contract for frontdoor development,
+validation, and builds.
+
+## Package Modules
+
+The main package is organized by responsibility:
+
+| Package area | Responsibility |
+| --- | --- |
+| `api/v1` | Typed API envelopes and route response models |
+| `core` | Configuration, security, storage, observability, device, validation, geometry, and processing primitives |
+| `lux_depth_v3` | Main depth, materials, enhancement, artifact, run-card, and validation pipeline |
+| `depth` | Depth backend interfaces, registry, Depth Pro/DA3 style backend integration, and depth utilities |
+| `stage_graph`, `execution_graph`, `streaming`, `events`, `runtime`, `storage` | Execution primitives, scheduling, progress, event persistence, sandboxing, workers, and CAS/ledger storage |
+| `spatial_ai` | Reconstruction, segmentation, materials, ingest, and orchestration research surfaces |
+| `ingest`, `attestation`, `schemas` | Machine-mode metadata, provenance, archive attestation, and schema contracts |
+| `vlm_captioning`, `vlm`, `models` | Optional advisory captioning and model manifest helpers |
+| `pipelines`, `processors`, `enhancers`, `rendering`, `upscaling` | Image/video processing workflows and reusable processing engines |
+| `metrics`, `reporting`, `evals`, `analyzers`, `dev` | Validation, reporting, evaluation, and development tooling |
+
+Cross-module dependencies should remain directional. Shared primitives belong
+in `core`, interface packages, or focused helpers. High-level pipelines should
+not be imported by low-level utilities.
+
+## Pipeline And Job Flow
+
+The portal/orchestrator flow is:
+
+```text
+1. Frontdoor authenticates browser traffic and forwards allowed API requests.
+2. Backend returns config metadata and preset catalogs for the selected pipeline.
+3. `/v1/config-preview` normalizes arguments, validates paths, and returns
+   expected commands, outputs, warnings, and readiness.
+4. `/v1/jobs` enforces auth, rate limits, path policy, and readiness preflight.
+5. The backend starts the selected runner or internal job path.
+6. Events, status snapshots, and artifacts are exposed through job routes.
+7. Pipeline outputs include governed manifests, provenance, run cards, fixity
+   evidence, and advisory sidecars where enabled.
 ```
 
-### Processors
-**Purpose**: Core data transformation engines
+The governed pipeline set exposed through `/v1/readiness` currently covers
+`lux-depth-v3` and archive gates A/B/C. Per-pipeline readiness can be `ready`,
+`degraded`, or `blocked`; transport success is not the same as dispatch
+readiness.
 
-**Characteristics**:
-- Stateful or stateless operations
-- Well-defined input/output contracts
-- Reusable across pipelines
-- Optimized for performance
-- Extensive error checking
+## CLI And Runtime Entry Points
 
-**Example**:
-```python
-# material_response/engine.py
-from transformation_portal.processors.material_response.engine import MaterialResponseEngine
+Primary console scripts include:
 
-engine = MaterialResponseEngine.from_config(
-    {"profile": "luxury_interior", "texture_boost": 0.25}
-)
-enhanced_image = engine.apply(image)
+- `lux-depth-v3` for depth, materials, PBR, enhancement, APEX, and run-card
+  workflows.
+- `depth-aware-dof` for single-image depth-aware depth-of-field packaging.
+
+Operational runtime scripts live under `scripts/setup/`, `scripts/dev/`,
+`scripts/validation/`, and `scripts/pipelines/`. Optional local runtimes belong
+under `.runtime/` or dedicated venv paths managed by setup scripts, not ambient
+global Python installations.
+
+## Configuration And Presets
+
+Runtime configuration is governed by structured loaders and validation:
+
+- `config/` contains presets, runtime manifests, model locks, asset manifests,
+  budgets, and environment-independent configuration.
+- `config/presets/` separates stable, canary, and experimental presets.
+- `requirements/lock_ownership.yml` and related validators define dependency
+  lock ownership.
+- API schemas, machine-mode schemas, run-card schemas, and contract snapshots
+  are checked by focused tests and validation scripts.
+
+Avoid ad hoc `yaml.safe_load` in new runtime code unless it is routed through
+an approved loader boundary. The repo enforces YAML governance separately.
+
+## Dependency And Runtime Governance
+
+Dependency installation is not ad hoc. The governed paths are:
+
+```bash
+make install-core
+make repair-core-venv
+make check-environment
 ```
 
-### Enhancers
-**Purpose**: Specialized improvement algorithms
+The layered lock model separates:
 
-**Characteristics**:
-- Domain-specific enhancements
-- Often stateless functions
-- Composable with other enhancers
-- Well-documented parameters
+- Core runtime dependencies.
+- Development and CI tooling.
+- Security/tooling/archive layers.
+- Target-owned Darwin arm64 ML locks.
+- Optional local runtimes for DA3, Depth Pro, RAW ingest, SAM2, CoreML, and
+  FastVLM.
 
-**Example**:
-```python
-# enhance_aerial.py
-def enhance_aerial(image, settings):
-    """Enhance aerial photography with atmospheric effects."""
-    # Apply enhancements
-    return enhanced_image
+Linux x86_64 and Darwin x86_64 ML lock lanes are retired fail-closed stubs.
+Do not revive broad ML umbrella installs without a trusted checked-in lockfile
+contract and matching validation updates.
+
+## Security And Governance Boundaries
+
+Security-sensitive flows are centralized and fail closed:
+
+- API key enforcement on protected backend endpoints.
+- Trusted host and proxy controls.
+- Request size limits, rate limiting, and server-sent-event auth policy.
+- Allowed input/output roots and artifact path validation.
+- Frontdoor session cookies, Access posture, local user fixtures, and session
+  scaling checks.
+- RUM telemetry allow-lists, rollout controls, and sink policy tests.
+- Dependency pinning, lock ownership, banned dependency checks, and workflow
+  governance.
+
+Any change to auth, path handling, telemetry, dependency policy, or artifact
+serving must include focused tests and should preserve fail-closed behavior.
+
+## Testing And Validation
+
+Validation is layered by risk:
+
+```bash
+make test-fast
+make test-orchestrator-contract
+make test-frontdoor-contract
+make validate-portal-browser
+make validate-frontdoor-browser
+make ci
 ```
 
-### Analyzers
-**Purpose**: Code quality and workflow analysis
+Additional governance checks include:
 
-**Characteristics**:
-- Introspection and reporting
-- Non-invasive analysis
-- Dashboard and CLI interfaces
-- Monitoring and alerting
-
-### Utils
-**Purpose**: Shared utility functions
-
-**Characteristics**:
-- No business logic
-- Pure functions preferred
-- Well-tested
-- Broadly applicable
-
-**Anti-patterns to avoid**:
-- Don't put business logic in utils
-- Don't create circular dependencies
-- Don't add too many utilities (creates bloat)
-
-## Dependency Management
-
-### Internal Dependencies
-
-**Allowed**:
-- Utils can import from standard library only
-- Enhancers can import from utils
-- Processors can import from utils and enhancers
-- Pipelines can import from all lower layers
-- Analyzers can import from all layers (read-only)
-
-**Forbidden**:
-- No circular dependencies
-- Utils cannot import from other transformation_portal modules
-- Processors cannot import from pipelines
-
-### External Dependencies
-
-**Core Dependencies** (required for all):
-- numpy, Pillow, scipy, typer
-
-**Optional Dependencies**:
-- `[tiff]`: tifffile, imagecodecs
-- `[ml]`: torch, diffusers, transformers, controlnet-aux
-- `[dev]`: pytest, flake8, pylint
-
-**Adding New Dependencies**:
-1. Check if existing dependency can be used
-2. Evaluate size and maintenance status
-3. Add to appropriate optional-dependencies group
-4. Update documentation
-
-## Data Flow
-
-### Typical Processing Flow
-
-```
-Input
-  ↓
-[Pipeline] ← coordinates
-  ↓
-[Processor] ← transforms
-  ↓
-[Enhancer] ← improves
-  ↓
-[Processor] ← finalizes
-  ↓
-Output
+```bash
+make check-requirements-lock-contract
+make check-dependency-pinning
+make check-ci-sync
+make check-portal-asset-budgets
+make check-docs
+make check-doc-heading-links
+python3 scripts/governance/check_docs_structure.py --all
 ```
 
-### Example: Render Processing
+Use focused tests for small changes and broaden to contract/browser/live
+validation when touching shared behavior, public routes, selectors, pipeline
+dispatch, auth, dependency governance, or artifact handling.
 
-```
-Raw Render (render.jpg)
-  ↓
-lux_render_pipeline.py
-  ├─→ Load image
-  ├─→ AI enhancement (Stable Diffusion + ControlNet)
-  ├─→ Material Response enhancement
-  │     └─→ material_response/core.py
-  │           ├─→ Detect materials
-  │           ├─→ Apply physics-based enhancements
-  │           └─→ Return enhanced
-  ├─→ Color grading (LUT application)
-  ├─→ Sharpening and export
-  └─→ Save result (render_enhanced.jpg)
-```
+## Extension Rules
 
-## Testing Strategy
+When adding or changing architecture:
 
-### Test Organization
+1. Choose the narrowest package boundary that owns the behavior.
+2. Preserve public route shapes, API envelope names, CLI flags, selectors, and
+   artifact contracts unless the change explicitly updates them.
+3. Keep optional model/runtime dependencies out of the core layer.
+4. Add structured validation instead of relying on ambient shell state.
+5. Prefer existing loaders, serializers, storage helpers, path guards, and
+   response models over one-off parsing or JSON/YAML writes.
+6. Update tests, docs, and validation targets in the same patch as behavior
+   changes.
+7. Keep generated artifacts out of the worktree, or update ignore/governance
+   rules when a new generated path becomes normal workflow output.
 
-```
-tests/
-├── test_pipelines/
-├── test_processors/
-├── test_enhancers/
-├── test_analyzers/
-├── test_rendering/
-└── test_utils/
-```
+## Related Documents
 
-### Testing Principles
-
-1. **Unit Tests**: Test individual functions/classes
-2. **Integration Tests**: Test module interactions
-3. **End-to-End Tests**: Test complete workflows
-4. **Performance Tests**: Verify speed requirements
-5. **Regression Tests**: Prevent breaking changes
-
-### Test Coverage Goals
-
-- Utils: 95%+ coverage
-- Processors: 85%+ coverage
-- Pipelines: 75%+ coverage
-- Enhancers: 80%+ coverage
-
-## Configuration Management
-
-### YAML Configuration Pattern
-
-```yaml
-# config/preset_name.yaml
-pipeline:
-  name: "signature_estate"
-
-processor:
-  material_response:
-    enabled: true
-    strength: 0.7
-
-  color_grading:
-    lut: "assets/luts/location_aesthetic/Montecito_Golden_Hour.cube"
-    opacity: 0.75
-
-output:
-  format: "tiff"
-  bit_depth: 16
-  quality: 100
-```
-
-### Loading Configuration
-
-```python
-from pathlib import Path
-import yaml
-
-def load_config(config_path):
-    """Load YAML configuration."""
-    with open(config_path) as f:
-        return yaml.safe_load(f)
-
-# Usage
-config = load_config('config/signature_estate.yaml')
-```
-
-## Error Handling
-
-### Standard Error Pattern
-
-```python
-class TransformationPortalError(Exception):
-    """Base exception for all transformation portal errors."""
-    pass
-
-class ProcessingError(TransformationPortalError):
-    """Error during image processing."""
-    pass
-
-class ConfigurationError(TransformationPortalError):
-    """Invalid configuration."""
-    pass
-
-# Usage
-def process_image(image_path, config):
-    if not image_path.exists():
-        raise ProcessingError(f"Image not found: {image_path}")
-
-    if not validate_config(config):
-        raise ConfigurationError(f"Invalid config: {config}")
-
-    # Process...
-```
-
-### Error Recovery
-
-- Provide helpful error messages
-- Include context in exceptions
-- Log errors with traceback
-- Offer suggestions for fixes
-
-## Performance Considerations
-
-### Lazy Imports
-
-```python
-# Good: Lazy import for optional functionality
-def render_with_ai(image):
-    from transformation_portal.pipelines import lux_render_pipeline
-    return lux_render_pipeline.process(image)
-
-# Avoid: Top-level import of heavy dependencies
-# from transformation_portal.pipelines import lux_render_pipeline
-```
-
-### Caching
-
-```python
-from functools import lru_cache
-
-@lru_cache(maxsize=100)
-def load_model(model_name):
-    """Load model with caching."""
-    return expensive_model_load(model_name)
-```
-
-### Batch Processing
-
-```python
-def process_batch(images, batch_size=10):
-    """Process images in batches for better memory usage."""
-    for i in range(0, len(images), batch_size):
-        batch = images[i:i+batch_size]
-        yield process_images(batch)
-```
-
-## Versioning and Compatibility
-
-### Semantic Versioning
-
-- MAJOR: Breaking API changes
-- MINOR: New features, backward compatible
-- PATCH: Bug fixes, backward compatible
-
-### Deprecation Policy
-
-1. Mark feature as deprecated
-2. Add deprecation warning
-3. Document migration path
-4. Remove after 2 minor versions
-
-### Example Deprecation
-
-```python
-import warnings
-
-def old_function():
-    warnings.warn(
-        "old_function is deprecated, use new_function instead",
-        DeprecationWarning,
-        stacklevel=2
-    )
-    return new_function()
-```
-
-## Future Architecture Goals
-
-### Completed (v2.0.0 - Current)
-- [x] Stable public API contracts (schema-aligned payloads)
-- [x] Preset stability taxonomy (stable / canary / experimental)
-- [x] Service hardening with `/ready` readiness checks
-- [x] Context-aware rendering workflows
-- [x] Unified CLI interface (`lux-depth-v3`)
-- [x] Backend registry with automatic fallback
-- [x] Performance monitoring (APEX System)
-
-### Near Term (v2.1.x)
-- [ ] Enhanced plugin architecture
-- [ ] Additional depth backend integrations
-- [ ] Async batch processing support
-- [ ] Extended RAW format support
-
-### Future (v3.0.0)
-- [ ] Distributed processing
-- [ ] Web API improvements
-- [ ] Enterprise features
-- [ ] CoreML optimization for Apple Silicon
-
-## Contributing
-
-### Adding a New Module
-
-1. Choose appropriate package (pipelines, processors, etc.)
-2. Create module with clear docstring
-3. Add unit tests (aim for 80%+ coverage)
-4. Update package `__init__.py` if needed
-5. Add documentation
-6. Update CHANGELOG
-
-### Code Review Checklist
-
-- [ ] Follows existing code style
-- [ ] Has docstrings and type hints
-- [ ] Includes tests
-- [ ] No circular dependencies
-- [ ] Performance considerations addressed
-- [ ] Error handling in place
-- [ ] Documentation updated
-
-## Questions?
-
-- See [CONTRIBUTING.md](../../CONTRIBUTING.md) for contribution guidelines
-- See [TROUBLESHOOTING.md](../guides/TROUBLESHOOTING.md) for common issues
-- Open an issue on GitHub for specific questions
+- [Portal + Orchestrator Quickstart](../guides/PORTAL_ORCHESTRATOR_QUICKSTART.md)
+- [Portal Secure Front Door Quickstart](../guides/PORTAL_SECURE_FRONTDOOR_QUICKSTART.md)
+- [Lux Depth V3 CLI Guide](../cli/LUX_DEPTH_V3_CLI_GUIDE.md)
+- [ADR-019 Depth Backend Unification](ADR-019-depth-backend-unification.md)
+- [ADR-032 Dependency Pinning Strategy](ADR-032-dependency-pinning-strategy.md)
+- [Documentation Map](../governance/DOCUMENTATION_MAP.md)

--- a/docs/architecture/CODEBASE_AUDIT_2026_Q1.md
+++ b/docs/architecture/CODEBASE_AUDIT_2026_Q1.md
@@ -32,7 +32,8 @@ Current posture as of this refresh:
   Python test files and 30 workflow YAML files were observed during this
   refresh.
 - Architecture decomposition has progressed, but the repository still contains
-  large integration files, especially `app.py` and `lux_depth_v3/orchestrator.py`.
+  large integration files, especially `app.py` and
+  `src/transformation_portal/lux_depth_v3/orchestrator.py`.
 - Full `make ci` was not run for this document refresh; conclusions below are
   based on static inspection plus documentation validation.
 
@@ -287,7 +288,7 @@ Current risks:
 | Priority | Workstream | Current recommendation |
 | --- | --- | --- |
 | P0 | Preserve contracts | Keep `/healthz`, `/ready`, `/v1/readiness`, job routes, frontdoor selectors, CLI flags, and schema names stable unless a change intentionally updates them with tests. |
-| P1 | Architecture debt | Continue incremental `app.py` and `lux_depth_v3/orchestrator.py` decomposition around already-extracted modules. |
+| P1 | Architecture debt | Continue incremental `app.py` and `src/transformation_portal/lux_depth_v3/orchestrator.py` decomposition around already-extracted modules. |
 | P1 | Frontdoor validation | Keep Node 22, frontdoor health, browser smoke selectors, and portal bundle generation deterministic. |
 | P1 | Dependency governance | Preserve lock ownership, marker contracts, retired ML lane stubs, and optional runtime setup boundaries. |
 | P2 | Documentation hygiene | Maintain current navigation through the documentation map; classify historical material instead of mass-updating dates. |
@@ -325,4 +326,5 @@ CI governance, more test coverage, and stronger telemetry/dependency policy.
 The main remaining engineering risk is not lack of governance; it is the size
 and coupling of central integration surfaces. Future work should preserve the
 current contracts while continuing narrow decomposition of `app.py`,
-`lux_depth_v3/orchestrator.py`, and adjacent runtime/portal seams.
+`src/transformation_portal/lux_depth_v3/orchestrator.py`, and adjacent
+runtime/portal seams.

--- a/docs/architecture/CODEBASE_AUDIT_2026_Q1.md
+++ b/docs/architecture/CODEBASE_AUDIT_2026_Q1.md
@@ -1,425 +1,328 @@
 # Transformation Portal Codebase Audit
 
-**Date:** 2026-03-15
-**Version:** v2.0.0 (Golden Path baseline)
-**Auditor:** Architect Agent
-**Scope:** Full repository health assessment with ratings and actionable roadmap
+**Original audit window:** 2026 Q1
+**Current refresh:** 2026-05-12
+**Repository baseline inspected:** `main` at `a3cf8030c docs(governance): refresh todo inventory baseline (#1723)`
+**Document classification:** current-support
+**Scope:** Refresh the Q1 audit against the current codebase, documentation
+baseline, and validation contracts without changing runtime behavior.
 
 ---
 
 ## Executive Summary
 
-The Transformation Portal is a **sophisticated, production-grade context-aware rendering engine** for luxury real estate and architectural visualization. The codebase demonstrates **strong fundamentals** in security, testing, and governance, but has **targeted areas requiring improvement** in code architecture, documentation organization, and CI/CD optimization.
+Transformation Portal is now best described as a governed image and video
+processing platform for luxury real estate rendering, architectural
+visualization, and editorial finishing. The March 2026 Q1 audit correctly
+identified strong foundations in security, dependency governance, test
+infrastructure, and performance discipline, but several facts in the original
+scorecard are now stale.
 
-### Overall Assessment: **7.6/10** (Good, with focused improvements needed)
+Current posture as of this refresh:
 
-| Category | Rating | Status |
-|----------|--------|--------|
-| **Security** | 8.5/10 | ✅ Phase 1 fixes complete |
-| **Testing** | 7.7/10 | ✅ Strong with documentation gaps |
-| **Dependency Management** | 8.2/10 | ✅ Excellent |
-| **Documentation** | 7.5/10 | ⚠️ Strong substance, organizational challenges |
-| **CI/CD** | 8.0/10 | ✅ Mature and sophisticated |
-| **Code Architecture** | 6.2/10 | ⚠️ Refactoring required |
-| **Performance Governance** | 8.0/10 | ✅ Strong Quality Firewall |
+- The browser-facing architecture is `Browser -> managed Next frontdoor ->
+  FastAPI backend`. A Cloudflare Worker, when present, remains frontdoor-only
+  and must not proxy directly to FastAPI.
+- Health/readiness contracts are active governed surfaces: `/healthz`,
+  `/ready`, and `/v1/readiness` preserve distinct wire shapes and test
+  coverage.
+- Documentation governance has moved from ad hoc cleanup to a May 11, 2026
+  repo-wide documentation baseline and inventory.
+- Testing and CI are substantially larger than the Q1 snapshot: roughly 606
+  Python test files and 30 workflow YAML files were observed during this
+  refresh.
+- Architecture decomposition has progressed, but the repository still contains
+  large integration files, especially `app.py` and `lux_depth_v3/orchestrator.py`.
+- Full `make ci` was not run for this document refresh; conclusions below are
+  based on static inspection plus documentation validation.
 
----
+## Current Directional Scorecard
 
-## Category Ratings (1-10 Scale)
+The old numerical scores are retained only as Q1 context. Current status should
+be read directionally unless a specific validation command is listed as proven
+green.
 
-### 1. Security: 8.5/10 ⭐⭐⭐⭐
+| Area | Current posture | Notes |
+| --- | --- | --- |
+| Security | Strong | Fail-closed path/auth posture, portal RUM controls, dependency scanning, and model/runtime governance are active. |
+| Testing | Strong, broad | Test surface has grown to about 606 Python test files with contract, smoke, governance, security, and fixture coverage. |
+| Dependency governance | Strong | Layered locks, ownership checks, retired ML lane stubs, and governed optional runtime installers remain central. |
+| Documentation | Improved, governed | May 11 repo-wide refresh classified current, support, mixed, historical, and archive-only docs. |
+| CI/CD | Mature, complex | 30 workflow YAML files and Make validation lanes cover CI, security, dependency, docs, portal, and pipeline checks. |
+| Code architecture | Mixed | Decomposition modules exist, but large integration files still require careful ownership and focused refactors. |
+| Performance governance | Strong but lane-specific | Quality firewall, benchmark isolation, APEX, ledger, and determinism surfaces remain active; full live performance status requires lane-specific runs. |
 
-**Strengths:**
-- ✅ Comprehensive security module (`core/security/`) with path validation, sanitization, and restricted unpickler
-- ✅ Banned dependency registry with hard-blocks (CVE-2024-27763 protection)
-- ✅ Multi-layer scanning: pip-audit, safety, bandit, CodeQL, gitleaks
-- ✅ Strong subprocess safety (no `shell=True` usage)
-- ✅ Model lock security with revision pinning
-- ✅ Plugin trust model with external plugins disabled by default
+## Current System Boundaries
 
-**Weaknesses (Pre-Phase 1 findings, now resolved):**
-- ~~❌ Unsafe pickle usage in cache layer (`depth/utils/cache.py`)~~ → ✅ Uses `safe_pickle_load`
-- ~~❌ Incomplete stub implementation (`lux_depth_v3/security.py`)~~ → ✅ Full implementation
-- ~~❌ Unvalidated subprocess arguments in v2_runner.py~~ → ✅ Path validation added
-- ⚠️ No authentication/authorization framework (acceptable for local CLI)
-- ⚠️ Temporary file handling undocumented
+### Frontdoor And Backend
 
-**Risk Matrix:**
+The current runtime topology is:
 
-| Issue | Severity | CVSS | Status |
-|-------|----------|------|--------|
-| Unsafe pickle in cache | HIGH | 8.1 | ✅ Fixed (uses safe_pickle_load) |
-| Unvalidated subprocess args | MEDIUM | 6.2 | ✅ Fixed (path validation added) |
-| Stub security implementation | MEDIUM | 5.5 | ✅ Fixed (full implementation) |
-| Temp file handling | MEDIUM | 5.0 | 🟡 Partial |
-
----
-
-### 2. Testing: 7.7/10 ⭐⭐⭐⭐
-
-**Strengths:**
-- ✅ Sophisticated tier strategy (Core → ML-fast → ML-slow)
-- ✅ 316 test files with comprehensive coverage
-- ✅ Determinism validation with FP state enforcement
-- ✅ Boundary enforcement tests (torch-free core tier)
-- ✅ Security tests (deserialization, checksums, plugins, isolation)
-- ✅ Smart CI integration with change classification
-
-**Weaknesses:**
-- ❌ Only 10 tests marked `@pytest.mark.unit` (should be 80+)
-- ❌ Only 5 tests marked `@pytest.mark.integration`
-- ❌ No `TESTING.md` or test strategy document
-- ❌ `/tests/golden/` directory empty
-- ⚠️ 279 conditional skips may hide flaky tests
-
-**Test Organization:**
-
-| Directory | Count | Quality |
-|-----------|-------|---------|
-| spatial_ai/ | 51 | ✅ Strong |
-| unit/ | 15 | ✅ Excellent |
-| security/ | 4 | ✅ Professional |
-| Root-level | 181 | ⚠️ Needs marker cleanup |
-
----
-
-### 3. Dependency Management: 8.2/10 ⭐⭐⭐⭐
-
-**Strengths:**
-- ✅ Sophisticated pip-tools layered architecture (base/ml/dev/ci)
-- ✅ Two-phase compilation prevents dependency conflicts
-- ✅ 100% pinned dependencies (zero floating deps)
-- ✅ ADR-032 compliant pinning strategy
-- ✅ Banned dependency registry with hard-blocks
-- ✅ Weekly automated updates with safety reports
-
-**Weaknesses:**
-- ⚠️ Lock files occasionally stale (base.txt older than base.in)
-- ⚠️ Dependabot/manual workflow conflict potential
-- ⚠️ ML tier not scanned by pip-audit in PR workflow
-- ⚠️ No SBOM (Software Bill of Materials) generation
-
-**Pinning Strategy:**
-
-| Style | Count | Usage |
-|-------|-------|-------|
-| Range Pin (`>=X,<Y`) | 65% | Production deps |
-| Lower-Bound (`>=X`) | 20% | Dev tools |
-| Strict Pin (`==X.Y.Z`) | 17% | Critical ML deps |
-| Unpinned | 0% | ✅ Excellent |
-
----
-
-### 4. Documentation: 7.5/10 ⭐⭐⭐⭐
-
-**Strengths:**
-- ✅ Excellent README (411 lines, comprehensive)
-- ✅ 42 Architecture Decision Records (ADRs)
-- ✅ Strong API contracts (MACHINE_MODE_CONTRACT.md)
-- ✅ Excellent TODO_INVENTORY.md (v2.1.0, 62 KB)
-- ✅ Keep a Changelog versioning discipline
-
-**Weaknesses:**
-- ❌ 99 directories for ~70 canonical documents (bloated)
-- ❌ Parallel ADR hierarchies (architecture/ + decisions/ + adr/)
-- ❌ 15+ stub documents (<50 lines)
-- ❌ 83% of docs missing "Last Updated" metadata
-- ❌ No V1→V2 migration guide
-
-**Documentation Scorecard:**
-
-| Aspect | Score |
-|--------|-------|
-| README Completeness | 9/10 |
-| Architecture Records | 8.5/10 |
-| User Guides | 7.5/10 |
-| Organization | 5.5/10 |
-
----
-
-### 5. CI/CD: 8.0/10 ⭐⭐⭐⭐
-
-**Strengths:**
-- ✅ Intelligent change detection (5x faster on docs-only PRs)
-- ✅ Multi-layered quality gates (lint, security, test, manifest)
-- ✅ Merkle proof verification for data integrity
-- ✅ Determinism cross-ISA testing
-- ✅ Comprehensive dependency locking
-- ✅ CI gate aggregator pattern for branch protection
-
-**Weaknesses:**
-- ⚠️ Actions not pinned to commit SHAs (use @v6, @v7, @v8)
-- ⚠️ No intra-job test parallelization (sequential pytest)
-- ⚠️ mypy is soft-fail (type errors don't block)
-- ⚠️ No pytest-rerunfailures for flaky tests
-- ⚠️ `fail-fast: true` hides multi-branch failures
-
-**Build Times:**
-
-| Job | Timeout | Status |
-|-----|---------|--------|
-| Lightweight | 5 min | ✅ Fast |
-| Lint | 20 min | ⚠️ Could optimize |
-| Test Matrix | 45 min | ⚠️ Sequential |
-| **Full Suite** | 65-75 min | ⚠️ Could be 40-50 min |
-
----
-
-### 6. Code Architecture: 6.2/10 ⭐⭐⭐
-
-**Strengths:**
-- ✅ Core module exemplary (0 internal cross-imports)
-- ✅ 8 well-designed interface ABCs
-- ✅ Protocol-driven design in spatial_ai/
-- ✅ Immutable data patterns (frozen dataclasses)
-- ✅ Comprehensive type hints
-- ✅ Lazy loading for ML dependencies
-
-**Critical Issues:**
-
-| Issue | File | LOC | Severity |
-|-------|------|-----|----------|
-| Monolithic orchestrator | `lux_depth_v3/orchestrator.py` | 6,108 | 🔴 CRITICAL |
-| Circular imports | `depth/ ↔ lux_depth_v3/` | N/A | 🔴 CRITICAL |
-| Giant pipeline files | `rendering_4k_pipeline.py` | 2,379 | 🟠 HIGH |
-| Unused interfaces | `interfaces/` | 800 | 🟡 MEDIUM |
-
-**Module Ratings:**
-
-| Module | LOC | Rating |
-|--------|-----|--------|
-| core/ | 2.7K | 9/10 ✅ |
-| interfaces/ | 0.8K | 8/10 ✅ |
-| spatial_ai/ | 14K | 7/10 ⚠️ |
-| depth/ | 10K | 5/10 ❌ |
-| pipelines/ | 7.8K | 4/10 ❌ |
-| lux_depth_v3/ | 21.5K | 3/10 ❌ |
-
----
-
-### 7. Performance Governance: 8.0/10 ⭐⭐⭐⭐
-
-**Strengths:**
-- ✅ Quality Firewall with p95/mean latency gates
-- ✅ Performance ledger tracking
-- ✅ Benchmark tests properly isolated (`@pytest.mark.benchmark`)
-- ✅ ADR-034 benchmark exclusion from PR gating
-- ✅ Determinism enforcement layer
-
-**Weaknesses:**
-- ⚠️ No nightly benchmark regression workflow active
-- ⚠️ Performance impact callouts missing in CHANGELOG
-- ⚠️ Some operations use Python loops instead of vectorized ops
-
----
-
-## Actionable Roadmap
-
-### Phase 1: Critical Security Fixes (1-2 days) ✅ COMPLETED
-
-**Effort:** 4-6 hours
-**Priority:** 🔴 CRITICAL
-**Status:** ✅ Implemented 2026-03-16
-
-| Task | File | Effort | Status |
-|------|------|--------|--------|
-| Replace unsafe pickle with `safe_pickle_load()` | `depth/utils/cache.py` | 30 min | ✅ Pre-existing |
-| Add path validation to subprocess calls | `lux_depth_v3/v2_runner.py` | 1 hour | ✅ Complete |
-| Complete security.py stub | `lux_depth_v3/security.py` | 2 hours | ✅ Complete |
-| Add security event logging | `core/security/*.py` | 1 hour | ✅ Complete |
-
-**Implementation Summary:**
-- `cache.py`: Already used `safe_pickle_load` - no changes needed
-- `v2_runner.py`: Added `safe_resolve_path` validation for all path arguments
-- `security.py`: Removed stub notice, added full implementation with logging
-- `path.py`, `serialization.py`: Added security event logging
-
----
-
-### Phase 2: Testing Improvements (1 week)
-
-**Effort:** 10-15 hours
-**Priority:** 🟠 HIGH
-**Status:** ✅ COMPLETE (core items)
-
-| Task | Effort | Impact | Status |
-|------|--------|--------|--------|
-| Retrofit `@pytest.mark.unit` to 80+ tests | 2 hours | Governance | ✅ Complete (81 files) |
-| Add `@pytest.mark.security` to all security tests | 1 hour | Governance | ✅ Complete (7 files) |
-| Create `docs/testing/STRATEGY.md` | 3 hours | Documentation | ✅ Complete |
-| Migrate golden tests to `/tests/golden/` | 2 hours | Organization | ✅ Complete (fixtures exist) |
-| Add pytest-rerunfailures for flaky tests | 1 hour | CI Stability | ✅ Complete (v16.1 installed) |
-| Implement per-subsystem coverage thresholds | 2 hours | Quality | 🔄 Pending (future enhancement) |
-
-**Implementation Summary (2026-03-21):**
-- Created `docs/testing/STRATEGY.md` with comprehensive test strategy
-- Retrofitted `@pytest.mark.unit` markers to 71 additional test files (81 total)
-- Added `@pytest.mark.security` markers to 7 security-focused test files
-- Golden tests exist in `/tests/golden/` with fixtures for phase4, reconstruction, and run_card
-- pytest-rerunfailures configured via `requirements/dev.in` (>=14,<17), currently pinned to v16.1 in `requirements/dev.txt`
-
-**Example Test Strategy Doc:**
-```markdown
-# Test Strategy
-
-## Layer 1: Core (torch-free)
-- Markers: none (default), `not ml and not slow`
-- Duration: < 2 min
-- Coverage: 25% minimum
-
-## Layer 2: ML-Fast
-- Markers: `ml and not slow and not integration`
-- Duration: < 10 min
-- Ceiling: 70 tests (enforced)
-
-## Layer 3: ML-Slow
-- Markers: `ml and slow`
-- Duration: Nightly only
+```text
+Browser
+  -> managed Next frontdoor (`web/secure-landing`)
+  -> FastAPI backend (`app.py`)
+  -> orchestrator jobs, pipeline CLIs, local runtimes, and artifacts
 ```
 
----
+The frontdoor owns browser login/logout, Cloudflare Access posture, local smoke
+credentials, session handling, proxy behavior, frontdoor `/healthz`, RUM
+rollout controls, and portal bundle generation. Node 22.x is the enforced
+frontdoor runtime contract.
 
-### Phase 3: Documentation Organization (1 week)
+The FastAPI backend owns direct-debug portal behavior, typed API envelopes,
+pipeline readiness, job lifecycle, server-sent events, artifact serving, and
+protected API-key routes.
 
-**Effort:** 15-20 hours
-**Priority:** 🟡 MEDIUM
-**Status:** 🟢 IN PROGRESS (core items complete)
+### Health And Readiness
 
-| Task | Effort | Impact | Status |
-|------|--------|--------|--------|
-| Remove/complete 15+ stub documents | 2 hours | Cleanup | 🔄 Pending (stubs are redirects) |
-| Add "Last Updated" metadata to canonical docs | 4 hours | Governance | 🔄 In Progress |
-| Consolidate ADR storage (single directory) | 3 hours | Navigation | ✅ Complete |
-| Archive historical docs to `_archive/` | 2 hours | Clarity | ✅ Complete |
-| Create V1→V2 migration guide | 3 hours | Onboarding | ✅ Complete (updated) |
-| Expand PORTAL_ORCHESTRATOR_QUICKSTART | 2 hours | API Docs | 🔄 Pending |
+Current health contracts are intentionally split:
 
-**Implementation Summary (2026-03-21):**
-- Consolidated ADR storage: moved `docs/architecture/adr/` and `docs/architecture/decisions/` content to `docs/_archive/2026-Q1-consolidation/`
-- Updated `docs/migration/MIGRATION_GUIDE.md` to v2.0.0 with current breaking changes, new features, and deprecation schedule
-- Note: Many "stub" documents are compatibility redirects to canonical locations
+| Route | Contract |
+| --- | --- |
+| `/healthz` | Raw minimal liveness JSON with `ok` and `time`; not API-enveloped. |
+| `/ready` | Raw backend readiness JSON with `ok`, `time`, `version`, and optional verbose fields. |
+| `/v1/readiness` | `tp.orchestrator.readiness.v1` envelope with per-pipeline dispatch truth. |
 
-**Directory Consolidation:**
+The readiness matrix currently covers `lux-depth-v3` and archive gates A/B/C.
+Transport success is not sufficient to prove dispatch readiness; per-pipeline
+state can be `ready`, `degraded`, or `blocked`.
+
+### Pipeline And Artifact Surfaces
+
+Current governed surfaces include:
+
+- Lux Depth V3 depth, materials, PBR, enhancement, run-card, and artifact
+  workflows.
+- APEX quality and model-family characterization surfaces.
+- Archive gates A/B/C and machine-mode archive contracts.
+- Spatial AI reconstruction, segmentation, materials, and ingest research
+  surfaces.
+- Optional FastVLM advisory captioning through subprocess-isolated runtime
+  checks; captions remain advisory and are not quality-gate evidence.
+- Provenance, manifests, attestation, content-addressed storage, run cards, and
+  fixity evidence.
+
+## Findings By Area
+
+### 1. Security And Governance
+
+Current strengths:
+
+- Backend protected endpoints enforce API key policy when enabled.
+- Trusted-host, proxy, content-length, rate-limit, artifact-path, and allowed
+  root boundaries remain fail-closed surfaces.
+- Frontdoor session handling and Cloudflare Access posture are isolated from
+  direct backend debugging.
+- RUM telemetry has explicit allow-lists, rollout controls, retention/deletion
+  evidence, and sink-path governance.
+- Dependency security is governed through lockfiles, banned dependency checks,
+  pip-audit/security workflows, Bandit, CodeQL, and gitleaks.
+
+Current risks:
+
+- Security-sensitive code is spread across backend middleware, frontdoor
+  routing/session helpers, validation scripts, and pipeline path guards. Keep
+  future fixes narrow and contract-tested.
+- Optional local model runtimes introduce filesystem and download boundaries;
+  keep them under governed setup scripts and `.runtime/` contracts.
+
+### 2. Testing
+
+Current strengths:
+
+- The repository now has about 606 Python test files.
+- Coverage includes unit, contract, HTTP, browser-smoke script tests, security,
+  dependency governance, docs governance, ingest, archive, APEX, Materials V3,
+  spatial AI, and runtime fixtures.
+- `pytest-rerunfailures` and `pytest-xdist` are present in the governed dev
+  dependency layer.
+- Frontdoor has Node test, build, CSS, utility-ownership, and Playwright smoke
+  surfaces.
+
+Current risks:
+
+- Broad test volume increases triage cost. Failures should be grouped by root
+  cause: product regression, stale test contract, or environment/tooling.
+- Browser and optional-runtime validations can fail due to local Chrome,
+  sandbox, port, model, or network state. Do not weaken product contracts until
+  the failure class is proven.
+
+Primary validation lanes:
+
+```bash
+make test-fast
+make test-orchestrator-contract
+make test-frontdoor-contract
+make validate-portal-browser
+make validate-frontdoor-browser
+make ci
 ```
-docs/architecture/         # All ADRs (primary)
-docs/architecture/versions/ # Superseded ADR versions
-docs/_archive/2026-Q1/     # Historical sessions, status, pr_archive
+
+### 3. Dependency Management
+
+Current strengths:
+
+- `pyproject.toml` keeps broad package ranges while checked-in lockfiles enforce
+  tested combinations.
+- `requirements/` owns generic, dev, CI, security, tools-archive, and target
+  ML lock surfaces.
+- Darwin arm64 ML is the target-owned ML lane; Linux x86_64 and Darwin x86_64
+  ML lanes are retired fail-closed stubs.
+- Optional DA3, Depth Pro, RAW, SAM2, CoreML, and FastVLM runtimes have
+  explicit setup or validation commands.
+
+Current risks:
+
+- Direct `pip install ...` guidance is not the supported remediation path for
+  normal development health. Prefer Make targets and lock-governed installers.
+- Dependency updates must preserve marker contracts, lock ownership, and
+  current CI sync checks.
+
+Primary commands:
+
+```bash
+make install-core
+make repair-core-venv
+make check-environment
+make check-requirements-lock-contract
+make check-dependency-pinning
+make check-ci-sync
 ```
 
----
+### 4. Documentation
 
-### Phase 4: CI/CD Optimization (2 weeks)
+Current strengths:
 
-**Effort:** 20-25 hours
-**Priority:** 🟡 MEDIUM
-**Status:** 🟢 IN PROGRESS (core items complete)
+- The May 11 documentation refresh established current navigation and a
+  repo-wide classification inventory.
+- `docs/governance/DOCUMENTATION_MAP.md` is the current source of truth for
+  maintained navigation.
+- `docs/architecture/ARCHITECTURE.md` now reflects the current system topology
+  and contract boundaries.
+- Documentation topology is enforced by `scripts/governance/check_docs_structure.py`.
 
-| Task | Effort | Impact | Status |
-|------|--------|--------|--------|
-| Pin all actions to commit SHAs | 3 hours | Security | ✅ Complete |
-| Add pytest-xdist for test parallelization | 2 hours | 20-30% faster CI | ✅ Complete |
-| Make mypy hard-fail for critical modules | 2 hours | Type Safety | ✅ Complete |
-| Add per-test timeouts (`--timeout=60`) | 1 hour | Stability | 🔄 Pending |
-| Set `fail-fast: false` for comprehensive detection | 1 hour | Debugging | ✅ Pre-existing |
-| Implement nightly benchmark regression | 4 hours | Performance | 🔄 Pending |
-| Add SBOM generation | 3 hours | Compliance | 🔄 Pending |
+Current risks:
 
-**Implementation Summary (2026-03-21):**
-- Pinned all GitHub Actions to commit SHAs in `ci.yml` and `build.yml`
-- Added `pytest-xdist>=3.5,<4` to requirements for parallel test execution
-- Updated test commands to use `-n auto` for parallel execution
-- Made mypy type checking hard-fail (removed `continue-on-error: true`)
+- Historical and mixed docs intentionally retain old dates, commands, and
+  conclusions. Do not promote them as current guidance without checking the
+  documentation map.
+- Point-in-time reports should be refreshed only when they are classified as
+  current-support or linked by current navigation.
 
-**Projected CI Time Improvement:**
-- Before: 65-75 min (sequential tests)
-- After: 40-50 min (-35%) with parallel test execution
+Primary commands:
 
----
-
-### Phase 5: Architecture Refactoring (4-6 weeks)
-
-**Effort:** 90-130 hours
-**Priority:** 🟠 HIGH (long-term)
-
-| Task | Effort | Impact |
-|------|--------|--------|
-| Extract orchestrator into 4 focused classes | 40-60 hours | Maintainability |
-| Resolve circular imports (depth ↔ lux_depth_v3) | 10-15 hours | Modularity |
-| Break giant pipeline files into modules | 30-40 hours | Readability |
-| Implement Pipeline ABC contracts | 15-20 hours | Consistency |
-
-**Orchestrator Decomposition:**
-```
-lux_depth_v3/orchestrator.py (6,108 LOC)
-  ├── config_resolver.py (~1,000 LOC)
-  ├── pipeline_coordinator.py (~1,500 LOC)
-  ├── artifact_manager.py (~1,500 LOC)
-  └── execution_engine.py (~2,000 LOC)
+```bash
+make check-docs
+make check-stale-docs
+make check-doc-heading-links
+python3 scripts/governance/check_docs_structure.py --all
 ```
 
-**Expected Improvements:**
-- Maintainability: 5/10 → 8/10 (+60%)
-- Cyclomatic Complexity: ↓ 40-50%
-- Onboarding Time: ↓ 50%
+### 5. CI/CD
 
----
+Current strengths:
 
-## Summary Scorecard
+- `.github/workflows/` contains 30 workflow YAML files.
+- The local `make ci` target chains lint, serialization, YAML governance,
+  pip-tools cache, requirements lock contract, dependency pinning, CI sync,
+  portal asset budgets, fast tests, orchestrator contracts, and frontdoor
+  contracts.
+- CI includes security, dependency, documentation, ML, frontdoor, archive,
+  determinism, APEX, and quality firewall surfaces.
 
-### Category Breakdown
+Current risks:
 
-| Category | Current | Target | Gap |
-|----------|---------|--------|-----|
-| Security | 8.5 | 9.0 | -0.5 |
-| Testing | 7.7 | 8.5 | -0.8 |
-| Dependency Management | 8.2 | 9.0 | -0.8 |
-| Documentation | 7.5 | 8.5 | -1.0 |
-| CI/CD | 8.0 | 9.0 | -1.0 |
-| Code Architecture | 6.2 | 8.0 | -1.8 |
-| Performance | 8.0 | 8.5 | -0.5 |
-| **OVERALL** | **7.6** | **8.6** | **-1.0** |
+- Workflow count and optional lanes make triage noisy. Keep suspected
+  cancellations separate from confirmed root-cause failures.
+- Scheduled/main failures can be stale relative to HEAD. Verify current source
+  files and local validators before reopening already-fixed contract logic.
 
-### Investment vs. Return
+### 6. Code Architecture
 
-| Phase | Effort | Impact | Status |
-|-------|--------|--------|--------|
-| Phase 1: Security | 4-6 hours | Critical risk mitigation | ✅ Complete |
-| Phase 2: Testing | 10-15 hours | Governance + stability | ✅ Complete |
-| Phase 3: Documentation | 15-20 hours | Developer experience | 🟢 In Progress (core complete) |
-| Phase 4: CI/CD | 20-25 hours | 35% faster CI | ✅ Complete |
-| Phase 5: Architecture | 90-130 hours | Long-term maintainability | 🔄 Pending |
+Current strengths:
 
-### Recommended Priority Order
+- Package boundaries are clearer around `api/v1`, `core`, `lux_depth_v3`,
+  `depth`, `stage_graph`, `execution_graph`, `runtime`, `storage`,
+  `spatial_ai`, `ingest`, `attestation`, `schemas`, and frontdoor code.
+- ADR-043 introduced concrete decomposition targets and supporting
+  `lux_depth_v3` modules such as `config_resolver.py`,
+  `pipeline_coordinator.py`, `artifact_manager.py`, and `execution_engine.py`.
+- Typed API models and schema envelopes reduce ambiguity at the route boundary.
 
-1. **Phase 1** (Security) - ✅ COMPLETED
-2. **Phase 2** (Testing) - ✅ COMPLETED (strategy doc + markers + golden tests + rerunfailures)
-3. **Phase 4** (CI/CD) - ✅ COMPLETED (action pinning + xdist + mypy hard-fail)
-4. **Phase 3** (Documentation) - 🟢 IN PROGRESS (ADR consolidation + migration guide done)
-5. **Phase 5** (Architecture) - Strategic, phased over quarters (ADR-043 complete)
+Current risks:
 
----
+- `app.py` is still a large integration module, observed at about 8.9K lines.
+- `src/transformation_portal/lux_depth_v3/orchestrator.py` remains large,
+  observed at about 6.9K lines, even with extracted supporting modules.
+- Architecture work should continue as incremental, contract-preserving
+  slices. Avoid broad rewrites of orchestrator, portal, or frontdoor surfaces.
+
+Recommended refactor posture:
+
+- Extract only when it reduces real coupling or isolates a testable contract.
+- Keep public routes, schema names, CLI flags, selectors, and artifact paths
+  stable unless the change explicitly updates them.
+- Pair every behavior change with focused tests and the correct validation
+  lane.
+
+### 7. Performance And Determinism
+
+Current strengths:
+
+- APEX, quality firewall, performance ledger, benchmark markers, and
+  determinism harnesses remain active governance surfaces.
+- Run cards, manifests, provenance, content-addressed storage, and fixity
+  checks support repeatable artifact review.
+
+Current risks:
+
+- Live performance status is lane-specific. Static docs refreshes should not
+  claim benchmark health unless the relevant benchmark or APEX lane was run.
+- Optional ML backends and local model runtimes can shift performance and
+  availability; readiness should report those states explicitly.
+
+## Updated Roadmap
+
+| Priority | Workstream | Current recommendation |
+| --- | --- | --- |
+| P0 | Preserve contracts | Keep `/healthz`, `/ready`, `/v1/readiness`, job routes, frontdoor selectors, CLI flags, and schema names stable unless a change intentionally updates them with tests. |
+| P1 | Architecture debt | Continue incremental `app.py` and `lux_depth_v3/orchestrator.py` decomposition around already-extracted modules. |
+| P1 | Frontdoor validation | Keep Node 22, frontdoor health, browser smoke selectors, and portal bundle generation deterministic. |
+| P1 | Dependency governance | Preserve lock ownership, marker contracts, retired ML lane stubs, and optional runtime setup boundaries. |
+| P2 | Documentation hygiene | Maintain current navigation through the documentation map; classify historical material instead of mass-updating dates. |
+| P2 | CI triage | Group failures by current root cause and distinguish stale scheduled failures from HEAD regressions. |
+| P2 | Performance evidence | Treat benchmark/APEX/performance claims as current only after lane-specific validation. |
+
+## Validation For This Refresh
+
+This document refresh is documentation-only. The following commands should be
+used to validate the edit:
+
+```bash
+make check-docs
+make check-stale-docs
+make check-doc-heading-links
+python3 scripts/governance/check_docs_structure.py --all
+git diff --check
+```
+
+Full product validation remains outside this refresh unless explicitly run:
+
+```bash
+make ci
+make validate-portal-browser
+make validate-frontdoor-browser
+```
 
 ## Conclusion
 
-The Transformation Portal codebase is **production-grade with strong fundamentals**. The primary areas requiring attention are:
+The Q1 audit remains useful historical context, but the current codebase has
+moved beyond several March assumptions. The repository now has a more explicit
+managed-frontdoor topology, typed health/readiness contracts, broader docs and
+CI governance, more test coverage, and stronger telemetry/dependency policy.
 
-1. **Security fixes** (pickle, subprocess validation) - ✅ COMPLETED
-2. **Testing governance** (markers, strategy) - ✅ COMPLETED
-3. **CI/CD optimization** (action pinning, parallelization, type safety) - ✅ COMPLETED
-4. **Documentation organization** (ADR consolidation, migration guide) - 🟢 IN PROGRESS
-5. **Architecture debt** (monolithic orchestrator) - ✅ ADR-043 COMPLETED
-
-With the proposed roadmap, the overall score has improved significantly. Phases 1, 2, and 4 are complete. Phase 3 documentation consolidation is in progress. Phase 5 orchestrator decomposition was completed per ADR-043.
-
----
-
-**Next Steps:**
-1. ~~Review and approve this audit report~~ ✅
-2. ~~Create GitHub issues for Phase 1 tasks (Critical)~~ ✅
-3. ~~Schedule Phase 2-4 work in upcoming sprints~~ ✅
-4. ~~Plan Phase 5 architecture work as ADR-043~~ ✅ Complete
-5. Complete remaining Phase 3 documentation cleanup
-
-**Document Status:** Approved - Quarterly Refresh
-**Expires:** 2026-06-15 (quarterly refresh)
-**Last Updated:** 2026-03-21
+The main remaining engineering risk is not lack of governance; it is the size
+and coupling of central integration surfaces. Future work should preserve the
+current contracts while continuing narrow decomposition of `app.py`,
+`lux_depth_v3/orchestrator.py`, and adjacent runtime/portal seams.

--- a/docs/fixes/HEALTH_CHECK_REPORT.md
+++ b/docs/fixes/HEALTH_CHECK_REPORT.md
@@ -1,7 +1,7 @@
 # Transformation Portal Health Check Report
 
 **Generated:** 2026-05-12
-**Repository:** `/Users/richardcheetham/Desktop/Transformation_Portal`
+**Repository:** `REPO_ROOT` (`/path/to/Transformation_Portal`)
 **Branch:** `main` tracking `origin/main`
 **HEAD:** `a3cf8030c docs(governance): refresh todo inventory baseline (#1723)`
 **Working Tree:** Clean at inspection time

--- a/docs/fixes/HEALTH_CHECK_REPORT.md
+++ b/docs/fixes/HEALTH_CHECK_REPORT.md
@@ -1,423 +1,296 @@
-# Transformation Portal - Comprehensive Health Check Report
+# Transformation Portal Health Check Report
 
-**Generated:** 2025-11-07
-**Repository:** `/Users/rc/Transformation_Portal`
-**Branch:** `feat/rag-integration-complete`
-**Working Tree:** Clean (no uncommitted changes)
-
----
-
-## Overall Status: ⚠️  WARNING
-
-The repository is functional but has **critical dependency issues** that need immediate attention for development and testing workflows.
+**Generated:** 2026-05-12
+**Repository:** `/Users/richardcheetham/Desktop/Transformation_Portal`
+**Branch:** `main` tracking `origin/main`
+**HEAD:** `a3cf8030c docs(governance): refresh todo inventory baseline (#1723)`
+**Working Tree:** Clean at inspection time
 
 ---
 
-## 1. Code Quality ✓ PASS
+## Report Boundary
 
-### Python Syntax
-✅ All core scripts compile successfully:
-- `lux_render_pipeline.py`
-- `luxury_video_master_grader.py`
-- `luxury_tiff_batch_processor.py`
-- `material_response.py`
-- `depth_tools.py`
+This document is a point-in-time health snapshot for audit context under
+`docs/fixes/`. It is not promoted canonical operator guidance. Current
+operator navigation remains in `README.md`, `docs/README.md`, and
+`docs/governance/DOCUMENTATION_MAP.md`.
 
-### Architecture
-✅ Key components present and valid:
-- `architectural_context_engine.py` (18 KB)
-- `context_aware_pro_pipeline.py` (15 KB)
-- `context_aware_renderer.py` (10 KB)
+The snapshot reflects local inspection on May 12, 2026. Local dependency
+health and documentation topology passed. The full canonical `make ci` lane
+was not run for this report, so this report must not be read as an all-green
+repository certification.
 
-### Linting Tools
-⚠️  Not installed in current environment:
-- `flake8`: Not available (required for CI)
-- `pylint`: Not available (required for CI)
+---
 
-**Recommendation:** Install dev dependencies
+## Overall Status: Healthy With Bounded Maintenance Warnings
+
+The current repository is a governed image and video processing platform for
+luxury real estate rendering and architectural visualization. The checked
+state is substantially newer than the old 2025 RAG-branch report this file
+replaced.
+
+Current health signals:
+
+- Local Python dependency health passes with the repo `.venv`.
+- Documentation topology validation passes for the current docs layout.
+- The active health/readiness API contracts are implemented and covered by
+  focused tests.
+- Managed frontdoor and backend validation are Make-governed and Node/Python
+  version-gated.
+- The repository is large, about 91G at inspection time, which is a maintenance
+  concern but not evidence of a code-health failure by itself.
+
+Current validation boundary:
+
+- Proven green for this refresh: dependency health and docs topology checks.
+- Not run for this report: full `make ci`, browser smokes, and live pipeline
+  validations.
+- No current evidence supports the stale critical claims about missing Python
+  dependencies, Python 3.14 incompatibility, or a missing `depth_pipeline/`
+  runtime path.
+
+---
+
+## 1. Codebase Surface
+
+### Backend And Portal
+
+The FastAPI backend remains rooted in `app.py` and serves the portal and
+orchestrator API surface:
+
+- `GET /portal` serves the single-file portal UI.
+- `GET /portal/bootstrap` exposes standalone portal auth mode for direct
+  backend debugging.
+- `GET /healthz` is a minimal raw liveness probe.
+- `GET /ready` is raw readiness with optional verbose fields.
+- `GET /v1/readiness` is the governed pipeline readiness envelope.
+
+The managed Next frontdoor lives under `web/secure-landing` and enforces Node
+22.x through its runtime guard and package engine contract.
+
+### Health And Readiness Contracts
+
+Current health contracts are intentionally split by consumer:
+
+| Route | Shape | Purpose |
+| --- | --- | --- |
+| `/healthz` | Raw JSON with `ok` and `time` | Minimal liveness for frontdoors, probes, and load balancers |
+| `/ready` | Raw JSON with `ok`, `time`, `version`, and optional verbose fields | Backend readiness without the orchestrator API envelope |
+| `/v1/readiness` | `tp.orchestrator.readiness.v1` API envelope | Pipeline readiness for `lux-depth-v3` and archive gates A/B/C |
+
+The raw `/healthz` and `/ready` shapes are contract-sensitive. Do not wrap
+them in the versioned API envelope unless the external probe contract is
+explicitly changed and tests are updated in the same patch.
+
+### Current Major Subsystems
+
+The current repo contains active surfaces for:
+
+- Lux Depth V3 orchestration, depth backends, Materials V3 segmentation, PBR
+  outputs, APEX validation, and run-card governance.
+- Archive gates A/B/C with machine-mode and readiness coverage.
+- Spatial AI reconstruction, segmentation, materials, and ingest contracts.
+- Optional FastVLM advisory captioning through subprocess-isolated local
+  runtime paths; captions are advisory and not quality-gate evidence.
+- Managed frontdoor auth, local smoke credentials, session scaling, RUM
+  telemetry controls, retry-after UI, and portal asset governance.
+- Layered dependency lock governance, including generic Python locks and the
+  target-owned Darwin arm64 ML lock lane.
+
+---
+
+## 2. Local Environment Snapshot
+
+Observed local environment:
+
+| Component | Observed State |
+| --- | --- |
+| Python | `.venv/bin/python` reports `Python 3.12.13` |
+| Node | `node --version` reports `v22.22.2` |
+| Python dependency health | `.venv/bin/python -m pip check` passed |
+| Frontdoor Node contract | `web/secure-landing` declares `>=22 <23` |
+
+Observed installed package examples:
+
+| Package | Version |
+| --- | --- |
+| pytest | 9.0.3 |
+| hypothesis | 6.152.1 |
+| Pillow | 12.2.0 |
+| tifffile | 2026.3.3 |
+| fastapi | 0.136.1 |
+| starlette | 1.0.0 |
+| uvicorn | 0.46.0 |
+
+These observations replace the stale 2025 claims that tests were blocked by
+missing `hypothesis`, `Pillow`, `tifffile`, `tqdm`, `typer`, or `PyYAML`.
+
+---
+
+## 3. Test And Validation Surface
+
+Current observed scale:
+
+- About 606 Python test files under `tests/`.
+- 30 GitHub workflow YAML files under `.github/workflows/`.
+- 36 YAML/JSON config files under `config/`.
+
+Important local validation targets:
+
 ```bash
-pip install -r requirements-dev.txt
-```
-
----
-
-## 2. Test Suite ❌ CRITICAL
-
-### Status
-❌ **Test Execution Blocked:** Missing critical dependencies
-
-### Test Infrastructure
-✅ pytest installed (8.4.2)
-✅ 41 test files present in `tests/` directory
-✅ Makefile targets configured (`test-fast`, `test-full`, `test-novideo`)
-
-### Missing Dependencies Blocking Tests
-- ❌ `hypothesis` - Required for property-based testing
-- ❌ `Pillow (PIL)` - Required for image processing tests
-- ❌ `tifffile` - Required for TIFF processing tests
-- ❌ `tqdm` - Required for progress bar tests
-
-**Current Issue:** Cannot collect tests due to missing `hypothesis` in conftest
-
-**Recommendation:**
-```bash
-pip install -r requirements.txt
-pip install hypothesis
-```
-
----
-
-## 3. Dependencies ❌ CRITICAL
-
-### Python Environment
-- ✅ Python 3.14.0 installed
-- ⚠️  **WARNING:** Python 3.14 not tested in CI (supports 3.10, 3.11, 3.12)
-- ✅ Virtual environment active: `path/to/venv/bin/python`
-- ✅ pip 25.3 installed
-
-### Core Dependencies (8 critical packages)
-| Package | Status | Purpose |
-|---------|--------|---------|
-| numpy | ✅ 2.3.4 | Core array processing |
-| scipy | ✅ 1.16.3 | Scientific computing |
-| Pillow | ❌ MISSING | Image I/O and manipulation |
-| tifffile | ❌ MISSING | 16-bit TIFF support |
-| tqdm | ❌ MISSING | Progress bars |
-| typer | ❌ MISSING | CLI framework |
-| pytest | ✅ 8.4.2 | Testing framework |
-| hypothesis | ❌ MISSING | Property-based testing |
-
-**Status:** 2/8 critical dependencies installed (25%)
-
-### Additional Installed
-- ✅ scikit-learn 1.7.2
-- ✅ joblib 1.5.2
-
-### Dependency Files
-- ✅ `requirements.txt` (28 lines) - Production dependencies
-- ✅ `requirements-dev.txt` (23 lines) - Development dependencies
-- ✅ `requirements-ci.txt` (18 lines) - CI minimal dependencies
-- ✅ `pyproject.toml` (84 lines) - Package configuration
-
-**Recommendation:**
-```bash
-pip install -r requirements.txt
-pip install -r requirements-dev.txt
-```
-
----
-
-## 4. Configuration ✓ PASS
-
-### YAML Presets
-✅ 5 configuration files found:
-- `config/default_config.yaml`
-- `config/exterior_preset.yaml`
-- `config/pro_pipeline_config.yaml`
-- `config/aerial_preset.yaml`
-- `config/interior_preset.yaml`
-
-⚠️  Note: YAML validation skipped (PyYAML not installed)
-
-### GitHub Workflows
-✅ 4 workflow files validated:
-- `.github/workflows/build.yml` (CI lint + tests)
-- `.github/workflows/codeql.yml` (Security scanning)
-- `.github/workflows/issue_printer.yml`
-- `.github/workflows/summary.yml`
-
-### LUT Files
-✅ 6 `.cube` files found in `assets/luts/`
-
-### Package Configuration
-✅ `pyproject.toml` present with proper metadata:
-- Build system: setuptools>=65
-- Python requirement: >=3.10 ✓
-- Optional dependencies configured (tiff, ml, dev, all)
-
----
-
-## 5. Documentation ✓ PASS
-
-### Core Documentation
-- ✅ `README.md` (981 lines)
-  - Quick Start section
-  - Installation instructions
-  - Feature overview
-  - Table of Contents
-
-### Architecture Documentation
-- ✅ `docs/architecture/ARCHITECTURE.md` (483 lines)
-- ✅ `docs/performance/PERFORMANCE_OPTIMIZATION.md` (319 lines)
-
-### Version History
-- ✅ `docs/Version_History/changelog.md` (20 lines)
-
-### RAG System Documentation
-- ✅ `.github/agents/rag_system/README.md` present
-- ✅ RAG system modules: 9 Python files
-
-### Recent Updates
-- Context-aware rendering (November 2025)
-- Repository refactoring (October 2025)
-
----
-
-## 6. Repository Structure ⚠️  WARNING
-
-### Critical Directories
-✅ Present:
-- `tests/` (41 test files)
-- `config/` (5 YAML presets)
-- `assets/luts/` (6 LUT files)
-- `docs/` (documentation)
-- `.github/workflows/` (4 workflows)
-
-❌ Missing:
-- **`depth_pipeline/`** - NOT FOUND
-  - Expected: Depth Anything V2 integration modules
-  - Impact: Depth processing features may not be available
-
-### Core Scripts
-✅ All key processing scripts validated
-✅ Architectural context engine present
-✅ RAG system complete (9 modules)
-
-### RAG System Structure
-✅ Complete implementation:
-- `__init__.py`, `citation.py`, `classifier.py`, `cli.py`
-- `indexer.py`, `knowledge_engine.py`
-- `reranker.py`, `retriever.py`, `templates.py`
-
-### Repository Size
-⚠️  **25GB** - Consider cleanup of output/data directories
-
----
-
-## 7. Git Status ✓ PASS
-
-- ✅ Working Tree: Clean (no uncommitted changes)
-- ✅ Current Branch: `feat/rag-integration-complete`
-- ✅ Recent Commits (last 5):
-  - `6552cf8` feat: Complete RAG system integration
-  - `a3ad07d` feat: Improve install_models.py
-  - `cafd144` chore: Add process documentation
-  - `69ea0c2` docs: Add comprehensive RAG documentation
-  - `6a5905d` chore: Fix critical issues
-
-### .gitignore
-✅ Properly configured:
-- Excludes `__pycache__`, `*.pyc`, `.venv`, etc.
-
----
-
-## 8. External Tools ✓ PASS
-
-### FFmpeg
-✅ FFmpeg 8.0 installed:
-- zscale filter available (HDR support)
-- All required codecs present
-- Video processing ready
-
-### Git
-✅ Available and functioning
-
-### Make
-✅ Available:
-- Makefile with 11 targets configured
-- CI target: `lint` + `test-fast`
-
----
-
-## Severity Breakdown
-
-### 🔴 CRITICAL (2 issues)
-1. **Missing 6/8 critical Python dependencies**
-   - Blocks all testing and most development workflows
-
-2. **`depth_pipeline/` directory missing**
-   - Core depth processing feature unavailable
-
-### 🟡 WARNING (2 issues)
-1. **Python 3.14 not tested in CI**
-   - May have compatibility issues (CI tests 3.10-3.12)
-
-2. **Repository size: 25GB**
-   - Consider cleaning output/cache directories
-
-### 🟢 PASS (6 areas)
-1. Code quality - all scripts valid
-2. Documentation - comprehensive and up-to-date
-3. Configuration - all configs valid
-4. Git status - clean working tree
-5. External tools - FFmpeg ready
-6. Package configuration - pyproject.toml valid
-
----
-
-## Immediate Action Items
-
-### Priority 1 (Critical - Do First)
-
-**1. Install missing dependencies:**
-```bash
-cd /Users/rc/Transformation_Portal
-pip install -r requirements.txt
-pip install -r requirements-dev.txt
-```
-
-**2. Verify test suite works:**
-```bash
+make check-environment
 make test-fast
-make test-full
+make test-orchestrator-contract
+make test-frontdoor-contract
+make validate-portal-browser
+make validate-frontdoor-browser
+make ci
 ```
 
-### Priority 2 (Important - Do Soon)
+The canonical `make ci` target currently chains lint/governance checks,
+dependency-lock checks, portal asset budget checks, fast tests, orchestrator
+contracts, and managed frontdoor contracts. It was not run for this report.
 
-**3. Investigate missing `depth_pipeline/` directory:**
-```bash
-git log --all --full-history --oneline -- depth_pipeline/
-```
-Check if code was moved to another location, restore from git history if needed, or update documentation if deprecated.
+Live browser and pipeline validations can be slower and environment-sensitive.
+Classify failures by source before weakening product contracts:
 
-**4. Consider Python version compatibility:**
-- Test with Python 3.10-3.12 (CI versions)
-- Document any Python 3.14 specific issues
-
-### Priority 3 (Maintenance - Do Later)
-
-**5. Clean up repository size:**
-```bash
-du -sh output* data* *.log | sort -h
-```
-Review output/ directories, remove temporary files, consider .gitignore additions.
-
-**6. Run linting checks:**
-```bash
-make lint
-```
-Fix any critical issues.
+- Product logic regression: deterministic contract or smoke failure in the
+  current code.
+- Stale test logic: assertion no longer matches an intentional product
+  contract change.
+- Environment/tooling failure: missing browser runtime, occupied ports,
+  unavailable optional model runtime, network restriction, or sandbox issue.
 
 ---
 
-## What's Working Well
+## 4. Dependency Governance
 
-### ✅ Clean Git Status
-No uncommitted changes, ready for development
+The repo no longer uses ad-hoc dependency installation as the primary health
+fix path. Use the governed Make targets and layered lockfiles:
 
-### ✅ Complete RAG System
-Full implementation with 9 modules:
-- Indexer, Retriever, Reranker, Citation Generator
-- Knowledge Engine, Classifier, Templates
-- CLI interface included
+```bash
+make install-core
+make repair-core-venv
+make check-environment
+```
 
-### ✅ Architectural Context Engine
-New context-aware rendering capability:
-- `architectural_context_engine.py`
-- `context_aware_pro_pipeline.py`
-- `context_aware_renderer.py`
+Dependency policy is enforced through the `requirements/` layered inputs and
+locks, lock ownership metadata, and validation scripts such as:
 
-### ✅ Comprehensive Documentation
-- README: 981 lines with full quick start guide
-- Architecture docs: 483 lines
-- Performance optimization guide: 319 lines
+```bash
+make check-requirements-lock-contract
+make check-dependency-pinning
+make check-ci-sync
+```
 
-### ✅ Professional Test Infrastructure
-- 41 test files covering major modules
-- Makefile with fast/full/structure test targets
-- pytest and hypothesis configured
-
-### ✅ CI/CD Ready
-- 4 GitHub workflows configured
-- Matrix testing (Python 3.10/3.11/3.12, CPU/GPU)
-- Security scanning with CodeQL
-
-### ✅ FFmpeg Integration
-- Latest version (8.0) installed
-- Full codec support for video processing
-- HDR capabilities ready
-
-### ✅ Package Structure
-- Modern `pyproject.toml` configuration
-- Optional dependencies for different use cases
-- Proper Python version requirements
+ML installation remains capability-specific. Do not reintroduce a broad
+umbrella ML install path without a trusted checked-in lockfile contract.
 
 ---
 
-## Recommendations
+## 5. Documentation And Repository Structure
 
-### 1. Dependency Installation (CRITICAL)
-Execute immediately to restore full functionality:
+Documentation governance is active and strict:
+
+- `docs/README.md` is the only maintained file allowed directly under `docs/`.
+- Current navigation belongs in `docs/governance/DOCUMENTATION_MAP.md`.
+- Historical and point-in-time reports remain available for audit context, but
+  they are not current operator guidance unless promoted by the documentation
+  map.
+- `docs/fixes/HEALTH_CHECK_REPORT.md` remains a point-in-time report, not a
+  canonical runbook.
+
+Observed docs validation checks for this refresh:
 
 ```bash
-pip install Pillow tifffile tqdm typer hypothesis PyYAML
+make check-docs
+make check-doc-heading-links
+python3 scripts/governance/check_docs_structure.py --all
+.venv/bin/python -m pytest -q tests/test_app_healthcheck_contract.py tests/api/v1/test_health_models.py tests/validation/test_environment_preflight.py
 ```
 
-Or install everything:
+All passed during refresh validation.
+
+---
+
+## 6. Repository Size
+
+The checkout size was observed at about 91G:
+
 ```bash
-pip install -r requirements.txt -r requirements-dev.txt
+du -sh .
 ```
 
-### 2. Depth Pipeline Investigation
-Determine status of `depth_pipeline/` directory:
+This is a maintenance warning, not a direct code-health failure. Before
+deleting anything, identify generated outputs and cache directories explicitly
+and preserve any user-owned artifacts. Prefer repo-governed cleanup targets:
 
 ```bash
-git log --all --full-history --oneline -- depth_pipeline/
+make clean
+make clean-frontdoor
+make clean-all
 ```
 
-Check if functionality moved to another module.
+Use destructive cleanup only when the target directories are confirmed
+generated and the user has approved removal.
 
-### 3. Python Version Strategy
-Consider using pyenv to test with CI-supported versions:
+---
 
-```bash
-pyenv install 3.10.x
-pyenv local 3.10.x
-make test-full
-```
+## 7. Recommended Operator Commands
 
-### 4. Repository Cleanup
-Identify and clean large directories:
+Use repo-governed commands instead of direct `pip install` remediation:
 
 ```bash
-du -sh output* data* *.log | sort -h
-```
-
-### 5. Enable Pre-commit Hooks
-Ensure code quality before commits:
-
-```bash
-make lint
+make install-core
+make repair-core-venv
+make check-environment
 make test-fast
+make test-orchestrator-contract
+make test-frontdoor-contract
+make validate-portal-browser
+make validate-frontdoor-browser
+make ci
+```
+
+For local full-stack bring-up:
+
+```bash
+make dev-write-env
+source /tmp/tp-local-http-all-on.env
+make dev-start
+```
+
+For managed frontdoor browser validation, keep the backend/frontdoor contract
+intact and use the governed smoke:
+
+```bash
+make validate-frontdoor-browser
 ```
 
 ---
 
 ## Conclusion
 
-### Overall Assessment: ⚠️  PARTIALLY HEALTHY
+### Assessment: Current Local Health Snapshot Is Positive, With Full-CI Boundary
 
-The Transformation Portal repository has a **solid foundation** with:
-- Excellent documentation
-- Clean git status
-- Complete RAG system integration
-- Professional CI/CD setup
+The current codebase does not match the old stale report. It is on `main`,
+uses Python 3.12 and Node 22, has active dependency governance, and exposes
+typed health/readiness contracts with focused test coverage.
 
-However, **critical dependency issues** prevent running tests or using core image processing features.
+Proven green during this refresh:
 
-### Primary Blocker
-Missing 6 critical Python dependencies
+- Python dependency health via `.venv/bin/python -m pip check`.
+- Documentation organization via `make check-docs`.
+- Documentation heading links via `make check-doc-heading-links`.
+- Documentation topology via `python3 scripts/governance/check_docs_structure.py --all`.
+- Focused health/preflight tests via `.venv/bin/python -m pytest -q tests/test_app_healthcheck_contract.py tests/api/v1/test_health_models.py tests/validation/test_environment_preflight.py`.
 
-### Next Steps
-1. Install dependencies (5 minutes)
-2. Run test suite (2-5 minutes)
-3. Investigate `depth_pipeline` status (10 minutes)
-4. Resume normal development workflow
+Still not proven by this report:
 
-**Estimated Time to Full Health:** 15-20 minutes
+- Full canonical `make ci`.
+- Live backend/frontdoor browser smokes.
+- Live optional ML/runtime validations.
 
-After installing dependencies, the repository should be fully functional for development and testing. The recent RAG integration and architectural context engine additions represent significant enhancements to the codebase.
-
----
-
-*Report generated by Transformation Portal Specialist Agent*
+The correct next step for release or merge confidence is to run the applicable
+governed validation lane, not to follow the obsolete ad-hoc dependency install
+steps from the prior version of this report.

--- a/docs/fixes/HEALTH_CHECK_REPORT.md
+++ b/docs/fixes/HEALTH_CHECK_REPORT.md
@@ -11,7 +11,7 @@
 ## Report Boundary
 
 This document is a point-in-time health snapshot for audit context under
-`docs/fixes/`. It is not promoted canonical operator guidance. Current
+`docs/fixes/`. It is not promoted as canonical operator guidance. Current
 operator navigation remains in `README.md`, `docs/README.md`, and
 `docs/governance/DOCUMENTATION_MAP.md`.
 
@@ -37,8 +37,9 @@ Current health signals:
   focused tests.
 - Managed frontdoor and backend validation are Make-governed and Node/Python
   version-gated.
-- The repository is large, about 91G at inspection time, which is a maintenance
-  concern but not evidence of a code-health failure by itself.
+- The repository is large, approximately 91 GiB at inspection time (`du -sh`
+  reported `91G`), which is a maintenance concern but not evidence of a
+  code-health failure by itself.
 
 Current validation boundary:
 
@@ -215,7 +216,8 @@ All passed during refresh validation.
 
 ## 6. Repository Size
 
-The checkout size was observed at about 91G:
+The checkout size was observed at approximately 91 GiB (`du -sh` reported
+`91G`):
 
 ```bash
 du -sh .


### PR DESCRIPTION
## Summary
- Refresh stale architecture and audit report docs against the current May 2026 repository state.
- Replace outdated branch, dependency, topology, test-count, and Q1-scorecard claims with current frontdoor/backend, health/readiness, dependency-governance, and docs-governance boundaries.

## Changes
- Rewrote the maintained architecture overview around the managed Next frontdoor, FastAPI backend, route/readiness contracts, module boundaries, pipeline flow, security posture, and validation lanes.
- Updated the Q1 codebase audit as a current-support refresh instead of a stale March scorecard.
- Replaced the health check report with a current point-in-time snapshot and repo-governed remediation commands.
- No runtime behavior, routes, selectors, schemas, CLI flags, dependency locks, or workflow behavior changed.

## Validation
Proven green:
- make check-docs
- make check-stale-docs
- make check-doc-heading-links
- python3 scripts/governance/check_docs_structure.py --all
- git diff --check
- .venv/bin/python -m pytest -q tests/test_app_healthcheck_contract.py tests/api/v1/test_health_models.py tests/validation/test_environment_preflight.py
- pre-commit hooks during commit

Not run:
- make ci
- make validate-portal-browser
- make validate-frontdoor-browser

## Risk
- Documentation-only change; no migration, auth, runtime, or operational behavior change.
- Bounded and revert-safe because it only updates three docs files and preserves route/selector/API/CLI contract wording as documentation.