### PR TITLE
docs(tests): refresh test status evidence

### DIFF
--- a/docs/testing/STRATEGY.md
+++ b/docs/testing/STRATEGY.md
@@ -293,13 +293,16 @@ make test-fast
 pytest -v tests/ -ra -m "(unit or security or regression or golden or integration) and not ml and not slow and not benchmark" --maxfail=1
 ```
 
-### With ML Dependencies
+### Broad Non-Video Suite
 
 ```bash
 make test-novideo
-# or (matches PR-gating expression)
-pytest -v tests/ -ra -m "ml and not slow and not integration and not benchmark" --maxfail=1
+# or
+pytest -q -k "not video_master_grader"
 ```
+
+This convenience target excludes the luxury video master grader tests. It is
+not an ML-only selector.
 
 ### Full Suite
 

--- a/scripts/README_QUALITY_CONTROL.md
+++ b/scripts/README_QUALITY_CONTROL.md
@@ -469,6 +469,6 @@ When adding new quality checks:
 ## See Also
 
 - [Main README](../README.md) - Project overview
-- [CI Configuration](.github/workflows/build.yml) - GitHub Actions setup
-- [Testing Guide](tests/TEST_STATUS.md) - Test suite documentation
-- [Coding Standards](../docs/architecture/ARCHITECTURE.md) - Code style guidelines
+- [CI Configuration](../.github/workflows/build.yml) - GitHub Actions setup
+- [Testing Guide](../tests/TEST_STATUS.md) - Test suite documentation
+- [Repository Architecture](../docs/architecture/ARCHITECTURE.md) - System architecture overview

--- a/tests/TEST_STATUS.md
+++ b/tests/TEST_STATUS.md
@@ -1,13 +1,13 @@
 # Test Run Summary
 
-Last updated: 2026-05-11 23:47:19 PDT
+Last updated: 2026-05-12
 
 ## Proven Green
 
 - `make test-fast`
-  - Result: 77 passed in 2.51s
+  - Result: 77 passed in 2.91s
 - `.venv/bin/python -m pytest --collect-only -q tests`
-  - Result: 10289 tests collected in 4.92s
+  - Result: 9971 tests collected in 2.95s
 
 ## Incomplete
 

--- a/tests/TEST_STATUS.md
+++ b/tests/TEST_STATUS.md
@@ -1,5 +1,16 @@
 # Test Run Summary
 
-- Command: `pytest`
-- Date: Wed Oct  1 07:26:50 UTC 2025
-- Result: 18 passed, 1 skipped
+Last updated: 2026-05-11 23:47:19 PDT
+
+## Proven Green
+
+- `make test-fast`
+  - Result: 77 passed in 2.51s
+- `.venv/bin/python -m pytest --collect-only -q tests`
+  - Result: 10289 tests collected in 4.92s
+
+## Incomplete
+
+- `make test-novideo`
+  - Result: intentionally stopped during discovery because the broad non-video suite was too slow for this pass.
+  - This is not counted as a green full-suite result.


### PR DESCRIPTION
## Summary
- Refresh stale test-status evidence that still reported an October 2025 pytest snapshot.
- Correct adjacent testing/quality docs so local test guidance and relative links match current repo behavior.

## Changes
- Update tests/TEST_STATUS.md with current focused validation and explicit incomplete broad-suite status.
- Correct docs/testing/STRATEGY.md so make test-novideo is documented as the broad non-video selector, not an ML-only lane.
- Fix scripts/README_QUALITY_CONTROL.md relative links and relabel the architecture reference accurately.

## Validation
Proven green:
- make test-fast
- .venv/bin/python -m pytest --collect-only -q tests
- make check-stale-docs
- make check-doc-heading-links
- git diff --check
- git diff --cached --check
- pre-commit hooks during git commit

Still failing:
- None observed.

Incomplete:
- make test-novideo was intentionally stopped during discovery because the broad non-video suite was too slow for this pass; this PR does not claim full-suite green.

## Risk
- Documentation-only change; no runtime, selector, route, API envelope, CLI, or test-contract behavior changes.
- Revert-safe and bounded to three docs/test-status files.