### PR TITLE
chore: expand Dependabot Node coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,19 +1,89 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
   - package-ecosystem: "pip"
     directory: "/"
     target-branch: "main"
     open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "automated"
     schedule:
       interval: "weekly"
+      day: "tuesday"
+      time: "10:00"
+      timezone: "Etc/UTC"
   - package-ecosystem: "github-actions"
     directory: "/"
     target-branch: "main"
     open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "automated"
     schedule:
       interval: "weekly"
+      day: "tuesday"
+      time: "10:15"
+      timezone: "Etc/UTC"
+  - package-ecosystem: "npm"
+    directory: "/"
+    target-branch: "main"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "automated"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "10:30"
+      timezone: "Etc/UTC"
+    groups:
+      root-node-tooling:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+          - "@*/*"
+        update-types:
+          - "minor"
+          - "patch"
+  - package-ecosystem: "npm"
+    directory: "/web/secure-landing"
+    target-branch: "main"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "automated"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "10:45"
+      timezone: "Etc/UTC"
+    groups:
+      frontdoor-node:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+          - "@*/*"
+        update-types:
+          - "minor"
+          - "patch"
+  - package-ecosystem: "npm"
+    directory: "/cloudflare/transformationportal-worker"
+    target-branch: "main"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "automated"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "11:00"
+      timezone: "Etc/UTC"
+    groups:
+      cloudflare-worker-node:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+          - "@*/*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/docs/governance/DEPENDABOT_PR_GOVERNANCE.md
+++ b/docs/governance/DEPENDABOT_PR_GOVERNANCE.md
@@ -3,16 +3,17 @@
 **Purpose**: Define triage policy and merge criteria for Dependabot-generated pull requests
 **Owner**: Transformation Portal Architect
 **Created**: 2026-03-26
-**Last Updated**: 2026-04-23
+**Last Updated**: 2026-05-12
 
 ---
 
 ## Overview
 
-This document establishes governance for reviewing and merging Dependabot PRs in accordance with the repository's enforced policy controls. Dependabot updates fall into two categories:
+This document establishes governance for reviewing and merging Dependabot PRs in accordance with the repository's enforced policy controls. Dependabot updates fall into three categories:
 
 1. **GitHub Actions updates** (`package-ecosystem: "github-actions"`)
 2. **Python dependency updates** (`package-ecosystem: "pip"`)
+3. **Node dependency updates** (`package-ecosystem: "npm"`) for `/`, `/web/secure-landing`, and `/cloudflare/transformationportal-worker`
 
 Each category has different risk profiles and merge criteria.
 
@@ -29,6 +30,7 @@ The following are the enforced controls that constrain Dependabot PR acceptance:
 | Action SHA pinning | `enforcement.yml` → `action-pins` job | Third-party actions must be SHA-pinned; official `actions/*@v...` tags are currently allowed, and enforcement is strictest in critical workflows |
 | Banned dependencies | `enforcement.yml` → `banned-dependencies` job | Blocked packages cannot be introduced |
 | Dependency constraints | `build.yml` → `dependency-constraints` job; `ci-quality-firewall.yml` → `validate-dependency-constraints` job | ADR-032 constraint validation |
+| Node runtime boundaries | `web/secure-landing/package.json`; `cloudflare/transformationportal-worker/package.json`; root `package.json` | Frontdoor updates must preserve Node 22, exact Next pin posture, and Cloudflare Worker tooling separation |
 
 ---
 
@@ -52,6 +54,23 @@ The following are the enforced controls that constrain Dependabot PR acceptance:
 | **Medium** | Minor bump, non-pinned dependency | Feature updates to utilities | Review changelog, test coverage |
 | **High** | Any change to exact-pinned dependencies | `starlette`, `fastapi`, `uvicorn` | **HOLD** - requires curated PR |
 | **Critical** | Major version bump to exact-pinned dependencies | `starlette` 0.x → 1.0 | **DO NOT MERGE** as routine bump |
+
+### Node Dependency Updates
+
+Dependabot tracks three checked-in npm lockfile roots:
+
+- `/` for root worker-build tooling.
+- `/web/secure-landing` for the managed Next frontdoor.
+- `/cloudflare/transformationportal-worker` for the frontdoor-only Cloudflare Worker package.
+
+Minor and patch version updates are grouped per directory to reduce PR noise. Major updates remain separate PRs and must be reviewed as compatibility changes.
+
+| Risk Level | Criteria | Examples | Merge Policy |
+|------------|----------|----------|--------------|
+| **Low** | Patch bump in isolated tooling | `wrangler` patch, `@cloudflare/workers-types` patch | Merge after package-lock diff and relevant dry-run/test pass |
+| **Medium** | Minor bump in frontdoor runtime or test tooling | `@playwright/test`, `stylelint`, `argon2` minor | Run `make test-frontdoor-contract` or narrower frontdoor lane before merge |
+| **High** | Exact-pinned frontdoor framework or lock metadata change | `next`, npm package-manager metadata | Require frontdoor contract/build validation and package-lock review |
+| **Critical** | Major framework/runtime boundary change | `next` major, React major, Node engine range change | Curated PR only; do not routine-merge |
 
 ---
 
@@ -190,6 +209,7 @@ Before merging any Dependabot PR:
 - [ ] CI is green on the PR
 - [ ] Change does not modify exact-pinned dependencies in `requirements/base.in`
 - [ ] For major action bumps: runner compatibility verified
+- [ ] For Node major bumps: frontdoor/worker compatibility and package-lock platform metadata reviewed
 - [ ] For post-merge-validation workflows: risk accepted or manual smoke completed
 - [ ] No batching of unrelated risk levels
 
@@ -204,6 +224,7 @@ Before merging any Dependabot PR:
 | 2026-04-16 | Recorded the FastAPI 0.136.0 curated baseline and the "dep pin changed" checklist | Architect |
 | 2026-04-16 | Added ML alert dismissal/remediation governance for supported vs frozen target-owned lanes | Architect |
 | 2026-04-23 | Synced the exact-pinned web stack block with the curated Uvicorn 0.45.0 baseline | Architect |
+| 2026-05-12 | Added npm Dependabot coverage and per-directory grouped minor/patch policy | Architect |
 
 ---
 

--- a/docs/governance/DEPENDABOT_PR_GOVERNANCE.md
+++ b/docs/governance/DEPENDABOT_PR_GOVERNANCE.md
@@ -16,6 +16,9 @@ This document establishes governance for reviewing and merging Dependabot PRs in
 3. **Node dependency updates** (`package-ecosystem: "npm"`) for `/`, `/web/secure-landing`, and `/cloudflare/transformationportal-worker`
 
 Each category has different risk profiles and merge criteria.
+All configured Dependabot entries carry the `dependencies` and `automated`
+labels and use staggered Tuesday UTC schedules so update PRs remain
+classifiable without arriving in one burst.
 
 ---
 

--- a/scripts/validation/check_dependabot_config.py
+++ b/scripts/validation/check_dependabot_config.py
@@ -18,11 +18,21 @@ DEPENDABOT_PATH = REPO_ROOT / ".github" / "dependabot.yml"
 REQUIRED_UPDATES = {
     ("pip", "/"),
     ("github-actions", "/"),
+    ("npm", "/"),
+    ("npm", "/cloudflare/transformationportal-worker"),
+    ("npm", "/web/secure-landing"),
+}
+REQUIRED_NPM_GROUPS = {
+    ("npm", "/"): "root-node-tooling",
+    ("npm", "/cloudflare/transformationportal-worker"): "cloudflare-worker-node",
+    ("npm", "/web/secure-landing"): "frontdoor-node",
 }
 REQUIRED_TARGET_BRANCH = "main"
 REQUIRED_INTERVAL = "weekly"
 REQUIRED_OPEN_PR_LIMIT = 5
 REQUIRED_PIP_EXCLUDE_PATHS: set[str] = set()
+REQUIRED_NPM_GROUP_PATTERNS = {"*", "@*/*"}
+REQUIRED_NPM_GROUP_UPDATE_TYPES = {"minor", "patch"}
 
 
 def _load_config(text: str) -> dict[str, Any]:
@@ -101,6 +111,42 @@ def validate_dependabot_config(text: str) -> list[str]:
                 }
                 for missing in sorted(missing_excludes):
                     errors.append(f"dependabot update ('pip', '/') must exclude unsupported manifest {missing!r}")
+
+        required_group = REQUIRED_NPM_GROUPS.get(pair)
+        if required_group is not None:
+            groups = entry.get("groups")
+            if not isinstance(groups, dict):
+                errors.append(f"dependabot update {pair!r} must define npm version-update groups")
+                continue
+
+            group = groups.get(required_group)
+            if not isinstance(group, dict):
+                errors.append(f"dependabot update {pair!r} must define npm group {required_group!r}")
+                continue
+
+            if group.get("applies-to") != "version-updates":
+                errors.append(f"dependabot npm group {required_group!r} must apply to version-updates")
+
+            patterns = group.get("patterns")
+            if not isinstance(patterns, list):
+                errors.append(f"dependabot npm group {required_group!r} must define patterns as a list")
+            else:
+                missing_patterns = REQUIRED_NPM_GROUP_PATTERNS - {
+                    value for value in patterns if isinstance(value, str) and value
+                }
+                for missing in sorted(missing_patterns):
+                    errors.append(f"dependabot npm group {required_group!r} must include pattern {missing!r}")
+
+            update_types = group.get("update-types")
+            if not isinstance(update_types, list):
+                errors.append(f"dependabot npm group {required_group!r} must define update-types as a list")
+            else:
+                normalized_update_types = {value for value in update_types if isinstance(value, str) and value}
+                if normalized_update_types != REQUIRED_NPM_GROUP_UPDATE_TYPES:
+                    errors.append(
+                        f"dependabot npm group {required_group!r} must group only "
+                        f"{sorted(REQUIRED_NPM_GROUP_UPDATE_TYPES)!r} updates"
+                    )
 
     missing = REQUIRED_UPDATES - seen_pairs
     for pair in sorted(missing):

--- a/scripts/validation/check_dependabot_config.py
+++ b/scripts/validation/check_dependabot_config.py
@@ -27,8 +27,20 @@ REQUIRED_NPM_GROUPS = {
     ("npm", "/cloudflare/transformationportal-worker"): "cloudflare-worker-node",
     ("npm", "/web/secure-landing"): "frontdoor-node",
 }
+REQUIRED_SCHEDULES = {
+    ("pip", "/"): {"interval": "weekly", "day": "tuesday", "time": "10:00", "timezone": "Etc/UTC"},
+    ("github-actions", "/"): {"interval": "weekly", "day": "tuesday", "time": "10:15", "timezone": "Etc/UTC"},
+    ("npm", "/"): {"interval": "weekly", "day": "tuesday", "time": "10:30", "timezone": "Etc/UTC"},
+    ("npm", "/web/secure-landing"): {"interval": "weekly", "day": "tuesday", "time": "10:45", "timezone": "Etc/UTC"},
+    ("npm", "/cloudflare/transformationportal-worker"): {
+        "interval": "weekly",
+        "day": "tuesday",
+        "time": "11:00",
+        "timezone": "Etc/UTC",
+    },
+}
 REQUIRED_TARGET_BRANCH = "main"
-REQUIRED_INTERVAL = "weekly"
+REQUIRED_LABELS = {"automated", "dependencies"}
 REQUIRED_OPEN_PR_LIMIT = 5
 REQUIRED_PIP_EXCLUDE_PATHS: set[str] = set()
 REQUIRED_NPM_GROUP_PATTERNS = {"*", "@*/*"}
@@ -97,9 +109,22 @@ def validate_dependabot_config(text: str) -> list[str]:
         if entry.get("open-pull-requests-limit") != REQUIRED_OPEN_PR_LIMIT:
             errors.append(f"dependabot update {pair!r} must set open-pull-requests-limit " f"to {REQUIRED_OPEN_PR_LIMIT}")
 
+        labels = entry.get("labels")
+        if not isinstance(labels, list):
+            errors.append(f"dependabot update {pair!r} must define labels as a list")
+        else:
+            normalized_labels = {value for value in labels if isinstance(value, str) and value}
+            if normalized_labels != REQUIRED_LABELS:
+                errors.append(f"dependabot update {pair!r} must use labels {sorted(REQUIRED_LABELS)!r}")
+
         schedule = entry.get("schedule")
-        if not isinstance(schedule, dict) or schedule.get("interval") != REQUIRED_INTERVAL:
-            errors.append(f"dependabot update {pair!r} must use a {REQUIRED_INTERVAL!r} schedule")
+        required_schedule = REQUIRED_SCHEDULES.get(pair)
+        if not isinstance(schedule, dict):
+            errors.append(f"dependabot update {pair!r} must define schedule as a mapping")
+        elif required_schedule is not None:
+            for key, expected_value in required_schedule.items():
+                if schedule.get(key) != expected_value:
+                    errors.append(f"dependabot update {pair!r} must set schedule {key!r} to {expected_value!r}")
 
         if pair == ("pip", "/"):
             exclude_paths = entry.get("exclude-paths")

--- a/tests/test_check_dependabot_config.py
+++ b/tests/test_check_dependabot_config.py
@@ -21,20 +21,38 @@ updates:
     directory: "/"
     target-branch: "main"
     open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "automated"
     schedule:
       interval: "weekly"
+      day: "tuesday"
+      time: "10:00"
+      timezone: "Etc/UTC"
   - package-ecosystem: "github-actions"
     directory: "/"
     target-branch: "main"
     open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "automated"
     schedule:
       interval: "weekly"
+      day: "tuesday"
+      time: "10:15"
+      timezone: "Etc/UTC"
   - package-ecosystem: "npm"
     directory: "/"
     target-branch: "main"
     open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "automated"
     schedule:
       interval: "weekly"
+      day: "tuesday"
+      time: "10:30"
+      timezone: "Etc/UTC"
     groups:
       root-node-tooling:
         applies-to: "version-updates"
@@ -48,8 +66,14 @@ updates:
     directory: "/web/secure-landing"
     target-branch: "main"
     open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "automated"
     schedule:
       interval: "weekly"
+      day: "tuesday"
+      time: "10:45"
+      timezone: "Etc/UTC"
     groups:
       frontdoor-node:
         applies-to: "version-updates"
@@ -63,8 +87,14 @@ updates:
     directory: "/cloudflare/transformationportal-worker"
     target-branch: "main"
     open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "automated"
     schedule:
       interval: "weekly"
+      day: "tuesday"
+      time: "11:00"
+      timezone: "Etc/UTC"
     groups:
       cloudflare-worker-node:
         applies-to: "version-updates"
@@ -104,6 +134,25 @@ def test_missing_open_pr_limit_is_reported() -> None:
     broken = valid_dependabot_text().replace("    open-pull-requests-limit: 5\n", "", 1)
     errors = dependabot_contract.validate_dependabot_config(broken)
     assert ("dependabot update ('pip', '/') must set open-pull-requests-limit to 5") in errors
+
+
+def test_missing_labels_are_reported() -> None:
+    broken = valid_dependabot_text().replace(
+        """    labels:
+      - "dependencies"
+      - "automated"
+""",
+        "",
+        1,
+    )
+    errors = dependabot_contract.validate_dependabot_config(broken)
+    assert "dependabot update ('pip', '/') must define labels as a list" in errors
+
+
+def test_staggered_schedule_drift_is_reported() -> None:
+    broken = valid_dependabot_text().replace('      time: "10:45"', '      time: "10:30"', 1)
+    errors = dependabot_contract.validate_dependabot_config(broken)
+    assert "dependabot update ('npm', '/web/secure-landing') must set schedule 'time' to '10:45'" in errors
 
 
 def test_pip_exclude_paths_are_not_required_after_retired_manifests_are_removed() -> None:

--- a/tests/test_check_dependabot_config.py
+++ b/tests/test_check_dependabot_config.py
@@ -29,6 +29,51 @@ updates:
     open-pull-requests-limit: 5
     schedule:
       interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/"
+    target-branch: "main"
+    open-pull-requests-limit: 5
+    schedule:
+      interval: "weekly"
+    groups:
+      root-node-tooling:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+          - "@*/*"
+        update-types:
+          - "minor"
+          - "patch"
+  - package-ecosystem: "npm"
+    directory: "/web/secure-landing"
+    target-branch: "main"
+    open-pull-requests-limit: 5
+    schedule:
+      interval: "weekly"
+    groups:
+      frontdoor-node:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+          - "@*/*"
+        update-types:
+          - "minor"
+          - "patch"
+  - package-ecosystem: "npm"
+    directory: "/cloudflare/transformationportal-worker"
+    target-branch: "main"
+    open-pull-requests-limit: 5
+    schedule:
+      interval: "weekly"
+    groups:
+      cloudflare-worker-node:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+          - "@*/*"
+        update-types:
+          - "minor"
+          - "patch"
 """
 
 
@@ -45,12 +90,13 @@ def test_missing_target_branch_is_reported() -> None:
 def test_unsupported_update_target_is_reported() -> None:
     broken = valid_dependabot_text().replace(
         'package-ecosystem: "github-actions"',
-        'package-ecosystem: "npm"',
+        'package-ecosystem: "gomod"',
     )
     errors = dependabot_contract.validate_dependabot_config(broken)
     assert (
-        "dependabot config contains unsupported update target ('npm', '/'); "
-        "expected only [('github-actions', '/'), ('pip', '/')]"
+        "dependabot config contains unsupported update target ('gomod', '/'); "
+        "expected only [('github-actions', '/'), ('npm', '/'), "
+        "('npm', '/cloudflare/transformationportal-worker'), ('npm', '/web/secure-landing'), ('pip', '/')]"
     ) in errors
 
 
@@ -141,3 +187,38 @@ updates:
 """
     errors = dependabot_contract.validate_dependabot_config(broken)
     assert "dependabot config contains duplicate update target ('pip', '/')" in errors
+
+
+def test_missing_npm_group_is_reported() -> None:
+    broken = valid_dependabot_text().replace(
+        """    groups:
+      frontdoor-node:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+          - "@*/*"
+        update-types:
+          - "minor"
+          - "patch"
+""",
+        "",
+    )
+    errors = dependabot_contract.validate_dependabot_config(broken)
+    assert "dependabot update ('npm', '/web/secure-landing') must define npm version-update groups" in errors
+
+
+def test_npm_group_must_keep_major_updates_separate() -> None:
+    broken = valid_dependabot_text().replace(
+        """        update-types:
+          - "minor"
+          - "patch"
+""",
+        """        update-types:
+          - "major"
+          - "minor"
+          - "patch"
+""",
+        1,
+    )
+    errors = dependabot_contract.validate_dependabot_config(broken)
+    assert "dependabot npm group 'root-node-tooling' must group only ['minor', 'patch'] updates" in errors


### PR DESCRIPTION
## Summary
- Add Dependabot npm version-update coverage for the tracked Node lockfile roots: `/`, `/web/secure-landing`, and `/cloudflare/transformationportal-worker`.
- Stagger weekly Dependabot schedules and apply consistent dependency automation labels.
- Group npm minor/patch updates per directory while leaving major updates separate for compatibility review.
- Update the Dependabot config validator, focused tests, and governance doc to lock the new policy.

## Validation
Proven green:
- `.venv/bin/python scripts/validation/check_dependabot_config.py`
- `.venv/bin/pytest tests/test_check_dependabot_config.py -q`
- `make validate-ci`
- `make check-docs`
- `make check-stale-docs`
- `make check-doc-heading-links`
- `.venv/bin/python scripts/governance/check_docs_structure.py --all`
- `git diff --check`
- `git diff --cached --check`
- pre-commit hooks during commit

Still failing:
- None observed.

## Risk
- Configuration/governance-only change; no runtime code, dependency pins, lockfiles, routes, selectors, or CLI behavior changed.
- Major npm updates remain ungrouped so framework/runtime boundary changes still receive separate review.
- Revert-safe and bounded to Dependabot policy plus its local validation contract.