### PR TITLE
[codex] Consolidate FastVLM runtime dependency updates

### DIFF
--- a/config/fastvlm_runtime_requirements.txt
+++ b/config/fastvlm_runtime_requirements.txt
@@ -23,7 +23,7 @@ gradio_client==2.5.0
 groovy==0.1.2
 h11==0.16.0
 hf-gradio==0.4.1
-hf-xet==1.4.3
+hf-xet==1.5.0
 httpcore==1.0.9
 httpx==0.28.1
 huggingface_hub==1.13.0
@@ -38,7 +38,7 @@ mpmath==1.3.0
 multidict==6.7.1
 multiprocess==0.70.19
 networkx==3.6.1
-numpy==2.2.6
+numpy==2.4.4
 opencv-python==4.10.0.84
 orjson==3.11.8
 packaging==26.2
@@ -48,8 +48,8 @@ propcache==0.4.1
 protobuf==7.34.1
 pyaml==26.2.1
 pyarrow==24.0.0
-pydantic==2.13.3
-pydantic_core==2.46.3
+pydantic==2.13.4
+pydantic_core==2.46.4
 pydub==0.25.1
 Pygments==2.20.0
 python-dateutil==2.9.0.post0
@@ -57,11 +57,11 @@ python-multipart==0.0.27
 pytz==2026.1.post1
 PyYAML==6.0.3
 regex==2026.4.4
-requests==2.33.1
+requests==2.34.0
 rich==15.0.0
 safehttpx==0.1.7
 safetensors==0.7.0
-scipy==1.13.1
+scipy==1.15.0
 semantic-version==2.10.0
 shellingham==1.5.4
 six==1.17.0


### PR DESCRIPTION
## Summary
- Supersedes Dependabot PRs #1737, #1738, #1739, and #1740 in one resolver-clean FastVLM runtime update.
- Updates hf-xet, numpy, pydantic, pydantic-core, requests, and the minimum SciPy companion pin required by numpy 2.4.4.

## Validation
- `.venv/bin/python -m pip install --dry-run --ignore-installed -r config/fastvlm_runtime_requirements.txt`
- `.venv/bin/python -m pytest tests/vlm_captioning/test_fastvlm_runtime.py tests/vlm_captioning/test_fastvlm_runtime_manifest.py tests/vlm_captioning/test_cli.py -q`

## Supersedes
- #1737
- #1738
- #1739
- #1740