### PR TITLE
[codex] Update Cloudflare worker tooling dependencies

### DIFF
--- a/cloudflare/transformationportal-worker/package-lock.json
+++ b/cloudflare/transformationportal-worker/package-lock.json
@@ -9,6 +9,9 @@
         "@cloudflare/workers-types": "4.20260511.1",
         "typescript": "6.0.3",
         "wrangler": "4.90.1"
+      },
+      "engines": {
+        "node": ">=22 <23"
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {

--- a/cloudflare/transformationportal-worker/package-lock.json
+++ b/cloudflare/transformationportal-worker/package-lock.json
@@ -6,9 +6,9 @@
     "": {
       "name": "transformationportal-worker",
       "devDependencies": {
-        "@cloudflare/workers-types": "4.20260503.1",
-        "typescript": "5.8.3",
-        "wrangler": "4.87.0"
+        "@cloudflare/workers-types": "4.20260511.1",
+        "typescript": "6.0.3",
+        "wrangler": "4.90.1"
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {
@@ -38,9 +38,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260430.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260430.1.tgz",
-      "integrity": "sha512-ADohZUHf7NBvPp2PdZig2Opxx+hDkk3ve7jrTne3JRx9kDSB73zc4LzcEeEN8LKkbAcqZmvfRJfpChSlusu0lA==",
+      "version": "1.20260508.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260508.1.tgz",
+      "integrity": "sha512-IT3r6VgiSwIesL4AJbxjgxvIxwWZqM7BKkhYAzOKHl4GF2M0TxeOahUIXd+CYXVZgHX8ceEg+MXbEehPelJyNg==",
       "cpu": [
         "x64"
       ],
@@ -55,9 +55,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260430.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260430.1.tgz",
-      "integrity": "sha512-/DoYC/1wHs+YRZzzqSQg1/EHB4hiv1yV5U8FnmapRRIzVaPtnt+ApeOXeMrIdKidgKOI8TqQzgBU8xbIM7Cl4Q==",
+      "version": "1.20260508.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260508.1.tgz",
+      "integrity": "sha512-JTVsisOJPcNKw0qovPjqyBWYahfdhUh7/9NICiG5wxaEQ45PYKdoqNq0hOAAIqvqoxsKZBvTgcPTJREPqk7avA==",
       "cpu": [
         "arm64"
       ],
@@ -72,9 +72,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260430.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260430.1.tgz",
-      "integrity": "sha512-koJhBWvEVZPKCVFtMLp2iMHlYr+lFCF47wGbnlKdHVlemV0zTxJEyHI8aLlrhPLhBmOmYLp46rXw09/qJkRIhQ==",
+      "version": "1.20260508.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260508.1.tgz",
+      "integrity": "sha512-zO38pCc27YlsZiPYcaZnosy0/t7abXrRU3VEO1oKfUvnaCpHgphDG+VsrmHL+kntda6hrtNwg2jLeMAqqIjnjw==",
       "cpu": [
         "x64"
       ],
@@ -89,9 +89,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260430.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260430.1.tgz",
-      "integrity": "sha512-hMdapNAzNQZDXGGkg4Slydc3fRJP5FUZLJVVcZCW/+imhhJro9Z1rv5n/wfR+txKoSWhTYR8eOp8Pyi2bzLzlw==",
+      "version": "1.20260508.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260508.1.tgz",
+      "integrity": "sha512-XhJa780Ia6MNIrtxn/ruZHS79b9pu5EKPfRNReaUqxy8erPT2fs93axMfFoS9kIkcaRRj/1TOUKcTeAMoywY7w==",
       "cpu": [
         "arm64"
       ],
@@ -106,9 +106,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260430.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260430.1.tgz",
-      "integrity": "sha512-jS3ffixjb5USOwz4frw4WzCz0HrjVxkgyU3WiYb06N7hBAfN6eOrveAJ4QRef0+suK4V1vQFoB1oKdRBsXe9Dw==",
+      "version": "1.20260508.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260508.1.tgz",
+      "integrity": "sha512-QdDOK3B/Ul1s3QmIwDrFyx9230to6LsNmWcVR8w+TYjNZuRPzqQBgusp78LO7MlqCoEl9dvIcN00jkJnLtBSfw==",
       "cpu": [
         "x64"
       ],
@@ -123,9 +123,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "4.20260503.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260503.1.tgz",
-      "integrity": "sha512-8VKtafR4fNMtddutOnam3yq3AQvrl9bzuMio3B3AEAfrdx7xaaDV0Oyxz54P07lODwX0jydukGLC1rpDdYXAAA==",
+      "version": "4.20260511.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260511.1.tgz",
+      "integrity": "sha512-FA+si7cOq9i/gtCHhIc0XJL0l1F/ApF+m00752Aj7WZFJrj3ZulT2T8/+rT3BabMT0QEnqFEGIqCgrmqhgEfMg==",
       "dev": true,
       "license": "MIT OR Apache-2.0"
     },
@@ -1319,16 +1319,16 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "4.20260430.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260430.0.tgz",
-      "integrity": "sha512-MWvMm3Siho9Yj7lbJZidLs8hbrRvIcOrif2mnsHQZdvoKfedpea+GaN8XJxbpRcq0B2WzNI1BB1ihdnqes3/ZA==",
+      "version": "4.20260508.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260508.0.tgz",
+      "integrity": "sha512-h3aG+PA8jEH76V4ZtBAbs3g7kjMfHJUF8hPvxeeajLTKwir+G+dqfBODg5yF9MT29LqrZKCRQRqzfHPWX4kCIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
         "sharp": "^0.34.5",
         "undici": "7.24.8",
-        "workerd": "1.20260430.1",
+        "workerd": "1.20260508.1",
         "ws": "8.18.0",
         "youch": "4.1.0-beta.10"
       },
@@ -1354,9 +1354,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -1433,9 +1433,9 @@
       "optional": true
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1467,9 +1467,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20260430.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260430.1.tgz",
-      "integrity": "sha512-KEgIWyiw3Jmn+DCd/L3ePo5fmiiYb/UcwKvDWPf/nLLOiwShDFzDSsegU5NY/JcwgvO/QsLHVi2FYrbkcXNY5Q==",
+      "version": "1.20260508.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260508.1.tgz",
+      "integrity": "sha512-VlnjyH3AjVddpSK7J54nsCVgf8i2733pl8GjKttfNi7vN/hEjjAk20d2b1nDToOLKvRQpTewRnVkqaaeGHCaAw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -1480,17 +1480,17 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260430.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260430.1",
-        "@cloudflare/workerd-linux-64": "1.20260430.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260430.1",
-        "@cloudflare/workerd-windows-64": "1.20260430.1"
+        "@cloudflare/workerd-darwin-64": "1.20260508.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260508.1",
+        "@cloudflare/workerd-linux-64": "1.20260508.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260508.1",
+        "@cloudflare/workerd-windows-64": "1.20260508.1"
       }
     },
     "node_modules/wrangler": {
-      "version": "4.87.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.87.0.tgz",
-      "integrity": "sha512-lfhfKwLfQlowwgV0xhlYgE9fU3n0I30d4ccGY/rTCEm/n42Mjvlr0Ng3ZPNqlsrsKBcDR531V7dsPkgELvrk/Q==",
+      "version": "4.90.1",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.90.1.tgz",
+      "integrity": "sha512-u2KrieKSMfRM0toTst/CfDtcRraeoVjmcExcMWgILM/ytq3qcDhuOAULoZSyPHzma43lfLJy1BC544drFyqe1A==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
@@ -1498,10 +1498,10 @@
         "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.27.3",
-        "miniflare": "4.20260430.0",
+        "miniflare": "4.20260508.0",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260430.1"
+        "workerd": "1.20260508.1"
       },
       "bin": {
         "wrangler": "bin/wrangler.js",
@@ -1514,7 +1514,7 @@
         "fsevents": "~2.3.2"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20260430.1"
+        "@cloudflare/workers-types": "^4.20260508.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {

--- a/cloudflare/transformationportal-worker/package.json
+++ b/cloudflare/transformationportal-worker/package.json
@@ -8,6 +8,10 @@
     "deploy": "wrangler deploy",
     "dry-run": "wrangler deploy --dry-run"
   },
+  "engines": {
+    "node": ">=22 <23"
+  },
+  "packageManager": "npm@11.12.1",
   "devDependencies": {
     "@cloudflare/workers-types": "4.20260511.1",
     "typescript": "6.0.3",

--- a/cloudflare/transformationportal-worker/package.json
+++ b/cloudflare/transformationportal-worker/package.json
@@ -9,8 +9,8 @@
     "dry-run": "wrangler deploy --dry-run"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "4.20260503.1",
-    "typescript": "5.8.3",
-    "wrangler": "4.87.0"
+    "@cloudflare/workers-types": "4.20260511.1",
+    "typescript": "6.0.3",
+    "wrangler": "4.90.1"
   }
 }


### PR DESCRIPTION
## Summary
- Supersedes Dependabot PRs #1733 and #1734 with one worker-tooling update.
- Updates @cloudflare/workers-types to 4.20260511.1, wrangler to 4.90.1, and TypeScript to 6.0.3.
- Regenerates the worker package-lock with npm 11 while preserving optional package libc metadata.

## Validation
- `NPM_CONFIG_CACHE=/private/tmp/npm-cache npx -y npm@11.12.1 ci`
- `NPM_CONFIG_CACHE=/private/tmp/npm-cache npx -y npm@11.12.1 run typecheck`
- `NPM_CONFIG_CACHE=/private/tmp/npm-cache XDG_CONFIG_HOME=/private/tmp/wrangler-config npx -y npm@11.12.1 run dry-run`

## Supersedes
- #1733
- #1734