### PR TITLE
[codex] Update dependency review action pin

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Review dependency changes
-        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           warn-only: true
           retry-on-snapshot-warnings: true

--- a/tests/test_dependency_review_workflow.py
+++ b/tests/test_dependency_review_workflow.py
@@ -9,7 +9,7 @@ pytestmark = pytest.mark.unit
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "dependency-review.yml"
-DEPENDENCY_REVIEW_SHA = "2031cfc080254a8a887f58cffee85186f0e49e48"
+DEPENDENCY_REVIEW_SHA = "a1d282b36b6f3519aa1f3fc636f609c47dddb294"
 
 
 def _load_workflow() -> dict:


### PR DESCRIPTION
## Summary
- Supersedes Dependabot PR #1731 by applying the dependency-review-action v5.0.0 SHA pin and updating the repo test contract in the same branch.
- Keeps dependency review advisory-only and preserves existing workflow permissions.

## Validation
- `.venv/bin/python -m pytest tests/test_dependency_review_workflow.py -q`
- `make validate-ci`

## Supersedes
- #1731