### PR TITLE
[codex] Repair pypdf 6.11 lock update

### DIFF
--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -223,7 +223,7 @@ pygments==2.20.0
     #   rich
 pylint==4.0.5
     # via -r dev.in
-pypdf==6.10.2
+pypdf==6.11.0
     # via -r ci.in
 pyproject-api==1.10.0
     # via tox

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -130,7 +130,7 @@ pygments==2.20.0
     #   -c all.txt
     #   readme-renderer
     #   rich
-pypdf==6.10.2
+pypdf==6.11.0
     # via
     #   -c all.txt
     #   -r ci.in


### PR DESCRIPTION
## Summary
- Supersedes Dependabot PR #1735 with a contract-preserving pypdf 6.11.0 lock update.
- Keeps the governed non-Linux opencv-python marker in requirements/all.txt and preserves CI provenance comments.

## Validation
- `.venv/bin/python scripts/validation/check_requirements_lock_contract.py`
- `bash scripts/validate_dependency_constraints.sh --verbose`
- `.venv/bin/python scripts/validation/check_ci_dep_sync.py`
- `make check-requirements-lock-contract`
- `make check-ci-sync`
- `.venv/bin/python -m pytest tests/test_check_requirements_lock_contract.py tests/validation/test_check_ci_dep_sync.py -q`

## Supersedes
- #1735