### PR TITLE
fix(ci): harden ai advisory quota handling

### DIFF
--- a/.github/workflows/AI_WORKFLOW_PATTERN.md
+++ b/.github/workflows/AI_WORKFLOW_PATTERN.md
@@ -95,6 +95,7 @@ except Exception as e:
 ### Visibility
 - Warnings appear as annotations in GitHub Actions UI
 - Detailed errors logged to job logs (not PR comments)
+- Fallback AI-unavailable diagnostics stay in logs/output files, not PR comments
 - No secrets or sensitive data in warnings
 
 ---
@@ -116,6 +117,12 @@ def call_openai_with_retries(client, messages, model="gpt-4o-mini", max_retries=
             status = getattr(e, "status_code", None) or getattr(e, "http_status", None)
             if status == 429 or "429" in str(e) or "Rate limit" in str(e):
                 status_is_429 = True
+            error_code = getattr(e, "code", None)
+            error_type = getattr(e, "type", None)
+
+            # Quota/billing exhaustion is terminal for the current workflow run.
+            if status_is_429 and "insufficient_quota" in (error_code, error_type):
+                raise
 
             # Retry with exponential backoff
             if status_is_429 and attempt < max_retries:
@@ -134,6 +141,7 @@ def call_openai_with_retries(client, messages, model="gpt-4o-mini", max_retries=
 - `max_retries=6`: Sufficient for typical rate limits
 - Exponential backoff: 2^attempt seconds (capped at 60s)
 - Jitter: 0.5x to 1.5x to avoid thundering herd
+- `insufficient_quota`: Terminal quota/billing condition; log once and do not retry
 
 ---
 
@@ -268,7 +276,8 @@ steps:
 
 | Failure | Detection | Warning Source | Job Result |
 |---------|-----------|----------------|------------|
-| OpenAI rate limit | Exception after retries | Python `::warning::` | Success ✓ |
+| OpenAI transient rate limit | Exception after retries | Python `::warning::` | Success ✓ |
+| OpenAI quota exhausted | Non-retryable 429 classification | Python `::warning::` | Success ✓ |
 | OpenAI timeout | Step timeout (4 min) | Shell `::warning::` | Success ✓ |
 | Python crash | Exception | Python + Shell `::warning::` | Success ✓ |
 | Network error | Exception | Python `::warning::` | Success ✓ |

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -92,7 +92,8 @@ The repository includes three AI-powered advisory workflows that provide intelli
 - Triggered on pull request opened/synchronize/reopened events.
 - Reviews relevant code files (`.py`, `.js`, `.ts`, `.jsx`, `.tsx`, `.yml`, `.yaml`, `.json`, `.md`).
 - Uses OpenAI `gpt-4o-mini` model with retry logic for rate-limit handling.
-- Posts review comments with code quality assessment, bug detection, security concerns, and best practices.
+- Posts review comments with code quality assessment, bug detection, security concerns, and best practices when OpenAI returns real review content.
+- Keeps AI-unavailable fallback diagnostics in workflow logs instead of posting fallback PR comments.
 - Non-blocking: continues even if AI service fails.
 - Timeout-bounded: 4-minute step timeout, 10-minute job timeout.
 - Requires `OPENAI_API_KEY` in repository secrets.

--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -172,6 +172,15 @@ jobs:
           # Use retry logic with exponential backoff + jitter for rate-limit / transient errors.
           print("🤖 Requesting AI review from GPT-4o-mini with retry logic...")
 
+          def get_openai_error(response):
+              try:
+                  data = response.json()
+              except ValueError:
+                  return {}
+
+              error = data.get("error", {}) if isinstance(data, dict) else {}
+              return error if isinstance(error, dict) else {}
+
           def call_openai_with_retries(api_key, messages, model="gpt-4o-mini", max_retries=6, **kwargs):
               openai_headers = {
                   "Authorization": f"Bearer {api_key}",
@@ -202,13 +211,32 @@ jobs:
                           continue
                       raise RuntimeError("OpenAI request failed after retries") from e
 
-                  if response.status_code == 429 and attempt < max_retries:
-                      base_wait = min(60, 2 ** attempt)
-                      jitter = random.uniform(0.5, 1.5)
-                      wait = base_wait * jitter
-                      print(f"⚠️ Rate limited by OpenAI (attempt {attempt}/{max_retries}). Waiting {wait:.1f}s before retrying...")
-                      time.sleep(wait)
-                      continue
+                  if response.status_code == 429:
+                      error = get_openai_error(response)
+                      error_code = error.get("code")
+                      error_type = error.get("type")
+                      error_message = error.get("message", response.text)
+                      non_retryable_429_codes = {"insufficient_quota"}
+
+                      if error_code in non_retryable_429_codes or error_type in non_retryable_429_codes:
+                          raise RuntimeError(
+                              f"OpenAI HTTP 429 non-retryable {error_code or error_type}: "
+                              f"{error_message[:400]}"
+                          )
+
+                      if attempt < max_retries:
+                          base_wait = min(60, 2 ** attempt)
+                          jitter = random.uniform(0.5, 1.5)
+                          wait = base_wait * jitter
+                          print(
+                              f"⚠️ OpenAI retryable 429 "
+                              f"(code={error_code}, type={error_type}, attempt {attempt}/{max_retries}). "
+                              f"Waiting {wait:.1f}s before retrying..."
+                          )
+                          time.sleep(wait)
+                          continue
+
+                      raise RuntimeError(f"OpenAI HTTP 429: {response.text[:400]}")
 
                   if response.status_code >= 400:
                       raise RuntimeError(f"OpenAI HTTP {response.status_code}: {response.text[:400]}")
@@ -223,6 +251,7 @@ jobs:
           ]
 
           review_text = None
+          should_post_review_comment = False
           try:
               response = call_openai_with_retries(api_key, messages, model="gpt-4o-mini", max_retries=6)
               choices = response.get("choices") if isinstance(response, dict) else None
@@ -230,21 +259,23 @@ jobs:
                   first = choices[0] if choices else {}
                   message = first.get("message", {}) if isinstance(first, dict) else {}
                   review_text = message.get("content") if isinstance(message, dict) else None
+                  should_post_review_comment = bool(review_text)
               else:
                   print("⚠️ OpenAI returned an unexpected response structure.")
           except Exception as e:
-              # If retries exhausted or a non-retryable error occurred, provide a clear fallback review_text
-              print("::warning::AI Code Review OpenAI request failed (non-blocking). See job logs for diagnostic details.")
-              print("Detailed error classification (exception type and basic status/code):", file=sys.stderr)
+              # Keep advisory failures visible in CI logs without adding noisy PR comments.
+              print("::warning::AI Code Review OpenAI request failed non-blocking. See job logs for diagnostics.")
+              print("Detailed error classification:", file=sys.stderr)
               print(f"Exception type: {type(e).__name__}", file=sys.stderr)
-              err_str = str(e)
-              if "HTTP " in err_str:
-                  print(err_str[:500], file=sys.stderr)
-              review_text = ("⚠️ AI review unavailable: the AI service returned errors (rate limits or other). "
-                             "Please retry or review manually. See CI logs for diagnostic details (error type/status/code).")
+              print(str(e)[:500], file=sys.stderr)
+              review_text = (
+                  "AI review unavailable: the AI service returned a non-retryable or exhausted error. "
+                  "See CI logs for diagnostic details."
+              )
+              should_post_review_comment = False
 
-          # Post comment on PR (attempt even if fallback review_text used)
-          if review_text:
+          # Post comments only when OpenAI returned real review content.
+          if should_post_review_comment and review_text:
               comment_body = f"## AI Code Review\n\n{review_text}\n\n---\n*Generated by AI Code Review*"
 
               comment_url = f'https://api.github.com/repos/{repo}/issues/{pr_number}/comments'

--- a/docs/ci_cd/AI_RATE_LIMIT_MITIGATION.md
+++ b/docs/ci_cd/AI_RATE_LIMIT_MITIGATION.md
@@ -2,7 +2,7 @@
 
 **Issue:** GitHub Actions workflows using AI services (OpenAI) have experienced rate-limit errors (HTTP 429) during PR reviews and issue summarization, causing workflow failures or degraded experience.
 
-**Current State:** Some mitigation exists, but improvements needed for production reliability.
+**Current State:** AI code review is non-blocking, retries transient OpenAI 429 responses, treats `insufficient_quota` as terminal, and keeps fallback diagnostics in CI logs instead of posting fallback PR comments.
 
 ---
 
@@ -13,7 +13,9 @@
 ✅ **Has retry logic with exponential backoff:**
 - 6 retries with exponential backoff (2^attempt, capped at 60s)
 - Jitter (0.5x-1.5x) to avoid thundering herd
-- Graceful degradation: posts fallback message if all retries exhausted
+- Transient 429 responses are retried
+- `insufficient_quota` is treated as a terminal quota/billing condition and is not retried in the same workflow run
+- Graceful degradation writes a diagnostic fallback response and emits a CI warning without posting a fallback PR comment
 
 ✅ **Has concurrency control:**
 - `cancel-in-progress: true` reduces redundant API calls
@@ -22,6 +24,11 @@
 ✅ **Skips gracefully:**
 - Checks for `OPENAI_API_KEY` presence
 - Exits cleanly if key missing
+
+✅ **Suppresses noisy fallback comments:**
+- Real AI-generated reviews are posted as PR comments
+- AI-unavailable fallback messages stay in the workflow logs/output file
+- Operators should inspect CI logs for terminal quota diagnostics
 
 ### Issue Summarizer Workflow (`.github/workflows/summary.yml`)
 
@@ -34,9 +41,9 @@
 
 ## Recommended Improvements
 
-### 1. Make AI Workflows Non-Blocking (High Priority)
+### 1. Keep AI Workflows Non-Blocking (Implemented)
 
-**Change:** Make AI review/summary jobs **informational only**, not required status checks.
+**Contract:** AI review/summary jobs are **informational only**, not required status checks.
 
 **Implementation:**
 ```yaml
@@ -49,7 +56,7 @@ jobs:
 
 **Rationale:**
 - AI services are external dependencies with variable availability
-- Rate limits can block PR merges even when code is correct
+- Rate limits and quota exhaustion must not block PR merges when code is correct
 - Human review is the authoritative gate; AI is advisory
 
 ### 2. Add Retry Logic to Issue Summarizer (Medium Priority)
@@ -88,6 +95,7 @@ def call_openai_with_retries(client, messages, model="gpt-4o-mini", max_retries=
 **Rationale:**
 - Consistent error handling across AI workflows
 - Transient rate limits should not cause permanent failures
+- Terminal quota errors such as `insufficient_quota` should be logged once and not retried
 
 ### 3. Add Rate-Limit Budget Monitoring (Medium Priority)
 
@@ -120,7 +128,7 @@ check-quota:
 
 **Implementation:**
 - Count changed lines, files, modified areas (git diff stats only)
-- Post simple stats: "PR touches 5 files, +200/-50 lines, no AI review available"
+- Write simple stats to the job summary/output; avoid PR comments for AI-unavailable fallback text
 - No external API calls required
 
 **Rationale:**
@@ -146,17 +154,17 @@ check-quota:
 
 | Priority | Change | Impact | Effort | Recommended Timeline |
 |----------|--------|--------|--------|---------------------|
-| **High** | Make AI workflows non-blocking | Prevents PR merge blockage | Low (1 line change) | Immediate |
+| **Done** | Keep AI workflows non-blocking | Prevents PR merge blockage | Low (1 line change) | Implemented |
 | **Medium** | Add retry to issue summarizer | Improves reliability | Medium (30 mins) | Next sprint |
 | **Medium** | Add rate-limit budget monitoring | Proactive management | Medium (1-2 hours) | Next sprint |
-| **Low** | Add degraded mode fallback | Better UX when limited | High (2-3 hours) | Future consideration |
+| **Low** | Add degraded mode fallback | Better job-summary UX when limited | High (2-3 hours) | Future consideration |
 | **Low** | Alternative AI providers | Risk diversification | High (4-6 hours) | Future consideration |
 
 ---
 
-## Quick Win: Non-Blocking AI Workflows
+## Existing Contract: Non-Blocking AI Workflows
 
-**To implement immediately (1-line change per workflow):**
+**Configured behavior:**
 
 ```diff
 # .github/workflows/ai-code-review.yml
@@ -182,6 +190,7 @@ jobs:
 2. Trigger AI review workflow
 3. Verify that even if AI fails, PR can still merge
 4. Verify that AI comments still post when successful
+5. Verify that `insufficient_quota` logs a warning without repeated retries or a fallback PR comment
 
 ---
 
@@ -189,7 +198,7 @@ jobs:
 
 **To detect ongoing rate-limit issues:**
 
-1. **GitHub Actions logs:** Search for "Rate limited" or "429" in workflow runs
+1. **GitHub Actions logs:** Search for "Rate limited", "429", or `insufficient_quota` in workflow runs
 2. **OpenAI dashboard:** Monitor API usage and quota consumption
 3. **GitHub Issues:** Track rate-limit failures as incidents
 
@@ -209,9 +218,9 @@ jobs:
 
 ## Status
 
-**Current:** AI workflows have retry logic but can still block PRs when quota exhausted.
+**Current:** AI code review retries transient 429s, treats `insufficient_quota` as terminal, stays non-blocking, and avoids fallback PR comments.
 
-**Proposed:** Make workflows non-blocking + add retry to issue summarizer.
+**Proposed:** Add retry classification parity to issue summarizer and consider optional quota monitoring.
 
 **Owner:** Repository maintainers (requires workflow permission to modify).
 

--- a/tests/test_ai_code_review_workflow.py
+++ b/tests/test_ai_code_review_workflow.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+AI_CODE_REVIEW_PATH = REPO_ROOT / ".github" / "workflows" / "ai-code-review.yml"
+
+
+def _workflow_text() -> str:
+    return AI_CODE_REVIEW_PATH.read_text(encoding="utf-8")
+
+
+def _load_workflow() -> dict:
+    return yaml.load(_workflow_text(), Loader=yaml.BaseLoader)
+
+
+def _run_ai_code_review_step() -> dict:
+    workflow = _load_workflow()
+    steps = workflow["jobs"]["ai-review"]["steps"]
+    return next(step for step in steps if step.get("name") == "Run AI Code Review")
+
+
+def test_ai_code_review_workflow_remains_advisory_and_timeout_bounded() -> None:
+    workflow = _load_workflow()
+    job = workflow["jobs"]["ai-review"]
+    run_step = _run_ai_code_review_step()
+
+    assert job["continue-on-error"] == "true"
+    assert job["timeout-minutes"] == "10"
+    assert run_step["timeout-minutes"] == "4"
+
+
+def test_ai_code_review_classifies_insufficient_quota_as_non_retryable() -> None:
+    workflow = _workflow_text()
+
+    assert "def get_openai_error(response):" in workflow
+    assert 'non_retryable_429_codes = {"insufficient_quota"}' in workflow
+    assert "if response.status_code == 429:" in workflow
+    assert "OpenAI HTTP 429 non-retryable" in workflow
+
+
+def test_ai_code_review_preserves_transient_429_retry_behavior() -> None:
+    workflow = _workflow_text()
+
+    assert "OpenAI retryable 429" in workflow
+    assert "base_wait = min(60, 2 ** attempt)" in workflow
+    assert "jitter = random.uniform(0.5, 1.5)" in workflow
+    assert "time.sleep(wait)" in workflow
+
+
+def test_ai_code_review_preserves_network_exception_retries() -> None:
+    workflow = _workflow_text()
+
+    assert "except requests.RequestException as e:" in workflow
+    assert "OpenAI network error" in workflow
+    assert "OpenAI request failed after retries" in workflow
+
+
+def test_ai_code_review_suppresses_fallback_pr_comments() -> None:
+    workflow = _workflow_text()
+
+    assert "should_post_review_comment = False" in workflow
+    assert "should_post_review_comment = bool(review_text)" in workflow
+    assert "if should_post_review_comment and review_text:" in workflow
+    assert "Post comments only when OpenAI returned real review content." in workflow
+    assert "attempt even if fallback review_text used" not in workflow


### PR DESCRIPTION
## Summary
- Root cause: the AI advisory workflow retried every OpenAI HTTP 429 and posted fallback failure text as PR comments.
- This change classifies quota exhaustion as terminal and keeps fallback diagnostics in CI logs/output while preserving advisory behavior.

## Changes
- Add OpenAI error extraction and non-retryable `insufficient_quota` handling in `.github/workflows/ai-code-review.yml`.
- Preserve transient 429 backoff/jitter and network exception retries.
- Gate PR comments behind real AI-generated review content with `should_post_review_comment`.
- Add static workflow contract tests for advisory behavior, retry classification, network retries, and fallback-comment suppression.
- Update AI advisory workflow documentation and rate-limit guidance.

## Validation
Proven green:
- `source .venv/bin/activate && python -m pytest tests/test_dependency_review_workflow.py tests/test_ai_code_review_workflow.py -q`
- `source .venv/bin/activate && make validate-ci`
- Commit hooks: Black, isort, root placement, test markers, and gitleaks passed.

Still failing:
- None observed.

Failure classification:
- No product, stale-test, or environment/tooling failures observed.

## Risk
- Bounded to the advisory AI workflow, contract tests, and matching docs.
- No dependency-review workflow, route, selector, API, or blocking CI gate behavior changes.
- Revert-safe: reverting this commit restores the previous retry/comment behavior.
