### PR TITLE
fix(ci): harden smart triage quota handling

### DIFF
--- a/.github/workflows/smart-issue-management.yml
+++ b/.github/workflows/smart-issue-management.yml
@@ -2,9 +2,9 @@ name: Smart Issue Management
 
 on:
   issues:
-    types: [opened, reopened, labeled, unlabeled]
+    types: [opened, reopened]
   pull_request_target:
-    types: [opened, reopened, labeled, unlabeled]
+    types: [opened, reopened]
 
 # Concurrency control: cancel stale triage runs for the same item.
 concurrency:
@@ -114,6 +114,15 @@ jobs:
           # Use retry logic with exponential backoff + jitter for rate-limit / transient errors.
           print("🤖 Requesting AI classification with retry logic...")
 
+          def get_openai_error(response):
+              try:
+                  data = response.json()
+              except ValueError:
+                  return {}
+
+              error = data.get("error", {}) if isinstance(data, dict) else {}
+              return error if isinstance(error, dict) else {}
+
           def call_openai_with_retries(api_key, messages, model="gpt-4o-mini", max_retries=6, **kwargs):
               openai_headers = {
                   "Authorization": f"Bearer {api_key}",
@@ -142,13 +151,32 @@ jobs:
                           continue
                       raise RuntimeError("OpenAI request failed after retries") from e
 
-                  if response.status_code == 429 and attempt < max_retries:
-                      base_wait = min(60, 2 ** attempt)
-                      jitter = random.uniform(0.5, 1.5)
-                      wait = base_wait * jitter
-                      print(f"⚠️ Rate limited by OpenAI (attempt {attempt}/{max_retries}). Waiting {wait:.1f}s before retrying...")
-                      time.sleep(wait)
-                      continue
+                  if response.status_code == 429:
+                      error = get_openai_error(response)
+                      error_code = error.get("code")
+                      error_type = error.get("type")
+                      error_message = error.get("message", response.text)
+                      non_retryable_429_codes = {"insufficient_quota"}
+
+                      if error_code in non_retryable_429_codes or error_type in non_retryable_429_codes:
+                          raise RuntimeError(
+                              f"OpenAI HTTP 429 non-retryable {error_code or error_type}: "
+                              f"{error_message[:400]}"
+                          )
+
+                      if attempt < max_retries:
+                          base_wait = min(60, 2 ** attempt)
+                          jitter = random.uniform(0.5, 1.5)
+                          wait = base_wait * jitter
+                          print(
+                              f"⚠️ OpenAI retryable 429 "
+                              f"(code={error_code}, type={error_type}, attempt {attempt}/{max_retries}). "
+                              f"Waiting {wait:.1f}s before retrying..."
+                          )
+                          time.sleep(wait)
+                          continue
+
+                      raise RuntimeError(f"OpenAI HTTP 429: {response.text[:400]}")
 
                   if response.status_code >= 400:
                       raise RuntimeError(f"OpenAI HTTP {response.status_code}: {response.text[:400]}")
@@ -300,25 +328,7 @@ jobs:
                   print(f"HTTP status: {status}", file=sys.stderr)
               if error_code is not None:
                   print(f"Error code: {error_code}", file=sys.stderr)
-              # Post error comment (non-blocking)
-              error_comment = f"""## ⚠️ AI Triage Error
-
-          Unable to automatically classify this {'PR' if is_pr else 'issue'}.
-          Please manually add labels and priority.
-
-          Error type: {type(e).__name__}
-
-          ---
-          *The AI service may be experiencing rate limits. Please retry or classify manually.*
-          """
-              try:
-                  requests.post(
-                      f'https://api.github.com/repos/{repo}/issues/{issue_number}/comments',
-                      headers=headers,
-                      json={'body': error_comment}
-                  )
-              except Exception as post_err:
-                  print(f"⚠️ Failed to post error comment: {str(post_err)}")
+              # Fallback AI-unavailable diagnostics stay in logs only; do not post PR/issue comments.
 
           print("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
           print("✅ Smart Issue Triage Complete!")

--- a/tests/test_smart_issue_management_workflow.py
+++ b/tests/test_smart_issue_management_workflow.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SMART_TRIAGE_PATH = REPO_ROOT / ".github" / "workflows" / "smart-issue-management.yml"
+
+
+def _workflow_text() -> str:
+    return SMART_TRIAGE_PATH.read_text(encoding="utf-8")
+
+
+def _load_workflow() -> dict:
+    return yaml.load(_workflow_text(), Loader=yaml.BaseLoader)
+
+
+def _run_triage_step() -> dict:
+    workflow = _load_workflow()
+    steps = workflow["jobs"]["smart-triage"]["steps"]
+    return next(step for step in steps if step.get("name") == "Smart Issue/PR Triage")
+
+
+def test_smart_triage_workflow_remains_advisory_and_timeout_bounded() -> None:
+    workflow = _load_workflow()
+    job = workflow["jobs"]["smart-triage"]
+    run_step = _run_triage_step()
+
+    assert job["continue-on-error"] == "true"
+    assert job["timeout-minutes"] == "10"
+    assert run_step["timeout-minutes"] == "4"
+
+
+def test_smart_triage_classifies_insufficient_quota_as_non_retryable() -> None:
+    workflow = _workflow_text()
+
+    assert "def get_openai_error(response):" in workflow
+    assert 'non_retryable_429_codes = {"insufficient_quota"}' in workflow
+    assert "if response.status_code == 429:" in workflow
+    assert "OpenAI HTTP 429 non-retryable" in workflow
+
+
+def test_smart_triage_preserves_transient_429_retry_behavior() -> None:
+    workflow = _workflow_text()
+
+    assert "OpenAI retryable 429" in workflow
+    assert "base_wait = min(60, 2 ** attempt)" in workflow
+    assert "jitter = random.uniform(0.5, 1.5)" in workflow
+    assert "time.sleep(wait)" in workflow
+
+
+def test_smart_triage_preserves_network_exception_retries() -> None:
+    workflow = _workflow_text()
+
+    assert "except requests.RequestException as e:" in workflow
+    assert "OpenAI network error" in workflow
+    assert "OpenAI request failed after retries" in workflow
+
+
+def test_smart_triage_suppresses_fallback_pr_comments() -> None:
+    workflow = _workflow_text()
+
+    # Per AI_WORKFLOW_PATTERN.md, fallback AI-unavailable diagnostics stay in
+    # logs and must not be posted as PR/issue comments. The previous
+    # "## ⚠️ AI Triage Error" comment and its POST must both be gone.
+    assert "AI Triage Error" not in workflow
+    assert "error_comment" not in workflow
+    assert "Fallback AI-unavailable diagnostics stay in logs only" in workflow
+
+
+def test_smart_triage_trigger_excludes_label_events() -> None:
+    workflow = _load_workflow()
+    triggers = workflow["on"]
+
+    issues_types = triggers["issues"]["types"]
+    pr_types = triggers["pull_request_target"]["types"]
+
+    assert "labeled" not in issues_types
+    assert "unlabeled" not in issues_types
+    assert "labeled" not in pr_types
+    assert "unlabeled" not in pr_types
+    assert set(issues_types) == {"opened", "reopened"}
+    assert set(pr_types) == {"opened", "reopened"}


### PR DESCRIPTION
Apply the same quota-aware OpenAI handling that PR #1747 added to
ai-code-review.yml so smart issue triage stops looping on terminal
`insufficient_quota` and stops posting "AI Triage Error" PR comments
when the AI service is unavailable.

- Drop `labeled` / `unlabeled` from the issues and pull_request_target
  triggers so manual relabeling no longer re-invokes OpenAI.
- Add `get_openai_error` helper and classify HTTP 429 with
  `insufficient_quota` as non-retryable (no more 6-deep retry storms
  on a terminal billing error).
- Remove the fallback `## ⚠️ AI Triage Error` PR comment; keep
  diagnostics in job logs / stderr only, per AI_WORKFLOW_PATTERN.md.
- Add tests/test_smart_issue_management_workflow.py mirroring the
  contract tests for ai-code-review.yml.