### PR TITLE
test(plugins): cover plugin loader security lifecycle

### DIFF
--- a/tests/unit/plugins/loader_test_helpers.py
+++ b/tests/unit/plugins/loader_test_helpers.py
@@ -19,8 +19,7 @@ def isolated_loader(
         allow_external_plugins=True,
         auto_resolve_dependencies=auto_resolve_dependencies,
     )
-    for path in loader.get_search_paths():
-        loader.remove_search_path(path)
+    loader._search_paths.clear()  # noqa: SLF001 - tests need hermetic paths.
     loader.add_search_path(search_path)
     return loader
 

--- a/tests/unit/plugins/loader_test_helpers.py
+++ b/tests/unit/plugins/loader_test_helpers.py
@@ -1,0 +1,135 @@
+"""Helpers for isolated PluginLoader unit tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable, Mapping
+
+from transformation_portal.plugins.loader import PluginLoader
+
+
+def isolated_loader(
+    search_path: Path,
+    *,
+    auto_resolve_dependencies: bool = True,
+) -> PluginLoader:
+    """Return a loader whose discovery paths are limited to one temp path."""
+    loader = PluginLoader(
+        allow_external_plugins=True,
+        auto_resolve_dependencies=auto_resolve_dependencies,
+    )
+    for path in loader.get_search_paths():
+        loader.remove_search_path(path)
+    loader.add_search_path(search_path)
+    return loader
+
+
+def write_plugin_module(
+    directory: Path,
+    module_name: str,
+    *,
+    class_name: str = "DemoPlugin",
+    plugin_name: str = "demo_plugin",
+    plugin_type: str = "CUSTOM",
+    execute_result: str = "ok",
+    cleanup_counter: bool = False,
+) -> Path:
+    """Write a concrete PluginInterface implementation to a temp module."""
+    directory.mkdir(parents=True, exist_ok=True)
+    cleanup_method = (
+        """
+    def cleanup(self):
+        global cleanup_calls
+        cleanup_calls += 1
+        super().cleanup()
+"""
+        if cleanup_counter
+        else ""
+    )
+    module_path = directory / f"{module_name}.py"
+    module_path.write_text(
+        f"""from __future__ import annotations
+
+from transformation_portal.plugins.interface import PluginInterface, PluginMetadata, PluginType
+
+cleanup_calls = 0
+
+
+class {class_name}(PluginInterface):
+    def _create_metadata(self):
+        return PluginMetadata(
+            name={plugin_name!r},
+            version="1.0.0",
+            plugin_type=PluginType.{plugin_type},
+            description="test plugin",
+            author="tests",
+        )
+
+    def initialize(self, config=None):
+        self._initialized = True
+        self._config = config or {{}}
+
+    def execute(self, *args, **kwargs):
+        return {execute_result!r}
+{cleanup_method}
+""",
+        encoding="utf-8",
+    )
+    return module_path
+
+
+def write_plugin_json(
+    package_dir: Path,
+    *,
+    name: str = "demo_plugin",
+    module_name: str = "demo_plugin",
+    class_name: str = "DemoPlugin",
+    plugin_type: str = "custom",
+    dependencies: Iterable[str] = (),
+    extra: Mapping[str, object] | None = None,
+) -> Path:
+    """Write a plugin.json manifest for a temp plugin package."""
+    package_dir.mkdir(parents=True, exist_ok=True)
+    payload: dict[str, object] = {
+        "name": name,
+        "version": "1.0.0",
+        "plugin_type": plugin_type,
+        "entry_point": f"{module_name}:{class_name}",
+        "description": "test manifest",
+        "author": "tests",
+        "dependencies": list(dependencies),
+    }
+    if extra:
+        payload.update(extra)
+    manifest_path = package_dir / "plugin.json"
+    manifest_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    return manifest_path
+
+
+def write_pyproject_manifest(
+    package_dir: Path,
+    *,
+    name: str = "demo_plugin",
+    module_name: str = "demo_plugin",
+    class_name: str = "DemoPlugin",
+    plugin_type: str = "custom",
+    dependencies: Iterable[str] = (),
+) -> Path:
+    """Write a pyproject.toml plugin manifest for a temp plugin package."""
+    package_dir.mkdir(parents=True, exist_ok=True)
+    dependency_list = json.dumps(list(dependencies))
+    pyproject_path = package_dir / "pyproject.toml"
+    pyproject_path.write_text(
+        f"""[tool.transformation_portal.plugin]
+name = "{name}"
+version = "1.0.0"
+plugin_type = "{plugin_type}"
+entry_point = "{module_name}:{class_name}"
+description = "test manifest"
+author = "tests"
+dependencies = {dependency_list}
+""",
+        encoding="utf-8",
+    )
+    return pyproject_path

--- a/tests/unit/plugins/test_loader_dependency_errors.py
+++ b/tests/unit/plugins/test_loader_dependency_errors.py
@@ -1,0 +1,127 @@
+"""PluginLoader dependency and entry-point failure tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.unit.plugins.loader_test_helpers import (
+    isolated_loader,
+    write_plugin_json,
+    write_plugin_module,
+)
+
+pytestmark = [pytest.mark.unit]
+
+
+def _discover_single(tmp_path: Path):
+    discovered = isolated_loader(tmp_path).discover_all()
+    assert len(discovered) == 1
+    return discovered[0]
+
+
+def test_missing_dependency_is_recorded_as_load_error(tmp_path: Path):
+    package_dir = tmp_path / "missing_dependency_package"
+    write_plugin_module(
+        package_dir,
+        "missing_dependency_plugin",
+        class_name="MissingDependencyPlugin",
+        plugin_name="missing_dependency_plugin",
+    )
+    write_plugin_json(
+        package_dir,
+        name="missing_dependency_plugin",
+        module_name="missing_dependency_plugin",
+        class_name="MissingDependencyPlugin",
+        dependencies=["definitely_missing_package_for_loader_tests>=99"],
+    )
+
+    loaded = _discover_single(tmp_path)
+
+    assert loaded.plugin.metadata.name == "missing_dependency_plugin"
+    assert loaded.is_valid is False
+    assert loaded.load_errors == ["Missing dependency: definitely_missing_package_for_loader_tests>=99"]
+
+
+def test_installed_dependency_does_not_create_load_error(tmp_path: Path):
+    package_dir = tmp_path / "installed_dependency_package"
+    write_plugin_module(
+        package_dir,
+        "installed_dependency_plugin",
+        class_name="InstalledDependencyPlugin",
+        plugin_name="installed_dependency_plugin",
+    )
+    write_plugin_json(
+        package_dir,
+        name="installed_dependency_plugin",
+        module_name="installed_dependency_plugin",
+        class_name="InstalledDependencyPlugin",
+        dependencies=["sys>=0"],
+    )
+
+    loaded = _discover_single(tmp_path)
+
+    assert loaded.plugin.metadata.name == "installed_dependency_plugin"
+    assert loaded.is_valid is True
+    assert loaded.load_errors == []
+
+
+def test_invalid_entry_point_format_returns_load_error(tmp_path: Path):
+    package_dir = tmp_path / "invalid_entry_point_package"
+    write_plugin_json(
+        package_dir,
+        name="invalid_entry_point_plugin",
+        module_name="unused",
+        extra={"entry_point": "module.without.class"},
+    )
+
+    loaded = _discover_single(tmp_path)
+
+    assert loaded.plugin is None
+    assert loaded.module_name == ""
+    assert loaded.load_errors == ["Invalid entry_point format: module.without.class"]
+
+
+def test_missing_entry_point_class_returns_load_error(tmp_path: Path):
+    package_dir = tmp_path / "missing_class_package"
+    write_plugin_module(
+        package_dir,
+        "missing_class_plugin",
+        class_name="PresentPlugin",
+        plugin_name="missing_class_plugin",
+    )
+    write_plugin_json(
+        package_dir,
+        name="missing_class_plugin",
+        module_name="missing_class_plugin",
+        class_name="MissingPlugin",
+    )
+
+    loaded = _discover_single(tmp_path)
+
+    assert loaded.plugin is None
+    assert loaded.module_name == "missing_class_plugin"
+    assert loaded.load_errors == ["Class MissingPlugin not found in module missing_class_plugin"]
+
+
+def test_entry_point_class_must_inherit_plugin_interface(tmp_path: Path):
+    package_dir = tmp_path / "plain_class_package"
+    package_dir.mkdir()
+    (package_dir / "plain_class_plugin.py").write_text(
+        """class PlainClass:
+    pass
+""",
+        encoding="utf-8",
+    )
+    write_plugin_json(
+        package_dir,
+        name="plain_class_plugin",
+        module_name="plain_class_plugin",
+        class_name="PlainClass",
+    )
+
+    loaded = _discover_single(tmp_path)
+
+    assert loaded.plugin is None
+    assert loaded.load_errors == ["PlainClass does not inherit from PluginInterface"]

--- a/tests/unit/plugins/test_loader_external_paths.py
+++ b/tests/unit/plugins/test_loader_external_paths.py
@@ -1,0 +1,58 @@
+"""PluginLoader external path trust-boundary tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from transformation_portal.plugins.loader import PluginLoader
+
+pytestmark = [pytest.mark.unit, pytest.mark.security]
+
+
+def _builtin_loader_path() -> Path:
+    import transformation_portal.plugins.loader as loader_module
+
+    return (Path(loader_module.__file__).resolve().parent / "builtin").resolve()
+
+
+def test_env_plugin_path_ignored_when_external_loading_disabled(monkeypatch, tmp_path: Path):
+    env_path = tmp_path / "env_plugins"
+    monkeypatch.setenv("TRANSFORMATION_PORTAL_PLUGINS", str(env_path))
+    monkeypatch.delenv("TRANSFORMATION_PORTAL_ENABLE_EXTERNAL_PLUGINS", raising=False)
+
+    loader = PluginLoader()
+
+    assert [path.resolve() for path in loader.get_search_paths()] == [_builtin_loader_path()]
+
+
+def test_direct_external_path_rejected_when_external_loading_disabled(tmp_path: Path):
+    loader = PluginLoader(allow_external_plugins=False)
+
+    with pytest.raises(ValueError, match="External plugin paths are disabled"):
+        loader.add_search_path(tmp_path / "external")
+
+    assert [path.resolve() for path in loader.get_search_paths()] == [_builtin_loader_path()]
+
+
+def test_env_opt_in_adds_env_plugin_path(monkeypatch, tmp_path: Path):
+    env_path = tmp_path / "env_plugins"
+    monkeypatch.setenv("TRANSFORMATION_PORTAL_ENABLE_EXTERNAL_PLUGINS", "yes")
+    monkeypatch.setenv("TRANSFORMATION_PORTAL_PLUGINS", str(env_path))
+
+    loader = PluginLoader()
+    paths = [path.resolve() for path in loader.get_search_paths()]
+
+    assert _builtin_loader_path() in paths
+    assert env_path.resolve() in paths
+    assert (Path.home() / ".transformation_portal" / "plugins").resolve() in paths
+
+
+def test_constructor_opt_in_allows_programmatic_external_path(tmp_path: Path):
+    plugin_path = tmp_path / "programmatic_plugins"
+
+    loader = PluginLoader(allow_external_plugins=True)
+    loader.add_search_path(plugin_path)
+
+    assert plugin_path.resolve() in [path.resolve() for path in loader.get_search_paths()]

--- a/tests/unit/plugins/test_loader_file_plugins.py
+++ b/tests/unit/plugins/test_loader_file_plugins.py
@@ -1,0 +1,65 @@
+"""PluginLoader single-file plugin discovery tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.unit.plugins.loader_test_helpers import isolated_loader, write_plugin_module
+
+pytestmark = [pytest.mark.unit]
+
+
+def test_file_plugin_discovery_skips_private_modules(tmp_path: Path):
+    write_plugin_module(
+        tmp_path,
+        "public_file_plugin",
+        class_name="PublicFilePlugin",
+        plugin_name="public_file_plugin",
+    )
+    (tmp_path / "_private.py").write_text(
+        """raise AssertionError("private plugin modules must not be imported")
+""",
+        encoding="utf-8",
+    )
+
+    discovered = isolated_loader(tmp_path).discover_all()
+
+    assert [plugin.manifest.name for plugin in discovered if plugin.manifest] == ["public_file_plugin"]
+    assert discovered[0].source_path == tmp_path / "public_file_plugin.py"
+    assert discovered[0].module_name == "plugin_public_file_plugin"
+
+
+def test_file_plugin_discovery_loads_only_concrete_plugin_classes(tmp_path: Path):
+    (tmp_path / "mixed_file_plugin.py").write_text(
+        """from transformation_portal.plugins.interface import PluginInterface, PluginMetadata, PluginType
+
+
+class AbstractOnly(PluginInterface):
+    pass
+
+
+class ConcretePlugin(PluginInterface):
+    def _create_metadata(self):
+        return PluginMetadata(
+            name="concrete_file_plugin",
+            version="1.0.0",
+            plugin_type=PluginType.CUSTOM,
+        )
+
+    def initialize(self, config=None):
+        self._initialized = True
+
+    def execute(self, *args, **kwargs):
+        return "ok"
+""",
+        encoding="utf-8",
+    )
+
+    discovered = isolated_loader(tmp_path).discover_all()
+
+    assert len(discovered) == 1
+    assert discovered[0].manifest is not None
+    assert discovered[0].manifest.name == "concrete_file_plugin"
+    assert discovered[0].plugin.execute() == "ok"

--- a/tests/unit/plugins/test_loader_lifecycle.py
+++ b/tests/unit/plugins/test_loader_lifecycle.py
@@ -1,0 +1,86 @@
+"""PluginLoader lifecycle and singleton tests."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests.unit.plugins.loader_test_helpers import (
+    isolated_loader,
+    write_plugin_json,
+    write_plugin_module,
+)
+
+pytestmark = [pytest.mark.unit]
+
+
+def test_unload_plugin_calls_cleanup_and_removes_module_cache(tmp_path: Path):
+    package_dir = tmp_path / "lifecycle_package"
+    write_plugin_module(
+        package_dir,
+        "lifecycle_plugin",
+        class_name="LifecyclePlugin",
+        plugin_name="lifecycle_plugin",
+        cleanup_counter=True,
+    )
+    write_plugin_json(
+        package_dir,
+        name="lifecycle_plugin",
+        module_name="lifecycle_plugin",
+        class_name="LifecyclePlugin",
+    )
+    loader = isolated_loader(tmp_path)
+    loaded = loader.discover_all()[0]
+    module = sys.modules["lifecycle_plugin"]
+
+    assert loaded.module_name == "lifecycle_plugin"
+    assert loader.load_plugin("lifecycle_plugin") is loaded
+
+    assert loader.unload_plugin("lifecycle_plugin") is True
+
+    assert module.cleanup_calls == 1
+    assert loader.load_plugin("lifecycle_plugin") is None
+    assert "lifecycle_plugin" not in loader._module_cache  # noqa: SLF001 - lifecycle cache contract
+    assert "lifecycle_plugin" not in sys.modules
+
+
+def test_unload_missing_plugin_returns_false(tmp_path: Path):
+    assert isolated_loader(tmp_path).unload_plugin("missing_plugin") is False
+
+
+def test_reload_plugin_reloads_manifest_plugin(tmp_path: Path):
+    package_dir = tmp_path / "reload_package"
+    write_plugin_module(
+        package_dir,
+        "reload_plugin",
+        class_name="ReloadPlugin",
+        plugin_name="reload_plugin",
+        execute_result="first",
+    )
+    write_plugin_json(
+        package_dir,
+        name="reload_plugin",
+        module_name="reload_plugin",
+        class_name="ReloadPlugin",
+    )
+    loader = isolated_loader(tmp_path)
+    first = loader.discover_all()[0]
+
+    reloaded = loader.reload_plugin("reload_plugin")
+
+    assert reloaded is not None
+    assert reloaded is not first
+    assert reloaded.plugin.metadata.name == "reload_plugin"
+
+
+def test_get_global_loader_returns_stable_singleton(monkeypatch):
+    import transformation_portal.plugins.loader as loader_module
+
+    monkeypatch.setattr(loader_module, "_global_loader", None)
+
+    first = loader_module.get_global_loader()
+    second = loader_module.get_global_loader()
+
+    assert first is second

--- a/tests/unit/plugins/test_loader_manifest_loading.py
+++ b/tests/unit/plugins/test_loader_manifest_loading.py
@@ -39,6 +39,24 @@ def test_discovers_plugin_json_manifest(tmp_path: Path):
     assert discovered[0].is_valid is True
 
 
+def test_isolated_loader_discards_relative_env_default_path(monkeypatch, tmp_path: Path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("TRANSFORMATION_PORTAL_PLUGINS", "env_plugins")
+
+    env_package_dir = tmp_path / "env_plugins" / "env_package"
+    write_plugin_module(env_package_dir, "env_plugin", plugin_name="env_plugin")
+    write_plugin_json(env_package_dir, name="env_plugin", module_name="env_plugin")
+
+    target_root = tmp_path / "target_plugins"
+    target_package_dir = target_root / "target_package"
+    write_plugin_module(target_package_dir, "target_plugin", plugin_name="target_plugin")
+    write_plugin_json(target_package_dir, name="target_plugin", module_name="target_plugin")
+
+    discovered = isolated_loader(target_root).discover_all()
+
+    assert [plugin.manifest.name for plugin in discovered if plugin.manifest] == ["target_plugin"]
+
+
 def test_discovers_pyproject_manifest_when_plugin_json_absent(tmp_path: Path):
     package_dir = tmp_path / "pyproject_package"
     write_plugin_module(

--- a/tests/unit/plugins/test_loader_manifest_loading.py
+++ b/tests/unit/plugins/test_loader_manifest_loading.py
@@ -1,0 +1,83 @@
+"""PluginLoader manifest discovery tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.unit.plugins.loader_test_helpers import (
+    isolated_loader,
+    write_plugin_json,
+    write_plugin_module,
+    write_pyproject_manifest,
+)
+
+pytestmark = [pytest.mark.unit]
+
+
+def test_discovers_plugin_json_manifest(tmp_path: Path):
+    package_dir = tmp_path / "json_package"
+    write_plugin_module(
+        package_dir,
+        "json_plugin",
+        class_name="JsonPlugin",
+        plugin_name="json_plugin",
+        execute_result="json-ok",
+    )
+    write_plugin_json(
+        package_dir,
+        name="json_plugin",
+        module_name="json_plugin",
+        class_name="JsonPlugin",
+    )
+
+    discovered = isolated_loader(tmp_path).discover_all()
+
+    assert [plugin.manifest.name for plugin in discovered if plugin.manifest] == ["json_plugin"]
+    assert discovered[0].plugin.execute() == "json-ok"
+    assert discovered[0].is_valid is True
+
+
+def test_discovers_pyproject_manifest_when_plugin_json_absent(tmp_path: Path):
+    package_dir = tmp_path / "pyproject_package"
+    write_plugin_module(
+        package_dir,
+        "pyproject_plugin",
+        class_name="PyprojectPlugin",
+        plugin_name="pyproject_plugin",
+    )
+    write_pyproject_manifest(
+        package_dir,
+        name="pyproject_plugin",
+        module_name="pyproject_plugin",
+        class_name="PyprojectPlugin",
+    )
+
+    discovered = isolated_loader(tmp_path).discover_all()
+
+    assert len(discovered) == 1
+    assert discovered[0].manifest is not None
+    assert discovered[0].manifest.name == "pyproject_plugin"
+    assert discovered[0].plugin.metadata.name == "pyproject_plugin"
+
+
+def test_malformed_plugin_json_is_skipped(tmp_path: Path):
+    package_dir = tmp_path / "malformed_package"
+    package_dir.mkdir()
+    (package_dir / "plugin.json").write_text("{not valid json", encoding="utf-8")
+
+    assert isolated_loader(tmp_path).discover_all() == []
+
+
+def test_manifest_without_entry_point_is_ignored(tmp_path: Path):
+    package_dir = tmp_path / "missing_entry_point_package"
+    write_plugin_module(package_dir, "missing_entry_plugin", plugin_name="missing_entry_plugin")
+    write_plugin_json(
+        package_dir,
+        name="missing_entry_plugin",
+        module_name="missing_entry_plugin",
+        extra={"entry_point": ""},
+    )
+
+    assert isolated_loader(tmp_path).discover_all() == []


### PR DESCRIPTION
## Summary
- Adds Cold-Zone PR1 coverage for plugin loader security, manifest, dependency, discovery, and lifecycle contracts.
- Keeps runtime behavior unchanged and does not add package or branch coverage floors.

## Changes
- Adds isolated tmp_path plugin fixtures for loader unit tests.
- Covers external plugin path opt-in, plugin.json and pyproject.toml manifests, malformed/missing entry point cases, dependency load errors, file plugin discovery, unload cleanup, sys.modules/cache cleanup, reload, and the global loader singleton.
- Keeps all generated coverage/XML/HTML/JSON artifacts untracked.

## Validation
Proven green:
- .venv/bin/pytest tests/unit/plugins tests/security/test_plugin_loading_security.py
- .venv/bin/pytest tests/unit/plugins tests/security/test_plugin_loading_security.py --cov=transformation_portal.plugins.loader --cov-report=term-missing
- make test-fast
- make validate-ci
- make coverage-report
- .venv/bin/python scripts/ci/check_per_package_coverage.py coverage.xml
- .venv/bin/python scripts/ci/check_per_package_branch_coverage.py coverage.xml --dry-run
- .venv/bin/python scripts/ci/cold_zone_report.py coverage.xml --markdown-out /tmp/cold_zone_pr1_after.md --json-out /tmp/cold_zone_pr1_after.json
- .venv/bin/python -m black --check tests/unit/plugins/loader_test_helpers.py tests/unit/plugins/test_loader_external_paths.py tests/unit/plugins/test_loader_manifest_loading.py tests/unit/plugins/test_loader_dependency_errors.py tests/unit/plugins/test_loader_file_plugins.py tests/unit/plugins/test_loader_lifecycle.py
- git diff --check

Coverage evidence:
- Full cold-zone report: src/transformation_portal/plugins/loader.py is 246/293 lines, 83.96% line coverage; 59/92 branches, 64.13% branch coverage.
- This exceeds the PR1 target of baseline + 25 points from 33.45%, target 58.45%.

Still failing:
- None observed locally.

## Risk
- Test-only change; no production loader behavior, CLI, workflow, coverage floor, or runtime contract changes.
- Fixtures are deterministic and isolated to pytest tmp_path, so the change is bounded and revert-safe.