### PR TITLE
test(vlm): cover parser contracts in core lane

### DIFF
--- a/src/transformation_portal/vlm/quality_validator.py
+++ b/src/transformation_portal/vlm/quality_validator.py
@@ -244,7 +244,7 @@ List any critical issues found."""
             recommendations = []
 
         # Calculate overall score
-        overall_score = np.mean([score.score for score in scores])
+        overall_score = float(np.mean([score.score for score in scores]))
 
         # Determine overall status
         overall_status = self._determine_status(overall_score, scores, strict)
@@ -283,14 +283,15 @@ List any critical issues found."""
         enhanced_report = self.validate(enhanced, detailed=True)
 
         # Check for quality degradation
-        quality_improved = enhanced_report.overall_score > original_report.overall_score
+        quality_improved = bool(enhanced_report.overall_score > original_report.overall_score)
         new_artifacts = len(enhanced_report.artifacts) > len(original_report.artifacts)
+        score_delta = float(enhanced_report.overall_score - original_report.overall_score)
 
         # Enhancement-specific validation
         enhancement_validation = {
             "quality_improved": quality_improved,
             "new_artifacts_introduced": new_artifacts,
-            "score_delta": enhanced_report.overall_score - original_report.overall_score,
+            "score_delta": score_delta,
             "enhancement_valid": quality_improved and not new_artifacts,
         }
 
@@ -484,7 +485,8 @@ List any critical issues found."""
         recommendations = []
 
         if "recommendations:" in text.lower():
-            rec_section = text.split("RECOMMENDATIONS:")[-1].split("\n\n")[0]
+            header_start = text.lower().index("recommendations:")
+            rec_section = text[header_start + len("recommendations:") :].split("\n\n")[0]
 
             # Split into bullet points or lines
             for line in rec_section.split("\n"):

--- a/tests/vlm/test_quality_validator_parser.py
+++ b/tests/vlm/test_quality_validator_parser.py
@@ -1,0 +1,198 @@
+"""CPU/core parser tests for VLM quality validation."""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import Iterable
+
+import pytest
+
+from transformation_portal.vlm.quality_validator import QualityValidator, ValidationStatus
+
+pytestmark = [pytest.mark.unit]
+
+
+class FakeProcessor:
+    """Deterministic processor stub that never touches model runtimes."""
+
+    def __init__(self, responses: str | Iterable[str]):
+        if isinstance(responses, str):
+            responses = [responses]
+        self._responses = deque(responses)
+        self.calls: list[dict[str, object]] = []
+
+    def analyze_image(self, image, **kwargs):
+        self.calls.append({"image": image, **kwargs})
+        return self._responses.popleft()
+
+
+def _validator(response: str | Iterable[str]) -> QualityValidator:
+    return QualityValidator(llava_processor=FakeProcessor(response))
+
+
+def _detailed_response(
+    *,
+    realism: str = "8/10",
+    structural: str = "8/10",
+    materials: str = "8/10",
+    lighting: str = "8/10",
+    aesthetic: str = "8/10",
+    artifacts: str = "None",
+    recommendations: str = "- Preserve current processing settings.",
+) -> str:
+    return f"""
+1. PHOTOGRAPHIC REALISM (0-10):
+   Score: {realism}
+   Issues: None
+
+2. STRUCTURAL ACCURACY (0-10):
+   Score: {structural}
+   Issues: None
+
+3. MATERIAL CONSISTENCY (0-10):
+   Score: {materials}
+   Issues: None
+
+4. LIGHTING PLAUSIBILITY (0-10):
+   Score: {lighting}
+   Issues: None
+
+5. AESTHETIC QUALITY (0-10):
+   Score: {aesthetic}
+   Issues: None
+
+ARTIFACTS: {artifacts}
+
+RECOMMENDATIONS:
+{recommendations}
+
+OVERALL ASSESSMENT: Professional architectural photography.
+"""
+
+
+def test_processor_injection_uses_fake_processor_without_ml_runtime() -> None:
+    fake = FakeProcessor(_detailed_response())
+    validator = QualityValidator(llava_processor=fake)
+
+    report = validator.validate("image-token", detailed=True)
+
+    assert report.overall_status is ValidationStatus.PASS
+    assert fake.calls[0]["image"] == "image-token"
+    assert fake.calls[0]["temperature"] == 0.1
+    assert fake.calls[0]["max_new_tokens"] == 1024
+
+
+@pytest.mark.parametrize(
+    ("text", "aspect", "expected"),
+    [
+        ("photographic realism\nScore: 8/10\nIssues: none", "photographic realism", 8.0),
+        ("material consistency is acceptable at 8.5/10 today", "material consistency", 8.5),
+        ("lighting plausibility has no numeric rating", "lighting plausibility", 5.0),
+    ],
+)
+def test_extract_score_accepts_score_formats_and_defaults(
+    text: str,
+    aspect: str,
+    expected: float,
+) -> None:
+    validator = _validator(_detailed_response())
+
+    assert validator._extract_score(text.lower(), aspect) == expected
+
+
+@pytest.mark.parametrize(
+    ("score", "expected"),
+    [
+        (7.0, ValidationStatus.PASS),
+        (5.0, ValidationStatus.WARNING),
+        (4.99, ValidationStatus.FAIL),
+    ],
+)
+def test_score_to_status_threshold_boundaries(score: float, expected: ValidationStatus) -> None:
+    validator = _validator(_detailed_response())
+
+    assert validator._score_to_status(score) is expected
+
+
+def test_validate_strict_mode_fails_when_any_aspect_fails() -> None:
+    validator = _validator(_detailed_response(realism="9/10", structural="4/10"))
+
+    relaxed = validator.validate("image-token", detailed=True, strict=False)
+    validator.processor = FakeProcessor(_detailed_response(realism="9/10", structural="4/10"))
+    strict = validator.validate("image-token", detailed=True, strict=True)
+
+    assert relaxed.overall_status is ValidationStatus.PASS
+    assert strict.overall_status is ValidationStatus.FAIL
+    assert strict.passed_validation is False
+
+
+def test_extract_artifacts_covers_quality_keywords() -> None:
+    validator = _validator(_detailed_response())
+    text = """
+ARTIFACTS: halo around windows, banding in the sky, blur on edges,
+synthetic texture patches, and overexposed highlights.
+"""
+
+    artifacts = validator._extract_artifacts(text)
+
+    assert {"halo", "banding", "blur", "synthetic", "overexposed"}.issubset(artifacts)
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        (
+            "RECOMMENDATIONS:\n- Reduce sharpening halos.\n- Preserve window detail.",
+            ["Reduce sharpening halos.", "Preserve window detail."],
+        ),
+        (
+            "recommendations:\n- lower exposure in the sky.\n* rebalance warm interior light.",
+            ["lower exposure in the sky.", "rebalance warm interior light."],
+        ),
+        (
+            "RECOMMENDATIONS:\n1. Reduce synthetic texture.\n2. Re-run material pass.",
+            ["Reduce synthetic texture.", "Re-run material pass."],
+        ),
+    ],
+)
+def test_extract_recommendations_handles_headers_bullets_and_numbering(
+    text: str,
+    expected: list[str],
+) -> None:
+    validator = _validator(_detailed_response())
+
+    assert validator._extract_recommendations(text) == expected
+
+
+def test_validate_enhancement_detects_improvement_without_new_artifacts() -> None:
+    validator = _validator(
+        [
+            _detailed_response(realism="6/10", structural="6/10", artifacts="minor blur"),
+            _detailed_response(realism="8/10", structural="8/10", artifacts="minor blur"),
+        ]
+    )
+
+    result = validator.validate_enhancement("original", "enhanced")
+
+    assert result["enhancement_validation"] == {
+        "quality_improved": True,
+        "new_artifacts_introduced": False,
+        "score_delta": pytest.approx(0.8),
+        "enhancement_valid": True,
+    }
+
+
+def test_validate_enhancement_detects_regression_and_new_artifacts() -> None:
+    validator = _validator(
+        [
+            _detailed_response(realism="8/10", structural="8/10", artifacts="None"),
+            _detailed_response(realism="6/10", structural="6/10", artifacts="halo and banding"),
+        ]
+    )
+
+    result = validator.validate_enhancement("original", "enhanced")
+
+    assert result["enhancement_validation"]["quality_improved"] is False
+    assert result["enhancement_validation"]["new_artifacts_introduced"] is True
+    assert result["enhancement_validation"]["score_delta"] == pytest.approx(-0.8)
+    assert result["enhancement_validation"]["enhancement_valid"] is False

--- a/tests/vlm/test_scene_analyzer_parser.py
+++ b/tests/vlm/test_scene_analyzer_parser.py
@@ -1,0 +1,243 @@
+"""CPU/core parser tests for VLM scene analysis."""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import Iterable
+
+import pytest
+
+from transformation_portal.vlm.scene_analyzer import (
+    ArchitecturalStyle,
+    RoomType,
+    SceneAnalysis,
+    SceneAnalyzer,
+    SpaceType,
+)
+
+pytestmark = [pytest.mark.unit]
+
+
+class FakeProcessor:
+    """Deterministic processor stub that never touches model runtimes."""
+
+    def __init__(self, responses: str | Iterable[str]):
+        if isinstance(responses, str):
+            responses = [responses]
+        self._responses = deque(responses)
+        self.calls: list[dict[str, object]] = []
+
+    def analyze_image(self, image, **kwargs):
+        self.calls.append({"image": image, **kwargs})
+        return self._responses.popleft()
+
+
+def _analyzer(response: str = "Interior kitchen with marble and natural light.") -> SceneAnalyzer:
+    return SceneAnalyzer(llava_processor=FakeProcessor(response))
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("Interior room with indoor seating", SpaceType.INTERIOR),
+        ("Exterior facade and outdoor courtyard", SpaceType.EXTERIOR),
+        ("Drone aerial overhead estate view", SpaceType.AERIAL),
+        ("Abstract architectural mood board", SpaceType.UNKNOWN),
+    ],
+)
+def test_extract_space_type_matrix(text: str, expected: SpaceType) -> None:
+    assert _analyzer()._extract_space_type(text) is expected
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("chef kitchen with island", RoomType.KITCHEN),
+        ("spa bathroom with stone tub", RoomType.BATHROOM),
+        ("primary bedroom suite", RoomType.BEDROOM),
+        ("open living room lounge", RoomType.LIVING),
+        ("formal dining area", RoomType.DINING),
+        ("library and office", RoomType.OFFICE),
+        ("poolside pool area", RoomType.POOL_AREA),
+        ("courtyard patio terrace", RoomType.COURTYARD),
+        ("foyer entryway entrance", RoomType.ENTRY),
+        ("gallery corridor", RoomType.UNKNOWN),
+    ],
+)
+def test_extract_room_type_matrix(text: str, expected: RoomType) -> None:
+    assert _analyzer()._extract_room_type(text) is expected
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("Spanish Mediterranean villa with terracotta roof", ArchitecturalStyle.MEDITERRANEAN),
+        ("Modern home with clean mid-century lines", ArchitecturalStyle.MODERN),
+        ("Coastal beach estate by the sea", ArchitecturalStyle.COASTAL),
+        ("Palatial luxury estate with grand entry", ArchitecturalStyle.LUXURY_ESTATE),
+        ("Unclassified architectural reference", ArchitecturalStyle.UNKNOWN),
+    ],
+)
+def test_extract_style_matrix(text: str, expected: ArchitecturalStyle) -> None:
+    assert _analyzer()._extract_style(text) is expected
+
+
+def test_extract_materials_covers_luxury_material_keywords() -> None:
+    text = "Marble counters, walnut wood floors, glass walls, metal railings, stone fireplace, fabric drapery."
+
+    materials = _analyzer()._extract_materials(text)
+
+    assert {"marble", "wood", "glass", "metal", "stone", "fabric"}.issubset(materials)
+
+
+def test_extract_luxury_features_covers_expected_keywords() -> None:
+    text = "High ceilings, designer fixtures, ocean view, and smart home automation define the room."
+
+    features = _analyzer()._extract_luxury_features(text)
+
+    assert {"high ceiling", "designer", "ocean view", "smart home"}.issubset(features)
+
+
+def test_extract_lighting_prefers_explicit_section() -> None:
+    text = "LIGHTING: Soft natural light from clerestory windows\nOther notes follow."
+
+    assert _analyzer()._extract_lighting(text) == "soft natural light from clerestory windows"
+
+
+def test_extract_lighting_falls_back_to_keyword() -> None:
+    assert _analyzer()._extract_lighting("The room is lit by dramatic light across stone.") == "dramatic light"
+
+
+def test_analyze_uses_fake_processor_and_parses_structured_response() -> None:
+    fake = FakeProcessor("""
+1. SPACE TYPE: Interior
+2. ROOM TYPE: Kitchen
+3. ARCHITECTURAL STYLE: Modern coastal
+4. MATERIALS: marble, wood, glass, metal
+5. LUXURY FEATURES: high ceilings, designer fixtures, ocean view, smart home
+6. LIGHTING: Natural light from large windows
+""")
+    analyzer = SceneAnalyzer(llava_processor=fake)
+
+    analysis = analyzer.analyze("image-token")
+
+    assert analysis.space_type is SpaceType.INTERIOR
+    assert analysis.room_type is RoomType.KITCHEN
+    assert analysis.architectural_style is ArchitecturalStyle.MODERN
+    assert {"marble", "wood", "glass", "metal"}.issubset(analysis.materials)
+    assert {"high ceiling", "designer", "ocean view", "smart home"}.issubset(analysis.luxury_features)
+    assert analysis.lighting_conditions == "natural light from large windows"
+    assert fake.calls[0]["image"] == "image-token"
+    assert fake.calls[0]["temperature"] == 0.1
+
+
+@pytest.mark.parametrize(
+    ("analysis", "expected"),
+    [
+        (
+            SceneAnalysis(
+                space_type=SpaceType.INTERIOR,
+                room_type=RoomType.KITCHEN,
+                architectural_style=ArchitecturalStyle.MODERN,
+                materials=["marble"],
+                luxury_features=[],
+                lighting_conditions="standard lighting",
+                confidence=0.85,
+                raw_analysis="",
+            ),
+            {
+                "suggested_preset": "kitchen-bright",
+                "enhancement_strength": pytest.approx(0.405),
+                "material_response_strength": 0.75,
+            },
+        ),
+        (
+            SceneAnalysis(
+                space_type=SpaceType.INTERIOR,
+                room_type=RoomType.BATHROOM,
+                architectural_style=ArchitecturalStyle.UNKNOWN,
+                materials=["stone"],
+                luxury_features=[],
+                lighting_conditions="standard lighting",
+                confidence=0.85,
+                raw_analysis="",
+            ),
+            {
+                "suggested_preset": "bathroom-spa",
+                "enhancement_strength": 0.4,
+                "material_response_strength": 0.7,
+            },
+        ),
+        (
+            SceneAnalysis(
+                space_type=SpaceType.INTERIOR,
+                room_type=RoomType.BEDROOM,
+                architectural_style=ArchitecturalStyle.UNKNOWN,
+                materials=["fabric"],
+                luxury_features=[],
+                lighting_conditions="standard lighting",
+                confidence=0.85,
+                raw_analysis="",
+            ),
+            {"suggested_preset": "bedroom-cozy", "enhancement_strength": 0.35},
+        ),
+        (
+            SceneAnalysis(
+                space_type=SpaceType.INTERIOR,
+                room_type=RoomType.POOL_AREA,
+                architectural_style=ArchitecturalStyle.UNKNOWN,
+                materials=["tile"],
+                luxury_features=["infinity pool"],
+                lighting_conditions="standard lighting",
+                confidence=0.85,
+                raw_analysis="",
+            ),
+            {
+                "suggested_preset": "pool-luxury",
+                "enhancement_strength": 0.5,
+                "atmospheric_effects": True,
+            },
+        ),
+        (
+            SceneAnalysis(
+                space_type=SpaceType.EXTERIOR,
+                room_type=None,
+                architectural_style=ArchitecturalStyle.MEDITERRANEAN,
+                materials=["stone"],
+                luxury_features=[],
+                lighting_conditions="golden hour",
+                confidence=0.85,
+                raw_analysis="",
+            ),
+            {
+                "atmospheric_effects": True,
+                "color_grading": "california-golden-hour",
+            },
+        ),
+        (
+            SceneAnalysis(
+                space_type=SpaceType.AERIAL,
+                room_type=None,
+                architectural_style=ArchitecturalStyle.LUXURY_ESTATE,
+                materials=["stone"],
+                luxury_features=["ocean view"],
+                lighting_conditions="natural light",
+                confidence=0.85,
+                raw_analysis="",
+            ),
+            {
+                "suggested_preset": "aerial-estate",
+                "atmospheric_effects": True,
+                "preserve_lighting": True,
+            },
+        ),
+    ],
+)
+def test_get_processing_recommendations_matrix(
+    analysis: SceneAnalysis,
+    expected: dict[str, object],
+) -> None:
+    recommendations = _analyzer().get_processing_recommendations(analysis)
+
+    for key, expected_value in expected.items():
+        assert recommendations[key] == expected_value


### PR DESCRIPTION
## Summary
- Implements Cold-Zone PR3 for VLM parser coverage in the cpu/core lane.
- Adds deterministic parser tests for `QualityValidator` and `SceneAnalyzer`, and fixes the small parser/report normalization issues exposed by those tests.

## Changes
- Adds `tests/vlm/test_quality_validator_parser.py` with unit-only coverage for fake processor injection, detailed score parsing, threshold boundaries, strict mode, artifact extraction, recommendation extraction, and enhancement comparison.
- Adds `tests/vlm/test_scene_analyzer_parser.py` with unit-only coverage for space type, room type, style, materials, luxury features, lighting, analyzer injection, and processing recommendations.
- Updates `QualityValidator` to parse `recommendations:` case-insensitively and return plain Python scalar values for aggregate scores and enhancement deltas.
- Keeps the PR3 scope limited to parser coverage; no coverage floors or PR4+ suites are added.

## Validation
Proven green:
- `.venv/bin/pytest tests/vlm/test_quality_validator_parser.py tests/vlm/test_scene_analyzer_parser.py tests/vlm/test_vlm_import_without_ml_runtime.py -q` (`48 passed`)
- `.venv/bin/pytest tests/vlm/test_llava.py tests/vlm/test_quality_validator.py tests/vlm/test_scene_analyzer.py -m ml` (`65 passed`)
- `.venv/bin/pytest tests/vlm -m "not ml" --cov=transformation_portal.vlm --cov-report=term-missing` (`48 passed, 65 deselected`; VLM line coverage `70.17%`)
- `make test-fast` (`77 passed`)
- `make validate-ci`
- `make check-test-markers`
- `make coverage-report` (`9446 passed, 55 skipped, 912 deselected`)
- `.venv/bin/python scripts/ci/check_per_package_coverage.py coverage.xml`
- `.venv/bin/python scripts/ci/check_per_package_branch_coverage.py coverage.xml --dry-run`
- `.venv/bin/python scripts/ci/cold_zone_report.py coverage.xml --markdown-out /tmp/cold_zone_pr3_after.md --json-out /tmp/cold_zone_pr3_after.json`
- `git diff --check`

Still failing:
- None in local validation.

Coverage notes:
- `cold_zone_report.py` reports `quality_validator.py` at `73.13%` line coverage and `scene_analyzer.py` at `99.32%` line coverage in the generated full-suite report.

## Risk
- Low. The behavior change is limited to case-insensitive recommendation parsing and scalar normalization in report dictionaries.
- Tests use injected fake processors and do not load `torch`, `transformers`, models, GPUs, or network resources in the cpu/core lane.
