### PR TITLE
test(streaming): cover image load save stages

### DIFF
--- a/tests/unit/streaming/_helpers.py
+++ b/tests/unit/streaming/_helpers.py
@@ -1,0 +1,25 @@
+"""Shared helpers for streaming stage unit tests."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, TypeVar
+
+T = TypeVar("T")
+
+
+class RecordingIOPool:
+    """Small async worker-pool stand-in for deterministic process() tests."""
+
+    def __init__(self, *, record_result: bool = False) -> None:
+        self._record_result = record_result
+        self.calls: list[Path] = []
+
+    async def run_io(self, func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
+        result = func(*args, **kwargs)
+        recorded = result if self._record_result else args[0]
+        if not isinstance(recorded, Path):
+            raise TypeError("RecordingIOPool only records pathlib.Path values")
+        self.calls.append(recorded)
+        return result

--- a/tests/unit/streaming/test_image_data.py
+++ b/tests/unit/streaming/test_image_data.py
@@ -1,0 +1,34 @@
+"""Unit coverage for streaming ImageData contracts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from transformation_portal.streaming.stages import ImageData
+
+pytestmark = pytest.mark.unit
+
+
+def test_image_data_shape_and_dtype_for_valid_array(tmp_path: Path) -> None:
+    array = np.zeros((8, 6, 3), dtype=np.uint8)
+    image_data = ImageData(array=array, path=tmp_path / "frame.png")
+
+    assert image_data.shape == (8, 6, 3)
+    assert image_data.dtype == np.uint8
+    assert image_data.depth_map is None
+    assert image_data.metadata == {}
+
+
+def test_image_data_shape_and_dtype_for_none_array(tmp_path: Path) -> None:
+    image_data = ImageData(
+        array=None,
+        path=tmp_path / "missing.png",
+        metadata={"source": "fixture"},
+    )
+
+    assert image_data.shape == ()
+    assert image_data.dtype is None
+    assert image_data.metadata == {"source": "fixture"}

--- a/tests/unit/streaming/test_image_load_stage.py
+++ b/tests/unit/streaming/test_image_load_stage.py
@@ -1,0 +1,214 @@
+"""Unit coverage for ImageLoadStage contracts."""
+
+from __future__ import annotations
+
+import asyncio
+import builtins
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from transformation_portal.streaming.stages import ImageLoadStage
+
+pytestmark = pytest.mark.unit
+
+
+class RecordingIOPool:
+    """Small async worker-pool stand-in for deterministic process() tests."""
+
+    def __init__(self) -> None:
+        self.calls: list[Path] = []
+
+    async def run_io(self, func, *args, **kwargs):
+        self.calls.append(args[0])
+        return func(*args, **kwargs)
+
+
+class FakeImage:
+    """Context-manager image stub that supports np.array(image)."""
+
+    format = "JPEG"
+    mode = "RGB"
+    size = (6, 8)
+
+    def __init__(self, *, exif: dict[int, Any] | BaseException | None = None) -> None:
+        self._exif_fixture = exif
+        self._array = np.zeros((8, 6, 3), dtype=np.uint8)
+
+    def __enter__(self) -> "FakeImage":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def __array__(self, dtype=None) -> np.ndarray:
+        return self._array.astype(dtype) if dtype is not None else self._array
+
+    def _getexif(self):
+        if isinstance(self._exif_fixture, BaseException):
+            raise self._exif_fixture
+        return self._exif_fixture
+
+
+def test_image_load_stage_loads_png_metadata(tmp_path: Path) -> None:
+    image_path = tmp_path / "sample.png"
+    source = np.zeros((8, 6, 3), dtype=np.uint8)
+    source[..., 0] = 255
+    Image.fromarray(source, mode="RGB").save(image_path)
+
+    image_data = ImageLoadStage(load_exif=False)._load_sync(image_path)
+
+    assert image_data.path == image_path
+    assert image_data.array.shape == (8, 6, 3)
+    assert image_data.array.dtype == np.uint8
+    assert image_data.metadata["original_path"] == str(image_path)
+    assert image_data.metadata["filename"] == "sample.png"
+    assert image_data.metadata["format"] == "PNG"
+    assert image_data.metadata["mode"] == "RGB"
+    assert image_data.metadata["size"] == (6, 8)
+    assert image_data.metadata["loaded_with"] == "PIL"
+    assert image_data.metadata["dtype"] == "uint8"
+    assert image_data.metadata["shape"] == (8, 6, 3)
+    assert image_data.metadata["memory_mb"] > 0
+
+
+def test_image_load_stage_tiff_falls_back_to_pil_when_tifffile_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    image_path = tmp_path / "sample.tiff"
+    source = np.full((8, 6), 120, dtype=np.uint8)
+    Image.fromarray(source, mode="L").save(image_path, format="TIFF")
+    original_import = builtins.__import__
+
+    def blocked_tifffile_import(name: str, *args: Any, **kwargs: Any):
+        if name == "tifffile":
+            raise ImportError("tifffile intentionally unavailable")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", blocked_tifffile_import)
+
+    image_data = ImageLoadStage(load_exif=False)._load_sync(image_path)
+
+    assert image_data.array.shape == (8, 6)
+    assert image_data.metadata["format"] == "TIFF"
+    assert image_data.metadata["loaded_with"] == "PIL"
+    assert image_data.metadata["dtype"] == "uint8"
+
+
+def test_image_load_stage_uses_tifffile_for_tiff_when_available(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    image_path = tmp_path / "sample.tif"
+    image_path.write_bytes(b"placeholder")
+    fake_tifffile = types.SimpleNamespace(
+        imread=lambda path: np.full((8, 6), 42, dtype=np.uint8),
+    )
+    monkeypatch.setitem(sys.modules, "tifffile", fake_tifffile)
+
+    image_data = ImageLoadStage(load_exif=False)._load_sync(image_path)
+
+    assert image_data.array.shape == (8, 6)
+    assert image_data.metadata["format"] == "TIFF"
+    assert image_data.metadata["loaded_with"] == "tifffile"
+    assert image_data.metadata["dtype"] == "uint8"
+
+
+def test_image_load_stage_converts_16bit_images_to_float32(tmp_path: Path) -> None:
+    image_path = tmp_path / "depth.png"
+    source = np.linspace(0, 65535, 8 * 6, dtype=np.uint16).reshape(8, 6)
+    Image.fromarray(source, mode="I;16").save(image_path)
+
+    image_data = ImageLoadStage(load_exif=False, convert_16bit=True)._load_sync(image_path)
+
+    assert image_data.array.shape == (8, 6)
+    assert image_data.array.dtype == np.float32
+    assert 0.0 <= float(image_data.array.min()) <= float(image_data.array.max()) <= 1.0
+    assert image_data.metadata["converted_from"] == "uint16"
+    assert image_data.metadata["dtype"] == "float32"
+
+
+def test_image_load_stage_can_preserve_16bit_dtype(tmp_path: Path) -> None:
+    image_path = tmp_path / "depth.png"
+    source = np.full((8, 6), 1024, dtype=np.uint16)
+    Image.fromarray(source, mode="I;16").save(image_path)
+
+    image_data = ImageLoadStage(load_exif=False, convert_16bit=False)._load_sync(image_path)
+
+    assert image_data.array.dtype == np.uint16
+    assert image_data.metadata["dtype"] == "uint16"
+    assert "converted_from" not in image_data.metadata
+
+
+def test_image_load_stage_ignores_exif_extraction_errors(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    image_path = tmp_path / "sample.png"
+    image_path.write_bytes(b"placeholder")
+    monkeypatch.setattr(Image, "open", lambda path: FakeImage(exif=OSError("bad exif block")))
+
+    image_data = ImageLoadStage(load_exif=True)._load_sync(image_path)
+
+    assert image_data.metadata["format"] == "JPEG"
+    assert "exif" not in image_data.metadata
+
+
+def test_image_load_stage_records_supported_exif_values(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    image_path = tmp_path / "sample.jpg"
+    image_path.write_bytes(b"placeholder")
+    monkeypatch.setattr(
+        Image,
+        "open",
+        lambda path: FakeImage(exif={1: "camera", 2: 42, 3: object(), 4: b"raw"}),
+    )
+
+    image_data = ImageLoadStage(load_exif=True)._load_sync(image_path)
+
+    assert image_data.metadata["exif"] == {1: "camera", 2: 42, 4: b"raw"}
+
+
+def test_image_load_stage_process_uses_injected_worker_pool(tmp_path: Path) -> None:
+    image_path = tmp_path / "sample.png"
+    Image.fromarray(np.zeros((8, 6, 3), dtype=np.uint8), mode="RGB").save(image_path)
+    pool = RecordingIOPool()
+    stage = ImageLoadStage(load_exif=False, worker_pool=pool)  # type: ignore[arg-type]
+
+    image_data = asyncio.run(stage.process(image_path))
+
+    assert pool.calls == [image_path]
+    assert image_data.path == image_path
+    assert image_data.array.shape == (8, 6, 3)
+
+
+def test_image_load_stage_startup_shutdown_manage_owned_worker_pool() -> None:
+    async def runner() -> None:
+        stage = ImageLoadStage(max_concurrent=1)
+        assert stage._worker_pool is None
+        await stage.startup()
+        assert stage._worker_pool is not None
+        assert stage._worker_pool._active is True
+        await stage.shutdown()
+        assert stage._worker_pool._active is False
+
+    asyncio.run(runner())
+
+
+def test_image_load_stage_process_uses_default_executor_without_worker_pool(tmp_path: Path) -> None:
+    image_path = tmp_path / "sample.png"
+    Image.fromarray(np.zeros((8, 6, 3), dtype=np.uint8), mode="RGB").save(image_path)
+    stage = ImageLoadStage(load_exif=False)
+
+    image_data = asyncio.run(stage.process(image_path))
+
+    assert image_data.path == image_path
+    assert image_data.metadata["loaded_with"] == "PIL"

--- a/tests/unit/streaming/test_image_load_stage.py
+++ b/tests/unit/streaming/test_image_load_stage.py
@@ -13,20 +13,10 @@ import numpy as np
 import pytest
 from PIL import Image
 
+from tests.unit.streaming._helpers import RecordingIOPool
 from transformation_portal.streaming.stages import ImageLoadStage
 
 pytestmark = pytest.mark.unit
-
-
-class RecordingIOPool:
-    """Small async worker-pool stand-in for deterministic process() tests."""
-
-    def __init__(self) -> None:
-        self.calls: list[Path] = []
-
-    async def run_io(self, func, *args, **kwargs):
-        self.calls.append(args[0])
-        return func(*args, **kwargs)
 
 
 class FakeImage:
@@ -191,14 +181,19 @@ def test_image_load_stage_process_uses_injected_worker_pool(tmp_path: Path) -> N
 
 
 def test_image_load_stage_startup_shutdown_manage_owned_worker_pool() -> None:
+    def marker() -> str:
+        return "ready"
+
     async def runner() -> None:
         stage = ImageLoadStage(max_concurrent=1)
         assert stage._worker_pool is None
         await stage.startup()
-        assert stage._worker_pool is not None
-        assert stage._worker_pool._active is True
+        worker_pool = stage._worker_pool
+        assert worker_pool is not None
+        assert await worker_pool.run_io(marker) == "ready"
         await stage.shutdown()
-        assert stage._worker_pool._active is False
+        with pytest.raises(RuntimeError, match="WorkerPool not active"):
+            await worker_pool.run_io(marker)
 
     asyncio.run(runner())
 

--- a/tests/unit/streaming/test_image_save_stage.py
+++ b/tests/unit/streaming/test_image_save_stage.py
@@ -1,0 +1,198 @@
+"""Unit coverage for ImageSaveStage contracts."""
+
+from __future__ import annotations
+
+import asyncio
+import builtins
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from transformation_portal.streaming.stages import ImageData, ImageLoadStage, ImageSaveStage, create_luxury_pipeline_stages
+
+pytestmark = pytest.mark.unit
+
+
+class RecordingIOPool:
+    """Small async worker-pool stand-in for deterministic process() tests."""
+
+    def __init__(self) -> None:
+        self.calls: list[Path] = []
+
+    async def run_io(self, func, *args, **kwargs):
+        output_path = func(*args, **kwargs)
+        self.calls.append(output_path)
+        return output_path
+
+
+def test_image_save_stage_writes_float_tiff(tmp_path: Path) -> None:
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+    image_data = ImageData(
+        array=np.linspace(0.0, 1.0, 8 * 6 * 3, dtype=np.float32).reshape(8, 6, 3),
+        path=tmp_path / "frame.png",
+    )
+    stage = ImageSaveStage(output_dir=output_dir, output_format="TIFF", suffix="_float")
+
+    saved = stage._save_sync(image_data)
+
+    assert saved == output_dir / "frame_float.tiff"
+    assert saved.exists()
+    assert saved.stat().st_size > 0
+
+
+def test_image_save_stage_tiff_falls_back_to_pil_when_tifffile_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+    image_data = ImageData(
+        array=np.full((8, 6, 3), 127, dtype=np.uint8),
+        path=tmp_path / "frame.png",
+    )
+    stage = ImageSaveStage(output_dir=output_dir, output_format="TIFF", suffix="_fallback")
+    original_import = builtins.__import__
+
+    def blocked_tifffile_import(name: str, *args: Any, **kwargs: Any):
+        if name == "tifffile":
+            raise ImportError("tifffile intentionally unavailable")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", blocked_tifffile_import)
+
+    saved = stage._save_sync(image_data)
+
+    assert saved == output_dir / "frame_fallback.tiff"
+    assert saved.exists()
+    with Image.open(saved) as image:
+        assert image.format == "TIFF"
+        assert image.size == (6, 8)
+
+
+def test_image_save_stage_writes_float_png_as_uint8(tmp_path: Path) -> None:
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+    image_data = ImageData(
+        array=np.full((8, 6, 3), 0.5, dtype=np.float32),
+        path=tmp_path / "frame.tiff",
+    )
+    stage = ImageSaveStage(output_dir=output_dir, output_format="PNG", suffix="_preview")
+
+    saved = stage._save_sync(image_data)
+
+    assert saved == output_dir / "frame_preview.png"
+    with Image.open(saved) as image:
+        assert image.mode == "RGB"
+        assert image.size == (6, 8)
+        assert np.asarray(image).dtype == np.uint8
+
+
+def test_image_save_stage_process_creates_output_dir_and_updates_metadata(tmp_path: Path) -> None:
+    output_dir = tmp_path / "nested" / "output"
+    image_data = ImageData(
+        array=np.full((8, 6, 3), 0.25, dtype=np.float32),
+        path=tmp_path / "frame.png",
+    )
+
+    async def runner() -> ImageData:
+        stage = ImageSaveStage(output_dir=output_dir, output_format="PNG", suffix="_done")
+        await stage.startup()
+        try:
+            return await stage.process(image_data)
+        finally:
+            await stage.shutdown()
+
+    result = asyncio.run(runner())
+
+    output_path = output_dir / "frame_done.png"
+    assert output_dir.is_dir()
+    assert output_path.exists()
+    assert result.metadata["output_path"] == str(output_path)
+
+
+def test_image_save_stage_process_uses_injected_worker_pool(tmp_path: Path) -> None:
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+    pool = RecordingIOPool()
+    image_data = ImageData(
+        array=np.zeros((8, 6, 3), dtype=np.uint8),
+        path=tmp_path / "frame.png",
+    )
+    stage = ImageSaveStage(
+        output_dir=output_dir,
+        output_format="PNG",
+        suffix="_pool",
+        worker_pool=pool,  # type: ignore[arg-type]
+    )
+
+    result = asyncio.run(stage.process(image_data))
+
+    output_path = output_dir / "frame_pool.png"
+    assert pool.calls == [output_path]
+    assert result.metadata["output_path"] == str(output_path)
+    assert output_path.exists()
+
+
+def test_image_save_stage_process_uses_default_executor_without_worker_pool(tmp_path: Path) -> None:
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+    image_data = ImageData(
+        array=np.zeros((8, 6, 3), dtype=np.uint8),
+        path=tmp_path / "frame.png",
+    )
+    stage = ImageSaveStage(output_dir=output_dir, output_format="PNG", suffix="_direct")
+
+    result = asyncio.run(stage.process(image_data))
+
+    output_path = output_dir / "frame_direct.png"
+    assert result.metadata["output_path"] == str(output_path)
+    assert output_path.exists()
+
+
+def test_image_save_stage_defaults_unknown_format_to_tiff_extension(tmp_path: Path) -> None:
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+    image_data = ImageData(
+        array=np.zeros((8, 6, 3), dtype=np.uint8),
+        path=tmp_path / "frame.png",
+    )
+    stage = ImageSaveStage(output_dir=output_dir, output_format="unknown", suffix="_fallback")
+
+    saved = stage._save_sync(image_data)
+
+    assert saved == output_dir / "frame_fallback.tiff"
+    assert saved.exists()
+
+
+def test_create_luxury_pipeline_stages_can_build_load_save_only_subset(tmp_path: Path) -> None:
+    stages = create_luxury_pipeline_stages(
+        output_dir=tmp_path / "out",
+        enable_depth=False,
+        enable_material=False,
+        enable_color_grading=False,
+    )
+
+    assert [stage.name for stage in stages] == ["image_load", "image_save"]
+    assert isinstance(stages[0], ImageLoadStage)
+    assert isinstance(stages[1], ImageSaveStage)
+
+
+def test_image_save_stage_writes_jpeg_with_quality(tmp_path: Path) -> None:
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+    image_data = ImageData(
+        array=np.full((8, 6, 3), 190, dtype=np.uint8),
+        path=tmp_path / "frame.png",
+    )
+    stage = ImageSaveStage(output_dir=output_dir, output_format="JPEG", quality=80, suffix="_display")
+
+    saved = stage._save_sync(image_data)
+
+    assert saved == output_dir / "frame_display.jpg"
+    with Image.open(saved) as image:
+        assert image.format == "JPEG"
+        assert image.size == (6, 8)

--- a/tests/unit/streaming/test_image_save_stage.py
+++ b/tests/unit/streaming/test_image_save_stage.py
@@ -11,21 +11,10 @@ import numpy as np
 import pytest
 from PIL import Image
 
+from tests.unit.streaming._helpers import RecordingIOPool
 from transformation_portal.streaming.stages import ImageData, ImageLoadStage, ImageSaveStage, create_luxury_pipeline_stages
 
 pytestmark = pytest.mark.unit
-
-
-class RecordingIOPool:
-    """Small async worker-pool stand-in for deterministic process() tests."""
-
-    def __init__(self) -> None:
-        self.calls: list[Path] = []
-
-    async def run_io(self, func, *args, **kwargs):
-        output_path = func(*args, **kwargs)
-        self.calls.append(output_path)
-        return output_path
 
 
 def test_image_save_stage_writes_float_tiff(tmp_path: Path) -> None:
@@ -118,7 +107,7 @@ def test_image_save_stage_process_creates_output_dir_and_updates_metadata(tmp_pa
 def test_image_save_stage_process_uses_injected_worker_pool(tmp_path: Path) -> None:
     output_dir = tmp_path / "out"
     output_dir.mkdir()
-    pool = RecordingIOPool()
+    pool = RecordingIOPool(record_result=True)
     image_data = ImageData(
         array=np.zeros((8, 6, 3), dtype=np.uint8),
         path=tmp_path / "frame.png",

--- a/tests/unit/streaming/test_image_save_stage.py
+++ b/tests/unit/streaming/test_image_save_stage.py
@@ -31,8 +31,9 @@ class RecordingIOPool:
 def test_image_save_stage_writes_float_tiff(tmp_path: Path) -> None:
     output_dir = tmp_path / "out"
     output_dir.mkdir()
+    image_array = np.arange(8 * 6 * 3, dtype=np.float32).reshape(8, 6, 3) / np.float32(8 * 6 * 3 - 1)
     image_data = ImageData(
-        array=np.linspace(0.0, 1.0, 8 * 6 * 3, dtype=np.float32).reshape(8, 6, 3),
+        array=image_array,
         path=tmp_path / "frame.png",
     )
     stage = ImageSaveStage(output_dir=output_dir, output_format="TIFF", suffix="_float")


### PR DESCRIPTION
## Summary
- Implement Cold-Zone Coverage Program PR6 subset 1 for src/transformation_portal/streaming/stages.py.
- Add deterministic CPU/core unit coverage for ImageData, ImageLoadStage, and ImageSaveStage only.
- Keep PR6b scope out of this slice: no depth backend, material response, or worker-pool lifecycle production changes.

## Changes
- Added tests/unit/streaming/test_image_data.py for ImageData shape and dtype contracts, including None arrays.
- Added tests/unit/streaming/test_image_load_stage.py for PNG metadata, TIFF tifffile path, TIFF PIL fallback, 16-bit conversion and preservation, EXIF success/error handling, injected worker-pool processing, owned pool startup/shutdown, and default executor processing.
- Added tests/unit/streaming/test_image_save_stage.py for float TIFF, TIFF PIL fallback, float PNG, JPEG quality path, output metadata and directory creation, injected/default executor processing, unknown-format TIFF fallback, and load/save-only factory construction.
- No production source changes and no coverage floors.

## Validation
Proven green:
- .venv/bin/pytest tests/unit/streaming/test_image_data.py tests/unit/streaming/test_image_load_stage.py tests/unit/streaming/test_image_save_stage.py -q - 21 passed
- .venv/bin/pytest tests/test_streaming_stages.py tests/test_streaming_async_pipeline.py tests/unit/streaming -q - 79 passed
- .venv/bin/pytest tests/test_streaming_stages.py tests/unit/streaming/test_image_data.py tests/unit/streaming/test_image_load_stage.py tests/unit/streaming/test_image_save_stage.py --cov=transformation_portal.streaming.stages --cov-report=term-missing -q - streaming/stages.py reached 40.25% in the focused run
- make test-fast - 77 passed
- make validate-ci
- make check-test-markers
- make coverage-report - 9526 passed, 55 skipped, 912 deselected; coverage.xml written
- .venv/bin/python scripts/ci/check_per_package_coverage.py coverage.xml
- .venv/bin/python scripts/ci/check_per_package_branch_coverage.py coverage.xml --dry-run
- .venv/bin/python scripts/ci/cold_zone_report.py coverage.xml --markdown-out /tmp/cold_zone_pr6_after.md --json-out /tmp/cold_zone_pr6_after.json
- git diff --check
- git diff --cached --check

Coverage evidence:
- Temporary cold-zone report: src/transformation_portal/streaming/stages.py is 240/542 lines covered, 44.28% line coverage, 45/166 branches covered, 27.11% branch coverage.

Still failing:
- None observed.

Failure classification:
- None.

## Risk
- Risk is limited to additive unit tests; production code is unchanged.
- Fixtures are tiny 8x6 arrays/images and stay in tmp_path.
- No network, model runtime, GPU, or multiprocessing is introduced in the default lane.
- Revert-safe: this PR removes only tests and does not alter runtime contracts.