### PR TITLE
feat(orchestrator): pessimistic restart-recovery sweep on FastAPI startup (Phase 1.C)

### DIFF
--- a/app.py
+++ b/app.py
@@ -61,6 +61,8 @@ from transformation_portal.ingest.upload_staging import (
     stage_upload_batch,
 )
 from transformation_portal.lux_depth_v3.model_registry import resolve_model_spec, resolve_registry_key, visible_cli_model_specs
+from transformation_portal.orchestrator import get_job_repository
+from transformation_portal.orchestrator.recovery import sweep_orphaned_jobs
 from transformation_portal.portal import archive_index_preflight as _portal_archive_index_preflight
 from transformation_portal.portal import asset_bundle as _portal_asset_bundle
 from transformation_portal.portal import job_artifacts as _portal_job_artifacts
@@ -7715,6 +7717,24 @@ async def _orchestrator_lifespan(app: "FastAPI") -> "AsyncGenerator[None, None]"
             " TP_API_KEY is unset; protected /v1 endpoints"
             " will return AUTH_CONFIGURATION_ERROR."
         )
+
+    # Phase 1.C restart recovery: at process startup the runtime registry
+    # is empty by construction, so any job the repository still records as
+    # queued/running is necessarily orphaned by a previous process. Mark
+    # them failed with worker_lost_on_restart so SSE late-clients see a
+    # terminal done event instead of hanging on a dead state.
+    #
+    # Memory backend (default): the repository is per-process so there are
+    # no orphans and the sweep is a deterministic no-op.
+    # Postgres backend (TP_ORCHESTRATOR_STATE_BACKEND=postgres): the sweep
+    # does the real work.
+    try:
+        swept = await sweep_orphaned_jobs(get_job_repository())
+        app.state.restart_recovery_swept = list(swept)
+    except Exception:  # noqa: BLE001 - never block startup on recovery
+        LOGGER.exception("orchestrator restart recovery sweep failed; continuing startup")
+        app.state.restart_recovery_swept = []
+
     existing_task = getattr(app.state, "cleanup_task", None)
     if existing_task is None or existing_task.done():
         app.state.cleanup_task = asyncio.create_task(_cleanup_loop())
@@ -7727,6 +7747,13 @@ async def _orchestrator_lifespan(app: "FastAPI") -> "AsyncGenerator[None, None]"
             with suppress(asyncio.CancelledError):
                 await cleanup_task
             app.state.cleanup_task = None
+        # Best-effort dispose of the repository's connection pool. The
+        # memory backend's close() is a no-op; the Postgres backend
+        # disposes its shared AsyncEngine.
+        try:
+            await get_job_repository().close()
+        except Exception:  # noqa: BLE001 - never block shutdown on close
+            LOGGER.exception("orchestrator repository close failed")
 
 
 app = FastAPI(

--- a/app.py
+++ b/app.py
@@ -7728,12 +7728,28 @@ async def _orchestrator_lifespan(app: "FastAPI") -> "AsyncGenerator[None, None]"
     # no orphans and the sweep is a deterministic no-op.
     # Postgres backend (TP_ORCHESTRATOR_STATE_BACKEND=postgres): the sweep
     # does the real work.
+    #
+    # Cache the repository on app.state so startup and shutdown share the
+    # same instance: avoids double construction and prevents a confusing
+    # "config error during shutdown" if TP_DATABASE_URL was misconfigured
+    # at boot - the misconfig surfaces once at startup and shutdown is a
+    # quiet no-op rather than a second loud failure.
     try:
-        swept = await sweep_orphaned_jobs(get_job_repository())
-        app.state.restart_recovery_swept = list(swept)
+        repo = get_job_repository()
     except Exception:  # noqa: BLE001 - never block startup on recovery
-        LOGGER.exception("orchestrator restart recovery sweep failed; continuing startup")
+        LOGGER.exception("orchestrator repository construction failed; skipping restart recovery")
+        repo = None
+    app.state.job_repository = repo
+
+    if repo is None:
         app.state.restart_recovery_swept = []
+    else:
+        try:
+            swept = await sweep_orphaned_jobs(repo)
+            app.state.restart_recovery_swept = list(swept)
+        except Exception:  # noqa: BLE001 - never block startup on recovery
+            LOGGER.exception("orchestrator restart recovery sweep failed; continuing startup")
+            app.state.restart_recovery_swept = []
 
     existing_task = getattr(app.state, "cleanup_task", None)
     if existing_task is None or existing_task.done():
@@ -7749,11 +7765,16 @@ async def _orchestrator_lifespan(app: "FastAPI") -> "AsyncGenerator[None, None]"
             app.state.cleanup_task = None
         # Best-effort dispose of the repository's connection pool. The
         # memory backend's close() is a no-op; the Postgres backend
-        # disposes its shared AsyncEngine.
-        try:
-            await get_job_repository().close()
-        except Exception:  # noqa: BLE001 - never block shutdown on close
-            LOGGER.exception("orchestrator repository close failed")
+        # disposes its shared AsyncEngine. Reuse the repository instance
+        # cached at startup so a startup-time construction failure isn't
+        # re-emitted at shutdown.
+        repo_for_close = getattr(app.state, "job_repository", None)
+        if repo_for_close is not None:
+            try:
+                await repo_for_close.close()
+            except Exception:  # noqa: BLE001 - never block shutdown on close
+                LOGGER.exception("orchestrator repository close failed")
+        app.state.job_repository = None
 
 
 app = FastAPI(

--- a/docs/governance/PRODUCTION_HARDENING_GAP_2026-05-13.md
+++ b/docs/governance/PRODUCTION_HARDENING_GAP_2026-05-13.md
@@ -78,7 +78,7 @@ implementations or precursors for the items below.
 
 ### 5.1 Phase 1 - durable jobs
 
-**Updated 2026-05-13: Phase 1.A and Phase 1.B have landed.**
+**Updated 2026-05-13: Phase 1.A, Phase 1.B, and Phase 1.C have landed.**
 
 Already done:
 

--- a/docs/governance/PRODUCTION_HARDENING_GAP_2026-05-13.md
+++ b/docs/governance/PRODUCTION_HARDENING_GAP_2026-05-13.md
@@ -83,12 +83,12 @@ implementations or precursors for the items below.
 Already done:
 
 - `JobRepository` and `JobEventStore` Protocols + `JobRecord` dataclass + memory backend (Phase 1.A, PR #1756).
-- `PostgresJobRepository` + `PostgresJobEventStore` + SQLAlchemy 2.x async ORM + Alembic initial migration + docker-compose Postgres service + `make db-upgrade` / `make db-revision` / `make test-orchestrator-postgres-contract` (Phase 1.B, this PR). Backend selected via `TP_ORCHESTRATOR_STATE_BACKEND=memory|postgres` and `TP_DATABASE_URL`. See `docs/runtimes/orchestrator-postgres.md` for the operator runbook.
+- `PostgresJobRepository` + `PostgresJobEventStore` + SQLAlchemy 2.x async ORM + Alembic initial migration + docker-compose Postgres service + `make db-upgrade` / `make db-revision` / `make test-orchestrator-postgres-contract` (Phase 1.B, PR #1758). Backend selected via `TP_ORCHESTRATOR_STATE_BACKEND=memory|postgres` and `TP_DATABASE_URL`. See `docs/runtimes/orchestrator-postgres.md` for the operator runbook.
+- Pessimistic restart recovery (Phase 1.C, this PR). `src/transformation_portal/orchestrator/recovery.py:sweep_orphaned_jobs` runs on every FastAPI startup via `_orchestrator_lifespan` in `app.py`: any job that the repository still records as `queued` or `running` but that no live worker in the runtime registry is executing is marked `failed` with `error.code = "worker_lost_on_restart"`. SSE late-clients now see a terminal `done` after a restart instead of hanging. Memory backend: deterministic no-op (per-process state). Postgres backend: durable. The lifespan also disposes the repository's connection pool on shutdown.
 
 Still net-new (follow-up commits / PRs on this branch):
 
-- `app.py` does **not yet** route writes through the repository. The legacy `JOBS: Dict[str, Job]` at `app.py:1002` remains authoritative until the wiring commit lands. Phase 1.B's contract tests prove the Postgres backend is behavior-identical to the memory backend so the cut-over is a single, isolated change.
-- Deterministic restart recovery (Phase 1.C). The `sweep_orphaned` method on both backends is implemented and contract-tested; the FastAPI lifespan hook that calls it is the Phase 1.C deliverable.
+- `app.py` does **not yet** route writes through the repository. The legacy `JOBS: Dict[str, Job]` at `app.py:1002` remains authoritative until the wiring commit lands. Phase 1.B's contract tests prove the Postgres backend is behavior-identical to the memory backend so the cut-over is a single, isolated change. Phase 1.C's sweeper operates on the repository directly so it is unaffected by this gap; once the wiring lands, the sweeper will correctly mark live jobs as orphaned only when the dict and repo agree.
 - `JobCreateRequest` exists at `src/transformation_portal/api/v1/jobs.py:130` but is still "defined, not yet wired" as a handler parameter. Pydantic envelope models in route decorators are still OpenAPI-doc-only (Phase 1.D).
 
 ### 5.2 Phase 2 - worker split

--- a/src/transformation_portal/orchestrator/recovery.py
+++ b/src/transformation_portal/orchestrator/recovery.py
@@ -1,0 +1,82 @@
+"""Pessimistic restart recovery for the orchestrator.
+
+Phase 1.C wires the existing ``JobRepository.sweep_orphaned`` into the
+FastAPI lifespan: on every startup, any job that the repository still
+records as ``queued`` or ``running`` but that no live worker in this
+process is executing is marked ``failed`` with an explicit
+``worker_lost_on_restart`` error. SSE clients reconnecting after a
+restart see a terminal ``done`` with the recovery error rather than
+hanging on a state that can no longer make progress.
+
+Memory backend: the repository is per-process so it is empty at startup
+and the sweeper is a deterministic no-op. Postgres backend (Phase 1.B):
+the repository persists across restarts and the sweeper does the real
+work.
+
+The runtime registry (``runtime_handles``) tracks live ``proc`` /
+``terminate_task`` entries within the current process. At startup that
+registry is empty, which is exactly the contract the sweeper expects:
+any active row with no live worker is by definition orphaned.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import List, Optional
+
+from transformation_portal.orchestrator.runtime_handles import (
+    RuntimeRegistry,
+    get_runtime_registry,
+)
+from transformation_portal.orchestrator.storage.base import JobRepository
+
+logger = logging.getLogger(__name__)
+
+WORKER_LOST_REASON_CODE = "worker_lost_on_restart"
+
+
+async def sweep_orphaned_jobs(
+    repository: JobRepository,
+    *,
+    runtime_registry: Optional[RuntimeRegistry] = None,
+    reason_code: str = WORKER_LOST_REASON_CODE,
+) -> List[str]:
+    """Mark any active job without a live worker as ``failed``.
+
+    Returns the list of swept ids so callers (or tests) can log /
+    metric the recovery without re-querying. The error payload is
+    fixed by the contract:
+
+        {"code": "worker_lost_on_restart",
+         "message": "Process did not survive backend restart."}
+
+    ``last_event_at`` / ``finished_at`` / ``done_published_at`` are all
+    set to the same timestamp so SSE late-clients see a terminal
+    ``done`` event.
+
+    The optional ``runtime_registry`` lets callers pass an alternative
+    registry (test isolation). In production, the default singleton is
+    used: at process startup it is empty by construction, so every
+    active row in the repository is treated as orphaned.
+    """
+    registry = runtime_registry if runtime_registry is not None else get_runtime_registry()
+    live = registry.live_job_ids()
+
+    swept = await repository.sweep_orphaned(live_job_ids=live, reason_code=reason_code)
+
+    if swept:
+        logger.warning(
+            "orchestrator restart recovery marked %d orphaned job(s) as failed: %s",
+            len(swept),
+            sorted(swept),
+        )
+    else:
+        logger.info(
+            "orchestrator restart recovery: no orphaned jobs (live=%d)",
+            len(live),
+        )
+
+    return swept
+
+
+__all__ = ["WORKER_LOST_REASON_CODE", "sweep_orphaned_jobs"]

--- a/src/transformation_portal/orchestrator/recovery.py
+++ b/src/transformation_portal/orchestrator/recovery.py
@@ -22,23 +22,37 @@ any active row with no live worker is by definition orphaned.
 from __future__ import annotations
 
 import logging
-from typing import List, Optional
+from typing import List, Optional, Protocol
 
-from transformation_portal.orchestrator.runtime_handles import (
-    RuntimeRegistry,
-    get_runtime_registry,
-)
+from transformation_portal.orchestrator.runtime_handles import get_runtime_registry
 from transformation_portal.orchestrator.storage.base import JobRepository
 
 logger = logging.getLogger(__name__)
 
 WORKER_LOST_REASON_CODE = "worker_lost_on_restart"
 
+# How many swept ids to include in the WARNING-level log line. The full
+# list is still emitted at DEBUG so operators can opt in via log level
+# without paying the cost (or polluting the warning channel) on every
+# restart of a Postgres backend that's been offline for a while.
+_SWEPT_LOG_SAMPLE_LIMIT = 20
+
+
+class LiveJobIdsProvider(Protocol):
+    """Minimal contract the sweeper needs from a runtime registry.
+
+    Anything with ``live_job_ids() -> list[str]`` satisfies it. Today
+    that's ``RuntimeRegistry``; Phase 2's Redis-lease-backed registry
+    will satisfy the same Protocol without the sweeper changing.
+    """
+
+    def live_job_ids(self) -> List[str]: ...
+
 
 async def sweep_orphaned_jobs(
     repository: JobRepository,
     *,
-    runtime_registry: Optional[RuntimeRegistry] = None,
+    runtime_registry: Optional[LiveJobIdsProvider] = None,
     reason_code: str = WORKER_LOST_REASON_CODE,
 ) -> List[str]:
     """Mark any active job without a live worker as ``failed``.
@@ -65,10 +79,20 @@ async def sweep_orphaned_jobs(
     swept = await repository.sweep_orphaned(live_job_ids=live, reason_code=reason_code)
 
     if swept:
+        sorted_ids = sorted(swept)
+        sample = sorted_ids[:_SWEPT_LOG_SAMPLE_LIMIT]
         logger.warning(
-            "orchestrator restart recovery marked %d orphaned job(s) as failed: %s",
+            "orchestrator restart recovery marked %d orphaned job(s) as failed " "(sample of up to %d: %s)",
             len(swept),
-            sorted(swept),
+            _SWEPT_LOG_SAMPLE_LIMIT,
+            sample,
+        )
+        # Full list goes to DEBUG so operators can opt in via log level
+        # without flooding the warning channel.
+        logger.debug(
+            "orchestrator restart recovery: full swept id list (%d): %s",
+            len(swept),
+            sorted_ids,
         )
     else:
         logger.info(

--- a/tests/orchestrator/test_lifespan_recovery.py
+++ b/tests/orchestrator/test_lifespan_recovery.py
@@ -1,0 +1,80 @@
+"""End-to-end test for the FastAPI lifespan restart-recovery wiring.
+
+The unit tests in ``test_restart_recovery.py`` exercise
+``sweep_orphaned_jobs`` directly. This file proves the wiring inside
+``app.py``'s ``_orchestrator_lifespan`` actually invokes the sweep on
+startup and stashes the result so operators can observe it via
+``app.state.restart_recovery_swept``.
+
+Memory backend only - the Postgres backend is verified by the
+parametrized contract tests when ``TP_TEST_POSTGRES_URL`` is set. We
+deliberately do not seed orphans here because cross-event-loop reuse
+of the memory backend's per-job ``asyncio.Lock`` instances between an
+``asyncio.run(...)`` setup loop and the ``TestClient`` lifespan loop
+is fragile across Python versions. The wiring contract being pinned
+is "the lifespan calls the sweeper and exposes its result"; the
+sweeper's own behavior is fully covered elsewhere.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+import app as orchestrator_app
+from transformation_portal.orchestrator import reset_singletons
+from transformation_portal.orchestrator.runtime_handles import reset_runtime_registry
+
+pytestmark = [pytest.mark.unit]
+
+
+@pytest.fixture(autouse=True)
+def _reset_orchestrator_singletons() -> None:
+    reset_singletons()
+    reset_runtime_registry()
+    yield
+    reset_singletons()
+    reset_runtime_registry()
+
+
+def test_orchestrator_lifespan_runs_restart_recovery_sweep() -> None:
+    """The lifespan must call ``sweep_orphaned_jobs`` and stash its result."""
+    with TestClient(orchestrator_app.app):
+        # The lifespan startup completed without raising. The swept list
+        # is exposed on app.state so operators can log / metric it.
+        swept = getattr(orchestrator_app.app.state, "restart_recovery_swept", None)
+        assert swept is not None, (
+            "lifespan did not set app.state.restart_recovery_swept; " "sweep_orphaned_jobs may not have been wired"
+        )
+        assert isinstance(swept, list)
+
+
+def test_orchestrator_lifespan_recovery_handles_repository_failures() -> None:
+    """If the sweeper raises, startup must continue and stash an empty list.
+
+    Phase 1.C contract: restart recovery is best-effort - a transient
+    Postgres outage at boot must not block the orchestrator from
+    serving requests. The exception is logged but not propagated.
+    """
+    import transformation_portal.orchestrator.recovery as recovery_module
+    from transformation_portal.orchestrator.storage import base as storage_base
+
+    original = recovery_module.sweep_orphaned_jobs
+
+    async def _failing_sweep(*_args, **_kwargs):
+        raise storage_base.RepositoryError("simulated transient failure")
+
+    recovery_module.sweep_orphaned_jobs = _failing_sweep
+    # app.py imported sweep_orphaned_jobs at module-load, so monkeypatch
+    # the symbol it actually calls too.
+    original_in_app = orchestrator_app.sweep_orphaned_jobs
+    orchestrator_app.sweep_orphaned_jobs = _failing_sweep
+    try:
+        with TestClient(orchestrator_app.app):
+            swept = getattr(orchestrator_app.app.state, "restart_recovery_swept", None)
+            assert swept == [], (
+                "failed sweep must leave restart_recovery_swept as an empty list " "rather than propagating the exception"
+            )
+    finally:
+        recovery_module.sweep_orphaned_jobs = original
+        orchestrator_app.sweep_orphaned_jobs = original_in_app

--- a/tests/orchestrator/test_restart_recovery.py
+++ b/tests/orchestrator/test_restart_recovery.py
@@ -1,0 +1,141 @@
+"""Phase 1.C - tests for the restart-recovery sweeper.
+
+The sweeper itself runs against a ``JobRepository`` so the same
+contract assertions apply to memory and Postgres. The Postgres branch
+auto-skips when ``TP_TEST_POSTGRES_URL`` is unset.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import pytest
+
+from transformation_portal.orchestrator import (
+    JobEventStore,
+    JobRecord,
+    JobRepository,
+)
+from transformation_portal.orchestrator.recovery import (
+    WORKER_LOST_REASON_CODE,
+    sweep_orphaned_jobs,
+)
+from transformation_portal.orchestrator.runtime_handles import RuntimeRegistry
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+RepoAndEvents = Tuple[JobRepository, JobEventStore]
+
+
+def _record(job_id: str, *, created_at: float = 1.0) -> JobRecord:
+    return JobRecord(id=job_id, created_at=created_at)
+
+
+async def test_sweep_marks_running_and_queued_jobs_failed(
+    repository_and_events: RepoAndEvents,
+) -> None:
+    """At startup with no live workers, every active job must be marked failed."""
+    repo, _ = repository_and_events
+    await repo.create(_record("queued-1"))
+    await repo.create(_record("queued-2"))
+    await repo.create(_record("running-1"))
+    await repo.update("running-1", state="running", started_at=2.0)
+    await repo.create(_record("running-2"))
+    await repo.update("running-2", state="running", started_at=3.0)
+    # A pre-existing terminal job must not be touched.
+    await repo.create(_record("done-1"))
+    await repo.update("done-1", state="succeeded", finished_at=4.0, done_published_at=4.0)
+
+    empty_registry = RuntimeRegistry()
+    swept = await sweep_orphaned_jobs(repo, runtime_registry=empty_registry)
+
+    assert set(swept) == {"queued-1", "queued-2", "running-1", "running-2"}
+
+    for jid in swept:
+        rec = await repo.get(jid)
+        assert rec is not None
+        assert rec.state == "failed"
+        assert rec.finished_at is not None
+        assert rec.done_published_at is not None
+        assert rec.last_event_at is not None
+        assert rec.error == {
+            "code": WORKER_LOST_REASON_CODE,
+            "message": "Process did not survive backend restart.",
+        }
+
+    done = await repo.get("done-1")
+    assert done is not None
+    assert done.state == "succeeded"
+    assert done.error is None
+
+
+async def test_sweep_excludes_jobs_with_live_workers(
+    repository_and_events: RepoAndEvents,
+) -> None:
+    """Jobs whose ids are in ``runtime_registry.live_job_ids`` must survive."""
+    repo, _ = repository_and_events
+    await repo.create(_record("alive"))
+    await repo.update("alive", state="running", started_at=1.0)
+    await repo.create(_record("dead"))
+    await repo.update("dead", state="running", started_at=2.0)
+
+    class _FakeRegistry:
+        def live_job_ids(self) -> list[str]:
+            return ["alive"]
+
+    swept = await sweep_orphaned_jobs(repo, runtime_registry=_FakeRegistry())  # type: ignore[arg-type]
+
+    assert swept == ["dead"]
+    alive = await repo.get("alive")
+    assert alive is not None and alive.state == "running"
+
+
+async def test_sweep_is_noop_when_no_active_jobs(
+    repository_and_events: RepoAndEvents,
+) -> None:
+    """Sweeping a repository with no queued/running rows returns an empty list."""
+    repo, _ = repository_and_events
+    await repo.create(_record("done-only"))
+    await repo.update("done-only", state="succeeded", finished_at=1.0)
+
+    swept = await sweep_orphaned_jobs(repo, runtime_registry=RuntimeRegistry())
+    assert swept == []
+
+
+async def test_sweep_is_idempotent(
+    repository_and_events: RepoAndEvents,
+) -> None:
+    """A second sweep right after the first must touch nothing."""
+    repo, _ = repository_and_events
+    await repo.create(_record("orphan"))
+    await repo.update("orphan", state="running", started_at=1.0)
+
+    first = await sweep_orphaned_jobs(repo, runtime_registry=RuntimeRegistry())
+    assert first == ["orphan"]
+
+    second = await sweep_orphaned_jobs(repo, runtime_registry=RuntimeRegistry())
+    assert second == []
+
+    rec = await repo.get("orphan")
+    assert rec is not None and rec.state == "failed"
+
+
+async def test_sweep_uses_default_registry_when_none_passed(
+    repository_and_events: RepoAndEvents,
+) -> None:
+    """The production code path - no explicit registry - must work too.
+
+    The default registry (``get_runtime_registry``) is the process
+    singleton; tests cannot easily reset it without affecting other
+    tests, so we keep this as a smoke test that asserts the call shape
+    and that a freshly-created job not present in the default registry
+    is treated as orphaned.
+    """
+    repo, _ = repository_and_events
+    await repo.create(_record("default-registry-orphan"))
+    await repo.update("default-registry-orphan", state="queued")
+
+    swept = await sweep_orphaned_jobs(repo)
+    # The default singleton may contain unrelated entries from earlier
+    # tests, but our just-created job_id is not in it.
+    assert "default-registry-orphan" in swept

--- a/tests/orchestrator/test_restart_recovery.py
+++ b/tests/orchestrator/test_restart_recovery.py
@@ -83,7 +83,9 @@ async def test_sweep_excludes_jobs_with_live_workers(
         def live_job_ids(self) -> list[str]:
             return ["alive"]
 
-    swept = await sweep_orphaned_jobs(repo, runtime_registry=_FakeRegistry())  # type: ignore[arg-type]
+    # _FakeRegistry satisfies the LiveJobIdsProvider Protocol structurally,
+    # so no type: ignore is needed.
+    swept = await sweep_orphaned_jobs(repo, runtime_registry=_FakeRegistry())
 
     assert swept == ["dead"]
     alive = await repo.get("alive")


### PR DESCRIPTION
## Summary

Phase 1.C of the durable-jobs hardening roadmap. On every orchestrator startup the FastAPI lifespan now sweeps the `JobRepository` for jobs the database still records as `queued`/`running` but that no live worker in this process is executing, and marks them `failed` with `error.code = "worker_lost_on_restart"`. SSE late-clients reconnecting after a restart see a terminal `done` event instead of hanging on a dead state.

The repository's `sweep_orphaned` method (introduced in Phase 1.A and contract-tested in both backends since Phase 1.B) does the heavy lifting; this PR adds the lifespan wiring, a thin `recovery.sweep_orphaned_jobs` wrapper, and the regression tests.

Motivation: [`docs/governance/PRODUCTION_HARDENING_GAP_2026-05-13.md`](https://github.com/RC219805/Transformation_Portal/blob/main/docs/governance/PRODUCTION_HARDENING_GAP_2026-05-13.md) §5.1 (updated in this PR to mark Phase 1.C complete).

## What's new

- **`src/transformation_portal/orchestrator/recovery.py`** — `sweep_orphaned_jobs(repository, *, runtime_registry=None, reason_code="worker_lost_on_restart")`. Reads `RuntimeRegistry.live_job_ids()` so jobs whose process is still alive in the current orchestrator are excluded. Logs at `WARNING` when it sweeps (with the id list) and `INFO` when it doesn't.
- **`tests/orchestrator/test_restart_recovery.py`** — five backend-parametrized unit tests: basic sweep marks running+queued failed and leaves terminal jobs alone; live-worker exclusion; no-op when no active jobs; idempotency; default-registry path.
- **`tests/orchestrator/test_lifespan_recovery.py`** — two end-to-end integration tests via `TestClient`: assert `app.state.restart_recovery_swept` is set after lifespan startup, and a monkeypatched failure path that proves a transient sweeper exception does not block startup.

## What changed in `app.py`

- New imports: `get_job_repository`, `sweep_orphaned_jobs`.
- `_orchestrator_lifespan` now:
  - **On startup**: calls `await sweep_orphaned_jobs(get_job_repository())` inside a `try/except` (best-effort, never blocks startup), exposes the swept-id list as `app.state.restart_recovery_swept` so operators can log/metric it.
  - **On shutdown**: best-effort `await get_job_repository().close()` to dispose the repository's connection pool (no-op for memory; releases the SQLAlchemy `AsyncEngine` for Postgres).

## Backend behavior

| Backend | Behavior |
| --- | --- |
| `memory` (default) | Per-process state; the repository is empty at startup so `sweep_orphaned` is a deterministic no-op. The wiring still runs so `app.state.restart_recovery_swept = []`. |
| `postgres` (`TP_ORCHESTRATOR_STATE_BACKEND=postgres`) | The repository persists across restarts; the sweep does the real work. Any job that survived a previous process is marked failed with `worker_lost_on_restart`. |

## Test plan

- [x] `pytest -q tests/orchestrator/test_restart_recovery.py -m unit` — 5/5 pass on memory backend (Postgres branch auto-skips when `TP_TEST_POSTGRES_URL` is unset).
- [x] `pytest -q tests/orchestrator/test_lifespan_recovery.py -m unit` — 2/2 pass (lifespan wiring + best-effort failure path).
- [x] `pytest -q tests/orchestrator/ tests/test_app_orchestrator_runtime.py tests/test_app_orchestrator_contract_http.py -m unit` — **443 passed + 1 skipped**. Existing 410-test orchestrator HTTP contract suite still green.
- [x] `make check-stale-docs`, `make check-doc-heading-links`, `make check-json-serialization`, `make check-python-headers`, `make check-yaml-governance` — all clean.
- [x] Pre-commit (15 hooks) on every changed file — pass.
- [x] `python -c "import app; print('app.py imports OK')"` — orchestrator module imports do not break the FastAPI app load path.

## What this PR explicitly does NOT change

- `app.py` orchestrator handlers — still use the legacy `JOBS: Dict[str, Job]`. The follow-up commit/PR on this track wires every write site through the repository. Phase 1.C's sweeper operates on the repository directly, so it is unaffected by this gap; once the wiring lands, the sweeper will correctly mark live jobs as orphaned only when the dict and repo agree.
- The `JobRepository.sweep_orphaned` contract or its tests (already in place from Phase 1.A/1.B).
- Frontdoor (Phase 3), artifact storage (Phase 4), or runtime Pydantic envelope validation (Phase 1.D).

## Sequencing

| Layer | Scope | Status |
| --- | --- | --- |
| 1.A | Protocols + memory backend | ✓ merged as PR #1756 |
| 1.B | Postgres backend + Alembic + docker-compose + Makefile + runtime doc | ✓ merged as PR #1758 |
| **1.C** | **`sweep_orphaned_jobs` + FastAPI lifespan wiring** | **this PR** |
| 1.A wiring | Refactor `app.py` to route writes through the repository | follow-up |
| 1.D | Runtime Pydantic validation on `/v1`/`/v2` envelopes | follow-up |

Each layer lands as its own small PR per the gap doc's "small reviewable units" rule.

## Notes for reviewers

- The lifespan wiring catches `Exception` around the sweep call and around `repo.close()` — restart recovery and pool disposal are both best-effort. A transient Postgres outage at boot must not prevent the orchestrator from serving requests; the failure is logged at `ERROR` via `LOGGER.exception(...)` and the swept list defaults to `[]`. The `test_orchestrator_lifespan_recovery_handles_repository_failures` test pins this contract.
- `RuntimeRegistry.live_job_ids()` reads the *current* process registry, which is empty at startup. As Phase 2 introduces real horizontal workers, the sweeper signature already supports passing a richer set of live ids (e.g., from a Redis lease).
- The error payload shape (`{"code": "worker_lost_on_restart", "message": ...}`) is identical to what the Phase 1.A contract test (`test_sweep_orphaned_marks_active_jobs_failed`) and Phase 1.B Postgres backend already produce; no wire change to SSE clients or `_serialize_job`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EPqVEoqKMc7AKTJVyTvBh6)_