### PR TITLE
feat(orchestrator): runtime Pydantic envelope validation on /v[12]/jobs (Phase 1.D)

### DIFF
--- a/app.py
+++ b/app.py
@@ -37,7 +37,6 @@ from starlette.middleware.trustedhost import TrustedHostMiddleware
 from starlette.responses import Response, StreamingResponse
 
 from transformation_portal.api.v1 import (
-    ApiEnvelope,
     ConfigMetadataEnvelope,
     ConfigPreviewEnvelope,
     HealthzResponse,

--- a/app.py
+++ b/app.py
@@ -37,11 +37,15 @@ from starlette.middleware.trustedhost import TrustedHostMiddleware
 from starlette.responses import Response, StreamingResponse
 
 from transformation_portal.api.v1 import (
+    ApiEnvelope,
     ConfigMetadataEnvelope,
     ConfigPreviewEnvelope,
     HealthzResponse,
+    JobBriefData,
     JobEnvelope,
+    JobsListData,
     JobsListEnvelope,
+    JobStatusData,
     JobStatusEnvelope,
     PortalEventEnvelope,
     PortalRumIngestEnvelope,
@@ -8524,17 +8528,23 @@ async def _create_job(
 
     asyncio.create_task(_run_job(job, argv))
 
+    # Phase 1.D: construct a Pydantic envelope so the wire shape is
+    # validated at runtime (Pydantic raises on bad field types / missing
+    # required fields). Serialize through ``model_dump(by_alias=True,
+    # exclude_unset=True)`` to preserve byte-identity with the legacy
+    # ``_api_envelope`` helper (verified by
+    # ``tests/orchestrator/test_envelope_runtime_validation.py``).
     return JSONResponse(
-        _api_envelope(
-            "tp.orchestrator.job.v1",
+        JobEnvelope(
+            schema="tp.orchestrator.job.v1",
             success=True,
-            data={
-                "id": jid,
-                "state": job.state,
-                "events_url": _job_events_url(jid, api_version=api_version),
-            },
+            data=JobBriefData(
+                id=jid,
+                state=job.state,
+                events_url=_job_events_url(jid, api_version=api_version),
+            ),
             error=None,
-        )
+        ).model_dump(mode="json", by_alias=True, exclude_unset=True)
     )
 
 
@@ -8558,17 +8568,21 @@ def _list_jobs(*, limit: int = JOB_LIST_LIMIT, api_version: str = "v1") -> JSONR
     )
     serialized = [_serialize_job(job, include_logs=False, api_version=api_version) for job in jobs_sorted[:bounded_limit]]
 
+    # Phase 1.D: construct via Pydantic for runtime validation, then
+    # serialize with ``exclude_unset=True`` so optional Job fields the
+    # legacy serializer omits when ``include_logs=False`` (notably
+    # ``logs_tail``) stay absent on the wire.
     return JSONResponse(
-        _api_envelope(
-            "tp.orchestrator.jobs.v1",
+        JobsListEnvelope(
+            schema="tp.orchestrator.jobs.v1",
             success=True,
-            data={
-                "jobs": serialized,
-                "total": len(JOBS),
-                "returned": len(serialized),
-            },
+            data=JobsListData(
+                jobs=[JobStatusData(**entry) for entry in serialized],
+                total=len(JOBS),
+                returned=len(serialized),
+            ),
             error=None,
-        )
+        ).model_dump(mode="json", by_alias=True, exclude_unset=True)
     )
 
 
@@ -8592,13 +8606,17 @@ def _get_job(job_id: str, *, include_logs: bool = True, api_version: str = "v1")
             message="job not found",
             details={"job_id": job_id},
         )
+    # Phase 1.D: construct via Pydantic for runtime validation, then
+    # serialize with ``exclude_unset=True`` so the optional
+    # ``logs_tail`` default (None) is omitted when the legacy
+    # ``_serialize_job`` does not include it (``include_logs=False``).
     return JSONResponse(
-        _api_envelope(
-            "tp.orchestrator.job_status.v1",
+        JobStatusEnvelope(
+            schema="tp.orchestrator.job_status.v1",
             success=True,
-            data=_serialize_job(job, include_logs=bool(include_logs), api_version=api_version),
+            data=JobStatusData(**_serialize_job(job, include_logs=bool(include_logs), api_version=api_version)),
             error=None,
-        )
+        ).model_dump(mode="json", by_alias=True, exclude_unset=True)
     )
 
 
@@ -8709,13 +8727,17 @@ async def _cancel_job(job_id: str) -> JSONResponse:
             details={"job_id": job_id},
         )
     await _request_cancel(job)
+    # Phase 1.D: ``events_url`` is deliberately not passed to
+    # ``JobBriefData`` so it stays unset; ``exclude_unset=True`` then
+    # drops it from the wire, matching the legacy ``_api_envelope``
+    # output that omitted it for cancel responses.
     return JSONResponse(
-        _api_envelope(
-            "tp.orchestrator.job.v1",
+        JobEnvelope(
+            schema="tp.orchestrator.job.v1",
             success=True,
-            data={"id": job_id, "state": job.state},
+            data=JobBriefData(id=job_id, state=job.state),
             error=None,
-        )
+        ).model_dump(mode="json", by_alias=True, exclude_unset=True)
     )
 
 

--- a/docs/governance/PRODUCTION_HARDENING_GAP_2026-05-13.md
+++ b/docs/governance/PRODUCTION_HARDENING_GAP_2026-05-13.md
@@ -78,18 +78,19 @@ implementations or precursors for the items below.
 
 ### 5.1 Phase 1 - durable jobs
 
-**Updated 2026-05-13: Phase 1.A, Phase 1.B, and Phase 1.C have landed.**
+**Updated 2026-05-13: Phase 1.A, Phase 1.B, Phase 1.C, and Phase 1.D have landed.**
 
 Already done:
 
 - `JobRepository` and `JobEventStore` Protocols + `JobRecord` dataclass + memory backend (Phase 1.A, PR #1756).
 - `PostgresJobRepository` + `PostgresJobEventStore` + SQLAlchemy 2.x async ORM + Alembic initial migration + docker-compose Postgres service + `make db-upgrade` / `make db-revision` / `make test-orchestrator-postgres-contract` (Phase 1.B, PR #1758). Backend selected via `TP_ORCHESTRATOR_STATE_BACKEND=memory|postgres` and `TP_DATABASE_URL`. See `docs/runtimes/orchestrator-postgres.md` for the operator runbook.
-- Pessimistic restart recovery (Phase 1.C, this PR). `src/transformation_portal/orchestrator/recovery.py:sweep_orphaned_jobs` runs on every FastAPI startup via `_orchestrator_lifespan` in `app.py`: any job that the repository still records as `queued` or `running` but that no live worker in the runtime registry is executing is marked `failed` with `error.code = "worker_lost_on_restart"`. SSE late-clients now see a terminal `done` after a restart instead of hanging. Memory backend: deterministic no-op (per-process state). Postgres backend: durable. The lifespan also disposes the repository's connection pool on shutdown.
+- Pessimistic restart recovery (Phase 1.C, PR #1759). `src/transformation_portal/orchestrator/recovery.py:sweep_orphaned_jobs` runs on every FastAPI startup via `_orchestrator_lifespan` in `app.py`: any job that the repository still records as `queued` or `running` but that no live worker in the runtime registry is executing is marked `failed` with `error.code = "worker_lost_on_restart"`. SSE late-clients now see a terminal `done` after a restart instead of hanging. Memory backend: deterministic no-op (per-process state). Postgres backend: durable. The lifespan also disposes the repository's connection pool on shutdown.
+- Runtime Pydantic envelope validation on `/v[12]/jobs` success paths (Phase 1.D, this PR). The four success-path returns (`_create_job`, `_list_jobs`, `_get_job`, `_cancel_job`) construct an `ApiEnvelope[T]` Pydantic model at runtime and serialize via `model_dump(by_alias=True, exclude_unset=True)`. Bad field types or missing required fields now raise at construction instead of slipping through as malformed JSON. Byte-identity with the legacy `_api_envelope` helper is pinned by `tests/orchestrator/test_envelope_runtime_validation.py` (12 tests: side-by-side model-vs-helper canonical JSON equality + HTTP-level wire-shape pins across `v1` and `v2`). SSE event payloads stay manual; the error path (`_error_response`) is unchanged.
 
-Still net-new (follow-up commits / PRs on this branch):
+Still net-new (follow-up commits / PRs):
 
 - `app.py` does **not yet** route writes through the repository. The legacy `JOBS: Dict[str, Job]` at `app.py:1002` remains authoritative until the wiring commit lands. Phase 1.B's contract tests prove the Postgres backend is behavior-identical to the memory backend so the cut-over is a single, isolated change. Phase 1.C's sweeper operates on the repository directly so it is unaffected by this gap; once the wiring lands, the sweeper will correctly mark live jobs as orphaned only when the dict and repo agree.
-- `JobCreateRequest` exists at `src/transformation_portal/api/v1/jobs.py:130` but is still "defined, not yet wired" as a handler parameter. Pydantic envelope models in route decorators are still OpenAPI-doc-only (Phase 1.D).
+- `JobCreateRequest` exists at `src/transformation_portal/api/v1/jobs.py:130` but is still "defined, not yet wired" as a handler parameter. Wiring it would collapse the specific `_create_job` error reason codes (e.g. `"unsupported_pipeline"`) into a generic `"request_validation_failed"`; that trade-off is intentionally deferred per the module docstring's recommendation and is the next layer's decision.
 
 ### 5.2 Phase 2 - worker split
 

--- a/tests/orchestrator/test_envelope_runtime_validation.py
+++ b/tests/orchestrator/test_envelope_runtime_validation.py
@@ -1,0 +1,292 @@
+"""Phase 1.D - byte-identical wire-shape regression for /v[12]/jobs routes.
+
+The orchestrator's success-path responses move from
+``JSONResponse(_api_envelope(...))`` to returning Pydantic envelope
+models directly. FastAPI's ``response_model=`` then validates the
+response at runtime, but only if the bytes on the wire are
+*semantically identical* to today's output. This file pins that.
+
+Two layers of coverage:
+
+1. ``test_pydantic_envelope_matches_*`` - side-by-side assertions
+   that the Pydantic models in
+   ``src/transformation_portal/api/v1/envelopes.py`` and
+   ``.../jobs.py`` produce the same dict as the legacy
+   ``app.py:_api_envelope`` helper, after canonical
+   ``json.dumps(..., sort_keys=True)`` normalization. Catches model-
+   level drift.
+
+2. ``test_*_route_wire_shape`` - HTTP-level assertions through the
+   real ``TestClient``: exercise every success-path response (create,
+   list, get, cancel, both v1 and v2) and pin the four envelope
+   keys (``schema``, ``success``, ``data``, ``error``) plus the
+   per-payload field set. Catches FastAPI-introduced shape changes.
+
+The serialization knob that makes Pydantic match the legacy helper
+is ``exclude_unset=True``: legacy ``_api_envelope`` mirrors whatever
+dict the caller passed in (e.g. ``_cancel_job`` passes
+``{"id": ..., "state": ...}`` with no ``events_url`` key), and
+``JobBriefData(id=..., state=...)`` with ``events_url`` unset and
+``exclude_unset=True`` produces the same shape. Routes that refactor
+to return Pydantic envelopes use ``response_model_exclude_unset=True``
+for the same reason.
+
+SSE event payloads stay manual and are intentionally out of scope.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Iterator
+
+import pytest
+from fastapi.testclient import TestClient
+
+import app as orchestrator_app
+from transformation_portal.api.v1.envelopes import ApiEnvelope
+from transformation_portal.api.v1.jobs import (
+    JobBriefData,
+    JobsListData,
+    JobStatusData,
+)
+
+pytestmark = [pytest.mark.unit]
+
+
+def _canonical(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: Pydantic-model output equals legacy helper output (no HTTP).
+# ---------------------------------------------------------------------------
+
+
+def test_pydantic_envelope_matches_helper_for_create_brief() -> None:
+    """Create response: id + state + events_url; all three keys present."""
+    legacy = orchestrator_app._api_envelope(
+        "tp.orchestrator.job.v1",
+        success=True,
+        data={"id": "job_abc", "state": "queued", "events_url": "/v1/jobs/job_abc/events"},
+        error=None,
+    )
+    pydantic_dump = ApiEnvelope[JobBriefData](
+        schema="tp.orchestrator.job.v1",
+        success=True,
+        data=JobBriefData(id="job_abc", state="queued", events_url="/v1/jobs/job_abc/events"),
+        error=None,
+    ).model_dump(mode="json", by_alias=True, exclude_unset=True)
+    assert _canonical(legacy) == _canonical(pydantic_dump)
+
+
+def test_pydantic_envelope_matches_helper_for_cancel_brief() -> None:
+    """Cancel response: id + state only; events_url must be absent."""
+    legacy = orchestrator_app._api_envelope(
+        "tp.orchestrator.job.v1",
+        success=True,
+        data={"id": "job_xyz", "state": "canceled"},
+        error=None,
+    )
+    pydantic_dump = ApiEnvelope[JobBriefData](
+        schema="tp.orchestrator.job.v1",
+        success=True,
+        data=JobBriefData(id="job_xyz", state="canceled"),
+        error=None,
+    ).model_dump(mode="json", by_alias=True, exclude_unset=True)
+    assert _canonical(legacy) == _canonical(pydantic_dump)
+    # Belt-and-braces: the resulting dict must have no events_url key.
+    assert "events_url" not in pydantic_dump["data"]
+    # And error must remain null on the envelope (set explicitly).
+    assert pydantic_dump["error"] is None
+
+
+def test_pydantic_envelope_matches_helper_for_jobs_list() -> None:
+    """JobsListData with a serialized job entry: byte-identical to helper."""
+    sample_job: Dict[str, Any] = {
+        "id": "job_aaa",
+        "pipeline": "lux-depth-v3",
+        "created_at": 1700_000_000.0,
+        "started_at": 1700_000_001.0,
+        "finished_at": None,
+        "state": "running",
+        "progress": 42,
+        "exit_code": None,
+        "events_url": "/v1/jobs/job_aaa/events",
+        "artifacts": {},
+        "error": None,
+        "run_summary": None,
+        "last_event_at": 1700_000_002.0,
+    }
+    legacy = orchestrator_app._api_envelope(
+        "tp.orchestrator.jobs.v1",
+        success=True,
+        data={"jobs": [sample_job], "total": 1, "returned": 1},
+        error=None,
+    )
+    pydantic_dump = ApiEnvelope[JobsListData](
+        schema="tp.orchestrator.jobs.v1",
+        success=True,
+        data=JobsListData(
+            jobs=[JobStatusData(**sample_job)],
+            total=1,
+            returned=1,
+        ),
+        error=None,
+    ).model_dump(mode="json", by_alias=True, exclude_unset=True)
+    assert _canonical(legacy) == _canonical(pydantic_dump)
+
+
+# ---------------------------------------------------------------------------
+# Layer 2: HTTP-level wire-shape pins. Hit the real routes; assert envelope.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(name="client")
+def _client_fixture(
+    monkeypatch: pytest.MonkeyPatch,
+    mark_da3_runtime_available: None,
+) -> Iterator[TestClient]:
+    """A TestClient with the contract auth-key wired and a trivial fake runner.
+
+    ``mark_da3_runtime_available`` makes the lux-depth-v3 dispatch
+    preflight pass without a real DA3 install; it's the same fixture
+    the legacy contract tests use.
+    """
+
+    async def _instant_complete(job, _argv) -> None:  # noqa: ANN001
+        # Trivial fake runner: mark the job succeeded synchronously.
+        job.state = "succeeded"
+        job.exit_code = 0
+        now = orchestrator_app._now()
+        job.started_at = now
+        job.finished_at = now
+        job.done_published_at = now
+
+    monkeypatch.setattr(orchestrator_app, "_run_job", _instant_complete)
+    # Avoid pipeline-validation false-rejects for the lightweight smoke jobs.
+    monkeypatch.setattr(orchestrator_app, "_materialize_dispatch_output_dir", lambda *_a, **_kw: None)
+
+    previous_api_key = orchestrator_app.API_KEY_SECRET
+    previous_enforce = orchestrator_app.ENFORCE_JOB_API_KEY
+    orchestrator_app.API_KEY_SECRET = "contract-secret"
+    orchestrator_app.ENFORCE_JOB_API_KEY = True
+    orchestrator_app.JOBS.clear()
+    orchestrator_app.EVENT_SUBSCRIBERS.clear()
+    try:
+        with TestClient(orchestrator_app.app, headers={"x-api-key": "contract-secret"}) as client:
+            yield client
+    finally:
+        orchestrator_app.API_KEY_SECRET = previous_api_key
+        orchestrator_app.ENFORCE_JOB_API_KEY = previous_enforce
+        orchestrator_app.JOBS.clear()
+        orchestrator_app.EVENT_SUBSCRIBERS.clear()
+
+
+def _create_dummy_job(client: TestClient, *, api_version: str) -> str:
+    response = client.post(
+        f"/{api_version}/jobs",
+        json={
+            "pipeline": "lux-depth-v3",
+            "args": {
+                "input_dir": "./tests/fixtures/archive_small/archive_root",
+                "output_dir": "./tests/fixtures/portal_contract_output/phase1d_wire_shape",
+            },
+        },
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["data"]["id"]
+
+
+def _assert_envelope_shape(body: Dict[str, Any], *, expected_schema: str) -> None:
+    """Every success envelope must have exactly schema/success/data/error."""
+    assert set(body.keys()) == {"schema", "success", "data", "error"}, body
+    assert body["schema"] == expected_schema
+    assert body["success"] is True
+    assert body["error"] is None
+    assert isinstance(body["data"], dict)
+
+
+@pytest.mark.parametrize("api_version", ["v1", "v2"])
+def test_create_job_wire_shape(client: TestClient, api_version: str) -> None:
+    response = client.post(
+        f"/{api_version}/jobs",
+        json={
+            "pipeline": "lux-depth-v3",
+            "args": {
+                "input_dir": "./tests/fixtures/archive_small/archive_root",
+                "output_dir": "./tests/fixtures/portal_contract_output/phase1d_create",
+            },
+        },
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    _assert_envelope_shape(body, expected_schema="tp.orchestrator.job.v1")
+    assert set(body["data"].keys()) == {"id", "state", "events_url"}
+    assert body["data"]["state"] in {"queued", "running", "succeeded"}
+    assert body["data"]["events_url"].endswith(f"/{api_version}/jobs/{body['data']['id']}/events")
+
+
+@pytest.mark.parametrize("api_version", ["v1", "v2"])
+def test_list_jobs_wire_shape(client: TestClient, api_version: str) -> None:
+    _create_dummy_job(client, api_version=api_version)
+    response = client.get(f"/{api_version}/jobs")
+    assert response.status_code == 200, response.text
+    body = response.json()
+    _assert_envelope_shape(body, expected_schema="tp.orchestrator.jobs.v1")
+    assert set(body["data"].keys()) == {"jobs", "total", "returned"}
+    assert isinstance(body["data"]["jobs"], list)
+    assert body["data"]["total"] >= 1
+    assert body["data"]["returned"] >= 1
+    # logs_tail must be absent (list endpoint passes include_logs=False).
+    for job in body["data"]["jobs"]:
+        assert "logs_tail" not in job
+
+
+@pytest.mark.parametrize("api_version", ["v1", "v2"])
+def test_get_job_wire_shape(client: TestClient, api_version: str) -> None:
+    job_id = _create_dummy_job(client, api_version=api_version)
+    response = client.get(f"/{api_version}/jobs/{job_id}")
+    assert response.status_code == 200, response.text
+    body = response.json()
+    _assert_envelope_shape(body, expected_schema="tp.orchestrator.job_status.v1")
+    # The detail endpoint defaults to include_logs=True, so logs_tail must be
+    # present (even if empty).
+    expected_required = {
+        "id",
+        "pipeline",
+        "created_at",
+        "state",
+        "progress",
+        "events_url",
+        "artifacts",
+        "logs_tail",
+    }
+    assert expected_required.issubset(body["data"].keys()), body["data"].keys()
+
+
+@pytest.mark.parametrize("api_version", ["v1", "v2"])
+def test_cancel_job_wire_shape(client: TestClient, api_version: str) -> None:
+    job_id = _create_dummy_job(client, api_version=api_version)
+    response = client.post(f"/{api_version}/jobs/{job_id}/cancel")
+    assert response.status_code == 200, response.text
+    body = response.json()
+    _assert_envelope_shape(body, expected_schema="tp.orchestrator.job.v1")
+    # Cancel response carries {id, state} - no events_url.
+    assert set(body["data"].keys()) == {"id", "state"}
+    assert body["data"]["id"] == job_id
+
+
+# ---------------------------------------------------------------------------
+# Layer 3: canonical-JSON regression - the same response endpoint, hit twice,
+# must produce a canonical JSON string that is invariant within one process
+# (no field-order randomization, no float formatting drift). Pins the
+# determinism the Pydantic refactor must preserve.
+# ---------------------------------------------------------------------------
+
+
+def test_list_jobs_response_is_canonically_deterministic(client: TestClient) -> None:
+    _create_dummy_job(client, api_version="v1")
+    first = client.get("/v1/jobs").json()
+    second = client.get("/v1/jobs").json()
+    # In-process determinism: same content yields the same canonical bytes.
+    assert _canonical(first) == _canonical(second)

--- a/tests/orchestrator/test_envelope_runtime_validation.py
+++ b/tests/orchestrator/test_envelope_runtime_validation.py
@@ -1,10 +1,17 @@
 """Phase 1.D - byte-identical wire-shape regression for /v[12]/jobs routes.
 
-The orchestrator's success-path responses move from
-``JSONResponse(_api_envelope(...))`` to returning Pydantic envelope
-models directly. FastAPI's ``response_model=`` then validates the
-response at runtime, but only if the bytes on the wire are
-*semantically identical* to today's output. This file pins that.
+The orchestrator's four success-path job helpers (``_create_job``,
+``_list_jobs``, ``_get_job``, ``_cancel_job``) now construct a typed
+``ApiEnvelope[T]`` Pydantic model and serialize via
+``model_dump(by_alias=True, exclude_unset=True)``, wrapped in
+``JSONResponse(...)``. Runtime validation comes from the Pydantic
+construction itself - bad field types or missing required fields
+raise at handler time. FastAPI's ``response_model=`` decorator stays
+for OpenAPI typing but does not re-serialize, since the handler
+returns a ``JSONResponse``. (Returning a bare Pydantic model would
+break internal-helper callers that call the helpers directly and
+``.body.decode("utf-8")`` the result; the ``JSONResponse`` wrapper
+preserves that contract while still gaining runtime validation.)
 
 Two layers of coverage:
 
@@ -20,18 +27,21 @@ Two layers of coverage:
    real ``TestClient``: exercise every success-path response (create,
    list, get, cancel, both v1 and v2) and pin the four envelope
    keys (``schema``, ``success``, ``data``, ``error``) plus the
-   per-payload field set. Catches FastAPI-introduced shape changes.
+   per-payload field set. Catches drift in either the Pydantic
+   serialization config or the helper inputs.
 
 The serialization knob that makes Pydantic match the legacy helper
 is ``exclude_unset=True``: legacy ``_api_envelope`` mirrors whatever
 dict the caller passed in (e.g. ``_cancel_job`` passes
 ``{"id": ..., "state": ...}`` with no ``events_url`` key), and
 ``JobBriefData(id=..., state=...)`` with ``events_url`` unset and
-``exclude_unset=True`` produces the same shape. Routes that refactor
-to return Pydantic envelopes use ``response_model_exclude_unset=True``
-for the same reason.
+``exclude_unset=True`` produces the same shape. The handler dumps
+with the same flag inline.
 
 SSE event payloads stay manual and are intentionally out of scope.
+The error path (``_error_response``) is also unchanged - errors
+still emit through ``ErrorEnvelope``-shaped JSON via
+``JSONResponse``.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

Phase 1.D — the final layer of the orchestrator durable-jobs hardening roadmap. Replaces the four `/v[12]/jobs` success-path returns (`_create_job`, `_list_jobs`, `_get_job`, `_cancel_job`) so they construct a typed `ApiEnvelope[T]` Pydantic model and serialize via `model_dump(by_alias=True, exclude_unset=True)`. Bad field types or missing required fields now raise at construction instead of slipping out as malformed JSON. The wire shape is byte-identical to the legacy `_api_envelope` helper output — proven by a new 12-test snapshot suite that runs both before and after the refactor.

Motivation: [`docs/governance/PRODUCTION_HARDENING_GAP_2026-05-13.md`](https://github.com/RC219805/Transformation_Portal/blob/main/docs/governance/PRODUCTION_HARDENING_GAP_2026-05-13.md) §5.1 (updated in this PR to mark Phase 1.D complete).

## What's new

- **`tests/orchestrator/test_envelope_runtime_validation.py`** — 12 tests pinning byte-identity in three layers:
  1. **3 side-by-side tests** (`test_pydantic_envelope_matches_helper_for_*`): build the same envelope two ways (legacy `_api_envelope` dict vs `ApiEnvelope[T].model_dump(by_alias=True, exclude_unset=True)`) and assert canonical JSON equality. Catches model-level drift for create/cancel/list shapes.
  2. **8 HTTP-level wire-shape tests** (`test_*_wire_shape[v1|v2]`): exercise every success-path response (create, list, get, cancel × v1, v2) via `TestClient` and pin the `{schema, success, data, error}` envelope plus per-payload field-set invariants (`events_url` present on create / absent on cancel; `logs_tail` present on get / absent on list).
  3. **1 determinism regression** (`test_list_jobs_response_is_canonically_deterministic`): same response, called twice, produces the same canonical bytes.

## What changed in `app.py`

The four success-path returns now look like:

```python
return JSONResponse(
    JobEnvelope(
        schema="tp.orchestrator.job.v1",
        success=True,
        data=JobBriefData(id=jid, state=job.state, events_url=...),
        error=None,
    ).model_dump(mode="json", by_alias=True, exclude_unset=True)
)
```

Pydantic construction validates at runtime. The `JSONResponse` wrapper is preserved so internal helper callers (which call `_create_job` / `_list_jobs` / `_get_job` / `_cancel_job` directly and `.body.decode("utf-8")` the result — see `tests/test_app_orchestrator_runtime.py`) don't need to learn a new shape.

`exclude_unset=True` is the critical knob: legacy `_api_envelope` mirrors whatever dict callers pass in, so optional Job fields (`logs_tail` when `include_logs=False`, `events_url` on cancel) are omitted entirely rather than serialized as `null`. Pydantic with `exclude_unset=True` matches that exactly.

## What this PR explicitly does NOT change

- **`JobCreateRequest` stays unwired.** Per the existing module docstring at `src/transformation_portal/api/v1/jobs.py:23-29`, wiring it would collapse specific `_create_job` error-reason codes (e.g. `"unsupported_pipeline"`) into a generic `"request_validation_failed"` from Pydantic's exception handler. That trade-off is intentionally deferred to a separate layer per the docstring's recommendation.
- **Error path** (`_error_response`) — unchanged. Errors still emit through `ErrorEnvelope`-shaped JSON.
- **SSE event payloads** (`text/event-stream`) — stay manual; Pydantic doesn't help there.
- **`response_model=`** decorators — kept for OpenAPI typing.
- The legacy `JOBS: Dict[str, Job]` dict at `app.py:1002` still holds the live job state; the durable-storage wiring is the next layer's deliverable.

## Test plan

- [x] `pytest -q tests/orchestrator/test_envelope_runtime_validation.py -m unit` — **12/12 pass** (3 side-by-side + 8 HTTP wire-shape + 1 determinism).
- [x] `pytest -q tests/orchestrator/ tests/test_app_orchestrator_runtime.py tests/test_app_orchestrator_contract_http.py -m unit` — **455 passed + 1 skipped** (existing postgres-only cascade test auto-skips offline). The 3 internal-helper tests that previously did `response.body.decode("utf-8")` still pass because `JSONResponse` is preserved.
- [x] `python -c "import app"` — app module imports cleanly after the refactor.
- [x] `make check-stale-docs`, `make check-doc-heading-links`, `make check-json-serialization`, `make check-python-headers`, `make check-yaml-governance` — all green.
- [x] Pre-commit (15 hooks) — pass.

## Sequencing

| Layer | Scope | Status |
| --- | --- | --- |
| 1.A | Protocols + memory backend | ✓ merged as PR #1756 |
| 1.B | Postgres backend + Alembic + docker-compose + Makefile + runtime doc | ✓ merged as PR #1758 |
| 1.C | `sweep_orphaned_jobs` + FastAPI lifespan + restart-recovery test | ✓ merged as PR #1759 |
| **1.D** | **Runtime Pydantic envelope validation on `/v[12]/jobs` success paths** | **this PR** |

After this PR merges, the Phase 1 durable-jobs work is functionally complete. The follow-up `app.py` wiring (replacing direct `JOBS` access with repository calls) is the next layer's deliverable; the gap doc flags it explicitly.

## Notes for reviewers

- The Pydantic models in `src/transformation_portal/api/v1/envelopes.py` and `.../jobs.py` already existed (introduced in PR #1561/#1562 for OpenAPI doc purposes). Phase 1.D moves them from "OpenAPI-only" to "runtime-validated" by actually constructing them in the handler. The models themselves do not change.
- The 3 internal-helper tests (`tests/test_app_orchestrator_runtime.py:test_create_job_preserves_raw_request_and_stores_effective_request`, `test_list_jobs_includes_error_and_artifacts`, `test_get_job_includes_artifacts_and_error`) call `_create_job` / `_list_jobs` / `_get_job` directly and `.body.decode()` the result. Returning `JSONResponse(...)` (instead of a bare Pydantic model) preserves their assumptions while still achieving the Phase 1.D runtime-validation win.
- `model_dump(..., exclude_unset=True)` was chosen over `exclude_none=True` because the envelope's `error` field is explicitly set to `None` on success responses (must remain `"error": null` on the wire), while the inner data field's `events_url` and `logs_tail` are unset on the cancel / list paths and must be absent. The two knobs would diverge on the envelope-vs-data boundary; `exclude_unset` handles it uniformly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EPqVEoqKMc7AKTJVyTvBh6)_