### PR TITLE
ci(coverage): ratchet cold-zone package floors

### DIFF
--- a/docs/testing/COLD_ZONE_COVERAGE_PROGRAM.md
+++ b/docs/testing/COLD_ZONE_COVERAGE_PROGRAM.md
@@ -1,9 +1,9 @@
 # Cold-Zone Coverage Program
 
 **Document Status:** Active proposal
-**Last Updated:** 2026-05-12
+**Last Updated:** 2026-05-13
 **Related Docs:** `docs/testing/STRATEGY.md`, `docs/testing/test_coverage_improvement_plan.md`
-**Related Scripts:** `scripts/ci/check_per_package_coverage.py`
+**Related Scripts:** `scripts/ci/check_per_package_coverage.py`, `scripts/ci/check_per_package_branch_coverage.py`
 **Related ADRs:** ADR-031 (test dependency isolation), ADR-044 (marker enforcement)
 
 > This document supersedes the unrevised "cold-zone testing optimization strategy"
@@ -477,21 +477,32 @@ Added to `PACKAGE_FLOORS` in `scripts/ci/check_per_package_coverage.py`
 **after** the baseline report lands, set 5-10 points below the measured
 stable coverage. Ratchet upward after two consecutive stable CI runs.
 
-Initial candidate floors (to be confirmed against baseline):
+Post-PR7 floors landed after baseline review. They are deliberately
+conservative, set roughly 5-10 points below the measured 2026-05-13 coverage:
 
 ```python
-PackageFloor("src/transformation_portal/plugins/", 60.0)
-PackageFloor("src/transformation_portal/stage_graph/", 60.0)
-PackageFloor("src/transformation_portal/vlm/", 60.0)
-PackageFloor("src/transformation_portal/depth/", 50.0)
+PackageFloor("src/transformation_portal/plugins/", 45.0)
+PackageFloor("src/transformation_portal/stage_graph/", 70.0)
+PackageFloor("src/transformation_portal/vlm/", 65.0)
+PackageFloor("src/transformation_portal/depth/", 55.0)
 PackageFloor("src/transformation_portal/streaming/", 50.0)
 PackageFloor(
     "src/transformation_portal/spatial_ai/reconstruction/",
-    50.0,
+    42.0,
 )
 ```
 
-Numbers are placeholders. Actual floors land in the PR after PR 0.
+| Package prefix | Measured 2026-05-13 line coverage | Enforced floor |
+| --- | ---: | ---: |
+| `src/transformation_portal/plugins/` | 51.40% | 45.0% |
+| `src/transformation_portal/stage_graph/` | 77.38% | 70.0% |
+| `src/transformation_portal/vlm/` | 72.41% | 65.0% |
+| `src/transformation_portal/depth/` | 64.64% | 55.0% |
+| `src/transformation_portal/streaming/` | 56.64% | 50.0% |
+| `src/transformation_portal/spatial_ai/reconstruction/` | 48.58% | 42.0% |
+
+Branch coverage remains reported by the sibling branch checker in dry-run mode
+until branch floors have two consecutive stable CI baselines.
 
 ### 12.2 Touched-file rule (per-PR, reviewer-enforced)
 

--- a/scripts/ci/check_per_package_coverage.py
+++ b/scripts/ci/check_per_package_coverage.py
@@ -80,6 +80,15 @@ PACKAGE_FLOORS: tuple[PackageFloor, ...] = (
         30.0,
         exclude_prefixes=("src/transformation_portal/lux_depth_v3/validators/",),
     ),
+    # Cold-Zone Coverage Program post-PR7 ratchets. These floors were
+    # set conservatively below the 2026-05-13 post-PR7 measured baseline
+    # so regressions fail without overfitting to one local coverage run.
+    PackageFloor("src/transformation_portal/plugins/", 45.0),
+    PackageFloor("src/transformation_portal/stage_graph/", 70.0),
+    PackageFloor("src/transformation_portal/vlm/", 65.0),
+    PackageFloor("src/transformation_portal/depth/", 55.0),
+    PackageFloor("src/transformation_portal/streaming/", 50.0),
+    PackageFloor("src/transformation_portal/spatial_ai/reconstruction/", 42.0),
 )
 
 

--- a/tests/spatial_ai/reconstruction/test_contract_gap_ratcheting.py
+++ b/tests/spatial_ai/reconstruction/test_contract_gap_ratcheting.py
@@ -1,0 +1,132 @@
+"""CPU-only reconstruction contract tests for cold-zone ratchet stability."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from transformation_portal.spatial_ai.reconstruction.contracts import CameraParams, GaussianSplat, ReconstructionInput, Scene3D
+
+pytestmark = pytest.mark.unit
+
+
+def _camera() -> CameraParams:
+    return CameraParams(
+        intrinsics=np.eye(3, dtype=np.float32),
+        extrinsics=np.eye(4, dtype=np.float32),
+        width=2,
+        height=2,
+    )
+
+
+def _splat_kwargs() -> dict[str, np.ndarray]:
+    return {
+        "positions": np.zeros((2, 3), dtype=np.float32),
+        "colors": np.full((2, 3), 0.5, dtype=np.float32),
+        "scales": np.ones((2, 3), dtype=np.float32),
+        "rotations": np.tile(np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float32), (2, 1)),
+        "opacities": np.full((2, 1), 0.5, dtype=np.float32),
+    }
+
+
+def _input_kwargs() -> dict[str, object]:
+    images = [np.zeros((2, 2, 3), dtype=np.float32), np.ones((2, 2, 3), dtype=np.float32)]
+    return {
+        "images": images,
+        "gamma": 1.0,
+        "cameras": [_camera(), _camera()],
+        "tier": "apex_research",
+    }
+
+
+def test_camera_rejects_non_float32_extrinsics() -> None:
+    with pytest.raises(ValueError, match="Extrinsics must be float32"):
+        CameraParams(
+            intrinsics=np.eye(3, dtype=np.float32),
+            extrinsics=np.eye(4, dtype=np.float64),
+            width=2,
+            height=2,
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("positions", np.zeros((2, 3), dtype=np.float64), "Positions must be float32"),
+        ("colors", np.zeros((2, 2), dtype=np.float32), r"Colors must be \(2, 3\)"),
+        ("colors", np.zeros((2, 3), dtype=np.float64), "Colors must be float32"),
+        ("scales", np.zeros((2, 2), dtype=np.float32), r"Scales must be \(2, 3\)"),
+        ("scales", np.zeros((2, 3), dtype=np.float64), "Scales must be float32"),
+        ("rotations", np.zeros((2, 3), dtype=np.float32), r"Rotations must be \(2, 4\)"),
+        ("rotations", np.zeros((2, 4), dtype=np.float64), "Rotations must be float32"),
+        ("opacities", np.zeros((2,), dtype=np.float32), r"Opacities must be \(2, 1\)"),
+        ("opacities", np.zeros((2, 1), dtype=np.float64), "Opacities must be float32"),
+    ],
+)
+def test_gaussian_splat_rejects_malformed_core_arrays(field: str, value: np.ndarray, message: str) -> None:
+    kwargs = _splat_kwargs()
+    kwargs[field] = value
+
+    with pytest.raises(ValueError, match=message):
+        GaussianSplat(**kwargs)
+
+
+@pytest.mark.parametrize(
+    ("sh_coefficients", "message"),
+    [
+        (np.zeros((2, 3), dtype=np.float32), "SH coefficients must be"),
+        (np.zeros((1, 2, 3), dtype=np.float32), "SH coefficients must have 2 entries"),
+        (np.zeros((2, 2, 2), dtype=np.float32), "SH coefficients must have 3 color channels"),
+    ],
+)
+def test_gaussian_splat_rejects_malformed_spherical_harmonics(
+    sh_coefficients: np.ndarray,
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        GaussianSplat(**_splat_kwargs(), sh_coefficients=sh_coefficients)
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        (
+            {"images": [np.zeros((2, 2, 3), dtype=np.float64), np.zeros((2, 2, 3), dtype=np.float32)]},
+            "Image 0 must be float32",
+        ),
+        ({"images": [np.zeros((2, 2), dtype=np.float32), np.zeros((2, 2, 3), dtype=np.float32)]}, r"Image 0 must be"),
+        ({"depth_maps": [np.zeros((2, 2), dtype=np.float32)]}, "Number of depth maps"),
+        (
+            {"depth_maps": [np.zeros((2, 2), dtype=np.float64), np.zeros((2, 2), dtype=np.float32)]},
+            "Depth map 0 must be float32",
+        ),
+        (
+            {"depth_maps": [np.zeros((1, 2), dtype=np.float32), np.zeros((2, 2), dtype=np.float32)]},
+            "Depth map 0 shape",
+        ),
+        ({"masks": [np.zeros((2, 2), dtype=bool)]}, "Number of masks"),
+        ({"masks": [np.zeros((2, 2), dtype=np.uint8), np.zeros((2, 2), dtype=bool)]}, "Mask 0 must be bool"),
+        ({"masks": [np.zeros((1, 2), dtype=bool), np.zeros((2, 2), dtype=bool)]}, "Mask 0 shape"),
+        ({"material_maps": [{"albedo": np.zeros((2, 2, 3), dtype=np.float32)}]}, "Number of material maps"),
+    ],
+)
+def test_reconstruction_input_rejects_malformed_optional_inputs(
+    overrides: dict[str, object],
+    message: str,
+) -> None:
+    kwargs = _input_kwargs()
+    kwargs.update(overrides)
+
+    with pytest.raises(ValueError, match=message):
+        ReconstructionInput(**kwargs)
+
+
+def test_scene_rejects_negative_iteration() -> None:
+    with pytest.raises(ValueError, match="Iteration must be non-negative"):
+        Scene3D(
+            splats=GaussianSplat(**_splat_kwargs()),
+            cameras=[_camera(), _camera()],
+            rmse=0.0,
+            iteration=-1,
+            convergence="converged",
+        )

--- a/tests/test_check_per_package_coverage.py
+++ b/tests/test_check_per_package_coverage.py
@@ -394,14 +394,20 @@ class TestMain:
 
 class TestDefaultFloors:
     def test_post_pr7_cold_zone_ratchets_are_configured(self, script_module):
-        floors = {floor.prefix: floor.floor for floor in script_module.PACKAGE_FLOORS}
+        prefixes = [floor.prefix for floor in script_module.PACKAGE_FLOORS]
+        assert len(prefixes) == len(set(prefixes))
 
-        assert floors["src/transformation_portal/plugins/"] == 45.0
-        assert floors["src/transformation_portal/stage_graph/"] == 70.0
-        assert floors["src/transformation_portal/vlm/"] == 65.0
-        assert floors["src/transformation_portal/depth/"] == 55.0
-        assert floors["src/transformation_portal/streaming/"] == 50.0
-        assert floors["src/transformation_portal/spatial_ai/reconstruction/"] == 42.0
+        floors = {floor.prefix: floor.floor for floor in script_module.PACKAGE_FLOORS}
+        expected_floors = {
+            "src/transformation_portal/plugins/": 45.0,
+            "src/transformation_portal/stage_graph/": 70.0,
+            "src/transformation_portal/vlm/": 65.0,
+            "src/transformation_portal/depth/": 55.0,
+            "src/transformation_portal/streaming/": 50.0,
+            "src/transformation_portal/spatial_ai/reconstruction/": 42.0,
+        }
+
+        assert {prefix: floors[prefix] for prefix in expected_floors} == expected_floors
 
 
 class TestRenderTable:

--- a/tests/test_check_per_package_coverage.py
+++ b/tests/test_check_per_package_coverage.py
@@ -392,6 +392,18 @@ class TestMain:
         assert rc == 0
 
 
+class TestDefaultFloors:
+    def test_post_pr7_cold_zone_ratchets_are_configured(self, script_module):
+        floors = {floor.prefix: floor.floor for floor in script_module.PACKAGE_FLOORS}
+
+        assert floors["src/transformation_portal/plugins/"] == 45.0
+        assert floors["src/transformation_portal/stage_graph/"] == 70.0
+        assert floors["src/transformation_portal/vlm/"] == 65.0
+        assert floors["src/transformation_portal/depth/"] == 55.0
+        assert floors["src/transformation_portal/streaming/"] == 50.0
+        assert floors["src/transformation_portal/spatial_ai/reconstruction/"] == 42.0
+
+
 class TestRenderTable:
     def test_pass_and_fail_rows_distinguishable(self, script_module):
         results = [


### PR DESCRIPTION
## Summary
- Ratchet the Cold-Zone Coverage Program after PR7 by enforcing conservative line coverage floors for the measured cold-zone packages.
- Keep branch coverage in dry-run mode with no branch floors until branch baselines have stabilized.

## Changes
- Adds package floors for plugins, stage_graph, vlm, depth, streaming, and spatial_ai/reconstruction in `scripts/ci/check_per_package_coverage.py`.
- Documents the 2026-05-13 measured line coverage and enforced floors in `docs/testing/COLD_ZONE_COVERAGE_PROGRAM.md`.
- Adds a unit guard so the post-PR7 cold-zone floors cannot be removed silently.
- Does not change global `--cov-fail-under` and does not add branch floors.

## Validation
Proven green:
- `.venv/bin/python -m black --check --line-length=127 scripts/ci/check_per_package_coverage.py tests/test_check_per_package_coverage.py`
- `.venv/bin/python -m isort --check-only --diff --profile=black --line-length=127 scripts/ci/check_per_package_coverage.py tests/test_check_per_package_coverage.py`
- `.venv/bin/pytest tests/test_check_per_package_coverage.py tests/test_check_per_package_branch_coverage.py tests/test_validate_ci_config.py -q`
- `make validate-ci`
- `make test-fast`
- `make coverage-report`
- `.venv/bin/python scripts/ci/check_per_package_coverage.py coverage.xml`
- `.venv/bin/python scripts/ci/check_per_package_branch_coverage.py coverage.xml --dry-run`
- `PYTHON_BIN=.venv/bin/python ./scripts/lint_runner.sh pr`
- `git diff --check`

Still failing:
- None observed locally.

## Risk
- Bounded to CI coverage enforcement and documentation.
- Floors are set below the measured post-PR7 baseline, so the change catches real regressions without overfitting to a single exact coverage result.
- Revert-safe: removing this commit restores the previous package-floor contract.