### PR TITLE
feat(orchestrator): introduce QueueBroker protocol + memory backend + worker runner skeleton (Phase 2.A)

### DIFF
--- a/docs/governance/PRODUCTION_HARDENING_GAP_2026-05-13.md
+++ b/docs/governance/PRODUCTION_HARDENING_GAP_2026-05-13.md
@@ -94,13 +94,17 @@ Still net-new (follow-up commits / PRs):
 
 ### 5.2 Phase 2 - worker split
 
-- No queue broker, no Redis client, no lease and no heartbeat machinery.
-- Execution today is in-process: `async def _run_job(job, argv)`
-  (`app.py:8788`) calls `asyncio.create_subprocess_exec` at `app.py:8808`.
-  Exit code 0 yields `succeeded`; nonzero yields `failed` with no
-  retryability concept.
-- No `worker_lost` state, no stale-job sweeper, no deduplication.
-- Env vars `TP_ORCHESTRATOR_QUEUE_BACKEND`, `TP_REDIS_URL` are unrecognized.
+**Updated 2026-05-13: Phase 2.A has landed.**
+
+Already done:
+
+- `QueueBroker` Protocol + `JobEnqueueRequest` / `JobLease` dataclasses + `MemoryQueueBroker` (Phase 2.A, this PR). Backend selected via `TP_ORCHESTRATOR_QUEUE_BACKEND=memory|redis`; the `redis` branch is recognised but its import will fail until Phase 2.B lands. The broker contract pins lease/heartbeat semantics (`acquire_lease` / `extend_lease` / `release_lease` / `reclaim_expired_leases`), pre-lease and in-flight cancellation, and admission-collision detection. A worker runner skeleton (`src/transformation_portal/orchestrator/worker.py`) wraps the broker in a poll-with-backoff supervisor loop, a heartbeat coroutine, cooperative `CancelledByOrchestrator` handling, and a `JobExecutor` callable seam that Phase 2.C will replace with the real subprocess dispatch. 17 backend-parametrized contract tests run today against `memory`; the Redis branch will activate when `TP_TEST_REDIS_URL` is set in Phase 2.B.
+
+Still net-new (follow-up commits / PRs on this track):
+
+- `RedisQueueBroker` + `redis-py` async client + docker-compose redis service + `make test-worker-redis-contract` (Phase 2.B). Mirrors the Phase 1.B pattern.
+- `app.py` wiring: replace `asyncio.create_subprocess_exec` in `_run_job` with `await broker.enqueue(...)`. The worker runner becomes the actual consumer; the orchestrator process no longer spawns dispatch subprocesses (Phase 2.C).
+- `worker_lost` state distinct from `failed` + retry classification + integration with the Phase 1.C restart sweeper so the broker's `reclaim_expired_leases` and the repository's `sweep_orphaned` agree on which jobs to mark (Phase 2.D). Env vars `TP_WORKER_*` already accepted by `worker.py`'s `_config_from_env` are documented but not yet wired to a runtime registry.
 
 ### 5.3 Phase 3 - external sessions
 

--- a/src/transformation_portal/orchestrator/queue/__init__.py
+++ b/src/transformation_portal/orchestrator/queue/__init__.py
@@ -1,0 +1,86 @@
+"""Queue-broker factory keyed off ``TP_ORCHESTRATOR_QUEUE_BACKEND``.
+
+Phase 2.A ships the Protocol + the in-process ``memory`` backend.
+The ``redis`` branch is recognised but its import will fail until
+Phase 2.B wires the Redis backend module.
+
+Supported backends:
+
+- ``memory`` (default) — single-process FIFO + lease table.
+  Restart loses state.
+- ``redis`` — added in Phase 2.B; requires ``TP_REDIS_URL``.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+from transformation_portal.orchestrator.queue.base import (
+    JobEnqueueRequest,
+    JobLease,
+    LeaseNotHeldError,
+    LeaseStatus,
+    QueueBroker,
+    QueueBrokerError,
+)
+
+_BACKEND_ENV = "TP_ORCHESTRATOR_QUEUE_BACKEND"
+_REDIS_URL_ENV = "TP_REDIS_URL"
+
+_broker: Optional[QueueBroker] = None
+
+
+def _selected_backend() -> str:
+    return os.getenv(_BACKEND_ENV, "memory").strip().lower() or "memory"
+
+
+def get_queue_broker() -> QueueBroker:
+    """Return the singleton broker, constructing it on first use."""
+    global _broker
+    if _broker is not None:
+        return _broker
+
+    backend = _selected_backend()
+    if backend == "memory":
+        from transformation_portal.orchestrator.queue.memory import MemoryQueueBroker
+
+        _broker = MemoryQueueBroker()
+        return _broker
+
+    if backend == "redis":
+        try:
+            from transformation_portal.orchestrator.queue.redis import RedisQueueBroker
+        except ImportError as exc:
+            raise RuntimeError(
+                f"{_BACKEND_ENV}=redis requires the redis-py async client + "
+                "the RedisQueueBroker module from Phase 2.B. Until that PR "
+                "lands, only the memory backend is available."
+            ) from exc
+
+        redis_url = os.getenv(_REDIS_URL_ENV, "").strip()
+        if not redis_url:
+            raise RuntimeError(f"{_BACKEND_ENV}=redis requires {_REDIS_URL_ENV} to be set " "(e.g. redis://localhost:6379/0).")
+
+        _broker = RedisQueueBroker(redis_url=redis_url)
+        return _broker
+
+    raise RuntimeError(f"Unsupported {_BACKEND_ENV}={backend!r}; expected 'memory' or 'redis'.")
+
+
+def reset_singleton() -> None:
+    """Drop the cached singleton. Tests call this between cases."""
+    global _broker
+    _broker = None
+
+
+__all__ = [
+    "JobEnqueueRequest",
+    "JobLease",
+    "LeaseNotHeldError",
+    "LeaseStatus",
+    "QueueBroker",
+    "QueueBrokerError",
+    "get_queue_broker",
+    "reset_singleton",
+]

--- a/src/transformation_portal/orchestrator/queue/base.py
+++ b/src/transformation_portal/orchestrator/queue/base.py
@@ -118,12 +118,16 @@ class QueueBroker(ABC):
 
     @abstractmethod
     async def enqueue(self, request: JobEnqueueRequest) -> None:
-        """Admit a job for execution. Idempotent on ``job_id``.
+        """Admit a job for execution.
 
-        A second ``enqueue`` for the same ``job_id`` while the first
-        is still pending or running raises ``QueueBrokerError`` so
-        admission collisions surface loudly rather than producing a
-        duplicate execution.
+        ``job_id`` is treated as a unique admission token: while the
+        first enqueue is still pending in the queue or held by a
+        worker, a second ``enqueue`` for the same ``job_id`` raises
+        ``QueueBrokerError``. Admission collisions therefore surface
+        loudly at the orchestrator boundary rather than producing a
+        duplicate execution downstream. Re-enqueueing the same id is
+        only valid after the broker has released the previous slot
+        (worker called ``release_lease`` or the job was cancelled).
         """
 
     @abstractmethod
@@ -171,8 +175,12 @@ class QueueBroker(ABC):
 
         Returns the list of reclaimed job ids so callers can
         ``await repo.update(jid, ...)`` them as ``worker_lost`` in
-        Phase 2.D. Memory backend uses real-time clock; Postgres /
-        Redis backends accept ``now`` so tests can pin time.
+        Phase 2.D. The ``now`` parameter is the time source the
+        backend compares against the stored lease deadlines: the
+        memory backend uses ``time.monotonic()`` (so wall-clock
+        adjustments don't move deadlines), and the Phase 2.B Redis
+        backend will use Redis server time. Tests pass an explicit
+        ``now`` to pin time deterministically.
         """
 
     @abstractmethod

--- a/src/transformation_portal/orchestrator/queue/base.py
+++ b/src/transformation_portal/orchestrator/queue/base.py
@@ -1,0 +1,213 @@
+"""Queue Protocols for orchestrator job admission and worker pickup.
+
+Phase 2 introduces ``QueueBroker`` so the orchestrator can decouple
+admission (FastAPI handler returns immediately after enqueue) from
+execution (a worker process picks up the job and runs it). Layer 2.A
+ships the Protocol + an in-process ``MemoryQueueBroker``; later
+layers add a Redis backend (2.B), wire ``app.py`` to enqueue (2.C),
+and add ``worker_lost`` semantics + retry classification (2.D).
+
+The broker stores only ``job_id`` plus a small dispatch payload (the
+argv list and api_version). Authoritative job state lives in the
+``JobRepository`` introduced in Phase 1; the worker fetches the
+``JobRecord`` from the repository when it starts a leased job.
+
+Lease/heartbeat contract:
+
+- ``acquire_lease(worker_id, *, lease_seconds)`` removes the next
+  ready job from the queue and grants the calling worker exclusive
+  access for ``lease_seconds``. Returns ``None`` when the queue is
+  empty; the caller should poll-with-backoff in that case.
+- ``extend_lease(worker_id, job_id, *, lease_seconds)`` is the
+  worker's heartbeat. The broker rejects the call if the worker no
+  longer holds the lease (e.g. it was reclaimed after an expiry).
+- ``release_lease(worker_id, job_id)`` is called by the worker once
+  the job has reached a terminal state. Idempotent; ignores leases
+  that don't exist.
+- ``reclaim_expired_leases(*, now)`` is the broker's housekeeping:
+  any lease whose deadline has passed is reclaimed and the job is
+  re-queued for another worker. Returns the list of reclaimed job
+  ids so callers (or tests) can log / metric it.
+- ``cancel(job_id)`` removes a still-queued job, or marks an
+  in-progress job for cancellation so the next ``extend_lease`` from
+  the worker returns ``LeaseStatus.cancelled`` and the worker can
+  surface the cancellation cleanly.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+
+class QueueBrokerError(RuntimeError):
+    """Base class for queue-broker failures (lease conflicts, IO, etc.)."""
+
+
+class LeaseNotHeldError(QueueBrokerError):
+    """Raised when ``extend_lease`` / ``release_lease`` finds no matching lease.
+
+    Surfaces the case where a worker's lease was reclaimed (likely
+    after a heartbeat-expiry sweep) and another worker may now hold
+    the job. The losing worker must stop processing.
+    """
+
+    def __init__(self, worker_id: str, job_id: str) -> None:
+        super().__init__(f"worker {worker_id!r} does not hold lease on job {job_id!r}")
+        self.worker_id = worker_id
+        self.job_id = job_id
+
+
+class LeaseStatus(str, Enum):
+    """Result codes for ``extend_lease``.
+
+    ``active`` — lease was extended by the requested amount.
+    ``cancelled`` — the orchestrator has called ``cancel(job_id)``
+    while the worker was running. The worker should stop the
+    underlying subprocess and call ``release_lease``.
+    """
+
+    active = "active"
+    cancelled = "cancelled"
+
+
+@dataclass
+class JobEnqueueRequest:
+    """Payload the orchestrator hands the broker on enqueue.
+
+    The broker stores this verbatim and returns it on ``acquire_lease``
+    so the worker has everything it needs to dispatch the job
+    without fetching the repository for the dispatch argv. Job
+    metadata (state, progress, logs, artifacts) still lives in the
+    ``JobRepository``.
+    """
+
+    job_id: str
+    argv: List[str]
+    api_version: str = "v1"
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class JobLease:
+    """What the broker hands back to the worker that successfully acquires.
+
+    ``deadline`` is the absolute monotonic-time-equivalent (epoch
+    seconds) at which the lease expires unless the worker calls
+    ``extend_lease``. The worker should heartbeat well before the
+    deadline (typical: every ``lease_seconds // 3``).
+    """
+
+    job_id: str
+    worker_id: str
+    deadline: float
+    request: JobEnqueueRequest
+
+
+class QueueBroker(ABC):
+    """Async queue-broker contract.
+
+    Implementations:
+    - ``MemoryQueueBroker`` — in-process; useful for tests, local
+      single-instance dev, and as the default until Phase 2.B Redis.
+    - ``RedisQueueBroker`` — Phase 2.B; SETNX-style lease + sorted-set
+      queue; survives orchestrator/worker restarts.
+    """
+
+    @abstractmethod
+    async def enqueue(self, request: JobEnqueueRequest) -> None:
+        """Admit a job for execution. Idempotent on ``job_id``.
+
+        A second ``enqueue`` for the same ``job_id`` while the first
+        is still pending or running raises ``QueueBrokerError`` so
+        admission collisions surface loudly rather than producing a
+        duplicate execution.
+        """
+
+    @abstractmethod
+    async def acquire_lease(
+        self,
+        worker_id: str,
+        *,
+        lease_seconds: float,
+    ) -> Optional[JobLease]:
+        """Pull the next ready job and grant ``worker_id`` exclusive access.
+
+        Returns ``None`` when the queue is empty. Blocking semantics
+        are intentionally NOT part of the contract; backends that
+        support a long-poll mode expose it as a separate method.
+        """
+
+    @abstractmethod
+    async def extend_lease(
+        self,
+        worker_id: str,
+        job_id: str,
+        *,
+        lease_seconds: float,
+    ) -> LeaseStatus:
+        """Heartbeat: extend the lease deadline by ``lease_seconds``.
+
+        Raises ``LeaseNotHeldError`` if the worker has been reclaimed
+        (its lease expired and another worker may now hold the job).
+        Returns ``LeaseStatus.cancelled`` if the orchestrator has
+        called ``cancel(job_id)`` while the worker was running.
+        """
+
+    @abstractmethod
+    async def release_lease(self, worker_id: str, job_id: str) -> None:
+        """Worker is done with the job (success, failure, or cancelled).
+
+        Idempotent: releasing a lease the worker doesn't hold is a
+        no-op (e.g. when the worker calls release after a previous
+        ``extend_lease`` already raised ``LeaseNotHeldError``).
+        """
+
+    @abstractmethod
+    async def reclaim_expired_leases(self, *, now: float) -> List[str]:
+        """Broker housekeeping: re-queue any job whose lease has expired.
+
+        Returns the list of reclaimed job ids so callers can
+        ``await repo.update(jid, ...)`` them as ``worker_lost`` in
+        Phase 2.D. Memory backend uses real-time clock; Postgres /
+        Redis backends accept ``now`` so tests can pin time.
+        """
+
+    @abstractmethod
+    async def cancel(self, job_id: str) -> bool:
+        """Mark a job as cancellation-requested.
+
+        Returns ``True`` if the job was still in the broker (queued
+        or leased), ``False`` if it had already been released. A
+        leased job is not pulled away from its worker; instead, the
+        next ``extend_lease`` returns ``LeaseStatus.cancelled`` and
+        the worker handles graceful shutdown of the subprocess.
+        """
+
+    @abstractmethod
+    async def queued_job_ids(self) -> List[str]:
+        """Snapshot the FIFO queue (for tests and operator inspection)."""
+
+    @abstractmethod
+    async def leased_job_ids(self) -> List[str]:
+        """Snapshot the in-flight job ids (for tests and operator inspection)."""
+
+    @abstractmethod
+    async def reset(self) -> None:
+        """Test-only: clear all queue + lease state."""
+
+    async def close(self) -> None:
+        """Optional shutdown hook for backends that hold connections."""
+        return None
+
+
+__all__ = [
+    "JobEnqueueRequest",
+    "JobLease",
+    "LeaseNotHeldError",
+    "LeaseStatus",
+    "QueueBroker",
+    "QueueBrokerError",
+]

--- a/src/transformation_portal/orchestrator/queue/memory.py
+++ b/src/transformation_portal/orchestrator/queue/memory.py
@@ -1,0 +1,163 @@
+"""In-process ``QueueBroker`` for tests, single-instance dev, and as the default.
+
+State lives in process memory; a process restart loses any queued or
+leased jobs. The Phase 1.C restart sweeper (``sweep_orphaned_jobs``)
+will mark those orphaned-from-the-broker jobs as ``failed`` /
+``worker_lost`` once Phase 2.D wires the runtime registry to read
+broker state.
+
+Lease deadlines use ``time.monotonic()`` so they survive system clock
+adjustments. The broker accepts a ``now`` parameter on
+``reclaim_expired_leases`` for test determinism; in production the
+sweeper uses ``time.monotonic()``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections import deque
+from dataclasses import dataclass
+from typing import Deque, Dict, List, Optional, Set
+
+from transformation_portal.orchestrator.queue.base import (
+    JobEnqueueRequest,
+    JobLease,
+    LeaseNotHeldError,
+    LeaseStatus,
+    QueueBroker,
+    QueueBrokerError,
+)
+
+
+@dataclass
+class _Lease:
+    worker_id: str
+    deadline: float
+    request: JobEnqueueRequest
+    cancellation_requested: bool = False
+
+
+class MemoryQueueBroker(QueueBroker):
+    """Single-process broker backed by an asyncio-safe FIFO and lease table."""
+
+    def __init__(self) -> None:
+        self._queue: Deque[JobEnqueueRequest] = deque()
+        # job_id -> _Lease for jobs currently leased to a worker.
+        self._leases: Dict[str, _Lease] = {}
+        # All job_ids the broker is responsible for (queued + leased).
+        # Lets ``enqueue`` reject collisions cheaply and ``queued_job_ids``
+        # / ``leased_job_ids`` stay consistent without scanning.
+        self._tracked: Set[str] = set()
+        # Cancellation marker for jobs that were cancelled before any
+        # worker called ``acquire_lease``: the request is dropped from
+        # the queue and the cancellation marker is consumed as a no-op
+        # so a future enqueue with the same id is allowed.
+        self._cancelled_pre_lease: Set[str] = set()
+        self._lock = asyncio.Lock()
+
+    async def enqueue(self, request: JobEnqueueRequest) -> None:
+        async with self._lock:
+            if request.job_id in self._tracked:
+                raise QueueBrokerError(f"job {request.job_id!r} already pending in the queue or leased")
+            self._queue.append(request)
+            self._tracked.add(request.job_id)
+
+    async def acquire_lease(
+        self,
+        worker_id: str,
+        *,
+        lease_seconds: float,
+    ) -> Optional[JobLease]:
+        if lease_seconds <= 0:
+            raise QueueBrokerError("lease_seconds must be positive")
+        async with self._lock:
+            while self._queue:
+                request = self._queue.popleft()
+                if request.job_id in self._cancelled_pre_lease:
+                    # Pre-lease cancellation consumed; drop the queue entry.
+                    self._cancelled_pre_lease.discard(request.job_id)
+                    self._tracked.discard(request.job_id)
+                    continue
+                deadline = time.monotonic() + lease_seconds
+                self._leases[request.job_id] = _Lease(
+                    worker_id=worker_id,
+                    deadline=deadline,
+                    request=request,
+                )
+                return JobLease(
+                    job_id=request.job_id,
+                    worker_id=worker_id,
+                    deadline=deadline,
+                    request=request,
+                )
+            return None
+
+    async def extend_lease(
+        self,
+        worker_id: str,
+        job_id: str,
+        *,
+        lease_seconds: float,
+    ) -> LeaseStatus:
+        if lease_seconds <= 0:
+            raise QueueBrokerError("lease_seconds must be positive")
+        async with self._lock:
+            lease = self._leases.get(job_id)
+            if lease is None or lease.worker_id != worker_id:
+                raise LeaseNotHeldError(worker_id=worker_id, job_id=job_id)
+            if lease.cancellation_requested:
+                return LeaseStatus.cancelled
+            lease.deadline = time.monotonic() + lease_seconds
+            return LeaseStatus.active
+
+    async def release_lease(self, worker_id: str, job_id: str) -> None:
+        async with self._lock:
+            lease = self._leases.get(job_id)
+            if lease is None or lease.worker_id != worker_id:
+                # Idempotent: nothing to release.
+                return
+            self._leases.pop(job_id, None)
+            self._tracked.discard(job_id)
+
+    async def reclaim_expired_leases(self, *, now: float) -> List[str]:
+        async with self._lock:
+            expired = [jid for jid, lease in self._leases.items() if lease.deadline <= now]
+            for jid in expired:
+                lease = self._leases.pop(jid)
+                # Re-queue the dispatch payload at the head so the
+                # reclaimed job is the next one a worker picks up.
+                self._queue.appendleft(lease.request)
+                # job_id stays in self._tracked (it's still in flight,
+                # just back in the queue).
+            return expired
+
+    async def cancel(self, job_id: str) -> bool:
+        async with self._lock:
+            if job_id not in self._tracked:
+                return False
+            lease = self._leases.get(job_id)
+            if lease is not None:
+                lease.cancellation_requested = True
+                return True
+            # Still queued; mark for drop at the next acquire.
+            self._cancelled_pre_lease.add(job_id)
+            return True
+
+    async def queued_job_ids(self) -> List[str]:
+        async with self._lock:
+            return [request.job_id for request in self._queue]
+
+    async def leased_job_ids(self) -> List[str]:
+        async with self._lock:
+            return list(self._leases.keys())
+
+    async def reset(self) -> None:
+        async with self._lock:
+            self._queue.clear()
+            self._leases.clear()
+            self._tracked.clear()
+            self._cancelled_pre_lease.clear()
+
+
+__all__ = ["MemoryQueueBroker"]

--- a/src/transformation_portal/orchestrator/queue/memory.py
+++ b/src/transformation_portal/orchestrator/queue/memory.py
@@ -49,11 +49,6 @@ class MemoryQueueBroker(QueueBroker):
         # Lets ``enqueue`` reject collisions cheaply and ``queued_job_ids``
         # / ``leased_job_ids`` stay consistent without scanning.
         self._tracked: Set[str] = set()
-        # Cancellation marker for jobs that were cancelled before any
-        # worker called ``acquire_lease``: the request is dropped from
-        # the queue and the cancellation marker is consumed as a no-op
-        # so a future enqueue with the same id is allowed.
-        self._cancelled_pre_lease: Set[str] = set()
         self._lock = asyncio.Lock()
 
     async def enqueue(self, request: JobEnqueueRequest) -> None:
@@ -72,26 +67,21 @@ class MemoryQueueBroker(QueueBroker):
         if lease_seconds <= 0:
             raise QueueBrokerError("lease_seconds must be positive")
         async with self._lock:
-            while self._queue:
-                request = self._queue.popleft()
-                if request.job_id in self._cancelled_pre_lease:
-                    # Pre-lease cancellation consumed; drop the queue entry.
-                    self._cancelled_pre_lease.discard(request.job_id)
-                    self._tracked.discard(request.job_id)
-                    continue
-                deadline = time.monotonic() + lease_seconds
-                self._leases[request.job_id] = _Lease(
-                    worker_id=worker_id,
-                    deadline=deadline,
-                    request=request,
-                )
-                return JobLease(
-                    job_id=request.job_id,
-                    worker_id=worker_id,
-                    deadline=deadline,
-                    request=request,
-                )
-            return None
+            if not self._queue:
+                return None
+            request = self._queue.popleft()
+            deadline = time.monotonic() + lease_seconds
+            self._leases[request.job_id] = _Lease(
+                worker_id=worker_id,
+                deadline=deadline,
+                request=request,
+            )
+            return JobLease(
+                job_id=request.job_id,
+                worker_id=worker_id,
+                deadline=deadline,
+                request=request,
+            )
 
     async def extend_lease(
         self,
@@ -138,10 +128,17 @@ class MemoryQueueBroker(QueueBroker):
                 return False
             lease = self._leases.get(job_id)
             if lease is not None:
+                # In-flight: surface via ``LeaseStatus.cancelled`` on
+                # the next ``extend_lease``; the worker handles the
+                # graceful shutdown of its subprocess.
                 lease.cancellation_requested = True
                 return True
-            # Still queued; mark for drop at the next acquire.
-            self._cancelled_pre_lease.add(job_id)
+            # Still queued: drop the entry immediately so
+            # ``queued_job_ids`` reflects reality and a fresh
+            # ``enqueue`` of the same id is allowed without first
+            # waiting for a worker to ``acquire_lease``.
+            self._queue = deque(request for request in self._queue if request.job_id != job_id)
+            self._tracked.discard(job_id)
             return True
 
     async def queued_job_ids(self) -> List[str]:
@@ -157,7 +154,6 @@ class MemoryQueueBroker(QueueBroker):
             self._queue.clear()
             self._leases.clear()
             self._tracked.clear()
-            self._cancelled_pre_lease.clear()
 
 
 __all__ = ["MemoryQueueBroker"]

--- a/src/transformation_portal/orchestrator/worker.py
+++ b/src/transformation_portal/orchestrator/worker.py
@@ -53,7 +53,15 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class WorkerConfig:
-    """Tunables for the worker loop. All optional, all env-overridable."""
+    """Tunables for the worker loop.
+
+    ``worker_id`` is required so ``acquire_lease`` / ``extend_lease``
+    can identify the lease holder; the timing knobs are optional and
+    env-overridable via ``_config_from_env``. Production callers
+    typically build the config via ``_config_from_env``, which
+    generates a ``worker_id`` of the form ``worker_<8 hex chars>``
+    when ``TP_WORKER_ID`` is unset.
+    """
 
     worker_id: str
     lease_seconds: float = 30.0
@@ -72,12 +80,14 @@ class CancelledByOrchestrator(Exception):
     """
 
 
-# Signature: ``executor(request, *, cancellation_event) -> int`` where the
+# Signature: ``executor(request, cancellation_event) -> int`` where the
 # return value is an exit code (0 = succeeded, nonzero = failed) that the
-# caller will translate into a JobRepository state update. The
-# ``cancellation_event`` is set by the heartbeat loop when the broker reports
-# ``LeaseStatus.cancelled``; the executor must observe it and exit promptly
-# so the lease can be released.
+# caller will translate into a JobRepository state update. Both arguments
+# are positional so the type alias matches the ``WorkerRunner.step`` /
+# ``_default_executor`` call shape exactly. ``cancellation_event`` is set
+# by the heartbeat loop when the broker reports ``LeaseStatus.cancelled``;
+# the executor must observe it and exit promptly so the lease can be
+# released.
 JobExecutor = Callable[[JobEnqueueRequest, asyncio.Event], Awaitable[int]]
 
 
@@ -211,8 +221,14 @@ async def run_worker_forever(
     """Supervisor loop with exponential backoff when the queue is empty.
 
     ``stop_event`` lets tests / signal handlers ask the loop to exit
-    cleanly between jobs.
+    cleanly between jobs. When this function constructs the broker
+    itself (caller passed ``broker=None``), it also disposes of it
+    via ``await broker.close()`` on exit so the Phase 2.B Redis
+    backend doesn't leak network connections on SIGINT/SIGTERM.
+    Brokers passed in by the caller are left to the caller's
+    lifecycle.
     """
+    broker_was_constructed = broker is None
     broker = broker if broker is not None else get_queue_broker()
     config = config if config is not None else _config_from_env()
     runner = WorkerRunner(broker=broker, config=config, executor=executor)
@@ -222,18 +238,25 @@ async def run_worker_forever(
     logger.info(
         "worker %s starting (lease=%ss, hb=%ss)", config.worker_id, config.lease_seconds, config.heartbeat_interval_seconds
     )
-    while not stop_event.is_set():
-        did_work = await runner.step()
-        if did_work:
-            backoff = config.poll_interval_seconds
-            continue
-        # Empty queue - exponential backoff capped at max_poll_backoff_seconds.
-        try:
-            await asyncio.wait_for(stop_event.wait(), timeout=backoff)
-        except asyncio.TimeoutError:
-            pass
-        backoff = min(backoff * 2, config.max_poll_backoff_seconds)
-    logger.info("worker %s stopping", config.worker_id)
+    try:
+        while not stop_event.is_set():
+            did_work = await runner.step()
+            if did_work:
+                backoff = config.poll_interval_seconds
+                continue
+            # Empty queue - exponential backoff capped at max_poll_backoff_seconds.
+            try:
+                await asyncio.wait_for(stop_event.wait(), timeout=backoff)
+            except asyncio.TimeoutError:
+                pass
+            backoff = min(backoff * 2, config.max_poll_backoff_seconds)
+    finally:
+        if broker_was_constructed:
+            try:
+                await broker.close()
+            except Exception:  # noqa: BLE001 - never block shutdown on close
+                logger.exception("worker %s broker close failed", config.worker_id)
+        logger.info("worker %s stopping", config.worker_id)
 
 
 def _config_from_env() -> WorkerConfig:

--- a/src/transformation_portal/orchestrator/worker.py
+++ b/src/transformation_portal/orchestrator/worker.py
@@ -1,0 +1,284 @@
+"""Worker runner that consumes jobs from the ``QueueBroker``.
+
+Phase 2.A ships the consumer skeleton. The worker is **not yet
+wired** as the actual job executor: ``app.py``'s
+``asyncio.create_subprocess_exec`` call still happens in-band
+(orchestrator process) and the real cut-over to "orchestrator
+enqueues, worker consumes" is the Phase 2.C deliverable.
+
+This module exists in 2.A so the contract is reviewable end-to-end:
+the worker loop, the heartbeat cadence, the cancellation handling,
+and the lease release are all in one place. Phase 2.C will replace
+the ``_default_executor`` placeholder with the real subprocess
+dispatch (the same code path ``_run_job`` uses today, factored out
+of ``app.py``).
+
+Layout:
+
+- ``WorkerRunner`` — the consumer. Polls the broker for a lease,
+  delegates execution to a pluggable async ``executor`` callable,
+  heartbeats while the executor runs, releases the lease on
+  completion, and handles ``LeaseStatus.cancelled`` by signalling
+  the executor.
+- ``run_worker_forever`` — the supervisor loop. Runs ``WorkerRunner
+  .step`` repeatedly with backoff when the queue is empty.
+- ``main`` — the CLI entry point (``python -m
+  transformation_portal.orchestrator.worker``); reads
+  ``TP_WORKER_*`` env vars and spawns ``run_worker_forever``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import signal
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Awaitable, Callable, Optional
+
+from transformation_portal.orchestrator.queue import (
+    LeaseStatus,
+    QueueBroker,
+    get_queue_broker,
+)
+from transformation_portal.orchestrator.queue.base import (
+    JobEnqueueRequest,
+    LeaseNotHeldError,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class WorkerConfig:
+    """Tunables for the worker loop. All optional, all env-overridable."""
+
+    worker_id: str
+    lease_seconds: float = 30.0
+    heartbeat_interval_seconds: float = 10.0
+    poll_interval_seconds: float = 0.25
+    max_poll_backoff_seconds: float = 5.0
+
+
+class CancelledByOrchestrator(Exception):
+    """Raised inside the executor when the broker reports cancellation.
+
+    The default executor (placeholder) catches this and shuts down
+    cleanly; Phase 2.C's real subprocess executor will translate
+    this into a SIGTERM-then-SIGKILL of the dispatch subprocess and
+    will mark the job ``canceled`` via the JobRepository.
+    """
+
+
+# Signature: ``executor(request, *, cancellation_event) -> int`` where the
+# return value is an exit code (0 = succeeded, nonzero = failed) that the
+# caller will translate into a JobRepository state update. The
+# ``cancellation_event`` is set by the heartbeat loop when the broker reports
+# ``LeaseStatus.cancelled``; the executor must observe it and exit promptly
+# so the lease can be released.
+JobExecutor = Callable[[JobEnqueueRequest, asyncio.Event], Awaitable[int]]
+
+
+async def _default_executor(
+    request: JobEnqueueRequest,
+    cancellation_event: asyncio.Event,
+) -> int:
+    """Phase 2.A placeholder executor.
+
+    Logs that a job was received, sleeps briefly to simulate work,
+    and exits 0. Phase 2.C replaces this with the real subprocess
+    dispatch carved out of ``app.py:_run_job``.
+    """
+    logger.info(
+        "phase2a placeholder executor processing job_id=%s argv=%s",
+        request.job_id,
+        request.argv,
+    )
+    # Cooperative cancel: break out of the simulated work as soon as the
+    # heartbeat signals cancellation, just like the real executor will.
+    try:
+        await asyncio.wait_for(cancellation_event.wait(), timeout=0.1)
+    except asyncio.TimeoutError:
+        pass
+    if cancellation_event.is_set():
+        raise CancelledByOrchestrator()
+    return 0
+
+
+class WorkerRunner:
+    """One worker's main loop. Re-entrant across leases; one job at a time."""
+
+    def __init__(
+        self,
+        *,
+        broker: QueueBroker,
+        config: WorkerConfig,
+        executor: JobExecutor = _default_executor,
+    ) -> None:
+        self._broker = broker
+        self._config = config
+        self._executor = executor
+
+    async def step(self) -> bool:
+        """Process at most one job. Returns ``True`` if work was done.
+
+        Callers loop on this; a ``False`` return is the signal to
+        back off and poll again.
+        """
+        lease = await self._broker.acquire_lease(
+            self._config.worker_id,
+            lease_seconds=self._config.lease_seconds,
+        )
+        if lease is None:
+            return False
+
+        cancellation_event = asyncio.Event()
+        heartbeat_task = asyncio.create_task(self._heartbeat_loop(lease.job_id, cancellation_event))
+        try:
+            try:
+                exit_code = await self._executor(lease.request, cancellation_event)
+                logger.info(
+                    "worker %s finished job %s with exit_code=%s",
+                    self._config.worker_id,
+                    lease.job_id,
+                    exit_code,
+                )
+            except CancelledByOrchestrator:
+                logger.info(
+                    "worker %s observed cancellation for job %s",
+                    self._config.worker_id,
+                    lease.job_id,
+                )
+            except Exception:  # noqa: BLE001 - executor errors are job-level
+                logger.exception(
+                    "worker %s executor raised for job %s",
+                    self._config.worker_id,
+                    lease.job_id,
+                )
+        finally:
+            heartbeat_task.cancel()
+            try:
+                await heartbeat_task
+            except (asyncio.CancelledError, LeaseNotHeldError):
+                pass
+            await self._broker.release_lease(self._config.worker_id, lease.job_id)
+        return True
+
+    async def _heartbeat_loop(
+        self,
+        job_id: str,
+        cancellation_event: asyncio.Event,
+    ) -> None:
+        while True:
+            await asyncio.sleep(self._config.heartbeat_interval_seconds)
+            try:
+                status = await self._broker.extend_lease(
+                    self._config.worker_id,
+                    job_id,
+                    lease_seconds=self._config.lease_seconds,
+                )
+            except LeaseNotHeldError:
+                # Our lease was reclaimed by the broker (likely because
+                # this worker fell behind on its heartbeat). Signal
+                # cancellation so the executor stops; the orchestrator
+                # will see worker_lost via the broker's reclaim sweep.
+                logger.warning(
+                    "worker %s lost lease on job %s; signalling cancellation",
+                    self._config.worker_id,
+                    job_id,
+                )
+                cancellation_event.set()
+                return
+            if status is LeaseStatus.cancelled:
+                logger.info(
+                    "worker %s received cancellation for job %s",
+                    self._config.worker_id,
+                    job_id,
+                )
+                cancellation_event.set()
+                return
+
+
+async def run_worker_forever(
+    *,
+    broker: Optional[QueueBroker] = None,
+    config: Optional[WorkerConfig] = None,
+    executor: JobExecutor = _default_executor,
+    stop_event: Optional[asyncio.Event] = None,
+) -> None:
+    """Supervisor loop with exponential backoff when the queue is empty.
+
+    ``stop_event`` lets tests / signal handlers ask the loop to exit
+    cleanly between jobs.
+    """
+    broker = broker if broker is not None else get_queue_broker()
+    config = config if config is not None else _config_from_env()
+    runner = WorkerRunner(broker=broker, config=config, executor=executor)
+    stop_event = stop_event if stop_event is not None else asyncio.Event()
+
+    backoff = config.poll_interval_seconds
+    logger.info(
+        "worker %s starting (lease=%ss, hb=%ss)", config.worker_id, config.lease_seconds, config.heartbeat_interval_seconds
+    )
+    while not stop_event.is_set():
+        did_work = await runner.step()
+        if did_work:
+            backoff = config.poll_interval_seconds
+            continue
+        # Empty queue - exponential backoff capped at max_poll_backoff_seconds.
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=backoff)
+        except asyncio.TimeoutError:
+            pass
+        backoff = min(backoff * 2, config.max_poll_backoff_seconds)
+    logger.info("worker %s stopping", config.worker_id)
+
+
+def _config_from_env() -> WorkerConfig:
+    return WorkerConfig(
+        worker_id=os.getenv("TP_WORKER_ID", f"worker_{uuid.uuid4().hex[:8]}"),
+        lease_seconds=float(os.getenv("TP_WORKER_LEASE_SECONDS", "30")),
+        heartbeat_interval_seconds=float(os.getenv("TP_WORKER_HEARTBEAT_SECONDS", "10")),
+        poll_interval_seconds=float(os.getenv("TP_WORKER_POLL_SECONDS", "0.25")),
+        max_poll_backoff_seconds=float(os.getenv("TP_WORKER_MAX_BACKOFF_SECONDS", "5.0")),
+    )
+
+
+def main() -> None:
+    """``python -m transformation_portal.orchestrator.worker`` entry point."""
+    logging.basicConfig(
+        level=os.getenv("TP_WORKER_LOG_LEVEL", "INFO"),
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+    stop_event = asyncio.Event()
+
+    def _request_stop(_signum: int, _frame: object) -> None:
+        logger.info("received signal; requesting worker stop")
+        stop_event.set()
+
+    signal.signal(signal.SIGINT, _request_stop)
+    signal.signal(signal.SIGTERM, _request_stop)
+
+    asyncio.run(run_worker_forever(stop_event=stop_event))
+
+
+if __name__ == "__main__":  # pragma: no cover - executed via `python -m ...`
+    main()
+
+
+# Time helper for tests that want to pin "now" for the broker sweeper.
+def monotonic_now() -> float:
+    return time.monotonic()
+
+
+__all__ = [
+    "CancelledByOrchestrator",
+    "JobExecutor",
+    "WorkerConfig",
+    "WorkerRunner",
+    "main",
+    "monotonic_now",
+    "run_worker_forever",
+]

--- a/tests/orchestrator/test_queue_contract.py
+++ b/tests/orchestrator/test_queue_contract.py
@@ -232,10 +232,18 @@ async def test_reclaim_no_op_when_no_leases(broker: QueueBroker) -> None:
 
 async def test_cancel_pre_lease_drops_queue_entry(broker: QueueBroker) -> None:
     await broker.enqueue(_request("job-cancel-pre"))
+    assert await broker.queued_job_ids() == ["job-cancel-pre"]
+
     assert await broker.cancel("job-cancel-pre") is True
-    # The next acquire skips the cancelled entry and returns None.
+    # The cancelled job_id must be gone from the queue immediately,
+    # not deferred to the next acquire. queued_job_ids reflects the
+    # post-cancel reality.
+    assert await broker.queued_job_ids() == []
+    # The next acquire returns None (queue is empty).
     assert await broker.acquire_lease("worker-1", lease_seconds=10.0) is None
-    # And a fresh enqueue with the same id is allowed (the slot was freed).
+    # And a fresh enqueue with the same id is allowed without first
+    # waiting for a worker to acquire (the slot was freed at cancel
+    # time).
     await broker.enqueue(_request("job-cancel-pre"))
     second = await broker.acquire_lease("worker-1", lease_seconds=10.0)
     assert second is not None and second.job_id == "job-cancel-pre"

--- a/tests/orchestrator/test_queue_contract.py
+++ b/tests/orchestrator/test_queue_contract.py
@@ -1,0 +1,287 @@
+"""Phase 2.A - shared contract tests for every ``QueueBroker`` backend.
+
+Memory backend is always included; the Redis backend (Phase 2.B)
+will activate when ``TP_TEST_REDIS_URL`` is set, mirroring the
+Phase 1.B Postgres pattern.
+
+Coverage:
+
+- enqueue / acquire round-trip + FIFO order
+- duplicate enqueue rejection (admission-collision detection)
+- lease deadlines pin in-flight ownership
+- heartbeat-extension contract (only the holder can extend)
+- pre-lease cancellation drops the queue entry
+- in-flight cancellation surfaces via ``LeaseStatus.cancelled``
+- lease-expiry sweeper re-queues abandoned jobs
+- worker runner end-to-end through the broker (1 step,
+  placeholder executor) using the in-memory backend.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from typing import AsyncIterator
+
+import pytest
+import pytest_asyncio
+
+from transformation_portal.orchestrator.queue import (
+    JobEnqueueRequest,
+    LeaseStatus,
+    QueueBroker,
+    QueueBrokerError,
+    reset_singleton,
+)
+from transformation_portal.orchestrator.queue.base import LeaseNotHeldError
+from transformation_portal.orchestrator.queue.memory import MemoryQueueBroker
+from transformation_portal.orchestrator.worker import (
+    WorkerConfig,
+    WorkerRunner,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+_REDIS_URL_ENV = "TP_TEST_REDIS_URL"
+
+
+def _available_backends() -> list[str]:
+    backends = ["memory"]
+    if os.getenv(_REDIS_URL_ENV, "").strip():
+        backends.append("redis")
+    return backends
+
+
+@pytest.fixture(params=_available_backends())
+def backend(request: pytest.FixtureRequest) -> str:
+    return request.param
+
+
+@pytest_asyncio.fixture
+async def broker(backend: str) -> AsyncIterator[QueueBroker]:
+    """Yield a freshly-reset ``QueueBroker`` for the parameterized backend."""
+    reset_singleton()
+    if backend == "memory":
+        instance: QueueBroker = MemoryQueueBroker()
+    elif backend == "redis":
+        try:
+            from transformation_portal.orchestrator.queue.redis import RedisQueueBroker
+        except ImportError:
+            pytest.skip("redis backend module not available; expected in Phase 2.B")
+        instance = RedisQueueBroker(redis_url=os.environ[_REDIS_URL_ENV])
+        await instance.reset()
+    else:
+        raise RuntimeError(f"unknown backend {backend!r}")
+    try:
+        yield instance
+    finally:
+        await instance.reset()
+        await instance.close()
+        reset_singleton()
+
+
+def _request(job_id: str, *, argv: list[str] | None = None) -> JobEnqueueRequest:
+    return JobEnqueueRequest(
+        job_id=job_id,
+        argv=argv if argv is not None else ["lux-depth-v3", "--input", "x", "--output", "y"],
+        api_version="v1",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Enqueue + acquire
+# ---------------------------------------------------------------------------
+
+
+async def test_enqueue_then_acquire_round_trip(broker: QueueBroker) -> None:
+    await broker.enqueue(_request("job-A"))
+    assert await broker.queued_job_ids() == ["job-A"]
+
+    lease = await broker.acquire_lease("worker-1", lease_seconds=10.0)
+    assert lease is not None
+    assert lease.job_id == "job-A"
+    assert lease.worker_id == "worker-1"
+    assert lease.deadline > 0
+    assert lease.request.argv == ["lux-depth-v3", "--input", "x", "--output", "y"]
+
+    assert await broker.queued_job_ids() == []
+    assert await broker.leased_job_ids() == ["job-A"]
+
+
+async def test_acquire_returns_none_on_empty_queue(broker: QueueBroker) -> None:
+    assert await broker.acquire_lease("worker-1", lease_seconds=10.0) is None
+
+
+async def test_enqueue_preserves_fifo_across_workers(broker: QueueBroker) -> None:
+    for jid in ("job-1", "job-2", "job-3"):
+        await broker.enqueue(_request(jid))
+
+    leased = []
+    for worker in ("worker-A", "worker-B", "worker-C"):
+        lease = await broker.acquire_lease(worker, lease_seconds=10.0)
+        assert lease is not None
+        leased.append(lease.job_id)
+
+    assert leased == ["job-1", "job-2", "job-3"]
+
+
+async def test_duplicate_enqueue_raises(broker: QueueBroker) -> None:
+    await broker.enqueue(_request("job-dup"))
+    with pytest.raises(QueueBrokerError):
+        await broker.enqueue(_request("job-dup"))
+
+
+async def test_acquire_lease_rejects_non_positive_lease(broker: QueueBroker) -> None:
+    with pytest.raises(QueueBrokerError):
+        await broker.acquire_lease("worker", lease_seconds=0)
+    with pytest.raises(QueueBrokerError):
+        await broker.acquire_lease("worker", lease_seconds=-1)
+
+
+# ---------------------------------------------------------------------------
+# Heartbeat / extend
+# ---------------------------------------------------------------------------
+
+
+async def test_extend_lease_keeps_lease_active(broker: QueueBroker) -> None:
+    await broker.enqueue(_request("job-hb"))
+    lease = await broker.acquire_lease("worker-1", lease_seconds=10.0)
+    assert lease is not None
+    initial_deadline = lease.deadline
+    # Sleep a tiny bit so monotonic time advances measurably.
+    await asyncio.sleep(0.01)
+    status = await broker.extend_lease("worker-1", "job-hb", lease_seconds=20.0)
+    assert status is LeaseStatus.active
+    # Lease moved further into the future.
+    fresh = await broker.leased_job_ids()
+    assert fresh == ["job-hb"]
+    # initial_deadline + (20 - elapsed) should be greater than initial_deadline.
+    # We can't reach inside without a getter; assert via reclaim no-op.
+    reclaimed = await broker.reclaim_expired_leases(now=initial_deadline + 1.0)
+    assert reclaimed == [], "lease should not have expired after the extension"
+
+
+async def test_extend_lease_rejects_non_holder(broker: QueueBroker) -> None:
+    await broker.enqueue(_request("job-other"))
+    lease = await broker.acquire_lease("worker-A", lease_seconds=10.0)
+    assert lease is not None
+    with pytest.raises(LeaseNotHeldError):
+        await broker.extend_lease("worker-B", "job-other", lease_seconds=10.0)
+
+
+async def test_extend_lease_rejects_unknown_job(broker: QueueBroker) -> None:
+    with pytest.raises(LeaseNotHeldError):
+        await broker.extend_lease("worker-1", "ghost", lease_seconds=10.0)
+
+
+# ---------------------------------------------------------------------------
+# Release
+# ---------------------------------------------------------------------------
+
+
+async def test_release_lease_clears_in_flight_state(broker: QueueBroker) -> None:
+    await broker.enqueue(_request("job-rel"))
+    await broker.acquire_lease("worker-1", lease_seconds=10.0)
+    await broker.release_lease("worker-1", "job-rel")
+    assert await broker.leased_job_ids() == []
+    assert await broker.queued_job_ids() == []
+    # And a fresh enqueue with the same id is now allowed.
+    await broker.enqueue(_request("job-rel"))
+
+
+async def test_release_lease_is_idempotent(broker: QueueBroker) -> None:
+    await broker.enqueue(_request("job-rel2"))
+    await broker.acquire_lease("worker-1", lease_seconds=10.0)
+    await broker.release_lease("worker-1", "job-rel2")
+    # Releasing again must not raise.
+    await broker.release_lease("worker-1", "job-rel2")
+    # Releasing a job we never owned must not raise either.
+    await broker.release_lease("worker-1", "never-existed")
+
+
+# ---------------------------------------------------------------------------
+# Lease expiry / reclaim
+# ---------------------------------------------------------------------------
+
+
+async def test_reclaim_expired_leases_requeues_abandoned_jobs(broker: QueueBroker) -> None:
+    await broker.enqueue(_request("job-exp"))
+    lease = await broker.acquire_lease("worker-A", lease_seconds=10.0)
+    assert lease is not None
+
+    # Pretend the worker died: sweep with a future "now" past the lease.
+    reclaimed = await broker.reclaim_expired_leases(now=lease.deadline + 5.0)
+    assert reclaimed == ["job-exp"]
+
+    assert await broker.leased_job_ids() == []
+    # The reclaimed job is back at the head of the queue.
+    again = await broker.acquire_lease("worker-B", lease_seconds=10.0)
+    assert again is not None
+    assert again.job_id == "job-exp"
+
+
+async def test_reclaim_no_op_when_no_leases(broker: QueueBroker) -> None:
+    assert await broker.reclaim_expired_leases(now=time.monotonic() + 1000.0) == []
+
+
+# ---------------------------------------------------------------------------
+# Cancellation
+# ---------------------------------------------------------------------------
+
+
+async def test_cancel_pre_lease_drops_queue_entry(broker: QueueBroker) -> None:
+    await broker.enqueue(_request("job-cancel-pre"))
+    assert await broker.cancel("job-cancel-pre") is True
+    # The next acquire skips the cancelled entry and returns None.
+    assert await broker.acquire_lease("worker-1", lease_seconds=10.0) is None
+    # And a fresh enqueue with the same id is allowed (the slot was freed).
+    await broker.enqueue(_request("job-cancel-pre"))
+    second = await broker.acquire_lease("worker-1", lease_seconds=10.0)
+    assert second is not None and second.job_id == "job-cancel-pre"
+
+
+async def test_cancel_inflight_surfaces_via_extend_lease(broker: QueueBroker) -> None:
+    await broker.enqueue(_request("job-cancel-inflight"))
+    lease = await broker.acquire_lease("worker-1", lease_seconds=10.0)
+    assert lease is not None
+
+    assert await broker.cancel("job-cancel-inflight") is True
+    status = await broker.extend_lease("worker-1", "job-cancel-inflight", lease_seconds=10.0)
+    assert status is LeaseStatus.cancelled
+
+    # The worker still holds the lease until it releases.
+    assert await broker.leased_job_ids() == ["job-cancel-inflight"]
+    await broker.release_lease("worker-1", "job-cancel-inflight")
+    assert await broker.leased_job_ids() == []
+
+
+async def test_cancel_unknown_job_returns_false(broker: QueueBroker) -> None:
+    assert await broker.cancel("nope") is False
+
+
+# ---------------------------------------------------------------------------
+# Worker runner integration (memory broker only).
+# ---------------------------------------------------------------------------
+
+
+async def test_worker_runner_step_processes_one_job(broker: QueueBroker) -> None:
+    """End-to-end: enqueue -> WorkerRunner.step -> lease released."""
+    await broker.enqueue(_request("job-worker-1"))
+    config = WorkerConfig(
+        worker_id="worker-end-to-end",
+        lease_seconds=2.0,
+        heartbeat_interval_seconds=5.0,  # never fires inside the short test
+        poll_interval_seconds=0.05,
+    )
+    runner = WorkerRunner(broker=broker, config=config)
+    did_work = await runner.step()
+    assert did_work is True
+    assert await broker.leased_job_ids() == []
+    assert await broker.queued_job_ids() == []
+
+
+async def test_worker_runner_step_returns_false_on_empty_queue(broker: QueueBroker) -> None:
+    config = WorkerConfig(worker_id="worker-empty")
+    runner = WorkerRunner(broker=broker, config=config)
+    assert await runner.step() is False


### PR DESCRIPTION
## Summary

Phase 2.A of the production hardening roadmap — the queue-broker abstraction, in-memory backend, worker runner skeleton, and parametrized contract tests. **No `app.py` wiring**: the orchestrator still spawns dispatch subprocesses in-band; the cut-over to "orchestrator enqueues, worker consumes" is the Phase 2.C deliverable. This PR mirrors the Phase 1.A pattern (Protocol + memory backend + tests, no behavioral change at the HTTP boundary).

Motivation: [`docs/governance/PRODUCTION_HARDENING_GAP_2026-05-13.md`](https://github.com/RC219805/Transformation_Portal/blob/main/docs/governance/PRODUCTION_HARDENING_GAP_2026-05-13.md) §5.2 (updated in this PR to mark 2.A complete).

## What's new

- **`src/transformation_portal/orchestrator/queue/base.py`** — `QueueBroker` async ABC; `JobEnqueueRequest` / `JobLease` dataclasses; `LeaseStatus` enum (`active` | `cancelled`); `QueueBrokerError` + `LeaseNotHeldError`. The contract pins lease/heartbeat semantics: `acquire_lease` / `extend_lease` / `release_lease` / `reclaim_expired_leases` / `cancel`, plus the introspection helpers (`queued_job_ids`, `leased_job_ids`).
- **`src/transformation_portal/orchestrator/queue/memory.py`** — `MemoryQueueBroker`, asyncio-safe FIFO + lease table, `time.monotonic` deadlines, per-job admission-collision detection. Pre-lease cancellation drops the queue entry; in-flight cancellation surfaces via `LeaseStatus.cancelled` on the next `extend_lease` so the worker can shut down its subprocess cleanly.
- **`src/transformation_portal/orchestrator/queue/__init__.py`** — Factory keyed off `TP_ORCHESTRATOR_QUEUE_BACKEND` (default `memory`; `redis` recognised, `ImportError` until Phase 2.B). Same pattern as the storage factory.
- **`src/transformation_portal/orchestrator/worker.py`** — `WorkerRunner` consumer loop with heartbeat coroutine, cooperative `CancelledByOrchestrator` handling, `JobExecutor` callable seam (placeholder `_default_executor` in 2.A; Phase 2.C swaps in the real subprocess dispatch carved out of `app.py:_run_job`). Includes `run_worker_forever` supervisor and a `python -m transformation_portal.orchestrator.worker` entry point with `TP_WORKER_*` env-var config (`TP_WORKER_ID`, `TP_WORKER_LEASE_SECONDS`, `TP_WORKER_HEARTBEAT_SECONDS`, `TP_WORKER_POLL_SECONDS`, `TP_WORKER_MAX_BACKOFF_SECONDS`).
- **`tests/orchestrator/test_queue_contract.py`** — 17 backend-parametrized tests:
  - **Enqueue + acquire**: round-trip, FIFO across workers, duplicate-enqueue rejection, lease validation.
  - **Heartbeat / extend**: keeps the lease active, rejects non-holders, rejects unknown jobs.
  - **Release**: clears in-flight state, idempotent.
  - **Lease expiry / reclaim**: re-queues abandoned jobs at the head, no-op when nothing leased.
  - **Cancellation**: pre-lease drops the entry; in-flight surfaces via `LeaseStatus.cancelled`.
  - **Worker integration**: `WorkerRunner.step` end-to-end against the placeholder executor.

The Postgres branch in the parametrization auto-skips when `TP_TEST_REDIS_URL` is unset, so the offline lane stays clean.

## Backend behavior

| Backend | Behavior |
| --- | --- |
| `memory` (default) | Per-process FIFO + lease table; restart loses queue state. Useful for tests, local single-instance dev, and as the default until Phase 2.B Redis lands. |
| `redis` | Recognised by the factory but the import fails until Phase 2.B; raises `RuntimeError` with actionable text on backend selection. |

## Test plan

- [x] `pytest -q tests/orchestrator/test_queue_contract.py -m unit` — **17/17 pass** on the memory backend (Redis branch skips when `TP_TEST_REDIS_URL` is unset).
- [x] `pytest -q tests/orchestrator/ tests/test_app_orchestrator_runtime.py tests/test_app_orchestrator_contract_http.py -m unit` — **472 passed + 1 skipped**. No regression in the Phase 1 surface.
- [x] `python -c "import transformation_portal.orchestrator.queue; import transformation_portal.orchestrator.worker"` — clean imports.
- [x] Factory smoke: `TP_ORCHESTRATOR_QUEUE_BACKEND=memory` returns `MemoryQueueBroker`; `=redis` raises with actionable text.
- [x] `make check-stale-docs`, `make check-doc-heading-links`, `make check-json-serialization`, `make check-python-headers`, `make check-yaml-governance` — all green.
- [x] Pre-commit (15 hooks) — pass.

## What this PR explicitly does NOT change

- **`app.py` orchestrator handlers** — still spawn subprocesses in-band via `asyncio.create_subprocess_exec` at `app.py:8808`. The cut-over to "orchestrator enqueues, worker consumes" is **Phase 2.C**; the worker-runner placeholder executor proves the contract end-to-end without touching production code paths.
- **`worker_lost` job state** — distinct from `failed`; requires the broker's `reclaim_expired_leases` to talk to `JobRepository.sweep_orphaned`. **Phase 2.D** deliverable.
- **`RedisQueueBroker`** — Phase 2.B.
- The Phase 1 surfaces (`JobRepository`, `JobEventStore`, restart sweeper, Pydantic envelopes) — unchanged.

## Sequencing

| Layer | Scope | Status |
| --- | --- | --- |
| **2.A** | **`QueueBroker` Protocol + memory backend + worker runner skeleton + contract tests** | **this PR** |
| 2.B | `RedisQueueBroker` + docker-compose redis + `make test-worker-redis-contract` | follow-up |
| 2.C | `app.py` wiring: orchestrator enqueues; worker consumes; `_run_job` becomes `_default_executor`'s replacement | follow-up |
| 2.D | `worker_lost` state + retry classification + `reclaim_expired_leases` ↔ `sweep_orphaned` integration | follow-up |

## Notes for reviewers

- The `WorkerRunner.step` shape (`-> bool`) is deliberate so tests can step the loop deterministically. The supervisor `run_worker_forever` does the polling-with-backoff outside the per-step contract.
- The placeholder `_default_executor` is intentionally minimal — it just logs, briefly checks the cancellation event, and exits 0. Phase 2.C will replace it with the real subprocess dispatch (the same code path `_run_job` uses today, factored out of `app.py`).
- `LeaseNotHeldError` raised inside `_heartbeat_loop` is caught when the heartbeat task is cancelled at end-of-step. It also signals the cancellation event so the executor exits promptly when the broker reclaims a lease (the worker-died-but-came-back-confused case).
- All async APIs use a single `asyncio.Lock` per broker instance — sufficient for single-process correctness in 2.A. Phase 2.B's Redis backend uses SETNX-style atomic ops so it doesn't need the in-process lock.
- `time.monotonic()` is used for lease deadlines so the broker tolerates wall-clock adjustments. The `now` parameter on `reclaim_expired_leases` lets tests pin time deterministically.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EPqVEoqKMc7AKTJVyTvBh6)_