### PR TITLE
feat(orchestrator): Redis-backed QueueBroker (Phase 2.B)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ PHASE6_SMOKE_TESTS := \
 	tests/test_lux_render_pipeline_smoke.py \
 	tests/lux_depth_v3/test_orchestrator_smoke.py
 
-.PHONY: help test-fast test-novideo test-full test-integration test-structure test-utils test-orchestrator-contract test-orchestrator-http-contract test-orchestrator-postgres-contract test-portal-contract test-frontdoor-contract test-archive-gate-contract db-upgrade db-revision seed-frontdoor-user run-frontdoor-local run-backend-local run-backend-local-noreload dev-write-env dev-start dev-stop check-vercel-env validate-orchestrator-http validate-portal-lux-materials-live validate-portal-fastvlm-captioning-live validate-portal-css-layer-parity validate-portal-browser validate-frontdoor-browser validate-frontdoor-deployment-gate audit-pipeline-readiness coverage-fast-scope coverage-report coverage-diff coverage-package venv repair-core-venv setup clean \
+.PHONY: help test-fast test-novideo test-full test-integration test-structure test-utils test-orchestrator-contract test-orchestrator-http-contract test-orchestrator-postgres-contract test-worker-redis-contract test-portal-contract test-frontdoor-contract test-archive-gate-contract db-upgrade db-revision seed-frontdoor-user run-frontdoor-local run-backend-local run-backend-local-noreload dev-write-env dev-start dev-stop check-vercel-env validate-orchestrator-http validate-portal-lux-materials-live validate-portal-fastvlm-captioning-live validate-portal-css-layer-parity validate-portal-browser validate-frontdoor-browser validate-frontdoor-deployment-gate audit-pipeline-readiness coverage-fast-scope coverage-report coverage-diff coverage-package venv repair-core-venv setup clean \
         lint lint-parity ci ci-full pre-commit install-hooks quality-check fix-quality validate-ci organize-docs check-json-serialization check-piptools-cache \
         check-python-headers check-yaml-governance check-stale-docs check-doc-heading-links lock lock-prod lock-ci lock-dev install-core install-ml install-ml-core install-ml-raw install-ml-sam2 install-ml-coreml install-fastvlm-runtime check-fastvlm-runtime docs docs-clean \
         check check-test-markers check-ci-sync check-todo-governance check-environment check-portal-asset-budgets check-dependency-pinning validate-full validate-quick clean-frontdoor clean-all check-worktree \
@@ -294,6 +294,22 @@ test-orchestrator-postgres-contract:
 		exit 1; \
 	fi
 	@TP_TEST_POSTGRES_URL="$(TP_TEST_POSTGRES_URL)" "$(PY)" -m pytest -q tests/orchestrator -m unit
+
+# Phase 2.B - durable queue broker. Requires TP_TEST_REDIS_URL pointing at an
+# empty Redis database (typically the docker-compose `redis` service). The
+# contract fixture under tests/orchestrator/test_queue_contract.py uses a
+# per-test key prefix sweep, so any TP_TEST_REDIS_URL that the test process
+# can reach is safe to use.
+test-worker-redis-contract:
+	@echo "Running queue-broker contract suite against Redis backend..."
+	@if [ -z "$(TP_TEST_REDIS_URL)" ]; then \
+		echo "ERROR: TP_TEST_REDIS_URL is not set. Example:"; \
+		echo "  docker compose up -d redis"; \
+		echo "  TP_TEST_REDIS_URL=redis://127.0.0.1:6379/0 \\"; \
+		echo "    make test-worker-redis-contract"; \
+		exit 1; \
+	fi
+	@TP_TEST_REDIS_URL="$(TP_TEST_REDIS_URL)" "$(PY)" -m pytest -q tests/orchestrator/test_queue_contract.py -m unit
 
 # Apply orchestrator schema migrations against TP_DATABASE_URL.
 db-upgrade:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -139,11 +139,44 @@ services:
       retries: 5
       start_period: 10s
 
+  # Durable queue broker backend (Phase 2.B).
+  #
+  # Optional service: only required when the orchestrator runs with
+  # TP_ORCHESTRATOR_QUEUE_BACKEND=redis. The default `memory` backend
+  # never touches Redis. Start with:
+  #
+  #     docker compose up -d redis
+  #     TP_TEST_REDIS_URL=redis://127.0.0.1:6379/0 make test-worker-redis-contract
+  #
+  # AOF is enabled so queued jobs and active leases survive a Redis
+  # restart, matching the durable-by-default contract documented in
+  # docs/governance/PRODUCTION_HARDENING_GAP_2026-05-13.md §5.2.
+  redis:
+    image: redis:7-alpine
+    container_name: transformation-portal-redis
+    command:
+      - redis-server
+      - --appendonly
+      - "yes"
+      - --maxmemory-policy
+      - "noeviction"
+    ports:
+      - "${TP_REDIS_PUBLIC_PORT:-127.0.0.1:6379}:6379"
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "PING"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
+
 volumes:
   input:
   output:
   config:
   postgres_data:
+  redis_data:
 
 networks:
   default:

--- a/docs/governance/PRODUCTION_HARDENING_GAP_2026-05-13.md
+++ b/docs/governance/PRODUCTION_HARDENING_GAP_2026-05-13.md
@@ -94,15 +94,15 @@ Still net-new (follow-up commits / PRs):
 
 ### 5.2 Phase 2 - worker split
 
-**Updated 2026-05-13: Phase 2.A has landed.**
+**Updated 2026-05-13: Phases 2.A and 2.B have landed.**
 
 Already done:
 
-- `QueueBroker` Protocol + `JobEnqueueRequest` / `JobLease` dataclasses + `MemoryQueueBroker` (Phase 2.A, this PR). Backend selected via `TP_ORCHESTRATOR_QUEUE_BACKEND=memory|redis`; the `redis` branch is recognised but its import will fail until Phase 2.B lands. The broker contract pins lease/heartbeat semantics (`acquire_lease` / `extend_lease` / `release_lease` / `reclaim_expired_leases`), pre-lease and in-flight cancellation, and admission-collision detection. A worker runner skeleton (`src/transformation_portal/orchestrator/worker.py`) wraps the broker in a poll-with-backoff supervisor loop, a heartbeat coroutine, cooperative `CancelledByOrchestrator` handling, and a `JobExecutor` callable seam that Phase 2.C will replace with the real subprocess dispatch. 17 backend-parametrized contract tests run today against `memory`; the Redis branch will activate when `TP_TEST_REDIS_URL` is set in Phase 2.B.
+- `QueueBroker` Protocol + `JobEnqueueRequest` / `JobLease` dataclasses + `MemoryQueueBroker` (Phase 2.A). Backend selected via `TP_ORCHESTRATOR_QUEUE_BACKEND=memory|redis`. The broker contract pins lease/heartbeat semantics (`acquire_lease` / `extend_lease` / `release_lease` / `reclaim_expired_leases`), pre-lease and in-flight cancellation, and admission-collision detection. A worker runner skeleton (`src/transformation_portal/orchestrator/worker.py`) wraps the broker in a poll-with-backoff supervisor loop, a heartbeat coroutine, cooperative `CancelledByOrchestrator` handling, and a `JobExecutor` callable seam that Phase 2.C will replace with the real subprocess dispatch.
+- `RedisQueueBroker` (Phase 2.B, this PR) backed by `redis>=5` async client + a docker-compose `redis` service (AOF on, `noeviction` policy, healthcheck) + `make test-worker-redis-contract`. Atomicity for acquire / extend / release / reclaim / cancel is implemented as server-side Lua so admission collisions and lease handoff never produce partial state, and lease deadlines are pinned to the Redis server clock (via `redis.call('TIME')`) so a multi-host fleet shares a single source of truth. Per-test `key_prefix` isolation lets pytest-xdist and shared-tenant Redis deployments coexist. The Phase 2.A contract test suite (17 cases) now runs against both backends; Redis activates when `TP_TEST_REDIS_URL` is set, mirroring the Phase 1.B Postgres pattern.
 
 Still net-new (follow-up commits / PRs on this track):
 
-- `RedisQueueBroker` + `redis-py` async client + docker-compose redis service + `make test-worker-redis-contract` (Phase 2.B). Mirrors the Phase 1.B pattern.
 - `app.py` wiring: replace `asyncio.create_subprocess_exec` in `_run_job` with `await broker.enqueue(...)`. The worker runner becomes the actual consumer; the orchestrator process no longer spawns dispatch subprocesses (Phase 2.C).
 - `worker_lost` state distinct from `failed` + retry classification + integration with the Phase 1.C restart sweeper so the broker's `reclaim_expired_leases` and the repository's `sweep_orphaned` agree on which jobs to mark (Phase 2.D). Env vars `TP_WORKER_*` already accepted by `worker.py`'s `_config_from_env` are documented but not yet wired to a runtime registry.
 

--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -273,6 +273,8 @@ pyyaml==6.0.3
     #   pre-commit
 readme-renderer==44.0
     # via twine
+redis==6.4.0
+    # via -r base.in
 referencing==0.37.0
     # via
     #   jsonschema

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -35,3 +35,9 @@ imagecodecs>=2023.9.18,<2027
 SQLAlchemy[asyncio]>=2.0,<2.2  # async ORM for PostgresJobRepository / PostgresJobEventStore
 asyncpg>=0.29,<1                # libpq-free async Postgres driver paired with SQLAlchemy[asyncio]
 alembic>=1.13,<2                # schema migration tool for the orchestrator job/event tables
+
+# Queue broker backend (Phase 2.B). Memory backend remains default; Redis
+# activates when TP_ORCHESTRATOR_QUEUE_BACKEND=redis and TP_REDIS_URL is set.
+# The client is always installed so the contract test suite and the
+# RedisQueueBroker module load without an optional-extra dance.
+redis>=5.0,<7                   # asyncio Redis client for RedisQueueBroker

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -120,6 +120,10 @@ pygments==2.20.0
     # via
     #   -c all.txt
     #   rich
+redis==6.4.0
+    # via
+    #   -c all.txt
+    #   -r base.in
 referencing==0.37.0
     # via
     #   -c all.txt

--- a/src/transformation_portal/orchestrator/queue/__init__.py
+++ b/src/transformation_portal/orchestrator/queue/__init__.py
@@ -1,14 +1,16 @@
 """Queue-broker factory keyed off ``TP_ORCHESTRATOR_QUEUE_BACKEND``.
 
-Phase 2.A ships the Protocol + the in-process ``memory`` backend.
-The ``redis`` branch is recognised but its import will fail until
-Phase 2.B wires the Redis backend module.
+Phase 2.A shipped the Protocol + the in-process ``memory`` backend.
+Phase 2.B adds the ``redis`` backend behind ``TP_REDIS_URL`` so a
+fleet of workers can consume from a single durable queue.
 
 Supported backends:
 
 - ``memory`` (default) — single-process FIFO + lease table.
   Restart loses state.
-- ``redis`` — added in Phase 2.B; requires ``TP_REDIS_URL``.
+- ``redis`` — Phase 2.B; requires ``TP_REDIS_URL``. Survives
+  orchestrator/worker restarts; lease deadlines pinned to the Redis
+  server clock so multi-host workers share a single source of truth.
 """
 
 from __future__ import annotations
@@ -53,9 +55,9 @@ def get_queue_broker() -> QueueBroker:
             from transformation_portal.orchestrator.queue.redis import RedisQueueBroker
         except ImportError as exc:
             raise RuntimeError(
-                f"{_BACKEND_ENV}=redis requires the redis-py async client + "
-                "the RedisQueueBroker module from Phase 2.B. Until that PR "
-                "lands, only the memory backend is available."
+                f"{_BACKEND_ENV}=redis requires the redis-py async client. "
+                "Reinstall the base runtime dependencies (`make install-core`) "
+                "to pick up `redis>=5`."
             ) from exc
 
         redis_url = os.getenv(_REDIS_URL_ENV, "").strip()

--- a/src/transformation_portal/orchestrator/queue/base.py
+++ b/src/transformation_portal/orchestrator/queue/base.py
@@ -28,12 +28,14 @@ Lease/heartbeat contract:
   any lease whose deadline has passed is reclaimed and the job is
   re-queued for another worker. Returns the list of reclaimed job
   ids so callers (or tests) can log / metric it. Production callers
-  should pass ``await broker.server_time()`` so deadlines and "now"
-  share a single source of truth across a multi-host fleet.
+  must pass ``await broker.server_time()`` — ``deadline`` and
+  ``now`` only mean the same thing when they share one clock.
 - ``server_time()`` returns the broker's authoritative clock value
-  (``time.monotonic`` for memory, Redis ``TIME`` for Redis). Use
-  this whenever comparing against a lease deadline to defeat host
-  clock drift.
+  and defines the time domain in which ``JobLease.deadline`` is
+  expressed (``time.monotonic`` for memory, Redis ``TIME`` Unix
+  epoch for Redis). Always compare a ``deadline`` against
+  ``await broker.server_time()`` — never against a host's local
+  wall clock — to defeat clock drift in a multi-host fleet.
 - ``cancel(job_id)`` removes a still-queued job, or marks an
   in-progress job for cancellation so the next ``extend_lease`` from
   the worker returns ``LeaseStatus.cancelled`` and the worker can
@@ -101,10 +103,16 @@ class JobEnqueueRequest:
 class JobLease:
     """What the broker hands back to the worker that successfully acquires.
 
-    ``deadline`` is the absolute monotonic-time-equivalent (epoch
-    seconds) at which the lease expires unless the worker calls
-    ``extend_lease``. The worker should heartbeat well before the
-    deadline (typical: every ``lease_seconds // 3``).
+    ``deadline`` is the absolute clock value (a float) at which the
+    lease expires unless the worker calls ``extend_lease``. The
+    backend's ``server_time()`` is the only valid clock to compare it
+    against — the memory backend stamps deadlines from
+    ``time.monotonic()``, the Redis backend stamps them from Redis
+    ``TIME`` (Unix epoch). Callers must never compare ``deadline``
+    against a host's local wall clock; always use
+    ``await broker.server_time()`` for the comparison boundary. The
+    worker should heartbeat well before the deadline (typical: every
+    ``lease_seconds // 3``).
     """
 
     job_id: str

--- a/src/transformation_portal/orchestrator/queue/base.py
+++ b/src/transformation_portal/orchestrator/queue/base.py
@@ -27,7 +27,13 @@ Lease/heartbeat contract:
 - ``reclaim_expired_leases(*, now)`` is the broker's housekeeping:
   any lease whose deadline has passed is reclaimed and the job is
   re-queued for another worker. Returns the list of reclaimed job
-  ids so callers (or tests) can log / metric it.
+  ids so callers (or tests) can log / metric it. Production callers
+  should pass ``await broker.server_time()`` so deadlines and "now"
+  share a single source of truth across a multi-host fleet.
+- ``server_time()`` returns the broker's authoritative clock value
+  (``time.monotonic`` for memory, Redis ``TIME`` for Redis). Use
+  this whenever comparing against a lease deadline to defeat host
+  clock drift.
 - ``cancel(job_id)`` removes a still-queued job, or marks an
   in-progress job for cancellation so the next ``extend_lease`` from
   the worker returns ``LeaseStatus.cancelled`` and the worker can
@@ -36,6 +42,7 @@ Lease/heartbeat contract:
 
 from __future__ import annotations
 
+import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from enum import Enum
@@ -175,12 +182,17 @@ class QueueBroker(ABC):
 
         Returns the list of reclaimed job ids so callers can
         ``await repo.update(jid, ...)`` them as ``worker_lost`` in
-        Phase 2.D. The ``now`` parameter is the time source the
-        backend compares against the stored lease deadlines: the
-        memory backend uses ``time.monotonic()`` (so wall-clock
-        adjustments don't move deadlines), and the Phase 2.B Redis
-        backend will use Redis server time. Tests pass an explicit
-        ``now`` to pin time deterministically.
+        Phase 2.D.
+
+        The ``now`` argument is the value the backend compares
+        against the stored lease deadlines. Production callers
+        should pass ``await broker.server_time()`` so deadlines
+        (written from the same clock by ``acquire_lease`` /
+        ``extend_lease``) and the sweep boundary share one source of
+        truth. The explicit float is retained for tests and
+        deterministic simulation: ``reclaim_expired_leases(now=
+        lease.deadline + delta)`` lets a single-process test pin
+        time without sleeping.
         """
 
     @abstractmethod
@@ -205,6 +217,19 @@ class QueueBroker(ABC):
     @abstractmethod
     async def reset(self) -> None:
         """Test-only: clear all queue + lease state."""
+
+    async def server_time(self) -> float:
+        """Return the broker's authoritative clock value.
+
+        Production callers pair this with ``reclaim_expired_leases``
+        so the sweep boundary lives in the same time domain as the
+        deadlines written by ``acquire_lease`` / ``extend_lease``.
+        The default implementation uses ``time.monotonic()`` so
+        single-process backends (memory) and tests behave as a
+        process-local monotonic clock; the Redis backend overrides
+        it to read ``TIME`` from the Redis server.
+        """
+        return time.monotonic()
 
     async def close(self) -> None:
         """Optional shutdown hook for backends that hold connections."""

--- a/src/transformation_portal/orchestrator/queue/redis.py
+++ b/src/transformation_portal/orchestrator/queue/redis.py
@@ -28,9 +28,12 @@ Hash fields on ``{prefix}job:<job_id>``::
 Atomicity is implemented via server-side Lua so that admission
 collisions, lease handoff, heartbeat extension, and reclaim each
 happen in a single round-trip with no chance of partial state. Lease
-deadlines use the Redis server clock (``TIME``) — every worker
-process resolves "now" against the same source of truth, so wall
-clock drift on individual hosts cannot move deadlines.
+deadlines are written from Redis ``TIME`` inside the acquire / extend
+scripts. Production sweepers must read "now" back from the same
+clock — call ``await broker.server_time()`` and pass the result to
+``reclaim_expired_leases`` — so host wall-clock drift on individual
+worker boxes cannot push leases into "expired" early or hold them
+past their real deadline.
 """
 
 from __future__ import annotations
@@ -375,6 +378,18 @@ class RedisQueueBroker(QueueBroker):
     async def leased_job_ids(self) -> List[str]:
         items = await self._client.zrange(self._leases_key, 0, -1)
         return [_decode(item) for item in items]
+
+    async def server_time(self) -> float:
+        """Read the Redis server clock — the broker's source of truth.
+
+        Lease deadlines are written from Redis ``TIME`` inside the
+        acquire / extend Lua scripts, so production sweepers must
+        compare against this same clock to defeat host wall-clock
+        drift in a multi-host fleet. Returns seconds since the Unix
+        epoch as a float (microsecond resolution from Redis).
+        """
+        seconds, microseconds = await self._client.time()
+        return float(seconds) + float(microseconds) / 1_000_000
 
     async def reset(self) -> None:
         """Test-only: drop every key under ``key_prefix``.

--- a/src/transformation_portal/orchestrator/queue/redis.py
+++ b/src/transformation_portal/orchestrator/queue/redis.py
@@ -1,0 +1,428 @@
+"""Redis-backed ``QueueBroker`` for multi-instance orchestrator deployments.
+
+Phase 2.B parallel to Phase 1.B: the broker survives orchestrator /
+worker restarts and lets a fleet of workers consume from a single
+queue. Selectable via ``TP_ORCHESTRATOR_QUEUE_BACKEND=redis``
+together with ``TP_REDIS_URL``.
+
+Storage layout (all keys prefixed by ``key_prefix``, default ``tp:queue:``)::
+
+    {prefix}ready                LIST   FIFO of job_ids ready for pickup.
+    {prefix}leases               ZSET   member=job_id, score=deadline (Redis
+                                        server seconds since epoch).
+    {prefix}tracked              SET    every job_id the broker is currently
+                                        responsible for (queued + leased).
+    {prefix}job:<job_id>         HASH   dispatch payload + lease metadata.
+
+Hash fields on ``{prefix}job:<job_id>``::
+
+    request                JSON  ``JobEnqueueRequest`` payload, set on enqueue
+                                 and never overwritten.
+    worker_id              str   worker holding the lease (absent when queued).
+    deadline               float Redis server time at which the lease expires.
+    cancellation_requested '0' | '1'  Set to '1' by ``cancel`` for an
+                                      in-flight job; surfaced via the next
+                                      ``extend_lease`` as
+                                      ``LeaseStatus.cancelled``.
+
+Atomicity is implemented via server-side Lua so that admission
+collisions, lease handoff, heartbeat extension, and reclaim each
+happen in a single round-trip with no chance of partial state. Lease
+deadlines use the Redis server clock (``TIME``) — every worker
+process resolves "now" against the same source of truth, so wall
+clock drift on individual hosts cannot move deadlines.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, List, Optional
+
+from redis.asyncio import Redis
+from redis.commands.core import AsyncScript
+
+from transformation_portal.ingest.canonical_json import dumps_json
+from transformation_portal.orchestrator.queue.base import (
+    JobEnqueueRequest,
+    JobLease,
+    LeaseNotHeldError,
+    LeaseStatus,
+    QueueBroker,
+    QueueBrokerError,
+)
+
+logger = logging.getLogger(__name__)
+
+
+_DEFAULT_KEY_PREFIX = "tp:queue:"
+
+
+# ---------------------------------------------------------------------------
+# Lua scripts.
+# Each script is documented with the keys it reads/writes and the argv shape
+# so the call sites below are readable. Scripts return small payloads (string
+# or array) rather than reaching into Python types from Lua.
+# ---------------------------------------------------------------------------
+
+
+# KEYS: ready, leases, tracked, job_hash
+# ARGV: job_id, request_json
+# Returns: 1 on success, 0 if the job_id was already tracked.
+_LUA_ENQUEUE = """
+if redis.call('SADD', KEYS[3], ARGV[1]) == 0 then
+    return 0
+end
+redis.call('HSET', KEYS[4], 'request', ARGV[2])
+redis.call('RPUSH', KEYS[1], ARGV[1])
+return 1
+"""
+
+
+# KEYS: ready, leases, job_hash_prefix
+# ARGV: worker_id, lease_seconds
+# Returns: nil if empty, else {job_id, request_json, deadline}.
+# Computes ``now`` from ``redis.call('TIME')`` so every worker resolves
+# deadlines against the same clock.
+_LUA_ACQUIRE = """
+local job_id = redis.call('LPOP', KEYS[1])
+if not job_id then
+    return nil
+end
+local t = redis.call('TIME')
+local now = tonumber(t[1]) + tonumber(t[2]) / 1000000
+local deadline = now + tonumber(ARGV[2])
+local job_key = KEYS[3] .. job_id
+local request_json = redis.call('HGET', job_key, 'request')
+redis.call('HSET', job_key, 'worker_id', ARGV[1], 'deadline', tostring(deadline))
+redis.call('HDEL', job_key, 'cancellation_requested')
+redis.call('ZADD', KEYS[2], deadline, job_id)
+return {job_id, request_json, tostring(deadline)}
+"""
+
+
+# KEYS: leases, job_hash
+# ARGV: worker_id, job_id, lease_seconds
+# Returns:
+#   'active'           lease extended; new deadline written.
+#   'cancelled'        cancellation_requested == '1'; worker should release.
+#   'not_held'         lease absent or held by a different worker.
+_LUA_EXTEND = """
+local lease_score = redis.call('ZSCORE', KEYS[1], ARGV[2])
+if not lease_score then
+    return 'not_held'
+end
+local holder = redis.call('HGET', KEYS[2], 'worker_id')
+if holder ~= ARGV[1] then
+    return 'not_held'
+end
+local cancel = redis.call('HGET', KEYS[2], 'cancellation_requested')
+if cancel == '1' then
+    return 'cancelled'
+end
+local t = redis.call('TIME')
+local now = tonumber(t[1]) + tonumber(t[2]) / 1000000
+local deadline = now + tonumber(ARGV[3])
+redis.call('HSET', KEYS[2], 'deadline', tostring(deadline))
+redis.call('ZADD', KEYS[1], deadline, ARGV[2])
+return 'active'
+"""
+
+
+# KEYS: leases, tracked, job_hash
+# ARGV: worker_id, job_id
+# Returns: 1 if released, 0 if no-op (idempotent).
+_LUA_RELEASE = """
+local holder = redis.call('HGET', KEYS[3], 'worker_id')
+if holder ~= ARGV[1] then
+    return 0
+end
+redis.call('ZREM', KEYS[1], ARGV[2])
+redis.call('SREM', KEYS[2], ARGV[2])
+redis.call('DEL', KEYS[3])
+return 1
+"""
+
+
+# KEYS: ready, leases, tracked, job_hash_prefix
+# ARGV: now
+# Returns: array of reclaimed job_ids.
+# Re-queues each expired job at the head of ``ready`` so it is the
+# next one picked up by a worker (matches MemoryQueueBroker semantics).
+_LUA_RECLAIM = """
+local expired = redis.call('ZRANGEBYSCORE', KEYS[2], '-inf', ARGV[1])
+for i = 1, #expired do
+    local job_id = expired[i]
+    local job_key = KEYS[4] .. job_id
+    redis.call('ZREM', KEYS[2], job_id)
+    redis.call('HDEL', job_key, 'worker_id', 'deadline')
+    redis.call('LPUSH', KEYS[1], job_id)
+end
+return expired
+"""
+
+
+# KEYS: ready, leases, tracked, job_hash
+# ARGV: job_id
+# Returns:
+#   'absent'     job_id not tracked; caller returns False.
+#   'inflight'   marked cancellation_requested; caller returns True.
+#   'queued'     removed from ready list; caller returns True.
+_LUA_CANCEL = """
+if redis.call('SISMEMBER', KEYS[3], ARGV[1]) == 0 then
+    return 'absent'
+end
+local in_leases = redis.call('ZSCORE', KEYS[2], ARGV[1])
+if in_leases then
+    redis.call('HSET', KEYS[4], 'cancellation_requested', '1')
+    return 'inflight'
+end
+redis.call('LREM', KEYS[1], 0, ARGV[1])
+redis.call('SREM', KEYS[3], ARGV[1])
+redis.call('DEL', KEYS[4])
+return 'queued'
+"""
+
+
+class RedisQueueBroker(QueueBroker):
+    """Multi-instance ``QueueBroker`` backed by Redis.
+
+    A single Redis instance is assumed; ``redis_url`` follows the
+    standard ``redis://[:password@]host:port/db`` form. The broker
+    holds a connection pool for the lifetime of the instance and
+    releases it on ``close``; ``run_worker_forever`` calls ``close``
+    on shutdown.
+
+    ``key_prefix`` lets parallel test runs (or shared-tenant Redis
+    deployments) isolate their state without flushing the entire
+    database. Production code typically accepts the default.
+    """
+
+    def __init__(
+        self,
+        *,
+        redis_url: str,
+        key_prefix: str = _DEFAULT_KEY_PREFIX,
+        client: Optional[Redis] = None,
+    ) -> None:
+        if not key_prefix.endswith(":"):
+            key_prefix = key_prefix + ":"
+        self._redis_url = redis_url
+        self._key_prefix = key_prefix
+        # Tests may inject a client (e.g. a fakeredis instance); production
+        # constructs one from the URL.
+        self._client: Redis = (
+            client
+            if client is not None
+            else Redis.from_url(
+                redis_url,
+                decode_responses=True,
+            )
+        )
+        self._owns_client = client is None
+        self._scripts_registered = False
+        self._enqueue_script: Optional[AsyncScript] = None
+        self._acquire_script: Optional[AsyncScript] = None
+        self._extend_script: Optional[AsyncScript] = None
+        self._release_script: Optional[AsyncScript] = None
+        self._reclaim_script: Optional[AsyncScript] = None
+        self._cancel_script: Optional[AsyncScript] = None
+
+    # ------------------------------------------------------------------ keys
+
+    @property
+    def _ready_key(self) -> str:
+        return f"{self._key_prefix}ready"
+
+    @property
+    def _leases_key(self) -> str:
+        return f"{self._key_prefix}leases"
+
+    @property
+    def _tracked_key(self) -> str:
+        return f"{self._key_prefix}tracked"
+
+    @property
+    def _job_hash_prefix(self) -> str:
+        return f"{self._key_prefix}job:"
+
+    def _job_hash_key(self, job_id: str) -> str:
+        return f"{self._job_hash_prefix}{job_id}"
+
+    def _register_scripts(self) -> None:
+        if self._scripts_registered:
+            return
+        self._enqueue_script = self._client.register_script(_LUA_ENQUEUE)
+        self._acquire_script = self._client.register_script(_LUA_ACQUIRE)
+        self._extend_script = self._client.register_script(_LUA_EXTEND)
+        self._release_script = self._client.register_script(_LUA_RELEASE)
+        self._reclaim_script = self._client.register_script(_LUA_RECLAIM)
+        self._cancel_script = self._client.register_script(_LUA_CANCEL)
+        self._scripts_registered = True
+
+    # ------------------------------------------------------------------ API
+
+    async def enqueue(self, request: JobEnqueueRequest) -> None:
+        self._register_scripts()
+        payload = dumps_json(
+            {
+                "job_id": request.job_id,
+                "argv": request.argv,
+                "api_version": request.api_version,
+                "metadata": request.metadata,
+            },
+            sort_keys=True,
+        )
+        assert self._enqueue_script is not None
+        added = await self._enqueue_script(
+            keys=[self._ready_key, self._leases_key, self._tracked_key, self._job_hash_key(request.job_id)],
+            args=[request.job_id, payload],
+        )
+        if int(added) == 0:
+            raise QueueBrokerError(f"job {request.job_id!r} already pending in the queue or leased")
+
+    async def acquire_lease(
+        self,
+        worker_id: str,
+        *,
+        lease_seconds: float,
+    ) -> Optional[JobLease]:
+        if lease_seconds <= 0:
+            raise QueueBrokerError("lease_seconds must be positive")
+        self._register_scripts()
+        assert self._acquire_script is not None
+        result = await self._acquire_script(
+            keys=[self._ready_key, self._leases_key, self._job_hash_prefix],
+            args=[worker_id, str(lease_seconds)],
+        )
+        if result is None:
+            return None
+        job_id, request_json, deadline_str = result
+        if isinstance(job_id, bytes):
+            job_id = job_id.decode("utf-8")
+        if isinstance(request_json, bytes):
+            request_json = request_json.decode("utf-8")
+        if isinstance(deadline_str, bytes):
+            deadline_str = deadline_str.decode("utf-8")
+        request = _deserialize_request(request_json)
+        deadline = float(deadline_str)
+        return JobLease(
+            job_id=job_id,
+            worker_id=worker_id,
+            deadline=deadline,
+            request=request,
+        )
+
+    async def extend_lease(
+        self,
+        worker_id: str,
+        job_id: str,
+        *,
+        lease_seconds: float,
+    ) -> LeaseStatus:
+        if lease_seconds <= 0:
+            raise QueueBrokerError("lease_seconds must be positive")
+        self._register_scripts()
+        assert self._extend_script is not None
+        result = await self._extend_script(
+            keys=[self._leases_key, self._job_hash_key(job_id)],
+            args=[worker_id, job_id, str(lease_seconds)],
+        )
+        outcome = _decode(result)
+        if outcome == "not_held":
+            raise LeaseNotHeldError(worker_id=worker_id, job_id=job_id)
+        if outcome == "cancelled":
+            return LeaseStatus.cancelled
+        if outcome == "active":
+            return LeaseStatus.active
+        raise QueueBrokerError(f"unexpected extend_lease outcome from Redis: {outcome!r}")
+
+    async def release_lease(self, worker_id: str, job_id: str) -> None:
+        self._register_scripts()
+        assert self._release_script is not None
+        await self._release_script(
+            keys=[self._leases_key, self._tracked_key, self._job_hash_key(job_id)],
+            args=[worker_id, job_id],
+        )
+
+    async def reclaim_expired_leases(self, *, now: float) -> List[str]:
+        self._register_scripts()
+        assert self._reclaim_script is not None
+        result = await self._reclaim_script(
+            keys=[self._ready_key, self._leases_key, self._tracked_key, self._job_hash_prefix],
+            args=[str(now)],
+        )
+        return [_decode(item) for item in result]
+
+    async def cancel(self, job_id: str) -> bool:
+        self._register_scripts()
+        assert self._cancel_script is not None
+        result = await self._cancel_script(
+            keys=[self._ready_key, self._leases_key, self._tracked_key, self._job_hash_key(job_id)],
+            args=[job_id],
+        )
+        outcome = _decode(result)
+        if outcome == "absent":
+            return False
+        if outcome in ("inflight", "queued"):
+            return True
+        raise QueueBrokerError(f"unexpected cancel outcome from Redis: {outcome!r}")
+
+    async def queued_job_ids(self) -> List[str]:
+        items = await self._client.lrange(self._ready_key, 0, -1)
+        return [_decode(item) for item in items]
+
+    async def leased_job_ids(self) -> List[str]:
+        items = await self._client.zrange(self._leases_key, 0, -1)
+        return [_decode(item) for item in items]
+
+    async def reset(self) -> None:
+        """Test-only: drop every key under ``key_prefix``.
+
+        Uses ``SCAN`` (not ``KEYS``) so we never block Redis on a
+        shared instance, and never touches keys outside the broker's
+        prefix — multiple parametrized test runs can share a Redis
+        with different ``key_prefix`` values.
+        """
+        pattern = f"{self._key_prefix}*"
+        cursor = 0
+        first = True
+        while first or cursor != 0:
+            first = False
+            cursor, keys = await self._client.scan(cursor=cursor, match=pattern, count=500)
+            if keys:
+                await self._client.delete(*keys)
+
+    async def close(self) -> None:
+        if not self._owns_client:
+            return
+        try:
+            await self._client.aclose()
+        except AttributeError:
+            # redis-py < 5.0 used ``close`` + ``connection_pool.disconnect``.
+            await self._client.close()  # type: ignore[func-returns-value]
+            await self._client.connection_pool.disconnect()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _decode(value: Any) -> str:
+    if isinstance(value, bytes):
+        return value.decode("utf-8")
+    return str(value) if value is not None else ""
+
+
+def _deserialize_request(payload: str) -> JobEnqueueRequest:
+    data = json.loads(payload)
+    return JobEnqueueRequest(
+        job_id=data["job_id"],
+        argv=list(data["argv"]),
+        api_version=data.get("api_version", "v1"),
+        metadata=dict(data.get("metadata") or {}),
+    )
+
+
+__all__ = ["RedisQueueBroker"]

--- a/src/transformation_portal/orchestrator/queue/redis.py
+++ b/src/transformation_portal/orchestrator/queue/redis.py
@@ -40,10 +40,9 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any, List, Optional
+from typing import TYPE_CHECKING, Any, List, Optional
 
 from redis.asyncio import Redis
-from redis.commands.core import AsyncScript
 
 from transformation_portal.ingest.canonical_json import dumps_json
 from transformation_portal.orchestrator.queue.base import (
@@ -54,6 +53,14 @@ from transformation_portal.orchestrator.queue.base import (
     QueueBroker,
     QueueBrokerError,
 )
+
+if TYPE_CHECKING:
+    # ``AsyncScript`` lives in ``redis.commands.core`` today, but that
+    # module is internal-ish — redis-py reorganizes it occasionally. Keep
+    # the import behind ``TYPE_CHECKING`` so the broker module loads on
+    # any redis-py 5.x / 6.x even if the path moves; at runtime we store
+    # the script handles as ``Any`` (they're called as callables anyway).
+    from redis.commands.core import AsyncScript  # noqa: F401
 
 logger = logging.getLogger(__name__)
 
@@ -224,12 +231,12 @@ class RedisQueueBroker(QueueBroker):
         )
         self._owns_client = client is None
         self._scripts_registered = False
-        self._enqueue_script: Optional[AsyncScript] = None
-        self._acquire_script: Optional[AsyncScript] = None
-        self._extend_script: Optional[AsyncScript] = None
-        self._release_script: Optional[AsyncScript] = None
-        self._reclaim_script: Optional[AsyncScript] = None
-        self._cancel_script: Optional[AsyncScript] = None
+        self._enqueue_script: Optional[Any] = None
+        self._acquire_script: Optional[Any] = None
+        self._extend_script: Optional[Any] = None
+        self._release_script: Optional[Any] = None
+        self._reclaim_script: Optional[Any] = None
+        self._cancel_script: Optional[Any] = None
 
     # ------------------------------------------------------------------ keys
 

--- a/tests/orchestrator/test_queue_contract.py
+++ b/tests/orchestrator/test_queue_contract.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import asyncio
 import os
 import time
+import uuid
 from typing import AsyncIterator
 
 import pytest
@@ -59,8 +60,13 @@ def backend(request: pytest.FixtureRequest) -> str:
 
 
 @pytest_asyncio.fixture
-async def broker(backend: str) -> AsyncIterator[QueueBroker]:
-    """Yield a freshly-reset ``QueueBroker`` for the parameterized backend."""
+async def broker(backend: str, request: pytest.FixtureRequest) -> AsyncIterator[QueueBroker]:
+    """Yield a freshly-reset ``QueueBroker`` for the parameterized backend.
+
+    Redis instances use a per-test ``key_prefix`` so parallel test
+    runs (pytest-xdist) and shared-tenant Redis deployments never
+    collide and never touch keys outside the broker's namespace.
+    """
     reset_singleton()
     if backend == "memory":
         instance: QueueBroker = MemoryQueueBroker()
@@ -69,7 +75,12 @@ async def broker(backend: str) -> AsyncIterator[QueueBroker]:
             from transformation_portal.orchestrator.queue.redis import RedisQueueBroker
         except ImportError:
             pytest.skip("redis backend module not available; expected in Phase 2.B")
-        instance = RedisQueueBroker(redis_url=os.environ[_REDIS_URL_ENV])
+        # Per-test key prefix isolates parallel runs and survives shared Redis.
+        prefix = f"tp:test:{uuid.uuid4().hex[:12]}:"
+        instance = RedisQueueBroker(
+            redis_url=os.environ[_REDIS_URL_ENV],
+            key_prefix=prefix,
+        )
         await instance.reset()
     else:
         raise RuntimeError(f"unknown backend {backend!r}")

--- a/tests/orchestrator/test_queue_contract.py
+++ b/tests/orchestrator/test_queue_contract.py
@@ -236,31 +236,39 @@ async def test_reclaim_no_op_when_no_leases(broker: QueueBroker) -> None:
     assert await broker.reclaim_expired_leases(now=time.monotonic() + 1000.0) == []
 
 
-async def test_server_time_advances_and_reclaims_against_broker_clock(broker: QueueBroker) -> None:
-    """``server_time()`` is the production sweeper's source of truth.
+async def test_server_time_shares_domain_with_lease_deadline(broker: QueueBroker) -> None:
+    """``server_time()`` and ``JobLease.deadline`` must share one clock.
 
-    Production callers (Phase 2.D's sweeper) pass
-    ``await broker.server_time()`` to ``reclaim_expired_leases`` so
-    that the deadlines written by ``acquire_lease`` and the boundary
-    used for the sweep share one clock. Verify the helper is
-    monotonic and that a sweep at ``server_time() + lease + slack``
-    reclaims an outstanding lease — i.e. the two values are
-    actually expressed in the same time domain.
+    Production sweepers (Phase 2.D) pass ``await broker.server_time()``
+    to ``reclaim_expired_leases`` and compare it against the deadlines
+    written by ``acquire_lease``. Verify the two values live in the
+    same time domain *without* sleeping: bracket the acquire call
+    between two ``server_time()`` reads, then prove the resulting
+    deadline falls inside ``[t_before + lease_seconds,
+    t_after + lease_seconds]``. That window can only hold if both
+    clocks measure the same thing.
     """
-    t0 = await broker.server_time()
-    await asyncio.sleep(0.01)
-    t1 = await broker.server_time()
-    assert t1 >= t0  # monotonic non-decreasing within the same broker
-
-    await broker.enqueue(_request("job-server-clock"))
-    lease = await broker.acquire_lease("worker-clock", lease_seconds=0.1)
+    lease_seconds = 30.0
+    t_before = await broker.server_time()
+    await broker.enqueue(_request("job-clock-domain"))
+    lease = await broker.acquire_lease("worker-clock", lease_seconds=lease_seconds)
     assert lease is not None
+    t_after = await broker.server_time()
 
-    # Wait past the lease using broker time, then sweep with broker time.
-    await asyncio.sleep(0.15)
-    now = await broker.server_time()
-    reclaimed = await broker.reclaim_expired_leases(now=now)
-    assert "job-server-clock" in reclaimed
+    # server_time is non-decreasing across the call.
+    assert t_after >= t_before
+    # And the lease's deadline lives in the same time domain — it must be
+    # bracketed by [t_before + lease, t_after + lease]. Any other clock
+    # would put deadline outside this window.
+    assert t_before + lease_seconds <= lease.deadline <= t_after + lease_seconds
+
+    # A sweep at "now == deadline - epsilon" must NOT reclaim the lease
+    # (deadline strictly in the future). A sweep at "now == deadline"
+    # must reclaim it (the broker uses <= for expiry).
+    not_yet = await broker.reclaim_expired_leases(now=lease.deadline - 1.0)
+    assert "job-clock-domain" not in not_yet
+    just_expired = await broker.reclaim_expired_leases(now=lease.deadline)
+    assert "job-clock-domain" in just_expired
 
 
 # ---------------------------------------------------------------------------

--- a/tests/orchestrator/test_queue_contract.py
+++ b/tests/orchestrator/test_queue_contract.py
@@ -236,6 +236,33 @@ async def test_reclaim_no_op_when_no_leases(broker: QueueBroker) -> None:
     assert await broker.reclaim_expired_leases(now=time.monotonic() + 1000.0) == []
 
 
+async def test_server_time_advances_and_reclaims_against_broker_clock(broker: QueueBroker) -> None:
+    """``server_time()`` is the production sweeper's source of truth.
+
+    Production callers (Phase 2.D's sweeper) pass
+    ``await broker.server_time()`` to ``reclaim_expired_leases`` so
+    that the deadlines written by ``acquire_lease`` and the boundary
+    used for the sweep share one clock. Verify the helper is
+    monotonic and that a sweep at ``server_time() + lease + slack``
+    reclaims an outstanding lease — i.e. the two values are
+    actually expressed in the same time domain.
+    """
+    t0 = await broker.server_time()
+    await asyncio.sleep(0.01)
+    t1 = await broker.server_time()
+    assert t1 >= t0  # monotonic non-decreasing within the same broker
+
+    await broker.enqueue(_request("job-server-clock"))
+    lease = await broker.acquire_lease("worker-clock", lease_seconds=0.1)
+    assert lease is not None
+
+    # Wait past the lease using broker time, then sweep with broker time.
+    await asyncio.sleep(0.15)
+    now = await broker.server_time()
+    reclaimed = await broker.reclaim_expired_leases(now=now)
+    assert "job-server-clock" in reclaimed
+
+
 # ---------------------------------------------------------------------------
 # Cancellation
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Phase 2.B of the Production Hardening Plan (gap doc §5.2). Adds a Redis backend to the Phase 2.A `QueueBroker` Protocol so a fleet of orchestrator + worker processes can consume from a single durable queue. Memory backend stays the default — behavior is unchanged when `TP_ORCHESTRATOR_QUEUE_BACKEND` is unset.

- `RedisQueueBroker` backed by `redis>=5` async client. Atomicity for `enqueue` / `acquire_lease` / `extend_lease` / `release_lease` / `reclaim_expired_leases` / `cancel` is implemented as server-side Lua so admission collisions and lease handoff never produce partial state.
- Lease deadlines pinned to the Redis server clock (`redis.call('TIME')`) so a multi-host fleet shares one source of truth for "now" and wall-clock drift on individual hosts cannot move deadlines.
- Phase 2.A's 17-test contract suite is now parametrized over `memory` and `redis`; the redis branch activates when `TP_TEST_REDIS_URL` is set, mirroring the Phase 1.B Postgres pattern. Per-test `key_prefix` lets pytest-xdist and shared-tenant Redis coexist without colliding on keys.
- `docker-compose.yml` gains a `redis` service (AOF on, `noeviction` policy, healthcheck). `make test-worker-redis-contract` runs the contract suite against it.

Selectable via `TP_ORCHESTRATOR_QUEUE_BACKEND=redis` together with `TP_REDIS_URL`. The factory raises a friendly error if `TP_REDIS_URL` is unset (parallel to the Phase 1.B `TP_DATABASE_URL` gate).

### Storage layout

All keys live under `key_prefix` (default `tp:queue:`):

| Key                    | Type | Role                                                    |
| ---------------------- | ---- | ------------------------------------------------------- |
| `{prefix}ready`        | LIST | FIFO of `job_id`s ready for pickup.                     |
| `{prefix}leases`       | ZSET | `score=deadline`, `member=job_id`. O(log n) reclaim.    |
| `{prefix}tracked`      | SET  | every `job_id` in flight; cheap admission-collision check. |
| `{prefix}job:<job_id>` | HASH | `request` (JSON), `worker_id`, `deadline`, `cancellation_requested`. |

### What this PR does NOT change

- `app.py` still spawns dispatch subprocesses in-band; the orchestrator-enqueues / worker-consumes cut-over is Phase 2.C.
- No `worker_lost` state yet; that distinction + retry classification + integration with the Phase 1.C restart sweeper is Phase 2.D.
- No SSE / metric surface changes; the broker is still purely a queue contract.

## Test plan

- [x] `pytest -q tests/orchestrator/test_queue_contract.py -m unit` → 17 memory cases green.
- [x] `TP_TEST_REDIS_URL=redis://127.0.0.1:6379/0 pytest -q tests/orchestrator/test_queue_contract.py -m unit` → 17 memory + 17 redis = 34 cases green.
- [x] `pytest -q tests/orchestrator/test_queue_contract.py -m unit -n 4` (xdist parallel) — 34/34 green; per-test key prefixes hold.
- [x] `pytest -q tests/orchestrator -m unit` → full orchestrator suite 62 passed, 1 skipped.
- [x] `pytest -q tests/test_app_orchestrator_runtime.py tests/test_app_orchestrator_contract_http.py` → 410/410 green.
- [x] `scripts/validation/check_requirements_lock_contract.py` → headers match Python 3.11; lockfile contract intact.
- [x] `scripts/validation/check_raw_json_usage.py` → uses `transformation_portal.ingest.canonical_json.dumps_json` for the payload write.
- [x] `scripts/validation/check_dependency_pinning.py` / `check_yaml_governance_boundary.py` / `check_piptools_cache_tracked.py` / `check_python_headers.py` → green.
- [x] Factory smoke: `TP_ORCHESTRATOR_QUEUE_BACKEND=redis TP_REDIS_URL=...` returns `RedisQueueBroker`; missing URL raises `RuntimeError` with actionable message.

Closes part of the work tracked in `docs/governance/PRODUCTION_HARDENING_GAP_2026-05-13.md` §5.2.

https://claude.ai/code/session_01EPqVEoqKMc7AKTJVyTvBh6

---
_Generated by [Claude Code](https://claude.ai/code/session_01EPqVEoqKMc7AKTJVyTvBh6)_