### PR TITLE
ci(coverage): report cold-zone branch baselines

### DIFF
--- a/docs/testing/COLD_ZONE_COVERAGE_PROGRAM.md
+++ b/docs/testing/COLD_ZONE_COVERAGE_PROGRAM.md
@@ -502,7 +502,10 @@ PackageFloor(
 | `src/transformation_portal/spatial_ai/reconstruction/` | 48.58% | 42.0% |
 
 Branch coverage remains reported by the sibling branch checker in dry-run mode
-until branch floors have two consecutive stable CI baselines.
+until branch floors have two consecutive stable CI baselines. With no branch
+floors configured, `check_per_package_branch_coverage.py --dry-run` still emits
+a cold-zone package table for the prefixes above so CI logs capture the measured
+branch baseline without enforcing it.
 
 ### 12.2 Touched-file rule (per-PR, reviewer-enforced)
 

--- a/scripts/ci/check_per_package_branch_coverage.py
+++ b/scripts/ci/check_per_package_branch_coverage.py
@@ -30,8 +30,20 @@ class BranchFloor:
     exclude_prefixes: tuple[str, ...] = field(default_factory=tuple)
 
 
-# PR 0 only wires branch reporting. Actual floors land after baseline review.
+# PR 0 only wires branch reporting. Actual floors land after stable branch
+# baselines are reviewed.
 BRANCH_FLOORS: tuple[BranchFloor, ...] = ()
+
+# While branch floors are empty, CI still runs this checker in ``--dry-run`` mode
+# to capture package-level branch baselines for later ratchets.
+DRY_RUN_BRANCH_PREFIXES: tuple[str, ...] = (
+    "src/transformation_portal/plugins/",
+    "src/transformation_portal/stage_graph/",
+    "src/transformation_portal/vlm/",
+    "src/transformation_portal/depth/",
+    "src/transformation_portal/streaming/",
+    "src/transformation_portal/spatial_ai/reconstruction/",
+)
 
 
 @dataclass(frozen=True)
@@ -73,14 +85,20 @@ def aggregate(coverage_xml: Path, floors: Iterable[BranchFloor]) -> list[BranchR
     return results
 
 
-def render_table(results: list[BranchResult], *, dry_run: bool) -> str:
+def aggregate_prefixes(coverage_xml: Path, prefixes: Iterable[str]) -> list[BranchResult]:
+    return aggregate(coverage_xml, (BranchFloor(prefix, 0.0) for prefix in prefixes))
+
+
+def render_table(results: list[BranchResult], *, dry_run: bool, enforce_floors: bool = True) -> str:
     header = f"{'Package':<60}  {'Branches':>14}  {'Coverage':>10}  {'Floor':>8}  Status"
     lines = [header, "-" * len(header)]
     for result in results:
         ratio = f"{result.covered}/{result.valid}" if result.valid else "0/0"
         pct = f"{result.percentage:6.2f}%" if result.valid else "  N/A  "
-        floor = f"{result.floor:5.1f}%"
-        if result.passed:
+        floor = f"{result.floor:5.1f}%" if enforce_floors else "  N/A  "
+        if not enforce_floors:
+            status = "DRY-RUN" if dry_run else "INFO"
+        elif result.passed:
             status = "PASS"
         else:
             status = "DRY-RUN" if dry_run else "FAIL"
@@ -115,6 +133,8 @@ def main(argv: list[str] | None = None) -> int:
     if not BRANCH_FLOORS:
         print("No per-package branch coverage floors configured.")
         if args.dry_run:
+            results = aggregate_prefixes(args.coverage_xml, DRY_RUN_BRANCH_PREFIXES)
+            print(render_table(results, dry_run=True, enforce_floors=False))
             print("Dry-run branch coverage check completed; no floors enforced.")
         return 0
 

--- a/tests/test_check_per_package_branch_coverage.py
+++ b/tests/test_check_per_package_branch_coverage.py
@@ -107,12 +107,41 @@ def test_missing_coverage_xml_returns_2(script_module, tmp_path: Path):
     assert script_module.main([str(tmp_path / "missing.xml"), "--dry-run"]) == 2
 
 
-def test_no_default_branch_floors_is_success(script_module, tmp_path: Path, capsys):
+def test_no_default_branch_floors_reports_dry_run_baselines(script_module, tmp_path: Path, capsys):
     coverage = tmp_path / "coverage.xml"
-    _write_coverage(coverage, [("src/pkg/x.py", [{"hits": 1}])])
+    _write_coverage(
+        coverage,
+        [
+            (
+                "src/transformation_portal/plugins/loader.py",
+                [{"hits": 1, "condition_coverage": "50% (1/2)"}],
+            ),
+            (
+                "src/transformation_portal/stage_graph/policy.py",
+                [{"hits": 1, "condition_coverage": "100% (2/2)"}],
+            ),
+        ],
+    )
 
     rc = script_module.main([str(coverage), "--dry-run"])
 
     captured = capsys.readouterr()
     assert rc == 0
     assert "No per-package branch coverage floors configured" in captured.out
+    assert "src/transformation_portal/plugins/" in captured.out
+    assert "src/transformation_portal/stage_graph/" in captured.out
+    assert "1/2" in captured.out
+    assert "  N/A" in captured.out
+    assert "DRY-RUN" in captured.out
+
+
+def test_no_default_branch_floors_without_dry_run_is_success(script_module, tmp_path: Path, capsys):
+    coverage = tmp_path / "coverage.xml"
+    _write_coverage(coverage, [("src/pkg/x.py", [{"hits": 1}])])
+
+    rc = script_module.main([str(coverage)])
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "No per-package branch coverage floors configured" in captured.out
+    assert "Package" not in captured.out


### PR DESCRIPTION
## Summary
- Adds branch-baseline evidence to the existing dry-run checker for the Cold-Zone package set.
- Keeps `BRANCH_FLOORS` empty, so this does not enforce branch floors or change the global coverage gate.

## Changes
- Adds a dry-run prefix list for the current Cold-Zone packages.
- Emits a branch coverage table with `N/A` floors and `DRY-RUN` status when no branch floors are configured.
- Covers dry-run baseline output and non-dry-run no-floor behavior in unit tests.
- Documents that the dry-run table is used to collect stable branch baselines before any future floor ratchet.

## Validation
Proven green:
- `.venv/bin/pytest tests/test_check_per_package_branch_coverage.py tests/test_validate_ci_config.py -q`
- `make validate-ci`
- `make test-fast`
- `.venv/bin/python -m black --check --diff --line-length=127 scripts/ci/check_per_package_branch_coverage.py tests/test_check_per_package_branch_coverage.py`
- `.venv/bin/python -m isort --check-only --diff --profile=black --line-length=127 scripts/ci/check_per_package_branch_coverage.py tests/test_check_per_package_branch_coverage.py`
- `make coverage-report` (9634 passed, 56 skipped, 912 deselected)
- `.venv/bin/python scripts/ci/check_per_package_coverage.py coverage.xml`
- `.venv/bin/python scripts/ci/check_per_package_branch_coverage.py coverage.xml --dry-run`
- `git diff --check`

Still failing:
- None observed locally.

## Risk
- Bounded to coverage reporting and tests.
- Revert-safe: removing this change restores the prior no-floor dry-run message without touching line floors, test selection, or pytest coverage settings.