### PR TITLE
ci(coverage): enforce cold-zone branch floors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -756,12 +756,12 @@ jobs:
             ls -lh coverage.xml htmlcov/ || true
           fi
 
-          # Enforce per-package line floors and dry-run branch coverage reporting
+          # Enforce per-package line and branch coverage floors
           # (core tier only, only when tests passed and a coverage.xml was actually
           # produced — failed runs already exited via rc above).
           if [ "${{ matrix.test-type }}" != "ml" ] && [ "$rc" -eq 0 ] && [ -f coverage.xml ]; then
             python scripts/ci/check_per_package_coverage.py coverage.xml || rc=$?
-            python scripts/ci/check_per_package_branch_coverage.py coverage.xml --dry-run || rc=$?
+            python scripts/ci/check_per_package_branch_coverage.py coverage.xml || rc=$?
           fi
 
           # Cleanup regardless of outcome

--- a/docs/testing/COLD_ZONE_COVERAGE_PROGRAM.md
+++ b/docs/testing/COLD_ZONE_COVERAGE_PROGRAM.md
@@ -501,11 +501,29 @@ PackageFloor(
 | `src/transformation_portal/streaming/` | 56.64% | 50.0% |
 | `src/transformation_portal/spatial_ai/reconstruction/` | 48.58% | 42.0% |
 
-Branch coverage remains reported by the sibling branch checker in dry-run mode
-until branch floors have two consecutive stable CI baselines. With no branch
-floors configured, `check_per_package_branch_coverage.py --dry-run` still emits
-a cold-zone package table for the prefixes above so CI logs capture the measured
-branch baseline without enforcing it.
+Post-baseline branch floors also landed after dry-run baseline review. They are
+set roughly 5-10 points below the measured 2026-05-13 branch coverage:
+
+```python
+BranchFloor("src/transformation_portal/plugins/", 30.0)
+BranchFloor("src/transformation_portal/stage_graph/", 60.0)
+BranchFloor("src/transformation_portal/vlm/", 50.0)
+BranchFloor("src/transformation_portal/depth/", 40.0)
+BranchFloor("src/transformation_portal/streaming/", 25.0)
+BranchFloor(
+    "src/transformation_portal/spatial_ai/reconstruction/",
+    45.0,
+)
+```
+
+| Package prefix | Measured 2026-05-13 branch coverage | Enforced floor |
+| --- | ---: | ---: |
+| `src/transformation_portal/plugins/` | 39.86% | 30.0% |
+| `src/transformation_portal/stage_graph/` | 66.46% | 60.0% |
+| `src/transformation_portal/vlm/` | 58.82% | 50.0% |
+| `src/transformation_portal/depth/` | 47.13% | 40.0% |
+| `src/transformation_portal/streaming/` | 32.79% | 25.0% |
+| `src/transformation_portal/spatial_ai/reconstruction/` | 50.93% | 45.0% |
 
 ### 12.2 Touched-file rule (per-PR, reviewer-enforced)
 

--- a/scripts/ci/check_per_package_branch_coverage.py
+++ b/scripts/ci/check_per_package_branch_coverage.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-"""Dry-run branch-coverage reporting for governed package prefixes.
+"""Enforce branch-coverage floors for governed package prefixes.
 
-PR 0 intentionally does not enforce branch floors yet. This companion to
-``check_per_package_coverage.py`` reads the same Cobertura ``coverage.xml`` and
-can enforce branch floors once they are configured, but CI wires it in
-``--dry-run`` mode until the cold-zone baseline is reviewed.
+This companion to ``check_per_package_coverage.py`` reads the same Cobertura
+``coverage.xml`` and enforces conservative branch floors for the cold-zone
+package set. ``--dry-run`` remains available for local floor proposals, but CI
+uses enforcing mode.
 """
 
 from __future__ import annotations
@@ -30,12 +30,20 @@ class BranchFloor:
     exclude_prefixes: tuple[str, ...] = field(default_factory=tuple)
 
 
-# PR 0 only wires branch reporting. Actual floors land after stable branch
-# baselines are reviewed.
-BRANCH_FLOORS: tuple[BranchFloor, ...] = ()
+# Cold-Zone Coverage Program branch ratchets. These floors were set
+# conservatively below the measured 2026-05-13 branch baseline so regressions
+# fail without overfitting to one exact run.
+BRANCH_FLOORS: tuple[BranchFloor, ...] = (
+    BranchFloor("src/transformation_portal/plugins/", 30.0),
+    BranchFloor("src/transformation_portal/stage_graph/", 60.0),
+    BranchFloor("src/transformation_portal/vlm/", 50.0),
+    BranchFloor("src/transformation_portal/depth/", 40.0),
+    BranchFloor("src/transformation_portal/streaming/", 25.0),
+    BranchFloor("src/transformation_portal/spatial_ai/reconstruction/", 45.0),
+)
 
-# While branch floors are empty, CI still runs this checker in ``--dry-run`` mode
-# to capture package-level branch baselines for later ratchets.
+# If a future branch temporarily clears floors, dry-run mode still reports the
+# package-level branch baselines needed for review.
 DRY_RUN_BRANCH_PREFIXES: tuple[str, ...] = (
     "src/transformation_portal/plugins/",
     "src/transformation_portal/stage_graph/",

--- a/scripts/validate_ci_config.py
+++ b/scripts/validate_ci_config.py
@@ -36,8 +36,7 @@ class CIValidator:
     MIN_CHECKOUT_MAJOR = 4
     REQUIRED_FLAKE8_FATAL_CODES = {"E9", "F63", "F7", "F82"}
     ML_NO_COV_BLOCK_PATTERN = re.compile(
-        r'if\s+\[\s*"\$\{\{\s*matrix\.test-type\s*\}\}"\s*=\s*"ml"\s*\]\s*;\s*then\s*\n\s*'
-        r'COV_FLAGS="--no-cov"'
+        r'if\s+\[\s*"\$\{\{\s*matrix\.test-type\s*\}\}"\s*=\s*"ml"\s*\]\s*;\s*then\s*\n\s*' r'COV_FLAGS="--no-cov"'
     )
     CORE_COV_FLAGS_PATTERN = re.compile(r'else\s*\n\s*COV_FLAGS="(?P<flags>[^"]*)"')
     REQUIRED_CORE_COVERAGE_FLAGS = (
@@ -47,7 +46,8 @@ class CIValidator:
         "--cov-report=html",
         "--cov-fail-under",
     )
-    REQUIRED_BRANCH_DRY_RUN_CHECK = "python scripts/ci/check_per_package_branch_coverage.py coverage.xml --dry-run"
+    REQUIRED_BRANCH_COVERAGE_CHECK = "python scripts/ci/check_per_package_branch_coverage.py coverage.xml"
+    FORBIDDEN_BRANCH_DRY_RUN_CHECK = "python scripts/ci/check_per_package_branch_coverage.py coverage.xml --dry-run"
 
     def __init__(self, repo_root: Path, fix_mode: bool = False):
         self.repo_root = repo_root
@@ -324,10 +324,17 @@ class CIValidator:
             self.log_error(f"build.yml:test: Core test leg must retain coverage generation flags: {missing}")
             valid = False
 
-        if self.REQUIRED_BRANCH_DRY_RUN_CHECK not in run_script:
+        if self.REQUIRED_BRANCH_COVERAGE_CHECK not in run_script:
             self.log_error(
-                "build.yml:test: Core test leg must retain branch coverage dry-run check "
-                f"{self.REQUIRED_BRANCH_DRY_RUN_CHECK!r}"
+                "build.yml:test: Core test leg must retain branch coverage enforcement check "
+                f"{self.REQUIRED_BRANCH_COVERAGE_CHECK!r}"
+            )
+            valid = False
+
+        if self.FORBIDDEN_BRANCH_DRY_RUN_CHECK in run_script:
+            self.log_error(
+                "build.yml:test: Core test leg must enforce branch coverage without --dry-run "
+                f"({self.FORBIDDEN_BRANCH_DRY_RUN_CHECK!r} is no longer allowed)"
             )
             valid = False
 

--- a/scripts/validate_ci_config.py
+++ b/scripts/validate_ci_config.py
@@ -19,6 +19,7 @@ Options:
 
 import argparse
 import re
+import shlex
 import sys
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple
@@ -46,8 +47,9 @@ class CIValidator:
         "--cov-report=html",
         "--cov-fail-under",
     )
-    REQUIRED_BRANCH_COVERAGE_CHECK = "python scripts/ci/check_per_package_branch_coverage.py coverage.xml"
-    FORBIDDEN_BRANCH_DRY_RUN_CHECK = "python scripts/ci/check_per_package_branch_coverage.py coverage.xml --dry-run"
+    BRANCH_COVERAGE_SCRIPT = "scripts/ci/check_per_package_branch_coverage.py"
+    BRANCH_COVERAGE_XML = "coverage.xml"
+    REQUIRED_BRANCH_COVERAGE_CHECK = f"python {BRANCH_COVERAGE_SCRIPT} {BRANCH_COVERAGE_XML}"
 
     def __init__(self, repo_root: Path, fix_mode: bool = False):
         self.repo_root = repo_root
@@ -324,21 +326,40 @@ class CIValidator:
             self.log_error(f"build.yml:test: Core test leg must retain coverage generation flags: {missing}")
             valid = False
 
-        if self.REQUIRED_BRANCH_COVERAGE_CHECK not in run_script:
+        branch_coverage_commands = self._branch_coverage_checker_commands(run_script)
+        if not any(self.BRANCH_COVERAGE_XML in command for command in branch_coverage_commands):
             self.log_error(
                 "build.yml:test: Core test leg must retain branch coverage enforcement check "
                 f"{self.REQUIRED_BRANCH_COVERAGE_CHECK!r}"
             )
             valid = False
 
-        if self.FORBIDDEN_BRANCH_DRY_RUN_CHECK in run_script:
+        if any("--dry-run" in command for command in branch_coverage_commands):
             self.log_error(
                 "build.yml:test: Core test leg must enforce branch coverage without --dry-run "
-                f"({self.FORBIDDEN_BRANCH_DRY_RUN_CHECK!r} is no longer allowed)"
+                f"({self.BRANCH_COVERAGE_SCRIPT!r} invocations may not include '--dry-run')"
             )
             valid = False
 
         return valid
+
+    @classmethod
+    def _branch_coverage_checker_commands(cls, run_script: str) -> List[List[str]]:
+        """Return shell-tokenized branch coverage checker invocations."""
+        logical_script = run_script.replace("\\\n", " ")
+        commands: List[List[str]] = []
+        for raw_line in logical_script.splitlines():
+            if cls.BRANCH_COVERAGE_SCRIPT not in raw_line:
+                continue
+            try:
+                tokens = shlex.split(raw_line, comments=True, posix=True)
+            except ValueError:
+                tokens = raw_line.split()
+            if cls.BRANCH_COVERAGE_SCRIPT not in tokens:
+                continue
+            script_index = tokens.index(cls.BRANCH_COVERAGE_SCRIPT)
+            commands.append(tokens[script_index:])
+        return commands
 
     @staticmethod
     def _find_step_by_name(steps: List[Dict], name: str) -> Optional[Dict]:

--- a/tests/test_check_per_package_branch_coverage.py
+++ b/tests/test_check_per_package_branch_coverage.py
@@ -1,4 +1,4 @@
-"""Unit tests for branch-coverage dry-run checker."""
+"""Unit tests for branch-coverage checker."""
 
 from __future__ import annotations
 
@@ -107,7 +107,18 @@ def test_missing_coverage_xml_returns_2(script_module, tmp_path: Path):
     assert script_module.main([str(tmp_path / "missing.xml"), "--dry-run"]) == 2
 
 
-def test_no_default_branch_floors_reports_dry_run_baselines(script_module, tmp_path: Path, capsys):
+def test_default_branch_floors_cover_cold_zone_prefixes(script_module):
+    assert tuple(floor.prefix for floor in script_module.BRANCH_FLOORS) == (
+        "src/transformation_portal/plugins/",
+        "src/transformation_portal/stage_graph/",
+        "src/transformation_portal/vlm/",
+        "src/transformation_portal/depth/",
+        "src/transformation_portal/streaming/",
+        "src/transformation_portal/spatial_ai/reconstruction/",
+    )
+
+
+def test_empty_branch_floors_report_dry_run_baselines(script_module, tmp_path: Path, monkeypatch, capsys):
     coverage = tmp_path / "coverage.xml"
     _write_coverage(
         coverage,
@@ -122,6 +133,7 @@ def test_no_default_branch_floors_reports_dry_run_baselines(script_module, tmp_p
             ),
         ],
     )
+    monkeypatch.setattr(script_module, "BRANCH_FLOORS", ())
 
     rc = script_module.main([str(coverage), "--dry-run"])
 
@@ -135,9 +147,10 @@ def test_no_default_branch_floors_reports_dry_run_baselines(script_module, tmp_p
     assert "DRY-RUN" in captured.out
 
 
-def test_no_default_branch_floors_without_dry_run_is_success(script_module, tmp_path: Path, capsys):
+def test_empty_branch_floors_without_dry_run_is_success(script_module, tmp_path: Path, monkeypatch, capsys):
     coverage = tmp_path / "coverage.xml"
     _write_coverage(coverage, [("src/pkg/x.py", [{"hits": 1}])])
+    monkeypatch.setattr(script_module, "BRANCH_FLOORS", ())
 
     rc = script_module.main([str(coverage)])
 
@@ -145,3 +158,24 @@ def test_no_default_branch_floors_without_dry_run_is_success(script_module, tmp_
     assert rc == 0
     assert "No per-package branch coverage floors configured" in captured.out
     assert "Package" not in captured.out
+
+
+def test_enforced_branch_floor_miss_returns_1(script_module, tmp_path: Path, monkeypatch, capsys):
+    coverage = tmp_path / "coverage.xml"
+    _write_coverage(
+        coverage,
+        [
+            (
+                "src/pkg/branchy.py",
+                [{"hits": 1, "condition_coverage": "25% (1/4)"}],
+            )
+        ],
+    )
+    monkeypatch.setattr(script_module, "BRANCH_FLOORS", (script_module.BranchFloor("src/pkg/", 90.0),))
+
+    rc = script_module.main([str(coverage)])
+
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "FAIL" in captured.out
+    assert "src/pkg/: 25.00% < floor 90.0%" in captured.err

--- a/tests/test_check_per_package_branch_coverage.py
+++ b/tests/test_check_per_package_branch_coverage.py
@@ -108,13 +108,13 @@ def test_missing_coverage_xml_returns_2(script_module, tmp_path: Path):
 
 
 def test_default_branch_floors_cover_cold_zone_prefixes(script_module):
-    assert tuple(floor.prefix for floor in script_module.BRANCH_FLOORS) == (
-        "src/transformation_portal/plugins/",
-        "src/transformation_portal/stage_graph/",
-        "src/transformation_portal/vlm/",
-        "src/transformation_portal/depth/",
-        "src/transformation_portal/streaming/",
-        "src/transformation_portal/spatial_ai/reconstruction/",
+    assert tuple((floor.prefix, floor.floor) for floor in script_module.BRANCH_FLOORS) == (
+        ("src/transformation_portal/plugins/", 30.0),
+        ("src/transformation_portal/stage_graph/", 60.0),
+        ("src/transformation_portal/vlm/", 50.0),
+        ("src/transformation_portal/depth/", 40.0),
+        ("src/transformation_portal/streaming/", 25.0),
+        ("src/transformation_portal/spatial_ai/reconstruction/", 45.0),
     )
 
 

--- a/tests/test_validate_ci_config.py
+++ b/tests/test_validate_ci_config.py
@@ -114,6 +114,18 @@ def test_build_workflow_core_leg_rejects_branch_coverage_dry_run(tmp_path: Path)
     assert any("must enforce branch coverage without --dry-run" in error for error in validator.errors)
 
 
+def test_build_workflow_core_leg_rejects_branch_coverage_dry_run_with_spacing(tmp_path: Path) -> None:
+    workflow_path = _mutated_build_workflow(
+        tmp_path,
+        "python scripts/ci/check_per_package_branch_coverage.py coverage.xml || rc=$?",
+        "python scripts/ci/check_per_package_branch_coverage.py coverage.xml  \\\n" "            --dry-run || rc=$?",
+    )
+    validator, config = _load_config(workflow_path)
+
+    assert validator.validate_build_coverage_contract(workflow_path, config) is False
+    assert any("must enforce branch coverage without --dry-run" in error for error in validator.errors)
+
+
 def test_build_workflow_coverage_upload_keeps_html_artifact_path(tmp_path: Path) -> None:
     workflow_path = _build_workflow_without_upload_path(tmp_path, "htmlcov/")
     validator, config = _load_config(workflow_path)

--- a/tests/test_validate_ci_config.py
+++ b/tests/test_validate_ci_config.py
@@ -90,16 +90,28 @@ def test_build_workflow_core_leg_keeps_xml_coverage_generation(tmp_path: Path) -
     )
 
 
-def test_build_workflow_core_leg_keeps_branch_coverage_dry_run(tmp_path: Path) -> None:
+def test_build_workflow_core_leg_keeps_branch_coverage_enforcement(tmp_path: Path) -> None:
     workflow_path = _mutated_build_workflow(
         tmp_path,
-        "python scripts/ci/check_per_package_branch_coverage.py coverage.xml --dry-run || rc=$?",
-        "echo branch coverage dry-run removed",
+        "python scripts/ci/check_per_package_branch_coverage.py coverage.xml || rc=$?",
+        "echo branch coverage enforcement removed",
     )
     validator, config = _load_config(workflow_path)
 
     assert validator.validate_build_coverage_contract(workflow_path, config) is False
-    assert any("must retain branch coverage dry-run check" in error for error in validator.errors)
+    assert any("must retain branch coverage enforcement check" in error for error in validator.errors)
+
+
+def test_build_workflow_core_leg_rejects_branch_coverage_dry_run(tmp_path: Path) -> None:
+    workflow_path = _mutated_build_workflow(
+        tmp_path,
+        "python scripts/ci/check_per_package_branch_coverage.py coverage.xml || rc=$?",
+        "python scripts/ci/check_per_package_branch_coverage.py coverage.xml --dry-run || rc=$?",
+    )
+    validator, config = _load_config(workflow_path)
+
+    assert validator.validate_build_coverage_contract(workflow_path, config) is False
+    assert any("must enforce branch coverage without --dry-run" in error for error in validator.errors)
 
 
 def test_build_workflow_coverage_upload_keeps_html_artifact_path(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Converts the Cold-Zone branch coverage checker from evidence-only dry-run mode to CI-enforced branch floors.
- Sets conservative branch floors 5-10 points below the measured 2026-05-13 cold-zone branch baselines.

## Changes
- Adds `BRANCH_FLOORS` for plugins, stage_graph, vlm, depth, streaming, and reconstruction.
- Updates the core coverage workflow to run `check_per_package_branch_coverage.py coverage.xml` without `--dry-run`.
- Tightens the CI workflow validator so the branch enforcement call must remain present and `--dry-run` is rejected.
- Updates branch coverage checker tests for configured defaults, empty-floor fallback, dry-run behavior, and enforced failures.
- Documents the measured branch baselines and enforced floors in `docs/testing/COLD_ZONE_COVERAGE_PROGRAM.md`.

## Validation
Proven green:
- `.venv/bin/pytest tests/test_check_per_package_branch_coverage.py tests/test_validate_ci_config.py -q`
- `make validate-ci`
- `make test-fast`
- `.venv/bin/python -m black --check --diff --line-length=127 scripts/ci/check_per_package_branch_coverage.py scripts/validate_ci_config.py tests/test_check_per_package_branch_coverage.py tests/test_validate_ci_config.py`
- `.venv/bin/python -m isort --check-only --diff --profile=black --line-length=127 scripts/ci/check_per_package_branch_coverage.py scripts/validate_ci_config.py tests/test_check_per_package_branch_coverage.py tests/test_validate_ci_config.py`
- `make coverage-report` (9637 passed, 56 skipped, 912 deselected)
- `.venv/bin/python scripts/ci/check_per_package_coverage.py coverage.xml`
- `.venv/bin/python scripts/ci/check_per_package_branch_coverage.py coverage.xml`
- `git diff --check`

External evidence:
- Main push build after #1766 completed successfully at `3770504098825ae01065ea93eeb5e500ff2cdad9`.

Still failing:
- None observed locally.

## Risk
- This is a CI ratchet: future branch coverage regressions in the cold-zone package set will fail the core coverage lane.
- Floors are deliberately below measured coverage, so the change is bounded and revert-safe if a CI-only measurement drift appears.