### PR TITLE
ci(coverage): report cold-zone touched file evidence

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -762,6 +762,8 @@ jobs:
           if [ "${{ matrix.test-type }}" != "ml" ] && [ "$rc" -eq 0 ] && [ -f coverage.xml ]; then
             python scripts/ci/check_per_package_coverage.py coverage.xml || rc=$?
             python scripts/ci/check_per_package_branch_coverage.py coverage.xml || rc=$?
+            git fetch --no-tags --depth=1 origin main:refs/remotes/origin/main || rc=$?
+            python scripts/ci/check_cold_zone_touched_files.py coverage.xml --compare-ref origin/main || rc=$?
           fi
 
           # Cleanup regardless of outcome

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,7 @@ Quick reference for common workflows and commands in this repo.
 - `python3 scripts/validation/generate_design_tokens_doc.py --check` verify the generated `docs/design/tokens.md` reference outside Make.
 - `python3 scripts/ci/cold_zone_report.py coverage.xml --markdown-out docs/testing/cold_zone_baseline_YYYY-MM-DD.md --json-out /tmp/cold-zone-baseline.json` generate the cold-zone coverage baseline after `make coverage-report`.
 - `python3 scripts/ci/check_per_package_branch_coverage.py coverage.xml` enforce cold-zone per-package branch coverage floors after pytest-cov; add `--dry-run` only for local floor proposal/reporting runs.
+- `python3 scripts/ci/check_cold_zone_touched_files.py coverage.xml --compare-ref origin/main` report touched cold-zone file coverage evidence after pytest-cov; it fails only when touched cold-zone files are missing from `coverage.xml`.
 - `./scripts/validation/run_full_validation_suite.sh` all-in-one validation orchestrator.
 - `./scripts/validation/run_full_validation_suite.sh --quick` skip browser smokes for faster iteration.
 - `./scripts/validation/run_full_validation_suite.sh --skip-frontdoor` Python-only validation.

--- a/docs/testing/COLD_ZONE_COVERAGE_PROGRAM.md
+++ b/docs/testing/COLD_ZONE_COVERAGE_PROGRAM.md
@@ -533,6 +533,14 @@ For any PR touching a cold-zone file:
 - New lines must be covered unless explicitly justified.
 - New untested branches require reviewer sign-off in the PR body.
 
+The core coverage lane now runs
+`scripts/ci/check_cold_zone_touched_files.py coverage.xml --compare-ref origin/main`
+after the package line and branch coverage ratchets. The check reports line
+coverage, branch coverage, missed line ranges, and missed branch counts for any
+touched cold-zone source file. It fails only when a touched cold-zone file is
+missing from `coverage.xml`; percentage regressions and newly untested branches
+remain review decisions documented in the PR body.
+
 ---
 
 ## 13. Test quality bar

--- a/scripts/ci/check_cold_zone_touched_files.py
+++ b/scripts/ci/check_cold_zone_touched_files.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Report coverage evidence for cold-zone files touched by a PR.
+
+This script supports the Cold-Zone Coverage Program touched-file rule. It does
+not enforce per-file percentage floors; package floors remain the automated
+ratchet. Instead, it fails closed when a touched cold-zone source file is not
+present in ``coverage.xml``, because reviewers cannot verify whether coverage
+decreased without measurement data.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+try:
+    from scripts.ci.cobertura_xml import CoberturaFile, load_cobertura_files
+except ModuleNotFoundError:  # pragma: no cover - direct script execution fallback
+    from cobertura_xml import CoberturaFile, load_cobertura_files  # type: ignore[no-redef]
+
+
+COLD_ZONE_PREFIXES: tuple[str, ...] = (
+    "src/transformation_portal/plugins/",
+    "src/transformation_portal/stage_graph/",
+    "src/transformation_portal/vlm/",
+    "src/transformation_portal/depth/",
+    "src/transformation_portal/streaming/",
+    "src/transformation_portal/spatial_ai/reconstruction/",
+)
+
+
+@dataclass(frozen=True)
+class TouchedFileCoverage:
+    """Coverage facts for one touched cold-zone source file."""
+
+    filename: str
+    covered_lines: int
+    valid_lines: int
+    covered_branches: int
+    valid_branches: int
+    missed_line_ranges: tuple[str, ...]
+    missed_branch_count: int
+
+    @classmethod
+    def from_cobertura_file(cls, coverage_file: CoberturaFile) -> "TouchedFileCoverage":
+        return cls(
+            filename=coverage_file.filename,
+            covered_lines=coverage_file.covered_lines,
+            valid_lines=coverage_file.valid_lines,
+            covered_branches=coverage_file.branch_covered,
+            valid_branches=coverage_file.branch_valid,
+            missed_line_ranges=coverage_file.missed_line_ranges,
+            missed_branch_count=coverage_file.missed_branch_count,
+        )
+
+    @property
+    def line_percentage(self) -> float | None:
+        if self.valid_lines == 0:
+            return None
+        return 100.0 * self.covered_lines / self.valid_lines
+
+    @property
+    def branch_percentage(self) -> float | None:
+        if self.valid_branches == 0:
+            return None
+        return 100.0 * self.covered_branches / self.valid_branches
+
+
+@dataclass(frozen=True)
+class TouchedReport:
+    """Report payload for touched cold-zone coverage evidence."""
+
+    compare_ref: str
+    touched_files: tuple[str, ...]
+    measured_files: tuple[TouchedFileCoverage, ...]
+    missing_files: tuple[str, ...]
+
+
+def _normalize_repo_path(path: str) -> str:
+    normalized = path.replace("\\", "/")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    if normalized.startswith("/"):
+        normalized = normalized[1:]
+    return normalized
+
+
+def _is_cold_zone_source(path: str) -> bool:
+    normalized = _normalize_repo_path(path)
+    return normalized.endswith(".py") and any(normalized.startswith(prefix) for prefix in COLD_ZONE_PREFIXES)
+
+
+def _coverage_index(files: Iterable[CoberturaFile]) -> dict[str, CoberturaFile]:
+    indexed: dict[str, CoberturaFile] = {}
+    for coverage_file in files:
+        indexed[coverage_file.filename] = coverage_file
+        if coverage_file.filename.startswith("src/"):
+            indexed[coverage_file.filename.removeprefix("src/")] = coverage_file
+    return indexed
+
+
+def collect_changed_files(compare_ref: str, *, repo_root: Path) -> tuple[str, ...]:
+    """Return files changed relative to ``compare_ref``.
+
+    Prefer a three-dot diff so local runs compare against the merge base. Shallow
+    CI checkouts can lack that merge base even after fetching ``origin/main``;
+    in that case, fall back to a direct tree diff against the fetched base ref.
+    """
+    result = subprocess.run(
+        ["git", "diff", "--name-only", "--diff-filter=ACMRT", f"{compare_ref}...HEAD"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    message = result.stderr.strip() or result.stdout.strip() or f"git diff exited {result.returncode}"
+    if result.returncode != 0 and "no merge base" in message.lower():
+        result = subprocess.run(
+            ["git", "diff", "--name-only", "--diff-filter=ACMRT", compare_ref, "HEAD"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        message = result.stderr.strip() or result.stdout.strip() or f"git diff exited {result.returncode}"
+
+    if result.returncode != 0:
+        raise RuntimeError(message)
+    return tuple(_normalize_repo_path(line) for line in result.stdout.splitlines() if line.strip())
+
+
+def build_report(coverage_xml: Path, changed_files: Iterable[str], *, compare_ref: str) -> TouchedReport:
+    measured_by_path = _coverage_index(load_cobertura_files(coverage_xml))
+    touched = tuple(sorted({_normalize_repo_path(path) for path in changed_files if _is_cold_zone_source(path)}))
+
+    measured: list[TouchedFileCoverage] = []
+    missing: list[str] = []
+    for filename in touched:
+        coverage_file = measured_by_path.get(filename)
+        if coverage_file is None:
+            missing.append(filename)
+            continue
+        measured.append(TouchedFileCoverage.from_cobertura_file(coverage_file))
+
+    return TouchedReport(
+        compare_ref=compare_ref,
+        touched_files=touched,
+        measured_files=tuple(measured),
+        missing_files=tuple(missing),
+    )
+
+
+def _format_percent(value: float | None) -> str:
+    if value is None:
+        return "N/A"
+    return f"{value:.2f}%"
+
+
+def _format_ranges(ranges: tuple[str, ...]) -> str:
+    return ", ".join(ranges) if ranges else "-"
+
+
+def render_report(report: TouchedReport) -> str:
+    """Render a terminal-friendly touched-file coverage table."""
+    lines = [
+        "Cold-zone touched-file coverage report",
+        f"Compare ref: {report.compare_ref}",
+        f"Touched cold-zone source files: {len(report.touched_files)}",
+    ]
+
+    if not report.touched_files:
+        lines.append("No cold-zone source files changed relative to the compare ref.")
+        return "\n".join(lines)
+
+    header = (
+        f"{'File':<72}  {'Lines':>12}  {'Line %':>8}  "
+        f"{'Branches':>12}  {'Branch %':>8}  {'Missed Lines':<24}  {'Missed Branches':>15}"
+    )
+    lines.extend(["", header, "-" * len(header)])
+    for row in report.measured_files:
+        line_ratio = f"{row.covered_lines}/{row.valid_lines}"
+        branch_ratio = f"{row.covered_branches}/{row.valid_branches}"
+        lines.append(
+            f"{row.filename:<72}  {line_ratio:>12}  {_format_percent(row.line_percentage):>8}  "
+            f"{branch_ratio:>12}  {_format_percent(row.branch_percentage):>8}  "
+            f"{_format_ranges(row.missed_line_ranges):<24}  {row.missed_branch_count:>15}"
+        )
+
+    if report.missing_files:
+        lines.extend(["", "Missing coverage entries:"])
+        for filename in report.missing_files:
+            lines.append(f"  - {filename}")
+
+    lines.extend(
+        [
+            "",
+            "Reviewer note: this report supplies evidence for the touched-file rule; "
+            "new untested lines or branches still require PR-body justification.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "coverage_xml",
+        nargs="?",
+        default="coverage.xml",
+        type=Path,
+        help="Path to Cobertura coverage.xml produced by pytest-cov.",
+    )
+    parser.add_argument(
+        "--compare-ref",
+        default="origin/main",
+        help="Git ref used as the base for touched-file detection.",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path.cwd(),
+        help="Repository root used for git diff execution.",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.coverage_xml.is_file():
+        print(
+            f"check_cold_zone_touched_files: coverage.xml not found at {args.coverage_xml}. "
+            "This script must run after pytest-cov produces the report.",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        changed_files = collect_changed_files(args.compare_ref, repo_root=args.repo_root)
+    except RuntimeError as exc:
+        print(
+            f"check_cold_zone_touched_files: unable to diff against {args.compare_ref}: {exc}",
+            file=sys.stderr,
+        )
+        return 2
+
+    report = build_report(args.coverage_xml, changed_files, compare_ref=args.compare_ref)
+    print(render_report(report))
+
+    if report.missing_files:
+        print(
+            "check_cold_zone_touched_files: touched cold-zone files are missing from coverage.xml.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_ci_config.py
+++ b/scripts/validate_ci_config.py
@@ -50,6 +50,11 @@ class CIValidator:
     BRANCH_COVERAGE_SCRIPT = "scripts/ci/check_per_package_branch_coverage.py"
     BRANCH_COVERAGE_XML = "coverage.xml"
     REQUIRED_BRANCH_COVERAGE_CHECK = f"python {BRANCH_COVERAGE_SCRIPT} {BRANCH_COVERAGE_XML}"
+    COLD_ZONE_TOUCHED_FILE_SCRIPT = "scripts/ci/check_cold_zone_touched_files.py"
+    REQUIRED_COLD_ZONE_TOUCHED_FILE_CHECK = (
+        f"python {COLD_ZONE_TOUCHED_FILE_SCRIPT} {BRANCH_COVERAGE_XML} --compare-ref origin/main"
+    )
+    REQUIRED_COLD_ZONE_COMPARE_REF_FETCH = "git fetch --no-tags --depth=1 origin main:refs/remotes/origin/main"
 
     def __init__(self, repo_root: Path, fix_mode: bool = False):
         self.repo_root = repo_root
@@ -341,25 +346,72 @@ class CIValidator:
             )
             valid = False
 
+        touched_file_commands = self._script_invocations(run_script, self.COLD_ZONE_TOUCHED_FILE_SCRIPT)
+        if not any(
+            self.BRANCH_COVERAGE_XML in command and self._command_has_option_value(command, "--compare-ref", "origin/main")
+            for command in touched_file_commands
+        ):
+            self.log_error(
+                "build.yml:test: Core test leg must retain cold-zone touched-file coverage evidence check "
+                f"{self.REQUIRED_COLD_ZONE_TOUCHED_FILE_CHECK!r}"
+            )
+            valid = False
+
+        if not self._has_required_command(run_script, self.REQUIRED_COLD_ZONE_COMPARE_REF_FETCH):
+            self.log_error(
+                "build.yml:test: Core test leg must fetch origin/main before cold-zone touched-file evidence "
+                f"{self.REQUIRED_COLD_ZONE_COMPARE_REF_FETCH!r}"
+            )
+            valid = False
+
         return valid
 
     @classmethod
     def _branch_coverage_checker_commands(cls, run_script: str) -> List[List[str]]:
         """Return shell-tokenized branch coverage checker invocations."""
+        return cls._script_invocations(run_script, cls.BRANCH_COVERAGE_SCRIPT)
+
+    @staticmethod
+    def _script_invocations(run_script: str, script_path: str) -> List[List[str]]:
+        """Return shell-tokenized invocations for a Python script path."""
         logical_script = run_script.replace("\\\n", " ")
         commands: List[List[str]] = []
         for raw_line in logical_script.splitlines():
-            if cls.BRANCH_COVERAGE_SCRIPT not in raw_line:
+            if script_path not in raw_line:
                 continue
             try:
                 tokens = shlex.split(raw_line, comments=True, posix=True)
             except ValueError:
                 tokens = raw_line.split()
-            if cls.BRANCH_COVERAGE_SCRIPT not in tokens:
+            if script_path not in tokens:
                 continue
-            script_index = tokens.index(cls.BRANCH_COVERAGE_SCRIPT)
+            script_index = tokens.index(script_path)
             commands.append(tokens[script_index:])
         return commands
+
+    @staticmethod
+    def _has_required_command(run_script: str, required_command: str) -> bool:
+        """Return True when a shell script contains the required command tokens."""
+        expected_tokens = shlex.split(required_command, comments=True, posix=True)
+        logical_script = run_script.replace("\\\n", " ")
+        for raw_line in logical_script.splitlines():
+            try:
+                tokens = shlex.split(raw_line, comments=True, posix=True)
+            except ValueError:
+                tokens = raw_line.split()
+            if len(tokens) >= len(expected_tokens) and tokens[: len(expected_tokens)] == expected_tokens:
+                return True
+        return False
+
+    @staticmethod
+    def _command_has_option_value(command: List[str], option: str, value: str) -> bool:
+        """Return True when command contains ``--option value`` or ``--option=value``."""
+        for index, token in enumerate(command):
+            if token == option and index + 1 < len(command) and command[index + 1] == value:
+                return True
+            if token == f"{option}={value}":
+                return True
+        return False
 
     @staticmethod
     def _find_step_by_name(steps: List[Dict], name: str) -> Optional[Dict]:

--- a/tests/test_check_cold_zone_touched_files.py
+++ b/tests/test_check_cold_zone_touched_files.py
@@ -1,0 +1,216 @@
+"""Unit tests for cold-zone touched-file coverage evidence reporting."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+pytestmark = [pytest.mark.unit]
+
+
+def _load_script_module():
+    repo_root = Path(__file__).resolve().parents[1]
+    script_path = repo_root / "scripts" / "ci" / "check_cold_zone_touched_files.py"
+    spec = importlib.util.spec_from_file_location("check_cold_zone_touched_files", script_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module", name="script_module")
+def _script_module_fixture():
+    return _load_script_module()
+
+
+def _write_coverage(
+    path: Path,
+    classes: list[tuple[str, list[dict[str, str | int]]]],
+    sources: list[str] | None = None,
+) -> None:
+    body = ['<?xml version="1.0" ?>', "<coverage>"]
+    if sources:
+        body.append("  <sources>")
+        for source in sources:
+            body.append(f"    <source>{source}</source>")
+        body.append("  </sources>")
+    body.extend(["  <packages>", "    <package>", "      <classes>"])
+    for filename, lines in classes:
+        body.append(f'        <class name="x" filename="{filename}">')
+        body.append("          <lines>")
+        for idx, attrs in enumerate(lines, start=1):
+            branch_attrs = ""
+            if "condition_coverage" in attrs:
+                branch_attrs = f' branch="true" condition-coverage="{attrs["condition_coverage"]}"'
+            body.append(f'            <line number="{idx}" hits="{attrs["hits"]}"{branch_attrs}/>')
+        body.append("          </lines>")
+        body.append("        </class>")
+    body.extend(["      </classes>", "    </package>", "  </packages>", "</coverage>"])
+    path.write_text("\n".join(body), encoding="utf-8")
+
+
+def test_normalize_repo_path_only_removes_explicit_relative_prefixes(script_module):
+    assert script_module._normalize_repo_path("./src/transformation_portal/depth/tools.py") == (
+        "src/transformation_portal/depth/tools.py"
+    )
+    assert script_module._normalize_repo_path(".github/workflows/build.yml") == ".github/workflows/build.yml"
+    assert script_module._normalize_repo_path("../src/transformation_portal/depth/tools.py") == (
+        "../src/transformation_portal/depth/tools.py"
+    )
+    assert script_module._normalize_repo_path("/src/transformation_portal/depth/tools.py") == (
+        "src/transformation_portal/depth/tools.py"
+    )
+
+
+def test_build_report_filters_to_touched_cold_zone_sources(script_module, tmp_path: Path):
+    coverage = tmp_path / "coverage.xml"
+    _write_coverage(
+        coverage,
+        [
+            (
+                "src/transformation_portal/depth/tools.py",
+                [
+                    {"hits": 1},
+                    {"hits": 0, "condition_coverage": "50% (1/2)"},
+                    {"hits": 0},
+                    {"hits": 1, "condition_coverage": "100% (2/2)"},
+                ],
+            ),
+            ("src/transformation_portal/plugins/registry.py", [{"hits": 1}]),
+        ],
+    )
+
+    report = script_module.build_report(
+        coverage,
+        [
+            "README.md",
+            "tests/unit/depth/test_tools.py",
+            "src/transformation_portal/depth/tools.py",
+            "src/transformation_portal/not_cold.py",
+        ],
+        compare_ref="origin/main",
+    )
+
+    assert report.touched_files == ("src/transformation_portal/depth/tools.py",)
+    assert report.missing_files == ()
+    assert len(report.measured_files) == 1
+    measured = report.measured_files[0]
+    assert measured.covered_lines == 2
+    assert measured.valid_lines == 4
+    assert measured.line_percentage == 50.0
+    assert measured.covered_branches == 3
+    assert measured.valid_branches == 4
+    assert measured.branch_percentage == 75.0
+    assert measured.missed_line_ranges == ("2-3",)
+    assert measured.missed_branch_count == 1
+
+
+def test_render_report_includes_missed_ranges_and_branch_counts(script_module, tmp_path: Path):
+    coverage = tmp_path / "coverage.xml"
+    _write_coverage(
+        coverage,
+        [
+            (
+                "src/transformation_portal/streaming/stages.py",
+                [
+                    {"hits": 1},
+                    {"hits": 0, "condition_coverage": "50% (1/2)"},
+                    {"hits": 1},
+                ],
+            )
+        ],
+    )
+    report = script_module.build_report(
+        coverage,
+        ["src/transformation_portal/streaming/stages.py"],
+        compare_ref="origin/main",
+    )
+
+    rendered = script_module.render_report(report)
+
+    assert "Cold-zone touched-file coverage report" in rendered
+    assert "Touched cold-zone source files: 1" in rendered
+    assert "src/transformation_portal/streaming/stages.py" in rendered
+    assert "2/3" in rendered
+    assert "66.67%" in rendered
+    assert "1/2" in rendered
+    assert "50.00%" in rendered
+    assert "2" in rendered
+    assert "Reviewer note:" in rendered
+
+
+def test_missing_touched_coverage_entry_fails_closed(script_module, tmp_path: Path, capsys, monkeypatch):
+    coverage = tmp_path / "coverage.xml"
+    _write_coverage(coverage, [("src/transformation_portal/depth/other.py", [{"hits": 1}])])
+    monkeypatch.setattr(
+        script_module,
+        "collect_changed_files",
+        lambda compare_ref, *, repo_root: ("src/transformation_portal/depth/tools.py",),
+    )
+
+    rc = script_module.main([str(coverage), "--compare-ref", "origin/main", "--repo-root", str(tmp_path)])
+
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "Missing coverage entries:" in captured.out
+    assert "src/transformation_portal/depth/tools.py" in captured.out
+    assert "touched cold-zone files are missing from coverage.xml" in captured.err
+
+
+def test_no_touched_cold_zone_sources_passes(script_module, tmp_path: Path, capsys, monkeypatch):
+    coverage = tmp_path / "coverage.xml"
+    _write_coverage(coverage, [("src/transformation_portal/depth/tools.py", [{"hits": 1}])])
+    monkeypatch.setattr(script_module, "collect_changed_files", lambda compare_ref, *, repo_root: ("README.md",))
+
+    rc = script_module.main([str(coverage), "--compare-ref", "origin/main", "--repo-root", str(tmp_path)])
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "Touched cold-zone source files: 0" in captured.out
+    assert "No cold-zone source files changed" in captured.out
+
+
+def test_missing_coverage_xml_returns_2(script_module, tmp_path: Path):
+    assert script_module.main([str(tmp_path / "missing.xml")]) == 2
+
+
+def test_git_diff_failure_returns_2(script_module, tmp_path: Path, capsys, monkeypatch):
+    coverage = tmp_path / "coverage.xml"
+    _write_coverage(coverage, [("src/transformation_portal/depth/tools.py", [{"hits": 1}])])
+
+    def fail_diff(compare_ref, *, repo_root):
+        raise RuntimeError("bad revision")
+
+    monkeypatch.setattr(script_module, "collect_changed_files", fail_diff)
+
+    rc = script_module.main([str(coverage), "--compare-ref", "origin/missing", "--repo-root", str(tmp_path)])
+
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert "unable to diff against origin/missing: bad revision" in captured.err
+
+
+def test_collect_changed_files_falls_back_when_shallow_checkout_has_no_merge_base(script_module, tmp_path: Path, monkeypatch):
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        del kwargs
+        calls.append(cmd)
+        if cmd[-1] == "origin/main...HEAD":
+            return SimpleNamespace(returncode=128, stdout="", stderr="fatal: origin/main...HEAD: no merge base")
+        return SimpleNamespace(returncode=0, stdout="./src/transformation_portal/depth/tools.py\n", stderr="")
+
+    monkeypatch.setattr(script_module.subprocess, "run", fake_run)
+
+    changed_files = script_module.collect_changed_files("origin/main", repo_root=tmp_path)
+
+    assert changed_files == ("src/transformation_portal/depth/tools.py",)
+    assert calls == [
+        ["git", "diff", "--name-only", "--diff-filter=ACMRT", "origin/main...HEAD"],
+        ["git", "diff", "--name-only", "--diff-filter=ACMRT", "origin/main", "HEAD"],
+    ]

--- a/tests/test_validate_ci_config.py
+++ b/tests/test_validate_ci_config.py
@@ -118,12 +118,60 @@ def test_build_workflow_core_leg_rejects_branch_coverage_dry_run_with_spacing(tm
     workflow_path = _mutated_build_workflow(
         tmp_path,
         "python scripts/ci/check_per_package_branch_coverage.py coverage.xml || rc=$?",
-        "python scripts/ci/check_per_package_branch_coverage.py coverage.xml  \\\n" "            --dry-run || rc=$?",
+        "python scripts/ci/check_per_package_branch_coverage.py coverage.xml  \\\n            --dry-run || rc=$?",
     )
     validator, config = _load_config(workflow_path)
 
     assert validator.validate_build_coverage_contract(workflow_path, config) is False
     assert any("must enforce branch coverage without --dry-run" in error for error in validator.errors)
+
+
+def test_build_workflow_core_leg_keeps_cold_zone_touched_file_evidence(tmp_path: Path) -> None:
+    workflow_path = _mutated_build_workflow(
+        tmp_path,
+        "python scripts/ci/check_cold_zone_touched_files.py coverage.xml --compare-ref origin/main || rc=$?",
+        "echo cold-zone touched-file evidence removed",
+    )
+    validator, config = _load_config(workflow_path)
+
+    assert validator.validate_build_coverage_contract(workflow_path, config) is False
+    assert any("must retain cold-zone touched-file coverage evidence check" in error for error in validator.errors)
+
+
+def test_build_workflow_core_leg_requires_touched_file_compare_ref(tmp_path: Path) -> None:
+    workflow_path = _mutated_build_workflow(
+        tmp_path,
+        "python scripts/ci/check_cold_zone_touched_files.py coverage.xml --compare-ref origin/main || rc=$?",
+        "python scripts/ci/check_cold_zone_touched_files.py coverage.xml || rc=$?",
+    )
+    validator, config = _load_config(workflow_path)
+
+    assert validator.validate_build_coverage_contract(workflow_path, config) is False
+    assert any("must retain cold-zone touched-file coverage evidence check" in error for error in validator.errors)
+
+
+def test_build_workflow_core_leg_accepts_equals_form_compare_ref(tmp_path: Path) -> None:
+    workflow_path = _mutated_build_workflow(
+        tmp_path,
+        "python scripts/ci/check_cold_zone_touched_files.py coverage.xml --compare-ref origin/main || rc=$?",
+        "python scripts/ci/check_cold_zone_touched_files.py coverage.xml --compare-ref=origin/main || rc=$?",
+    )
+    validator, config = _load_config(workflow_path)
+
+    assert validator.validate_build_coverage_contract(workflow_path, config) is True
+    assert validator.errors == []
+
+
+def test_build_workflow_core_leg_fetches_cold_zone_compare_ref(tmp_path: Path) -> None:
+    workflow_path = _mutated_build_workflow(
+        tmp_path,
+        "git fetch --no-tags --depth=1 origin main:refs/remotes/origin/main || rc=$?",
+        "echo origin main fetch removed",
+    )
+    validator, config = _load_config(workflow_path)
+
+    assert validator.validate_build_coverage_contract(workflow_path, config) is False
+    assert any("must fetch origin/main before cold-zone touched-file evidence" in error for error in validator.errors)
 
 
 def test_build_workflow_coverage_upload_keeps_html_artifact_path(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Implements the next Cold-Zone Coverage Program phase by making the touched-file rule auditable in CI.
- Adds a narrow coverage evidence checker that reports touched cold-zone source file line/branch coverage and fails only when touched cold-zone files are absent from coverage.xml.

## Changes
- Added scripts/ci/check_cold_zone_touched_files.py using the shared Cobertura parser and git three-dot diff against origin/main.
- Wired the checker into the core build coverage lane after the line and branch package ratchets.
- Extended scripts/validate_ci_config.py so build.yml validation fails if the touched-file evidence check is removed or loses its origin/main compare ref.
- Added focused unit coverage for filtering, missed-line ranges, branch counts, missing XML exit code 2, missing coverage entries, no-op diffs, and git diff failures.
- Documented the command in AGENTS.md and docs/testing/COLD_ZONE_COVERAGE_PROGRAM.md.

## Validation
Proven green:
- .venv/bin/pytest tests/test_check_cold_zone_touched_files.py tests/test_validate_ci_config.py
- make validate-ci
- make test-fast
- make coverage-report
- .venv/bin/python scripts/ci/check_per_package_coverage.py coverage.xml
- .venv/bin/python scripts/ci/check_per_package_branch_coverage.py coverage.xml
- .venv/bin/python scripts/ci/check_cold_zone_touched_files.py coverage.xml --compare-ref origin/main
- make lint-parity
- git diff --check

Still failing:
- None observed.

Failure classification:
- No product logic, stale test, or environment/tooling failures observed.

## Risk
- Runtime risk is low: this is CI tooling and documentation only.
- The new CI check is intentionally bounded: it does not introduce new percentage floors and only fails when review evidence is missing from coverage.xml.
- Revert-safe as a single workflow/tooling slice.