### PR TITLE
feat(frontdoor): cut sessions.js over to SessionStore factory + ship ioredis (Phase 3.B)

### DIFF
--- a/docs/governance/PRODUCTION_HARDENING_GAP_2026-05-13.md
+++ b/docs/governance/PRODUCTION_HARDENING_GAP_2026-05-13.md
@@ -109,24 +109,20 @@ Still net-new (follow-up commits / PRs on this track):
 
 ### 5.3 Phase 3 - external sessions
 
-**Updated 2026-05-13: Phase 3.A has landed.**
+**Updated 2026-05-13: Phase 3.A and Phase 3.B have landed.**
 
 Already done:
 
-- `SessionStore` contract + factory + `SqliteSessionStore` + `RedisSessionStore` skeleton (Phase 3.A, this PR). Lives under `web/secure-landing/lib/session-store/` with one module per concern: `contract.js` (JSDoc-typed wire shape), `sqlite-store.js` (refactor of the pre-Phase-3 SQLite logic — schema and statements byte-identical), `redis-store.js` (ioredis-backed implementation; the `ioredis` import is lazy so sqlite-only deployments don't pay for it), and `index.js` (factory keyed off `TP_FRONTDOOR_SESSION_STORE=sqlite|redis`, default `sqlite`). New env vars: `TP_FRONTDOOR_SESSION_STORE`, `TP_FRONTDOOR_REDIS_URL`, `TP_FRONTDOOR_REDIS_KEY_PREFIX` (default `tp:frontdoor:`).
-- `evaluateSessionScaling()` gate flip (Phase 3.A, this PR). Accepts `sessionStoreBackend` and returns `ok: true` for `multi_instance` / `ephemeral_runtime` modes when `sessionStoreBackend === "redis"`, while keeping the `single_instance` + SQLite default green. Invalid mode declarations still fail closed; unknown backend values (e.g. typo'd `memcached`) fall back to SQLite gate semantics so a misconfigured store can never silently unlock the gate. Verified by 9 cases in `tests/session-scaling.test.mjs` + 7 cases in the new `tests/session-store.test.mjs`.
+- `SessionStore` contract + factory + `SqliteSessionStore` + `RedisSessionStore` (Phase 3.A). Lives under `web/secure-landing/lib/session-store/` with one module per concern: `contract.js` (JSDoc-typed wire shape), `sqlite-store.js` (refactor of the pre-Phase-3 SQLite logic — schema and statements byte-identical), `redis-store.js` (ioredis-backed implementation), and `index.js` (factory keyed off `TP_FRONTDOOR_SESSION_STORE=sqlite|redis`, default `sqlite`). Env vars: `TP_FRONTDOOR_SESSION_STORE`, `TP_FRONTDOOR_REDIS_URL`, `TP_FRONTDOOR_REDIS_KEY_PREFIX` (default `tp:frontdoor:`).
+- `evaluateSessionScaling()` gate flip (Phase 3.A). Accepts `sessionStoreBackend` and returns `ok: true` for `multi_instance` / `ephemeral_runtime` modes when `sessionStoreBackend === "redis"`, while keeping the `single_instance` + SQLite default green. Invalid mode declarations still fail closed; unknown backend values fall back to SQLite gate semantics so a misconfigured store can never silently unlock the gate.
+- `sessions.js` cut-over (Phase 3.B, this PR). The frontdoor's session helpers now delegate to `getSessionStore()` rather than touching `better-sqlite3` directly. Persistence-touching helpers (`createAnonymousSession`, `getSessionById`, `getSessionFromRequest`, `rotateAuthenticatedSession`, `destroySession`, `isLoginThrottled`, `recordLoginAttempt`, `revokeSessionOnAccessFailure`) became async; pure-cookie / CSRF helpers (`setSessionCookie`, `clearSessionCookie`, `validateCsrfToken`, `getRemoteAddress`) stay sync since they never touched the store. Every Next.js route handler that imports the helpers (`app/login`, `app/logout`, `app/portal`, `app/portal/bootstrap`, `app/v1/[...path]`) was updated to `await`. The audit-event payloads and the SQLite schema / SQL surface are byte-identical to the pre-Phase-3 implementation — the only observable change is the new backend selection and the async signatures.
+- `ioredis` runtime dep (Phase 3.B, this PR). `web/secure-landing/package.json` pins `ioredis: ^5.7.0` (lock resolves to 5.10.1) and `npm run build` succeeds with the dep present. The `redis-store.js` module's lazy `await import("ioredis")` pattern is unchanged — production multi-instance deployments set the env vars and the runtime activates the Redis path automatically.
+- Test coverage. 250 frontdoor cases pass via `npm test`, including the 11 `tests/session-store.test.mjs` cases (SqliteSessionStore round-trip + RedisSessionStore login-throttle path through an injected fake client) and the 9 `tests/session-scaling.test.mjs` cases (gate semantics for sqlite + redis + invalid modes + unknown backends). The 13-case `tests/auth-flow.test.mjs` integration test exercises the async surface of `createAnonymousSession` / `rotateAuthenticatedSession` / `recordLoginAttempt` / `isLoginThrottled` end-to-end against the SQLite store. The 132-case `tests/routes.test.mjs` HTTP integration suite covers every async-bound route handler in the new shape.
 
-Still net-new (follow-up commits / PRs on this track):
+Still net-new (follow-up tracks):
 
-- `sessions.js` cut-over (Phase 3.B). The frontdoor's session helpers (`createAnonymousSession`, `getSessionFromRequest`, `rotateAuthenticatedSession`, `destroySession`, `validateCsrfToken`, `isLoginThrottled`, `recordLoginAttempt`) still use `better-sqlite3` directly. Switching them to consume `getSessionStore()` is async-shaped (Redis is async in Node) and ripples through every Next.js route handler that calls them, so it is intentionally deferred to a follow-up PR. The Phase 3.A factory + contract make the cut-over a mechanical rewire rather than a parallel implementation.
-- `ioredis` runtime dependency. The `RedisSessionStore` module imports it lazily so sqlite deployments don't need it on disk, but the production multi-instance lane will need a checked-in `package.json` dependency + a wheel-style smoke that builds the Next.js app with the redis branch active. Phase 3.B will land that.
-
-Pre-Phase-3 baseline (now resolved by Phase 3.A scaffolding):
-
-- ~~No `SessionStore` interface, no Redis client in `web/secure-landing/`.~~ Resolved by the new `lib/session-store/` module.
-- ~~Env var `TP_FRONTDOOR_SESSION_STORE` is unrecognized.~~ Now read by `lib/config.js` and surfaced through `evaluateSessionScaling`.
-- ~~The readiness gate already exists; it just needs to be unblocked when Redis is configured.~~ Done in `lib/session-scaling.js`.
-- `better-sqlite3` is still the active backend for the running session helpers; cross-instance sharing waits on Phase 3.B.
+- Operator runbook for the multi-instance Redis deployment (env vars, Cloudflare Workers preview pin, session-replay smoke against the redis branch). Tracked under Phase 5 pilot deployment rather than Phase 3.
+- `RedisSessionStore.persistSession` and `touchSession` set TTL on every write; a follow-up could swap this for `EXPIRE` after a `WATCH`/`MULTI` round-trip to make the absolute timeout strictly monotonic under tab-noise. Not required for the paid-pilot blast radius; logged here as a known follow-up.
 
 ### 5.4 Phase 4 - artifact lifecycle
 

--- a/web/secure-landing/app/login/route.js
+++ b/web/secure-landing/app/login/route.js
@@ -281,7 +281,7 @@ function redirectToLogin(request, errorCode, session, returnTo = "") {
 
 export async function GET(request) {
   const requestedReturnTo = validatePortalReturnTo(request.nextUrl.searchParams.get("returnTo"));
-  const currentSession = getSessionFromRequest(request, { touch: false });
+  const currentSession = await getSessionFromRequest(request, { touch: false });
   let session = currentSession;
   if (currentSession?.authenticated) {
     const authState = await resolveAuthenticatedAccessSession(request, { touch: false });
@@ -291,14 +291,14 @@ export async function GET(request) {
       );
     }
     if (authState.revokeSession) {
-      revokeSessionOnAccessFailure(currentSession, authState.errorCode);
+      await revokeSessionOnAccessFailure(currentSession, authState.errorCode);
       session = null;
     }
   }
 
   // Mint an anonymous session before credentials are posted so the hidden CSRF
   // token on the login form is bound to a server-side session from the start.
-  session = session || createAnonymousSession();
+  session = session || (await createAnonymousSession());
   const accessContext = await resolveAccessContext(request);
   const rumTraceparent = resolveRequestTraceparent(request);
   const rumEnabled = isFrontdoorRumTelemetryEnabled({ traceparent: rumTraceparent });
@@ -353,9 +353,9 @@ export async function POST(request) {
 
   emitLoginRum(LOGIN_RUM_EVENT_TYPES.ATTEMPT);
 
-  let session = getSessionFromRequest(request, { touch: false });
+  let session = await getSessionFromRequest(request, { touch: false });
   if (!session) {
-    session = createAnonymousSession();
+    session = await createAnonymousSession();
   }
 
   if (!validateOriginAndReferrer(request)) {
@@ -406,7 +406,7 @@ export async function POST(request) {
   const remoteAddr = getRemoteAddress(request);
   const throttleKey = `${accessContext.accessEmail || "local"}:${username.toLowerCase()}:${remoteAddr}`;
 
-  if (isLoginThrottled(throttleKey)) {
+  if (await isLoginThrottled(throttleKey)) {
     audit("login_throttle", {
       username: username.toLowerCase(),
       accessEmail: accessContext.accessEmail,
@@ -422,7 +422,7 @@ export async function POST(request) {
     accessEmail: accessContext.accessEmail,
     allowAccessBypass: accessContext.bypass
   });
-  recordLoginAttempt({
+  await recordLoginAttempt({
     throttleKey,
     success: Boolean(user),
     remoteAddr
@@ -439,9 +439,9 @@ export async function POST(request) {
     return redirectToLogin(request, "invalid", session, requestedReturnTo);
   }
 
-  const authenticatedSession = rotateAuthenticatedSession(session, user);
+  const authenticatedSession = await rotateAuthenticatedSession(session, user);
   if (session?.id) {
-    destroySession(session.id, "rotation_cleanup");
+    await destroySession(session.id, "rotation_cleanup");
   }
 
   audit("login_success", {

--- a/web/secure-landing/app/logout/route.js
+++ b/web/secure-landing/app/logout/route.js
@@ -43,7 +43,7 @@ export async function POST(request) {
 
   emitLogoutRum(LOGOUT_RUM_EVENT_TYPES.ATTEMPT);
 
-  const session = getSessionFromRequest(request, { touch: false });
+  const session = await getSessionFromRequest(request, { touch: false });
   if (!validateOriginAndReferrer(request)) {
     audit("csrf_failure", { path: "/logout" });
     emitLogoutRum(LOGOUT_RUM_EVENT_TYPES.FAILURE, LOGOUT_RUM_FAILURE_CODES.CSRF);
@@ -62,7 +62,7 @@ export async function POST(request) {
   }
 
   if (session?.id) {
-    destroySession(session.id, "logout");
+    await destroySession(session.id, "logout");
   }
 
   emitLogoutRum(LOGOUT_RUM_EVENT_TYPES.SUCCESS);

--- a/web/secure-landing/app/portal/bootstrap/route.js
+++ b/web/secure-landing/app/portal/bootstrap/route.js
@@ -88,7 +88,7 @@ export async function GET(request) {
       extra: traceId ? { traceId } : {}
     });
     if (authState.revokeSession) {
-      revokeSessionOnAccessFailure(authState.session, authState.errorCode);
+      await revokeSessionOnAccessFailure(authState.session, authState.errorCode);
     }
 
     const response = withTraceparent(applySecurityHeaders(

--- a/web/secure-landing/app/portal/route.js
+++ b/web/secure-landing/app/portal/route.js
@@ -158,7 +158,7 @@ export async function GET(request) {
     }
 
     if (authState.revokeSession) {
-      revokeSessionOnAccessFailure(authState.session, authState.errorCode);
+      await revokeSessionOnAccessFailure(authState.session, authState.errorCode);
     }
 
     const response = applySecurityHeaders(NextResponse.redirect(loginUrl, 302));

--- a/web/secure-landing/app/v1/[...path]/route.js
+++ b/web/secure-landing/app/v1/[...path]/route.js
@@ -160,7 +160,7 @@ async function handleProxy(request, { params }) {
   if (!authState.ok) {
     const reason = classifyManagedAccessFailure(authState.errorCode);
     if (authState.revokeSession) {
-      revokeSessionOnAccessFailure(authState.session, authState.errorCode);
+      await revokeSessionOnAccessFailure(authState.session, authState.errorCode);
     }
     auditManagedSurfaceFailure("v1_proxy", {
       actor: authState.session,

--- a/web/secure-landing/lib/access.js
+++ b/web/secure-landing/lib/access.js
@@ -86,7 +86,7 @@ function classifyAuthenticatedAccessFailure(errorCode) {
 }
 
 export async function resolveAuthenticatedAccessSession(request, { touch = false } = {}) {
-  const session = getSessionFromRequest(request, { touch });
+  const session = await getSessionFromRequest(request, { touch });
   if (!session?.authenticated) {
     return {
       ok: false,
@@ -143,7 +143,7 @@ export async function resolveAuthenticatedAccessSession(request, { touch = false
   };
 }
 
-export function revokeSessionOnAccessFailure(session, errorCode) {
+export async function revokeSessionOnAccessFailure(session, errorCode) {
   if (!session?.id) return;
-  destroySession(session.id, errorCode || "access_validation_failure");
+  await destroySession(session.id, errorCode || "access_validation_failure");
 }

--- a/web/secure-landing/lib/session-store/index.js
+++ b/web/secure-landing/lib/session-store/index.js
@@ -58,6 +58,18 @@ export function resetSessionStoreSingleton() {
   _cachedBackend = null;
 }
 
+/**
+ * Test-only: inject a pre-built store into the factory singleton so
+ * ``sessions.js`` (which calls ``getSessionStore()`` on every request)
+ * resolves against the fake. Use ``resetSessionStoreSingleton()`` to drop
+ * the override between cases. Not exported via ``index.js`` consumers in
+ * production — production code only ever calls ``getSessionStore()``.
+ */
+export function __setSessionStoreForTesting(store, backend = null) {
+  _cachedStore = store;
+  _cachedBackend = backend || store?.backend || null;
+}
+
 // Re-export the canonical backend list so callers can compare against
 // stable string constants instead of magic strings.
 export { SESSION_STORE_BACKEND } from "../session-scaling.js";

--- a/web/secure-landing/lib/sessions.js
+++ b/web/secure-landing/lib/sessions.js
@@ -207,8 +207,24 @@ export function validateCsrfToken(session, token) {
 }
 
 async function pruneLoginAttempts(currentTime) {
+  const store = getSessionStore();
+  // Phase 3.B perf note: the Redis backend sets a per-bucket TTL inside
+  // ``recordLoginAttempt`` (PEXPIRE = absoluteTimeoutMs), so old failure
+  // buckets auto-expire without an inline sweep. The pre-Phase-3 helper
+  // delegated unconditionally and the Redis implementation backs that with
+  // a ``SCAN ${prefix}login:*`` of every bucket — twice per login attempt
+  // (once from ``isLoginThrottled``, once from ``recordLoginAttempt``).
+  // That's O(N-throttle-keys) on every credential POST in a multi-host
+  // fleet. Short-circuit here so the Redis path relies on TTL +
+  // ``ZCOUNT(sinceMs, +inf)``'s built-in window filter (already used by
+  // ``countLoginFailures``) and never pays the global scan. SQLite keeps
+  // the inline prune because its ``login_attempts`` table has no TTL and
+  // would otherwise accumulate forever.
+  if (store.backend === "redis") {
+    return;
+  }
   const cutoff = currentTime - getConfig().loginWindowMs;
-  await getSessionStore().pruneLoginAttempts(cutoff);
+  await store.pruneLoginAttempts(cutoff);
 }
 
 export async function isLoginThrottled(throttleKey) {

--- a/web/secure-landing/lib/sessions.js
+++ b/web/secure-landing/lib/sessions.js
@@ -1,15 +1,36 @@
 import { randomBytes, timingSafeEqual } from "node:crypto";
 
 import { getConfig } from "./config.js";
-import { getDb } from "./db.js";
+import { getSessionStore } from "./session-store/index.js";
 import { audit } from "./audit.js";
+
+/**
+ * @fileoverview Frontdoor session helpers (Phase 3.B cut-over).
+ *
+ * Before Phase 3.B these functions called ``better-sqlite3`` directly through
+ * ``./db.js``. Phase 3.B delegates every persistence-touching helper to the
+ * factory-returned ``SessionStore`` (``./session-store/index.js``) so the
+ * ``sqlite`` and ``redis`` backends become interchangeable at deploy time.
+ *
+ * Sync vs async surface:
+ *
+ *   - Sync (no I/O): ``getRemoteAddress``, ``setSessionCookie``,
+ *     ``clearSessionCookie``, ``validateCsrfToken``. These never touched the
+ *     store and keep their pre-Phase-3 signatures.
+ *   - Async (delegates to the store): ``createAnonymousSession``,
+ *     ``getSessionById``, ``getSessionFromRequest``, ``rotateAuthenticatedSession``,
+ *     ``destroySession``, ``isLoginThrottled``, ``recordLoginAttempt``.
+ *     Callers must ``await`` these — Phase 3.B updated every call site
+ *     under ``app/`` and ``lib/access.js`` to match.
+ *
+ * The audit-event payloads, CSRF-token shape, and cookie semantics are
+ * intentionally byte-identical to the pre-Phase-3 implementation so the
+ * cut-over is observable only via the new backend selection and the new
+ * async signatures.
+ */
 
 function nowMs() {
   return Date.now();
-}
-
-function getSessionDb() {
-  return getDb(getConfig().sessionDbPath);
 }
 
 function generateId() {
@@ -36,47 +57,8 @@ function rowToSession(row) {
   };
 }
 
-function persistSession(record) {
-  const db = getSessionDb();
-  db.prepare(
-    `
-      INSERT INTO sessions (
-        id,
-        created_at,
-        last_seen_at,
-        idle_expires_at,
-        absolute_expires_at,
-        csrf_token,
-        authenticated,
-        username,
-        access_email,
-        role,
-        rotated_from
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `
-  ).run(
-    record.id,
-    record.createdAt,
-    record.lastSeenAt,
-    record.idleExpiresAt,
-    record.absoluteExpiresAt,
-    record.csrfToken,
-    record.authenticated ? 1 : 0,
-    record.username,
-    record.accessEmail,
-    record.role,
-    record.rotatedFrom || null
-  );
-  return record;
-}
-
 function isExpired(row, currentTime) {
   return row.idle_expires_at <= currentTime || row.absolute_expires_at <= currentTime;
-}
-
-function deleteSessionRecord(sessionId) {
-  if (!sessionId) return;
-  getSessionDb().prepare("DELETE FROM sessions WHERE id = ?").run(sessionId);
 }
 
 export function getRemoteAddress(request) {
@@ -88,34 +70,37 @@ export function getRemoteAddress(request) {
   return forwardedFor.split(",")[0].trim() || "unknown";
 }
 
-export function createAnonymousSession() {
+export async function createAnonymousSession() {
   const config = getConfig();
+  const store = getSessionStore();
   const currentTime = nowMs();
-  const record = persistSession({
+  const record = {
     id: generateId(),
-    createdAt: currentTime,
-    lastSeenAt: currentTime,
-    idleExpiresAt: currentTime + config.sessionIdleTimeoutMs,
-    absoluteExpiresAt: currentTime + config.sessionAbsoluteTimeoutMs,
-    csrfToken: generateCsrfToken(),
+    created_at: currentTime,
+    last_seen_at: currentTime,
+    idle_expires_at: currentTime + config.sessionIdleTimeoutMs,
+    absolute_expires_at: currentTime + config.sessionAbsoluteTimeoutMs,
+    csrf_token: generateCsrfToken(),
     authenticated: false,
     username: null,
-    accessEmail: null,
-    role: null
-  });
+    access_email: null,
+    role: null,
+    rotated_from: null
+  };
+  await store.persistSession(record);
   audit("session_created", { authenticated: false });
-  return record;
+  return rowToSession(record);
 }
 
-export function getSessionById(sessionId, { touch = false } = {}) {
+export async function getSessionById(sessionId, { touch = false } = {}) {
   if (!sessionId) return null;
-  const db = getSessionDb();
-  const row = db.prepare("SELECT * FROM sessions WHERE id = ?").get(sessionId);
+  const store = getSessionStore();
+  const row = await store.getRawSessionRow(sessionId);
   if (!row) return null;
 
   const currentTime = nowMs();
   if (isExpired(row, currentTime)) {
-    deleteSessionRecord(sessionId);
+    await store.deleteSession(sessionId);
     audit("session_expired", {
       authenticated: Boolean(row.authenticated),
       username: row.username || null,
@@ -125,45 +110,42 @@ export function getSessionById(sessionId, { touch = false } = {}) {
   }
 
   if (touch) {
-    db.prepare(
-      `
-        UPDATE sessions
-        SET last_seen_at = ?, idle_expires_at = ?
-        WHERE id = ?
-      `
-    ).run(currentTime, currentTime + getConfig().sessionIdleTimeoutMs, sessionId);
+    const newIdle = currentTime + getConfig().sessionIdleTimeoutMs;
+    await store.touchSession(sessionId, currentTime, newIdle);
     row.last_seen_at = currentTime;
-    row.idle_expires_at = currentTime + getConfig().sessionIdleTimeoutMs;
+    row.idle_expires_at = newIdle;
   }
 
   return rowToSession(row);
 }
 
-export function getSessionFromRequest(request, { touch = false } = {}) {
+export async function getSessionFromRequest(request, { touch = false } = {}) {
   const sessionId = request.cookies.get(getConfig().sessionCookieName)?.value || "";
   return getSessionById(sessionId, { touch });
 }
 
-export function rotateAuthenticatedSession(existingSession, user) {
+export async function rotateAuthenticatedSession(existingSession, user) {
+  const store = getSessionStore();
   if (existingSession?.id) {
-    deleteSessionRecord(existingSession.id);
+    await store.deleteSession(existingSession.id);
   }
 
   const config = getConfig();
   const currentTime = nowMs();
-  const record = persistSession({
+  const record = {
     id: generateId(),
-    createdAt: currentTime,
-    lastSeenAt: currentTime,
-    idleExpiresAt: currentTime + config.sessionIdleTimeoutMs,
-    absoluteExpiresAt: currentTime + config.sessionAbsoluteTimeoutMs,
-    csrfToken: generateCsrfToken(),
+    created_at: currentTime,
+    last_seen_at: currentTime,
+    idle_expires_at: currentTime + config.sessionIdleTimeoutMs,
+    absolute_expires_at: currentTime + config.sessionAbsoluteTimeoutMs,
+    csrf_token: generateCsrfToken(),
     authenticated: true,
     username: user.username,
-    accessEmail: user.accessEmail,
+    access_email: user.accessEmail,
     role: user.role,
-    rotatedFrom: existingSession?.id || null
-  });
+    rotated_from: existingSession?.id || null
+  };
+  await store.persistSession(record);
 
   audit("session_rotated", {
     username: user.username,
@@ -176,13 +158,14 @@ export function rotateAuthenticatedSession(existingSession, user) {
     accessEmail: user.accessEmail,
     role: user.role
   });
-  return record;
+  return rowToSession(record);
 }
 
-export function destroySession(sessionId, reason = "logout") {
+export async function destroySession(sessionId, reason = "logout") {
   if (!sessionId) return;
-  const existing = getSessionById(sessionId, { touch: false });
-  deleteSessionRecord(sessionId);
+  const store = getSessionStore();
+  const existing = await getSessionById(sessionId, { touch: false });
+  await store.deleteSession(sessionId);
   audit("session_destroyed", {
     reason,
     authenticated: Boolean(existing?.authenticated),
@@ -223,41 +206,33 @@ export function validateCsrfToken(session, token) {
   return timingSafeEqual(Buffer.from(sessionToken), Buffer.from(candidate));
 }
 
-function pruneLoginAttempts(currentTime) {
+async function pruneLoginAttempts(currentTime) {
   const cutoff = currentTime - getConfig().loginWindowMs;
-  getSessionDb().prepare("DELETE FROM login_attempts WHERE attempted_at < ?").run(cutoff);
+  await getSessionStore().pruneLoginAttempts(cutoff);
 }
 
-export function isLoginThrottled(throttleKey) {
+export async function isLoginThrottled(throttleKey) {
   const currentTime = nowMs();
-  pruneLoginAttempts(currentTime);
-  const row = getSessionDb()
-    .prepare(
-      `
-        SELECT COUNT(*) AS failures
-        FROM login_attempts
-        WHERE throttle_key = ?
-          AND success = 0
-          AND attempted_at >= ?
-      `
-    )
-    .get(throttleKey, currentTime - getConfig().loginWindowMs);
-  return Number(row?.failures || 0) >= getConfig().loginAttemptLimit;
+  await pruneLoginAttempts(currentTime);
+  const failures = await getSessionStore().countLoginFailures(
+    throttleKey,
+    currentTime - getConfig().loginWindowMs
+  );
+  return failures >= getConfig().loginAttemptLimit;
 }
 
-export function recordLoginAttempt({ throttleKey, success, remoteAddr }) {
+export async function recordLoginAttempt({ throttleKey, success, remoteAddr }) {
   const currentTime = nowMs();
-  pruneLoginAttempts(currentTime);
-  getSessionDb()
-    .prepare(
-      `
-        INSERT INTO login_attempts (throttle_key, attempted_at, success, remote_addr)
-        VALUES (?, ?, ?, ?)
-      `
-    )
-    .run(throttleKey, currentTime, success ? 1 : 0, remoteAddr || null);
+  await pruneLoginAttempts(currentTime);
+  const store = getSessionStore();
+  await store.recordLoginAttempt({
+    throttle_key: throttleKey,
+    attempted_at: currentTime,
+    success: success ? 1 : 0,
+    remote_addr: remoteAddr || null
+  });
 
   if (success) {
-    getSessionDb().prepare("DELETE FROM login_attempts WHERE throttle_key = ?").run(throttleKey);
+    await store.resetLoginAttempts(throttleKey);
   }
 }

--- a/web/secure-landing/package-lock.json
+++ b/web/secure-landing/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "argon2": "^0.44.0",
         "better-sqlite3": "^12.10.0",
+        "ioredis": "^5.7.0",
         "next": "16.2.6",
         "react": "^19.2.6",
         "react-dom": "^19.2.6"
@@ -1160,6 +1161,12 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@ioredis/commands": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.1.tgz",
+      "integrity": "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==",
+      "license": "MIT"
+    },
     "node_modules/@keyv/bigmap": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz",
@@ -1229,9 +1236,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1247,9 +1251,6 @@
       "integrity": "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1267,9 +1268,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1285,9 +1283,6 @@
       "integrity": "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1653,6 +1648,15 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1779,7 +1783,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1815,6 +1818,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=4.0.0"
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/detect-libc": {
@@ -2032,6 +2044,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -2259,6 +2272,30 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
+    "node_modules/ioredis": {
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.10.1.tgz",
+      "integrity": "sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "1.5.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -2399,6 +2436,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+      "license": "MIT"
+    },
     "node_modules/lodash.truncate": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
@@ -2492,7 +2541,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -2919,6 +2967,27 @@
         "node": ">= 6"
       }
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -3175,6 +3244,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",

--- a/web/secure-landing/package.json
+++ b/web/secure-landing/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "argon2": "^0.44.0",
     "better-sqlite3": "^12.10.0",
+    "ioredis": "^5.7.0",
     "next": "16.2.6",
     "react": "^19.2.6",
     "react-dom": "^19.2.6"

--- a/web/secure-landing/tests/auth-flow.test.mjs
+++ b/web/secure-landing/tests/auth-flow.test.mjs
@@ -181,8 +181,8 @@ test("session rotation creates a new authenticated session id", async () => {
   const temp = withTempDb();
   try {
     const sessions = await import(`../lib/sessions.js?case=${Date.now()}`);
-    const anon = sessions.createAnonymousSession();
-    const rotated = sessions.rotateAuthenticatedSession(anon, {
+    const anon = await sessions.createAnonymousSession();
+    const rotated = await sessions.rotateAuthenticatedSession(anon, {
       username: "admin",
       accessEmail: "admin@example.com",
       role: "admin"
@@ -190,7 +190,7 @@ test("session rotation creates a new authenticated session id", async () => {
 
     assert.notEqual(rotated.id, anon.id);
     assert.equal(rotated.authenticated, true);
-    assert.equal(sessions.getSessionById(rotated.id, { touch: false })?.username, "admin");
+    assert.equal((await sessions.getSessionById(rotated.id, { touch: false }))?.username, "admin");
   } finally {
     temp.cleanup();
   }
@@ -203,14 +203,14 @@ test("login throttling trips after repeated failures in the same window", async 
     const key = "admin@example.com:admin:127.0.0.1";
 
     for (let index = 0; index < 5; index += 1) {
-      sessions.recordLoginAttempt({
+      await sessions.recordLoginAttempt({
         throttleKey: key,
         success: false,
         remoteAddr: "127.0.0.1"
       });
     }
 
-    assert.equal(sessions.isLoginThrottled(key), true);
+    assert.equal(await sessions.isLoginThrottled(key), true);
   } finally {
     temp.cleanup();
   }

--- a/web/secure-landing/tests/login-rum.test.mjs
+++ b/web/secure-landing/tests/login-rum.test.mjs
@@ -272,7 +272,7 @@ test("login POST emits no RUM events when the shared RUM master flag is disabled
   try {
     const sessions = await importFresh("../lib/sessions.js");
     const { POST } = await importFresh("../app/login/route.js");
-    const session = sessions.createAnonymousSession();
+    const session = await sessions.createAnonymousSession();
     const request = buildPostRequest({ session, csrfToken: session.csrfToken });
 
     const response = await POST(request);
@@ -298,7 +298,7 @@ test("login POST emits no RUM events when the front-door RUM flag is disabled", 
   try {
     const sessions = await importFresh("../lib/sessions.js");
     const { POST } = await importFresh("../app/login/route.js");
-    const session = sessions.createAnonymousSession();
+    const session = await sessions.createAnonymousSession();
     const request = buildPostRequest({ session, csrfToken: session.csrfToken });
 
     const response = await POST(request);
@@ -325,7 +325,7 @@ test("login POST emits no RUM events when front-door rollout percent samples out
   try {
     const sessions = await importFresh("../lib/sessions.js");
     const { POST } = await importFresh("../app/login/route.js");
-    const session = sessions.createAnonymousSession();
+    const session = await sessions.createAnonymousSession();
     const request = buildPostRequest({ session, csrfToken: session.csrfToken });
 
     const response = await POST(request);
@@ -347,7 +347,7 @@ test("login POST emits attempt + success events on successful credential rotatio
   try {
     const sessions = await importFresh("../lib/sessions.js");
     const { POST } = await importFresh("../app/login/route.js");
-    const session = sessions.createAnonymousSession();
+    const session = await sessions.createAnonymousSession();
     const request = buildPostRequest({ session, csrfToken: session.csrfToken });
 
     const response = await POST(request);
@@ -394,7 +394,7 @@ test("login POST emits attempt + failure(csrf) when the CSRF token mismatches", 
   try {
     const sessions = await importFresh("../lib/sessions.js");
     const { POST } = await importFresh("../app/login/route.js");
-    const session = sessions.createAnonymousSession();
+    const session = await sessions.createAnonymousSession();
     const request = buildPostRequest({ session, csrfToken: "wrong-token" });
 
     const response = await POST(request);
@@ -421,7 +421,7 @@ test("login POST emits attempt + failure(configuration) when no users are config
   try {
     const sessions = await importFresh("../lib/sessions.js");
     const { POST } = await importFresh("../app/login/route.js");
-    const session = sessions.createAnonymousSession();
+    const session = await sessions.createAnonymousSession();
     const request = buildPostRequest({ session, csrfToken: session.csrfToken });
 
     const response = await POST(request);
@@ -447,7 +447,7 @@ test("login POST emits attempt + failure(access) when CF Access verification fai
   try {
     const sessions = await importFresh("../lib/sessions.js");
     const { POST } = await importFresh("../app/login/route.js");
-    const session = sessions.createAnonymousSession();
+    const session = await sessions.createAnonymousSession();
     const form = new URLSearchParams({
       username: "admin",
       password: "correct horse battery staple",
@@ -487,7 +487,7 @@ test("login POST emits attempt + failure(invalid) when the password is wrong", a
   try {
     const sessions = await importFresh("../lib/sessions.js");
     const { POST } = await importFresh("../app/login/route.js");
-    const session = sessions.createAnonymousSession();
+    const session = await sessions.createAnonymousSession();
     const request = buildPostRequest({
       session,
       csrfToken: session.csrfToken,
@@ -524,10 +524,10 @@ test("login POST emits attempt + failure(throttled) when the throttle limit is r
     const remoteAddr = "unknown";
     const throttleKey = `admin@example.com:admin:${remoteAddr}`;
     for (let i = 0; i < 6; i += 1) {
-      sessions.recordLoginAttempt({ throttleKey, success: false, remoteAddr });
+      await sessions.recordLoginAttempt({ throttleKey, success: false, remoteAddr });
     }
 
-    const session = sessions.createAnonymousSession();
+    const session = await sessions.createAnonymousSession();
     const request = buildPostRequest({ session, csrfToken: session.csrfToken });
 
     const response = await POST(request);
@@ -553,7 +553,7 @@ test("login POST success clears a stale client failure marker without setting a 
   try {
     const sessions = await importFresh("../lib/sessions.js");
     const { POST } = await importFresh("../app/login/route.js");
-    const session = sessions.createAnonymousSession();
+    const session = await sessions.createAnonymousSession();
     const request = buildPostRequest({
       session,
       csrfToken: session.csrfToken,
@@ -589,7 +589,7 @@ test("login POST failure clears a stale client success marker without setting a 
   try {
     const sessions = await importFresh("../lib/sessions.js");
     const { POST } = await importFresh("../app/login/route.js");
-    const session = sessions.createAnonymousSession();
+    const session = await sessions.createAnonymousSession();
     const request = buildPostRequest({
       session,
       csrfToken: "wrong-token",
@@ -626,7 +626,7 @@ test("login POST still returns the normal redirect when the RUM emitter fetch re
   try {
     const sessions = await importFresh("../lib/sessions.js");
     const { POST } = await importFresh("../app/login/route.js");
-    const session = sessions.createAnonymousSession();
+    const session = await sessions.createAnonymousSession();
     const request = buildPostRequest({ session, csrfToken: session.csrfToken });
 
     const response = await POST(request);

--- a/web/secure-landing/tests/logout-rum.test.mjs
+++ b/web/secure-landing/tests/logout-rum.test.mjs
@@ -126,9 +126,9 @@ async function flushFireAndForget() {
   await new Promise((resolve) => setImmediate(resolve));
 }
 
-function buildAuthenticatedSession(sessions) {
-  return sessions.rotateAuthenticatedSession(
-    sessions.createAnonymousSession(),
+async function buildAuthenticatedSession(sessions) {
+  return await sessions.rotateAuthenticatedSession(
+    await sessions.createAnonymousSession(),
     {
       username: "admin",
       accessEmail: "admin@example.com",
@@ -201,7 +201,7 @@ test("logout POST emits no RUM events when the shared RUM master flag is disable
   try {
     const sessions = await importFresh("../lib/sessions.js");
     const { POST } = await importFresh("../app/logout/route.js");
-    const session = buildAuthenticatedSession(sessions);
+    const session = await buildAuthenticatedSession(sessions);
     const request = buildLogoutPostRequest({ session, csrfHeader: session.csrfToken });
 
     const response = await POST(request);
@@ -211,7 +211,7 @@ test("logout POST emits no RUM events when the shared RUM master flag is disable
     assert.equal(response.headers.get("location"), "https://portal.example.com/login");
     assert.equal(rumCalls.length, 0, `expected zero RUM calls when disabled, got ${rumCalls.length}`);
     // Session was destroyed even though RUM was off — RUM must never alter behavior.
-    assert.equal(sessions.getSessionById(session.id, { touch: false }), null);
+    assert.equal(await sessions.getSessionById(session.id, { touch: false }), null);
   } finally {
     restoreFetch();
     env.cleanup();
@@ -226,7 +226,7 @@ test("logout POST emits no RUM events when the front-door RUM flag is disabled",
   try {
     const sessions = await importFresh("../lib/sessions.js");
     const { POST } = await importFresh("../app/logout/route.js");
-    const session = buildAuthenticatedSession(sessions);
+    const session = await buildAuthenticatedSession(sessions);
     const request = buildLogoutPostRequest({ session, csrfHeader: session.csrfToken });
 
     const response = await POST(request);
@@ -235,7 +235,7 @@ test("logout POST emits no RUM events when the front-door RUM flag is disabled",
     assert.equal(response.status, 303);
     assert.equal(response.headers.get("location"), "https://portal.example.com/login");
     assert.equal(rumCalls.length, 0, `expected zero RUM calls when disabled, got ${rumCalls.length}`);
-    assert.equal(sessions.getSessionById(session.id, { touch: false }), null);
+    assert.equal(await sessions.getSessionById(session.id, { touch: false }), null);
   } finally {
     restoreFetch();
     env.cleanup();
@@ -254,7 +254,7 @@ test("logout POST emits no RUM events when front-door rollout percent samples ou
   try {
     const sessions = await importFresh("../lib/sessions.js");
     const { POST } = await importFresh("../app/logout/route.js");
-    const session = buildAuthenticatedSession(sessions);
+    const session = await buildAuthenticatedSession(sessions);
     const request = buildLogoutPostRequest({ session, csrfHeader: session.csrfToken });
 
     const response = await POST(request);
@@ -263,7 +263,7 @@ test("logout POST emits no RUM events when front-door rollout percent samples ou
     assert.equal(response.status, 303);
     assert.equal(response.headers.get("location"), "https://portal.example.com/login");
     assert.equal(rumCalls.length, 0, `expected sampled-out RUM calls, got ${rumCalls.length}`);
-    assert.equal(sessions.getSessionById(session.id, { touch: false }), null);
+    assert.equal(await sessions.getSessionById(session.id, { touch: false }), null);
   } finally {
     restoreFetch();
     env.cleanup();
@@ -278,7 +278,7 @@ test("logout POST emits attempt + success on the happy path with an authenticate
   try {
     const sessions = await importFresh("../lib/sessions.js");
     const { POST } = await importFresh("../app/logout/route.js");
-    const session = buildAuthenticatedSession(sessions);
+    const session = await buildAuthenticatedSession(sessions);
     const request = buildLogoutPostRequest({ session, csrfHeader: session.csrfToken });
 
     const response = await POST(request);
@@ -306,7 +306,7 @@ test("logout POST emits attempt + success on the happy path with an authenticate
     assert.deepEqual(success.body.metadata, {});
 
     // Session is destroyed on the success path.
-    assert.equal(sessions.getSessionById(session.id, { touch: false }), null);
+    assert.equal(await sessions.getSessionById(session.id, { touch: false }), null);
 
     // Backend auth + traceparent are forwarded.
     assert.equal(attempt.headers["authorization"], "Bearer backend-secret");
@@ -361,7 +361,7 @@ test("logout POST emits attempt + failure(csrf) when Origin/Referrer validation 
   try {
     const sessions = await importFresh("../lib/sessions.js");
     const { POST } = await importFresh("../app/logout/route.js");
-    const session = buildAuthenticatedSession(sessions);
+    const session = await buildAuthenticatedSession(sessions);
     // Cross-origin POST: the route's validateOriginAndReferrer rejects
     // this (Origin header doesn't match the URL's origin) before even
     // looking at x-csrf-token.
@@ -384,7 +384,7 @@ test("logout POST emits attempt + failure(csrf) when Origin/Referrer validation 
     // Existing route behavior: Origin/Referrer failure does NOT destroy the
     // session in storage, only clears the cookie. RUM emit must not change
     // that.
-    assert.notEqual(sessions.getSessionById(session.id, { touch: false }), null);
+    assert.notEqual(await sessions.getSessionById(session.id, { touch: false }), null);
 
     assertNoPiiInRumPosts(rumCalls);
   } finally {
@@ -401,7 +401,7 @@ test("logout POST emits attempt + failure(csrf) when the x-csrf-token header mis
   try {
     const sessions = await importFresh("../lib/sessions.js");
     const { POST } = await importFresh("../app/logout/route.js");
-    const session = buildAuthenticatedSession(sessions);
+    const session = await buildAuthenticatedSession(sessions);
     const request = buildLogoutPostRequest({ session, csrfHeader: "wrong-token" });
 
     const response = await POST(request);
@@ -415,7 +415,7 @@ test("logout POST emits attempt + failure(csrf) when the x-csrf-token header mis
     assert.deepEqual(rumCalls[1].body.metadata, { failure_code: "csrf" });
 
     // CSRF token failure does NOT destroy the session in storage either.
-    assert.notEqual(sessions.getSessionById(session.id, { touch: false }), null);
+    assert.notEqual(await sessions.getSessionById(session.id, { touch: false }), null);
 
     assertNoPiiInRumPosts(rumCalls);
   } finally {
@@ -441,7 +441,7 @@ test("logout POST still completes the redirect when the RUM emitter fetch reject
   try {
     const sessions = await importFresh("../lib/sessions.js");
     const { POST } = await importFresh("../app/logout/route.js");
-    const session = buildAuthenticatedSession(sessions);
+    const session = await buildAuthenticatedSession(sessions);
     const request = buildLogoutPostRequest({ session, csrfHeader: session.csrfToken });
 
     const response = await POST(request);
@@ -451,7 +451,7 @@ test("logout POST still completes the redirect when the RUM emitter fetch reject
     assert.equal(response.headers.get("location"), "https://portal.example.com/login");
     // Session is still destroyed even when RUM fetches reject — RUM is
     // strictly best-effort and cannot change the session-destruction path.
-    assert.equal(sessions.getSessionById(session.id, { touch: false }), null);
+    assert.equal(await sessions.getSessionById(session.id, { touch: false }), null);
     assert.equal(rumCalls.length, 2, "fetch was attempted for both events");
     assert.equal(unhandled.length, 0, "emitter must catch all rejections");
   } finally {
@@ -473,7 +473,7 @@ test("logout POST does not emit RUM events when no backend api key is configured
   try {
     const sessions = await importFresh("../lib/sessions.js");
     const { POST } = await importFresh("../app/logout/route.js");
-    const session = buildAuthenticatedSession(sessions);
+    const session = await buildAuthenticatedSession(sessions);
     const request = buildLogoutPostRequest({ session, csrfHeader: session.csrfToken });
 
     const response = await POST(request);

--- a/web/secure-landing/tests/routes.contract.gaps.test.mjs
+++ b/web/secure-landing/tests/routes.contract.gaps.test.mjs
@@ -111,7 +111,7 @@ test("production login POST ignores the local bypass flag unless development mod
     const sessions = await importFresh("../lib/sessions.js");
     const { POST } = await importFresh("../app/login/route.js");
 
-    const anonymousSession = sessions.createAnonymousSession();
+    const anonymousSession = await sessions.createAnonymousSession();
     const request = buildRequest("https://portal.example.com/login", {
       method: "POST",
       headers: new Headers({
@@ -130,7 +130,7 @@ test("production login POST ignores the local bypass flag unless development mod
 
     assert.equal(response.status, 303);
     assert.equal(response.headers.get("location"), "https://portal.example.com/login?error=access");
-    assert.equal(sessions.getSessionById(anonymousSession.id, { touch: false })?.authenticated, false);
+    assert.equal((await sessions.getSessionById(anonymousSession.id, { touch: false }))?.authenticated, false);
   } finally {
     env.cleanup();
   }

--- a/web/secure-landing/tests/routes.test.mjs
+++ b/web/secure-landing/tests/routes.test.mjs
@@ -568,7 +568,7 @@ test("login POST rotates the session and redirects authenticated users to /porta
     const restoreFetch = withMockedAccessCerts();
 
     try {
-      const anonymousSession = sessions.createAnonymousSession();
+      const anonymousSession = await sessions.createAnonymousSession();
       const form = new URLSearchParams({
         username: "admin",
         password: "correct horse battery staple",
@@ -594,9 +594,9 @@ test("login POST rotates the session and redirects authenticated users to /porta
       assert.equal(response.headers.get("location"), "https://portal.example.com/portal");
       assert.ok(rotatedCookie.value);
       assert.notEqual(rotatedCookie.value, anonymousSession.id);
-      assert.equal(sessions.getSessionById(anonymousSession.id, { touch: false }), null);
+      assert.equal(await sessions.getSessionById(anonymousSession.id, { touch: false }), null);
 
-      const authenticatedSession = sessions.getSessionById(rotatedCookie.value, { touch: false });
+      const authenticatedSession = await sessions.getSessionById(rotatedCookie.value, { touch: false });
       assert.equal(authenticatedSession?.authenticated, true);
       assert.equal(authenticatedSession?.username, "admin");
       assert.match(rotatedCookie.raw, /HttpOnly/);
@@ -629,7 +629,7 @@ test("login POST redirects authenticated users to a validated returnTo route", a
     const restoreFetch = withMockedAccessCerts();
 
     try {
-      const anonymousSession = sessions.createAnonymousSession();
+      const anonymousSession = await sessions.createAnonymousSession();
       const form = new URLSearchParams({
         username: "admin",
         password: "correct horse battery staple",
@@ -709,7 +709,7 @@ test("login GET serves a minimal branded sign-in shell and boots an anonymous se
     assert.doesNotMatch(html, /Local development bypass is enabled\./);
     assert.doesNotMatch(html, /TP_CF_ACCESS_TEAM_DOMAIN/);
     assert.ok(sessionCookie.value);
-    assert.equal(sessions.getSessionById(sessionCookie.value, { touch: false })?.authenticated, false);
+    assert.equal((await sessions.getSessionById(sessionCookie.value, { touch: false }))?.authenticated, false);
   } finally {
     env.cleanup();
   }
@@ -744,8 +744,8 @@ test("login GET redirects authenticated sessions to a validated returnTo route",
     const restoreFetch = withMockedAccessCerts();
 
     try {
-      const authenticatedSession = sessions.rotateAuthenticatedSession(
-        sessions.createAnonymousSession(),
+      const authenticatedSession = await sessions.rotateAuthenticatedSession(
+        await sessions.createAnonymousSession(),
         {
           username: "admin",
           accessEmail: "admin@example.com",
@@ -866,8 +866,8 @@ test("homepage GET is stateless and ignores authenticated session hints", async 
     const sessions = await importFresh("../lib/sessions.js");
     const db = getDb(env.dbPath);
     const { GET } = await importFresh("../app/route.js");
-    const authenticatedSession = sessions.rotateAuthenticatedSession(
-      sessions.createAnonymousSession(),
+    const authenticatedSession = await sessions.rotateAuthenticatedSession(
+      await sessions.createAnonymousSession(),
       {
         username: "admin",
         accessEmail: "admin@example.com",
@@ -931,7 +931,7 @@ test("homepage GET does not touch session state even when a stale cookie is pres
   try {
     const sessions = await importFresh("../lib/sessions.js");
     const { GET } = await importFresh("../app/route.js");
-    const expiredSession = sessions.createAnonymousSession();
+    const expiredSession = await sessions.createAnonymousSession();
     const db = getDb(env.dbPath);
     const now = Date.now();
     db.prepare("UPDATE sessions SET idle_expires_at = ?, absolute_expires_at = ? WHERE id = ?").run(
@@ -978,7 +978,7 @@ test("login POST keeps failures generic when Access email does not match the con
     const restoreFetch = withMockedAccessCerts();
 
     try {
-      const anonymousSession = sessions.createAnonymousSession();
+      const anonymousSession = await sessions.createAnonymousSession();
       const request = buildRequest("https://portal.example.com/login", {
         method: "POST",
         headers: new Headers({
@@ -999,7 +999,7 @@ test("login POST keeps failures generic when Access email does not match the con
 
       assert.equal(response.status, 303);
       assert.equal(response.headers.get("location"), "https://portal.example.com/login?error=invalid");
-      assert.equal(sessions.getSessionById(anonymousSession.id, { touch: false })?.authenticated, false);
+      assert.equal((await sessions.getSessionById(anonymousSession.id, { touch: false }))?.authenticated, false);
     } finally {
       restoreFetch();
     }
@@ -1027,7 +1027,7 @@ test("login POST preserves a validated returnTo when sign-in fails", async () =>
     const restoreFetch = withMockedAccessCerts();
 
     try {
-      const anonymousSession = sessions.createAnonymousSession();
+      const anonymousSession = await sessions.createAnonymousSession();
       const request = buildRequest("https://portal.example.com/login", {
         method: "POST",
         headers: new Headers({
@@ -1079,7 +1079,7 @@ test("login POST rejects invalid CSRF before credential verification", async () 
     const restoreFetch = withMockedAccessCerts();
 
     try {
-      const anonymousSession = sessions.createAnonymousSession();
+      const anonymousSession = await sessions.createAnonymousSession();
       const request = buildRequest("https://portal.example.com/login", {
         method: "POST",
         headers: new Headers({
@@ -1100,7 +1100,7 @@ test("login POST rejects invalid CSRF before credential verification", async () 
 
       assert.equal(response.status, 303);
       assert.equal(response.headers.get("location"), "https://portal.example.com/login?error=csrf");
-      assert.equal(sessions.getSessionById(anonymousSession.id, { touch: false })?.authenticated, false);
+      assert.equal((await sessions.getSessionById(anonymousSession.id, { touch: false }))?.authenticated, false);
     } finally {
       restoreFetch();
     }
@@ -1126,7 +1126,7 @@ test("login POST rejects convenience headers without a verified Access JWT in pr
     const sessions = await importFresh("../lib/sessions.js");
     const { POST } = await importFresh("../app/login/route.js");
 
-    const anonymousSession = sessions.createAnonymousSession();
+    const anonymousSession = await sessions.createAnonymousSession();
     const request = buildRequest("https://portal.example.com/login", {
       method: "POST",
       headers: new Headers({
@@ -1147,7 +1147,7 @@ test("login POST rejects convenience headers without a verified Access JWT in pr
 
     assert.equal(response.status, 303);
     assert.equal(response.headers.get("location"), "https://portal.example.com/login?error=access");
-    assert.equal(sessions.getSessionById(anonymousSession.id, { touch: false })?.authenticated, false);
+    assert.equal((await sessions.getSessionById(anonymousSession.id, { touch: false }))?.authenticated, false);
   } finally {
     env.cleanup();
   }
@@ -1172,7 +1172,7 @@ test("login POST rejects Access JWTs with the wrong audience", async () => {
     const restoreFetch = withMockedAccessCerts();
 
     try {
-      const anonymousSession = sessions.createAnonymousSession();
+      const anonymousSession = await sessions.createAnonymousSession();
       const request = buildRequest("https://portal.example.com/login", {
         method: "POST",
         headers: new Headers({
@@ -1219,7 +1219,7 @@ test("login POST rejects Access JWTs with the wrong issuer", async () => {
     const restoreFetch = withMockedAccessCerts();
 
     try {
-      const anonymousSession = sessions.createAnonymousSession();
+      const anonymousSession = await sessions.createAnonymousSession();
       const request = buildRequest("https://portal.example.com/login", {
         method: "POST",
         headers: new Headers({
@@ -1265,7 +1265,7 @@ test("production ignores the local bypass flag without a verified Access JWT", a
     const sessions = await importFresh("../lib/sessions.js");
     const { POST } = await importFresh("../app/login/route.js");
 
-    const anonymousSession = sessions.createAnonymousSession();
+    const anonymousSession = await sessions.createAnonymousSession();
     const request = buildRequest("https://portal.example.com/login", {
       method: "POST",
       headers: new Headers({
@@ -1308,7 +1308,7 @@ test("development local bypass still allows login without Cloudflare Access", as
     const sessions = await importFresh("../lib/sessions.js");
     const { POST } = await importFresh("../app/login/route.js");
 
-    const anonymousSession = sessions.createAnonymousSession();
+    const anonymousSession = await sessions.createAnonymousSession();
     const request = buildRequest("http://localhost:3000/login", {
       method: "POST",
       headers: new Headers({
@@ -1351,7 +1351,7 @@ test("development local bypass login still works when the browser omits origin a
     const sessions = await importFresh("../lib/sessions.js");
     const { POST } = await importFresh("../app/login/route.js");
 
-    const anonymousSession = sessions.createAnonymousSession();
+    const anonymousSession = await sessions.createAnonymousSession();
     const request = buildRequest("http://127.0.0.1:3000/login", {
       method: "POST",
       headers: new Headers({
@@ -1394,7 +1394,7 @@ test("login POST ignores untrusted host overrides when building redirect targets
     const sessions = await importFresh("../lib/sessions.js");
     const { POST } = await importFresh("../app/login/route.js");
 
-    const anonymousSession = sessions.createAnonymousSession();
+    const anonymousSession = await sessions.createAnonymousSession();
     const request = buildRequest("https://portal.example.com/login", {
       method: "POST",
       headers: new Headers({
@@ -1441,7 +1441,7 @@ test("login POST rejects invalid returnTo values and falls back to /portal", asy
     const sessions = await importFresh("../lib/sessions.js");
     const { POST } = await importFresh("../app/login/route.js");
 
-    const anonymousSession = sessions.createAnonymousSession();
+    const anonymousSession = await sessions.createAnonymousSession();
     const request = buildRequest("http://127.0.0.1:3000/login", {
       method: "POST",
       headers: new Headers({
@@ -1473,8 +1473,8 @@ test("logout POST invalidates the authenticated session and clears the cookie", 
     const sessions = await importFresh("../lib/sessions.js");
     const { POST } = await importFresh("../app/logout/route.js");
 
-    const authenticatedSession = sessions.rotateAuthenticatedSession(
-      sessions.createAnonymousSession(),
+    const authenticatedSession = await sessions.rotateAuthenticatedSession(
+      await sessions.createAnonymousSession(),
       {
         username: "admin",
         accessEmail: "admin@example.com",
@@ -1495,7 +1495,7 @@ test("logout POST invalidates the authenticated session and clears the cookie", 
 
     assert.equal(response.status, 303);
     assert.equal(response.headers.get("location"), "https://portal.example.com/login");
-    assert.equal(sessions.getSessionById(authenticatedSession.id, { touch: false }), null);
+    assert.equal(await sessions.getSessionById(authenticatedSession.id, { touch: false }), null);
     assert.match(response.headers.get("set-cookie") || "", /__Host-tp_session=/);
   } finally {
     env.cleanup();
@@ -1507,16 +1507,16 @@ test("expired sessions are removed for both idle and absolute timeout breaches",
 
   try {
     const sessions = await importFresh("../lib/sessions.js");
-    const idleExpired = sessions.createAnonymousSession();
-    const absoluteExpired = sessions.createAnonymousSession();
+    const idleExpired = await sessions.createAnonymousSession();
+    const absoluteExpired = await sessions.createAnonymousSession();
     const db = getDb(env.dbPath);
     const now = Date.now();
 
     db.prepare("UPDATE sessions SET idle_expires_at = ? WHERE id = ?").run(now - 1_000, idleExpired.id);
     db.prepare("UPDATE sessions SET absolute_expires_at = ? WHERE id = ?").run(now - 1_000, absoluteExpired.id);
 
-    assert.equal(sessions.getSessionById(idleExpired.id, { touch: false }), null);
-    assert.equal(sessions.getSessionById(absoluteExpired.id, { touch: false }), null);
+    assert.equal(await sessions.getSessionById(idleExpired.id, { touch: false }), null);
+    assert.equal(await sessions.getSessionById(absoluteExpired.id, { touch: false }), null);
   } finally {
     env.cleanup();
   }
@@ -1531,8 +1531,8 @@ test("managed bootstrap returns actor metadata and CSRF for authenticated sessio
     const restoreFetch = withMockedAccessCerts();
 
     try {
-      const authenticatedSession = sessions.rotateAuthenticatedSession(
-        sessions.createAnonymousSession(),
+      const authenticatedSession = await sessions.rotateAuthenticatedSession(
+        await sessions.createAnonymousSession(),
         {
           username: "admin",
           accessEmail: "admin@example.com",
@@ -1579,8 +1579,8 @@ test("managed bootstrap enables the artifact viewer modal for rollout cohorts", 
   try {
     const sessions = await importFresh("../lib/sessions.js");
     const { GET } = await importFresh("../app/portal/bootstrap/route.js");
-    const authenticatedSession = sessions.rotateAuthenticatedSession(
-      sessions.createAnonymousSession(),
+    const authenticatedSession = await sessions.rotateAuthenticatedSession(
+      await sessions.createAnonymousSession(),
       {
         username: "admin",
         accessEmail: "admin@example.com",
@@ -1614,8 +1614,8 @@ test("managed bootstrap enables review surface deferral for rollout cohorts", as
   try {
     const sessions = await importFresh("../lib/sessions.js");
     const { GET } = await importFresh("../app/portal/bootstrap/route.js");
-    const authenticatedSession = sessions.rotateAuthenticatedSession(
-      sessions.createAnonymousSession(),
+    const authenticatedSession = await sessions.rotateAuthenticatedSession(
+      await sessions.createAnonymousSession(),
       {
         username: "admin",
         accessEmail: "admin@example.com",
@@ -1650,8 +1650,8 @@ test("managed bootstrap enables staged uploads for rollout cohorts", async () =>
   try {
     const sessions = await importFresh("../lib/sessions.js");
     const { GET } = await importFresh("../app/portal/bootstrap/route.js");
-    const authenticatedSession = sessions.rotateAuthenticatedSession(
-      sessions.createAnonymousSession(),
+    const authenticatedSession = await sessions.rotateAuthenticatedSession(
+      await sessions.createAnonymousSession(),
       {
         username: "admin",
         accessEmail: "admin@example.com",
@@ -1686,8 +1686,8 @@ test("managed bootstrap enables rum telemetry for rollout cohorts", async () => 
   try {
     const sessions = await importFresh("../lib/sessions.js");
     const { GET } = await importFresh("../app/portal/bootstrap/route.js");
-    const authenticatedSession = sessions.rotateAuthenticatedSession(
-      sessions.createAnonymousSession(),
+    const authenticatedSession = await sessions.rotateAuthenticatedSession(
+      await sessions.createAnonymousSession(),
       {
         username: "admin",
         accessEmail: "admin@example.com",
@@ -1724,8 +1724,8 @@ test("managed bootstrap rum telemetry ignores front-door RUM rollout controls", 
   try {
     const sessions = await importFresh("../lib/sessions.js");
     const { GET } = await importFresh("../app/portal/bootstrap/route.js");
-    const authenticatedSession = sessions.rotateAuthenticatedSession(
-      sessions.createAnonymousSession(),
+    const authenticatedSession = await sessions.rotateAuthenticatedSession(
+      await sessions.createAnonymousSession(),
       {
         username: "admin",
         accessEmail: "admin@example.com",
@@ -1761,8 +1761,8 @@ test("managed bootstrap enables FastVLM captioning for enabled rollout cohorts",
   try {
     const sessions = await importFresh("../lib/sessions.js");
     const { GET } = await importFresh("../app/portal/bootstrap/route.js");
-    const authenticatedSession = sessions.rotateAuthenticatedSession(
-      sessions.createAnonymousSession(),
+    const authenticatedSession = await sessions.rotateAuthenticatedSession(
+      await sessions.createAnonymousSession(),
       {
         username: "admin",
         accessEmail: "admin@example.com",
@@ -1799,8 +1799,8 @@ test("managed bootstrap keeps FastVLM captioning disabled when the master switch
   try {
     const sessions = await importFresh("../lib/sessions.js");
     const { GET } = await importFresh("../app/portal/bootstrap/route.js");
-    const authenticatedSession = sessions.rotateAuthenticatedSession(
-      sessions.createAnonymousSession(),
+    const authenticatedSession = await sessions.rotateAuthenticatedSession(
+      await sessions.createAnonymousSession(),
       {
         username: "admin",
         accessEmail: "admin@example.com",
@@ -1837,8 +1837,8 @@ test("managed bootstrap keeps FastVLM captioning disabled when rollout is zero",
   try {
     const sessions = await importFresh("../lib/sessions.js");
     const { GET } = await importFresh("../app/portal/bootstrap/route.js");
-    const authenticatedSession = sessions.rotateAuthenticatedSession(
-      sessions.createAnonymousSession(),
+    const authenticatedSession = await sessions.rotateAuthenticatedSession(
+      await sessions.createAnonymousSession(),
       {
         username: "admin",
         accessEmail: "admin@example.com",
@@ -1875,8 +1875,8 @@ test("managed bootstrap echoes traceparent and includes trace id in audit payloa
     const restoreFetch = withMockedAccessCerts();
 
     try {
-      const authenticatedSession = sessions.rotateAuthenticatedSession(
-        sessions.createAnonymousSession(),
+      const authenticatedSession = await sessions.rotateAuthenticatedSession(
+        await sessions.createAnonymousSession(),
         {
           username: "admin",
           accessEmail: "admin@example.com",
@@ -1919,8 +1919,8 @@ test("managed bootstrap rejects authenticated sessions without a current Access 
     const sessions = await importFresh("../lib/sessions.js");
     const { GET } = await importFresh("../app/portal/bootstrap/route.js");
 
-    const authenticatedSession = sessions.rotateAuthenticatedSession(
-      sessions.createAnonymousSession(),
+    const authenticatedSession = await sessions.rotateAuthenticatedSession(
+      await sessions.createAnonymousSession(),
       {
         username: "admin",
         accessEmail: "admin@example.com",
@@ -1943,7 +1943,7 @@ test("managed bootstrap rejects authenticated sessions without a current Access 
     assert.equal(body.reason, "auth_failure");
     assert.equal(body.retryable, false);
     assert.match(response.headers.get("set-cookie") || "", /__Host-tp_session=/);
-    assert.equal(sessions.getSessionById(authenticatedSession.id, { touch: false }), null);
+    assert.equal(await sessions.getSessionById(authenticatedSession.id, { touch: false }), null);
   } finally {
     env.cleanup();
   }
@@ -1991,8 +1991,8 @@ test("managed bootstrap classifies Access verification outages as retryable acce
     const sessions = await importFresh("../lib/sessions.js");
     const { GET } = await importFresh("../app/portal/bootstrap/route.js");
 
-    const authenticatedSession = sessions.rotateAuthenticatedSession(
-      sessions.createAnonymousSession(),
+    const authenticatedSession = await sessions.rotateAuthenticatedSession(
+      await sessions.createAnonymousSession(),
       {
         username: "admin",
         accessEmail: "admin@example.com",
@@ -2046,8 +2046,8 @@ test("portal returns 503 with no-store when the FastAPI UI origin is unavailable
   try {
     const sessions = await importFresh("../lib/sessions.js");
     const { GET } = await importFresh("../app/portal/route.js");
-    const authenticatedSession = sessions.rotateAuthenticatedSession(
-      sessions.createAnonymousSession(),
+    const authenticatedSession = await sessions.rotateAuthenticatedSession(
+      await sessions.createAnonymousSession(),
       {
         username: "admin",
         accessEmail: "admin@example.com",
@@ -2104,8 +2104,8 @@ test("portal renders waiting recovery posture for Access outages", async () => {
     };
 
     try {
-      const authenticatedSession = sessions.rotateAuthenticatedSession(
-        sessions.createAnonymousSession(),
+      const authenticatedSession = await sessions.rotateAuthenticatedSession(
+        await sessions.createAnonymousSession(),
         {
           username: "admin",
           accessEmail: "admin@example.com",
@@ -2147,8 +2147,8 @@ test("portal returns configuration guidance when managed access config is incomp
   try {
     const sessions = await importFresh("../lib/sessions.js");
     const { GET } = await importFresh("../app/portal/route.js");
-    const authenticatedSession = sessions.rotateAuthenticatedSession(
-      sessions.createAnonymousSession(),
+    const authenticatedSession = await sessions.rotateAuthenticatedSession(
+      await sessions.createAnonymousSession(),
       {
         username: "admin",
         accessEmail: "admin@example.com",
@@ -2191,8 +2191,8 @@ test("portal redirects to login with route context and clears the session when A
   try {
     const sessions = await importFresh("../lib/sessions.js");
     const { GET } = await importFresh("../app/portal/route.js");
-    const authenticatedSession = sessions.rotateAuthenticatedSession(
-      sessions.createAnonymousSession(),
+    const authenticatedSession = await sessions.rotateAuthenticatedSession(
+      await sessions.createAnonymousSession(),
       {
         username: "admin",
         accessEmail: "admin@example.com",
@@ -2218,7 +2218,7 @@ test("portal redirects to login with route context and clears the session when A
       "https://portal.example.com/login?returnTo=%2Fportal%3Fview%3Dreview%26job%3Djob_demo%26artifact%3Dsynthetic%252Freview-primary.png%26compare%3D1"
     );
     assert.match(response.headers.get("set-cookie") || "", /__Host-tp_session=/);
-    assert.equal(sessions.getSessionById(authenticatedSession.id, { touch: false }), null);
+    assert.equal(await sessions.getSessionById(authenticatedSession.id, { touch: false }), null);
   } finally {
     env.cleanup();
   }
@@ -2722,8 +2722,8 @@ test("v1 POST rejects requests missing valid same-origin CSRF protections", asyn
     const sessions = await importFresh("../lib/sessions.js");
     const route = await importFresh("../app/v1/[...path]/route.js");
 
-    const authenticatedSession = sessions.rotateAuthenticatedSession(
-      sessions.createAnonymousSession(),
+    const authenticatedSession = await sessions.rotateAuthenticatedSession(
+      await sessions.createAnonymousSession(),
       {
         username: "admin",
         accessEmail: "admin@example.com",
@@ -2759,8 +2759,8 @@ test("v1 rejects authenticated sessions without a current Access JWT", async () 
     const sessions = await importFresh("../lib/sessions.js");
     const route = await importFresh("../app/v1/[...path]/route.js");
 
-    const authenticatedSession = sessions.rotateAuthenticatedSession(
-      sessions.createAnonymousSession(),
+    const authenticatedSession = await sessions.rotateAuthenticatedSession(
+      await sessions.createAnonymousSession(),
       {
         username: "admin",
         accessEmail: "admin@example.com",
@@ -2785,7 +2785,7 @@ test("v1 rejects authenticated sessions without a current Access JWT", async () 
       assert.equal(body.error.details.reason, "auth_failure");
       assert.equal(body.error.details.retryable, false);
       assert.match(response.headers.get("set-cookie") || "", /__Host-tp_session=/);
-      assert.equal(sessions.getSessionById(authenticatedSession.id, { touch: false }), null);
+      assert.equal(await sessions.getSessionById(authenticatedSession.id, { touch: false }), null);
     } finally {
       env.cleanup();
   }
@@ -2800,8 +2800,8 @@ test("v1 returns forbidden when the current Access identity does not match the a
     const restoreFetch = withMockedAccessCerts();
 
     try {
-      const authenticatedSession = sessions.rotateAuthenticatedSession(
-        sessions.createAnonymousSession(),
+      const authenticatedSession = await sessions.rotateAuthenticatedSession(
+        await sessions.createAnonymousSession(),
         {
           username: "admin",
           accessEmail: "admin@example.com",
@@ -2828,7 +2828,7 @@ test("v1 returns forbidden when the current Access identity does not match the a
       assert.equal(body.error.details.reason, "auth_failure");
       assert.equal(body.error.details.retryable, false);
       assert.match(response.headers.get("set-cookie") || "", /__Host-tp_session=/);
-      assert.equal(sessions.getSessionById(authenticatedSession.id, { touch: false }), null);
+      assert.equal(await sessions.getSessionById(authenticatedSession.id, { touch: false }), null);
     } finally {
       restoreFetch();
     }
@@ -2848,8 +2848,8 @@ test("v1 reports managed proxy config failures when the backend API key is missi
     const restoreFetch = withMockedAccessCerts();
 
     try {
-      const authenticatedSession = sessions.rotateAuthenticatedSession(
-        sessions.createAnonymousSession(),
+      const authenticatedSession = await sessions.rotateAuthenticatedSession(
+        await sessions.createAnonymousSession(),
         {
           username: "admin",
           accessEmail: "admin@example.com",
@@ -2908,8 +2908,8 @@ test("v1 normalizes upstream outages into a structured retryable error envelope"
     });
 
     try {
-      const authenticatedSession = sessions.rotateAuthenticatedSession(
-        sessions.createAnonymousSession(),
+      const authenticatedSession = await sessions.rotateAuthenticatedSession(
+        await sessions.createAnonymousSession(),
         {
           username: "admin",
           accessEmail: "admin@example.com",
@@ -2988,8 +2988,8 @@ test("v1 preserves rate-limit retry headers and envelope on upstream 429", async
     });
 
     try {
-      const authenticatedSession = sessions.rotateAuthenticatedSession(
-        sessions.createAnonymousSession(),
+      const authenticatedSession = await sessions.rotateAuthenticatedSession(
+        await sessions.createAnonymousSession(),
         {
           username: "admin",
           accessEmail: "admin@example.com",
@@ -3062,8 +3062,8 @@ test("v1 normalizes upstream auth responses into managed config failures", async
       });
 
       try {
-        const authenticatedSession = sessions.rotateAuthenticatedSession(
-          sessions.createAnonymousSession(),
+        const authenticatedSession = await sessions.rotateAuthenticatedSession(
+          await sessions.createAnonymousSession(),
           {
             username: "admin",
             accessEmail: "admin@example.com",
@@ -3116,8 +3116,8 @@ test("v1 forwards browser traceparent upstream and includes trace id in queue-ac
     const sessions = await importFresh("../lib/sessions.js");
     const route = await importFresh("../app/v1/[...path]/route.js");
 
-    const authenticatedSession = sessions.rotateAuthenticatedSession(
-      sessions.createAnonymousSession(),
+    const authenticatedSession = await sessions.rotateAuthenticatedSession(
+      await sessions.createAnonymousSession(),
       {
         username: "admin",
         accessEmail: "admin@example.com",
@@ -3189,8 +3189,8 @@ test("v1 SSE proxy preserves event-stream framing while injecting backend auth s
     const sessions = await importFresh("../lib/sessions.js");
     const route = await importFresh("../app/v1/[...path]/route.js");
 
-    const authenticatedSession = sessions.rotateAuthenticatedSession(
-      sessions.createAnonymousSession(),
+    const authenticatedSession = await sessions.rotateAuthenticatedSession(
+      await sessions.createAnonymousSession(),
       {
         username: "admin",
         accessEmail: "admin@example.com",
@@ -3267,8 +3267,8 @@ test("v1 artifact proxy passes binary previews through the managed front door wi
     const sessions = await importFresh("../lib/sessions.js");
     const route = await importFresh("../app/v1/[...path]/route.js");
 
-    const authenticatedSession = sessions.rotateAuthenticatedSession(
-      sessions.createAnonymousSession(),
+    const authenticatedSession = await sessions.rotateAuthenticatedSession(
+      await sessions.createAnonymousSession(),
       {
         username: "admin",
         accessEmail: "admin@example.com",
@@ -3868,7 +3868,7 @@ test("development cookies relax __Host/Secure requirements for local HTTP", asyn
   try {
     const sessions = await importFresh("../lib/sessions.js");
     const response = NextResponse.json({ ok: true });
-    const anonymousSession = sessions.createAnonymousSession();
+    const anonymousSession = await sessions.createAnonymousSession();
 
     sessions.setSessionCookie(response, anonymousSession.id);
 

--- a/web/secure-landing/tests/session-store.test.mjs
+++ b/web/secure-landing/tests/session-store.test.mjs
@@ -292,3 +292,124 @@ test("RedisSessionStore.recordLoginAttempt rejects missing throttle_key", async 
   );
   assert.equal(fake.calls.length, 0);
 });
+
+// ---------------------------------------------------------------------------
+// Phase 3.B perf regression — the login hot path must NOT trigger a global
+// Redis SCAN of ``${prefix}login:*`` on every credential POST. Codex flagged
+// this on PR #1773: ``sessions.js:pruneLoginAttempts`` was delegated to the
+// store unconditionally, which on the Redis backend translates to a full
+// scan of every throttle bucket twice per login attempt
+// (``isLoginThrottled`` + ``recordLoginAttempt``).
+// ---------------------------------------------------------------------------
+
+
+test("sessions.isLoginThrottled does not trigger a Redis SCAN on the hot login path", async () => {
+  // Phase 3.B regression: pre-fix, ``sessions.pruneLoginAttempts`` delegated
+  // unconditionally to the store, and ``RedisSessionStore.pruneLoginAttempts``
+  // is a ``SCAN ${prefix}login:*`` of every throttle bucket. With many
+  // historical throttle keys that's an O(N) scan per credential POST, and
+  // ``isLoginThrottled`` + ``recordLoginAttempt`` triggered it twice per
+  // attempt. The fix: short-circuit the delegation when the store is
+  // backed by Redis — per-bucket ``PEXPIRE`` (set in ``recordLoginAttempt``)
+  // handles auto-expiry, and ``ZCOUNT(sinceMs, +inf)`` already filters
+  // stale entries from the count.
+  const { __setSessionStoreForTesting, resetSessionStoreSingleton } = await import(
+    "../lib/session-store/index.js"
+  );
+
+  const fake = _makeFakeRedisClient();
+  // Pull the scan response shape that ``RedisSessionStore.pruneLoginAttempts``
+  // uses so the test can observe SCAN invocations if the short-circuit
+  // regresses.
+  fake.scan = async (cursor, ...rest) => {
+    fake.calls.push(["scan", cursor, ...rest]);
+    return ["0", []];
+  };
+  const redisStore = new RedisSessionStore({
+    redisUrl: "redis://fake",
+    keyPrefix: "tp:test:",
+    idleTimeoutMs: 60_000,
+    absoluteTimeoutMs: 3_600_000,
+    client: fake
+  });
+  let pruneInvocations = 0;
+  const originalPrune = redisStore.pruneLoginAttempts.bind(redisStore);
+  redisStore.pruneLoginAttempts = async (...args) => {
+    pruneInvocations += 1;
+    return originalPrune(...args);
+  };
+
+  // Steer ``getConfig().sessionStoreBackend`` to "redis" so the factory's
+  // cache key matches the injected store — otherwise ``getSessionStore()``
+  // sees ``_cachedBackend = "redis"`` but config says "sqlite" and
+  // rebuilds the singleton from scratch.
+  const previousBackend = process.env.TP_FRONTDOOR_SESSION_STORE;
+  const previousRedisUrl = process.env.TP_FRONTDOOR_REDIS_URL;
+  process.env.TP_FRONTDOOR_SESSION_STORE = "redis";
+  process.env.TP_FRONTDOOR_REDIS_URL = "redis://fake";
+
+  __setSessionStoreForTesting(redisStore, "redis");
+  try {
+    const sessions = await import(`../lib/sessions.js?case=${Date.now()}-${Math.random()}`);
+    await sessions.isLoginThrottled("user-a");
+    await sessions.recordLoginAttempt({
+      throttleKey: "user-a",
+      success: false,
+      remoteAddr: "127.0.0.1"
+    });
+    const scanCalls = fake.calls.filter((entry) => entry[0] === "scan");
+    assert.equal(
+      scanCalls.length,
+      0,
+      "Redis SCAN must not run on the login hot path; rely on per-bucket TTL + ZCOUNT instead"
+    );
+    assert.equal(
+      pruneInvocations,
+      0,
+      "sessions.js must skip the store's pruneLoginAttempts for the Redis backend"
+    );
+    // The recordLoginAttempt call must still write the failure + set TTL.
+    const zadd = fake.calls.filter((entry) => entry[0] === "zadd");
+    const pexpire = fake.calls.filter((entry) => entry[0] === "pexpire");
+    assert.equal(zadd.length, 1);
+    assert.equal(pexpire.length, 1);
+  } finally {
+    if (previousBackend === undefined) {
+      delete process.env.TP_FRONTDOOR_SESSION_STORE;
+    } else {
+      process.env.TP_FRONTDOOR_SESSION_STORE = previousBackend;
+    }
+    if (previousRedisUrl === undefined) {
+      delete process.env.TP_FRONTDOOR_REDIS_URL;
+    } else {
+      process.env.TP_FRONTDOOR_REDIS_URL = previousRedisUrl;
+    }
+    resetSessionStoreSingleton();
+  }
+});
+
+
+test("RedisSessionStore.pruneLoginAttempts performs a SCAN-and-trim sweep (baseline behavior)", async () => {
+  // Pin the Redis store's prune semantics so the regression test below can
+  // assert that ``sessions.pruneLoginAttempts`` deliberately bypasses this
+  // path for the Redis backend.
+  const fake = _makeFakeRedisClient();
+  // The fake doesn't seed scan responses; SCAN returns an empty cursor 0
+  // immediately. The test still observes that pruneLoginAttempts CALLS
+  // ``scan`` at least once — that's the expensive global sweep we don't
+  // want triggered on the login hot path.
+  fake.scan = async (cursor, ...rest) => {
+    fake.calls.push(["scan", cursor, ...rest]);
+    return ["0", []];
+  };
+  const store = new RedisSessionStore({
+    redisUrl: "redis://fake",
+    keyPrefix: "tp:test:",
+    idleTimeoutMs: 60_000,
+    absoluteTimeoutMs: 3_600_000,
+    client: fake
+  });
+  await store.pruneLoginAttempts(0);
+  const scanCalls = fake.calls.filter((entry) => entry[0] === "scan");
+  assert.ok(scanCalls.length >= 1, "RedisSessionStore.pruneLoginAttempts must SCAN buckets");
+});


### PR DESCRIPTION
## Summary

Phase 3.B of the Production Hardening Plan (gap doc §5.3) — the cut-over PR queued at the end of Phase 3.A. The frontdoor's session helpers now delegate to `getSessionStore()` instead of touching `better-sqlite3` directly, `ioredis` is a checked-in runtime dependency, and every Next.js route handler that imports them has been updated to `await` the now-async helpers.

### lib/sessions.js refactor

Persistence-touching helpers became `async` and delegate to the factory-returned store:

- `createAnonymousSession`
- `getSessionById`
- `getSessionFromRequest`
- `rotateAuthenticatedSession`
- `destroySession`
- `isLoginThrottled`
- `recordLoginAttempt`

Pure cookie / CSRF helpers stay sync — they never touched the store:

- `setSessionCookie`, `clearSessionCookie`, `validateCsrfToken`, `getRemoteAddress`

The audit-event payloads, the SQLite schema, and the cookie semantics are byte-identical to the pre-Phase-3 implementation. The only observable changes are the new backend selection (`TP_FRONTDOOR_SESSION_STORE=sqlite|redis`) and the async call signatures.

### Route handler updates

`app/login`, `app/logout`, `app/portal`, `app/portal/bootstrap`, `app/v1/[...path]` — every call site that hit a now-async helper got `await`-shaped. `lib/access.js:revokeSessionOnAccessFailure` became async too (it `await`s `destroySession`).

### ioredis runtime dep

`web/secure-landing/package.json` pins `ioredis: ^5.7.0` (lock resolves to 5.10.1). `redis-store.js:loadRedisClient`'s lazy-import dance is kept for safety, but in practice `ioredis` is always available on every build.

### Test plan

- [x] `npm test` → 250 / 250 frontdoor cases green.
- [x] `npm run build` succeeds with the new dep installed and the async path live.
- [x] 117 `sessions.X(...)` call sites under `tests/` updated to `await`. A handful of test-local helpers (`buildAuthenticatedSession` in `logout-rum.test.mjs`) became `async` to host the awaits, and 5 `await sessions.foo()?.bar` sites were corrected to `(await sessions.foo())?.bar` so the optional chain runs against the resolved value rather than the Promise.
- [x] `tests/auth-flow.test.mjs` (13 cases) exercises the async surface of `createAnonymousSession` / `rotateAuthenticatedSession` / `recordLoginAttempt` / `isLoginThrottled` end-to-end against the SQLite store.
- [x] `tests/routes.test.mjs` (132 cases) covers every async-bound route handler in the new shape.
- [x] `tests/session-store.test.mjs` (11 cases) covers `SqliteSessionStore` round-trip + the `RedisSessionStore` login-throttle path through an injected fake client.

Governance doc §5.3 updated to mark Phase 3.B landed and reclassify the remaining operator-runbook work to Phase 5 (pilot deployment).

https://claude.ai/code/session_01EPqVEoqKMc7AKTJVyTvBh6

---
_Generated by [Claude Code](https://claude.ai/code/session_01EPqVEoqKMc7AKTJVyTvBh6)_