### PR TITLE
fix(orchestrator): harden terminal overlay authority

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ PHASE6_SMOKE_TESTS := \
 	tests/test_lux_render_pipeline_smoke.py \
 	tests/lux_depth_v3/test_orchestrator_smoke.py
 
-.PHONY: help test-fast test-novideo test-full test-integration test-structure test-utils test-orchestrator-contract test-orchestrator-http-contract test-artifact-s3-contract test-orchestrator-postgres-contract test-worker-redis-contract test-portal-contract test-frontdoor-contract test-archive-gate-contract db-upgrade db-revision seed-frontdoor-user run-frontdoor-local run-backend-local run-backend-local-noreload dev-write-env dev-start dev-stop check-vercel-env validate-orchestrator-http validate-portal-lux-materials-live validate-portal-fastvlm-captioning-live validate-portal-css-layer-parity validate-portal-browser validate-frontdoor-browser validate-frontdoor-deployment-gate audit-pipeline-readiness coverage-fast-scope coverage-report coverage-diff coverage-package venv repair-core-venv setup clean \
+.PHONY: help test-fast test-novideo test-full test-integration test-structure test-utils test-orchestrator-contract test-orchestrator-http-contract test-artifact-s3-contract test-orchestrator-postgres-contract test-orchestrator-postgres-app-contract test-worker-redis-contract test-portal-contract test-frontdoor-contract test-archive-gate-contract db-upgrade db-revision seed-frontdoor-user run-frontdoor-local run-backend-local run-backend-local-noreload dev-write-env dev-start dev-stop check-vercel-env validate-orchestrator-http validate-portal-lux-materials-live validate-portal-fastvlm-captioning-live validate-portal-css-layer-parity validate-portal-browser validate-frontdoor-browser validate-frontdoor-deployment-gate audit-pipeline-readiness coverage-fast-scope coverage-report coverage-diff coverage-package venv repair-core-venv setup clean \
         lint lint-parity ci ci-full pre-commit install-hooks quality-check fix-quality validate-ci organize-docs check-json-serialization check-piptools-cache \
         check-python-headers check-yaml-governance check-stale-docs check-doc-heading-links lock lock-prod lock-ci lock-dev install-core install-ml install-ml-core install-ml-raw install-ml-sam2 install-ml-coreml install-fastvlm-runtime check-fastvlm-runtime docs docs-clean \
         check check-test-markers check-ci-sync check-todo-governance check-environment check-portal-asset-budgets check-dependency-pinning validate-full validate-quick clean-frontdoor clean-all check-worktree \
@@ -299,6 +299,17 @@ test-orchestrator-postgres-contract:
 		exit 1; \
 	fi
 	@TP_TEST_POSTGRES_URL="$(TP_TEST_POSTGRES_URL)" "$(PY)" -m pytest -q tests/orchestrator -m unit
+
+test-orchestrator-postgres-app-contract:
+	@echo "Running Postgres-backed orchestrator app authority smoke..."
+	@if [ -z "$(TP_TEST_POSTGRES_URL)" ]; then \
+		echo "ERROR: TP_TEST_POSTGRES_URL is not set. Example:"; \
+		echo "  docker compose up -d postgres"; \
+		echo "  TP_TEST_POSTGRES_URL=postgresql+asyncpg://tp:tp_dev_password@127.0.0.1:5432/transformation_portal \\"; \
+		echo "    make test-orchestrator-postgres-app-contract"; \
+		exit 1; \
+	fi
+	@TP_TEST_POSTGRES_URL="$(TP_TEST_POSTGRES_URL)" "$(PY)" -m pytest -q tests/orchestrator/test_postgres_app_authority.py -m unit
 
 # Phase 2.B - durable queue broker. Requires TP_TEST_REDIS_URL pointing at an
 # empty Redis database (typically the docker-compose `redis` service). The

--- a/app.py
+++ b/app.py
@@ -1210,6 +1210,21 @@ def _overlay_runtime_state(job: Job, cached: Optional[Job]) -> Job:
             cached.progress = job.progress
             cached.exit_code = job.exit_code
         return cached
+    cached_is_terminal = cached.finished_at is not None or cached.state in _TERMINAL_JOB_STATES
+    durable_is_terminal = job.finished_at is not None or job.state in _TERMINAL_JOB_STATES
+    if cached_is_terminal and not durable_is_terminal:
+        # A terminal runtime cache means the local runner already finished,
+        # but its final repository persist may have failed or lagged. Keep
+        # the terminal view so list/detail do not regress to stale active
+        # durable state; still accept durable artifact metadata from other
+        # paths that may have advanced after completion.
+        cached.artifacts = job.artifacts
+        cached.artifact_lookup = job.artifact_lookup
+        cached.artifact_store_mirrored = job.artifact_store_mirrored
+        cached.artifact_store_backend = job.artifact_store_backend
+        if job.cancel_requested:
+            cached.cancel_requested = True
+        return cached
     proc = cached.proc
     terminate_task = cached.terminate_task
     cached.created_at = job.created_at

--- a/app.py
+++ b/app.py
@@ -1185,6 +1185,10 @@ def _job_from_record(record: JobRecord) -> Job:
     )
 
 
+def _has_durable_artifact_metadata(job: Job) -> bool:
+    return bool(job.artifacts) or bool(job.artifact_lookup)
+
+
 def _overlay_runtime_state(job: Job, cached: Optional[Job]) -> Job:
     if cached is None:
         return job
@@ -1218,10 +1222,11 @@ def _overlay_runtime_state(job: Job, cached: Optional[Job]) -> Job:
         # the terminal view so list/detail do not regress to stale active
         # durable state; still accept durable artifact metadata from other
         # paths that may have advanced after completion.
-        cached.artifacts = job.artifacts
-        cached.artifact_lookup = job.artifact_lookup
-        cached.artifact_store_mirrored = job.artifact_store_mirrored
-        cached.artifact_store_backend = job.artifact_store_backend
+        if _has_durable_artifact_metadata(job):
+            cached.artifacts = job.artifacts
+            cached.artifact_lookup = job.artifact_lookup
+            cached.artifact_store_mirrored = job.artifact_store_mirrored
+            cached.artifact_store_backend = job.artifact_store_backend
         if job.cancel_requested:
             cached.cancel_requested = True
         return cached

--- a/docs/runtimes/orchestrator-postgres.md
+++ b/docs/runtimes/orchestrator-postgres.md
@@ -117,6 +117,10 @@ docker compose up -d postgres
 make db-upgrade
 TP_TEST_POSTGRES_URL=postgresql+asyncpg://tp:tp_dev_password@127.0.0.1:5432/transformation_portal \
   make test-orchestrator-postgres-contract
+
+# Postgres-backed app route authority smoke (manual/opt-in).
+TP_TEST_POSTGRES_URL=postgresql+asyncpg://tp:tp_dev_password@127.0.0.1:5432/transformation_portal \
+  make test-orchestrator-postgres-app-contract
 ```
 
 `tests/orchestrator/conftest.py` auto-skips the Postgres branch when
@@ -132,6 +136,7 @@ TP_TEST_POSTGRES_URL=postgresql+asyncpg://tp:tp_dev_password@127.0.0.1:5432/tran
 | Backups | Out of scope for Phase 1.B; document in the provider's runbook. The orchestrator never assumes durability beyond commit. |
 | Schema changes | Always go through Alembic and `make db-revision` so the migration graph stays linear. |
 | Secret rotation | `TP_DATABASE_URL` is read once at engine construction; a rotation requires a process restart. The restart sweeper (Phase 1.C, follow-up) will mark any orphaned `running` jobs `failed` with `error.code = worker_lost_on_restart`. |
+| Repository unavailable recovery | `JOB_REPOSITORY_UNAVAILABLE` is fail-closed and redacted. If it appears after fixing `TP_DATABASE_URL`, restart the backend process because repository construction failure is latched in process state. |
 
 ## Known limits in this layer
 

--- a/tests/orchestrator/test_postgres_app_authority.py
+++ b/tests/orchestrator/test_postgres_app_authority.py
@@ -1,0 +1,222 @@
+"""Opt-in Postgres app-route authority smoke for Phase 1.E.
+
+These tests exercise the FastAPI route handlers against the real
+Postgres ``JobRepository`` backend. They are intentionally excluded from
+offline CI unless ``TP_TEST_POSTGRES_URL`` is provided by the operator.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, AsyncIterator
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+import app as orchestrator_app
+from transformation_portal.orchestrator import reset_singletons
+from transformation_portal.orchestrator.artifact_store import reset_singleton as reset_artifact_store_singleton
+from transformation_portal.orchestrator.queue import reset_singleton as reset_queue_singleton
+from transformation_portal.orchestrator.recovery import WORKER_LOST_REASON_CODE, sweep_orphaned_jobs
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+_POSTGRES_URL_ENV = "TP_TEST_POSTGRES_URL"
+
+
+@pytest_asyncio.fixture
+async def postgres_app_client(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> AsyncIterator[tuple[AsyncClient, Any]]:
+    database_url = os.getenv(_POSTGRES_URL_ENV, "").strip()
+    if not database_url:
+        pytest.skip(f"{_POSTGRES_URL_ENV} is not set; skipping Postgres app authority smoke")
+    try:
+        import transformation_portal.orchestrator.storage.postgres  # noqa: F401
+    except ImportError:
+        pytest.skip("sqlalchemy[asyncio] not installed; skipping postgres")
+
+    monkeypatch.setenv("TP_ORCHESTRATOR_STATE_BACKEND", "postgres")
+    monkeypatch.setenv("TP_DATABASE_URL", database_url)
+    monkeypatch.setenv("TP_ARTIFACT_STORE", "local")
+    monkeypatch.setenv("TP_ARTIFACT_LOCAL_ROOT", str(tmp_path / "artifact-store"))
+    monkeypatch.setattr(orchestrator_app, "API_KEY_SECRET", "contract-secret")
+    monkeypatch.setattr(orchestrator_app, "ENFORCE_JOB_API_KEY", True)
+    monkeypatch.setattr(orchestrator_app, "ALLOW_SSE_QUERY_API_KEY", False)
+
+    reset_singletons()
+    reset_queue_singleton()
+    reset_artifact_store_singleton()
+    orchestrator_app.app.state.job_repository = None
+    orchestrator_app.app.state.job_repository_unavailable = False
+    orchestrator_app.JOBS.clear()
+    orchestrator_app.EVENT_SUBSCRIBERS.clear()
+    orchestrator_app.RATE_LIMIT_BUCKETS.clear()
+
+    repo = orchestrator_app._job_repository()
+    await repo.reset()
+
+    transport = ASGITransport(app=orchestrator_app.app)
+    try:
+        async with AsyncClient(
+            transport=transport,
+            base_url="http://testserver",
+            headers={"x-api-key": "contract-secret"},
+        ) as client:
+            yield client, repo
+    finally:
+        orchestrator_app.JOBS.clear()
+        orchestrator_app.EVENT_SUBSCRIBERS.clear()
+        orchestrator_app.RATE_LIMIT_BUCKETS.clear()
+        await repo.reset()
+        await repo.close()
+        reset_singletons()
+        reset_queue_singleton()
+        reset_artifact_store_singleton()
+        orchestrator_app.app.state.job_repository = None
+        orchestrator_app.app.state.job_repository_unavailable = False
+
+
+@pytest.mark.parametrize("api_prefix", ["/v1", "/v2"])
+async def test_postgres_create_list_detail_survive_runtime_cache_clear(
+    postgres_app_client: tuple[AsyncClient, Any],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    mark_da3_runtime_available: None,
+    api_prefix: str,
+) -> None:
+    client, _ = postgres_app_client
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    input_dir.mkdir()
+    (input_dir / "frame.jpg").write_bytes(b"fixture")
+    monkeypatch.setattr(orchestrator_app, "ALLOWED_INPUT_ROOTS", [tmp_path.resolve()])
+    monkeypatch.setattr(orchestrator_app, "ALLOWED_OUTPUT_ROOTS", [tmp_path.resolve()])
+
+    async def _noop_dispatch(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(orchestrator_app, "_dispatch_job", _noop_dispatch)
+
+    create_response = await client.post(
+        f"{api_prefix}/jobs",
+        json={
+            "pipeline": "lux-depth-v3",
+            "args": {
+                "input_dir": str(input_dir),
+                "output_dir": str(output_dir),
+                "non_commercial_ok": True,
+            },
+        },
+    )
+    assert create_response.status_code == 200
+    job_id = create_response.json()["data"]["id"]
+    orchestrator_app.JOBS.clear()
+
+    list_response = await client.get(f"{api_prefix}/jobs")
+    detail_response = await client.get(f"{api_prefix}/jobs/{job_id}")
+
+    assert list_response.status_code == 200
+    assert any(job["id"] == job_id for job in list_response.json()["data"]["jobs"])
+    assert detail_response.status_code == 200
+    detail = detail_response.json()["data"]
+    assert detail["id"] == job_id
+    assert detail["state"] == "queued"
+
+
+@pytest.mark.parametrize("api_prefix", ["/v1", "/v2"])
+async def test_postgres_cancel_writes_repository_after_runtime_cache_clear(
+    postgres_app_client: tuple[AsyncClient, Any],
+    api_prefix: str,
+) -> None:
+    client, repo = postgres_app_client
+    job = orchestrator_app.Job(
+        id=f"pg_cancel_{api_prefix.strip('/')}",
+        created_at=orchestrator_app._now(),
+        state="queued",
+        request={"pipeline": "lux-depth-v3"},
+    )
+    await repo.create(orchestrator_app._record_from_job(job))
+    orchestrator_app.JOBS.clear()
+
+    response = await client.post(f"{api_prefix}/jobs/{job.id}/cancel")
+
+    assert response.status_code == 200
+    assert response.json()["data"] == {"id": job.id, "state": "queued"}
+    record = await repo.get(job.id)
+    assert record is not None
+    assert record.cancel_requested is True
+
+
+@pytest.mark.parametrize("api_prefix", ["/v1", "/v2"])
+async def test_postgres_artifact_fetch_and_delete_use_repository_metadata_after_runtime_cache_clear(
+    postgres_app_client: tuple[AsyncClient, Any],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    api_prefix: str,
+) -> None:
+    client, repo = postgres_app_client
+    output_dir = tmp_path / f"artifact-{api_prefix.strip('/')}"
+    artifact_path = output_dir / "renders" / "hero.txt"
+    artifact_path.parent.mkdir(parents=True)
+    artifact_path.write_bytes(b"postgres artifact")
+    monkeypatch.setattr(orchestrator_app, "ALLOWED_OUTPUT_ROOTS", [tmp_path.resolve()])
+    job = orchestrator_app.Job(
+        id=f"pg_artifact_{api_prefix.strip('/')}",
+        created_at=orchestrator_app._now(),
+        finished_at=orchestrator_app._now(),
+        done_published_at=orchestrator_app._now(),
+        state="succeeded",
+        progress=100,
+        exit_code=0,
+        request={"pipeline": "lux-depth-v3", "args": {"output_dir": str(output_dir)}},
+        effective_request={"pipeline": "lux-depth-v3", "args": {"output_dir": str(output_dir)}},
+    )
+    orchestrator_app._index_job_artifacts(job)
+    await repo.create(orchestrator_app._record_from_job(job))
+    await repo.set_artifacts(job.id, job.artifacts, job.artifact_lookup)
+    orchestrator_app.JOBS.clear()
+
+    fetch_response = await client.get(f"{api_prefix}/jobs/{job.id}/artifacts/renders/hero.txt")
+
+    assert fetch_response.status_code == 200
+    assert fetch_response.content == b"postgres artifact"
+    orchestrator_app.JOBS.clear()
+
+    delete_response = await client.delete(f"{api_prefix}/jobs/{job.id}/artifacts")
+
+    assert delete_response.status_code == 200
+    record = await repo.get(job.id)
+    assert record is not None
+    assert record.artifacts["lifecycle"]["deletion_status"] == "deleted"
+    orchestrator_app.JOBS.clear()
+    refetch_response = await client.get(f"{api_prefix}/jobs/{job.id}/artifacts/renders/hero.txt")
+    assert refetch_response.status_code == 410
+    assert refetch_response.json()["error"]["code"] == "ARTIFACT_DELETED"
+
+
+async def test_postgres_restart_sweep_exposes_worker_lost_after_runtime_cache_clear(
+    postgres_app_client: tuple[AsyncClient, Any],
+) -> None:
+    client, repo = postgres_app_client
+    job = orchestrator_app.Job(
+        id="pg_worker_lost_app",
+        created_at=orchestrator_app._now(),
+        started_at=orchestrator_app._now(),
+        state="running",
+        request={"pipeline": "lux-depth-v3"},
+    )
+    await repo.create(orchestrator_app._record_from_job(job))
+    orchestrator_app.JOBS.clear()
+
+    swept = await sweep_orphaned_jobs(repo)
+    response = await client.get(f"/v1/jobs/{job.id}")
+
+    assert swept == [job.id]
+    assert response.status_code == 200
+    body = response.json()["data"]
+    assert body["state"] == "worker_lost"
+    assert body["error"]["code"] == WORKER_LOST_REASON_CODE

--- a/tests/orchestrator/test_postgres_app_authority.py
+++ b/tests/orchestrator/test_postgres_app_authority.py
@@ -37,7 +37,11 @@ async def postgres_app_client(
     try:
         import transformation_portal.orchestrator.storage.postgres  # noqa: F401
     except ImportError:
-        pytest.skip("sqlalchemy[asyncio] not installed; skipping postgres")
+        pytest.fail(
+            f"{_POSTGRES_URL_ENV} is set, but sqlalchemy[asyncio]/asyncpg dependencies are unavailable. "
+            "Install the pinned base requirements before running the Postgres app authority contract.",
+            pytrace=False,
+        )
 
     monkeypatch.setenv("TP_ORCHESTRATOR_STATE_BACKEND", "postgres")
     monkeypatch.setenv("TP_DATABASE_URL", database_url)

--- a/tests/test_app_orchestrator_contract_http.py
+++ b/tests/test_app_orchestrator_contract_http.py
@@ -14,6 +14,7 @@ import os
 import re
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, Callable, Dict, List, Tuple
 from urllib.parse import parse_qs, urlparse
 
@@ -2896,6 +2897,45 @@ def test_cancel_reads_repository_state_after_runtime_cache_clear(client: TestCli
     record = asyncio.run(orchestrator_app._job_repository().get(job.id))
     assert record is not None
     assert record.cancel_requested is True
+
+
+def test_detail_and_list_preserve_terminal_runtime_overlay_when_repository_lags(client: TestClient) -> None:
+    job = orchestrator_app.Job(
+        id="job_terminal_overlay_http",
+        created_at=orchestrator_app._now(),
+        started_at=orchestrator_app._now(),
+        state="running",
+        progress=70,
+        request={"pipeline": "lux-depth-v3"},
+    )
+    _seed_job(job)
+    cached_job = orchestrator_app.Job(
+        id=job.id,
+        created_at=job.created_at,
+        started_at=job.started_at,
+        finished_at=orchestrator_app._now(),
+        done_published_at=orchestrator_app._now(),
+        last_event_at=orchestrator_app._now(),
+        state="succeeded",
+        progress=100,
+        exit_code=0,
+        request=job.request,
+        logs_tail=["finished locally"],
+    )
+    cached_job.proc = SimpleNamespace(returncode=0)
+    orchestrator_app.JOBS[job.id] = cached_job
+
+    detail_response = client.get(f"/v1/jobs/{job.id}")
+    list_response = client.get("/v1/jobs")
+
+    assert detail_response.status_code == 200
+    assert detail_response.json()["data"]["state"] == "succeeded"
+    assert detail_response.json()["data"]["progress"] == 100
+    assert list_response.status_code == 200
+    listed = list_response.json()["data"]["jobs"][0]
+    assert listed["id"] == job.id
+    assert listed["state"] == "succeeded"
+    assert listed["progress"] == 100
 
 
 def test_job_routes_fail_closed_when_repository_is_unavailable(

--- a/tests/test_app_orchestrator_runtime.py
+++ b/tests/test_app_orchestrator_runtime.py
@@ -5253,6 +5253,40 @@ def test_overlay_runtime_state_preserves_terminal_cache_over_stale_active_record
     assert result.artifact_store_backend == "local"
 
 
+def test_overlay_runtime_state_preserves_terminal_cache_artifacts_when_active_record_is_empty() -> None:
+    cached_job = orchestrator_app.Job(
+        id="job_terminal_cached_artifacts",
+        created_at=100.0,
+        started_at=101.0,
+        finished_at=120.0,
+        done_published_at=121.0,
+        state="succeeded",
+        progress=100,
+        exit_code=0,
+        artifacts={"items": [{"path": "result.txt"}]},
+        artifact_lookup={"result.txt": Path("/tmp/cached-result.txt")},
+        artifact_store_mirrored=True,
+        artifact_store_backend="local",
+    )
+    cached_job.proc = SimpleNamespace(returncode=0)
+    record_job = orchestrator_app.Job(
+        id=cached_job.id,
+        created_at=100.0,
+        started_at=101.0,
+        state="running",
+        progress=80,
+    )
+
+    result = orchestrator_app._overlay_runtime_state(record_job, cached_job)
+
+    assert result is cached_job
+    assert result.state == "succeeded"
+    assert result.artifacts == {"items": [{"path": "result.txt"}]}
+    assert result.artifact_lookup == {"result.txt": Path("/tmp/cached-result.txt")}
+    assert result.artifact_store_mirrored is True
+    assert result.artifact_store_backend == "local"
+
+
 def test_cleanup_expired_upload_batches_skips_when_retained_scan_fails(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_app_orchestrator_runtime.py
+++ b/tests/test_app_orchestrator_runtime.py
@@ -5210,6 +5210,49 @@ def test_overlay_runtime_state_preserves_live_cached_job() -> None:
     assert result.artifact_store_mirrored is True
 
 
+def test_overlay_runtime_state_preserves_terminal_cache_over_stale_active_record() -> None:
+    cached_job = orchestrator_app.Job(
+        id="job_terminal_overlay",
+        created_at=100.0,
+        started_at=101.0,
+        finished_at=120.0,
+        done_published_at=121.0,
+        last_event_at=121.0,
+        state="succeeded",
+        progress=100,
+        exit_code=0,
+        logs_tail=["finished"],
+        run_summary={"status": "ok"},
+    )
+    cached_job.proc = SimpleNamespace(returncode=0)
+    record_job = orchestrator_app.Job(
+        id=cached_job.id,
+        created_at=100.0,
+        started_at=101.0,
+        state="running",
+        progress=80,
+        artifacts={"lifecycle": {"mirror_status": "mirrored"}},
+        artifact_lookup={"result.txt": Path("/tmp/result.txt")},
+        artifact_store_mirrored=True,
+        artifact_store_backend="local",
+    )
+
+    result = orchestrator_app._overlay_runtime_state(record_job, cached_job)
+
+    assert result is cached_job
+    assert result.state == "succeeded"
+    assert result.progress == 100
+    assert result.finished_at == 120.0
+    assert result.done_published_at == 121.0
+    assert result.exit_code == 0
+    assert result.logs_tail == ["finished"]
+    assert result.run_summary == {"status": "ok"}
+    assert result.artifacts == {"lifecycle": {"mirror_status": "mirrored"}}
+    assert result.artifact_lookup == {"result.txt": Path("/tmp/result.txt")}
+    assert result.artifact_store_mirrored is True
+    assert result.artifact_store_backend == "local"
+
+
 def test_cleanup_expired_upload_batches_skips_when_retained_scan_fails(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- Prevent stale non-terminal repository rows from regressing a completed runtime job view when final persistence lags or fails.
- Preserve cached terminal artifact metadata when the durable row is still active and has no artifact metadata.
- Add an opt-in Postgres-backed app-route authority smoke target and document repository-unavailable restart recovery.

## Changes
- `_overlay_runtime_state()` now preserves terminal cached runtime state over stale active repository state while still accepting durable artifact/cancel metadata when the durable row has meaningful artifact metadata.
- Added unit and HTTP route coverage for terminal overlay precedence, including cached terminal artifacts surviving an empty stale active repository row.
- Added `tests/orchestrator/test_postgres_app_authority.py` plus `make test-orchestrator-postgres-app-contract` for manual Postgres route-path validation.
- Tightened the Postgres app contract target: no `TP_TEST_POSTGRES_URL` fails at Make level; a supplied URL with missing SQLAlchemy/asyncpg dependencies fails inside pytest instead of skipping.
- Updated `docs/runtimes/orchestrator-postgres.md` with `JOB_REPOSITORY_UNAVAILABLE` restart guidance.
- No public API, envelope, route, status-code, selector, or SSE payload changes.

## Validation
Proven green:
- `./.venv/bin/python -m black --check app.py tests/test_app_orchestrator_runtime.py tests/orchestrator/test_postgres_app_authority.py`
- `./.venv/bin/python -m pytest tests/test_app_orchestrator_runtime.py -k overlay_runtime_state` (`3 passed`)
- `./.venv/bin/python -m pytest tests/test_app_orchestrator_contract_http.py -k terminal_runtime_overlay` (`1 passed`)
- `./.venv/bin/python -m pytest tests/test_app_orchestrator_contract_http.py -k "repository_state or repo_artifact or repo_cancel or unavailable"` (`2 passed`)
- `./.venv/bin/python -m pytest -q tests/orchestrator/test_postgres_app_authority.py -m unit` (`7 skipped`, expected when `TP_TEST_POSTGRES_URL` is absent)
- `make test-orchestrator-contract` (`718 passed, 8 skipped`)
- commit hook: staged Python formatting, root placement, ADR guards, marker checks, gitleaks

Expected fail-closed checks in this local env:
- `make test-orchestrator-postgres-app-contract` fails with a clear `TP_TEST_POSTGRES_URL` requirement when the URL is absent.
- `TP_TEST_POSTGRES_URL=postgresql+asyncpg://tp:tp_dev_password@127.0.0.1:5432/transformation_portal make test-orchestrator-postgres-app-contract` fails because this local venv lacks `sqlalchemy`; this is the intended behavior for an explicitly requested Postgres app contract when dependencies are unavailable.

## Risk
- Runtime compatibility risk is low: the precedence change only applies when the cached runtime job is terminal and the repository row is still non-terminal.
- Artifact metadata risk is reduced: cached terminal artifacts are preserved unless the durable row has meaningful artifact metadata.
- Postgres app smoke is opt-in and manual; GitHub Actions service wiring is intentionally deferred.
- Revert-safe: the change is confined to overlay hydration, tests, one Make target, and operator docs.