### PR TITLE
ci(coverage): include app.py in coverage measurement scope

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -723,7 +723,7 @@ jobs:
             COV_FLAGS="--no-cov"
             echo "ML tier: coverage disabled for faster PR feedback"
           else
-            COV_FLAGS="--cov=src/transformation_portal --cov=src/tp --cov=lux_depth_v3 --cov-report=term-missing --cov-report=xml --cov-report=html --cov-fail-under=25"
+            COV_FLAGS="--cov=src/transformation_portal --cov=src/tp --cov=lux_depth_v3 --cov=app --cov-report=term-missing --cov-report=xml --cov-report=html --cov-fail-under=25"
             echo "Core tier: enforcing 25% minimum global coverage"
           fi
 

--- a/Makefile
+++ b/Makefile
@@ -485,6 +485,7 @@ coverage-report:
 		-m "not ml and not slow and not benchmark and not stress" \
 		--cov=src/transformation_portal \
 		--cov=src/tp \
+		--cov=app \
 		--cov-branch \
 		--cov-report=term-missing \
 		--cov-report=html:htmlcov \
@@ -525,6 +526,7 @@ coverage-package:
 	@"$(PY)" -m pytest tests/ \
 		-m "not ml and not slow and not benchmark and not stress" \
 		--cov=src/transformation_portal \
+		--cov=app \
 		--cov-branch \
 		--cov-report=xml:coverage.xml \
 		--cov-config=pyproject.toml \

--- a/docs/testing/test_coverage_improvement_plan.md
+++ b/docs/testing/test_coverage_improvement_plan.md
@@ -45,6 +45,13 @@ The repository has substantial test volume, but high-risk areas remain under-cov
 
 ## Coverage Gate Strategy
 
+### Measurement Scope
+
+The coverage runs (`make coverage-report`, `make coverage-package`, and the
+core test leg in `build.yml`) measure `src/transformation_portal`, `src/tp`,
+and the root `app.py` origin. `app.py` is in scope so the FastAPI surface and
+its `app.py` milestone targets below are actually enforced, not aspirational.
+
 ### Immediate Gate (Active)
 
 ```bash


### PR DESCRIPTION
The 10.6k-line FastAPI origin (app.py) sat outside every --cov scope, so
its coverage was invisible to the global gate and per-package ratchets
despite an existing tests/test_app_*.py suite. Add --cov=app to the
coverage-report and coverage-package Make targets and the build.yml core
test leg so the app.py milestone targets in the improvement plan are
actually enforced.

https://claude.ai/code/session_01RXQj3kz1AhWMA7HZL3AgoL