### PR TITLE
test(orchestrator): stabilize jobs list determinism check

### DIFF
--- a/tests/orchestrator/test_envelope_runtime_validation.py
+++ b/tests/orchestrator/test_envelope_runtime_validation.py
@@ -189,6 +189,7 @@ def _client_fixture(
     monkeypatch.setattr(orchestrator_app, "_run_job", _instant_complete)
     # Avoid pipeline-validation false-rejects for the lightweight smoke jobs.
     monkeypatch.setattr(orchestrator_app, "_materialize_dispatch_output_dir", lambda *_a, **_kw: None)
+    monkeypatch.setattr(orchestrator_app, "WORKER_POLL_INTERVAL_SECONDS", 0.01)
 
     previous_api_key = orchestrator_app.API_KEY_SECRET
     previous_enforce = orchestrator_app.ENFORCE_JOB_API_KEY
@@ -221,13 +222,16 @@ def _create_dummy_job(client: TestClient, *, api_version: str) -> str:
 
 def _wait_for_job_terminal(client: TestClient, job_id: str, *, api_version: str) -> None:
     last_body: Dict[str, Any] | None = None
-    for _ in range(50):
+    timeout_seconds = max(1.0, orchestrator_app.WORKER_POLL_INTERVAL_SECONDS * 5)
+    sleep_seconds = min(0.05, max(0.005, orchestrator_app.WORKER_POLL_INTERVAL_SECONDS / 5))
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
         response = client.get(f"/{api_version}/jobs/{job_id}")
         assert response.status_code == 200, response.text
         last_body = response.json()
         if last_body["data"]["state"] in orchestrator_app._TERMINAL_JOB_STATES:
             return
-        time.sleep(0.01)
+        time.sleep(sleep_seconds)
     pytest.fail(f"job {job_id} did not reach a terminal state; last response: {last_body}")
 
 

--- a/tests/orchestrator/test_envelope_runtime_validation.py
+++ b/tests/orchestrator/test_envelope_runtime_validation.py
@@ -47,6 +47,7 @@ still emit through ``ErrorEnvelope``-shaped JSON via
 from __future__ import annotations
 
 import json
+import time
 from typing import Any, Dict, Iterator
 
 import pytest
@@ -59,12 +60,25 @@ from transformation_portal.api.v1.jobs import (
     JobsListData,
     JobStatusData,
 )
+from transformation_portal.orchestrator import reset_singletons as reset_repository_singletons
+from transformation_portal.orchestrator.queue import reset_singleton as reset_queue_singleton
 
 pytestmark = [pytest.mark.unit]
 
 
 def _canonical(value: Any) -> str:
     return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def _reset_runtime_state() -> None:
+    reset_repository_singletons()
+    reset_queue_singleton()
+    orchestrator_app.app.state.job_repository = None
+    orchestrator_app.app.state.job_repository_unavailable = False
+    orchestrator_app.app.state.queue_broker = None
+    orchestrator_app.JOBS.clear()
+    orchestrator_app.EVENT_SUBSCRIBERS.clear()
+    orchestrator_app._LAST_EVENT_PERSISTED_AT.clear()
 
 
 # ---------------------------------------------------------------------------
@@ -178,18 +192,16 @@ def _client_fixture(
 
     previous_api_key = orchestrator_app.API_KEY_SECRET
     previous_enforce = orchestrator_app.ENFORCE_JOB_API_KEY
+    _reset_runtime_state()
     orchestrator_app.API_KEY_SECRET = "contract-secret"
     orchestrator_app.ENFORCE_JOB_API_KEY = True
-    orchestrator_app.JOBS.clear()
-    orchestrator_app.EVENT_SUBSCRIBERS.clear()
     try:
         with TestClient(orchestrator_app.app, headers={"x-api-key": "contract-secret"}) as client:
             yield client
     finally:
         orchestrator_app.API_KEY_SECRET = previous_api_key
         orchestrator_app.ENFORCE_JOB_API_KEY = previous_enforce
-        orchestrator_app.JOBS.clear()
-        orchestrator_app.EVENT_SUBSCRIBERS.clear()
+        _reset_runtime_state()
 
 
 def _create_dummy_job(client: TestClient, *, api_version: str) -> str:
@@ -205,6 +217,18 @@ def _create_dummy_job(client: TestClient, *, api_version: str) -> str:
     )
     assert response.status_code == 200, response.text
     return response.json()["data"]["id"]
+
+
+def _wait_for_job_terminal(client: TestClient, job_id: str, *, api_version: str) -> None:
+    last_body: Dict[str, Any] | None = None
+    for _ in range(50):
+        response = client.get(f"/{api_version}/jobs/{job_id}")
+        assert response.status_code == 200, response.text
+        last_body = response.json()
+        if last_body["data"]["state"] in orchestrator_app._TERMINAL_JOB_STATES:
+            return
+        time.sleep(0.01)
+    pytest.fail(f"job {job_id} did not reach a terminal state; last response: {last_body}")
 
 
 def _assert_envelope_shape(body: Dict[str, Any], *, expected_schema: str) -> None:
@@ -295,7 +319,8 @@ def test_cancel_job_wire_shape(client: TestClient, api_version: str) -> None:
 
 
 def test_list_jobs_response_is_canonically_deterministic(client: TestClient) -> None:
-    _create_dummy_job(client, api_version="v1")
+    job_id = _create_dummy_job(client, api_version="v1")
+    _wait_for_job_terminal(client, job_id, api_version="v1")
     first = client.get("/v1/jobs").json()
     second = client.get("/v1/jobs").json()
     # In-process determinism: same content yields the same canonical bytes.


### PR DESCRIPTION
## Summary
- The main-branch CI failure came from a jobs-list determinism test comparing two live responses while the broker worker could still advance job state.
- This narrows the fix to the test harness: isolate per-test in-memory repository/broker state and wait for the created job to reach a terminal state before canonical JSON comparison.

## Changes
- Reset orchestrator repository and queue singleton state around the envelope route TestClient fixture.
- Clear runtime job/event registries between envelope-route tests.
- Wait for the dummy job to reach a terminal state before asserting byte-stable list response serialization.

## Validation
- PYTHONPATH=/private/tmp/tp-main-ci-fix/src /Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin/pytest tests/orchestrator/test_envelope_runtime_validation.py -q
- PYTHONPATH=/private/tmp/tp-main-ci-fix/src /Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin/pytest tests/test_app_orchestrator_runtime.py::test_overlay_runtime_state_preserves_live_cached_job tests/test_app_orchestrator_runtime.py::test_overlay_runtime_state_preserves_terminal_cache_over_stale_active_record tests/test_app_orchestrator_runtime.py::test_overlay_runtime_state_preserves_terminal_cache_artifacts_when_active_record_is_empty tests/orchestrator/test_envelope_runtime_validation.py -q
- PYTHONPATH=/private/tmp/tp-main-ci-fix/src make test-orchestrator-contract PY=/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin/python
- git diff --check

## Risk
- Test-only change; no production route, schema, selector, or runtime behavior changes.
- Revert-safe if a broader test-isolation fixture replaces this local harness later.