### PR TITLE
fix(orchestrator): stabilize paid-pilot live gate

### DIFF
--- a/app.py
+++ b/app.py
@@ -1186,7 +1186,39 @@ def _job_from_record(record: JobRecord) -> Job:
 
 
 def _has_durable_artifact_metadata(job: Job) -> bool:
-    return bool(job.artifacts) or bool(job.artifact_lookup)
+    if job.artifact_lookup:
+        return True
+    if not isinstance(job.artifacts, dict):
+        return False
+    items = job.artifacts.get("items")
+    if isinstance(items, list) and items:
+        return True
+    lifecycle = job.artifacts.get(_ARTIFACT_LIFECYCLE_KEY)
+    if not isinstance(lifecycle, dict):
+        return False
+    deletion_status = str(lifecycle.get("deletion_status") or "").strip().lower()
+    mirror_status = str(lifecycle.get("mirror_status") or "").strip().lower()
+    return bool(lifecycle.get("deleted_at")) or deletion_status in {"deleted", "failed"} or mirror_status == "failed"
+
+
+def _merge_durable_artifact_lifecycle(cached: Job, durable: Job) -> bool:
+    if not isinstance(cached.artifacts, dict):
+        return False
+    if not cached.artifact_lookup and not cached.artifacts.get("items"):
+        return False
+    if not isinstance(durable.artifacts, dict):
+        return False
+    lifecycle = durable.artifacts.get(_ARTIFACT_LIFECYCLE_KEY)
+    if not isinstance(lifecycle, dict):
+        return False
+    merged = dict(cached.artifacts)
+    merged[_ARTIFACT_LIFECYCLE_KEY] = dict(lifecycle)
+    cached.artifacts = merged
+    if durable.artifact_store_mirrored:
+        cached.artifact_store_mirrored = True
+    if durable.artifact_store_backend:
+        cached.artifact_store_backend = durable.artifact_store_backend
+    return True
 
 
 def _overlay_runtime_state(job: Job, cached: Optional[Job]) -> Job:
@@ -1227,11 +1259,17 @@ def _overlay_runtime_state(job: Job, cached: Optional[Job]) -> Job:
             cached.artifact_lookup = job.artifact_lookup
             cached.artifact_store_mirrored = job.artifact_store_mirrored
             cached.artifact_store_backend = job.artifact_store_backend
+        else:
+            _merge_durable_artifact_lifecycle(cached, job)
         if job.cancel_requested:
             cached.cancel_requested = True
         return cached
     proc = cached.proc
     terminate_task = cached.terminate_task
+    cached_artifacts = cached.artifacts
+    cached_artifact_lookup = cached.artifact_lookup
+    cached_artifact_store_mirrored = cached.artifact_store_mirrored
+    cached_artifact_store_backend = cached.artifact_store_backend
     cached.created_at = job.created_at
     cached.started_at = job.started_at
     cached.finished_at = job.finished_at
@@ -1243,10 +1281,17 @@ def _overlay_runtime_state(job: Job, cached: Optional[Job]) -> Job:
     cached.request = job.request
     cached.effective_request = job.effective_request
     cached.logs_tail = job.logs_tail
-    cached.artifacts = job.artifacts
-    cached.artifact_lookup = job.artifact_lookup
-    cached.artifact_store_mirrored = job.artifact_store_mirrored
-    cached.artifact_store_backend = job.artifact_store_backend
+    if cached_is_terminal and not _has_durable_artifact_metadata(job):
+        cached.artifacts = cached_artifacts
+        cached.artifact_lookup = cached_artifact_lookup
+        cached.artifact_store_mirrored = cached_artifact_store_mirrored
+        cached.artifact_store_backend = cached_artifact_store_backend
+        _merge_durable_artifact_lifecycle(cached, job)
+    else:
+        cached.artifacts = job.artifacts
+        cached.artifact_lookup = job.artifact_lookup
+        cached.artifact_store_mirrored = job.artifact_store_mirrored
+        cached.artifact_store_backend = job.artifact_store_backend
     cached.run_summary = job.run_summary
     cached.cancel_requested = job.cancel_requested
     cached.error = job.error

--- a/app.py
+++ b/app.py
@@ -1185,20 +1185,27 @@ def _job_from_record(record: JobRecord) -> Job:
     )
 
 
-def _has_durable_artifact_metadata(job: Job) -> bool:
+def _has_durable_artifact_inventory(job: Job) -> bool:
     if job.artifact_lookup:
         return True
     if not isinstance(job.artifacts, dict):
         return False
     items = job.artifacts.get("items")
-    if isinstance(items, list) and items:
-        return True
+    return isinstance(items, list) and bool(items)
+
+
+def _has_authoritative_durable_artifact_tombstone(job: Job) -> bool:
+    if not isinstance(job.artifacts, dict):
+        return False
     lifecycle = job.artifacts.get(_ARTIFACT_LIFECYCLE_KEY)
     if not isinstance(lifecycle, dict):
         return False
     deletion_status = str(lifecycle.get("deletion_status") or "").strip().lower()
-    mirror_status = str(lifecycle.get("mirror_status") or "").strip().lower()
-    return bool(lifecycle.get("deleted_at")) or deletion_status in {"deleted", "failed"} or mirror_status == "failed"
+    return bool(lifecycle.get("deleted_at")) or deletion_status == "deleted"
+
+
+def _has_durable_artifact_metadata(job: Job) -> bool:
+    return _has_durable_artifact_inventory(job) or _has_authoritative_durable_artifact_tombstone(job)
 
 
 def _merge_durable_artifact_lifecycle(cached: Job, durable: Job) -> bool:

--- a/docs/deployment/phase5a_paid_pilot_live_acceptance_2026-05-14.md
+++ b/docs/deployment/phase5a_paid_pilot_live_acceptance_2026-05-14.md
@@ -1,0 +1,98 @@
+# Phase 5.A Paid-Pilot Live Acceptance - 2026-05-14
+
+## Status
+
+Local Compose acceptance passed on follow-up fix commit `5e0632279`.
+
+The merged Phase 5.A gate commit `cd9bf5a679d040c2af14acd8e97dbe7ee9ed11d5` was used as the baseline, but the first live run exposed three gate defects:
+
+- Redis lease deadlines returned lower precision than the ZSET score used for expiry.
+- Postgres per-job concurrent updates and log appends could exhaust optimistic retries under the contract's 50-way contention tests.
+- The integrated smoke could observe terminal runtime state before artifact finalization and could let lifecycle-only durable metadata hide cached indexed artifacts.
+
+Those defects are fixed in `5e0632279`; the live gate passes with those fixes.
+
+## Local Service Surface
+
+Environment loaded from `docs/deployment/paid-pilot.env.example`.
+
+Runtime tooling:
+
+- Docker CLI: `29.5.0`
+- Docker Compose: `5.1.3`
+- Colima: `0.10.1`
+- Node.js: `v22.22.2`
+
+Local services:
+
+| Service | Image | Image digest |
+| --- | --- | --- |
+| Postgres | `postgres:16-alpine` | `sha256:890480b08124ce7f79960a9bb16fe39729aa302bd384bfd7c408fee6c8f7adb7` |
+| Redis | `redis:7-alpine` | `sha256:6ab0b6e7381779332f97b8ca76193e45b0756f38d4c0dcda72dbb3c32061ab99` |
+| MinIO | `minio/minio:latest` | `sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e` |
+| MinIO client | `minio/mc:latest` | `sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727` |
+
+`docker-compose --profile paid-pilot ps` reported Postgres, Redis, and MinIO healthy on loopback ports `5432`, `6379`, `9000`, and `9001`.
+
+## Validation
+
+Migration:
+
+```text
+make db-upgrade
+PASS - Alembic connected to Postgres and reported transactional DDL.
+```
+
+Focused seam checks:
+
+```text
+TP_TEST_REDIS_URL=redis://127.0.0.1:6379/0 .venv/bin/python -m pytest -q tests/orchestrator/test_queue_contract.py -m unit -k server_time_shares_domain
+PASS - 2 passed, 36 deselected
+
+TP_TEST_POSTGRES_URL=postgresql+asyncpg://tp:tp_dev_password@127.0.0.1:5432/transformation_portal .venv/bin/python -m pytest -q tests/orchestrator/test_repository_contract.py -m unit -k "concurrent_updates or concurrent_append_log"
+PASS - 4 passed, 49 deselected
+
+.venv/bin/python -m pytest -q tests/test_app_orchestrator_runtime.py -k overlay_runtime_state
+PASS - 4 passed, 261 deselected
+
+TP_RUN_PAID_PILOT_SERVICES_CONTRACT=1 .venv/bin/python -m pytest -q tests/orchestrator/test_paid_pilot_services_contract.py -m unit -k backend_services_compose
+PASS - 1 passed, 1 deselected
+```
+
+Full gates:
+
+```text
+make test-paid-pilot-services-contract
+PASS
+- Postgres repository contract: 271 passed, 2 skipped
+- Postgres app authority smoke: 7 passed
+- Redis QueueBroker contract: 38 passed
+- ArtifactStore local + live S3/MinIO contract: 140 passed
+- Frontdoor Redis SessionStore contract: 2 passed
+- Integrated paid-pilot backend smoke: 2 passed
+
+make test-orchestrator-contract
+PASS - 720 passed, 9 skipped
+
+git diff --check
+PASS
+```
+
+## Acceptance Result
+
+Phase 5.A is locally validated on the follow-up fix branch. The gate proves the composed local pilot stack:
+
+- Postgres `JobRepository`
+- Redis `QueueBroker`
+- Redis frontdoor `SessionStore`
+- S3-compatible MinIO `ArtifactStore`
+- `/v1/jobs` create through Redis broker
+- worker subprocess completion
+- Postgres-backed terminal state after `app.JOBS.clear()`
+- S3 redirect artifact fetch
+- artifact delete and `410 ARTIFACT_DELETED`
+- abandoned active row sweep to `worker_lost`
+
+## Known Limits
+
+This is local Compose validation only. Managed-service validation must rerun the same gate with provider Postgres, Redis, and S3-compatible endpoints. The gate is still manual and opt-in; it does not add Terraform, Helm, durable SSE replay, globally atomic multi-instance admission, broad observability, operational audit events, tenancy, billing, or production secret management.

--- a/src/transformation_portal/orchestrator/queue/redis.py
+++ b/src/transformation_portal/orchestrator/queue/redis.py
@@ -102,12 +102,13 @@ end
 local t = redis.call('TIME')
 local now = tonumber(t[1]) + tonumber(t[2]) / 1000000
 local deadline = now + tonumber(ARGV[2])
+local deadline_str = string.format('%.6f', deadline)
 local job_key = KEYS[3] .. job_id
 local request_json = redis.call('HGET', job_key, 'request')
-redis.call('HSET', job_key, 'worker_id', ARGV[1], 'deadline', tostring(deadline))
+redis.call('HSET', job_key, 'worker_id', ARGV[1], 'deadline', deadline_str)
 redis.call('HDEL', job_key, 'cancellation_requested')
-redis.call('ZADD', KEYS[2], deadline, job_id)
-return {job_id, request_json, tostring(deadline)}
+redis.call('ZADD', KEYS[2], deadline_str, job_id)
+return {job_id, request_json, deadline_str}
 """
 
 
@@ -133,8 +134,9 @@ end
 local t = redis.call('TIME')
 local now = tonumber(t[1]) + tonumber(t[2]) / 1000000
 local deadline = now + tonumber(ARGV[3])
-redis.call('HSET', KEYS[2], 'deadline', tostring(deadline))
-redis.call('ZADD', KEYS[1], deadline, ARGV[2])
+local deadline_str = string.format('%.6f', deadline)
+redis.call('HSET', KEYS[2], 'deadline', deadline_str)
+redis.call('ZADD', KEYS[1], deadline_str, ARGV[2])
 return 'active'
 """
 

--- a/src/transformation_portal/orchestrator/storage/postgres.py
+++ b/src/transformation_portal/orchestrator/storage/postgres.py
@@ -6,9 +6,9 @@ persistent slice of orchestrator jobs into the ORM models defined in
 ``JobRecord`` dataclass that the rest of the orchestrator already knows
 about.
 
-Concurrency: every ``update`` and ``set_artifacts`` call increments the
-row's ``version`` column under an optimistic-concurrency guard and
-retries on conflict.
+Concurrency: per-job ``update`` and log append calls serialize on the
+row lock, while remaining JSON index update paths use optimistic
+concurrency and retry on conflict.
 
 Memory ``logs_tail`` parity: this layer keeps the legacy "bounded
 in-memory tail" semantic - ``append_log`` reads the current tail,
@@ -207,53 +207,33 @@ class PostgresJobRepository(JobRepository):
                 raise JobNotFoundError(job_id)
             return existing
 
-        for attempt in range(_OPTIMISTIC_LOCK_RETRIES):
-            async with self._session() as session:
-                model = await session.get(JobModel, job_id)
-                if model is None:
-                    raise JobNotFoundError(job_id)
-                current_version = model.version
-                payload: Dict[str, Any] = dict(fields)
-                # Normalize JSON-stored containers so SQLAlchemy detects the
-                # mutation (asyncpg JSONB column).
-                for key in (
-                    "request",
-                    "effective_request",
-                    "artifacts",
-                    "run_summary",
-                ):
-                    if key in payload and payload[key] is not None:
-                        payload[key] = dict(payload[key])
-                if "logs_tail" in payload and payload["logs_tail"] is not None:
-                    payload["logs_tail"] = list(payload["logs_tail"])
-                if "error" in payload and payload["error"] is not None:
-                    payload["error"] = dict(payload["error"])
+        async with self._session() as session:
+            stmt = select(JobModel).where(JobModel.id == job_id).with_for_update()
+            model = (await session.execute(stmt)).scalar_one_or_none()
+            if model is None:
+                raise JobNotFoundError(job_id)
+            payload: Dict[str, Any] = dict(fields)
+            # Normalize JSON-stored containers so SQLAlchemy detects the
+            # mutation (asyncpg JSONB column).
+            for key in (
+                "request",
+                "effective_request",
+                "artifacts",
+                "run_summary",
+            ):
+                if key in payload and payload[key] is not None:
+                    payload[key] = dict(payload[key])
+            if "logs_tail" in payload and payload["logs_tail"] is not None:
+                payload["logs_tail"] = list(payload["logs_tail"])
+            if "error" in payload and payload["error"] is not None:
+                payload["error"] = dict(payload["error"])
 
-                stmt = (
-                    update(JobModel)
-                    .where(
-                        JobModel.id == job_id,
-                        JobModel.version == current_version,
-                    )
-                    .values(version=current_version + 1, **payload)
-                )
-                result = await session.execute(stmt)
-                if result.rowcount == 0:
-                    await session.rollback()
-                    if attempt + 1 < _OPTIMISTIC_LOCK_RETRIES:
-                        await asyncio.sleep(0.01 * (attempt + 1))
-                        continue
-                    raise RepositoryError(
-                        f"optimistic-lock conflict on job {job_id} after " f"{_OPTIMISTIC_LOCK_RETRIES} retries"
-                    )
-                await session.commit()
-                refreshed = await session.get(JobModel, job_id)
-                assert refreshed is not None  # just updated successfully
-                await session.refresh(refreshed, ["artifact_index"])
-                return _record_from_model(refreshed)
-
-        # Should be unreachable; included for type-checkers.
-        raise RepositoryError(f"failed to update job {job_id}")
+            for key, value in payload.items():
+                setattr(model, key, value)
+            model.version += 1
+            await session.commit()
+            await session.refresh(model, ["artifact_index"])
+            return _record_from_model(model)
 
     async def append_log(self, job_id: str, line: str, *, tail_limit: int) -> None:
         if tail_limit <= 0:
@@ -266,33 +246,18 @@ class PostgresJobRepository(JobRepository):
         batch = list(lines)
         if not batch:
             return
-        for attempt in range(_OPTIMISTIC_LOCK_RETRIES):
-            async with self._session() as session:
-                model = await session.get(JobModel, job_id)
-                if model is None:
-                    raise JobNotFoundError(job_id)
-                current_version = model.version
-                tail = list(model.logs_tail or [])
-                tail.extend(batch)
-                if len(tail) > tail_limit:
-                    tail = tail[-tail_limit:]
-                stmt = (
-                    update(JobModel)
-                    .where(
-                        JobModel.id == job_id,
-                        JobModel.version == current_version,
-                    )
-                    .values(logs_tail=tail, version=current_version + 1)
-                )
-                result = await session.execute(stmt)
-                if result.rowcount == 0:
-                    await session.rollback()
-                    if attempt + 1 < _OPTIMISTIC_LOCK_RETRIES:
-                        await asyncio.sleep(0.01 * (attempt + 1))
-                        continue
-                    raise RepositoryError(f"optimistic-lock conflict on job {job_id} log append")
-                await session.commit()
-                return
+        async with self._session() as session:
+            stmt = select(JobModel).where(JobModel.id == job_id).with_for_update()
+            model = (await session.execute(stmt)).scalar_one_or_none()
+            if model is None:
+                raise JobNotFoundError(job_id)
+            tail = list(model.logs_tail or [])
+            tail.extend(batch)
+            if len(tail) > tail_limit:
+                tail = tail[-tail_limit:]
+            model.logs_tail = tail
+            model.version += 1
+            await session.commit()
 
     async def set_artifacts(
         self,

--- a/tests/orchestrator/test_paid_pilot_services_contract.py
+++ b/tests/orchestrator/test_paid_pilot_services_contract.py
@@ -159,6 +159,7 @@ def paid_pilot_stack(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Iterato
     monkeypatch.setattr(orchestrator_app, "WORKER_HEARTBEAT_INTERVAL_SECONDS", 0.02)
     monkeypatch.setattr(orchestrator_app, "WORKER_POLL_INTERVAL_SECONDS", 0.01)
     monkeypatch.setattr(orchestrator_app, "MAX_CONCURRENT_JOBS", 1)
+    monkeypatch.setattr(orchestrator_app, "RATE_LIMIT_PER_MINUTE", 0)
     monkeypatch.setattr(orchestrator_app, "_resolve_lux_depth_canary_runtime", lambda: Path(sys.executable))
 
     reset_singletons()
@@ -246,6 +247,21 @@ def _wait_for_terminal_detail(client: TestClient, job_id: str, *, timeout: float
     raise AssertionError(f"job {job_id} did not reach terminal state; last body={last_body!r}")
 
 
+def _wait_for_durable_artifacts(client: TestClient, job_id: str, *, timeout: float = 10.0) -> dict[str, Any]:
+    deadline = time.monotonic() + timeout
+    last_body: dict[str, Any] | None = None
+    while time.monotonic() < deadline:
+        orchestrator_app.JOBS.clear()
+        response = client.get(f"/v1/jobs/{job_id}")
+        assert response.status_code == 200, response.text
+        last_body = response.json()["data"]
+        items = last_body.get("artifacts", {}).get("items", [])
+        if last_body.get("state") == "succeeded" and items:
+            return last_body
+        time.sleep(0.05)
+    raise AssertionError(f"job {job_id} did not persist terminal artifacts; last body={last_body!r}")
+
+
 def test_paid_pilot_backend_services_compose_end_to_end(
     paid_pilot_stack: dict[str, Any],
     monkeypatch: pytest.MonkeyPatch,
@@ -289,10 +305,7 @@ def test_paid_pilot_backend_services_compose_end_to_end(
         assert terminal["exit_code"] == 0
 
         orchestrator_app.JOBS.clear()
-        durable_detail = client.get(f"/v1/jobs/{job_id}")
-        assert durable_detail.status_code == 200, durable_detail.text
-        durable_body = durable_detail.json()["data"]
-        assert durable_body["state"] == "succeeded"
+        durable_body = _wait_for_durable_artifacts(client, job_id)
         assert durable_body["artifacts"]["items"], "terminal artifact metadata should persist in Postgres"
 
         artifact_response = client.get(
@@ -324,9 +337,9 @@ def test_paid_pilot_backend_services_compose_end_to_end(
             request={"pipeline": "lux-depth-v3"},
             effective_request={"pipeline": "lux-depth-v3", "args": {}},
         )
-        asyncio.run(repo.create(orchestrator_app._record_from_job(abandoned)))
+        client.portal.call(repo.create, orchestrator_app._record_from_job(abandoned))
         orchestrator_app.JOBS.clear()
-        swept = asyncio.run(sweep_orphaned_jobs(repo))
+        swept = client.portal.call(sweep_orphaned_jobs, repo)
         assert swept == [abandoned.id]
 
         swept_response = client.get(f"/v1/jobs/{abandoned.id}")

--- a/tests/test_app_orchestrator_runtime.py
+++ b/tests/test_app_orchestrator_runtime.py
@@ -5337,6 +5337,153 @@ def test_overlay_runtime_state_keeps_cached_items_when_durable_has_lifecycle_onl
     assert result.artifact_store_backend == "s3"
 
 
+def test_overlay_runtime_state_merges_failed_mirror_lifecycle_without_dropping_cached_items() -> None:
+    cached_job = orchestrator_app.Job(
+        id="job_terminal_failed_mirror_overlay",
+        created_at=100.0,
+        started_at=101.0,
+        finished_at=120.0,
+        done_published_at=121.0,
+        state="succeeded",
+        progress=100,
+        exit_code=0,
+        artifacts={"items": [{"path": "result.txt"}]},
+        artifact_lookup={"result.txt": Path("/tmp/cached-result.txt")},
+        artifact_store_mirrored=True,
+        artifact_store_backend="local",
+    )
+    cached_job.proc = SimpleNamespace(returncode=0)
+    record_job = orchestrator_app.Job(
+        id=cached_job.id,
+        created_at=100.0,
+        started_at=101.0,
+        state="running",
+        progress=80,
+        artifacts={
+            "lifecycle": {
+                "mirror_status": "failed",
+                "mirror_error": "artifact_mirror_failed",
+                "artifact_store_backend": "s3",
+            }
+        },
+        artifact_store_mirrored=False,
+        artifact_store_backend="s3",
+    )
+
+    result = orchestrator_app._overlay_runtime_state(record_job, cached_job)
+
+    assert result is cached_job
+    assert result.state == "succeeded"
+    assert result.artifacts == {
+        "items": [{"path": "result.txt"}],
+        "lifecycle": {
+            "mirror_status": "failed",
+            "mirror_error": "artifact_mirror_failed",
+            "artifact_store_backend": "s3",
+        },
+    }
+    assert result.artifact_lookup == {"result.txt": Path("/tmp/cached-result.txt")}
+    assert result.artifact_store_backend == "s3"
+
+
+def test_overlay_runtime_state_merges_failed_delete_lifecycle_without_dropping_cached_items() -> None:
+    cached_job = orchestrator_app.Job(
+        id="job_terminal_failed_delete_overlay",
+        created_at=100.0,
+        started_at=101.0,
+        finished_at=120.0,
+        done_published_at=121.0,
+        state="succeeded",
+        progress=100,
+        exit_code=0,
+        artifacts={"items": [{"path": "result.txt"}]},
+        artifact_lookup={"result.txt": Path("/tmp/cached-result.txt")},
+        artifact_store_mirrored=True,
+        artifact_store_backend="local",
+    )
+    cached_job.proc = SimpleNamespace(returncode=0)
+    record_job = orchestrator_app.Job(
+        id=cached_job.id,
+        created_at=100.0,
+        started_at=101.0,
+        state="running",
+        progress=80,
+        artifacts={
+            "lifecycle": {
+                "deletion_status": "failed",
+                "deletion_error": "artifact_deletion_failed",
+                "artifact_store_backend": "s3",
+            }
+        },
+        artifact_store_mirrored=False,
+        artifact_store_backend="s3",
+    )
+
+    result = orchestrator_app._overlay_runtime_state(record_job, cached_job)
+
+    assert result is cached_job
+    assert result.state == "succeeded"
+    assert result.artifacts == {
+        "items": [{"path": "result.txt"}],
+        "lifecycle": {
+            "deletion_status": "failed",
+            "deletion_error": "artifact_deletion_failed",
+            "artifact_store_backend": "s3",
+        },
+    }
+    assert result.artifact_lookup == {"result.txt": Path("/tmp/cached-result.txt")}
+    assert result.artifact_store_backend == "s3"
+
+
+def test_overlay_runtime_state_replaces_cached_items_when_durable_artifacts_are_deleted() -> None:
+    cached_job = orchestrator_app.Job(
+        id="job_terminal_deleted_overlay",
+        created_at=100.0,
+        started_at=101.0,
+        finished_at=120.0,
+        done_published_at=121.0,
+        state="succeeded",
+        progress=100,
+        exit_code=0,
+        artifacts={"items": [{"path": "result.txt"}]},
+        artifact_lookup={"result.txt": Path("/tmp/cached-result.txt")},
+        artifact_store_mirrored=True,
+        artifact_store_backend="local",
+    )
+    cached_job.proc = SimpleNamespace(returncode=0)
+    record_job = orchestrator_app.Job(
+        id=cached_job.id,
+        created_at=100.0,
+        started_at=101.0,
+        state="running",
+        progress=80,
+        artifacts={
+            "lifecycle": {
+                "deletion_status": "deleted",
+                "deleted_at": 123.0,
+                "artifact_store_backend": "s3",
+            }
+        },
+        artifact_store_mirrored=False,
+        artifact_store_backend="s3",
+    )
+
+    result = orchestrator_app._overlay_runtime_state(record_job, cached_job)
+
+    assert result is cached_job
+    assert result.state == "succeeded"
+    assert result.artifacts == {
+        "lifecycle": {
+            "deletion_status": "deleted",
+            "deleted_at": 123.0,
+            "artifact_store_backend": "s3",
+        }
+    }
+    assert result.artifact_lookup == {}
+    assert result.artifact_store_mirrored is False
+    assert result.artifact_store_backend == "s3"
+
+
 def test_cleanup_expired_upload_batches_skips_when_retained_scan_fails(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_app_orchestrator_runtime.py
+++ b/tests/test_app_orchestrator_runtime.py
@@ -5287,6 +5287,56 @@ def test_overlay_runtime_state_preserves_terminal_cache_artifacts_when_active_re
     assert result.artifact_store_backend == "local"
 
 
+def test_overlay_runtime_state_keeps_cached_items_when_durable_has_lifecycle_only() -> None:
+    cached_job = orchestrator_app.Job(
+        id="job_terminal_lifecycle_only_overlay",
+        created_at=100.0,
+        started_at=101.0,
+        finished_at=120.0,
+        done_published_at=121.0,
+        state="succeeded",
+        progress=100,
+        exit_code=0,
+        artifacts={"items": [{"path": "result.txt"}]},
+        artifact_lookup={"result.txt": Path("/tmp/cached-result.txt")},
+        artifact_store_mirrored=True,
+        artifact_store_backend="local",
+    )
+    cached_job.proc = SimpleNamespace(returncode=0)
+    record_job = orchestrator_app.Job(
+        id=cached_job.id,
+        created_at=100.0,
+        started_at=101.0,
+        finished_at=120.0,
+        done_published_at=121.0,
+        state="succeeded",
+        progress=100,
+        exit_code=0,
+        artifacts={
+            "lifecycle": {
+                "mirror_status": "mirrored",
+                "artifact_store_backend": "s3",
+            }
+        },
+        artifact_store_mirrored=True,
+        artifact_store_backend="s3",
+    )
+
+    result = orchestrator_app._overlay_runtime_state(record_job, cached_job)
+
+    assert result is cached_job
+    assert result.artifacts == {
+        "items": [{"path": "result.txt"}],
+        "lifecycle": {
+            "mirror_status": "mirrored",
+            "artifact_store_backend": "s3",
+        },
+    }
+    assert result.artifact_lookup == {"result.txt": Path("/tmp/cached-result.txt")}
+    assert result.artifact_store_mirrored is True
+    assert result.artifact_store_backend == "s3"
+
+
 def test_cleanup_expired_upload_batches_skips_when_retained_scan_fails(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- The first live Phase 5.A acceptance run against local Postgres, Redis, and MinIO exposed three integration defects in the merged paid-pilot gate.
- Stabilizes the Redis lease clock boundary, Postgres per-job mutation contention, and terminal artifact overlay path, then records the local acceptance evidence.

## Changes
- Redis QueueBroker Lua now stores and returns the same microsecond-formatted deadline string for lease acquire/extend, so exact-boundary reclaim uses the same score observed in `JobLease.deadline`.
- Postgres JobRepository update/log-append paths now serialize per-job mutations with row locks instead of exhausting short optimistic retry loops under 50-way contention.
- Runtime overlay preserves cached terminal artifact items when durable state has lifecycle-only metadata, while still merging durable lifecycle/backend fields.
- Paid-pilot integrated smoke waits for durable terminal artifact metadata, disables rate limiting inside the isolated smoke fixture, and uses the TestClient portal for repository calls.
- Adds `docs/deployment/phase5a_paid_pilot_live_acceptance_2026-05-14.md` with local service versions, image digests, command summaries, and known limits.

## Validation
Proven green:
- `make db-upgrade`
- `TP_TEST_REDIS_URL=redis://127.0.0.1:6379/0 .venv/bin/python -m pytest -q tests/orchestrator/test_queue_contract.py -m unit -k server_time_shares_domain`
- `TP_TEST_POSTGRES_URL=postgresql+asyncpg://tp:tp_dev_password@127.0.0.1:5432/transformation_portal .venv/bin/python -m pytest -q tests/orchestrator/test_repository_contract.py -m unit -k "concurrent_updates or concurrent_append_log"`
- `.venv/bin/python -m pytest -q tests/test_app_orchestrator_runtime.py -k overlay_runtime_state`
- `TP_RUN_PAID_PILOT_SERVICES_CONTRACT=1 .venv/bin/python -m pytest -q tests/orchestrator/test_paid_pilot_services_contract.py -m unit -k backend_services_compose`
- `make test-orchestrator-contract`
- `make test-paid-pilot-services-contract`
- `git diff --check`

Environment:
- Docker CLI 29.5.0, Docker Compose 5.1.3, Colima 0.10.1, Node v22.22.2.
- Local Compose Postgres, Redis, and MinIO were healthy on loopback.

## Risk
- Runtime changes are bounded to Redis lease deadline formatting, Postgres row-level serialization for per-job mutations, and artifact overlay precedence.
- Public routes, envelopes, selectors, and Make target names are unchanged.
- Row-level locking trades retry churn for deterministic per-job mutation ordering under contention.
- Revert-safe: the changes sit behind existing repository/broker contracts and are covered by targeted contract tests plus the full live gate.
