### PR TITLE
ci(deployment): add clean managed paid-pilot gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ Quick reference for common workflows and commands in this repo.
 - `make test-artifact-s3-contract` run ArtifactStore local plus S3/moto contract tests; setting `TP_TEST_S3_URL` and `TP_TEST_S3_BUCKET` switches the S3 branch to a live S3-compatible endpoint.
 - `make test-frontdoor-redis-contract` run the managed frontdoor Redis SessionStore contract; requires `TP_FRONTDOOR_REDIS_URL=redis://127.0.0.1:6379/0`.
 - `make test-paid-pilot-services-contract` run the opt-in Postgres + Redis queue + Redis frontdoor sessions + S3-compatible artifact managed-services smoke gate; requires the env surface documented in `docs/deployment/paid_pilot_services.md`.
+- `make run-managed-paid-pilot-gate` run the provider-backed paid-pilot gate from a clean `env -i` process using `TP_MANAGED_PAID_PILOT_ENV_FILE` (default `/tmp/tp-managed-staging.env`); pass `MANAGED_PAID_PILOT_GATE_ARGS=--preflight-only` to validate the env without touching services.
 - `make test-portal-contract` run portal runtime/browser contract tests (`tests/test_app_orchestrator_runtime.py`, `tests/validation/test_portal_smoke_scripts.py`).
 - `make test-frontdoor-contract` run managed frontdoor Node 22 contract/build checks (`./scripts/setup/ensure_node_version.sh && cd web/secure-landing && npm test && npm run build`).
 - `make test-archive-gate-contract` run archive gate readiness + HTTP contract coverage for archive Gates A/B/C (`tests/test_app_orchestrator_runtime.py`, `tests/test_app_orchestrator_contract_http.py` with `-k "archive_gate"`).

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ PHASE6_SMOKE_TESTS := \
 	tests/test_lux_render_pipeline_smoke.py \
 	tests/lux_depth_v3/test_orchestrator_smoke.py
 
-.PHONY: help test-fast test-novideo test-full test-integration test-structure test-utils test-orchestrator-contract test-orchestrator-http-contract test-artifact-s3-contract test-orchestrator-postgres-contract test-orchestrator-postgres-app-contract test-worker-redis-contract test-frontdoor-redis-contract test-paid-pilot-services-contract test-portal-contract test-frontdoor-contract test-archive-gate-contract db-upgrade db-revision seed-frontdoor-user run-frontdoor-local run-backend-local run-backend-local-noreload dev-write-env dev-start dev-stop check-vercel-env validate-orchestrator-http validate-portal-lux-materials-live validate-portal-fastvlm-captioning-live validate-portal-css-layer-parity validate-portal-browser validate-frontdoor-browser validate-frontdoor-deployment-gate audit-pipeline-readiness coverage-fast-scope coverage-report coverage-diff coverage-package venv repair-core-venv setup clean \
+.PHONY: help test-fast test-novideo test-full test-integration test-structure test-utils test-orchestrator-contract test-orchestrator-http-contract test-artifact-s3-contract test-orchestrator-postgres-contract test-orchestrator-postgres-app-contract test-worker-redis-contract test-frontdoor-redis-contract test-paid-pilot-services-contract run-managed-paid-pilot-gate test-portal-contract test-frontdoor-contract test-archive-gate-contract db-upgrade db-revision seed-frontdoor-user run-frontdoor-local run-backend-local run-backend-local-noreload dev-write-env dev-start dev-stop check-vercel-env validate-orchestrator-http validate-portal-lux-materials-live validate-portal-fastvlm-captioning-live validate-portal-css-layer-parity validate-portal-browser validate-frontdoor-browser validate-frontdoor-deployment-gate audit-pipeline-readiness coverage-fast-scope coverage-report coverage-diff coverage-package venv repair-core-venv setup clean \
         lint lint-parity ci ci-full pre-commit install-hooks quality-check fix-quality validate-ci organize-docs check-json-serialization check-piptools-cache \
         check-python-headers check-yaml-governance check-stale-docs check-doc-heading-links lock lock-prod lock-ci lock-dev install-core install-ml install-ml-core install-ml-raw install-ml-sam2 install-ml-coreml install-fastvlm-runtime check-fastvlm-runtime docs docs-clean \
         check check-test-markers check-ci-sync check-todo-governance check-environment check-portal-asset-budgets check-dependency-pinning validate-full validate-quick clean-frontdoor clean-all check-worktree \
@@ -55,6 +55,7 @@ help:
 	@echo "  test-artifact-s3-contract  Run ArtifactStore local + S3/moto contract tests"
 	@echo "  test-frontdoor-redis-contract  Run managed frontdoor Redis SessionStore contract"
 	@echo "  test-paid-pilot-services-contract  Run opt-in Postgres + Redis + S3 pilot service gate"
+	@echo "  run-managed-paid-pilot-gate  Run provider paid-pilot gate from a clean env file"
 	@echo "  test-portal-contract  Run portal runtime/browser contract tests"
 	@echo "  test-frontdoor-contract  Run managed frontdoor Node contract/build checks"
 	@echo "  test-archive-gate-contract  Run archive gate readiness + HTTP contract tests (Gates A, B, C)"
@@ -384,6 +385,9 @@ test-paid-pilot-services-contract:
 	@$(MAKE) test-artifact-s3-contract
 	@$(MAKE) test-frontdoor-redis-contract
 	@TP_RUN_PAID_PILOT_SERVICES_CONTRACT=1 "$(PY)" -m pytest -q tests/orchestrator/test_paid_pilot_services_contract.py -m unit
+
+run-managed-paid-pilot-gate:
+	@./scripts/validation/run_managed_paid_pilot_gate.sh --env-file "$${TP_MANAGED_PAID_PILOT_ENV_FILE:-/tmp/tp-managed-staging.env}" $(MANAGED_PAID_PILOT_GATE_ARGS)
 
 # Apply orchestrator schema migrations against TP_DATABASE_URL.
 db-upgrade:

--- a/docs/deployment/managed_paid_pilot_staging_runbook.md
+++ b/docs/deployment/managed_paid_pilot_staging_runbook.md
@@ -109,7 +109,8 @@ isolated prefixes, and deletes S3 objects under isolated prefixes. Treat every
 - The disposable Postgres database is empty or approved for reset.
 - The disposable Redis DB or keyspace contains no production data.
 - The disposable S3 bucket contains no production data.
-- Staging secrets are loaded from the provider secret manager.
+- Staging secrets are loaded from the provider secret manager into a private
+  gate-only env file outside the repository.
 - Backend and frontdoor processes can reach each managed endpoint.
 
 ## Startup Order
@@ -117,30 +118,59 @@ isolated prefixes, and deletes S3 objects under isolated prefixes. Treat every
 1. Provision or select the managed Postgres, Redis, and S3-compatible
    resources.
 2. Create the disposable validation database, Redis namespace, and S3 bucket.
-3. Load the staging secret set into the shell or deployment environment.
-4. Run database migrations with `make db-upgrade`.
-5. Start the backend and frontdoor staging processes.
-6. Confirm `/ready` and frontdoor health checks are green.
-7. Run the component gates.
-8. Run `make test-paid-pilot-services-contract`.
-9. Capture validation evidence before opening paid-pilot admission.
+3. Write a private env file outside the repository, usually
+   `/tmp/tp-managed-staging.env`.
+4. Run the clean-process preflight.
+5. Run the clean-process gate, which applies migrations and then invokes
+   `make test-paid-pilot-services-contract`.
+6. Capture validation evidence before opening paid-pilot admission.
 
-## Migration Procedure
+## Clean Env File
 
-Run migrations against the staging `TP_DATABASE_URL` before the gate:
+Create a gate-only env file outside the repository. Do not use the local
+`/tmp/tp-local-http-all-on.env` development profile.
 
 ```bash
-source .venv/bin/activate
-
-export TP_ORCHESTRATOR_STATE_BACKEND=postgres
-export TP_DATABASE_URL='postgresql+asyncpg://<redacted>'
-
-make db-upgrade
+umask 077
+touch /tmp/tp-managed-staging.env
+chmod 600 /tmp/tp-managed-staging.env
+${EDITOR:-vi} /tmp/tp-managed-staging.env
 ```
 
-Do not point `TP_DATABASE_URL` at the disposable test database when migrating
-the staging deployment. `TP_TEST_POSTGRES_URL` is for contract and smoke reset
-behavior only.
+The file must contain real provider values only. The clean launcher rejects
+missing values, placeholder-like values, wrong selectors, local-development
+variables, and unsafe staging/test overlap for the destructive Postgres and S3
+resources.
+
+Do not include local-development variables such as `TP_API_KEY`,
+`TP_BACKEND_API_KEY`, `TP_FASTAPI_ORIGIN`, `TP_ALLOW_LOCAL_ACCESS_BYPASS`,
+`TP_FRONTDOOR_SESSION_DB`, `TP_FRONTDOOR_SESSION_SCALING_MODE`,
+`TP_PORTAL_DIRECT_DEBUG_COHORT_KEY`, telemetry log paths, upload staging vars,
+or FastVLM runtime vars.
+
+## Clean Env Preflight
+
+Run the preflight from any shell. The launcher re-execs itself through `env -i`
+with only `HOME`, `PATH`, `USER`, and `SHELL`, then sources the private env file:
+
+```bash
+TP_MANAGED_PAID_PILOT_ENV_FILE=/tmp/tp-managed-staging.env \
+MANAGED_PAID_PILOT_GATE_ARGS=--preflight-only \
+make run-managed-paid-pilot-gate
+```
+
+The expected preflight output is:
+
+```text
+missing: []
+placeholder-like: []
+wrong selectors: {}
+leaked local-dev vars: []
+unsafe managed/test overlap: {}
+Managed paid-pilot clean-env preflight passed.
+```
+
+Any non-empty bucket is an environment setup blocker, not a product failure.
 
 ## Component Gates
 
@@ -180,33 +210,16 @@ gate runs.
 
 ## Integrated Paid-Pilot Gate
 
-Run the full provider/staging composition gate after the component gates pass:
+Run the full provider/staging composition gate with the same private env file:
 
 ```bash
-source .venv/bin/activate
-
-export TP_ORCHESTRATOR_STATE_BACKEND=postgres
-export TP_DATABASE_URL='postgresql+asyncpg://<redacted>'
-export TP_TEST_POSTGRES_URL='postgresql+asyncpg://<redacted-disposable-test-db>'
-
-export TP_ORCHESTRATOR_QUEUE_BACKEND=redis
-export TP_REDIS_URL='rediss://<redacted>'
-export TP_TEST_REDIS_URL='rediss://<redacted-disposable-test-redis>'
-
-export TP_FRONTDOOR_SESSION_STORE=redis
-export TP_FRONTDOOR_REDIS_URL='rediss://<redacted-session-redis>'
-
-export TP_ARTIFACT_STORE=s3
-export TP_ARTIFACT_ENDPOINT_URL='https://<redacted-s3-compatible-endpoint>'
-export TP_TEST_S3_URL='https://<redacted-test-s3-compatible-endpoint>'
-export TP_ARTIFACT_BUCKET='<redacted-staging-artifact-bucket>'
-export TP_TEST_S3_BUCKET='<redacted-disposable-test-bucket>'
-export AWS_ACCESS_KEY_ID='<redacted>'
-export AWS_SECRET_ACCESS_KEY='<redacted>'
-
-make db-upgrade
-make test-paid-pilot-services-contract
+TP_MANAGED_PAID_PILOT_ENV_FILE=/tmp/tp-managed-staging.env \
+make run-managed-paid-pilot-gate
 ```
+
+The launcher runs `make db-upgrade` against staging `TP_DATABASE_URL`, not
+`TP_TEST_POSTGRES_URL`, before invoking `make test-paid-pilot-services-contract`.
+Do not point `TP_DATABASE_URL` at the disposable test database.
 
 The integrated gate must prove `/v1/jobs` creation through Redis broker
 enqueue, worker subprocess completion, Postgres-backed terminal state after
@@ -221,6 +234,7 @@ Record the following in the staging acceptance note or release record:
 - Git commit under test.
 - Provider names, regions, and service versions where available.
 - Redacted env selector summary.
+- Clean env preflight result.
 - `make db-upgrade` result.
 - Each component gate result.
 - `make test-paid-pilot-services-contract` result.

--- a/docs/deployment/paid_pilot_services.md
+++ b/docs/deployment/paid_pilot_services.md
@@ -90,6 +90,14 @@ Integrated pilot gate:
 make test-paid-pilot-services-contract
 ```
 
+Managed-provider staging should use the clean launcher so local development env
+does not leak into the gate:
+
+```bash
+TP_MANAGED_PAID_PILOT_ENV_FILE=/tmp/tp-managed-staging.env \
+make run-managed-paid-pilot-gate
+```
+
 The integrated smoke submits a real `/v1/jobs` request, enqueues through Redis, executes through the in-process worker pool with a tiny generated subprocess, persists terminal state in Postgres, mirrors artifacts to S3-compatible storage, verifies repository-backed artifact fetch/delete semantics after `app.JOBS.clear()`, and proves a separate abandoned active row sweeps to `worker_lost`.
 
 ## Startup Order

--- a/scripts/validation/run_managed_paid_pilot_gate.sh
+++ b/scripts/validation/run_managed_paid_pilot_gate.sh
@@ -80,7 +80,7 @@ if [[ "${CLEAN_PROCESS}" != "1" ]]; then
         HOME="${HOME:-}" \
         PATH="${CLEAN_PATH}" \
         USER="${USER:-}" \
-        SHELL="/bin/zsh" \
+        SHELL="/bin/bash" \
         /bin/bash "$0" \
         --_clean-process \
         "${REEXEC_ARGS[@]}"

--- a/scripts/validation/run_managed_paid_pilot_gate.sh
+++ b/scripts/validation/run_managed_paid_pilot_gate.sh
@@ -142,6 +142,7 @@ from __future__ import annotations
 
 import os
 import sys
+from urllib.parse import urlsplit
 
 required = {
     "TP_ORCHESTRATOR_STATE_BACKEND",
@@ -191,13 +192,29 @@ def placeholder_like(value: str) -> bool:
     return any(token in normalized for token in placeholder_tokens)
 
 
+def postgres_identity(value: str) -> tuple[str, str, int, str]:
+    parsed = urlsplit(value)
+    scheme = parsed.scheme.split("+", 1)[0]
+    host = (parsed.hostname or "").lower()
+    port = parsed.port or 5432
+    database = parsed.path.lstrip("/")
+    return (scheme, host, port, database)
+
+
+provider_env_names = sorted(
+    name for name in os.environ if name.startswith("TP_") or name.startswith("AWS_")
+)
 missing = sorted(name for name in required if not os.getenv(name, "").strip())
-placeholder = sorted(name for name in required if placeholder_like(os.getenv(name, "")))
+placeholder = sorted(name for name in provider_env_names if placeholder_like(os.getenv(name, "")))
 wrong = {name: os.getenv(name, "") for name, value in expected.items() if os.getenv(name) != value}
 leaked = sorted(name for name in os.environ if name in forbidden or name.startswith(forbidden_prefixes))
 unsafe_overlap: dict[str, str] = {}
-if os.getenv("TP_DATABASE_URL") and os.getenv("TP_DATABASE_URL") == os.getenv("TP_TEST_POSTGRES_URL"):
-    unsafe_overlap["TP_TEST_POSTGRES_URL"] = "must not equal TP_DATABASE_URL"
+db_url = os.getenv("TP_DATABASE_URL", "")
+test_db_url = os.getenv("TP_TEST_POSTGRES_URL", "")
+if db_url and test_db_url and postgres_identity(db_url) == postgres_identity(test_db_url):
+    unsafe_overlap["TP_TEST_POSTGRES_URL"] = (
+        "must not target the same Postgres host/port/database as TP_DATABASE_URL"
+    )
 if os.getenv("TP_ARTIFACT_BUCKET") and os.getenv("TP_ARTIFACT_BUCKET") == os.getenv("TP_TEST_S3_BUCKET"):
     unsafe_overlap["TP_TEST_S3_BUCKET"] = "must not equal TP_ARTIFACT_BUCKET"
 

--- a/scripts/validation/run_managed_paid_pilot_gate.sh
+++ b/scripts/validation/run_managed_paid_pilot_gate.sh
@@ -61,10 +61,15 @@ done
 
 if [[ "${CLEAN_PROCESS}" != "1" ]]; then
     NODE_BIN="$(command -v node 2>/dev/null || true)"
+    PYTHON_BIN="$("${REPO_ROOT}/scripts/setup/resolve_python_311.sh" 2>/dev/null || command -v python3 2>/dev/null || command -v python 2>/dev/null || true)"
     CLEAN_PATH="/usr/bin:/bin:/usr/sbin:/sbin"
     if [[ -n "${NODE_BIN}" ]]; then
         NODE_DIR="$(cd "$(dirname "${NODE_BIN}")" && pwd)"
         CLEAN_PATH="${NODE_DIR}:${CLEAN_PATH}"
+    fi
+    if [[ -n "${PYTHON_BIN}" ]]; then
+        PYTHON_DIR="$(cd "$(dirname "${PYTHON_BIN}")" && pwd)"
+        CLEAN_PATH="${PYTHON_DIR}:${CLEAN_PATH}"
     fi
     REEXEC_ARGS=(--env-file "${ENV_FILE}")
     if [[ "${PREFLIGHT_ONLY}" == "1" ]]; then
@@ -85,13 +90,12 @@ cd "${REPO_ROOT}"
 
 [[ -f "${ENV_FILE}" ]] || die "missing managed provider env file: ${ENV_FILE}"
 [[ "${ENV_FILE}" != "${REPO_ROOT}"/* ]] || die "managed provider env file must live outside the repository"
-[[ -f ".venv/bin/activate" ]] || die "missing .venv/bin/activate; run make install-core before this gate"
-[[ -x ".venv/bin/python" ]] || die "missing .venv/bin/python; run make install-core before this gate"
 
-.venv/bin/python - "${ENV_FILE}" <<'PY'
+PYTHON_BIN="$("${REPO_ROOT}/scripts/setup/resolve_python_311.sh")"
+
+"${PYTHON_BIN}" - "${ENV_FILE}" <<'PY'
 from __future__ import annotations
 
-import os
 import stat
 import sys
 from pathlib import Path
@@ -120,7 +124,12 @@ else:
     raise SystemExit(1)
 PY
 
-source .venv/bin/activate
+if [[ -f ".venv/bin/activate" ]]; then
+    source .venv/bin/activate
+    PYTHON_BIN="$(command -v python)"
+elif [[ "${PREFLIGHT_ONLY}" != "1" ]]; then
+    die "missing .venv/bin/activate; run make install-core before this gate"
+fi
 ./scripts/setup/ensure_node_version.sh
 
 set -a
@@ -128,7 +137,7 @@ set -a
 . "${ENV_FILE}"
 set +a
 
-python - <<'PY'
+"${PYTHON_BIN}" - <<'PY'
 from __future__ import annotations
 
 import os

--- a/scripts/validation/run_managed_paid_pilot_gate.sh
+++ b/scripts/validation/run_managed_paid_pilot_gate.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+#
+# Run the managed-provider paid-pilot gate from a clean process.
+#
+# This intentionally does not create or populate the provider env file. Operators
+# must provide real staging values and disposable TP_TEST_* resources outside the
+# repository, usually at /tmp/tp-managed-staging.env.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+DEFAULT_ENV_FILE="/tmp/tp-managed-staging.env"
+
+ENV_FILE="${DEFAULT_ENV_FILE}"
+PREFLIGHT_ONLY=0
+CLEAN_PROCESS=0
+
+usage() {
+    cat <<'EOF'
+Usage: scripts/validation/run_managed_paid_pilot_gate.sh [options]
+
+Options:
+  --env-file PATH      Provider env file to source (default: /tmp/tp-managed-staging.env)
+  --preflight-only     Validate the clean env and stop before migrations/tests
+  -h, --help           Show this help
+
+The env file must be outside the repository, mode 0600 or stricter, and contain
+real provider-managed Postgres, Redis, frontdoor Redis, and S3-compatible values.
+EOF
+}
+
+die() {
+    printf 'ERROR: %s\n' "$*" >&2
+    exit 1
+}
+
+while (($#)); do
+    case "$1" in
+        --env-file)
+            shift
+            [[ $# -gt 0 ]] || die "--env-file requires a path"
+            ENV_FILE="$1"
+            ;;
+        --preflight-only)
+            PREFLIGHT_ONLY=1
+            ;;
+        --_clean-process)
+            CLEAN_PROCESS=1
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            die "unknown argument: $1"
+            ;;
+    esac
+    shift
+done
+
+if [[ "${CLEAN_PROCESS}" != "1" ]]; then
+    NODE_BIN="$(command -v node 2>/dev/null || true)"
+    CLEAN_PATH="/usr/bin:/bin:/usr/sbin:/sbin"
+    if [[ -n "${NODE_BIN}" ]]; then
+        NODE_DIR="$(cd "$(dirname "${NODE_BIN}")" && pwd)"
+        CLEAN_PATH="${NODE_DIR}:${CLEAN_PATH}"
+    fi
+    REEXEC_ARGS=(--env-file "${ENV_FILE}")
+    if [[ "${PREFLIGHT_ONLY}" == "1" ]]; then
+        REEXEC_ARGS+=(--preflight-only)
+    fi
+
+    exec env -i \
+        HOME="${HOME:-}" \
+        PATH="${CLEAN_PATH}" \
+        USER="${USER:-}" \
+        SHELL="/bin/zsh" \
+        /bin/bash "$0" \
+        --_clean-process \
+        "${REEXEC_ARGS[@]}"
+fi
+
+cd "${REPO_ROOT}"
+
+[[ -f "${ENV_FILE}" ]] || die "missing managed provider env file: ${ENV_FILE}"
+[[ "${ENV_FILE}" != "${REPO_ROOT}"/* ]] || die "managed provider env file must live outside the repository"
+[[ -f ".venv/bin/activate" ]] || die "missing .venv/bin/activate; run make install-core before this gate"
+[[ -x ".venv/bin/python" ]] || die "missing .venv/bin/python; run make install-core before this gate"
+
+.venv/bin/python - "${ENV_FILE}" <<'PY'
+from __future__ import annotations
+
+import os
+import stat
+import sys
+from pathlib import Path
+
+env_file = Path(sys.argv[1])
+try:
+    mode = stat.S_IMODE(env_file.stat().st_mode)
+except OSError as exc:
+    print(f"ERROR: cannot stat managed provider env file: {exc}", file=sys.stderr)
+    raise SystemExit(1)
+
+if mode & 0o077:
+    print(
+        f"ERROR: managed provider env file must be chmod 600 or stricter; observed {oct(mode)}",
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
+
+repo_root = Path.cwd().resolve()
+try:
+    env_file.resolve().relative_to(repo_root)
+except ValueError:
+    pass
+else:
+    print("ERROR: managed provider env file must live outside the repository", file=sys.stderr)
+    raise SystemExit(1)
+PY
+
+source .venv/bin/activate
+./scripts/setup/ensure_node_version.sh
+
+set -a
+# shellcheck disable=SC1090
+. "${ENV_FILE}"
+set +a
+
+python - <<'PY'
+from __future__ import annotations
+
+import os
+import sys
+
+required = {
+    "TP_ORCHESTRATOR_STATE_BACKEND",
+    "TP_DATABASE_URL",
+    "TP_TEST_POSTGRES_URL",
+    "TP_ORCHESTRATOR_QUEUE_BACKEND",
+    "TP_REDIS_URL",
+    "TP_TEST_REDIS_URL",
+    "TP_FRONTDOOR_SESSION_STORE",
+    "TP_FRONTDOOR_REDIS_URL",
+    "TP_ARTIFACT_STORE",
+    "TP_ARTIFACT_ENDPOINT_URL",
+    "TP_TEST_S3_URL",
+    "TP_ARTIFACT_BUCKET",
+    "TP_TEST_S3_BUCKET",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+}
+
+expected = {
+    "TP_ORCHESTRATOR_STATE_BACKEND": "postgres",
+    "TP_ORCHESTRATOR_QUEUE_BACKEND": "redis",
+    "TP_FRONTDOOR_SESSION_STORE": "redis",
+    "TP_ARTIFACT_STORE": "s3",
+}
+
+forbidden = {
+    "TP_API_KEY",
+    "TP_BACKEND_API_KEY",
+    "TP_BACKEND_ORIGIN",
+    "TP_FASTAPI_ORIGIN",
+    "TP_ALLOWED_ORIGINS",
+    "TP_ALLOW_LOCAL_ACCESS_BYPASS",
+    "TP_FRONTDOOR_SESSION_DB",
+    "TP_FRONTDOOR_SESSION_SCALING_MODE",
+    "TP_PORTAL_DIRECT_DEBUG_COHORT_KEY",
+    "TP_PORTAL_RUM_LOG_PATH",
+    "TP_PORTAL_EVENT_LOG_PATH",
+    "TP_LOG_HEALTHCHECKS",
+}
+forbidden_prefixes = ("TP_FASTVLM_", "TP_PORTAL_FASTVLM_", "TP_PORTAL_UPLOAD_")
+placeholder_tokens = ("<", "redacted", "replace-", "...")
+
+
+def placeholder_like(value: str) -> bool:
+    normalized = value.lower()
+    return any(token in normalized for token in placeholder_tokens)
+
+
+missing = sorted(name for name in required if not os.getenv(name, "").strip())
+placeholder = sorted(name for name in required if placeholder_like(os.getenv(name, "")))
+wrong = {name: os.getenv(name, "") for name, value in expected.items() if os.getenv(name) != value}
+leaked = sorted(name for name in os.environ if name in forbidden or name.startswith(forbidden_prefixes))
+unsafe_overlap: dict[str, str] = {}
+if os.getenv("TP_DATABASE_URL") and os.getenv("TP_DATABASE_URL") == os.getenv("TP_TEST_POSTGRES_URL"):
+    unsafe_overlap["TP_TEST_POSTGRES_URL"] = "must not equal TP_DATABASE_URL"
+if os.getenv("TP_ARTIFACT_BUCKET") and os.getenv("TP_ARTIFACT_BUCKET") == os.getenv("TP_TEST_S3_BUCKET"):
+    unsafe_overlap["TP_TEST_S3_BUCKET"] = "must not equal TP_ARTIFACT_BUCKET"
+
+print("missing:", missing)
+print("placeholder-like:", placeholder)
+print("wrong selectors:", wrong)
+print("leaked local-dev vars:", leaked)
+print("unsafe managed/test overlap:", unsafe_overlap)
+
+raise SystemExit(1 if missing or placeholder or wrong or leaked or unsafe_overlap else 0)
+PY
+
+if [[ "${PREFLIGHT_ONLY}" == "1" ]]; then
+    printf '%s\n' "Managed paid-pilot clean-env preflight passed."
+    exit 0
+fi
+
+make db-upgrade
+make test-paid-pilot-services-contract

--- a/tests/validation/test_managed_paid_pilot_gate_script.py
+++ b/tests/validation/test_managed_paid_pilot_gate_script.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "validation" / "run_managed_paid_pilot_gate.sh"
+
+
+def _write_env_file(path: Path, *, extra: str = "") -> Path:
+    path.write_text(
+        "\n".join(
+            [
+                "TP_ORCHESTRATOR_STATE_BACKEND=postgres",
+                "TP_DATABASE_URL=postgresql+asyncpg://staging_user:secret@staging-db.example.test:5432/tp_staging",
+                "TP_TEST_POSTGRES_URL=postgresql+asyncpg://test_user:secret@test-db.example.test:5432/tp_validation",
+                "TP_ORCHESTRATOR_QUEUE_BACKEND=redis",
+                "TP_REDIS_URL=rediss://queue.example.test:6380/0",
+                "TP_TEST_REDIS_URL=rediss://queue-validation.example.test:6380/0",
+                "TP_FRONTDOOR_SESSION_STORE=redis",
+                "TP_FRONTDOOR_REDIS_URL=rediss://sessions.example.test:6380/0",
+                "TP_ARTIFACT_STORE=s3",
+                "TP_ARTIFACT_ENDPOINT_URL=https://s3.example.test",
+                "TP_TEST_S3_URL=https://s3-validation.example.test",
+                "TP_ARTIFACT_BUCKET=tp-staging-artifacts",
+                "TP_TEST_S3_BUCKET=tp-validation-artifacts",
+                "TP_ARTIFACT_REGION=us-west-2",
+                "AWS_ACCESS_KEY_ID=AKIATESTVALUE",
+                "AWS_SECRET_ACCESS_KEY=test-secret-value",
+                extra,
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    path.chmod(0o600)
+    return path
+
+
+def _run_preflight(env_file: Path, *, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(SCRIPT_PATH), "--env-file", str(env_file), "--preflight-only"],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_managed_paid_pilot_preflight_runs_from_clean_env(tmp_path: Path) -> None:
+    env_file = _write_env_file(tmp_path / "managed.env")
+    contaminated_env = dict(os.environ)
+    contaminated_env.update(
+        {
+            "TP_API_KEY": "local-dev-secret",
+            "TP_ALLOW_LOCAL_ACCESS_BYPASS": "1",
+            "TP_PORTAL_UPLOAD_ROOT": "/tmp/local-upload-root",
+        }
+    )
+
+    result = _run_preflight(env_file, env=contaminated_env)
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "missing: []" in result.stdout
+    assert "placeholder-like: []" in result.stdout
+    assert "wrong selectors: {}" in result.stdout
+    assert "leaked local-dev vars: []" in result.stdout
+    assert "unsafe managed/test overlap: {}" in result.stdout
+    assert "Managed paid-pilot clean-env preflight passed." in result.stdout
+
+
+def test_managed_paid_pilot_preflight_rejects_local_dev_vars_in_env_file(tmp_path: Path) -> None:
+    env_file = _write_env_file(
+        tmp_path / "managed.env",
+        extra="TP_ALLOW_LOCAL_ACCESS_BYPASS=1",
+    )
+
+    result = _run_preflight(env_file)
+
+    assert result.returncode == 1
+    assert "leaked local-dev vars: ['TP_ALLOW_LOCAL_ACCESS_BYPASS']" in result.stdout
+
+
+def test_managed_paid_pilot_preflight_rejects_unsafe_secret_file_mode(tmp_path: Path) -> None:
+    env_file = _write_env_file(tmp_path / "managed.env")
+    env_file.chmod(0o644)
+
+    result = _run_preflight(env_file)
+
+    assert result.returncode == 1
+    assert "managed provider env file must be chmod 600 or stricter" in result.stderr
+
+
+def test_managed_paid_pilot_preflight_rejects_staging_test_overlap(tmp_path: Path) -> None:
+    env_file = _write_env_file(
+        tmp_path / "managed.env",
+        extra="TP_TEST_S3_BUCKET=tp-staging-artifacts",
+    )
+
+    result = _run_preflight(env_file)
+
+    assert result.returncode == 1
+    assert "'TP_TEST_S3_BUCKET': 'must not equal TP_ARTIFACT_BUCKET'" in result.stdout

--- a/tests/validation/test_managed_paid_pilot_gate_script.py
+++ b/tests/validation/test_managed_paid_pilot_gate_script.py
@@ -106,6 +106,13 @@ def test_managed_paid_pilot_preflight_rejects_unsafe_secret_file_mode(tmp_path: 
     assert "managed provider env file must be chmod 600 or stricter" in result.stderr
 
 
+def test_managed_paid_pilot_clean_reexec_uses_portable_bash_shell() -> None:
+    script = SCRIPT_PATH.read_text(encoding="utf-8")
+
+    assert 'SHELL="/bin/bash"' in script
+    assert 'SHELL="/bin/zsh"' not in script
+
+
 def test_managed_paid_pilot_preflight_rejects_staging_test_overlap(tmp_path: Path) -> None:
     env_file = _write_env_file(
         tmp_path / "managed.env",

--- a/tests/validation/test_managed_paid_pilot_gate_script.py
+++ b/tests/validation/test_managed_paid_pilot_gate_script.py
@@ -43,10 +43,19 @@ def _write_env_file(path: Path, *, extra: str = "") -> Path:
 
 
 def _run_preflight(env_file: Path, *, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    fake_bin = env_file.parent / "fake-bin"
+    fake_bin.mkdir(exist_ok=True)
+    fake_node = fake_bin / "node"
+    fake_node.write_text("#!/bin/sh\nprintf '%s\\n' 'v22.22.2'\n", encoding="utf-8")
+    fake_node.chmod(0o755)
+
+    run_env = dict(os.environ) if env is None else dict(env)
+    run_env["PATH"] = f"{fake_bin}{os.pathsep}{run_env.get('PATH', '')}"
+
     return subprocess.run(
         ["bash", str(SCRIPT_PATH), "--env-file", str(env_file), "--preflight-only"],
         cwd=REPO_ROOT,
-        env=env,
+        env=run_env,
         text=True,
         capture_output=True,
         check=False,
@@ -107,3 +116,36 @@ def test_managed_paid_pilot_preflight_rejects_staging_test_overlap(tmp_path: Pat
 
     assert result.returncode == 1
     assert "'TP_TEST_S3_BUCKET': 'must not equal TP_ARTIFACT_BUCKET'" in result.stdout
+
+
+def test_managed_paid_pilot_preflight_rejects_optional_placeholder_region(tmp_path: Path) -> None:
+    env_file = _write_env_file(
+        tmp_path / "managed.env",
+        extra="TP_ARTIFACT_REGION='<region>'",
+    )
+
+    result = _run_preflight(env_file)
+
+    assert result.returncode == 1
+    assert "placeholder-like:" in result.stdout
+    assert "TP_ARTIFACT_REGION" in result.stdout
+
+
+def test_managed_paid_pilot_preflight_rejects_same_postgres_database_with_different_credentials(
+    tmp_path: Path,
+) -> None:
+    env_file = _write_env_file(
+        tmp_path / "managed.env",
+        extra="\n".join(
+            [
+                "TP_DATABASE_URL=postgresql+asyncpg://staging_user:secret@db.example.test:5432/tp",
+                "TP_TEST_POSTGRES_URL=postgresql+asyncpg://test_user:secret@db.example.test:5432/tp",
+            ]
+        ),
+    )
+
+    result = _run_preflight(env_file)
+
+    assert result.returncode == 1
+    assert "TP_TEST_POSTGRES_URL" in result.stdout
+    assert "same Postgres host/port/database" in result.stdout


### PR DESCRIPTION
## Summary
- Local all-on shell contamination made the managed-provider paid-pilot gate unsafe to run directly.
- Add a clean `env -i` launcher that fails before touching provider services unless a private env file contains real staging selectors and disposable validation resources.

## Changes
- Add `scripts/validation/run_managed_paid_pilot_gate.sh` to re-exec in a clean process, enforce private env-file placement and permissions, verify Node 22, reject placeholders/local-dev variables, reject unsafe staging/test overlap, then run `make db-upgrade` and `make test-paid-pilot-services-contract`.
- Add `make run-managed-paid-pilot-gate` with `TP_MANAGED_PAID_PILOT_ENV_FILE` and `MANAGED_PAID_PILOT_GATE_ARGS=--preflight-only`.
- Update `AGENTS.md`, the managed staging runbook, and the paid-pilot smoke-gate docs to route provider validation through the clean launcher.
- Add focused tests for clean-env re-exec, env-file permission failures, local-dev leakage rejection, and unsafe S3 bucket overlap rejection.

## Validation
Proven green:
- `./scripts/validation/run_managed_paid_pilot_gate.sh --help`
- `.venv/bin/pytest -q tests/validation/test_managed_paid_pilot_gate_script.py`
- `make -n run-managed-paid-pilot-gate MANAGED_PAID_PILOT_GATE_ARGS=--preflight-only`
- `make check-doc-heading-links`
- `make check-python-headers`
- `git diff --cached --check`
- `bash -n scripts/validation/run_managed_paid_pilot_gate.sh`
- `make help`
- Commit-time pre-commit hooks passed.

Still failing:
- None observed. The provider-backed gate itself was not run because real provider secrets and disposable `TP_TEST_*` resources are not available in this local session.

## Risk
- Bounded to a new operator launcher, Make target, docs, and focused tests; no app route, API envelope, selector, auth runtime, or browser-smoke contract changes.
- Revert-safe: removing the launcher and Make/docs references restores the previous manual paid-pilot gate path.
- The launcher intentionally fails closed before external service mutation unless clean env preflight passes.