### PR TITLE
test(depth): branch-ratchet depth/tools.py from ~85% to ~94%

### DIFF
--- a/tests/unit/depth/test_tools_batch_driver.py
+++ b/tests/unit/depth/test_tools_batch_driver.py
@@ -288,3 +288,309 @@ def test_main_preserves_legacy_fallof_alias(tmp_path, monkeypatch: pytest.Monkey
 
     assert exit_code == 0
     assert captured["opts"].falloff == 2.5
+
+
+def _build_depth_and_image(images: Path, depths: Path, base: str = "villa") -> Path:
+    _write_rgb(images / f"{base}_enh.png")
+    depth_path = depths / f"{base}_depth16.png"
+    _write_depth(depth_path)
+    return depth_path
+
+
+def test_process_single_runs_clarity_mode(tmp_path) -> None:
+    # Covers the clarity branch (lines 820-831) end-to-end through the batch
+    # driver — previously only the haze mode was exercised at this layer.
+    images = tmp_path / "images"
+    depths = tmp_path / "depths"
+    output = tmp_path / "out"
+    images.mkdir()
+    depths.mkdir()
+    output.mkdir()
+    depth_path = _build_depth_and_image(images, depths)
+    opts = tools.BatchOptions(
+        images_root=str(images),
+        depths_root=str(depths),
+        out_root=str(output),
+        mode="clarity",
+    )
+
+    base, out_path, error = tools._process_single(str(depth_path), opts)
+
+    assert base == "villa"
+    assert error is None
+    assert out_path is not None and Path(out_path).exists()
+
+
+def test_process_single_runs_do_mode(tmp_path) -> None:
+    # Covers the `do` (depth-of-field) branch (lines 832-846).
+    images = tmp_path / "images"
+    depths = tmp_path / "depths"
+    output = tmp_path / "out"
+    images.mkdir()
+    depths.mkdir()
+    output.mkdir()
+    depth_path = _build_depth_and_image(images, depths)
+    opts = tools.BatchOptions(
+        images_root=str(images),
+        depths_root=str(depths),
+        out_root=str(output),
+        mode="do",
+        quality="fast",
+    )
+
+    base, out_path, error = tools._process_single(str(depth_path), opts)
+
+    assert base == "villa"
+    assert error is None
+    assert out_path is not None and Path(out_path).exists()
+
+
+def test_process_single_rejects_unknown_mode(tmp_path) -> None:
+    # Unknown mode raises (line 847-848); the surrounding try/except converts
+    # it into an error tuple instead of propagating.
+    images = tmp_path / "images"
+    depths = tmp_path / "depths"
+    images.mkdir()
+    depths.mkdir()
+    depth_path = _build_depth_and_image(images, depths)
+    opts = tools.BatchOptions(
+        images_root=str(images),
+        depths_root=str(depths),
+        out_root=str(tmp_path / "out"),
+        mode="nonsense",
+    )
+
+    base, out_path, error = tools._process_single(str(depth_path), opts)
+
+    assert base == "villa"
+    assert out_path is None
+    assert error is not None and "nonsense" in error
+
+
+def test_process_single_uses_provided_mask_root(tmp_path) -> None:
+    # Drive the sky_path / building_path discovery branches inside
+    # _process_single (lines 798-805) so the mask-loaded code path is hit.
+    images = tmp_path / "images"
+    depths = tmp_path / "depths"
+    masks = tmp_path / "masks"
+    output = tmp_path / "out"
+    for d in (images, depths, masks, output):
+        d.mkdir()
+    depth_path = _build_depth_and_image(images, depths)
+    Image.fromarray(np.full((8, 8), 255, dtype=np.uint8), mode="L").save(
+        masks / "villa_mask_sky.png"
+    )
+    Image.fromarray(np.full((8, 8), 128, dtype=np.uint8), mode="L").save(
+        masks / "villa_mask_building.png"
+    )
+
+    opts = tools.BatchOptions(
+        images_root=str(images),
+        depths_root=str(depths),
+        out_root=str(output),
+        mask_root=str(masks),
+        mode="haze",
+    )
+
+    base, out_path, error = tools._process_single(str(depth_path), opts)
+
+    assert base == "villa"
+    assert error is None
+    assert out_path is not None and Path(out_path).exists()
+
+
+def test_process_batch_logs_error_summary_when_failures_occur(
+    tmp_path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Covers the error-summary block (lines 910-920) that fires only when at
+    # least one file fails.
+    depths = tmp_path / "depths"
+    depths.mkdir()
+    _write_depth(depths / "bad_depth16.png")
+
+    def fake_process_single(dp: str, opts: tools.BatchOptions):
+        return "bad", None, "synthetic failure"
+
+    monkeypatch.setattr(tools, "_process_single", fake_process_single)
+    caplog.set_level("ERROR", logger="depth_tools")
+    opts = tools.BatchOptions(
+        images_root=str(tmp_path / "images"),
+        depths_root=str(depths),
+        out_root=str(tmp_path / "out"),
+        workers=1,
+    )
+
+    errors = tools.process_batch(opts)
+
+    assert errors == 1
+    summary_records = [r for r in caplog.records if "ERROR SUMMARY" in r.message]
+    assert summary_records, "expected ERROR SUMMARY block in logs"
+
+
+def test_cli_progress_prints_progress_and_newline_on_complete(capsys) -> None:
+    # Covers _cli_progress (lines 1013-1016) — both the mid-stream carriage
+    # return and the final newline branch.
+    tools._cli_progress(1, 3, "villa")
+    tools._cli_progress(3, 3, "villa")
+
+    captured = capsys.readouterr().out
+    assert "Processed 1/3: villa" in captured
+    assert captured.endswith("\n")
+
+
+def test_main_verbose_flag_enables_debug_logging(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Covers the verbose==True branch (lines 1023-1024).
+    depths = tmp_path / "depths"
+    images = tmp_path / "images"
+    depths.mkdir()
+    images.mkdir()
+    _write_depth(depths / "villa_depth16.png")
+
+    original_level = tools._log.level
+    try:
+        monkeypatch.setattr(tools, "process_batch", lambda opts, progress=None: 0)
+        exit_code = tools.main(
+            [
+                "haze",
+                str(images),
+                str(depths),
+                str(tmp_path / "out"),
+                "--workers",
+                "1",
+                "--verbose",
+            ]
+        )
+        assert exit_code == 0
+        assert tools._log.level == 10  # logging.DEBUG
+    finally:
+        tools._log.setLevel(original_level)
+
+
+def test_main_returns_two_on_fatal_exception(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Covers the fatal-exception catch (lines 1104-1106): exit code 2 on
+    # unexpected error from process_batch.
+    depths = tmp_path / "depths"
+    images = tmp_path / "images"
+    depths.mkdir()
+    images.mkdir()
+    _write_depth(depths / "villa_depth16.png")
+
+    def boom(opts, progress=None):
+        raise RuntimeError("unexpected backend explosion")
+
+    monkeypatch.setattr(tools, "process_batch", boom)
+
+    exit_code = tools.main(
+        [
+            "haze",
+            str(images),
+            str(depths),
+            str(tmp_path / "out"),
+            "--workers",
+            "1",
+        ]
+    )
+
+    assert exit_code == 2
+
+
+def test_main_maps_haze_cli_options_to_batch_options(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Covers the haze-specific option-mapping branch (lines 1057-1062),
+    # currently only the `do` branch is tested.
+    captured: dict[str, tools.BatchOptions] = {}
+    depths = tmp_path / "depths"
+    images = tmp_path / "images"
+    output = tmp_path / "out"
+    depths.mkdir()
+    images.mkdir()
+    _write_depth(depths / "villa_depth16.png")
+
+    def fake_process_batch(opts: tools.BatchOptions, progress=None) -> int:
+        captured["opts"] = opts
+        return 0
+
+    monkeypatch.setattr(tools, "process_batch", fake_process_batch)
+
+    exit_code = tools.main(
+        [
+            "haze",
+            str(images),
+            str(depths),
+            str(output),
+            "--workers",
+            "1",
+            "--strength",
+            "0.42",
+            "--near",
+            "10",
+            "--far",
+            "90",
+            "--mids-gain",
+            "1.10",
+            "--haze-color",
+            "0.5",
+            "0.6",
+            "0.7",
+        ]
+    )
+
+    opts = captured["opts"]
+    assert exit_code == 0
+    assert opts.mode == "haze"
+    assert opts.strength == pytest.approx(0.42)
+    assert opts.near == pytest.approx(10.0)
+    assert opts.far == pytest.approx(90.0)
+    assert opts.mids_gain == pytest.approx(1.10)
+    assert opts.haze_color == pytest.approx((0.5, 0.6, 0.7))
+
+
+def test_main_maps_clarity_cli_options_to_batch_options(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Covers the clarity-specific option-mapping branch (lines 1063-1067).
+    captured: dict[str, tools.BatchOptions] = {}
+    depths = tmp_path / "depths"
+    images = tmp_path / "images"
+    output = tmp_path / "out"
+    depths.mkdir()
+    images.mkdir()
+    _write_depth(depths / "villa_depth16.png")
+
+    def fake_process_batch(opts: tools.BatchOptions, progress=None) -> int:
+        captured["opts"] = opts
+        return 0
+
+    monkeypatch.setattr(tools, "process_batch", fake_process_batch)
+
+    exit_code = tools.main(
+        [
+            "clarity",
+            str(images),
+            str(depths),
+            str(output),
+            "--workers",
+            "1",
+            "--amount",
+            "0.33",
+            "--radius",
+            "5",
+            "--near",
+            "25",
+            "--far",
+            "75",
+        ]
+    )
+
+    opts = captured["opts"]
+    assert exit_code == 0
+    assert opts.mode == "clarity"
+    assert opts.amount == pytest.approx(0.33)
+    assert opts.radius == 5
+    assert opts.near == pytest.approx(25.0)
+    assert opts.far == pytest.approx(75.0)

--- a/tests/unit/depth/test_tools_batch_driver.py
+++ b/tests/unit/depth/test_tools_batch_driver.py
@@ -377,12 +377,8 @@ def test_process_single_uses_provided_mask_root(tmp_path) -> None:
     for d in (images, depths, masks, output):
         d.mkdir()
     depth_path = _build_depth_and_image(images, depths)
-    Image.fromarray(np.full((8, 8), 255, dtype=np.uint8), mode="L").save(
-        masks / "villa_mask_sky.png"
-    )
-    Image.fromarray(np.full((8, 8), 128, dtype=np.uint8), mode="L").save(
-        masks / "villa_mask_building.png"
-    )
+    Image.fromarray(np.full((8, 8), 255, dtype=np.uint8), mode="L").save(masks / "villa_mask_sky.png")
+    Image.fromarray(np.full((8, 8), 128, dtype=np.uint8), mode="L").save(masks / "villa_mask_building.png")
 
     opts = tools.BatchOptions(
         images_root=str(images),
@@ -438,9 +434,7 @@ def test_cli_progress_prints_progress_and_newline_on_complete(capsys) -> None:
     assert captured.endswith("\n")
 
 
-def test_main_verbose_flag_enables_debug_logging(
-    tmp_path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_main_verbose_flag_enables_debug_logging(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     # Covers the verbose==True branch (lines 1023-1024).
     depths = tmp_path / "depths"
     images = tmp_path / "images"
@@ -468,9 +462,7 @@ def test_main_verbose_flag_enables_debug_logging(
         tools._log.setLevel(original_level)
 
 
-def test_main_returns_two_on_fatal_exception(
-    tmp_path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_main_returns_two_on_fatal_exception(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     # Covers the fatal-exception catch (lines 1104-1106): exit code 2 on
     # unexpected error from process_batch.
     depths = tmp_path / "depths"
@@ -498,9 +490,7 @@ def test_main_returns_two_on_fatal_exception(
     assert exit_code == 2
 
 
-def test_main_maps_haze_cli_options_to_batch_options(
-    tmp_path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_main_maps_haze_cli_options_to_batch_options(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     # Covers the haze-specific option-mapping branch (lines 1057-1062),
     # currently only the `do` branch is tested.
     captured: dict[str, tools.BatchOptions] = {}
@@ -550,9 +540,7 @@ def test_main_maps_haze_cli_options_to_batch_options(
     assert opts.haze_color == pytest.approx((0.5, 0.6, 0.7))
 
 
-def test_main_maps_clarity_cli_options_to_batch_options(
-    tmp_path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_main_maps_clarity_cli_options_to_batch_options(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     # Covers the clarity-specific option-mapping branch (lines 1063-1067).
     captured: dict[str, tools.BatchOptions] = {}
     depths = tmp_path / "depths"

--- a/tests/unit/depth/test_tools_batch_driver.py
+++ b/tests/unit/depth/test_tools_batch_driver.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import numpy as np
@@ -298,8 +299,8 @@ def _build_depth_and_image(images: Path, depths: Path, base: str = "villa") -> P
 
 
 def test_process_single_runs_clarity_mode(tmp_path) -> None:
-    # Covers the clarity branch (lines 820-831) end-to-end through the batch
-    # driver — previously only the haze mode was exercised at this layer.
+    # Covers the clarity branch end-to-end through the batch driver; previously
+    # only the haze mode was exercised at this layer.
     images = tmp_path / "images"
     depths = tmp_path / "depths"
     output = tmp_path / "out"
@@ -322,7 +323,7 @@ def test_process_single_runs_clarity_mode(tmp_path) -> None:
 
 
 def test_process_single_runs_do_mode(tmp_path) -> None:
-    # Covers the `do` (depth-of-field) branch (lines 832-846).
+    # Covers the `do` (depth-of-field) branch.
     images = tmp_path / "images"
     depths = tmp_path / "depths"
     output = tmp_path / "out"
@@ -346,8 +347,8 @@ def test_process_single_runs_do_mode(tmp_path) -> None:
 
 
 def test_process_single_rejects_unknown_mode(tmp_path) -> None:
-    # Unknown mode raises (line 847-848); the surrounding try/except converts
-    # it into an error tuple instead of propagating.
+    # Unknown mode raises; the surrounding try/except converts it into an error
+    # tuple instead of propagating.
     images = tmp_path / "images"
     depths = tmp_path / "depths"
     images.mkdir()
@@ -369,7 +370,7 @@ def test_process_single_rejects_unknown_mode(tmp_path) -> None:
 
 def test_process_single_uses_provided_mask_root(tmp_path) -> None:
     # Drive the sky_path / building_path discovery branches inside
-    # _process_single (lines 798-805) so the mask-loaded code path is hit.
+    # _process_single so the mask-loaded code path is hit.
     images = tmp_path / "images"
     depths = tmp_path / "depths"
     masks = tmp_path / "masks"
@@ -398,8 +399,8 @@ def test_process_single_uses_provided_mask_root(tmp_path) -> None:
 def test_process_batch_logs_error_summary_when_failures_occur(
     tmp_path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
-    # Covers the error-summary block (lines 910-920) that fires only when at
-    # least one file fails.
+    # Covers the error-summary block that fires only when at least one file
+    # fails.
     depths = tmp_path / "depths"
     depths.mkdir()
     _write_depth(depths / "bad_depth16.png")
@@ -424,8 +425,8 @@ def test_process_batch_logs_error_summary_when_failures_occur(
 
 
 def test_cli_progress_prints_progress_and_newline_on_complete(capsys) -> None:
-    # Covers _cli_progress (lines 1013-1016) — both the mid-stream carriage
-    # return and the final newline branch.
+    # Covers _cli_progress for both the mid-stream carriage return and the
+    # final newline branch.
     tools._cli_progress(1, 3, "villa")
     tools._cli_progress(3, 3, "villa")
 
@@ -435,7 +436,7 @@ def test_cli_progress_prints_progress_and_newline_on_complete(capsys) -> None:
 
 
 def test_main_verbose_flag_enables_debug_logging(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
-    # Covers the verbose==True branch (lines 1023-1024).
+    # Covers the verbose==True logging branch.
     depths = tmp_path / "depths"
     images = tmp_path / "images"
     depths.mkdir()
@@ -457,14 +458,14 @@ def test_main_verbose_flag_enables_debug_logging(tmp_path, monkeypatch: pytest.M
             ]
         )
         assert exit_code == 0
-        assert tools._log.level == 10  # logging.DEBUG
+        assert tools._log.level == logging.DEBUG
     finally:
         tools._log.setLevel(original_level)
 
 
 def test_main_returns_two_on_fatal_exception(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
-    # Covers the fatal-exception catch (lines 1104-1106): exit code 2 on
-    # unexpected error from process_batch.
+    # Covers the fatal-exception catch: exit code 2 on unexpected error from
+    # process_batch.
     depths = tmp_path / "depths"
     images = tmp_path / "images"
     depths.mkdir()
@@ -491,8 +492,8 @@ def test_main_returns_two_on_fatal_exception(tmp_path, monkeypatch: pytest.Monke
 
 
 def test_main_maps_haze_cli_options_to_batch_options(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
-    # Covers the haze-specific option-mapping branch (lines 1057-1062),
-    # currently only the `do` branch is tested.
+    # Covers the haze-specific option-mapping branch; currently only the `do`
+    # branch is tested.
     captured: dict[str, tools.BatchOptions] = {}
     depths = tmp_path / "depths"
     images = tmp_path / "images"
@@ -541,7 +542,7 @@ def test_main_maps_haze_cli_options_to_batch_options(tmp_path, monkeypatch: pyte
 
 
 def test_main_maps_clarity_cli_options_to_batch_options(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
-    # Covers the clarity-specific option-mapping branch (lines 1063-1067).
+    # Covers the clarity-specific option-mapping branch.
     captured: dict[str, tools.BatchOptions] = {}
     depths = tmp_path / "depths"
     images = tmp_path / "images"

--- a/tests/unit/depth/test_tools_cache_retry.py
+++ b/tests/unit/depth/test_tools_cache_retry.py
@@ -95,3 +95,26 @@ def test_retry_on_io_error_reraises_after_max_attempts(monkeypatch: pytest.Monke
 
     with pytest.raises(OSError, match="disk still unavailable"):
         always_fails()
+
+
+def test_retry_on_io_error_raises_runtime_error_when_loop_never_executes() -> None:
+    # max_attempts=0 makes range(1, 1) empty; the defensive RuntimeError
+    # fallback path (lines 244-246) must fire instead of returning None.
+    @tools.retry_on_io_error(max_attempts=0)
+    def never_runs() -> str:
+        return "unreachable"
+
+    with pytest.raises(RuntimeError, match="Retry wrapper failed without exception"):
+        never_runs()
+
+
+def test_format_cache_stats_emits_debug_log(caplog: pytest.LogCaptureFixture) -> None:
+    cache = tools.BoundedCache(maxsize=4)
+    cache.put("k", np.ones((1, 1), dtype=np.float32))
+    cache.get("k")
+    cache.get("missing")
+
+    caplog.set_level("DEBUG", logger="depth_tools")
+    tools._format_cache_stats("UnitProbe", cache.stats())
+
+    assert any("UnitProbe cache:" in record.message for record in caplog.records)

--- a/tests/unit/depth/test_tools_cache_retry.py
+++ b/tests/unit/depth/test_tools_cache_retry.py
@@ -99,7 +99,7 @@ def test_retry_on_io_error_reraises_after_max_attempts(monkeypatch: pytest.Monke
 
 def test_retry_on_io_error_raises_runtime_error_when_loop_never_executes() -> None:
     # max_attempts=0 makes range(1, 1) empty; the defensive RuntimeError
-    # fallback path (lines 244-246) must fire instead of returning None.
+    # fallback path must fire instead of returning None.
     @tools.retry_on_io_error(max_attempts=0)
     def never_runs() -> str:
         return "unreachable"

--- a/tests/unit/depth/test_tools_depth_and_masks.py
+++ b/tests/unit/depth/test_tools_depth_and_masks.py
@@ -124,3 +124,33 @@ def test_load_mask_returns_cached_copy(tmp_path) -> None:
 
     assert cached[0, 0] == 1.0
     assert tools._mask_cache.stats()["hits"] == 1
+
+
+def test_load_mask_accepts_uniform_rgb_without_warning(
+    tmp_path, caplog: pytest.LogCaptureFixture
+) -> None:
+    # When all three channels match, the "differing channels" debug log
+    # branch (lines 532-535) must NOT fire — the silent uniform-RGB path
+    # at line 538 should win.
+    mask_path = tmp_path / "villa_mask_building.png"
+    rgb = np.full((8, 8, 3), 200, dtype=np.uint8)
+    Image.fromarray(rgb, mode="RGB").save(mask_path)
+
+    caplog.set_level("DEBUG", logger="depth_tools")
+    mask = tools.load_mask(str(mask_path), "building", (8, 8), use_cache=False)
+
+    assert mask.shape == (8, 8)
+    assert mask.mean() == pytest.approx(200.0 / 255.0, abs=0.01)
+    assert not any("differing channels" in record.message for record in caplog.records)
+
+
+def test_load_mask_converts_palette_mode_to_grayscale(tmp_path) -> None:
+    # 'P' (palette) mode is none of L/RGBA/RGB, so the else-branch
+    # convert("L") on line 538 must run.
+    mask_path = tmp_path / "villa_mask_sky.png"
+    Image.fromarray(np.full((8, 8), 7, dtype=np.uint8), mode="P").save(mask_path)
+
+    mask = tools.load_mask(str(mask_path), "sky", (4, 4), use_cache=False)
+
+    assert mask.shape == (4, 4)
+    assert 0.0 <= float(mask.min()) <= float(mask.max()) <= 1.0

--- a/tests/unit/depth/test_tools_depth_and_masks.py
+++ b/tests/unit/depth/test_tools_depth_and_masks.py
@@ -128,8 +128,7 @@ def test_load_mask_returns_cached_copy(tmp_path) -> None:
 
 def test_load_mask_accepts_uniform_rgb_without_warning(tmp_path, caplog: pytest.LogCaptureFixture) -> None:
     # When all three channels match, the "differing channels" debug log
-    # branch (lines 532-535) must NOT fire — the silent uniform-RGB path
-    # at line 538 should win.
+    # branch must NOT fire; the silent uniform-RGB path should win.
     mask_path = tmp_path / "villa_mask_building.png"
     rgb = np.full((8, 8, 3), 200, dtype=np.uint8)
     Image.fromarray(rgb, mode="RGB").save(mask_path)
@@ -144,9 +143,9 @@ def test_load_mask_accepts_uniform_rgb_without_warning(tmp_path, caplog: pytest.
 
 def test_load_mask_converts_palette_mode_to_grayscale(tmp_path) -> None:
     # 'P' (palette) mode is none of L/RGBA/RGB, so the else-branch
-    # convert("L") on line 538 must run. Build via L.convert("P") so the
-    # saved PNG carries the default 256-entry palette on every Pillow
-    # version (raw mode="P" without a palette is flaky on save).
+    # convert("L") must run. Build via L.convert("P") so the saved PNG carries
+    # the default 256-entry palette on every Pillow version (raw mode="P"
+    # without a palette is flaky on save).
     mask_path = tmp_path / "villa_mask_sky.png"
     Image.fromarray(np.full((8, 8), 7, dtype=np.uint8), mode="L").convert("P").save(mask_path)
 

--- a/tests/unit/depth/test_tools_depth_and_masks.py
+++ b/tests/unit/depth/test_tools_depth_and_masks.py
@@ -126,9 +126,7 @@ def test_load_mask_returns_cached_copy(tmp_path) -> None:
     assert tools._mask_cache.stats()["hits"] == 1
 
 
-def test_load_mask_accepts_uniform_rgb_without_warning(
-    tmp_path, caplog: pytest.LogCaptureFixture
-) -> None:
+def test_load_mask_accepts_uniform_rgb_without_warning(tmp_path, caplog: pytest.LogCaptureFixture) -> None:
     # When all three channels match, the "differing channels" debug log
     # branch (lines 532-535) must NOT fire — the silent uniform-RGB path
     # at line 538 should win.

--- a/tests/unit/depth/test_tools_depth_and_masks.py
+++ b/tests/unit/depth/test_tools_depth_and_masks.py
@@ -144,9 +144,11 @@ def test_load_mask_accepts_uniform_rgb_without_warning(tmp_path, caplog: pytest.
 
 def test_load_mask_converts_palette_mode_to_grayscale(tmp_path) -> None:
     # 'P' (palette) mode is none of L/RGBA/RGB, so the else-branch
-    # convert("L") on line 538 must run.
+    # convert("L") on line 538 must run. Build via L.convert("P") so the
+    # saved PNG carries the default 256-entry palette on every Pillow
+    # version (raw mode="P" without a palette is flaky on save).
     mask_path = tmp_path / "villa_mask_sky.png"
-    Image.fromarray(np.full((8, 8), 7, dtype=np.uint8), mode="P").save(mask_path)
+    Image.fromarray(np.full((8, 8), 7, dtype=np.uint8), mode="L").convert("P").save(mask_path)
 
     mask = tools.load_mask(str(mask_path), "sky", (4, 4), use_cache=False)
 

--- a/tests/unit/depth/test_tools_discovery.py
+++ b/tests/unit/depth/test_tools_discovery.py
@@ -74,8 +74,8 @@ def test_find_mask_for_base_returns_none_without_mask_root() -> None:
 
 def test_find_file_for_base_falls_through_to_no_tag_score(tmp_path) -> None:
     # Candidate matches by extension but contains none of PRIORITY_TAGS;
-    # the score function must return its 9999999 fallback (line 400) and
-    # still produce a result rather than silently dropping the file.
+    # the score function must return its large fallback and still produce a
+    # result rather than silently dropping the file.
     target = tmp_path / "villa_plain.png"
     target.write_text("fixture", encoding="utf-8")
 
@@ -86,7 +86,7 @@ def test_find_file_for_base_falls_through_to_no_tag_score(tmp_path) -> None:
 
 def test_find_mask_for_base_iterates_exact_extension_list(tmp_path) -> None:
     # Place a non-PNG exact-extension match alongside the generic glob so the
-    # explicit ext loop (lines 411-415) wins over the fallback (line 417).
+    # explicit extension loop wins over the fallback glob.
     exact = tmp_path / "villa_mask_sky.tif"
     distractor = tmp_path / "villa_mask_sky.xyz"
     exact.write_text("fixture", encoding="utf-8")

--- a/tests/unit/depth/test_tools_discovery.py
+++ b/tests/unit/depth/test_tools_discovery.py
@@ -70,3 +70,26 @@ def test_find_mask_for_base_falls_back_to_generic_extension(tmp_path) -> None:
 
 def test_find_mask_for_base_returns_none_without_mask_root() -> None:
     assert tools.find_mask_for_base(None, "villa", "sky") is None
+
+
+def test_find_file_for_base_falls_through_to_no_tag_score(tmp_path) -> None:
+    # Candidate matches by extension but contains none of PRIORITY_TAGS;
+    # the score function must return its 9999999 fallback (line 400) and
+    # still produce a result rather than silently dropping the file.
+    target = tmp_path / "villa_plain.png"
+    target.write_text("fixture", encoding="utf-8")
+
+    match = tools.find_file_for_base(str(tmp_path), "villa")
+
+    assert match == str(target)
+
+
+def test_find_mask_for_base_iterates_exact_extension_list(tmp_path) -> None:
+    # Place a non-PNG exact-extension match alongside the generic glob so the
+    # explicit ext loop (lines 411-415) wins over the fallback (line 417).
+    exact = tmp_path / "villa_mask_sky.tif"
+    distractor = tmp_path / "villa_mask_sky.xyz"
+    exact.write_text("fixture", encoding="utf-8")
+    distractor.write_text("fixture", encoding="utf-8")
+
+    assert tools.find_mask_for_base(str(tmp_path), "villa", "sky") == str(exact)

--- a/tests/unit/depth/test_tools_effects.py
+++ b/tests/unit/depth/test_tools_effects.py
@@ -223,6 +223,7 @@ def test_gaussian_blur_float_cv2_backend_returns_normalized_output(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     # Exercise the cv2 backend branch (lines 306-319) via explicit selection.
+    pytest.importorskip("cv2")
     monkeypatch.setattr(tools, "_CV2_AVAILABLE", True)
     img = _image()
 
@@ -279,6 +280,7 @@ def test_bilateral_blur_float_cv2_path_handles_rgb_and_2d(
 ) -> None:
     # Exercise the per-channel loop (lines 358-362) AND the 2D branch
     # (lines 355-357). cv2 must be available for both.
+    pytest.importorskip("cv2")
     monkeypatch.setattr(tools, "_CV2_AVAILABLE", True)
 
     rgb_out = tools.bilateral_blur_float(_image(), _depth(), sigma_spatial=1.5)

--- a/tests/unit/depth/test_tools_effects.py
+++ b/tests/unit/depth/test_tools_effects.py
@@ -145,8 +145,8 @@ def test_apply_depth_dof_balanced_quality_skips_bilateral_for_low_complexity(
 def test_apply_depth_dof_balanced_quality_boosts_bilateral_for_high_complexity(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # Covers the high-complexity else branch (line 711): bilateral_sigma_depth
-    # must be scaled rather than skipped.
+    # Covers the high-complexity adaptive branch where bilateral_sigma_depth
+    # is scaled rather than skipped.
     seen_sigmas: list[float] = []
 
     monkeypatch.setattr(tools, "_CV2_AVAILABLE", True)
@@ -174,17 +174,26 @@ def test_apply_depth_dof_balanced_quality_boosts_bilateral_for_high_complexity(
 
 
 def test_apply_depth_dof_clarity_runs_unsharp_mask_branch() -> None:
-    # clarity > 1e-6 takes the unsharp-mask branch (lines 672-676).
-    out = tools.apply_depth_dof(
+    # clarity > 1e-6 takes the unsharp-mask branch and should alter output.
+    with_clarity = tools.apply_depth_dof(
         _image(),
         _depth(),
         edge_preserving=False,
         quality="fast",
         clarity=0.5,
     )
+    without_clarity = tools.apply_depth_dof(
+        _image(),
+        _depth(),
+        edge_preserving=False,
+        quality="fast",
+        clarity=0.0,
+    )
 
-    assert out.shape == (8, 8, 3)
-    assert out.dtype == np.float32
+    assert with_clarity.shape == without_clarity.shape
+    assert with_clarity.dtype == np.float32
+    assert np.isfinite(with_clarity).all()
+    assert not np.array_equal(with_clarity, without_clarity)
 
 
 def test_estimate_image_complexity_returns_bounded_float() -> None:
@@ -202,14 +211,16 @@ def test_estimate_image_complexity_returns_bounded_float() -> None:
 
 
 def test_gaussian_blur_float_short_circuits_below_threshold() -> None:
-    # sigma <= 0.5 returns the input untouched (line 287-288).
+    # sigma <= 0.5 returns the input untouched.
     img = _image()
     out = tools.gaussian_blur_float(img, sigma=0.3)
     assert out is img
 
 
 def test_gaussian_blur_float_scipy_handles_2d_input(monkeypatch: pytest.MonkeyPatch) -> None:
-    # Force the scipy 2D code path (line 300) by passing a 2D depth-like array.
+    # Force the SciPy 2D code path by passing a 2D depth-like array.
+    pytest.importorskip("scipy.ndimage")
+    assert tools.gaussian_filter is not None
     monkeypatch.setattr(tools, "_SCIPY_AVAILABLE", True)
     arr = _depth()
 
@@ -222,7 +233,7 @@ def test_gaussian_blur_float_scipy_handles_2d_input(monkeypatch: pytest.MonkeyPa
 def test_gaussian_blur_float_cv2_backend_returns_normalized_output(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # Exercise the cv2 backend branch (lines 306-319) via explicit selection.
+    # Exercise the cv2 backend branch via explicit selection.
     pytest.importorskip("cv2")
     monkeypatch.setattr(tools, "_CV2_AVAILABLE", True)
     img = _image()
@@ -234,7 +245,7 @@ def test_gaussian_blur_float_cv2_backend_returns_normalized_output(
 
 
 def test_gaussian_blur_float_pil_fallback_handles_2d(monkeypatch: pytest.MonkeyPatch) -> None:
-    # PIL fallback with 2D input (lines 322-326).
+    # PIL fallback with 2D input.
     monkeypatch.setattr(tools, "_SCIPY_AVAILABLE", False)
     monkeypatch.setattr(tools, "_CV2_AVAILABLE", False)
     arr = _depth()
@@ -246,7 +257,7 @@ def test_gaussian_blur_float_pil_fallback_handles_2d(monkeypatch: pytest.MonkeyP
 
 
 def test_gaussian_blur_float_pil_fallback_handles_rgb(monkeypatch: pytest.MonkeyPatch) -> None:
-    # PIL fallback with 3D input (lines 327-330).
+    # PIL fallback with 3D input.
     monkeypatch.setattr(tools, "_SCIPY_AVAILABLE", False)
     monkeypatch.setattr(tools, "_CV2_AVAILABLE", False)
 
@@ -259,7 +270,7 @@ def test_gaussian_blur_float_pil_fallback_handles_rgb(monkeypatch: pytest.Monkey
 def test_bilateral_blur_float_falls_back_to_gaussian_without_cv2(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # Lines 345-346: without cv2, bilateral degrades to gaussian.
+    # Without cv2, bilateral degrades to gaussian.
     monkeypatch.setattr(tools, "_CV2_AVAILABLE", False)
     called: dict[str, float] = {}
 
@@ -278,8 +289,8 @@ def test_bilateral_blur_float_falls_back_to_gaussian_without_cv2(
 def test_bilateral_blur_float_cv2_path_handles_rgb_and_2d(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # Exercise the per-channel loop (lines 358-362) AND the 2D branch
-    # (lines 355-357). cv2 must be available for both.
+    # Exercise the per-channel loop and the 2D branch. cv2 must be available
+    # for both.
     pytest.importorskip("cv2")
     monkeypatch.setattr(tools, "_CV2_AVAILABLE", True)
 
@@ -293,23 +304,22 @@ def test_bilateral_blur_float_cv2_path_handles_rgb_and_2d(
 
 def test_apply_depth_haze_handles_none_masks() -> None:
     # sky_mask=None and building_mask=None take the zero-mask shortcuts
-    # (lines 578-583); the no-mask path is structurally distinct from the
-    # masked path.
+    # before the structurally distinct masked path.
     out = tools.apply_depth_haze(_image(), _depth(), sky_mask=None, building_mask=None)
     assert out.shape == (8, 8, 3)
     assert 0.0 <= float(out.min()) <= float(out.max()) <= 1.0
 
 
 def test_apply_depth_haze_handles_empty_masks() -> None:
-    # The `.size == 0` arm of the same conditional (line 578/580).
+    # The `.size == 0` arm of the same mask-normalization conditional.
     empty = np.zeros((0,), dtype=np.float32)
     out = tools.apply_depth_haze(_image(), _depth(), sky_mask=empty, building_mask=empty)
     assert out.shape == (8, 8, 3)
 
 
 def test_apply_depth_clarity_handles_flat_depth() -> None:
-    # depth_range collapses to the 1e-6 floor (line 610); the function must
-    # still produce a valid float image rather than dividing by zero.
+    # depth_range collapses to the 1e-6 floor; the function must still produce
+    # a valid float image rather than dividing by zero.
     flat = np.full((8, 8), 0.5, dtype=np.float32)
     out = tools.apply_depth_clarity(_image(), flat, amount=0.3)
 

--- a/tests/unit/depth/test_tools_effects.py
+++ b/tests/unit/depth/test_tools_effects.py
@@ -140,3 +140,176 @@ def test_apply_depth_dof_balanced_quality_skips_bilateral_for_low_complexity(
 
     assert out.shape == (8, 8, 3)
     assert len(gaussian_calls) == 2
+
+
+def test_apply_depth_dof_balanced_quality_boosts_bilateral_for_high_complexity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Covers the high-complexity else branch (line 711): bilateral_sigma_depth
+    # must be scaled rather than skipped.
+    seen_sigmas: list[float] = []
+
+    monkeypatch.setattr(tools, "_CV2_AVAILABLE", True)
+    monkeypatch.setattr(tools, "_estimate_image_complexity", lambda img, depth: 0.8)
+
+    def fake_bilateral(img, depth, sigma_spatial, sigma_depth=0.08, diameter=None):
+        seen_sigmas.append(sigma_depth)
+        return np.full_like(img, 0.3)
+
+    monkeypatch.setattr(tools, "bilateral_blur_float", fake_bilateral)
+
+    out = tools.apply_depth_dof(
+        _image(),
+        _depth(),
+        quality="balanced",
+        clarity=0.0,
+        bilateral_sigma_depth=0.10,
+    )
+
+    assert out.shape == (8, 8, 3)
+    assert len(seen_sigmas) == 2
+    # 0.10 * (0.5 + 0.8 * 0.5) = 0.09; second call uses *0.75 of that
+    assert seen_sigmas[0] == pytest.approx(0.09)
+    assert seen_sigmas[1] == pytest.approx(0.09 * 0.75)
+
+
+def test_apply_depth_dof_clarity_runs_unsharp_mask_branch() -> None:
+    # clarity > 1e-6 takes the unsharp-mask branch (lines 672-676).
+    out = tools.apply_depth_dof(
+        _image(),
+        _depth(),
+        edge_preserving=False,
+        quality="fast",
+        clarity=0.5,
+    )
+
+    assert out.shape == (8, 8, 3)
+    assert out.dtype == np.float32
+
+
+def test_estimate_image_complexity_returns_bounded_float() -> None:
+    # Direct exercise — existing tests only mock this helper.
+    img = _image()
+    flat = np.zeros_like(_depth())
+    sharp = _depth()
+
+    flat_score = tools._estimate_image_complexity(img, flat)
+    sharp_score = tools._estimate_image_complexity(img, sharp)
+
+    assert 0.0 <= flat_score <= 1.0
+    assert 0.0 <= sharp_score <= 1.0
+    assert sharp_score >= flat_score
+
+
+def test_gaussian_blur_float_short_circuits_below_threshold() -> None:
+    # sigma <= 0.5 returns the input untouched (line 287-288).
+    img = _image()
+    out = tools.gaussian_blur_float(img, sigma=0.3)
+    assert out is img
+
+
+def test_gaussian_blur_float_scipy_handles_2d_input(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Force the scipy 2D code path (line 300) by passing a 2D depth-like array.
+    monkeypatch.setattr(tools, "_SCIPY_AVAILABLE", True)
+    arr = _depth()
+
+    out = tools.gaussian_blur_float(arr, sigma=1.0, backend="scipy")
+
+    assert out.shape == arr.shape
+    assert out.dtype == np.float32
+
+
+def test_gaussian_blur_float_cv2_backend_returns_normalized_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Exercise the cv2 backend branch (lines 306-319) via explicit selection.
+    monkeypatch.setattr(tools, "_CV2_AVAILABLE", True)
+    img = _image()
+
+    out = tools.gaussian_blur_float(img, sigma=1.5, backend="cv2")
+
+    assert out.shape == img.shape
+    assert 0.0 <= float(out.min()) <= float(out.max()) <= 1.0
+
+
+def test_gaussian_blur_float_pil_fallback_handles_2d(monkeypatch: pytest.MonkeyPatch) -> None:
+    # PIL fallback with 2D input (lines 322-326).
+    monkeypatch.setattr(tools, "_SCIPY_AVAILABLE", False)
+    monkeypatch.setattr(tools, "_CV2_AVAILABLE", False)
+    arr = _depth()
+
+    out = tools.gaussian_blur_float(arr, sigma=1.0)
+
+    assert out.shape == arr.shape
+    assert out.dtype == np.float32
+
+
+def test_gaussian_blur_float_pil_fallback_handles_rgb(monkeypatch: pytest.MonkeyPatch) -> None:
+    # PIL fallback with 3D input (lines 327-330).
+    monkeypatch.setattr(tools, "_SCIPY_AVAILABLE", False)
+    monkeypatch.setattr(tools, "_CV2_AVAILABLE", False)
+
+    out = tools.gaussian_blur_float(_image(), sigma=1.0)
+
+    assert out.shape == (8, 8, 3)
+    assert out.dtype == np.float32
+
+
+def test_bilateral_blur_float_falls_back_to_gaussian_without_cv2(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Lines 345-346: without cv2, bilateral degrades to gaussian.
+    monkeypatch.setattr(tools, "_CV2_AVAILABLE", False)
+    called: dict[str, float] = {}
+
+    def fake_gaussian(img, sigma, backend=None):
+        called["sigma"] = sigma
+        return np.full_like(img, 0.4)
+
+    monkeypatch.setattr(tools, "gaussian_blur_float", fake_gaussian)
+
+    out = tools.bilateral_blur_float(_image(), _depth(), sigma_spatial=2.0)
+
+    assert called["sigma"] == 2.0
+    assert out.shape == (8, 8, 3)
+
+
+def test_bilateral_blur_float_cv2_path_handles_rgb_and_2d(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Exercise the per-channel loop (lines 358-362) AND the 2D branch
+    # (lines 355-357). cv2 must be available for both.
+    monkeypatch.setattr(tools, "_CV2_AVAILABLE", True)
+
+    rgb_out = tools.bilateral_blur_float(_image(), _depth(), sigma_spatial=1.5)
+    gray_out = tools.bilateral_blur_float(_depth(), _depth(), sigma_spatial=1.5)
+
+    assert rgb_out.shape == (8, 8, 3)
+    assert gray_out.shape == (8, 8)
+    assert 0.0 <= float(rgb_out.min()) <= float(rgb_out.max()) <= 1.0
+
+
+def test_apply_depth_haze_handles_none_masks() -> None:
+    # sky_mask=None and building_mask=None take the zero-mask shortcuts
+    # (lines 578-583); the no-mask path is structurally distinct from the
+    # masked path.
+    out = tools.apply_depth_haze(_image(), _depth(), sky_mask=None, building_mask=None)
+    assert out.shape == (8, 8, 3)
+    assert 0.0 <= float(out.min()) <= float(out.max()) <= 1.0
+
+
+def test_apply_depth_haze_handles_empty_masks() -> None:
+    # The `.size == 0` arm of the same conditional (line 578/580).
+    empty = np.zeros((0,), dtype=np.float32)
+    out = tools.apply_depth_haze(_image(), _depth(), sky_mask=empty, building_mask=empty)
+    assert out.shape == (8, 8, 3)
+
+
+def test_apply_depth_clarity_handles_flat_depth() -> None:
+    # depth_range collapses to the 1e-6 floor (line 610); the function must
+    # still produce a valid float image rather than dividing by zero.
+    flat = np.full((8, 8), 0.5, dtype=np.float32)
+    out = tools.apply_depth_clarity(_image(), flat, amount=0.3)
+
+    assert out.shape == (8, 8, 3)
+    assert 0.0 <= float(out.min()) <= float(out.max()) <= 1.0

--- a/tests/unit/depth/test_tools_validation.py
+++ b/tests/unit/depth/test_tools_validation.py
@@ -69,3 +69,34 @@ def test_save_image_rgb_rejects_unknown_format(tmp_path) -> None:
 
     with pytest.raises(ValueError, match="Unsupported format"):
         tools.save_image_rgb(str(tmp_path / "render.bmp"), image, fmt="bmp")
+
+
+def test_save_image_rgb_writes_png_branch(tmp_path) -> None:
+    image = np.full((4, 6, 3), 0.5, dtype=np.float32)
+
+    saved = tools.save_image_rgb(str(tmp_path / "render.png"), image, fmt="png")
+
+    assert saved.endswith(".png")
+    assert Path(saved).exists()
+
+
+def test_save_image_rgb_writes_jpg_branch(tmp_path) -> None:
+    image = np.full((4, 6, 3), 0.5, dtype=np.float32)
+
+    saved = tools.save_image_rgb(str(tmp_path / "render.jpg"), image, fmt="jpeg", quality=80)
+
+    assert saved.endswith(".jpg")
+    assert Path(saved).exists()
+
+
+def test_save_image_rgb_falls_back_to_png_when_tifffile_unavailable(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The tifffile-unavailable branch must produce a PNG instead of failing.
+    monkeypatch.setattr(tools, "_TIFFFILE_AVAILABLE", False)
+    image = np.full((4, 4, 3), 0.25, dtype=np.float32)
+
+    saved = tools.save_image_rgb(str(tmp_path / "render.tif"), image, fmt="tif")
+
+    assert saved.endswith(".png")
+    assert Path(saved).exists()

--- a/tests/unit/depth/test_tools_validation.py
+++ b/tests/unit/depth/test_tools_validation.py
@@ -89,9 +89,7 @@ def test_save_image_rgb_writes_jpg_branch(tmp_path) -> None:
     assert Path(saved).exists()
 
 
-def test_save_image_rgb_falls_back_to_png_when_tifffile_unavailable(
-    tmp_path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_save_image_rgb_falls_back_to_png_when_tifffile_unavailable(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     # The tifffile-unavailable branch must produce a PNG instead of failing.
     monkeypatch.setattr(tools, "_TIFFFILE_AVAILABLE", False)
     image = np.full((4, 4, 3), 0.25, dtype=np.float32)


### PR DESCRIPTION
Adds 32 focused branch tests across the six existing tests/unit/depth/
test_tools_* files. Targets the partially-covered decisions in the
cold-zone baseline (docs/testing/cold_zone_baseline_2026-05-12.md) so
future regressions in the depth-effects, batch driver, and CLI surfaces
fail fast rather than slipping through the broad smoke suite.

Closes the following uncovered branches:
- BoundedCache + retry: unreachable RuntimeError fallback, debug log path
- save_image_rgb: PNG / JPG / tifffile-unavailable fallback branches
- find_file_for_base / find_mask_for_base: no-tag-match score fallback,
  explicit extension iteration over generic glob
- load_mask: uniform-RGB silent path, palette (P) mode conversion
- gaussian_blur_float: sigma<=0.5 short-circuit, scipy 2D, cv2 backend,
  PIL 2D + 3D fallbacks
- bilateral_blur_float: cv2-unavailable degradation, per-channel and 2D
  paths
- apply_depth_haze: None and zero-size mask arms
- apply_depth_clarity: flat-depth (depth_range=1e-6) edge
- apply_depth_dof: clarity>0 unsharp branch, high-complexity sigma boost
- _estimate_image_complexity: direct exercise (was only mocked)
- _process_single: clarity mode, do mode, unknown-mode rejection,
  mask-root discovery path
- process_batch: error-summary logging block
- main / CLI: _cli_progress mid-stream + final newline, --verbose debug
  level, fatal-exception exit code 2, haze + clarity option mapping

No production code touched; no new test files (extends peers per
COLD_ZONE_COVERAGE_PROGRAM.md placement rules); all new tests carry
the pytestmark = pytest.mark.unit marker established by their files.

Local measurement on tests/unit/depth/test_tools_*.py against
src/transformation_portal/depth/tools.py:
  before: 80.33% line, 145/170 branches
  after : 94.32% line, 160/170 branches

Branch-floor ratchet for src/transformation_portal/depth/ (currently
40%) is intentionally left to a follow-up PR after CI confirms the
measured uplift across the full marker matrix.