### PR TITLE
ci(coverage): ratchet depth package branch floor

### DIFF
--- a/docs/testing/COLD_ZONE_COVERAGE_PROGRAM.md
+++ b/docs/testing/COLD_ZONE_COVERAGE_PROGRAM.md
@@ -511,7 +511,7 @@ received the same stability ratchet:
 BranchFloor("src/transformation_portal/plugins/", 36.0)
 BranchFloor("src/transformation_portal/stage_graph/", 63.0)
 BranchFloor("src/transformation_portal/vlm/", 55.0)
-BranchFloor("src/transformation_portal/depth/", 40.0)
+BranchFloor("src/transformation_portal/depth/", 42.0)
 BranchFloor("src/transformation_portal/streaming/", 29.0)
 BranchFloor(
     "src/transformation_portal/spatial_ai/reconstruction/",
@@ -524,9 +524,14 @@ BranchFloor(
 | `src/transformation_portal/plugins/` | 39.86% | 36.0% |
 | `src/transformation_portal/stage_graph/` | 66.77% | 63.0% |
 | `src/transformation_portal/vlm/` | 58.82% | 55.0% |
-| `src/transformation_portal/depth/` | 41.76% | 40.0% |
+| `src/transformation_portal/depth/` | 44.19% | 42.0% |
 | `src/transformation_portal/streaming/` | 31.97% | 29.0% |
 | `src/transformation_portal/spatial_ai/reconstruction/` | 49.77% | 47.0% |
+
+The depth branch floor was raised after PR #1794 merged at
+`31361b27526b438dbc2220ada3e4f2f4145807de` and full CI run `25949723087`
+confirmed `src/transformation_portal/depth/` at 601/1360 branches (44.19%)
+in both core coverage lanes.
 
 ### 12.2 Touched-file rule (per-PR, reviewer-enforced)
 

--- a/scripts/ci/check_per_package_branch_coverage.py
+++ b/scripts/ci/check_per_package_branch_coverage.py
@@ -38,7 +38,7 @@ BRANCH_FLOORS: tuple[BranchFloor, ...] = (
     BranchFloor("src/transformation_portal/plugins/", 36.0),
     BranchFloor("src/transformation_portal/stage_graph/", 63.0),
     BranchFloor("src/transformation_portal/vlm/", 55.0),
-    BranchFloor("src/transformation_portal/depth/", 40.0),
+    BranchFloor("src/transformation_portal/depth/", 42.0),
     BranchFloor("src/transformation_portal/streaming/", 29.0),
     BranchFloor("src/transformation_portal/spatial_ai/reconstruction/", 47.0),
 )

--- a/scripts/ci/cobertura_xml.py
+++ b/scripts/ci/cobertura_xml.py
@@ -113,6 +113,10 @@ def _resolve_class_path(
     for root, prefix in source_pairs:
         if (root / norm).is_file():
             return f"{prefix.rstrip('/')}/{norm}"
+    for _, prefix in source_pairs:
+        repo_relative = f"{prefix.rstrip('/')}/{norm}"
+        if Path(repo_relative).is_file():
+            return repo_relative
     return norm if norm else None
 
 

--- a/tests/test_check_per_package_branch_coverage.py
+++ b/tests/test_check_per_package_branch_coverage.py
@@ -80,6 +80,41 @@ def test_aggregate_reads_branch_condition_counts_with_source_relative_paths(scri
     assert results[0].passed is True
 
 
+def test_aggregate_resolves_downloaded_ci_artifact_source_roots(script_module, tmp_path: Path, monkeypatch):
+    src_depth = tmp_path / "src" / "transformation_portal" / "depth"
+    src_depth.mkdir(parents=True)
+    (src_depth / "tools.py").write_text("# source file\n", encoding="utf-8")
+    coverage = tmp_path / "coverage.xml"
+    _write_coverage(
+        coverage,
+        [
+            (
+                "depth/tools.py",
+                [
+                    {"hits": 1, "condition_coverage": "50% (1/2)"},
+                    {"hits": 1, "condition_coverage": "100% (2/2)"},
+                ],
+            )
+        ],
+        sources=[
+            "/home/runner/work/Transformation_Portal/Transformation_Portal",
+            "/home/runner/work/Transformation_Portal/Transformation_Portal/src/tp",
+            "/home/runner/work/Transformation_Portal/Transformation_Portal/src/transformation_portal",
+        ],
+    )
+    monkeypatch.chdir(tmp_path)
+
+    results = script_module.aggregate(
+        coverage,
+        (script_module.BranchFloor("src/transformation_portal/depth/", 75.0),),
+    )
+
+    assert results[0].covered == 3
+    assert results[0].valid == 4
+    assert results[0].percentage == 75.0
+    assert results[0].passed is True
+
+
 def test_dry_run_reports_floor_miss_without_failing(script_module, tmp_path: Path, monkeypatch, capsys):
     coverage = tmp_path / "coverage.xml"
     _write_coverage(
@@ -112,7 +147,7 @@ def test_default_branch_floors_cover_cold_zone_prefixes(script_module):
         ("src/transformation_portal/plugins/", 36.0),
         ("src/transformation_portal/stage_graph/", 63.0),
         ("src/transformation_portal/vlm/", 55.0),
-        ("src/transformation_portal/depth/", 40.0),
+        ("src/transformation_portal/depth/", 42.0),
         ("src/transformation_portal/streaming/", 29.0),
         ("src/transformation_portal/spatial_ai/reconstruction/", 47.0),
     )


### PR DESCRIPTION
## Summary
Ratchets the depth package branch coverage floor after PR #1794 landed additional depth/tools.py branch coverage and full CI confirmed the package-level branch baseline.
Adds a narrow Cobertura source-root normalization fallback so downloaded CI coverage artifacts validate consistently when class filenames are relative to runner-only source roots.

## Changes
- Raises `src/transformation_portal/depth/` branch floor from `40.0%` to `42.0%`.
- Updates the branch-floor unit expectation and adds a downloaded-artifact source-root regression test.
- Documents the PR #1794 merge commit, CI run `25949723087`, and observed depth branch baseline.
- Keeps runtime source, workflows, and depth/tools tests untouched.

## Basis
- Test PR merged: #1794
- Merge commit: `31361b27526b438dbc2220ada3e4f2f4145807de`
- Full CI run: `25949723087`
- Full CI observed depth package branch coverage: `601/1360`, `44.19%`
- New enforced floor: `42.0%`, with 2.19 percentage points of headroom

## Validation
Proven green:
- `.venv/bin/python -m pytest tests/test_check_per_package_branch_coverage.py -q`
- `.venv/bin/python -m pytest tests/test_check_per_package_branch_coverage.py tests/test_check_per_package_coverage.py -q`
- `make validate-ci`
- `make test-fast`
- `make coverage-report`
- `.venv/bin/python scripts/ci/check_per_package_branch_coverage.py coverage.xml`
- `gh run download 25949723087 -n coverage-3.11-core -D /private/tmp/tp-depth-ratchet-1794/3.11`
- `gh run download 25949723087 -n coverage-3.12-core -D /private/tmp/tp-depth-ratchet-1794/3.12`
- `.venv/bin/python scripts/ci/check_per_package_branch_coverage.py /private/tmp/tp-depth-ratchet-1794/3.11/coverage.xml`
- `.venv/bin/python scripts/ci/check_per_package_branch_coverage.py /private/tmp/tp-depth-ratchet-1794/3.12/coverage.xml`
- `git diff --check`

Artifact evidence:
- Both `coverage-3.11-core` and `coverage-3.12-core` report `src/transformation_portal/depth/` at `601/1360`, `44.19%`, floor `42.0%`.

Still failing:
- None.

## Risk
Config/test/docs-only ratchet plus coverage-parser normalization for CI artifact parity. No runtime behavior changes. The change is bounded to coverage enforcement and revert-safe.