### PR TITLE
fix(config): confine preset extends resolution to approved roots

### DIFF
--- a/src/transformation_portal/compliance/licensing.py
+++ b/src/transformation_portal/compliance/licensing.py
@@ -680,9 +680,9 @@ def _deep_merge_preset(parent: Dict[str, Any], child: Dict[str, Any]) -> Dict[st
 
 
 def _is_relative_to(path: Path, root: Path) -> bool:
-    """Return True when resolved path is inside resolved root."""
+    """Return True when path resolves inside root."""
     try:
-        path.relative_to(root)
+        path.resolve().relative_to(root.resolve())
         return True
     except ValueError:
         return False
@@ -700,7 +700,12 @@ def _resolve_extends_target(extends_value: str, child_path: Path) -> Path:
     ``extends: foo`` and have it resolve to the sibling ``config/presets/foo.yaml``.
     """
     candidate = Path(extends_value)
-    if candidate.suffix not in {".yaml", ".yml"}:
+    if candidate.suffix:
+        if candidate.suffix not in {".yaml", ".yml"}:
+            raise LicenseRestrictionError(
+                f"`extends: {extends_value}` declared in {child_path} must reference a .yaml or .yml preset file."
+            )
+    else:
         candidate = candidate.with_suffix(".yaml")
 
     child_resolved = child_path.resolve()

--- a/src/transformation_portal/compliance/licensing.py
+++ b/src/transformation_portal/compliance/licensing.py
@@ -679,6 +679,15 @@ def _deep_merge_preset(parent: Dict[str, Any], child: Dict[str, Any]) -> Dict[st
     return merged
 
 
+def _is_relative_to(path: Path, root: Path) -> bool:
+    """Return True when resolved path is inside resolved root."""
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
 def _resolve_extends_target(extends_value: str, child_path: Path) -> Path:
     """Resolve an ``extends:`` reference to a concrete preset file path.
 
@@ -697,8 +706,13 @@ def _resolve_extends_target(extends_value: str, child_path: Path) -> Path:
     child_resolved = child_path.resolve()
     search_dirs = [child_path.parent, _shared_repo_root() / "config" / "presets"]
     for directory in search_dirs:
+        approved_root = directory.resolve()
         resolved = (directory / candidate).resolve()
         if resolved == child_resolved:
+            continue
+        if resolved.suffix not in {".yaml", ".yml"}:
+            continue
+        if not _is_relative_to(resolved, approved_root):
             continue
         # Require an actual preset file, not a directory or symlink to a dir.
         if resolved.is_file():

--- a/tests/compliance/test_licensing_gates.py
+++ b/tests/compliance/test_licensing_gates.py
@@ -1224,10 +1224,12 @@ class TestExtendsResolution:
             load_and_validate_preset(child)
 
     def test_extends_rejects_absolute_path_outside_approved_roots(self, tmp_path):
-        outside_parent = tmp_path.parent / "outside_parent.yaml"
-        child = tmp_path / "child.yaml"
+        nested = tmp_path / "nested"
+        nested.mkdir()
+        outside_parent = tmp_path / "outside_parent.yaml"
+        child = nested / "child.yaml"
         self._write_yaml(outside_parent, {"name": "outside", "tier": "stable"})
-        self._write_yaml(child, {"extends": str(outside_parent), "name": "child"})
+        self._write_yaml(child, {"extends": str(outside_parent.resolve()), "name": "child"})
 
         with pytest.raises(LicenseRestrictionError, match="could not be resolved"):
             load_and_validate_preset(child)
@@ -1279,6 +1281,22 @@ class TestExtendsResolution:
 
         assert merged["name"] == "child"
         assert merged["marker"] == "from_parent"
+
+    def test_extends_rejects_non_yaml_suffix(self, tmp_path):
+        parent = tmp_path / "parent.yaml"
+        child = tmp_path / "child.yaml"
+        self._write_yaml(
+            parent,
+            {
+                "name": "parent",
+                "tier": "stable",
+                "model": {"hf_id": "depth-anything/Depth-Anything-V3-Metric-Large-hf"},
+            },
+        )
+        self._write_yaml(child, {"extends": "parent.txt", "name": "child"})
+
+        with pytest.raises(LicenseRestrictionError, match="must reference a .yaml or .yml"):
+            load_and_validate_preset(child)
 
     def test_extends_skips_self_match_and_falls_through_to_config_presets(self, tmp_path):
         """A bare-name `extends:` whose first candidate is the child itself must

--- a/tests/compliance/test_licensing_gates.py
+++ b/tests/compliance/test_licensing_gates.py
@@ -1223,6 +1223,63 @@ class TestExtendsResolution:
         with pytest.raises(LicenseRestrictionError, match="could not be resolved"):
             load_and_validate_preset(child)
 
+    def test_extends_rejects_absolute_path_outside_approved_roots(self, tmp_path):
+        outside_parent = tmp_path.parent / "outside_parent.yaml"
+        child = tmp_path / "child.yaml"
+        self._write_yaml(outside_parent, {"name": "outside", "tier": "stable"})
+        self._write_yaml(child, {"extends": str(outside_parent), "name": "child"})
+
+        with pytest.raises(LicenseRestrictionError, match="could not be resolved"):
+            load_and_validate_preset(child)
+
+    def test_extends_rejects_path_traversal_outside_child_dir(self, tmp_path):
+        nested = tmp_path / "nested"
+        nested.mkdir()
+        outside_parent = tmp_path / "outside_parent.yaml"
+        child = nested / "child.yaml"
+        self._write_yaml(outside_parent, {"name": "outside", "tier": "stable"})
+        self._write_yaml(child, {"extends": "../outside_parent.yaml", "name": "child"})
+
+        with pytest.raises(LicenseRestrictionError, match="could not be resolved"):
+            load_and_validate_preset(child)
+
+    def test_extends_rejects_symlink_escape_outside_approved_roots(self, tmp_path):
+        nested = tmp_path / "nested"
+        nested.mkdir()
+        outside_parent = tmp_path / "outside_parent.yaml"
+        symlink = nested / "linked_parent.yaml"
+        child = nested / "child.yaml"
+        self._write_yaml(outside_parent, {"name": "outside", "tier": "stable"})
+        try:
+            symlink.symlink_to(outside_parent)
+        except OSError:
+            pytest.skip("symlink creation unsupported on this platform")
+        self._write_yaml(child, {"extends": "linked_parent.yaml", "name": "child"})
+
+        with pytest.raises(LicenseRestrictionError, match="could not be resolved"):
+            load_and_validate_preset(child)
+
+    def test_extends_allows_normal_sibling_parent(self, tmp_path):
+        nested = tmp_path / "nested"
+        nested.mkdir()
+        parent = nested / "parent.yaml"
+        child = nested / "child.yaml"
+        self._write_yaml(
+            parent,
+            {
+                "name": "parent",
+                "tier": "stable",
+                "model": {"hf_id": "depth-anything/Depth-Anything-V3-Metric-Large-hf"},
+                "marker": "from_parent",
+            },
+        )
+        self._write_yaml(child, {"extends": "parent", "name": "child"})
+
+        merged = load_and_validate_preset(child)
+
+        assert merged["name"] == "child"
+        assert merged["marker"] == "from_parent"
+
     def test_extends_skips_self_match_and_falls_through_to_config_presets(self, tmp_path):
         """A bare-name `extends:` whose first candidate is the child itself must
         skip the self-match and continue searching `config/presets/`.


### PR DESCRIPTION
## Summary
Hardens governed preset `extends:` resolution so parent presets must resolve inside approved roots.

## Scope
- Rejects absolute/path-traversal/symlink-escape parent references outside the searched preset roots.
- Keeps normal sibling inheritance and config/presets fallback behavior intact.
- Adds focused regression coverage for path confinement.

## Verification
- `pytest tests/compliance/test_licensing_gates.py::TestExtendsResolution -q`
- `python scripts/validation/check_yaml_governance_boundary.py`

Closes #1800.
