### PR TITLE
ci(security): wire check_unsafe_torch_load into pre-commit and security-unified

### DIFF
--- a/.github/workflows/security-unified.yml
+++ b/.github/workflows/security-unified.yml
@@ -236,6 +236,15 @@ jobs:
         run: |
           python scripts/security/pre_commit_security_check.py $(find . -name '*.py' -o -name '*.sh' -o -name '*.yaml' -o -name '*.yml' | grep -v '.venv' | grep -v 'deprecated' | head -100)
 
+      # CVE-2025-32434 defense-in-depth: scan for raw torch.load() calls that
+      # bypass weights_only=True. Soaking non-blocking for one quiet week from
+      # 2026-05-18 before promotion to a blocking gate. Tracking: I-1 in
+      # docs/governance/audit/PORTAL_AUDIT_2026-05-18_backlog.md.
+      - name: Check unsafe torch.load() usage (CVE-2025-32434)
+        continue-on-error: true
+        run: |
+          python scripts/validation/check_unsafe_torch_load.py --ci-mode --fix-suggestions
+
       - name: Validate .gitignore coverage
         run: |
           REQUIRED_PATTERNS=(

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -90,6 +90,13 @@ repos:
         files: ^tests/.*\.py$
         types: [python]
 
+      - id: check-unsafe-torch-load
+        name: Check Unsafe torch.load() Usage (CVE-2025-32434)
+        entry: scripts/setup/run_repo_python.sh scripts/validation/check_unsafe_torch_load.py
+        language: system
+        files: \.py$
+        pass_filenames: false
+
       - id: ban-tautological-tests
         name: Ban Tautological Test Assertions
         entry: scripts/setup/run_repo_python.sh scripts/ci/check_no_tautological_tests.py


### PR DESCRIPTION
Resolves backlog item I-1 from the 2026-05-18 portal-wide audit. The
CVE-2025-32434 scanner at scripts/validation/check_unsafe_torch_load.py
was fully implemented but unreferenced by any workflow or pre-commit
hook, so the documented hardening was unenforced.

- .pre-commit-config.yaml: add check-unsafe-torch-load hook that runs the
  scanner on any *.py change (pass_filenames: false — the script walks
  the repo and applies its own allowlist).
- .github/workflows/security-unified.yml: add a continue-on-error step in
  the security-gates job invoking the scanner with --ci-mode for GitHub
  annotations. Non-blocking during a one-quiet-week soak per the audit
  ratchet plan; promotion to blocking is a follow-up PR.

Working tree currently exits clean (0 violations across 1649 files);
existing 2 unit tests under tests/validation/test_check_unsafe_torch_load.py
still pass.