### PR TITLE
docs(adr-032): record Safety removal, promote pip-audit to sole blocking scanner

### DIFF
--- a/docs/architecture/ADR-032-dependency-pinning-strategy.md
+++ b/docs/architecture/ADR-032-dependency-pinning-strategy.md
@@ -167,7 +167,7 @@ Certain packages require minimum versions due to CVEs or security patches:
 
 **Security Monitoring Tools:**
 
-- `pip-audit` (in `requirements/security.in`): **Sole governed blocking dependency scanner.** Run in `.github/workflows/security-unified.yml` (`dependency-scan` job) on every PR and on the nightly + Tuesday-staggered schedules. **Block policy:** any HIGH or CRITICAL finding fails the job and blocks merge; LOW/MEDIUM are reported in the job summary only. **Exception process:** time-bound suppressions use `pip-audit --ignore-vuln <CVE-ID>` with an inline comment in the workflow naming the CVE, the upstream tracking link, and the removal trigger (e.g., the current `--ignore-vuln CVE-2026-4539` pending an upstream pygments fix). Suppressions are reviewed every quarter; un-removable ones escalate to the next Approved Exceptions table entry.
+- `pip-audit` (in `requirements/security.in`): **Sole governed blocking dependency scanner.** Run in `.github/workflows/security-unified.yml` (`dependency-scan` job) on every PR and on the nightly + Tuesday-staggered schedules. **Scan target:** the installed Python 3.11 environment built from `requirements/constraints.txt` + `requirements-ci.txt` + editable project install + `requirements/security.txt` — the workflow invokes `pip-audit` with no `-r` flag, so it audits resolved packages rather than a single lockfile spec. **Block policy:** any HIGH or CRITICAL finding fails the job and blocks merge; LOW/MEDIUM findings are non-blocking. **Where to find LOW/MEDIUM details:** the full pip-audit JSON is printed to the job log and uploaded as the `security-reports-<sha>` `audit-report.json` artifact (30-day retention); the GitHub step summary records only the total vulnerability count. **Exception process:** time-bound suppressions use `pip-audit --ignore-vuln <CVE-ID>` with an inline comment in the workflow naming the CVE, the upstream tracking link, and the removal trigger (e.g., the current `--ignore-vuln CVE-2026-4539` pending an upstream pygments fix). Suppressions are reviewed every quarter; un-removable ones escalate to the next Approved Exceptions table entry.
 - `bandit[toml]` (in `requirements/security.in`): Static security analysis for Python source.
 - Dependabot: GitHub-native automated PR creation for security patches.
 
@@ -615,7 +615,8 @@ Track implementation progress:
 Use this checklist every quarter (Feb, May, Aug, Nov):
 
 ### 1. Security Audit
-- [ ] Run `pip-audit -r requirements/<lockfile>.txt` on each governed `.txt` lockfile (mirrors the `security-unified.yml` invocation)
+- [ ] Reproduce the `security-unified.yml` `dependency-scan` job locally so quarterly results are comparable to merge-gate results: in a clean Python 3.11 venv, `pip install -c requirements/constraints.txt -r requirements-ci.txt`, then `pip install -c requirements/constraints.txt -e .`, then `pip install -r requirements/security.txt`, then `pip-audit --ignore-vuln <each-currently-active-suppression> --format json --output audit-report.json` against the installed environment (no `-r`, matching the workflow's scan target)
+- [ ] Cross-check the local audit JSON against the latest scheduled run's `security-reports-<sha>` artifact (30-day retention) — any delta is itself an audit finding
 - [ ] Review every active `--ignore-vuln` suppression in `.github/workflows/security-unified.yml`; remove any whose upstream fix has shipped
 - [ ] Check Dependabot alerts
 - [ ] Review NIST NVD for new CVEs
@@ -652,7 +653,7 @@ Use this checklist every quarter (Feb, May, Aug, Nov):
 
 **Document Version:** 1.1
 **Last Updated:** 2026-05-18 (Amendment A1)
-**Next Review:** 2026-05-16 (Q2 2026)
+**Next Review:** 2026-08-16 (Q3 2026; quarterly cadence per Appendix B)
 **Approvers:** Platform Engineering Team
 
 ---

--- a/docs/architecture/ADR-032-dependency-pinning-strategy.md
+++ b/docs/architecture/ADR-032-dependency-pinning-strategy.md
@@ -167,9 +167,11 @@ Certain packages require minimum versions due to CVEs or security patches:
 
 **Security Monitoring Tools:**
 
-- `safety` (in `ci.in`): Automated CVE scanning in CI
-- `bandit` (in `ci.in`): Static security analysis
-- Dependabot: GitHub-native automated PR creation for security patches
+- `pip-audit` (in `requirements/security.in`): **Sole governed blocking dependency scanner.** Run in `.github/workflows/security-unified.yml` (`dependency-scan` job) on every PR and on the nightly + Tuesday-staggered schedules. **Block policy:** any HIGH or CRITICAL finding fails the job and blocks merge; LOW/MEDIUM are reported in the job summary only. **Exception process:** time-bound suppressions use `pip-audit --ignore-vuln <CVE-ID>` with an inline comment in the workflow naming the CVE, the upstream tracking link, and the removal trigger (e.g., the current `--ignore-vuln CVE-2026-4539` pending an upstream pygments fix). Suppressions are reviewed every quarter; un-removable ones escalate to the next Approved Exceptions table entry.
+- `bandit[toml]` (in `requirements/security.in`): Static security analysis for Python source.
+- Dependabot: GitHub-native automated PR creation for security patches.
+
+> `safety` was removed from this toolchain in March 2026 — see the Amendments section below for rationale. Re-introduction requires a fresh ADR amendment.
 
 ---
 
@@ -562,8 +564,8 @@ Track implementation progress:
 
 ### Security Resources
 
-- **PyPI Advisory Database**: https://github.com/pypa/advisory-database
-- **Safety DB**: https://github.com/pyupio/safety-db
+- **PyPI Advisory Database**: https://github.com/pypa/advisory-database (data source backing `pip-audit`)
+- **pip-audit**: https://github.com/pypa/pip-audit
 - **Snyk Vulnerability Database**: https://security.snyk.io/
 
 ---
@@ -613,7 +615,8 @@ Track implementation progress:
 Use this checklist every quarter (Feb, May, Aug, Nov):
 
 ### 1. Security Audit
-- [ ] Run `safety check` on all `.txt` files
+- [ ] Run `pip-audit -r requirements/<lockfile>.txt` on each governed `.txt` lockfile (mirrors the `security-unified.yml` invocation)
+- [ ] Review every active `--ignore-vuln` suppression in `.github/workflows/security-unified.yml`; remove any whose upstream fix has shipped
 - [ ] Check Dependabot alerts
 - [ ] Review NIST NVD for new CVEs
 - [ ] Update security minimums table in ADR-032
@@ -647,10 +650,33 @@ Use this checklist every quarter (Feb, May, Aug, Nov):
 
 ---
 
-**Document Version:** 1.0
-**Last Updated:** 2026-02-16
+**Document Version:** 1.1
+**Last Updated:** 2026-05-18 (Amendment A1)
 **Next Review:** 2026-05-16 (Q2 2026)
 **Approvers:** Platform Engineering Team
+
+---
+
+## Amendments
+
+### A1 — 2026-05-18: Safety removal, pip-audit promoted to sole blocking scanner
+
+**Scope:** §3 "Security Monitoring Tools", Appendix B Quarterly Review §1, References → Security Resources.
+
+**Change:**
+- Removed `safety` from the documented security-monitoring toolchain.
+- Promoted `pip-audit` to **sole governed blocking dependency scanner**, with explicit block policy (HIGH/CRITICAL → fail) and `--ignore-vuln` exception process.
+- Corrected `bandit`'s home file (`requirements/security.in`, not `ci.in`).
+- Replaced the dead Safety DB external link with the upstream `pip-audit` repo.
+- Updated quarterly review §1 to invoke `pip-audit` and to require a sweep of active `--ignore-vuln` suppressions.
+
+**Rationale:** Safety was removed from `requirements/security.in` in March 2026 because (a) it pulls `nltk` as a transitive dependency, which generated ungoverned advisory noise, and (b) `pip-audit` provides equivalent CVE coverage via the PyPI Advisory Database without the transitive baggage. The change shipped in the workflow and the `security.in` source-of-truth then, but ADR-032 still cited Safety as a live tool — finding #8 in `docs/governance/PORTAL_AUDIT_REPO_WIDE_2026-05-18.md` flagged the drift, and this amendment closes it (backlog item I-4 in `docs/governance/audit/PORTAL_AUDIT_2026-05-18_backlog.md`).
+
+**Sources of truth for the new posture:**
+- `requirements/security.in` — toolchain composition (pip-audit + bandit; Safety removal recorded inline).
+- `.github/workflows/security-unified.yml` — invocation, blocking semantics, current `--ignore-vuln` suppressions.
+
+**Re-introduction policy:** Re-adding Safety (or any additional dependency scanner) requires a follow-up ADR amendment that explains how the transitive-dependency noise problem is mitigated and why pip-audit alone is insufficient.
 
 ---
 


### PR DESCRIPTION
Resolves backlog item I-4 from the 2026-05-18 portal-wide audit (finding
#8 — ADR-032 drift). ADR-032 §3 still cited 'safety (in ci.in)' as a
live tool even though Safety was removed from requirements/security.in
in March 2026 and security-unified.yml now runs only pip-audit as the
blocking dependency scanner.

- §3 Security Monitoring Tools: replace the Safety bullet with pip-audit
  posture — sole governed blocking scanner, HIGH/CRITICAL block policy,
  --ignore-vuln exception process (with the live CVE-2026-4539 example
  cross-linked to security-unified.yml). Fix bandit's home file
  (security.in, not ci.in).
- Appendix B quarterly review §1: 'safety check' -> 'pip-audit -r ...'
  + a new step requiring sweep of every active --ignore-vuln suppression.
- References → Security Resources: drop the dead Safety DB link, add the
  pip-audit upstream repo, annotate PyPI Advisory Database as pip-audit's
  data source.
- New Amendments section (A1, 2026-05-18) recording the change, its
  rationale, the cross-link to audit finding #8, and a re-introduction
  policy that requires a fresh ADR amendment to add Safety (or any other
  scanner) back. Document Version bumped 1.0 -> 1.1.