### PR TITLE
harden(docker): drop runtime stages to non-root tp user (UID 10001) [I-3]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,19 @@
 # Transformation Portal - Docker Image
 # Multi-stage build for optimized image size
+#
+# Runtime user contract (I-3 hardening, 2026-05-18):
+#   All runtime stages drop to an unprivileged user `tp` (UID/GID 10001
+#   by default; overridable via --build-arg TP_UID=... / TP_GID=...).
+#   Installs run as root; `USER tp` is set as the final directive of
+#   each runtime stage so the container's default execution identity
+#   is unprivileged. The `gpu` stage does not inherit from `base`
+#   (different base image) and therefore re-creates the same user.
 
 # Stage 1: Base image with system dependencies
 FROM python:3.11-slim as base
+
+ARG TP_UID=10001
+ARG TP_GID=10001
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
@@ -14,6 +25,16 @@ RUN apt-get update && apt-get install -y \
     libxrender-dev \
     && rm -rf /var/lib/apt/lists/*
 
+# Create the unprivileged runtime identity used by all derived stages.
+# /usr/sbin/nologin prevents interactive shell access if the container
+# is exec'd into without an explicit shell override.
+RUN groupadd --gid ${TP_GID} tp \
+    && useradd --uid ${TP_UID} --gid ${TP_GID} --create-home --shell /usr/sbin/nologin tp \
+    && mkdir -p /app/input /app/output /app/config /home/tp/.transformation_portal \
+    && chown -R tp:tp /app /home/tp
+
+ENV HOME=/home/tp
+
 WORKDIR /app
 
 # Stage 2: CPU-only image (lightweight)
@@ -23,7 +44,8 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
-RUN pip install --no-cache-dir -e .
+RUN pip install --no-cache-dir -e . \
+    && chown -R tp:tp /app
 
 ENV DEVICE=cpu
 EXPOSE 8000
@@ -34,10 +56,14 @@ EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
     CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/healthz', timeout=3).read()" || exit 1
 
+USER tp
 CMD ["python", "-m", "transformation_portal.cli"]
 
 # Stage 3: GPU image (CUDA support)
 FROM nvidia/cuda:12.1.0-runtime-ubuntu22.04 as gpu
+
+ARG TP_UID=10001
+ARG TP_GID=10001
 
 RUN apt-get update && apt-get install -y \
     python3.11 \
@@ -46,13 +72,24 @@ RUN apt-get update && apt-get install -y \
     libgl1-mesa-glx \
     && rm -rf /var/lib/apt/lists/*
 
+# Recreate the same unprivileged identity as `base`. The gpu stage does
+# not inherit from base (different upstream image), so this is duplicated
+# intentionally — keep the UID/GID/home in sync with the base stage above.
+RUN groupadd --gid ${TP_GID} tp \
+    && useradd --uid ${TP_UID} --gid ${TP_GID} --create-home --shell /usr/sbin/nologin tp \
+    && mkdir -p /app/input /app/output /app/config /home/tp/.transformation_portal \
+    && chown -R tp:tp /app /home/tp
+
+ENV HOME=/home/tp
+
 WORKDIR /app
 
 COPY requirements.txt .
 RUN pip3 install --no-cache-dir -r requirements.txt torch torchvision --index-url https://download.pytorch.org/whl/cu121
 
 COPY . .
-RUN pip3 install --no-cache-dir -e .
+RUN pip3 install --no-cache-dir -e . \
+    && chown -R tp:tp /app
 
 ENV DEVICE=cuda
 EXPOSE 8000
@@ -60,6 +97,7 @@ EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
     CMD python3 -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/healthz', timeout=3).read()" || exit 1
 
+USER tp
 CMD ["python3", "-m", "transformation_portal.cli"]
 
 # Stage 4: Apple Silicon optimized (M-series chips)
@@ -73,7 +111,8 @@ RUN pip install --no-cache-dir -r requirements.txt
 RUN pip install --no-cache-dir coremltools
 
 COPY . .
-RUN pip install --no-cache-dir -e ".[ml]"
+RUN pip install --no-cache-dir -e ".[ml]" \
+    && chown -R tp:tp /app
 
 ENV DEVICE=mps
 EXPOSE 8000
@@ -81,4 +120,5 @@ EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
     CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/healthz', timeout=3).read()" || exit 1
 
+USER tp
 CMD ["python", "-m", "transformation_portal.cli"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,19 +12,18 @@
 #   - worker service: one-shot batch process; no healthcheck.
 
 services:
-  # Bootstrap: ensure host bind-mount targets exist and are writable by
-  # the container's `tp` user (UID/GID 10001). Runs once per `compose up`
-  # and exits; cpu/gpu/worker services gate startup on its successful
-  # completion via `depends_on: condition: service_completed_successfully`.
+  # Bootstrap: ensure the writable host bind-mount target exists and is
+  # writable by the container's `tp` user (UID/GID 10001). Runs once per
+  # `compose up` and exits; cpu/gpu/worker services gate startup on its
+  # successful completion via `depends_on: condition: service_completed_successfully`.
   #
   # The init service is intentionally the ONLY service that runs as root;
   # app services keep the image-level `USER tp` for runtime hardening.
   #
-  # Ownership semantics on the host: after first run the three I/O dirs
-  # become owned by 10001:10001 (mode 0775). Operators who need to drop
-  # input files from the host can either be in supplementary group 10001
-  # or use `sudo install -o 10001 -g 10001 <file> ./input/`. This is a
-  # deliberate trade-off versus pre-#1808 root-everywhere behavior.
+  # Ownership semantics on the host: after first run ./output becomes owned
+  # by 10001:10001 (mode 0775). Input/config stay host-owned and are mounted
+  # read-only into the app containers, so tp-init does not mutate tracked
+  # repo content or developer-owned input directories.
   tp-init:
     image: alpine:3.19
     container_name: transformation-portal-init
@@ -34,14 +33,12 @@ services:
       - -c
       - |
         set -eu
-        mkdir -p /init/input /init/output /init/config
-        chown 10001:10001 /init/input /init/output /init/config
-        chmod 0775 /init/input /init/output /init/config
-        echo "tp-init: host bind-mount targets ready (owner=10001:10001 mode=0775)"
+        mkdir -p /init/output
+        chown 10001:10001 /init/output
+        chmod 0775 /init/output
+        echo "tp-init: output bind-mount target ready (owner=10001:10001 mode=0775)"
     volumes:
-      - ./input:/init/input
       - ./output:/init/output
-      - ./config:/init/config
     restart: "no"
 
   # CPU-only service (lightweight)
@@ -57,9 +54,9 @@ services:
     ports:
       - "8000:8000"
     volumes:
-      - ./input:/app/input
+      - ./input:/app/input:ro
       - ./output:/app/output
-      - ./config:/app/config
+      - ./config:/app/config:ro
       # State persists in named volume `tp_state` — Docker-managed ownership
       # inherits the image's tp:tp chown on first use, avoiding bind-mount
       # UID friction on Linux. Use `docker compose cp` for host inspection.
@@ -86,9 +83,9 @@ services:
     ports:
       - "8001:8000"
     volumes:
-      - ./input:/app/input
+      - ./input:/app/input:ro
       - ./output:/app/output
-      - ./config:/app/config
+      - ./config:/app/config:ro
       # State persists in named volume `tp_state` — see cpu service for rationale.
       - tp_state:/home/tp/.transformation_portal
     env_file:
@@ -120,9 +117,9 @@ services:
       tp-init:
         condition: service_completed_successfully
     volumes:
-      - ./input:/app/input
+      - ./input:/app/input:ro
       - ./output:/app/output
-      - ./config:/app/config
+      - ./config:/app/config:ro
       # State persists in named volume `tp_state` — see cpu service for rationale.
       - tp_state:/home/tp/.transformation_portal
     env_file:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,22 +21,26 @@ services:
   # app services keep the image-level `USER tp` for runtime hardening.
   #
   # Ownership semantics on the host: after first run ./output becomes owned
-  # by 10001:10001 (mode 0775). Input/config stay host-owned and are mounted
-  # read-only into the app containers, so tp-init does not mutate tracked
-  # repo content or developer-owned input directories.
+  # by the configured tp runtime UID/GID (defaults 10001:10001). Input/config
+  # stay host-owned and are mounted read-only into the app containers, so
+  # tp-init does not mutate tracked repo content or developer-owned input dirs.
   tp-init:
     image: alpine:3.19
     container_name: transformation-portal-init
     user: "0:0"
+    environment:
+      TP_UID: ${TP_UID:-10001}
+      TP_GID: ${TP_GID:-10001}
     command:
       - sh
       - -c
       - |
         set -eu
         mkdir -p /init/output
-        chown 10001:10001 /init/output
+        chown -R "$${TP_UID}:$${TP_GID}" /init/output
         chmod 0775 /init/output
-        echo "tp-init: output bind-mount target ready (owner=10001:10001 mode=0775)"
+        chmod -R u+rwX,g+rwX /init/output
+        echo "tp-init: output bind-mount target ready (owner=$${TP_UID}:$${TP_GID} mode=0775)"
     volumes:
       - ./output:/init/output
     restart: "no"
@@ -46,6 +50,9 @@ services:
     build:
       context: .
       target: cpu
+      args:
+        TP_UID: ${TP_UID:-10001}
+        TP_GID: ${TP_GID:-10001}
     image: transformation-portal:cpu
     container_name: transformation-portal-cpu
     depends_on:
@@ -74,6 +81,9 @@ services:
     build:
       context: .
       target: gpu
+      args:
+        TP_UID: ${TP_UID:-10001}
+        TP_GID: ${TP_GID:-10001}
     image: transformation-portal:gpu
     container_name: transformation-portal-gpu
     runtime: nvidia
@@ -111,6 +121,9 @@ services:
     build:
       context: .
       target: cpu
+      args:
+        TP_UID: ${TP_UID:-10001}
+        TP_GID: ${TP_GID:-10001}
     image: transformation-portal:cpu
     container_name: transformation-portal-worker
     depends_on:
@@ -135,6 +148,9 @@ services:
     build:
       context: .
       target: cpu
+      args:
+        TP_UID: ${TP_UID:-10001}
+        TP_GID: ${TP_GID:-10001}
     image: transformation-portal:cpu
     container_name: transformation-portal-monitor
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,38 @@
 #   - worker service: one-shot batch process; no healthcheck.
 
 services:
+  # Bootstrap: ensure host bind-mount targets exist and are writable by
+  # the container's `tp` user (UID/GID 10001). Runs once per `compose up`
+  # and exits; cpu/gpu/worker services gate startup on its successful
+  # completion via `depends_on: condition: service_completed_successfully`.
+  #
+  # The init service is intentionally the ONLY service that runs as root;
+  # app services keep the image-level `USER tp` for runtime hardening.
+  #
+  # Ownership semantics on the host: after first run the three I/O dirs
+  # become owned by 10001:10001 (mode 0775). Operators who need to drop
+  # input files from the host can either be in supplementary group 10001
+  # or use `sudo install -o 10001 -g 10001 <file> ./input/`. This is a
+  # deliberate trade-off versus pre-#1808 root-everywhere behavior.
+  tp-init:
+    image: alpine:3.19
+    container_name: transformation-portal-init
+    user: "0:0"
+    command:
+      - sh
+      - -c
+      - |
+        set -eu
+        mkdir -p /init/input /init/output /init/config
+        chown 10001:10001 /init/input /init/output /init/config
+        chmod 0775 /init/input /init/output /init/config
+        echo "tp-init: host bind-mount targets ready (owner=10001:10001 mode=0775)"
+    volumes:
+      - ./input:/init/input
+      - ./output:/init/output
+      - ./config:/init/config
+    restart: "no"
+
   # CPU-only service (lightweight)
   transformation-portal-cpu:
     build:
@@ -19,15 +51,19 @@ services:
       target: cpu
     image: transformation-portal:cpu
     container_name: transformation-portal-cpu
+    depends_on:
+      tp-init:
+        condition: service_completed_successfully
     ports:
       - "8000:8000"
     volumes:
       - ./input:/app/input
       - ./output:/app/output
       - ./config:/app/config
-      # Runtime user is `tp` (UID/GID 10001) defined in the Dockerfile;
-      # state directory lives under that user's HOME, not /root.
-      - ~/.transformation_portal:/home/tp/.transformation_portal
+      # State persists in named volume `tp_state` — Docker-managed ownership
+      # inherits the image's tp:tp chown on first use, avoiding bind-mount
+      # UID friction on Linux. Use `docker compose cp` for host inspection.
+      - tp_state:/home/tp/.transformation_portal
     env_file:
       - path: .env
         required: false
@@ -44,15 +80,17 @@ services:
     image: transformation-portal:gpu
     container_name: transformation-portal-gpu
     runtime: nvidia
+    depends_on:
+      tp-init:
+        condition: service_completed_successfully
     ports:
       - "8001:8000"
     volumes:
       - ./input:/app/input
       - ./output:/app/output
       - ./config:/app/config
-      # Runtime user is `tp` (UID/GID 10001) defined in the Dockerfile;
-      # state directory lives under that user's HOME, not /root.
-      - ~/.transformation_portal:/home/tp/.transformation_portal
+      # State persists in named volume `tp_state` — see cpu service for rationale.
+      - tp_state:/home/tp/.transformation_portal
     env_file:
       - path: .env
         required: false
@@ -78,13 +116,15 @@ services:
       target: cpu
     image: transformation-portal:cpu
     container_name: transformation-portal-worker
+    depends_on:
+      tp-init:
+        condition: service_completed_successfully
     volumes:
       - ./input:/app/input
       - ./output:/app/output
       - ./config:/app/config
-      # Runtime user is `tp` (UID/GID 10001) defined in the Dockerfile;
-      # state directory lives under that user's HOME, not /root.
-      - ~/.transformation_portal:/home/tp/.transformation_portal
+      # State persists in named volume `tp_state` — see cpu service for rationale.
+      - tp_state:/home/tp/.transformation_portal
     env_file:
       - path: .env
         required: false
@@ -93,7 +133,7 @@ services:
       - PYTHONUNBUFFERED=1
     command: python -m transformation_portal.cli batch-process /app/input /app/output --preset golden_hour
 
-  # Monitoring dashboard (optional)
+  # Monitoring dashboard (optional). No I/O bind mounts → no tp-init dependency.
   transformation-portal-monitor:
     build:
       context: .
@@ -103,9 +143,8 @@ services:
     ports:
       - "8080:8080"
     volumes:
-      # Runtime user is `tp` (UID/GID 10001) defined in the Dockerfile;
-      # state directory lives under that user's HOME, not /root.
-      - ~/.transformation_portal:/home/tp/.transformation_portal
+      # State persists in named volume `tp_state` — see cpu service for rationale.
+      - tp_state:/home/tp/.transformation_portal
     env_file:
       - path: .env
         required: false
@@ -231,6 +270,10 @@ volumes:
   input:
   output:
   config:
+  # tp_state holds the runtime user's state cache (plugins, model registry
+  # scratch, etc.). Named volume rather than bind so Docker preserves the
+  # image's tp:tp ownership and we don't fight host UIDs on Linux.
+  tp_state:
   postgres_data:
   redis_data:
   minio_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,9 @@ services:
       - ./input:/app/input
       - ./output:/app/output
       - ./config:/app/config
-      - ~/.transformation_portal:/root/.transformation_portal
+      # Runtime user is `tp` (UID/GID 10001) defined in the Dockerfile;
+      # state directory lives under that user's HOME, not /root.
+      - ~/.transformation_portal:/home/tp/.transformation_portal
     env_file:
       - path: .env
         required: false
@@ -48,7 +50,9 @@ services:
       - ./input:/app/input
       - ./output:/app/output
       - ./config:/app/config
-      - ~/.transformation_portal:/root/.transformation_portal
+      # Runtime user is `tp` (UID/GID 10001) defined in the Dockerfile;
+      # state directory lives under that user's HOME, not /root.
+      - ~/.transformation_portal:/home/tp/.transformation_portal
     env_file:
       - path: .env
         required: false
@@ -78,7 +82,9 @@ services:
       - ./input:/app/input
       - ./output:/app/output
       - ./config:/app/config
-      - ~/.transformation_portal:/root/.transformation_portal
+      # Runtime user is `tp` (UID/GID 10001) defined in the Dockerfile;
+      # state directory lives under that user's HOME, not /root.
+      - ~/.transformation_portal:/home/tp/.transformation_portal
     env_file:
       - path: .env
         required: false
@@ -97,7 +103,9 @@ services:
     ports:
       - "8080:8080"
     volumes:
-      - ~/.transformation_portal:/root/.transformation_portal
+      # Runtime user is `tp` (UID/GID 10001) defined in the Dockerfile;
+      # state directory lives under that user's HOME, not /root.
+      - ~/.transformation_portal:/home/tp/.transformation_portal
     env_file:
       - path: .env
         required: false

--- a/docs/governance/audit/PORTAL_AUDIT_2026-05-18_backlog.md
+++ b/docs/governance/audit/PORTAL_AUDIT_2026-05-18_backlog.md
@@ -19,6 +19,8 @@ Each item carries severity, effort, the files to touch, observable acceptance cr
 
 ### I-1. Wire `check_unsafe_torch_load.py` into pre-commit and security-unified.yml
 
+**Status:** Done — merged in PR #1806 (`70d45dda074f6e2fa0a6c1b49a5cfb5bf0793c53`) on 2026-05-18. Follow-up: flip `continue-on-error: true` → blocking after one quiet week (~2026-05-25).
+
 **Severity / Effort:** Medium / S
 **Tracks finding:** [#10](../PORTAL_AUDIT_REPO_WIDE_2026-05-18.md#63-security) — orphaned torch-load scanner
 **Files to touch:** `.pre-commit-config.yaml`, `.github/workflows/security-unified.yml`
@@ -48,6 +50,8 @@ Each item carries severity, effort, the files to touch, observable acceptance cr
 - `docker-compose.yml` either inherits the image user or sets `user:` explicitly on each service; volumes are mounted with mode compatible with the new uid/gid.
 
 ### I-4. Update ADR-032 to remove `safety` reference and document pip-audit posture
+
+**Status:** Done — merged in PR #1807 (`a699c161f3943006df9ef3a952d6e12498428152`) on 2026-05-18.
 
 **Severity / Effort:** Low / S
 **Tracks finding:** [#8](../PORTAL_AUDIT_REPO_WIDE_2026-05-18.md#64-ci-governance-and-licensing) — ADR-032 drift


### PR DESCRIPTION
Resolves backlog item I-3 from the 2026-05-18 portal-wide audit (finding #6 — container default is root). This PR hardens the runtime images by dropping cpu / gpu / apple-silicon stages to an unprivileged `tp` user, then updates compose so writable runtime state remains compatible with that non-root contract.

Dockerfile
- base stage: ARG `TP_UID=10001` / `TP_GID=10001` (overridable at build), create group `tp` + user `tp` with `--create-home` and `/usr/sbin/nologin`, pre-create `/app/{input,output,config}` and `/home/tp/.transformation_portal`, chown `/app` and `/home/tp`, set `HOME=/home/tp`.
- cpu, apple-silicon stages: installs still run as root; after editable install, `chown -R tp:tp /app`, then `USER tp` as the final runtime directive.
- gpu stage: re-creates the same `tp` user because it does not inherit from `base`; same UID/GID/home contract, same final `USER tp`.

docker-compose.yml
- Compose now forwards `TP_UID` / `TP_GID` build args (default `10001:10001`) into every app image build so the runtime image contract and the compose bootstrap stay aligned if an operator overrides the runtime UID/GID.
- Runtime state now uses `tp_state:/home/tp/.transformation_portal` for the four app-owned services instead of a `~/.transformation_portal` bind mount. Docker preserves the image-owned `tp:tp` state directory on first volume initialization, avoiding host-UID drift.
- New one-shot `tp-init` bootstrap service prepares only the writable bind mount: `./output`. It creates `/init/output`, recursively `chown`s existing contents to `${TP_UID}:${TP_GID}`, applies `u+rwX,g+rwX`, and exits.
- cpu / gpu / worker gate startup on `depends_on: tp-init: condition: service_completed_successfully`.
- App services now mount `./input` and `./config` read-only (`:ro`) and mount `./output` read-write. This keeps operator-supplied inputs/config host-owned while preserving a deterministic writable output contract for the non-root runtime user.
- monitor intentionally does not depend on `tp-init` because it has no input/output/config bind mounts.
- Existing host `~/.transformation_portal` migration is optional and manual if an operator wants to seed the new named volume from prior cache/state.

Backlog status (bundled doc cleanup)
- Mark I-1 (PR #1806, `70d45dda074f6e2fa0a6c1b49a5cfb5bf0793c53`) and I-4 (PR #1807, `a699c161f3943006df9ef3a952d6e12498428152`) Done so the backlog reflects merged state.

Validation
- `docker-compose config`
- `git diff --check`
- `make validate-ci`
- Docker daemon note: `docker-compose run --rm tp-init` remains the recommended host-side smoke for bind-mount ownership and recursive output migration, but it could not be executed in this environment because the local Docker daemon was unavailable (`/var/run/docker.sock` missing).
