### PR TITLE
test(sam2): align benchmark baselines

### DIFF
--- a/docs/performance/sam2_benchmarks.md
+++ b/docs/performance/sam2_benchmarks.md
@@ -54,7 +54,8 @@
 - **Subsequent runs:** Cached model, only inference time counted
 - **MPS acceleration:** Tests run on Apple Silicon with MPS backend
 - **CPU baseline:** Re-measured on the local Apple Silicon CPU path to keep the documented fallback budget explicit
-- **Memory profile:** Peak RSS includes model weights (~1.6GB) + activations
+- **Memory profile:** Peak RSS includes model weights (~1.6GB) + activations; the recorded budget is device-specific
+  (MPS ~1.7GB, local CPU fallback ~5.6GB), not a single cross-device `<2GB` threshold
 
 ## Test Execution
 

--- a/docs/performance/sam2_benchmarks.md
+++ b/docs/performance/sam2_benchmarks.md
@@ -1,26 +1,42 @@
 # SAM2 Backend Performance Baselines (Phase 4C)
 
-**Date:** 2026-02-18
-**Environment:** macOS, Python 3.11.14, torch 2.5.1, device=mps
-**Model:** SAM2.1 Hiera Large (`sam2.1_hiera_large.pt`, size not yet re-verified for the 2.1 release; prior checkpoint was ~856MB)
+**Last re-measured:** 2026-05-19
+**Model:** SAM2.1 Hiera Large (`sam2.1_hiera_large.pt`, ~856MB)
 **Test Suite:** tests/spatial_ai/segmentation/test_sam2_backend_performance.py
 
 ## Baseline Metrics
 
 ### Auto Mode (Automatic Mask Generation)
 
-#### 512x512 Image
+#### 512x512 Image - MPS
+
+- **Hardware target:** Apple Silicon MPS
+- **Last re-measured:** 2026-02-18
+- **Environment:** macOS, Python 3.11.14, torch 2.5.1, device=mps
 - **Mean latency:** 13.38s
 - **P95 latency:** 13.38s
 - **Median:** 13.38s
 - **Peak memory:** 1673 MB
 - **Masks generated:** 1 (simple gradient test image)
+- **Assertion threshold:** 20.07s (1.5x mean baseline)
 
-**Quality Firewall Thresholds:**
-- Mean regression threshold: +15% → 15.4s
-- P95 regression threshold: +10% → 14.7s
+#### 512x512 Image - CPU
 
-#### Expected Scaling
+- **Hardware target:** Local macOS arm64 Apple Silicon CPU (`TP_SAM2_BENCHMARK_DEVICE=cpu`)
+- **Last re-measured:** 2026-05-19
+- **Environment:** macOS 26.4.1 arm64, Python 3.12.13, torch 2.8.0, device=cpu
+- **Mean latency:** 42.66s
+- **P95 latency:** 42.93s
+- **Median:** 42.54s
+- **Peak memory:** 5617 MB
+- **Masks generated:** 1 (simple gradient test image)
+- **Assertion threshold:** 63.99s (1.5x mean baseline)
+
+**Bounded Smoke Thresholds:**
+- `test_auto_mode_latency_512x512` uses 1.5x the recorded mean baseline for the active device.
+- Devices without a recorded baseline skip this threshold assertion instead of using an inherited default.
+
+#### Historical MPS Expected Scaling
 - 1024x768 (0.79 MP): ~40s estimated
 - 2048x1536 (3.15 MP): ~120s estimated
 
@@ -37,16 +53,20 @@
 - **First run warm-up:** Model loading takes ~15-20s (one-time cost)
 - **Subsequent runs:** Cached model, only inference time counted
 - **MPS acceleration:** Tests run on Apple Silicon with MPS backend
+- **CPU baseline:** Re-measured on the local Apple Silicon CPU path to keep the documented fallback budget explicit
 - **Memory profile:** Peak RSS includes model weights (~1.6GB) + activations
 
 ## Test Execution
 
 ```bash
 # Run all benchmarks (takes ~10-15 minutes)
-pytest tests/spatial_ai/segmentation/test_sam2_backend_performance.py -v -s
+TP_RUN_BENCHMARKS=1 pytest tests/spatial_ai/segmentation/test_sam2_backend_performance.py -v -s
 
 # Run single test
-pytest tests/spatial_ai/segmentation/test_sam2_backend_performance.py::TestSAM2AutoModePerformance::test_auto_mode_latency_512x512 -v -s
+TP_RUN_BENCHMARKS=1 pytest tests/spatial_ai/segmentation/test_sam2_backend_performance.py::TestSAM2AutoModePerformance::test_auto_mode_latency_512x512 -v -s
+
+# Re-measure the CPU fallback baseline on Apple Silicon
+TP_RUN_BENCHMARKS=1 TP_SAM2_BENCHMARK_DEVICE=cpu pytest tests/spatial_ai/segmentation/test_sam2_backend_performance.py::TestSAM2AutoModePerformance::test_auto_mode_latency_512x512 -v -s
 ```
 
 ## Regression Detection
@@ -68,6 +88,6 @@ To establish a new baseline:
 
 - [ ] Run benchmarks on real luxury real estate images
 - [ ] Measure latency vs. mask count correlation
-- [ ] Add CPU baseline for comparison
+- [ ] Re-measure CPU baseline on a CI-like Linux CPU target if CPU enforcement expands beyond local fallback coverage
 - [ ] Add CUDA baseline (if available)
 - [ ] Profile memory by stage (encoder vs decoder vs post-processing)

--- a/tests/spatial_ai/segmentation/test_sam2_backend_performance.py
+++ b/tests/spatial_ai/segmentation/test_sam2_backend_performance.py
@@ -13,7 +13,8 @@ Success Criteria:
 - Produces machine-readable metrics for regression tracking
 - Baseline: 512x512 auto mode uses the measured device baselines recorded in
   docs/performance/sam2_benchmarks.md
-- Memory: < 2GB peak RSS for single inference
+- Memory: device-specific peak RSS follows the recorded baselines in
+  docs/performance/sam2_benchmarks.md (MPS ~1.7GB, CPU fallback ~5.6GB)
 
 Quality Firewall Integration:
 - p95 latency: block if > 10% increase
@@ -170,12 +171,7 @@ def sam2_backend(benchmark_checkpoint):
     """Create SAM2 backend for benchmarks (module-scoped to amortize load time)."""
     requested_device = os.environ.get(SAM2_BENCHMARK_DEVICE_ENV)
     if requested_device:
-        if requested_device not in SAM2Backend.SUPPORTED_DEVICES:
-            pytest.fail(
-                f"{SAM2_BENCHMARK_DEVICE_ENV}={requested_device!r} is invalid; "
-                f"expected one of {sorted(SAM2Backend.SUPPORTED_DEVICES)}"
-            )
-        device = requested_device
+        device = _validate_requested_benchmark_device(requested_device)
     else:
         device = _default_benchmark_device()
 
@@ -184,6 +180,12 @@ def sam2_backend(benchmark_checkpoint):
         checkpoint_path=benchmark_checkpoint,
         device=device,
     )
+    if requested_device and backend.device != requested_device:
+        pytest.fail(
+            f"{SAM2_BENCHMARK_DEVICE_ENV}={requested_device!r} was requested, "
+            f"but SAM2Backend resolved device {backend.device!r}; refusing to "
+            "record a benchmark under a silent fallback"
+        )
     return backend
 
 
@@ -196,6 +198,34 @@ def _default_benchmark_device() -> str:
     if torch.cuda.is_available():
         return "cuda"
     return "cpu"
+
+
+def _validate_requested_benchmark_device(requested_device: str) -> str:
+    """Validate benchmark-only device overrides before constructing the backend."""
+    import torch
+
+    concrete_devices = SAM2Backend.SUPPORTED_DEVICES - {"auto"}
+    if requested_device == "auto":
+        pytest.fail(
+            f"{SAM2_BENCHMARK_DEVICE_ENV}=auto is not a concrete benchmark target; "
+            "unset it for default selection or set one of "
+            f"{sorted(concrete_devices)}"
+        )
+    if requested_device not in concrete_devices:
+        pytest.fail(
+            f"{SAM2_BENCHMARK_DEVICE_ENV}={requested_device!r} is invalid; " f"expected one of {sorted(concrete_devices)}"
+        )
+    if requested_device == "cuda" and not torch.cuda.is_available():
+        pytest.fail(
+            f"{SAM2_BENCHMARK_DEVICE_ENV}=cuda was requested, but CUDA is not "
+            "available; refusing to benchmark a fallback device"
+        )
+    if requested_device == "mps" and not (hasattr(torch.backends, "mps") and torch.backends.mps.is_available()):
+        pytest.fail(
+            f"{SAM2_BENCHMARK_DEVICE_ENV}=mps was requested, but MPS is not "
+            "available; refusing to benchmark a fallback device"
+        )
+    return requested_device
 
 
 # ============================================================================

--- a/tests/spatial_ai/segmentation/test_sam2_backend_performance.py
+++ b/tests/spatial_ai/segmentation/test_sam2_backend_performance.py
@@ -11,7 +11,8 @@ Test Tiers:
 Success Criteria:
 - Runs with real SAM2 checkpoint (marked @ml @slow @benchmark)
 - Produces machine-readable metrics for regression tracking
-- Baseline: < 2s per 512x512 image on MPS (auto mode)
+- Baseline: 512x512 auto mode uses the measured device baselines recorded in
+  docs/performance/sam2_benchmarks.md
 - Memory: < 2GB peak RSS for single inference
 
 Quality Firewall Integration:
@@ -58,6 +59,13 @@ pytestmark = [pytest.mark.benchmark, pytest.mark.ml, pytest.mark.slow]
 # Skip all tests if torch not available
 if not HAS_TORCH:
     pytest.skip("torch not available", allow_module_level=True)
+
+SAM2_AUTO_512_BASELINE_SEC = {
+    "mps": 13.38,
+    "cpu": 42.66,
+}
+SAM2_AUTO_512_THRESHOLD_MULTIPLIER = 1.5
+SAM2_BENCHMARK_DEVICE_ENV = "TP_SAM2_BENCHMARK_DEVICE"
 
 
 # ============================================================================
@@ -160,15 +168,16 @@ def benchmark_video_frames(tmp_path_factory):
 @pytest.fixture(scope="module")
 def sam2_backend(benchmark_checkpoint):
     """Create SAM2 backend for benchmarks (module-scoped to amortize load time)."""
-    # Determine best device
-    import torch
-
-    if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
-        device = "mps"
-    elif torch.cuda.is_available():
-        device = "cuda"
+    requested_device = os.environ.get(SAM2_BENCHMARK_DEVICE_ENV)
+    if requested_device:
+        if requested_device not in SAM2Backend.SUPPORTED_DEVICES:
+            pytest.fail(
+                f"{SAM2_BENCHMARK_DEVICE_ENV}={requested_device!r} is invalid; "
+                f"expected one of {sorted(SAM2Backend.SUPPORTED_DEVICES)}"
+            )
+        device = requested_device
     else:
-        device = "cpu"
+        device = _default_benchmark_device()
 
     backend = SAM2Backend(
         model_size="large",  # Match the checkpoint we have
@@ -176,6 +185,17 @@ def sam2_backend(benchmark_checkpoint):
         device=device,
     )
     return backend
+
+
+def _default_benchmark_device() -> str:
+    """Resolve the default benchmark device without changing backend production policy."""
+    import torch
+
+    if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+        return "mps"
+    if torch.cuda.is_available():
+        return "cuda"
+    return "cpu"
 
 
 # ============================================================================
@@ -261,7 +281,9 @@ class TestSAM2AutoModePerformance:
     def test_auto_mode_latency_512x512(self, sam2_backend, benchmark_images):
         """Measure auto mode latency on 512x512 image.
 
-        Baseline: < 2s on MPS, < 5s on CPU
+        Baselines are measured means from docs/performance/sam2_benchmarks.md:
+        13.38s on MPS and 42.66s on CPU. The assertion allows 1.5x the
+        recorded baseline for the active device.
         """
         fixture = next(f for f in benchmark_images if f["width"] == 512)
         seg_input = SegmentationInput(
@@ -292,8 +314,16 @@ class TestSAM2AutoModePerformance:
         print(f"\n[AUTO 512x512] Mean: {metrics['mean_sec']:.3f}s, P95: {metrics['p95_sec']:.3f}s")
         print(f"[AUTO 512x512] Masks: {mask_count}, Peak memory: {peak_mem_mb:.1f}MB")
 
-        # Assertions (realistic limits based on MPS performance)
-        assert metrics["mean_sec"] < 20.0, "Auto mode should complete in < 20s (MPS baseline: ~13.5s)"
+        baseline_sec = SAM2_AUTO_512_BASELINE_SEC.get(sam2_backend.device)
+        if baseline_sec is None:
+            pytest.skip(f"No recorded 512x512 auto-mode baseline for device {sam2_backend.device!r}")
+        threshold_sec = baseline_sec * SAM2_AUTO_512_THRESHOLD_MULTIPLIER
+
+        assert metrics["mean_sec"] < threshold_sec, (
+            f"Auto mode mean latency should be < {threshold_sec:.2f}s "
+            f"({SAM2_AUTO_512_THRESHOLD_MULTIPLIER:.1f}x {sam2_backend.device} baseline {baseline_sec:.2f}s); "
+            f"got {metrics['mean_sec']:.3f}s"
+        )
         assert mask_count >= 0, "Should generate zero or more masks"
 
         # Store metrics for ledger (JSON format)


### PR DESCRIPTION
## Summary
- Align the SAM2 512x512 auto-mode benchmark docs, test docstrings, and assertion budget to measured baselines.
- Replace the legacy hard-coded `< 20s` check with a threshold derived from the recorded active-device baseline.

## Changes
- Record the 2026-05-19 CPU fallback measurement in `docs/performance/sam2_benchmarks.md` alongside the existing MPS baseline.
- Add benchmark-local constants for MPS/CPU 512x512 auto-mode means and a `1.5x` threshold multiplier.
- Add `TP_SAM2_BENCHMARK_DEVICE` to force benchmark device selection for re-measurement without changing production backend device policy.
- Skip the baseline-derived assertion for devices without a recorded baseline instead of inheriting an unrelated threshold.

## Validation
Proven green:
- `.venv/bin/pytest tests/spatial_ai/segmentation/test_sam2_backend_performance.py --collect-only`
- `.venv/bin/python -m black --check tests/spatial_ai/segmentation/test_sam2_backend_performance.py`
- `git diff --check`
- `git diff --cached --check`
- `TP_RUN_BENCHMARKS=1 TP_SAM2_BENCHMARK_DEVICE=cpu .venv/bin/pytest tests/spatial_ai/segmentation/test_sam2_backend_performance.py::TestSAM2AutoModePerformance::test_auto_mode_latency_512x512 -v -s`

Measured CPU baseline evidence:
- Final recorded baseline: mean `42.66s`, p95 `42.93s`, median `42.54s`, peak RSS `5617 MB`, 1 mask.
- Final committed assertion validation passed with mean `42.347s`, p95 `42.734s`, under the `63.99s` threshold.

Environment/tooling notes:
- Downloaded local ignored benchmark input with `.venv/bin/python scripts/download_sam2_checkpoint.py --model large`.
- `checkpoints/` and `output/performance_benchmarks/` artifacts remain ignored and are not part of this PR.

## Risk
- Low runtime risk: this changes benchmark documentation and benchmark-only test behavior, not production SAM2 inference.
- The new device override is scoped to the benchmark fixture and only affects explicit benchmark runs.
