### PR TITLE
security(fastvlm): bump idna to 3.15

### DIFF
--- a/config/fastvlm_runtime_requirements.txt
+++ b/config/fastvlm_runtime_requirements.txt
@@ -27,7 +27,7 @@ hf-xet==1.5.0
 httpcore==1.0.9
 httpx==0.28.1
 huggingface_hub==1.13.0
-idna==3.13
+idna==3.15
 Jinja2==3.1.6
 markdown-it-py==4.1.0
 MarkupSafe==3.0.3


### PR DESCRIPTION
## Summary
- Remediate Dependabot alert #203 for `idna` in the FastVLM runtime lockfile.
- Upgrade `idna` from `3.13` to patched `3.15`.

## Changes
- Update `config/fastvlm_runtime_requirements.txt`:
  - `idna==3.13` -> `idna==3.15`

## Validation
- `python -m pip install --dry-run --requirement config/fastvlm_runtime_requirements.txt`
- `python -m pip install --requirement config/fastvlm_runtime_requirements.txt --target /tmp/fastvlm-idna-smoke`
- Verified installed `idna.__version__ == "3.15"`
- `git diff --check`
- `./scripts/setup/install_fastvlm_runtime.sh --dry-run`

## Risk
- Low. This is a patch-level dependency update in a pinned FastVLM runtime requirements file.
- No application route, API envelope, model policy, Dockerfile, or production inference code changes.
