### PR TITLE
test(sam2): derive benchmark thresholds from baselines

### DIFF
--- a/docs/performance/sam2_benchmarks.md
+++ b/docs/performance/sam2_benchmarks.md
@@ -1,8 +1,15 @@
 # SAM2 Backend Performance Baselines (Phase 4C)
 
-**Last re-measured:** 2026-05-19
+**Last re-measured:** 2026-05-20
 **Model:** SAM2.1 Hiera Large (`sam2.1_hiera_large.pt`, ~856MB)
 **Test Suite:** tests/spatial_ai/segmentation/test_sam2_backend_performance.py
+
+## Threshold Policy
+
+- Latency assertions use `recorded mean latency * 1.5` for the active device.
+- Throughput assertions use `recorded FPS / 1.5` for the active device.
+- Devices without a recorded baseline for the specific benchmark case skip only that threshold assertion, still pass through the rest of the benchmark, and still write JSON metrics output.
+- The new 2026-05-20 CPU rows were measured locally with `TP_RUN_BENCHMARKS=1 TP_SAM2_BENCHMARK_DEVICE=cpu`.
 
 ## Baseline Metrics
 
@@ -32,42 +39,80 @@
 - **Masks generated:** 1 (simple gradient test image)
 - **Assertion threshold:** 63.99s (1.5x mean baseline)
 
-**Bounded Smoke Thresholds:**
-- `test_auto_mode_latency_512x512` uses 1.5x the recorded mean baseline for the active device.
-- Devices without a recorded baseline skip this threshold assertion instead of using an inherited default.
+#### 1024x768 Image - CPU
 
-#### Historical MPS Expected Scaling
-- 1024x768 (0.79 MP): ~40s estimated
-- 2048x1536 (3.15 MP): ~120s estimated
+- **Hardware target:** Local macOS arm64 Apple Silicon CPU (`TP_SAM2_BENCHMARK_DEVICE=cpu`)
+- **Last re-measured:** 2026-05-20
+- **Environment:** macOS 26.4.1 arm64, Python 3.12.13, torch 2.8.0, device=cpu
+- **Mean latency:** 46.924s
+- **P95 latency:** 47.26s
+- **Masks generated:** 1 (simple gradient test image)
+- **Assertion threshold:** 70.386s (1.5x mean baseline)
+
+#### Historical MPS Expected Scaling (Not Assertion Baselines)
+
+- 1024x768 (0.79 MP): previously estimated at ~40s
+- 2048x1536 (3.15 MP): previously estimated at ~120s
 
 ### Prompted Mode (Points/Bbox)
 
-**TBD** - Requires real model runs (lighter than auto mode)
+#### Points Mode 512x512 - CPU
+
+- **Hardware target:** Local macOS arm64 Apple Silicon CPU (`TP_SAM2_BENCHMARK_DEVICE=cpu`)
+- **Last re-measured:** 2026-05-20
+- **Environment:** macOS 26.4.1 arm64, Python 3.12.13, torch 2.8.0, device=cpu
+- **Mean latency:** 1.089s
+- **P95 latency:** 1.115s
+- **Median:** 1.099s
+- **Masks generated:** 3
+- **Assertion threshold:** 1.634s (1.5x mean baseline)
+
+#### Bbox Mode 512x512 - CPU
+
+- **Hardware target:** Local macOS arm64 Apple Silicon CPU (`TP_SAM2_BENCHMARK_DEVICE=cpu`)
+- **Last re-measured:** 2026-05-20
+- **Environment:** macOS 26.4.1 arm64, Python 3.12.13, torch 2.8.0, device=cpu
+- **Mean latency:** 1.107s
+- **P95 latency:** 1.114s
+- **Median:** 1.105s
+- **Masks generated:** 3
+- **Assertion threshold:** 1.661s (1.5x mean baseline)
 
 ### Video Mode (Frame Tracking)
 
-**TBD** - Requires real model runs
+#### 10-Frame 512x512 Tracking - CPU
+
+- **Hardware target:** Local macOS arm64 Apple Silicon CPU (`TP_SAM2_BENCHMARK_DEVICE=cpu`)
+- **Last re-measured:** 2026-05-20
+- **Environment:** macOS 26.4.1 arm64, Python 3.12.13, torch 2.8.0, device=cpu
+- **Total latency:** 13.112s for 10 frames
+- **Throughput:** 0.763 FPS
+- **Seconds per frame:** 1.311s
+- **Peak memory:** 4092 MB
+- **Tracked objects:** 10
+- **Assertion floor:** 0.509 FPS (mean FPS baseline / 1.5)
 
 ## Notes
 
 - **First run warm-up:** Model loading takes ~15-20s (one-time cost)
 - **Subsequent runs:** Cached model, only inference time counted
-- **MPS acceleration:** Tests run on Apple Silicon with MPS backend
+- **MPS acceleration:** The existing 512x512 auto-mode MPS row was measured on Apple Silicon with the MPS backend
 - **CPU baseline:** Re-measured on the local Apple Silicon CPU path to keep the documented fallback budget explicit
+- **MPS rows:** Only the 512x512 auto-mode MPS row is a recorded assertion baseline. Add MPS rows for the remaining modes only after running those exact benchmark cases under pytest on an MPS-capable environment.
 - **Memory profile:** Peak RSS includes model weights (~1.6GB) + activations; the recorded budget is device-specific
   (MPS ~1.7GB, local CPU fallback ~5.6GB), not a single cross-device `<2GB` threshold
 
 ## Test Execution
 
 ```bash
-# Run all benchmarks (takes ~10-15 minutes)
-TP_RUN_BENCHMARKS=1 pytest tests/spatial_ai/segmentation/test_sam2_backend_performance.py -v -s
+# Run all CPU benchmarks (takes several minutes)
+TP_RUN_BENCHMARKS=1 TP_SAM2_BENCHMARK_DEVICE=cpu .venv/bin/pytest tests/spatial_ai/segmentation/test_sam2_backend_performance.py -v -s
 
 # Run single test
-TP_RUN_BENCHMARKS=1 pytest tests/spatial_ai/segmentation/test_sam2_backend_performance.py::TestSAM2AutoModePerformance::test_auto_mode_latency_512x512 -v -s
+TP_RUN_BENCHMARKS=1 TP_SAM2_BENCHMARK_DEVICE=cpu .venv/bin/pytest tests/spatial_ai/segmentation/test_sam2_backend_performance.py::TestSAM2AutoModePerformance::test_auto_mode_latency_512x512 -v -s
 
-# Re-measure the CPU fallback baseline on Apple Silicon
-TP_RUN_BENCHMARKS=1 TP_SAM2_BENCHMARK_DEVICE=cpu pytest tests/spatial_ai/segmentation/test_sam2_backend_performance.py::TestSAM2AutoModePerformance::test_auto_mode_latency_512x512 -v -s
+# Re-measure MPS rows only on an environment where pytest reports MPS available
+TP_RUN_BENCHMARKS=1 TP_SAM2_BENCHMARK_DEVICE=mps .venv/bin/pytest tests/spatial_ai/segmentation/test_sam2_backend_performance.py -v -s
 ```
 
 ## Regression Detection
@@ -90,5 +135,6 @@ To establish a new baseline:
 - [ ] Run benchmarks on real luxury real estate images
 - [ ] Measure latency vs. mask count correlation
 - [ ] Re-measure CPU baseline on a CI-like Linux CPU target if CPU enforcement expands beyond local fallback coverage
+- [ ] Re-measure MPS baselines for 1024x768 auto, points, bbox, and video modes under pytest
 - [ ] Add CUDA baseline (if available)
 - [ ] Profile memory by stage (encoder vs decoder vs post-processing)

--- a/tests/spatial_ai/segmentation/test_sam2_backend_performance.py
+++ b/tests/spatial_ai/segmentation/test_sam2_backend_performance.py
@@ -11,8 +11,8 @@ Test Tiers:
 Success Criteria:
 - Runs with real SAM2 checkpoint (marked @ml @slow @benchmark)
 - Produces machine-readable metrics for regression tracking
-- Baseline: 512x512 auto mode uses the measured device baselines recorded in
-  docs/performance/sam2_benchmarks.md
+- Baseline: thresholded benchmark modes use measured device baselines recorded
+  in docs/performance/sam2_benchmarks.md
 - Memory: device-specific peak RSS follows the recorded baselines in
   docs/performance/sam2_benchmarks.md (MPS ~1.7GB, CPU fallback ~5.6GB)
 
@@ -61,11 +61,27 @@ pytestmark = [pytest.mark.benchmark, pytest.mark.ml, pytest.mark.slow]
 if not HAS_TORCH:
     pytest.skip("torch not available", allow_module_level=True)
 
-SAM2_AUTO_512_BASELINE_SEC = {
-    "mps": 13.38,
-    "cpu": 42.66,
+SAM2_BENCHMARK_THRESHOLD_MULTIPLIER = 1.5
+SAM2_BENCHMARK_LATENCY_BASELINES_SEC: Dict[str, Dict[str, float]] = {
+    "auto_mode_512x512": {
+        "mps": 13.38,
+        "cpu": 42.66,
+    },
+    "auto_mode_1024x768": {
+        "cpu": 46.924,
+    },
+    "points_mode_512x512": {
+        "cpu": 1.089,
+    },
+    "bbox_mode_512x512": {
+        "cpu": 1.107,
+    },
 }
-SAM2_AUTO_512_THRESHOLD_MULTIPLIER = 1.5
+SAM2_BENCHMARK_THROUGHPUT_BASELINES_FPS: Dict[str, Dict[str, float]] = {
+    "video_tracking_512x512": {
+        "cpu": 0.763,
+    },
+}
 SAM2_BENCHMARK_DEVICE_ENV = "TP_SAM2_BENCHMARK_DEVICE"
 
 
@@ -228,6 +244,52 @@ def _validate_requested_benchmark_device(requested_device: str) -> str:
     return requested_device
 
 
+def _recorded_latency_threshold_sec(case_name: str, device: str) -> tuple[float, float] | None:
+    """Return recorded latency baseline and derived threshold for a benchmark case."""
+    baseline_sec = SAM2_BENCHMARK_LATENCY_BASELINES_SEC[case_name].get(device)
+    if baseline_sec is None:
+        return None
+    return baseline_sec, baseline_sec * SAM2_BENCHMARK_THRESHOLD_MULTIPLIER
+
+
+def _recorded_throughput_floor_fps(case_name: str, device: str) -> tuple[float, float] | None:
+    """Return recorded throughput baseline and derived floor for a benchmark case."""
+    baseline_fps = SAM2_BENCHMARK_THROUGHPUT_BASELINES_FPS[case_name].get(device)
+    if baseline_fps is None:
+        return None
+    return baseline_fps, baseline_fps / SAM2_BENCHMARK_THRESHOLD_MULTIPLIER
+
+
+def _assert_mean_latency_within_baseline(case_name: str, device: str, mean_sec: float) -> None:
+    """Assert mean latency stays within the recorded device-specific budget."""
+    baseline = _recorded_latency_threshold_sec(case_name, device)
+    if baseline is None:
+        print(f"[BASELINE] No recorded {case_name} latency baseline for device {device!r}; skipping threshold assertion")
+        return
+
+    baseline_sec, threshold_sec = baseline
+    assert mean_sec < threshold_sec, (
+        f"{case_name} mean latency should be < {threshold_sec:.2f}s "
+        f"({SAM2_BENCHMARK_THRESHOLD_MULTIPLIER:.1f}x {device} baseline {baseline_sec:.2f}s); "
+        f"got {mean_sec:.3f}s"
+    )
+
+
+def _assert_throughput_within_baseline(case_name: str, device: str, fps: float) -> None:
+    """Assert throughput stays within the recorded device-specific budget."""
+    baseline = _recorded_throughput_floor_fps(case_name, device)
+    if baseline is None:
+        print(f"[BASELINE] No recorded {case_name} throughput baseline for device {device!r}; skipping threshold assertion")
+        return
+
+    baseline_fps, floor_fps = baseline
+    assert fps > floor_fps, (
+        f"{case_name} throughput should be > {floor_fps:.2f} FPS "
+        f"({device} baseline {baseline_fps:.2f} FPS / {SAM2_BENCHMARK_THRESHOLD_MULTIPLIER:.1f}); "
+        f"got {fps:.2f} FPS"
+    )
+
+
 # ============================================================================
 # Performance Measurement Utilities
 # ============================================================================
@@ -311,9 +373,8 @@ class TestSAM2AutoModePerformance:
     def test_auto_mode_latency_512x512(self, sam2_backend, benchmark_images):
         """Measure auto mode latency on 512x512 image.
 
-        Baselines are measured means from docs/performance/sam2_benchmarks.md:
-        13.38s on MPS and 42.66s on CPU. The assertion allows 1.5x the
-        recorded baseline for the active device.
+        Baselines are measured means from docs/performance/sam2_benchmarks.md.
+        The assertion allows 1.5x the recorded baseline for the active device.
         """
         fixture = next(f for f in benchmark_images if f["width"] == 512)
         seg_input = SegmentationInput(
@@ -344,16 +405,7 @@ class TestSAM2AutoModePerformance:
         print(f"\n[AUTO 512x512] Mean: {metrics['mean_sec']:.3f}s, P95: {metrics['p95_sec']:.3f}s")
         print(f"[AUTO 512x512] Masks: {mask_count}, Peak memory: {peak_mem_mb:.1f}MB")
 
-        baseline_sec = SAM2_AUTO_512_BASELINE_SEC.get(sam2_backend.device)
-        if baseline_sec is None:
-            pytest.skip(f"No recorded 512x512 auto-mode baseline for device {sam2_backend.device!r}")
-        threshold_sec = baseline_sec * SAM2_AUTO_512_THRESHOLD_MULTIPLIER
-
-        assert metrics["mean_sec"] < threshold_sec, (
-            f"Auto mode mean latency should be < {threshold_sec:.2f}s "
-            f"({SAM2_AUTO_512_THRESHOLD_MULTIPLIER:.1f}x {sam2_backend.device} baseline {baseline_sec:.2f}s); "
-            f"got {metrics['mean_sec']:.3f}s"
-        )
+        _assert_mean_latency_within_baseline("auto_mode_512x512", sam2_backend.device, metrics["mean_sec"])
         assert mask_count >= 0, "Should generate zero or more masks"
 
         # Store metrics for ledger (JSON format)
@@ -399,7 +451,7 @@ class TestSAM2AutoModePerformance:
         print(f"\n[AUTO 1024x768] Mean: {metrics['mean_sec']:.3f}s, P95: {metrics['p95_sec']:.3f}s")
         print(f"[AUTO 1024x768] Masks: {mask_count}")
 
-        assert metrics["mean_sec"] < 40.0, "HD should complete in < 40s"
+        _assert_mean_latency_within_baseline("auto_mode_1024x768", sam2_backend.device, metrics["mean_sec"])
         assert mask_count >= 0
 
         # Store metrics
@@ -487,7 +539,7 @@ class TestSAM2PromptedModePerformance:
         print(f"\n[POINTS] Mean: {metrics['mean_sec']:.3f}s, P95: {metrics['p95_sec']:.3f}s")
         print(f"[POINTS] Masks: {result.masks.shape[0]}")
 
-        assert metrics["mean_sec"] < 5.0, "Points mode should be fast (< 5s)"
+        _assert_mean_latency_within_baseline("points_mode_512x512", sam2_backend.device, metrics["mean_sec"])
 
         # Store metrics
         metrics_output = {
@@ -526,7 +578,7 @@ class TestSAM2PromptedModePerformance:
         print(f"\n[BBOX] Mean: {metrics['mean_sec']:.3f}s, P95: {metrics['p95_sec']:.3f}s")
         print(f"[BBOX] Masks: {result.masks.shape[0]}")
 
-        assert metrics["mean_sec"] < 5.0, "Bbox mode should be fast (< 5s)"
+        _assert_mean_latency_within_baseline("bbox_mode_512x512", sam2_backend.device, metrics["mean_sec"])
 
         # Store metrics
         metrics_output = {
@@ -556,7 +608,8 @@ class TestSAM2VideoModePerformance:
     def test_video_tracking_throughput(self, sam2_backend, benchmark_video_frames):
         """Measure video tracking throughput (FPS).
 
-        Baseline: > 1 FPS for 512x512 frames
+        Baselines are measured throughput from docs/performance/sam2_benchmarks.md.
+        The assertion allows a floor of the recorded FPS divided by 1.5.
         """
         seg_input = SegmentationInput(
             image=None,  # Video mode doesn't use image
@@ -593,7 +646,7 @@ class TestSAM2VideoModePerformance:
         print(f"[VIDEO] Peak memory: {peak_mem_mb:.1f}MB")
         print(f"[VIDEO] Tracked objects: {len(result.temporal_ids)}")
 
-        assert fps > 0.5, "Should achieve at least 0.5 FPS"
+        _assert_throughput_within_baseline("video_tracking_512x512", sam2_backend.device, fps)
         assert len(result.temporal_ids) > 0, "Should track at least one object"
 
         # Store metrics


### PR DESCRIPTION
## Summary
- Fixes #1817 by replacing the remaining fixed SAM2 benchmark thresholds with device-baseline-derived budgets.
- Records the new local CPU baselines for 1024x768 auto mode, points mode, bbox mode, and video throughput.
- Leaves #1814 open; a tracking comment was posted with the NVIDIA-host validation checklist.

Fixes #1817.

## Changes
- Added shared SAM2 benchmark helpers for latency thresholds and throughput floors.
- Replaced the stale fixed assertions for `1024x768 < 40s`, points/bbox `< 5s`, and video `> 0.5 FPS`.
- Kept existing MPS 512x512 auto-mode data and added CPU-only baselines for the newly measured modes.
- Updated `docs/performance/sam2_benchmarks.md` with the threshold policy, measurement environment, CPU baseline rows, and MPS follow-up note.
- Posted #1814 status comment: https://github.com/RC219805/Transformation_Portal/issues/1814#issuecomment-4501216522

## Validation
Proven green:
- `.venv/bin/pytest tests/spatial_ai/segmentation/test_sam2_backend_performance.py --collect-only -q` collected 7 tests.
- `.venv/bin/python -m black --check tests/spatial_ai/segmentation/test_sam2_backend_performance.py` passed.
- `TP_RUN_BENCHMARKS=1 TP_SAM2_BENCHMARK_DEVICE=cpu .venv/bin/pytest tests/spatial_ai/segmentation/test_sam2_backend_performance.py -v -s` passed with `6 passed, 1 skipped in 934.57s`.
- `.venv/bin/pytest tests/validation/test_dockerfile_contract.py -q` passed with `4 passed`.
- Commit-time pre-commit hooks passed.

Still failing / blocked:
- `TP_RUN_BENCHMARKS=1 TP_SAM2_BENCHMARK_DEVICE=mps .venv/bin/pytest tests/spatial_ai/segmentation/test_sam2_backend_performance.py -v -s` failed before benchmark setup with `TP_SAM2_BENCHMARK_DEVICE=mps was requested, but MPS is not available; refusing to benchmark a fallback device`.
- This is an environment/tooling blocker for MPS remeasurement in the pytest benchmark process, not a product logic failure. No new MPS rows were recorded.

## Risk
- Low runtime risk: this only changes benchmark test thresholds and performance documentation.
- Devices without recorded case-specific baselines skip those threshold assertions instead of inheriting another device's budget.
- Revert-safe: no API, CLI, route, selector, or production runtime behavior changes.
