### PR TITLE
types(orchestrator): add queue/storage/artifact_store to mypy whitelist [N-1]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -559,6 +559,9 @@ jobs:
         # Phase 0.3 expansion: mypy now also enforces a vetted slice of core/.
         # Phase 1.2 PR A expansion: the new api/ package is fully typed and
         # mypy-strict from the start, so it joins the whitelist.
+        # N-1 expansion (2026-05-24): the orchestrator/ paid-pilot Protocol
+        # packages (queue/, storage/, artifact_store/) are clean and join the
+        # whitelist; see docs/ci/TYPE_CHECKING_POLICY.md.
         # Per docs/ci/TYPE_CHECKING_POLICY.md, additions to this whitelist must
         # pass `mypy --config-file=mypy.ini <path>` before being added here.
         # Expand the list as packages are cleaned up; do NOT enable
@@ -567,6 +570,9 @@ jobs:
           mypy --config-file=mypy.ini \
             src/transformation_portal/api/ \
             src/transformation_portal/lux_depth_v3/ \
+            src/transformation_portal/orchestrator/queue/ \
+            src/transformation_portal/orchestrator/storage/ \
+            src/transformation_portal/orchestrator/artifact_store/ \
             src/transformation_portal/core/geometry/ \
             src/transformation_portal/core/processing/ \
             src/transformation_portal/core/ml_dependency_health.py \

--- a/docs/ci/TYPE_CHECKING_POLICY.md
+++ b/docs/ci/TYPE_CHECKING_POLICY.md
@@ -2,7 +2,45 @@
 
 **Status**: DRAFT (requires architect approval)
 **Owner**: Transformation Portal Architect
-**Last Updated**: 2026-02-04
+**Last Updated**: 2026-05-24
+
+---
+
+## Actively Enforced mypy Whitelist (current)
+
+This is the authoritative list of paths that the **blocking** mypy gate in
+`.github/workflows/build.yml` (`Type check with mypy (critical modules)`)
+enforces. Each path passes `mypy --config-file=mypy.ini <path>` cleanly;
+additions must do the same before being appended to the workflow list.
+
+**Enforced as of 2026-05-24:**
+
+- `src/transformation_portal/api/`
+- `src/transformation_portal/lux_depth_v3/`
+- `src/transformation_portal/orchestrator/queue/` *(added by N-1, 2026-05-24)*
+- `src/transformation_portal/orchestrator/storage/` *(added by N-1, 2026-05-24)*
+- `src/transformation_portal/orchestrator/artifact_store/` *(added by N-1, 2026-05-24)*
+- `src/transformation_portal/core/geometry/`
+- `src/transformation_portal/core/processing/`
+- `src/transformation_portal/core/ml_dependency_health.py`
+- `src/transformation_portal/core/da3_runtime.py`
+
+**N-1 tranche notes (2026-05-24):** the three `orchestrator/` paid-pilot
+Protocol packages were added together. `queue/` was already clean;
+`storage/` required correcting the `JobEventStore.events_since` abstract
+signature from `async def` to a plain `def` returning `AsyncIterator`
+(every backend is an async generator consumed via `async for`, so the
+`async def` form mis-typed it as a coroutine); `artifact_store/` required
+tightening one `Optional[int]` local that is always `len(body)` to `int`.
+
+**Remaining backlog (not yet enforced — candidates for the next tranche):**
+
+- `src/transformation_portal/spatial_ai/segmentation/` (16 files; not yet triaged)
+- `src/transformation_portal/core/` as a whole — blocked on ~21 currently-failing files (see workflow comment); enable per-file or per-subpackage, not wholesale.
+- `src/transformation_portal/events/`, `storage/` (top-level), `hardening/`, `rendering/` — untriaged.
+
+The phased strategy below predates the whitelist mechanism and is retained
+for historical context; the list above is the live source of truth.
 
 ---
 
@@ -300,6 +338,7 @@ type-check-core:
 |------|----------|-----------|
 | 2026-02-04 | Draft policy created | Gate 0 requires type checking strategy |
 | [TBD] | Phase 2 approved | After baseline formatting complete |
+| 2026-05-24 | N-1: added `orchestrator/{queue,storage,artifact_store}/` to the blocking whitelist | Audit finding #1 (whitelist-based type gating); paid-pilot Protocol packages were clean or needed only minor type fixes |
 
 ---
 

--- a/docs/ci/TYPE_CHECKING_POLICY.md
+++ b/docs/ci/TYPE_CHECKING_POLICY.md
@@ -42,11 +42,18 @@ tightening one `Optional[int]` local that is always `len(body)` to `int`.
 The phased strategy below predates the whitelist mechanism and is retained
 for historical context; the list above is the live source of truth.
 
+> ⚠️ **Historical snapshot.** Everything from the "Current State" section
+> onward is a dated 2026-02-04 snapshot describing the original gradual-typing
+> plan. Several of its bullets (e.g. "no explicit mypy enforcement in CI")
+> are no longer accurate and are contradicted by the enforced whitelist
+> above. Treat the section above as current policy; read what follows as
+> background only.
+
 ---
 
 ## Current State
 
-**Type checking status as of 2026-02-04**:
+**Type checking status as of 2026-02-04** *(historical snapshot — see warning above; superseded by the enforced whitelist)*:
 - ✅ Type hints exist in many modules (gradual typing)
 - ⚠️ No explicit mypy or pyright enforcement in CI workflows
 - ⚠️ `mypy.ini` exists in repository root but unclear if actively enforced

--- a/src/transformation_portal/orchestrator/artifact_store/s3.py
+++ b/src/transformation_portal/orchestrator/artifact_store/s3.py
@@ -289,7 +289,7 @@ class S3ArtifactStore(ArtifactStore):
         except Exception as exc:  # noqa: BLE001 - boto3 ClientError
             raise ArtifactStoreError(f"S3 put_object failed for {key}") from exc
 
-        size_bytes: Optional[int] = len(body)
+        size_bytes: int = len(body)
         if size_bytes > ARTIFACT_FINGERPRINT_MAX_BYTES:
             sha256_hex: Optional[str] = None
             status = "skipped_size"

--- a/src/transformation_portal/orchestrator/storage/base.py
+++ b/src/transformation_portal/orchestrator/storage/base.py
@@ -273,11 +273,12 @@ class JobEventStore(ABC):
 
         ``after_seq`` is exclusive. ``None`` yields from the beginning.
 
-        Declared as a plain ``def`` returning ``AsyncIterator`` (not
-        ``async def``) because every implementation is an async generator
-        consumed via ``async for``; an ``async def`` signature would type
-        the method as a coroutine that *returns* an iterator, which no
-        backend or caller uses.
+        The abstract contract is a plain ``def`` returning
+        ``AsyncIterator`` so callers can consume ``events_since()``
+        directly with ``async for``. Concrete backends may implement that
+        contract as async-generator methods (``async def`` with
+        ``yield``); callers must not ``await`` this method before
+        iterating it.
         """
 
     @abstractmethod

--- a/src/transformation_portal/orchestrator/storage/base.py
+++ b/src/transformation_portal/orchestrator/storage/base.py
@@ -263,7 +263,7 @@ class JobEventStore(ABC):
         """Persist one event and return the assigned ``seq``."""
 
     @abstractmethod
-    async def events_since(
+    def events_since(
         self,
         job_id: str,
         *,
@@ -272,6 +272,12 @@ class JobEventStore(ABC):
         """Yield events for ``job_id`` ordered by ``seq``.
 
         ``after_seq`` is exclusive. ``None`` yields from the beginning.
+
+        Declared as a plain ``def`` returning ``AsyncIterator`` (not
+        ``async def``) because every implementation is an async generator
+        consumed via ``async for``; an ``async def`` signature would type
+        the method as a coroutine that *returns* an iterator, which no
+        backend or caller uses.
         """
 
     @abstractmethod


### PR DESCRIPTION
## Summary

Addresses backlog item **N-1** (audit finding #1 — whitelist-based type gating), the only High-severity item in Tier 2. Expands the **blocking** mypy gate in `build.yml` by three cohesive `orchestrator/` paid-pilot Protocol packages — delivering beyond the "at least one tranche" acceptance criterion.

All three pass `mypy --config-file=mypy.ini` under the CI-pinned **mypy 1.20.1**; the full whitelist is green at **106 source files, 0 issues**.

## Tranches added

| Tranche | Work needed | Notes |
|---|---|---|
| `orchestrator/queue/` | None | Already clean (Protocol + memory + redis backends) |
| `orchestrator/storage/` | 1 signature fix | See below |
| `orchestrator/artifact_store/` | 1 annotation fix | `size_bytes: Optional[int]` → `int` (always `len(body)`); removes a spurious `int \| None` comparison flag. Behavior-preserving. |

### `storage/` fix — `JobEventStore.events_since`

The abstract signature was `async def ... -> AsyncIterator[JobEvent]`, which types the method as a **coroutine that returns an iterator**. Every backend (`memory.py`, `postgres.py`) actually implements it as an **async generator** (`async def` + `yield`, consumed via `async for`), and **all call sites use `async for`** (verified repo-wide — zero `await`-style callers). Changed the base to a plain `def ... -> AsyncIterator[JobEvent]`, the correct signature for an async-generator method.

Runtime-safe: the abstract body is a docstring only and is never invoked. The repository contract suite stays green (**27 passed, 1 postgres-skip**), including the `events_since` filter tests.

## Docs

- **`build.yml`**: add the three paths to the whitelist with an N-1 comment.
- **`docs/ci/TYPE_CHECKING_POLICY.md`**: add an "Actively Enforced mypy Whitelist (current)" section as the live source of truth (the prior doc only described an aspirational phased plan), record the N-1 tranche notes and the remaining untriaged backlog (`spatial_ai/segmentation/`, the rest of `core/`, etc.), and add a decision-log entry.

## Verification

- `python3 -m mypy --config-file=mypy.ini <full whitelist>` → `Success: no issues found in 106 source files`.
- `pytest tests/orchestrator/test_repository_contract.py` → 27 passed, 1 skipped (postgres).
- pre-commit (Black/isort/gitleaks/etc.) clean on all four changed files; doc gates green.

## Test plan

- [ ] CI `typecheck` job passes with the three new tranches in the blocking list.
- [ ] Reviewer: confirm the `events_since` base→`def` change is acceptable as a Protocol-signature correction (no behavioral change; aligns declared type with the async-generator reality).

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmHYWgNDC4Qhkr1zmDF5DX)_