### PR TITLE
tests(ml): add sampled coverage on cold packages; defer global floor ratchet [N-2]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -786,11 +786,12 @@ jobs:
       # The main ML test step runs with --no-cov for PR-feedback speed; this
       # follow-up step re-runs a small, focused subset of ML tests with coverage
       # tracing on src/transformation_portal/vlm and spatial_ai/segmentation,
-      # producing an advisory coverage-ml-sampled.xml artifact. Intentionally
-      # non-blocking (`continue-on-error: true`): the artifact is evidence for
-      # the cold-zone ratchet plan in docs/testing/COLD_ZONE_COVERAGE_PROGRAM.md,
-      # not a gate. Bypasses the marker-zero check by selecting both packages'
-      # ML-marked tests explicitly.
+      # producing advisory coverage-ml-sampled.xml / status artifacts.
+      # Intentionally non-blocking (`continue-on-error: true`): artifacts are
+      # evidence for the cold-zone ratchet plan in
+      # docs/testing/COLD_ZONE_COVERAGE_PROGRAM.md, not a gate. Bypasses the
+      # marker-zero check by selecting both packages' ML-marked tests
+      # explicitly, and writes a sentinel when the selection is empty.
       - name: ML sampled coverage (advisory, non-blocking)
         if: matrix.test-type == 'ml'
         continue-on-error: true
@@ -805,17 +806,28 @@ jobs:
         run: |
           set -euo pipefail
           echo "Running ML sampled coverage on vlm + spatial_ai/segmentation..."
+          status_file="coverage-ml-sampled-status.txt"
+          rm -f coverage-ml-sampled.xml "$status_file"
+          set +e
           pytest -v tests/vlm tests/spatial_ai/segmentation \
             -ra \
             -m "ml and not slow and not integration and not benchmark" \
             --cov=src/transformation_portal/vlm \
             --cov=src/transformation_portal/spatial_ai/segmentation \
             --cov-report=term \
-            --cov-report=xml:coverage-ml-sampled.xml \
-            || rc=$?
-          # Marker-zero (exit 5) is acceptable for sampled coverage — the
-          # artifact upload will surface an empty selection rather than a CI
-          # failure. Any other failure also tolerated; this step is advisory.
+            --cov-report=xml:coverage-ml-sampled.xml
+          pytest_rc=$?
+          set -e
+          if [ "$pytest_rc" -eq 0 ]; then
+            echo "status=coverage-generated" > "$status_file"
+          elif [ "$pytest_rc" -eq 5 ]; then
+            echo "::warning::ML sampled coverage selected zero tests (exit=5); uploading sentinel evidence."
+            echo "status=marker-zero" > "$status_file"
+          else
+            echo "::warning::ML sampled coverage exited $pytest_rc; advisory artifact retained when available."
+            echo "status=pytest-failed" > "$status_file"
+          fi
+          echo "pytest_exit_code=$pytest_rc" >> "$status_file"
           rm -rf /tmp/transformers_cache_cov /tmp/hf_home_cov || true
 
       # Only core legs generate coverage.xml/htmlcov; ML deliberately runs with --no-cov for fast PR feedback.
@@ -834,11 +846,14 @@ jobs:
       # Non-blocking and only meaningful when matrix.test-type == 'ml'.
       - name: Upload ML sampled coverage artifact
         if: always() && matrix.test-type == 'ml'
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: coverage-ml-sampled-${{ matrix.python-version }}
-          path: coverage-ml-sampled.xml
-          if-no-files-found: ignore
+          path: |
+            coverage-ml-sampled.xml
+            coverage-ml-sampled-status.txt
+          if-no-files-found: warn
           retention-days: 30
 
       - name: Final disk usage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -782,6 +782,42 @@ jobs:
 
           exit "$rc"
 
+      # N-2 (audit 2026-05-18 finding #2): ML sampled coverage on cold packages.
+      # The main ML test step runs with --no-cov for PR-feedback speed; this
+      # follow-up step re-runs a small, focused subset of ML tests with coverage
+      # tracing on src/transformation_portal/vlm and spatial_ai/segmentation,
+      # producing an advisory coverage-ml-sampled.xml artifact. Intentionally
+      # non-blocking (`continue-on-error: true`): the artifact is evidence for
+      # the cold-zone ratchet plan in docs/testing/COLD_ZONE_COVERAGE_PROGRAM.md,
+      # not a gate. Bypasses the marker-zero check by selecting both packages'
+      # ML-marked tests explicitly.
+      - name: ML sampled coverage (advisory, non-blocking)
+        if: matrix.test-type == 'ml'
+        continue-on-error: true
+        env:
+          PYTHONNOUSERSITE: "1"
+          HF_HOME: "/tmp/hf_home_cov"
+          TRANSFORMERS_CACHE: "/tmp/transformers_cache_cov"
+          TRANSFORMERS_OFFLINE: "1"
+          OMP_NUM_THREADS: "1"
+          MKL_NUM_THREADS: "1"
+          OPENBLAS_NUM_THREADS: "1"
+        run: |
+          set -euo pipefail
+          echo "Running ML sampled coverage on vlm + spatial_ai/segmentation..."
+          pytest -v tests/vlm tests/spatial_ai/segmentation \
+            -ra \
+            -m "ml and not slow and not integration and not benchmark" \
+            --cov=src/transformation_portal/vlm \
+            --cov=src/transformation_portal/spatial_ai/segmentation \
+            --cov-report=term \
+            --cov-report=xml:coverage-ml-sampled.xml \
+            || rc=$?
+          # Marker-zero (exit 5) is acceptable for sampled coverage — the
+          # artifact upload will surface an empty selection rather than a CI
+          # failure. Any other failure also tolerated; this step is advisory.
+          rm -rf /tmp/transformers_cache_cov /tmp/hf_home_cov || true
+
       # Only core legs generate coverage.xml/htmlcov; ML deliberately runs with --no-cov for fast PR feedback.
       - name: Upload coverage reports
         if: always() && matrix.test-type == 'core'
@@ -791,6 +827,17 @@ jobs:
           path: |
             coverage.xml
             htmlcov/
+          if-no-files-found: ignore
+          retention-days: 30
+
+      # N-2: companion artifact upload for the ML sampled coverage step above.
+      # Non-blocking and only meaningful when matrix.test-type == 'ml'.
+      - name: Upload ML sampled coverage artifact
+        if: always() && matrix.test-type == 'ml'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        with:
+          name: coverage-ml-sampled-${{ matrix.python-version }}
+          path: coverage-ml-sampled.xml
           if-no-files-found: ignore
           retention-days: 30
 

--- a/docs/governance/audit/PORTAL_AUDIT_2026-05-18_backlog.md
+++ b/docs/governance/audit/PORTAL_AUDIT_2026-05-18_backlog.md
@@ -81,7 +81,7 @@ Each item carries severity, effort, the files to touch, observable acceptance cr
 
 ### N-2. Add lightweight ML sampled coverage and raise the 25% core floor
 
-**Status:** Instrumentation landed 2026-05-25 (ML PR lane runs sampled `--cov` on `vlm` + `spatial_ai/segmentation`, uploaded as the `coverage-ml-sampled-*` artifact, non-blocking). The global `--cov-fail-under` ratchet from 25 → 30 is deferred until the trigger in `docs/testing/COLD_ZONE_COVERAGE_PROGRAM.md` §18.2 is met (two consecutive main-branch core runs ≥ 35% combined coverage + clean ML sampled artifact + no regressing PRs). A follow-up PR will flip the floor when evidence is in hand.
+**Status:** Instrumentation landed 2026-05-25 (ML PR lane runs sampled `--cov` on `vlm` + `spatial_ai/segmentation`, uploaded as the `coverage-ml-sampled-*` artifact, non-blocking). The global `--cov-fail-under` ratchet from 25 → 30 is deferred until the trigger in `docs/testing/COLD_ZONE_COVERAGE_PROGRAM.md` §17.2 is met (two consecutive main-branch core runs ≥ 35% combined coverage + clean ML sampled artifact + no regressing PRs). A follow-up PR will flip the floor when evidence is in hand.
 
 **Severity / Effort:** Medium / M
 **Tracks finding:** [#2](../PORTAL_AUDIT_REPO_WIDE_2026-05-18.md#61-code-quality-typing-and-test-enforcement) — fragmented coverage

--- a/docs/governance/audit/PORTAL_AUDIT_2026-05-18_backlog.md
+++ b/docs/governance/audit/PORTAL_AUDIT_2026-05-18_backlog.md
@@ -81,6 +81,8 @@ Each item carries severity, effort, the files to touch, observable acceptance cr
 
 ### N-2. Add lightweight ML sampled coverage and raise the 25% core floor
 
+**Status:** Instrumentation landed 2026-05-25 (ML PR lane runs sampled `--cov` on `vlm` + `spatial_ai/segmentation`, uploaded as the `coverage-ml-sampled-*` artifact, non-blocking). The global `--cov-fail-under` ratchet from 25 → 30 is deferred until the trigger in `docs/testing/COLD_ZONE_COVERAGE_PROGRAM.md` §18.2 is met (two consecutive main-branch core runs ≥ 35% combined coverage + clean ML sampled artifact + no regressing PRs). A follow-up PR will flip the floor when evidence is in hand.
+
 **Severity / Effort:** Medium / M
 **Tracks finding:** [#2](../PORTAL_AUDIT_REPO_WIDE_2026-05-18.md#61-code-quality-typing-and-test-enforcement) — fragmented coverage
 **Files to touch:** `.github/workflows/build.yml:722-728`, `scripts/ci/check_per_package_coverage.py`, `docs/testing/COLD_ZONE_COVERAGE_PROGRAM.md`

--- a/docs/testing/COLD_ZONE_COVERAGE_PROGRAM.md
+++ b/docs/testing/COLD_ZONE_COVERAGE_PROGRAM.md
@@ -620,7 +620,7 @@ adopt the same contract when their PR opens.
 
 ## 16. Out of scope
 
-- ~~Changing the global `--cov-fail-under` floor.~~ **Superseded 2026-05-25 by audit item N-2** — the 25 → 30 ratchet is now in scope (see §18 below). The original prohibition stood when this doc was self-contained; the audit places the floor inside the cold-zone program's responsibility.
+- ~~Changing the global `--cov-fail-under` floor.~~ **Superseded 2026-05-25 by audit item N-2** — the 25 → 30 ratchet is now in scope (see §17 below). The original prohibition stood when this doc was self-contained; the audit places the floor inside the cold-zone program's responsibility.
 - Touching `lux_depth_v3/` core seams beyond what existing per-package floors
   cover.
 - Rewriting `app.py` or `orchestrator.py` coverage strategy (covered by
@@ -630,26 +630,29 @@ adopt the same contract when their PR opens.
 
 ---
 
-## 18. N-2 — ML sampled coverage and global floor ratchet
+## 17. N-2 — ML sampled coverage and global floor ratchet
 
 Tracks backlog item N-2 (audit finding #2, fragmented coverage). Two
 deliverables, sequenced.
 
-### 18.1 ML sampled coverage on cold packages (landed)
+### 17.1 ML sampled coverage on cold packages (landed)
 
 The ML PR lane in `.github/workflows/build.yml` now runs an advisory,
 non-blocking `pytest --cov` over `src/transformation_portal/vlm` and
 `src/transformation_portal/spatial_ai/segmentation` after the main test
 step completes. The step is gated with `continue-on-error: true`; its
 output is uploaded as the `coverage-ml-sampled-<python-version>`
-artifact (30-day retention) for use as evidence in §18.2.
+artifact (30-day retention) for use as evidence in §17.2. The artifact
+also carries `coverage-ml-sampled-status.txt`, so marker-zero or other
+advisory pytest exits remain visible even when no coverage XML is
+produced.
 
 Selection: `pytest -m "ml and not slow and not integration and not
 benchmark"` over the two test trees only — keeps the sample focused on
 the cold packages without re-running the full ML suite under tracing
 overhead.
 
-### 18.2 Global `--cov-fail-under` ratchet (deferred)
+### 17.2 Global `--cov-fail-under` ratchet (deferred)
 
 The build.yml core lane currently sets `--cov-fail-under=25`. The
 audit's acceptance criterion is to ratchet that to `30` once the
@@ -667,17 +670,17 @@ cold-zone baseline shows stable margin on the affected packages.
 
 When all three hold, a follow-up PR flips
 `COV_FLAGS="... --cov-fail-under=30"` in build.yml and records the date
-the new floor took effect in §18.3 below.
+the new floor took effect in §17.3 below.
 
-### 18.3 Ratchet history
+### 17.3 Ratchet history
 
 | Date | Floor before | Floor after | Trigger evidence |
 |---|---:|---:|---|
-| 2026-05-25 | 25 | 25 | N-2 instrumentation landed; ratchet awaiting two consecutive ≥35% main runs (see §18.2). |
+| 2026-05-25 | 25 | 25 | N-2 instrumentation landed; ratchet awaiting two consecutive ≥35% main runs (see §17.2). |
 
 ---
 
-## 17. Open questions before PR 0
+## 18. Open questions before PR 0
 
 1. Should the cold-zone report be committed per run, or regenerated on demand?
    Recommendation: commit baseline once, regenerate on demand thereafter and

--- a/docs/testing/COLD_ZONE_COVERAGE_PROGRAM.md
+++ b/docs/testing/COLD_ZONE_COVERAGE_PROGRAM.md
@@ -1,10 +1,11 @@
 # Cold-Zone Coverage Program
 
 **Document Status:** Active proposal
-**Last Updated:** 2026-05-13
+**Last Updated:** 2026-05-25
 **Related Docs:** `docs/testing/STRATEGY.md`, `docs/testing/test_coverage_improvement_plan.md`
 **Related Scripts:** `scripts/ci/check_per_package_coverage.py`, `scripts/ci/check_per_package_branch_coverage.py`
 **Related ADRs:** ADR-031 (test dependency isolation), ADR-044 (marker enforcement)
+**Related audit items:** N-2 (audit `PORTAL_AUDIT_REPO_WIDE_2026-05-18.md` finding #2 — fragmented coverage)
 
 > This document supersedes the unrevised "cold-zone testing optimization strategy"
 > draft circulated 2026-05-12. It folds in a feasibility audit of the proposed
@@ -619,13 +620,60 @@ adopt the same contract when their PR opens.
 
 ## 16. Out of scope
 
-- Changing the global `--cov-fail-under` floor.
+- ~~Changing the global `--cov-fail-under` floor.~~ **Superseded 2026-05-25 by audit item N-2** — the 25 → 30 ratchet is now in scope (see §18 below). The original prohibition stood when this doc was self-contained; the audit places the floor inside the cold-zone program's responsibility.
 - Touching `lux_depth_v3/` core seams beyond what existing per-package floors
   cover.
 - Rewriting `app.py` or `orchestrator.py` coverage strategy (covered by
   `docs/testing/test_coverage_improvement_plan.md`).
 - ML-lane GPU validation (`integration` and `ml` lanes remain governed
   separately).
+
+---
+
+## 18. N-2 — ML sampled coverage and global floor ratchet
+
+Tracks backlog item N-2 (audit finding #2, fragmented coverage). Two
+deliverables, sequenced.
+
+### 18.1 ML sampled coverage on cold packages (landed)
+
+The ML PR lane in `.github/workflows/build.yml` now runs an advisory,
+non-blocking `pytest --cov` over `src/transformation_portal/vlm` and
+`src/transformation_portal/spatial_ai/segmentation` after the main test
+step completes. The step is gated with `continue-on-error: true`; its
+output is uploaded as the `coverage-ml-sampled-<python-version>`
+artifact (30-day retention) for use as evidence in §18.2.
+
+Selection: `pytest -m "ml and not slow and not integration and not
+benchmark"` over the two test trees only — keeps the sample focused on
+the cold packages without re-running the full ML suite under tracing
+overhead.
+
+### 18.2 Global `--cov-fail-under` ratchet (deferred)
+
+The build.yml core lane currently sets `--cov-fail-under=25`. The
+audit's acceptance criterion is to ratchet that to `30` once the
+cold-zone baseline shows stable margin on the affected packages.
+
+**Ratchet trigger (must hold before flipping):**
+
+1. Two consecutive main-branch core CI runs report combined line
+   coverage ≥ 35% (a five-point margin over the new 30 floor).
+2. The `coverage-ml-sampled-*` artifact from a main-branch run shows
+   the ML-lane sampled packages above their existing per-package
+   floors (`vlm ≥ 69%` per §12.1, no regression on
+   `spatial_ai/segmentation`).
+3. No open PR is reducing the core lane's combined coverage.
+
+When all three hold, a follow-up PR flips
+`COV_FLAGS="... --cov-fail-under=30"` in build.yml and records the date
+the new floor took effect in §18.3 below.
+
+### 18.3 Ratchet history
+
+| Date | Floor before | Floor after | Trigger evidence |
+|---|---:|---:|---|
+| 2026-05-25 | 25 | 25 | N-2 instrumentation landed; ratchet awaiting two consecutive ≥35% main runs (see §18.2). |
 
 ---
 


### PR DESCRIPTION
Addresses backlog item N-2 (audit finding #2 — fragmented coverage) in
two parts.

Part 1 (landed in this PR): The ML PR lane now runs an advisory,
non-blocking pytest --cov on src/transformation_portal/vlm and
src/transformation_portal/spatial_ai/segmentation after the main test
step. The step is gated `continue-on-error: true` and uploads
coverage-ml-sampled.xml as a per-Python-version artifact with 30-day
retention. Selection is the same marker expression the ML matrix uses
(`ml and not slow and not integration and not benchmark`), scoped to
tests/vlm and tests/spatial_ai/segmentation only — keeps the sample
focused on the cold packages without re-running the full ML suite
under tracing overhead. The main ML test step still runs with --no-cov
for PR feedback speed.

Part 2 (deferred): The `--cov-fail-under` ratchet from 25 → 30 needs
evidence the current global coverage holds a stable margin. The
acceptance criterion explicitly conditions it on "once the cold-zone
baseline shows stable margin on the affected packages." No measured
global figure exists in the repo today (cold_zone_baseline_2026-05-12.md
records per-file numbers only). Documented the ratchet trigger and the
follow-up plan in docs/testing/COLD_ZONE_COVERAGE_PROGRAM.md §18.2.
A follow-up PR will flip the floor when the trigger holds (two
consecutive main-branch core runs ≥ 35% combined coverage + clean
ML sampled artifact + no regressing PRs).

Docs:
- Cold-zone program §18 (new): records the ML sampled coverage step,
  the deferred floor ratchet, its trigger, and a ratchet-history table.
- §16 ("Out of scope"): the prior prohibition on changing the global
  --cov-fail-under floor is struck through with a 2026-05-25 note that
  audit item N-2 supersedes it; the prohibition was correct when the
  doc was self-contained.
- Backlog: N-2 marked with split-delivery Status line (instrumentation
  landed, ratchet deferred to follow-up with trigger).

Validation:
- build.yml YAML parses; pre-commit hooks all pass or skip cleanly.
- check-doc-heading-links, check_docs_structure, check_stale_docs_paths
  all green.
- Scope: 3 files, no changes to scripts/ci/check_per_package_coverage.py
  (per-package floors are unchanged; only the global floor is the N-2
  ratchet target).