### PR TITLE
fix(deps): bump starlette for main security gate

### DIFF
--- a/docs/governance/DEPENDABOT_PR_GOVERNANCE.md
+++ b/docs/governance/DEPENDABOT_PR_GOVERNANCE.md
@@ -3,7 +3,7 @@
 **Purpose**: Define triage policy and merge criteria for Dependabot-generated pull requests
 **Owner**: Transformation Portal Architect
 **Created**: 2026-03-26
-**Last Updated**: 2026-05-12
+**Last Updated**: 2026-05-26
 
 ---
 
@@ -82,9 +82,9 @@ Minor and patch version updates are grouped per directory to reduce PR noise. Ma
 The following dependencies are **exact-pinned** in `requirements/base.in` for API/UI parity and security baseline:
 
 ```
-fastapi==0.136.0
-starlette==1.0.0
-uvicorn==0.45.0
+fastapi==0.136.1
+starlette==1.0.1
+uvicorn==0.46.0
 aiofiles==25.1.0
 ```
 
@@ -228,6 +228,7 @@ Before merging any Dependabot PR:
 | 2026-04-16 | Added ML alert dismissal/remediation governance for supported vs frozen target-owned lanes | Architect |
 | 2026-04-23 | Synced the exact-pinned web stack block with the curated Uvicorn 0.45.0 baseline | Architect |
 | 2026-05-12 | Added npm Dependabot coverage and per-directory grouped minor/patch policy | Architect |
+| 2026-05-26 | Recorded the curated Starlette 1.0.1 patch for PYSEC-2026-161 and synced the current exact-pinned web stack baseline | Architect |
 
 ---
 

--- a/requirements/README.md
+++ b/requirements/README.md
@@ -119,11 +119,11 @@ The repository's governed web stack currently resolves to:
 
 | Dependency | Source of Truth | Current Version |
 |-----------|-----------------|-----------------|
-| FastAPI | `requirements/base.in` | `0.136.0` |
-| Starlette | `requirements/base.in` + `pyproject.toml` bound | `1.0.0` |
-| Uvicorn | `requirements/base.in` | `0.42.0` |
+| FastAPI | `requirements/base.in` | `0.136.1` |
+| Starlette | `requirements/base.in` + `pyproject.toml` bound | `1.0.1` |
+| Uvicorn | `requirements/base.in` | `0.46.0` |
 
-This baseline was validated and merged via the curated compatibility path on 2026-04-15. Do not treat future updates to these exact pins as routine dependency bumps; use the governance flow documented in `docs/governance/DEPENDABOT_PR_GOVERNANCE.md`.
+This baseline was validated and merged via the curated compatibility path, most recently on 2026-05-26 for the Starlette `PYSEC-2026-161` patch. Do not treat future updates to these exact pins as routine dependency bumps; use the governance flow documented in `docs/governance/DEPENDABOT_PR_GOVERNANCE.md`.
 
 ### Layered ML Strategy
 

--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -344,7 +344,7 @@ sqlalchemy[asyncio]==2.0.49
     #   -r base.in
     #   alembic
     #   sqlalchemy
-starlette==1.0.0
+starlette==1.0.1
     # via
     #   -r base.in
     #   fastapi
@@ -402,5 +402,5 @@ werkzeug==3.1.8
     # via moto
 xmltodict==1.0.4
     # via moto
-zipp==3.23.1
+zipp==4.1.0
     # via importlib-metadata

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -15,9 +15,10 @@ typer>=0.10.0,<1           # CLI framework
 tqdm>=4.66,<5              # progress bar utility
 
 # Web orchestration service stack (exact pins for API/UI parity)
-# Security: keep FastAPI + Starlette on patched baseline for CVE-2025-62727.
+# Security: keep FastAPI + Starlette on patched baseline for CVE-2025-62727
+# and PYSEC-2026-161.
 fastapi==0.136.1           # orchestrator API framework (validated against curated Starlette 1.x upgrade)
-starlette==1.0.0           # direct runtime import + curated Starlette 1.x validation target
+starlette==1.0.1           # direct runtime import + curated Starlette 1.x validation target
 uvicorn==0.46.0            # ASGI server runtime pin
 aiofiles==25.1.0           # async file I/O support for FastAPI file responses
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -183,7 +183,7 @@ sqlalchemy[asyncio]==2.0.49
     #   -r base.in
     #   alembic
     #   sqlalchemy
-starlette==1.0.0
+starlette==1.0.1
     # via
     #   -c all.txt
     #   -r base.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -203,7 +203,7 @@ virtualenv==21.2.1
     # via
     #   -c all.txt
     #   tox
-zipp==3.23.1
+zipp==4.1.0
     # via
     #   -c all.txt
     #   importlib-metadata

--- a/tests/test_secure_install_pilot_workflow.py
+++ b/tests/test_secure_install_pilot_workflow.py
@@ -103,10 +103,10 @@ def test_secure_install_pilot_readme_records_explicit_hash_policy() -> None:
 def test_requirements_readme_records_current_curated_web_runtime_baseline() -> None:
     readme = REQUIREMENTS_README_PATH.read_text(encoding="utf-8")
 
-    assert "| FastAPI | `requirements/base.in` | `0.136.0` |" in readme
-    assert "| Starlette | `requirements/base.in` + `pyproject.toml` bound | `1.0.0` |" in readme
-    assert "| Uvicorn | `requirements/base.in` | `0.42.0` |" in readme
-    assert "curated compatibility path on 2026-04-15" in readme
+    assert "| FastAPI | `requirements/base.in` | `0.136.1` |" in readme
+    assert "| Starlette | `requirements/base.in` + `pyproject.toml` bound | `1.0.1` |" in readme
+    assert "| Uvicorn | `requirements/base.in` | `0.46.0` |" in readme
+    assert "Starlette `PYSEC-2026-161` patch" in readme
 
 
 def test_dependabot_governance_doc_includes_dep_pin_changed_checklist() -> None:


### PR DESCRIPTION
## Summary
- Root cause: main `CI Quality Firewall (push)` failed because `requirements-ci.txt` resolved `starlette==1.0.0`, which `pip-audit` reports as `PYSEC-2026-161`.
- Bump the governed exact Starlette pin to `1.0.1` within the existing `pyproject.toml` `<1.1` bound and keep the firewall policy unchanged.

## Changes
- Updated `requirements/base.in`, `requirements/base.txt`, and `requirements/all.txt` to use `starlette==1.0.1`.
- Refreshed the generic lock output accepted by the Python 3.11 lock check, including the transitive `zipp==4.1.0` resolver refresh in `requirements/all.txt` and `requirements/ci.txt`.
- Synced the documented exact-pinned web stack baseline and the secure-install pilot baseline assertion.

## Validation
Proven green:
- `cd requirements && make compile LOCK_PYTHON_VERSION=3.11 PIP_COMPILE_BIN=/private/tmp/tp-lock-py311/bin/pip-compile`
- `cd requirements && make check LOCK_PYTHON_VERSION=3.11 PIP_COMPILE_BIN=/private/tmp/tp-lock-py311/bin/pip-compile`
- `python3 scripts/validation/check_requirements_lock_contract.py`
- `make check-dependency-pinning`
- `make check-ci-sync`
- `./.venv/bin/pip-audit --desc -r requirements-ci.txt --ignore-vuln CVE-2026-4539`
- `.venv/bin/pytest tests/test_secure_install_pilot_workflow.py -q`
- `make test-orchestrator-contract`
- `make test-portal-contract`
- `git diff --check`
- `make validate-ci`
- pre-commit hooks during commit

Still failing:
- None locally observed.

## Risk
- Bounded to the exact-pinned web runtime patch lane; no workflow policy relaxation or vulnerability ignore was added.
- `pyproject.toml` remains unchanged because the existing Starlette `>=0.49.1,<1.1` bound already permits `1.0.1` and excludes `1.1.0`.
- Revert-safe: restoring the previous pins reverts dependency behavior, but would also reintroduce the main firewall audit failure.