### PR TITLE
feat(architecture): implement cleanup governance seams

### DIFF
--- a/.github/workflows/performance-monitor.yml
+++ b/.github/workflows/performance-monitor.yml
@@ -225,7 +225,8 @@ jobs:
             }
 
       - name: Enforce nightly performance gate
-        if: steps.benchmark.outputs.status == 'regression'
+        # "failed" means the benchmark run itself was invalid, not product-green evidence.
+        if: steps.benchmark.outputs.status == 'regression' || steps.benchmark.outputs.status == 'failed'
         run: |
           echo "Performance regression exceeded the nightly-blocking threshold documented in docs/performance/GATE_POLICY.md."
           exit 1

--- a/.github/workflows/performance-monitor.yml
+++ b/.github/workflows/performance-monitor.yml
@@ -3,6 +3,7 @@
 # NOTE: This workflow does NOT run on PRs to avoid baseline comparison issues.
 # Benchmark baselines require cross-run persistence which workflow artifacts don't provide.
 # Baselines are stored in tools/benchmarks/baseline.json (if present).
+# Regression status is a nightly-blocking signal per docs/performance/GATE_POLICY.md.
 name: Performance Monitor
 
 on:
@@ -222,3 +223,9 @@ jobs:
                 labels: ['performance', 'regression', 'automated']
               });
             }
+
+      - name: Enforce nightly performance gate
+        if: steps.benchmark.outputs.status == 'regression'
+        run: |
+          echo "Performance regression exceeded the nightly-blocking threshold documented in docs/performance/GATE_POLICY.md."
+          exit 1

--- a/app.py
+++ b/app.py
@@ -3576,7 +3576,7 @@ def _job_create_validation_error_response(exc: ValidationError) -> JSONResponse:
     field = "payload"
     if isinstance(location, (list, tuple)) and location:
         field = ".".join(str(part) for part in location if part != "body") or "payload"
-    reason = "missing_required_field" if first_error.get("type") == "missing" else "invalid_request"
+    reason = "required" if first_error.get("type") == "missing" else "invalid_request"
     return _error_response(
         400,
         code="INVALID_ARGUMENT",
@@ -10103,10 +10103,12 @@ async def _job_events(
 
     async def gen() -> AsyncGenerator[str, None]:
         last_replayed_seq = replay_after_seq
+        replayed_any = False
         try:
             if replay_after_seq is not None:
                 try:
                     async for stored_event in _job_event_store().events_since(job_id, after_seq=replay_after_seq):
+                        replayed_any = True
                         last_replayed_seq = stored_event.seq
                         yield _sse(
                             stored_event.event_type,
@@ -10117,7 +10119,9 @@ async def _job_events(
                             return
                 except Exception:  # noqa: BLE001 - fall back to live stream/synthetic terminal event
                     LOGGER.debug("job event-store replay skipped/failed for %s", job_id, exc_info=True)
-            else:
+            if replay_after_seq is None or not replayed_any:
+                if replay_after_seq is not None:
+                    last_replayed_seq = None
                 yield _sse(
                     "state",
                     {

--- a/app.py
+++ b/app.py
@@ -33,15 +33,18 @@ from fastapi.exception_handlers import request_validation_exception_handler as f
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse, RedirectResponse
+from pydantic import ValidationError
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.middleware.trustedhost import TrustedHostMiddleware
 from starlette.responses import Response, StreamingResponse
 
+from transformation_portal.api.routes import JobRouteHandlers, create_jobs_router
 from transformation_portal.api.v1 import (
     ConfigMetadataEnvelope,
     ConfigPreviewEnvelope,
     HealthzResponse,
     JobBriefData,
+    JobCreateRequest,
     JobEnvelope,
     JobsListData,
     JobsListEnvelope,
@@ -69,6 +72,7 @@ from transformation_portal.orchestrator import (
     JobNotFoundError,
     JobRecord,
     JobRepository,
+    get_job_event_store,
     get_job_repository,
 )
 from transformation_portal.orchestrator.artifact_store import ArtifactNotFoundError as StoreArtifactNotFoundError
@@ -1135,6 +1139,10 @@ def _job_repository() -> JobRepository:
     return repo
 
 
+def _job_event_store():
+    return get_job_event_store()
+
+
 def _record_from_job(job: Job) -> JobRecord:
     return JobRecord(
         id=job.id,
@@ -1809,14 +1817,15 @@ def _now() -> float:
     return time.time()
 
 
-def _sse(event: str, data: Dict[str, Any]) -> str:
+def _sse(event: str, data: Dict[str, Any], *, event_id: Optional[int | str] = None) -> str:
     # SSE payload: event type + JSON data, double newline.
     payload = json.dumps(
         data,
         ensure_ascii=False,
         separators=(",", ":"),
     )
-    return f"event: {event}\ndata: {payload}\n\n"
+    event_id_line = "" if event_id is None else f"id: {event_id}\n"
+    return f"{event_id_line}event: {event}\ndata: {payload}\n\n"
 
 
 def _error_obj(
@@ -3558,6 +3567,29 @@ def _portal_issue_public_message(issue: Any, *, field: str = "payload") -> str:
     if "\n" in text or "\r" in text or "\x00" in text:
         return message
     return text
+
+
+def _job_create_validation_error_response(exc: ValidationError) -> JSONResponse:
+    errors = exc.errors()
+    first_error = errors[0] if errors else {}
+    location = first_error.get("loc") if isinstance(first_error, dict) else None
+    field = "payload"
+    if isinstance(location, (list, tuple)) and location:
+        field = ".".join(str(part) for part in location if part != "body") or "payload"
+    reason = "missing_required_field" if first_error.get("type") == "missing" else "invalid_request"
+    return _error_response(
+        400,
+        code="INVALID_ARGUMENT",
+        message=_portal_safe_error_message(reason, field=field),
+        details={"field": field, "reason": reason},
+    )
+
+
+def _validated_job_create_request(payload: Dict[str, Any]) -> JobCreateRequest | JSONResponse:
+    try:
+        return JobCreateRequest.model_validate(payload)
+    except ValidationError as exc:
+        return _job_create_validation_error_response(exc)
 
 
 def _portal_next_best_action_label(field: Any, default: str) -> str:
@@ -6377,6 +6409,18 @@ async def _publish_event(
     data: Dict[str, Any],
 ) -> None:
     event_at = _now()
+    event_seq: Optional[int] = None
+    try:
+        stored_event = await _job_event_store().append(
+            job_id,
+            event,
+            dict(data),
+            created_at=event_at,
+        )
+        event_seq = stored_event.seq
+    except Exception:  # noqa: BLE001 - live fanout must not fail on replay persistence lag
+        LOGGER.debug("job event-store append skipped/failed for %s event=%s", job_id, event, exc_info=True)
+
     job = JOBS.get(job_id)
     if job is not None:
         job.last_event_at = event_at
@@ -6393,6 +6437,8 @@ async def _publish_event(
         return
 
     payload = {"event": event, "data": data}
+    if event_seq is not None:
+        payload["id"] = event_seq
     stale_subscribers: List[str] = []
     for subscriber_id, queue in list(subscribers.items()):
         if queue.full():
@@ -9379,12 +9425,10 @@ async def create_job_v2(
     )
 
 
-@app.post("/v1/jobs", response_model=JobEnvelope)
 async def create_job_http(request: Request, payload: Dict[str, Any]) -> JSONResponse:
     return await create_job(payload, portal_actor=_portal_actor_from_request(request))
 
 
-@app.post("/v2/jobs", response_model=JobEnvelope)
 async def create_job_v2_http(request: Request, payload: Dict[str, Any]) -> JSONResponse:
     return await create_job_v2(payload, portal_actor=_portal_actor_from_request(request))
 
@@ -9421,6 +9465,10 @@ async def _create_job(
             message=_portal_issue_public_message(first_error, field=field),
             details={"field": field, "reason": reason},
         )
+
+    validated_request = _validated_job_create_request(payload)
+    if isinstance(validated_request, JSONResponse):
+        return validated_request
 
     readiness_snapshot = preview.get("readiness")
     if not isinstance(readiness_snapshot, dict):
@@ -9604,12 +9652,10 @@ async def _create_job(
     )
 
 
-@app.get("/v1/jobs", response_model=JobsListEnvelope)
 async def list_jobs(limit: int = JOB_LIST_LIMIT) -> JSONResponse:
     return await _list_jobs(limit=limit, api_version="v1")
 
 
-@app.get("/v2/jobs", response_model=JobsListEnvelope)
 async def list_jobs_v2(limit: int = JOB_LIST_LIMIT) -> JSONResponse:
     return await _list_jobs(limit=limit, api_version="v2")
 
@@ -9644,12 +9690,10 @@ async def _list_jobs(*, limit: int = JOB_LIST_LIMIT, api_version: str = "v1") ->
     )
 
 
-@app.get("/v1/jobs/{job_id}", response_model=JobStatusEnvelope)
 async def get_job(job_id: str, include_logs: bool = True) -> JSONResponse:
     return await _get_job(job_id, include_logs=include_logs, api_version="v1")
 
 
-@app.get("/v2/jobs/{job_id}", response_model=JobStatusEnvelope)
 async def get_job_v2(job_id: str, include_logs: bool = True) -> JSONResponse:
     return await _get_job(job_id, include_logs=include_logs, api_version="v2")
 
@@ -9681,22 +9725,18 @@ async def _get_job(job_id: str, *, include_logs: bool = True, api_version: str =
     )
 
 
-@app.get("/v1/jobs/{job_id}/artifacts/{artifact_path:path}")
 async def get_job_artifact(job_id: str, artifact_path: str) -> Response:
     return await _get_job_artifact(job_id, artifact_path)
 
 
-@app.get("/v2/jobs/{job_id}/artifacts/{artifact_path:path}")
 async def get_job_artifact_v2(job_id: str, artifact_path: str) -> Response:
     return await _get_job_artifact(job_id, artifact_path)
 
 
-@app.delete("/v1/jobs/{job_id}/artifacts", response_model=JobStatusEnvelope)
 async def delete_job_artifacts(job_id: str) -> JSONResponse:
     return await _delete_job_artifacts(job_id, api_version="v1")
 
 
-@app.delete("/v2/jobs/{job_id}/artifacts", response_model=JobStatusEnvelope)
 async def delete_job_artifacts_v2(job_id: str) -> JSONResponse:
     return await _delete_job_artifacts(job_id, api_version="v2")
 
@@ -9939,12 +9979,10 @@ async def _delete_job_artifacts(job_id: str, *, api_version: str = "v1") -> JSON
     )
 
 
-@app.post("/v1/jobs/{job_id}/cancel", response_model=JobEnvelope)
 async def cancel_job(job_id: str) -> JSONResponse:
     return await _cancel_job(job_id)
 
 
-@app.post("/v2/jobs/{job_id}/cancel", response_model=JobEnvelope)
 async def cancel_job_v2(job_id: str) -> JSONResponse:
     return await _cancel_job(job_id)
 
@@ -9979,7 +10017,6 @@ async def _cancel_job(job_id: str) -> JSONResponse:
     )
 
 
-@app.get("/v1/jobs/{job_id}/events")
 async def job_events(
     request: Request,
     job_id: str,
@@ -9987,12 +10024,46 @@ async def job_events(
     return await _job_events(request, job_id)
 
 
-@app.get("/v2/jobs/{job_id}/events")
 async def job_events_v2(
     request: Request,
     job_id: str,
 ) -> Response:
     return await _job_events(request, job_id)
+
+
+def _last_event_id_from_request(request: Request) -> Optional[int]:
+    headers = getattr(request, "headers", None) or {}
+    raw_value = headers.get("last-event-id")
+    if raw_value is None or not str(raw_value).strip():
+        return None
+    try:
+        last_event_id = int(str(raw_value).strip())
+    except ValueError as exc:
+        raise ValueError("Last-Event-ID must be a non-negative integer") from exc
+    if last_event_id < 0:
+        raise ValueError("Last-Event-ID must be a non-negative integer")
+    return last_event_id
+
+
+def _event_queue_seq(event_payload: Mapping[str, Any]) -> Optional[int]:
+    raw_value = event_payload.get("id")
+    if raw_value is None:
+        return None
+    try:
+        return int(raw_value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _terminal_done_payload(job: Job) -> Dict[str, Any]:
+    return {
+        "id": job.id,
+        "state": job.state,
+        "exit_code": job.exit_code,
+        "error": job.error,
+        "artifacts": job.artifacts,
+        "run_summary": job.run_summary or None,
+    }
 
 
 async def _job_events(
@@ -10013,6 +10084,16 @@ async def _job_events(
     if job.state not in ACTIVE_JOB_STATES and job.state != "canceled":
         _refresh_job_run_summary(job)
 
+    try:
+        replay_after_seq = _last_event_id_from_request(request)
+    except ValueError:
+        return _error_response(
+            400,
+            code="INVALID_ARGUMENT",
+            message="Last-Event-ID must be a non-negative integer",
+            details={"field": "Last-Event-ID", "reason": "invalid_request"},
+        )
+
     subscribers = EVENT_SUBSCRIBERS.setdefault(job_id, {})
     subscriber_id = uuid.uuid4().hex
     q: asyncio.Queue[Dict[str, Any]] = asyncio.Queue(
@@ -10021,15 +10102,30 @@ async def _job_events(
     subscribers[subscriber_id] = q
 
     async def gen() -> AsyncGenerator[str, None]:
+        last_replayed_seq = replay_after_seq
         try:
-            yield _sse(
-                "state",
-                {
-                    "id": job_id,
-                    "state": job.state,
-                    "progress": job.progress,
-                },
-            )
+            if replay_after_seq is not None:
+                try:
+                    async for stored_event in _job_event_store().events_since(job_id, after_seq=replay_after_seq):
+                        last_replayed_seq = stored_event.seq
+                        yield _sse(
+                            stored_event.event_type,
+                            stored_event.payload,
+                            event_id=stored_event.seq,
+                        )
+                        if stored_event.event_type == "done":
+                            return
+                except Exception:  # noqa: BLE001 - fall back to live stream/synthetic terminal event
+                    LOGGER.debug("job event-store replay skipped/failed for %s", job_id, exc_info=True)
+            else:
+                yield _sse(
+                    "state",
+                    {
+                        "id": job_id,
+                        "state": job.state,
+                        "progress": job.progress,
+                    },
+                )
             if job.done_published_at is not None:
                 # The 'done' event has already been published to all subscribers.
                 # For a late-connecting client, we can safely drain any queued
@@ -10037,23 +10133,16 @@ async def _job_events(
                 while True:
                     try:
                         ev = q.get_nowait()
-                        yield _sse(ev["event"], ev["data"])
+                        ev_seq = _event_queue_seq(ev)
+                        if last_replayed_seq is not None and ev_seq is not None and ev_seq <= last_replayed_seq:
+                            continue
+                        yield _sse(ev["event"], ev["data"], event_id=ev_seq)
                         if ev["event"] == "done":
                             return
                     except asyncio.QueueEmpty:
                         break
                 # No 'done' event was queued; generate a synthetic one from job state.
-                yield _sse(
-                    "done",
-                    {
-                        "id": job.id,
-                        "state": job.state,
-                        "exit_code": job.exit_code,
-                        "error": job.error,
-                        "artifacts": job.artifacts,
-                        "run_summary": job.run_summary or None,
-                    },
-                )
+                yield _sse("done", _terminal_done_payload(job))
                 return
             elif job.finished_at is not None:
                 # Job processing finished (state is terminal) but done_published_at
@@ -10074,7 +10163,10 @@ async def _job_events(
 
                 try:
                     ev = await asyncio.wait_for(q.get(), timeout=1.0)
-                    yield _sse(ev["event"], ev["data"])
+                    ev_seq = _event_queue_seq(ev)
+                    if last_replayed_seq is not None and ev_seq is not None and ev_seq <= last_replayed_seq:
+                        continue
+                    yield _sse(ev["event"], ev["data"], event_id=ev_seq)
                     if ev["event"] == "done":
                         break
                 except asyncio.TimeoutError:
@@ -10103,6 +10195,29 @@ async def _job_events(
             "Connection": "keep-alive",
         },
     )
+
+
+app.include_router(
+    create_jobs_router(
+        JobRouteHandlers(
+            create_job_http=create_job_http,
+            create_job_v2_http=create_job_v2_http,
+            list_jobs=list_jobs,
+            list_jobs_v2=list_jobs_v2,
+            get_job=get_job,
+            get_job_v2=get_job_v2,
+            get_job_artifact=get_job_artifact,
+            get_job_artifact_v2=get_job_artifact_v2,
+            delete_job_artifacts=delete_job_artifacts,
+            delete_job_artifacts_v2=delete_job_artifacts_v2,
+            cancel_job=cancel_job,
+            cancel_job_v2=cancel_job_v2,
+            job_events=job_events,
+            job_events_v2=job_events_v2,
+        ),
+        job_list_limit=JOB_LIST_LIMIT,
+    )
+)
 
 
 # ---------------------------------------------------------------------------

--- a/docs/architecture/ADR-049-plugin-manifest-trust.md
+++ b/docs/architecture/ADR-049-plugin-manifest-trust.md
@@ -1,0 +1,67 @@
+# ADR-049: Plugin Manifest Trust Boundary
+
+**Status:** Accepted
+**Date:** 2026-05-30
+**Owners:** Repository Architect, Portal Steward
+**Related:** [Portal audit backlog M-1](../governance/audit/PORTAL_AUDIT_2026-05-18_backlog.md#m-1-sandbox-or-sign-plugins-before-broader-use)
+
+## Context
+
+External plugins are already secure by default because discovery outside the
+built-in plugin root requires explicit opt-in. Once enabled, plugin packages
+run in the Transformation Portal process. That is acceptable for controlled
+local extension, but it needs a provenance gate before broader use.
+
+The near-term requirement is a least-invasive trust boundary for in-process
+plugins. Marketplace or multi-tenant execution requires a separate process or
+service boundary and a smaller API surface; that is intentionally deferred to a
+future architecture decision.
+
+## Decision
+
+Use signed `plugin.json` manifests plus a configured trust set for external
+plugin packages.
+
+- External plugin loading remains opt-in through
+  `TRANSFORMATION_PORTAL_ENABLE_EXTERNAL_PLUGINS` or the explicit loader
+  parameter.
+- When `TRANSFORMATION_PORTAL_PLUGIN_TRUST_STORE` or
+  `PluginLoader(plugin_trust_store_path=...)` is configured, external package
+  manifests must verify before any plugin module import occurs.
+- The initial verifier uses deterministic HMAC-SHA256 over canonical manifest
+  JSON, with `signature_algorithm`, `signature_key_id`, and `signature`
+  excluded from the signed payload.
+- Built-in plugins are trusted by repository review and are not required to
+  carry signatures.
+- External single-file plugins are skipped while a trust store is configured,
+  because they do not carry a manifest boundary.
+
+## Trust Store Shape
+
+```json
+{
+  "keys": {
+    "local-dev": "shared-secret"
+  }
+}
+```
+
+This is an in-process provenance check, not a sandbox. The trust store should
+be readable only by operators who are allowed to authorize local plugin code.
+
+## Consequences
+
+- Existing local plugin tests and unsigned external plugins keep their current
+  behavior when no trust store is configured.
+- Operators can require signed manifests without changing the public plugin
+  interface.
+- Unsigned or tampered external packages fail before import, which bounds the
+  highest-risk side effect.
+- Worker-process isolation remains deferred for marketplace or multi-tenant
+  plugin distribution.
+
+## Validation
+
+- Signed external `plugin.json` packages load with a matching trust store.
+- Unsigned external package manifests are rejected when trust is configured.
+- Tampered manifests are rejected before plugin module import.

--- a/docs/architecture/ARCHITECTURE_CLEANUP_BOARD.md
+++ b/docs/architecture/ARCHITECTURE_CLEANUP_BOARD.md
@@ -1,0 +1,63 @@
+# Architecture Cleanup Board
+
+**Status:** Active implementation ledger
+**Created:** 2026-05-30
+**Owner:** Transformation Portal Architect
+
+This board is the current cleanup execution surface. It intentionally does not
+re-open landed Tier 1 / Tier 2 audit work or landed monolith extraction seams.
+Use it to choose narrow implementation PRs that preserve route shapes,
+selectors, API envelopes, auth posture, and validation semantics.
+
+## Active Work
+
+| Priority | Area | Disposition | Source authority | Gate |
+| --- | --- | --- | --- | --- |
+| P0 | Jobs route decorators | implemented | `app.py` jobs route family; `tests/test_app_route_inventory.py` | `make test-orchestrator-http-contract` |
+| P0 | `JobCreateRequest` adoption | implemented | `src/transformation_portal/api/v1/jobs.py` | malformed payload + unsupported pipeline contract tests |
+| P1 | Durable SSE replay | implemented | existing `JobEventStore` storage surface | event-store contract + HTTP SSE replay tests |
+| P1 | Runtime licensing evidence | implemented | audit item M-2 and run-card schemas | run-card schema + licensing gate tests |
+| P1 | Performance gate policy | implemented | audit item M-3 and ADR-034 benchmark policy | doc/workflow parity review |
+| P2 | Plugin trust model | implemented | audit item M-1 | plugin trust-boundary tests + ADR |
+| P2 | Next mypy tranche | measure | `docs/ci/TYPE_CHECKING_POLICY.md` | `mypy --config-file=mypy.ini <path>` |
+| P2 | Cold-zone coverage ratchet | measure | `docs/testing/COLD_ZONE_COVERAGE_PROGRAM.md` | package/branch coverage scripts |
+| P3 | ADR-050 portal evidence | defer intentionally | portal modernization RFC evidence gate | pilot evidence artifact |
+
+## Historical References
+
+| Area | Current status | Do not repeat |
+| --- | --- | --- |
+| Audit Tier 1 | Complete as of the 2026-05-18 backlog updates | torch-load scanner wiring, SAM2 benchmark baseline alignment, Docker non-root runtime, ADR-032 pip-audit correction |
+| Audit Tier 2 | Complete except the explicitly deferred coverage-floor trigger | orchestrator mypy tranche, ML sampled coverage instrumentation, shared segmentation content digest |
+| Monolith seams | Landed through Target 5D in `MONOLITH_DECOMPOSITION_TARGETS.md` | lux-depth orchestrator helper extraction, portal asset/path/SAM2/archive/artifact helpers, segmentation split, rendering split, spatial AI result/config/graph seams |
+| Portal rewrite decision | Not approved | React/Next operator-console rewrite; ADR-050 evidence remains open |
+
+## Operating Rules
+
+- Pick one row per PR unless two rows share the same test fixture and failure
+  mode.
+- Preserve existing API envelopes, route templates, selectors, auth behavior,
+  and browser smoke observability.
+- Add or strengthen one focused gate in the same PR as each behavior change.
+- Treat service availability failures for Postgres, Redis, Docker, and browser
+  runtimes as environment/tooling blockers; do not weaken product contracts to
+  hide them.
+- Keep `src/tp` and `src/transformation_portal` as separate public import
+  surfaces.
+
+## Validation Backbone
+
+Use the narrowest relevant gate while iterating, then close implementation work
+with:
+
+```bash
+make ci-quick
+```
+
+When the touched surface includes managed frontdoor or live browser behavior,
+also run the relevant browser smoke:
+
+```bash
+make validate-frontdoor-browser
+make validate-portal-browser
+```

--- a/docs/architecture/ARCHITECTURE_CLEANUP_BOARD.md
+++ b/docs/architecture/ARCHITECTURE_CLEANUP_BOARD.md
@@ -16,7 +16,7 @@ selectors, API envelopes, auth posture, and validation semantics.
 | P0 | Jobs route decorators | implemented | `app.py` jobs route family; `tests/test_app_route_inventory.py` | `make test-orchestrator-http-contract` |
 | P0 | `JobCreateRequest` adoption | implemented | `src/transformation_portal/api/v1/jobs.py` | malformed payload + unsupported pipeline contract tests |
 | P1 | Durable SSE replay | implemented | existing `JobEventStore` storage surface | event-store contract + HTTP SSE replay tests |
-| P1 | Runtime licensing evidence | implemented | audit item M-2 and run-card schemas | run-card schema + licensing gate tests |
+| P1 | Runtime licensing evidence v1 | implemented | audit item M-2 and run-card schemas | run-card schema + licensing gate tests |
 | P1 | Performance gate policy | implemented | audit item M-3 and ADR-034 benchmark policy | doc/workflow parity review |
 | P2 | Plugin trust model | implemented | audit item M-1 | plugin trust-boundary tests + ADR |
 | P2 | Next mypy tranche | measure | `docs/ci/TYPE_CHECKING_POLICY.md` | `mypy --config-file=mypy.ini <path>` |

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -74,6 +74,7 @@ These ADRs remain active support material. Keep them in this directory, and revi
 | [ADR-045-monolith-decomposition-residuals.md](ADR-045-monolith-decomposition-residuals.md) | current-support-adr |
 | [ADR-046-app-path-security-helper-extraction.md](ADR-046-app-path-security-helper-extraction.md) | current-support-adr |
 | [ADR-047-managed-sam2-checkpoint-security-extraction.md](ADR-047-managed-sam2-checkpoint-security-extraction.md) | current-support-adr |
+| [ADR-049-plugin-manifest-trust.md](ADR-049-plugin-manifest-trust.md) | current-support-adr |
 | [templates/ADR-vjepa2-separate-repo-TEMPLATE.md](templates/ADR-vjepa2-separate-repo-TEMPLATE.md) | template (relocated 2026-05-16 out of the numbered ADR series; not a real ADR) |
 
 ## Review-Required Planning Docs
@@ -98,6 +99,7 @@ These non-canonical planning, evidence, and support docs remain in `docs/archite
 | [DUAL_REQUEST_QUICK_REF.md](DUAL_REQUEST_QUICK_REF.md) | review-required-planning |
 | [ML_CI_OPTIMIZATION_QUICKREF.md](ML_CI_OPTIMIZATION_QUICKREF.md) | review-required-planning |
 | [ML_CI_OPTIMIZATION_STRATEGIC_REVIEW.md](ML_CI_OPTIMIZATION_STRATEGIC_REVIEW.md) | review-required-planning |
+| [ARCHITECTURE_CLEANUP_BOARD.md](ARCHITECTURE_CLEANUP_BOARD.md) | review-required-planning |
 | [MONOLITH_DECOMPOSITION_TARGETS.md](MONOLITH_DECOMPOSITION_TARGETS.md) | review-required-planning |
 | [NIGHTLY_CHECKS_POSTMORTEM_2026-02-02.md](NIGHTLY_CHECKS_POSTMORTEM_2026-02-02.md) | review-required-planning |
 | [PBR-Integration-Final-Review.md](PBR-Integration-Final-Review.md) | review-required-planning |

--- a/docs/governance/DOCUMENTATION_MAP.md
+++ b/docs/governance/DOCUMENTATION_MAP.md
@@ -73,6 +73,7 @@ operator guidance unless they are linked here as canonical documents.
 | Production hardening gap (paid pilot) | [Production Hardening Gap - 2026-05-13](PRODUCTION_HARDENING_GAP_2026-05-13.md) | Paid-pilot baseline: what is already done, what is partial, what is net-new across Phases 1 through 7, plus pinned pilot acceptance commands and Phase 5.A local validation status |
 | Repo-wide audit baseline | [Portal Repo-Wide Audit - 2026-05-18](PORTAL_AUDIT_REPO_WIDE_2026-05-18.md) | Static repo-wide audit baseline as of 2026-05-18 covering CI/typing/coverage enforcement, ML runtime hotspots (SAM2, Gaussian rasterizer, segmentation cache hashing), container and plugin isolation, dependency/security governance, and software/model licensing |
 | Repo-wide audit backlog | [Portal Audit Backlog - 2026-05-18](audit/PORTAL_AUDIT_2026-05-18_backlog.md) | Companion remediation backlog for the 2026-05-18 audit: 12 actionable items across immediate / near-term / medium-term / long-term tiers with file targets and acceptance criteria |
+| Performance gate policy | [Performance Gate Policy](../performance/GATE_POLICY.md) | Maintained authority for PR-blocking, nightly-blocking, and advisory performance signals |
 | Test marker policy | [ADR-044 Test Marker Enforcement](../architecture/ADR-044-test-marker-enforcement.md) | Maintained |
 | Security hardening report | [security_best_practices_report.md](security_best_practices_report.md) | Maintained status record |
 
@@ -83,6 +84,7 @@ operator guidance unless they are linked here as canonical documents.
 | Architecture overview | [ARCHITECTURE.md](../architecture/ARCHITECTURE.md) | Maintained |
 | Architecture index | [architecture/README.md](../architecture/README.md) | Maintained; lists canonical, promoted, review-required, moved historical, and delete-candidate architecture dispositions |
 | Architecture triage ledger | [architecture-inventory-2026-05-12.csv](audit/architecture-inventory-2026-05-12.csv) | Current overlay for architecture-file disposition decisions |
+| Architecture cleanup board | [ARCHITECTURE_CLEANUP_BOARD.md](../architecture/ARCHITECTURE_CLEANUP_BOARD.md) | Active cleanup implementation ledger |
 | Depth backend unification | [ADR-019](../architecture/ADR-019-depth-backend-unification.md) | Maintained |
 | DA3 non-commercial research tier | [ADR-015](../architecture/ADR-015-da3-1-1-non-commercial-research-tier.md) | Maintained |
 | Portal orchestrator roadmap | [PORTAL_ORCHESTRATOR_ROADMAP.md](../architecture/PORTAL_ORCHESTRATOR_ROADMAP.md) | Maintained planning doc |
@@ -90,6 +92,7 @@ operator guidance unless they are linked here as canonical documents.
 | Portal UX/UI status snapshot | [Portal UX/UI Status Snapshot](../architecture/DNA_UX_UI_STRATEGY_REBASELINE_2026-04-08.md) | Current planning-context snapshot; does not choose the next implementation PR |
 | APEX workflow design | [APEX_WORKFLOW_DESIGN.md](../architecture/APEX_WORKFLOW_DESIGN.md) | Maintained |
 | Deterministic RAW ingest | [ADR-030](../architecture/ADR-030-phase2-deterministic-raw-ingest.md) | Maintained |
+| Plugin manifest trust | [ADR-049](../architecture/ADR-049-plugin-manifest-trust.md) | Maintained in-process external plugin trust boundary |
 | Determinism harness spec | [SPEC-DH-001](../architecture/specifications/SPEC-DH-001.md) | Locked |
 
 ## APEX And Archive Gates

--- a/docs/governance/audit/PORTAL_AUDIT_2026-05-18_backlog.md
+++ b/docs/governance/audit/PORTAL_AUDIT_2026-05-18_backlog.md
@@ -111,6 +111,9 @@ Each item carries severity, effort, the files to touch, observable acceptance cr
 
 ### M-1. Sandbox or sign plugins before broader use
 
+**Status:** Done in the architecture cleanup implementation branch: external `plugin.json`
+manifests can be signature-verified against a configured trust store before
+import, and ADR-049 records the in-process trust boundary.
 **Severity / Effort:** Medium / M
 **Tracks finding:** [#7](../PORTAL_AUDIT_REPO_WIDE_2026-05-18.md#63-security) — plugin trust boundary
 **Files to touch:** `src/transformation_portal/plugins/loader.py`, possibly a new `src/transformation_portal/plugins/signing.py`, `docs/architecture/`
@@ -121,6 +124,9 @@ Each item carries severity, effort, the files to touch, observable acceptance cr
 
 ### M-2. Emit machine-readable runtime license manifest in run cards
 
+**Status:** Done in the architecture cleanup implementation branch: newly
+emitted run cards and combined manifests carry an additive `licensing` block,
+with schema and legacy-reader tolerance coverage.
 **Severity / Effort:** Medium / M
 **Tracks finding:** [#9](../PORTAL_AUDIT_REPO_WIDE_2026-05-18.md#64-ci-governance-and-licensing) — mixed licensing
 **Files to touch:** `src/transformation_portal/lux_depth_v3/run_card_contract.py`, `src/transformation_portal/lux_depth_v3/artifact_manager.py`, `src/transformation_portal/lux_depth_v3/manifest.py`, `docs/schemas/`
@@ -131,6 +137,10 @@ Each item carries severity, effort, the files to touch, observable acceptance cr
 
 ### M-3. Unify performance gate policy
 
+**Status:** Done in the architecture cleanup implementation branch:
+`docs/performance/GATE_POLICY.md` defines advisory, nightly-blocking, and
+PR-blocking signals, benchmark-sensitive tests are marker-owned, and the
+scheduled performance monitor now fails on regression status.
 **Severity / Effort:** Medium / M
 **Tracks finding:** [#2 / #5 boundary](../PORTAL_AUDIT_REPO_WIDE_2026-05-18.md#7-remediation-roadmap) — fragmented perf governance
 **Files to touch:** `docs/performance/README.md`, `docs/performance/PHASE6_BUDGETS.md`, possibly `.github/workflows/build.yml` and nightly perf workflows

--- a/docs/governance/audit/PORTAL_AUDIT_2026-05-18_backlog.md
+++ b/docs/governance/audit/PORTAL_AUDIT_2026-05-18_backlog.md
@@ -124,9 +124,10 @@ import, and ADR-049 records the in-process trust boundary.
 
 ### M-2. Emit machine-readable runtime license manifest in run cards
 
-**Status:** Done in the architecture cleanup implementation branch: newly
-emitted run cards and combined manifests carry an additive `licensing` block,
-with schema and legacy-reader tolerance coverage.
+**Status:** Runtime licensing evidence v1 landed in the architecture cleanup
+implementation branch for emitted run cards and combined manifests.
+Multi-runtime aggregation across segmentation, VLM, materials, and
+reconstruction remains a follow-up.
 **Severity / Effort:** Medium / M
 **Tracks finding:** [#9](../PORTAL_AUDIT_REPO_WIDE_2026-05-18.md#64-ci-governance-and-licensing) — mixed licensing
 **Files to touch:** `src/transformation_portal/lux_depth_v3/run_card_contract.py`, `src/transformation_portal/lux_depth_v3/artifact_manager.py`, `src/transformation_portal/lux_depth_v3/manifest.py`, `docs/schemas/`

--- a/docs/performance/GATE_POLICY.md
+++ b/docs/performance/GATE_POLICY.md
@@ -33,7 +33,8 @@ run as bounded smoke checks.
 - Performance ledger baseline comparisons with explicit backend, device, and
   quality-tier metadata.
 - `.github/workflows/performance-monitor.yml` is schedule/manual only and fails
-  when pytest-benchmark reports a regression beyond its documented threshold.
+  when pytest-benchmark reports a regression beyond its documented threshold
+  or when benchmark execution fails and the run is not valid evidence.
 
 ## Advisory Signals
 

--- a/docs/performance/GATE_POLICY.md
+++ b/docs/performance/GATE_POLICY.md
@@ -1,0 +1,63 @@
+# Performance Gate Policy
+
+**Status:** Current policy
+**Created:** 2026-05-30
+**Owner:** Repository Architect
+
+This policy defines which performance signals are advisory, nightly-blocking,
+or PR-blocking. It aligns the performance ledger with ADR-034: wall-clock
+benchmarks stay out of fast PR gates unless they are deterministic enough to
+run as bounded smoke checks.
+
+## Enforcement Tiers
+
+| Tier | Scope | Enforcement | Marker / command |
+| --- | --- | --- | --- |
+| PR-blocking | Deterministic contract and budget checks that do not depend on host speed | Required local/CI validation | `make check-portal-asset-budgets`, schema and contract tests |
+| Nightly-blocking | Benchmarks with committed baselines and controlled variance | Scheduled or manual deep gate; failures require triage before baseline updates | `pytest -m benchmark`, `tools/performance_ledger.py` comparisons |
+| Advisory | Exploratory profiling, hardware-specific ML timing, and one-off reports | Evidence only; never used alone to block a merge | `docs/performance/*` reports and local profiler output |
+
+## Current PR-Blocking Signals
+
+- Frontdoor and portal asset size budgets.
+- Schema and manifest compatibility for emitted performance metadata.
+- Deterministic logic tests for performance helpers, such as parser,
+  percentile, and report-format contracts.
+
+## Current Nightly-Blocking Signals
+
+- SAM2 auto-mode latency and memory baselines when the checkpoint and matching
+  hardware/device lane are available.
+- Reconstruction and PBR performance budgets that carry `benchmark` or `slow`
+  markers and compare against a committed baseline.
+- Performance ledger baseline comparisons with explicit backend, device, and
+  quality-tier metadata.
+- `.github/workflows/performance-monitor.yml` is schedule/manual only and fails
+  when pytest-benchmark reports a regression beyond its documented threshold.
+
+## Advisory Signals
+
+- Local developer timing on unpinned hardware.
+- ML sampled coverage artifacts that include runtime measurements but are used
+  as cold-zone evidence rather than a merge gate.
+- Reports generated from partial image sets or experimental model variants.
+
+## Baseline Update Rules
+
+- Baselines are committed evidence, not auto-updated generated files.
+- Baseline changes require a PR review that names the hardware/device lane,
+  backend, model id, sample count, and reason for the change.
+- A performance regression should be fixed or explicitly accepted before a
+  baseline is raised.
+- Environment failures such as missing checkpoints, unavailable accelerators,
+  Docker unavailability, or service startup failures are reported as
+  tooling/environment blockers, not product-green evidence.
+
+## Workflow Alignment
+
+- Fast PR workflows should select deterministic tests and skip `benchmark` and
+  host-speed-sensitive `slow` tests.
+- Nightly/deep workflows may run benchmark-marked tests and performance-ledger
+  comparisons when their prerequisites are present.
+- New performance tests must choose a tier at introduction time and document
+  the exact command that owns the signal.

--- a/docs/performance/PHASE6_BUDGETS.md
+++ b/docs/performance/PHASE6_BUDGETS.md
@@ -3,6 +3,7 @@
 ## Purpose
 
 Define nightly regression budgets for the reconstruction rasterizer hot paths.
+The enforcement tier is governed by [Performance Gate Policy](GATE_POLICY.md).
 These budgets are enforced by:
 
 - `tests/spatial_ai/reconstruction/test_performance_budgets.py`

--- a/docs/performance/README.md
+++ b/docs/performance/README.md
@@ -7,6 +7,8 @@ The Transformation Portal performance ledger provides regression detection for p
 **Status:** Phase 2 tooling (v2.0.1+)
 **Enforcement:** Manual workflow, not a CI gate
 
+Current gate authority: [Performance Gate Policy](GATE_POLICY.md).
+
 ---
 
 ## Quick Start

--- a/docs/schemas/run_card/run_card.v1.schema.json
+++ b/docs/schemas/run_card/run_card.v1.schema.json
@@ -537,6 +537,69 @@
       ],
       "additionalProperties": false
     },
+    "licensing": {
+      "type": "object",
+      "required": [
+        "models",
+        "non_commercial_active",
+        "research_acknowledgement_required",
+        "schema_version",
+        "software_license_tier"
+      ],
+      "properties": {
+        "schema_version": {
+          "type": "string",
+          "const": "1.0"
+        },
+        "software_license_tier": {
+          "type": "string",
+          "minLength": 1
+        },
+        "models": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "id",
+              "license",
+              "runtime_role",
+              "requires_non_commercial_ok"
+            ],
+            "properties": {
+              "id": {
+                "type": "string",
+                "minLength": 1
+              },
+              "license": {
+                "type": "string",
+                "minLength": 1
+              },
+              "runtime_role": {
+                "type": "string",
+                "minLength": 1
+              },
+              "usage_class": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "requires_non_commercial_ok": {
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "non_commercial_active": {
+          "type": "boolean"
+        },
+        "research_acknowledgement_required": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
     "environment": {
       "type": "object",
       "required": [

--- a/docs/schemas/run_card/run_card.v2.schema.json
+++ b/docs/schemas/run_card/run_card.v2.schema.json
@@ -537,6 +537,69 @@
       ],
       "additionalProperties": false
     },
+    "licensing": {
+      "type": "object",
+      "required": [
+        "models",
+        "non_commercial_active",
+        "research_acknowledgement_required",
+        "schema_version",
+        "software_license_tier"
+      ],
+      "properties": {
+        "schema_version": {
+          "type": "string",
+          "const": "1.0"
+        },
+        "software_license_tier": {
+          "type": "string",
+          "minLength": 1
+        },
+        "models": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "id",
+              "license",
+              "runtime_role",
+              "requires_non_commercial_ok"
+            ],
+            "properties": {
+              "id": {
+                "type": "string",
+                "minLength": 1
+              },
+              "license": {
+                "type": "string",
+                "minLength": 1
+              },
+              "runtime_role": {
+                "type": "string",
+                "minLength": 1
+              },
+              "usage_class": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "requires_non_commercial_ok": {
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "non_commercial_active": {
+          "type": "boolean"
+        },
+        "research_acknowledgement_required": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
     "environment": {
       "type": "object",
       "required": [

--- a/src/transformation_portal/api/routes/__init__.py
+++ b/src/transformation_portal/api/routes/__init__.py
@@ -1,0 +1,5 @@
+"""FastAPI route factories for the portal origin."""
+
+from .jobs import JobRouteHandlers, create_jobs_router
+
+__all__ = ["JobRouteHandlers", "create_jobs_router"]

--- a/src/transformation_portal/api/routes/jobs.py
+++ b/src/transformation_portal/api/routes/jobs.py
@@ -1,0 +1,104 @@
+"""Jobs route factory for the FastAPI portal origin.
+
+The business logic remains owned by ``app.py`` for this seam. This module only
+owns the route decorators so route-family extraction can happen without changing
+wire contracts or endpoint behavior.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+from fastapi import APIRouter, Request
+from starlette.responses import Response
+
+from transformation_portal.api.v1 import (
+    JobEnvelope,
+    JobsListEnvelope,
+    JobStatusEnvelope,
+)
+
+
+@dataclass(frozen=True)
+class JobRouteHandlers:
+    """Injected app-owned handlers for the jobs route family."""
+
+    create_job_http: Callable[[Request, dict[str, Any]], Awaitable[Response]]
+    create_job_v2_http: Callable[[Request, dict[str, Any]], Awaitable[Response]]
+    list_jobs: Callable[[int], Awaitable[Response]]
+    list_jobs_v2: Callable[[int], Awaitable[Response]]
+    get_job: Callable[[str, bool], Awaitable[Response]]
+    get_job_v2: Callable[[str, bool], Awaitable[Response]]
+    get_job_artifact: Callable[[str, str], Awaitable[Response]]
+    get_job_artifact_v2: Callable[[str, str], Awaitable[Response]]
+    delete_job_artifacts: Callable[[str], Awaitable[Response]]
+    delete_job_artifacts_v2: Callable[[str], Awaitable[Response]]
+    cancel_job: Callable[[str], Awaitable[Response]]
+    cancel_job_v2: Callable[[str], Awaitable[Response]]
+    job_events: Callable[[Request, str], Awaitable[Response]]
+    job_events_v2: Callable[[Request, str], Awaitable[Response]]
+
+
+def create_jobs_router(handlers: JobRouteHandlers, *, job_list_limit: int) -> APIRouter:
+    """Create the dual-version jobs router without owning route behavior."""
+    router = APIRouter()
+
+    @router.post("/v1/jobs", response_model=JobEnvelope)
+    async def create_job_http(request: Request, payload: dict[str, Any]) -> Response:
+        return await handlers.create_job_http(request, payload)
+
+    @router.post("/v2/jobs", response_model=JobEnvelope)
+    async def create_job_v2_http(request: Request, payload: dict[str, Any]) -> Response:
+        return await handlers.create_job_v2_http(request, payload)
+
+    @router.get("/v1/jobs", response_model=JobsListEnvelope)
+    async def list_jobs(limit: int = job_list_limit) -> Response:
+        return await handlers.list_jobs(limit)
+
+    @router.get("/v2/jobs", response_model=JobsListEnvelope)
+    async def list_jobs_v2(limit: int = job_list_limit) -> Response:
+        return await handlers.list_jobs_v2(limit)
+
+    @router.get("/v1/jobs/{job_id}", response_model=JobStatusEnvelope)
+    async def get_job(job_id: str, include_logs: bool = True) -> Response:
+        return await handlers.get_job(job_id, include_logs)
+
+    @router.get("/v2/jobs/{job_id}", response_model=JobStatusEnvelope)
+    async def get_job_v2(job_id: str, include_logs: bool = True) -> Response:
+        return await handlers.get_job_v2(job_id, include_logs)
+
+    @router.get("/v1/jobs/{job_id}/artifacts/{artifact_path:path}")
+    async def get_job_artifact(job_id: str, artifact_path: str) -> Response:
+        return await handlers.get_job_artifact(job_id, artifact_path)
+
+    @router.get("/v2/jobs/{job_id}/artifacts/{artifact_path:path}")
+    async def get_job_artifact_v2(job_id: str, artifact_path: str) -> Response:
+        return await handlers.get_job_artifact_v2(job_id, artifact_path)
+
+    @router.delete("/v1/jobs/{job_id}/artifacts", response_model=JobStatusEnvelope)
+    async def delete_job_artifacts(job_id: str) -> Response:
+        return await handlers.delete_job_artifacts(job_id)
+
+    @router.delete("/v2/jobs/{job_id}/artifacts", response_model=JobStatusEnvelope)
+    async def delete_job_artifacts_v2(job_id: str) -> Response:
+        return await handlers.delete_job_artifacts_v2(job_id)
+
+    @router.post("/v1/jobs/{job_id}/cancel", response_model=JobEnvelope)
+    async def cancel_job(job_id: str) -> Response:
+        return await handlers.cancel_job(job_id)
+
+    @router.post("/v2/jobs/{job_id}/cancel", response_model=JobEnvelope)
+    async def cancel_job_v2(job_id: str) -> Response:
+        return await handlers.cancel_job_v2(job_id)
+
+    @router.get("/v1/jobs/{job_id}/events")
+    async def job_events(request: Request, job_id: str) -> Response:
+        return await handlers.job_events(request, job_id)
+
+    @router.get("/v2/jobs/{job_id}/events")
+    async def job_events_v2(request: Request, job_id: str) -> Response:
+        return await handlers.job_events_v2(request, job_id)
+
+    return router

--- a/src/transformation_portal/lux_depth_v3/manifest.py
+++ b/src/transformation_portal/lux_depth_v3/manifest.py
@@ -562,10 +562,11 @@ class CombinedManifest:
             "config_fingerprint",
             "environment",
             "backend_selection",
+            "licensing",
         ]:
             field_value = getattr(self, field_name)
             if field_value is not None:
-                if field_name in ["pbr_assets", "environment"]:
+                if field_name in ["pbr_assets", "environment", "licensing"]:
                     data[field_name] = field_value
                 else:
                     data[field_name] = asdict(field_value)
@@ -624,6 +625,8 @@ class CombinedManifest:
             manifest.pbr_assets = data["pbr_assets"]
         if "environment" in data:
             manifest.environment = data["environment"]
+        if "licensing" in data and data["licensing"] is not None:
+            manifest.licensing = dict(data["licensing"])
         if "start_time" in data:
             manifest.start_time = data["start_time"]
         if "end_time" in data:

--- a/src/transformation_portal/lux_depth_v3/manifest.py
+++ b/src/transformation_portal/lux_depth_v3/manifest.py
@@ -446,6 +446,7 @@ class CombinedManifest:
     start_time: Optional[str] = None
     end_time: Optional[str] = None
     backend_selection: Optional[BackendSelectionMetadata] = None
+    licensing: Optional[Dict[str, Any]] = None
 
     def save(self, path: Path) -> None:
         """Save manifest to JSON file.
@@ -467,10 +468,11 @@ class CombinedManifest:
             "config_fingerprint",
             "environment",
             "backend_selection",
+            "licensing",
         ]:
             field_value = getattr(self, field_name)
             if field_value is not None:
-                if field_name in ["pbr_assets", "environment"]:
+                if field_name in ["pbr_assets", "environment", "licensing"]:
                     # Already a dict, no need to convert
                     data[field_name] = field_value
                 else:
@@ -517,6 +519,8 @@ class CombinedManifest:
             manifest.environment = data["environment"]
         if "backend_selection" in data and data["backend_selection"] is not None:
             manifest.backend_selection = BackendSelectionMetadata.from_dict(data["backend_selection"])
+        if "licensing" in data and data["licensing"] is not None:
+            manifest.licensing = dict(data["licensing"])
         # Load timestamp fields
         if "start_time" in data:
             manifest.start_time = data["start_time"]

--- a/src/transformation_portal/lux_depth_v3/orchestrator.py
+++ b/src/transformation_portal/lux_depth_v3/orchestrator.py
@@ -146,7 +146,7 @@ from .reconstruction_runner import (
     run_scene_reconstruction,
     write_scene_debug_bundle,
 )
-from .run_card_contract import render_run_card_output_relative_path
+from .run_card_contract import build_runtime_licensing_manifest, render_run_card_output_relative_path
 from .scene_context import SceneContext
 from .scene_groups import SceneGroup, build_scene_groups
 from .scene_integrity import (
@@ -3436,6 +3436,11 @@ class EnhanceOrchestrator:
             for_manifest_write=True,
         )
 
+        manifest_backend_selection = backend_selection_metadata or self._active_backend_metadata or self._backend_metadata
+        manifest_model_contract = self._build_run_card_model_contract(
+            backend_selection=manifest_backend_selection.to_dict() if manifest_backend_selection is not None else None,
+        )
+
         manifest = CombinedManifest(
             input=InputMetadata(
                 image_path=str(image_input.path),
@@ -3474,7 +3479,11 @@ class EnhanceOrchestrator:
                 time.gmtime(pipeline_end_time),
             ),
             # ADR-023 Phase 3: Backend selection
-            backend_selection=(backend_selection_metadata or self._active_backend_metadata or self._backend_metadata),
+            backend_selection=manifest_backend_selection,
+            licensing=build_runtime_licensing_manifest(
+                model_contract=manifest_model_contract,
+                config=self.config,
+            ),
         )
         manifest.write(manifest_path)
         return input_sha
@@ -6724,6 +6733,10 @@ class EnhanceOrchestrator:
         )
         if model_contract is not None:
             run_card["model_contract"] = model_contract
+        run_card["licensing"] = build_runtime_licensing_manifest(
+            model_contract=model_contract,
+            config=self.config,
+        )
 
         def _json_default(obj: Any) -> Any:
             # --- ConfigFingerprint ---

--- a/src/transformation_portal/lux_depth_v3/run_card_contract.py
+++ b/src/transformation_portal/lux_depth_v3/run_card_contract.py
@@ -69,9 +69,62 @@ def render_run_card_output_relative_path(path_value: Any, output_root: Any) -> O
         return PurePosixPath(normalize_lexical_path(path_value).name).as_posix()
 
 
+def build_runtime_licensing_manifest(
+    *,
+    model_contract: Optional[Mapping[str, Any]] = None,
+    config: Any = None,
+) -> dict[str, Any]:
+    """Build machine-readable runtime licensing evidence for run cards/manifests."""
+    models: list[dict[str, Any]] = []
+    if isinstance(model_contract, Mapping):
+        model_id = str(
+            model_contract.get("resolved_repo_id")
+            or model_contract.get("canonical_model_key")
+            or model_contract.get("requested_model_selector")
+            or ""
+        ).strip()
+        license_id = str(model_contract.get("license_id") or "unknown").strip() or "unknown"
+        runtime_role = str(model_contract.get("backend_kind") or "depth").strip() or "depth"
+        usage_class = str(model_contract.get("usage_class") or "").strip()
+        requires_non_commercial_ok = bool(model_contract.get("requires_non_commercial_ok", False))
+        if model_id:
+            models.append(
+                {
+                    "id": model_id,
+                    "license": license_id,
+                    "runtime_role": runtime_role,
+                    "usage_class": usage_class or None,
+                    "requires_non_commercial_ok": requires_non_commercial_ok,
+                }
+            )
+    else:
+        requires_non_commercial_ok = False
+
+    non_commercial_ok = bool(getattr(config, "non_commercial_ok", False))
+    apple_research_ack = bool(getattr(config, "accept_apple_depth_pro_research_license", False))
+    research_tools_ack = bool(getattr(config, "accept_research_tools_license", False))
+    model_requires_research = any(
+        model.get("requires_non_commercial_ok") or "non_commercial" in str(model.get("usage_class") or "") for model in models
+    )
+    research_acknowledgement_required = bool(model_requires_research or apple_research_ack or research_tools_ack)
+    non_commercial_active = bool(non_commercial_ok and (model_requires_research or apple_research_ack or research_tools_ack))
+    software_license_tier = (
+        "research_or_non_commercial" if research_acknowledgement_required or non_commercial_active else "commercial"
+    )
+
+    return {
+        "schema_version": "1.0",
+        "software_license_tier": software_license_tier,
+        "models": models,
+        "non_commercial_active": non_commercial_active,
+        "research_acknowledgement_required": research_acknowledgement_required,
+    }
+
+
 __all__ = [
     "RUN_CARD_SCHEMA_URIS",
     "SUPPORTED_RUN_CARD_VERSIONS",
+    "build_runtime_licensing_manifest",
     "RunCardPathValidationError",
     "get_run_card_schema_uri",
     "get_run_card_schema_uri_for_payload",

--- a/src/transformation_portal/plugins/__init__.py
+++ b/src/transformation_portal/plugins/__init__.py
@@ -38,6 +38,7 @@ from .interface import (
 from .loader import LoadedPlugin, PluginLoader, PluginManifest, get_global_loader
 from .manager import ExecutionResult, PluginContext, PluginManager, PluginState, get_global_manager
 from .registry import PluginRegistry, get_global_registry
+from .signing import PluginSignatureError, sign_manifest, verify_manifest_signature
 from .validator import PluginValidator, ValidationIssue, ValidationResult, ValidationSeverity, quick_validate, validate_plugin
 
 __all__ = [
@@ -57,6 +58,9 @@ __all__ = [
     "PluginManifest",
     "LoadedPlugin",
     "get_global_loader",
+    "PluginSignatureError",
+    "sign_manifest",
+    "verify_manifest_signature",
     # Manager
     "PluginManager",
     "PluginState",

--- a/src/transformation_portal/plugins/loader.py
+++ b/src/transformation_portal/plugins/loader.py
@@ -12,10 +12,12 @@ from threading import Lock
 from typing import Any, Dict, List, Optional
 
 from .interface import PluginInterface, PluginMetadata, PluginType
+from .signing import PluginSignatureError, verify_manifest_signature
 
 logger = logging.getLogger(__name__)
 
 _ENABLE_EXTERNAL_PLUGINS_ENV = "TRANSFORMATION_PORTAL_ENABLE_EXTERNAL_PLUGINS"
+_PLUGIN_TRUST_STORE_ENV = "TRANSFORMATION_PORTAL_PLUGIN_TRUST_STORE"
 _TRUTHY_VALUES = {"1", "true", "yes", "on"}
 
 
@@ -45,6 +47,10 @@ class PluginManifest:
     homepage: str = ""
     tags: List[str] = field(default_factory=list)
     config_schema: Dict[str, Any] = field(default_factory=dict)
+    signature: Optional[str] = None
+    signature_algorithm: Optional[str] = None
+    signature_key_id: Optional[str] = None
+    raw_data: Dict[str, Any] = field(default_factory=dict, repr=False)
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "PluginManifest":
@@ -63,6 +69,10 @@ class PluginManifest:
             homepage=data.get("homepage", ""),
             tags=data.get("tags", []),
             config_schema=data.get("config_schema", {}),
+            signature=data.get("signature"),
+            signature_algorithm=data.get("signature_algorithm"),
+            signature_key_id=data.get("signature_key_id"),
+            raw_data=dict(data),
         )
 
     @classmethod
@@ -133,6 +143,7 @@ class PluginLoader:
         search_paths: Optional[List[Path]] = None,
         auto_resolve_dependencies: bool = True,
         allow_external_plugins: Optional[bool] = None,
+        plugin_trust_store_path: Optional[Path] = None,
     ):
         """Initialize plugin loader.
 
@@ -141,6 +152,8 @@ class PluginLoader:
             auto_resolve_dependencies: Automatically check dependencies on load
             allow_external_plugins: Enable user/env plugin discovery paths.
                 If None, reads TRANSFORMATION_PORTAL_ENABLE_EXTERNAL_PLUGINS.
+            plugin_trust_store_path: Optional JSON trust store for verifying
+                external plugin.json manifests before importing plugin code.
         """
         self._search_paths: List[Path] = []
         self._loaded_plugins: Dict[str, LoadedPlugin] = {}
@@ -149,6 +162,12 @@ class PluginLoader:
         self._auto_resolve_deps = auto_resolve_dependencies
         self._allow_external_plugins = (
             allow_external_plugins if allow_external_plugins is not None else _external_plugins_enabled_from_env()
+        )
+        env_trust_store = os.environ.get(_PLUGIN_TRUST_STORE_ENV)
+        self._plugin_trust_store_path = (
+            Path(plugin_trust_store_path).expanduser().resolve()
+            if plugin_trust_store_path is not None
+            else Path(env_trust_store).expanduser().resolve() if env_trust_store else None
         )
 
         # Add default paths
@@ -287,6 +306,19 @@ class PluginLoader:
                         logger.warning(f"Failed to parse {pyproject}: {e}")
 
             if manifest and manifest.entry_point:
+                signature_error = self._verify_manifest_trust(item, manifest)
+                if signature_error:
+                    discovered.append(
+                        LoadedPlugin(
+                            plugin=None,  # type: ignore
+                            manifest=manifest,
+                            source_path=item,
+                            module_name="",
+                            load_errors=[signature_error],
+                        )
+                    )
+                    continue
+
                 # Load the plugin from manifest
                 loaded = self._load_from_manifest(item, manifest)
                 if loaded:
@@ -307,6 +339,14 @@ class PluginLoader:
 
         # Find all .py files (non-recursive for file plugins)
         for py_file in search_path.glob("*.py"):
+            if self._requires_manifest_signature(py_file):
+                logger.warning(
+                    "Skipping external single-file plugin %s because %s requires signed plugin.json manifests",
+                    py_file,
+                    _PLUGIN_TRUST_STORE_ENV,
+                )
+                continue
+
             # Skip private/special files
             if py_file.name.startswith("_"):
                 continue
@@ -315,6 +355,37 @@ class PluginLoader:
             discovered.extend(loaded)
 
         return discovered
+
+    def _builtin_plugins_root(self) -> Path:
+        """Return the resolved built-in plugin package root."""
+        return (Path(__file__).resolve().parent / "builtin").resolve()
+
+    def _is_builtin_path(self, path: Path) -> bool:
+        """Return True when a plugin path is under the built-in plugin root."""
+        try:
+            Path(path).resolve().relative_to(self._builtin_plugins_root())
+        except ValueError:
+            return False
+        return True
+
+    def _requires_manifest_signature(self, path: Path) -> bool:
+        """Return True when an external plugin must pass signed-manifest trust."""
+        return self._plugin_trust_store_path is not None and not self._is_builtin_path(path)
+
+    def _verify_manifest_trust(self, package_dir: Path, manifest: PluginManifest) -> Optional[str]:
+        """Validate external package manifest trust before importing code."""
+        if not self._requires_manifest_signature(package_dir):
+            return None
+        if not manifest.raw_data:
+            return "External plugin packages require a signed plugin.json manifest when plugin trust is configured"
+        try:
+            verify_manifest_signature(
+                manifest.raw_data,
+                trust_store_path=self._plugin_trust_store_path,  # type: ignore[arg-type]
+            )
+        except (OSError, PluginSignatureError, json.JSONDecodeError) as exc:
+            return f"Plugin manifest signature verification failed: {exc}"
+        return None
 
     def _load_from_manifest(self, package_dir: Path, manifest: PluginManifest) -> Optional[LoadedPlugin]:
         """Load a plugin from its manifest.

--- a/src/transformation_portal/plugins/loader.py
+++ b/src/transformation_portal/plugins/loader.py
@@ -376,7 +376,7 @@ class PluginLoader:
         """Validate external package manifest trust before importing code."""
         if not self._requires_manifest_signature(package_dir):
             return None
-        if not manifest.raw_data:
+        if not (package_dir / "plugin.json").exists() or not manifest.raw_data:
             return "External plugin packages require a signed plugin.json manifest when plugin trust is configured"
         try:
             verify_manifest_signature(

--- a/src/transformation_portal/plugins/signing.py
+++ b/src/transformation_portal/plugins/signing.py
@@ -1,0 +1,99 @@
+"""Signed manifest verification for opt-in external plugins."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from transformation_portal.ingest.canonical_json import dumps_json
+
+PLUGIN_SIGNATURE_ALGORITHM = "hmac-sha256"
+PLUGIN_SIGNATURE_FIELDS = frozenset(
+    {
+        "signature",
+        "signature_algorithm",
+        "signature_key_id",
+    }
+)
+
+
+class PluginSignatureError(ValueError):
+    """Raised when a plugin manifest does not match the configured trust set."""
+
+
+def canonical_manifest_payload(manifest_data: Mapping[str, Any]) -> bytes:
+    """Return canonical JSON bytes for the signed portion of a manifest."""
+    signed_payload = {key: value for key, value in manifest_data.items() if key not in PLUGIN_SIGNATURE_FIELDS}
+    return dumps_json(
+        signed_payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def load_plugin_trust_store(path: Path) -> dict[str, str]:
+    """Load a key-id to shared-secret trust map from JSON."""
+    with open(path, encoding="utf-8") as f:
+        raw_store = json.load(f)
+
+    keys = raw_store.get("keys", raw_store) if isinstance(raw_store, dict) else None
+    if not isinstance(keys, dict):
+        raise PluginSignatureError("Plugin trust store must be a JSON object or contain a 'keys' object")
+
+    trust_store: dict[str, str] = {}
+    for key_id, secret in keys.items():
+        if not isinstance(key_id, str) or not key_id:
+            raise PluginSignatureError("Plugin trust store key ids must be non-empty strings")
+        if not isinstance(secret, str) or not secret:
+            raise PluginSignatureError(f"Plugin trust store secret for {key_id!r} must be a non-empty string")
+        trust_store[key_id] = secret
+    return trust_store
+
+
+def sign_manifest(manifest_data: Mapping[str, Any], *, secret: str) -> str:
+    """Return the hex HMAC-SHA256 signature for a manifest payload."""
+    return hmac.new(
+        secret.encode("utf-8"),
+        canonical_manifest_payload(manifest_data),
+        hashlib.sha256,
+    ).hexdigest()
+
+
+def verify_manifest_signature(manifest_data: Mapping[str, Any], *, trust_store_path: Path) -> None:
+    """Verify a plugin manifest against the configured trust store."""
+    algorithm = manifest_data.get("signature_algorithm")
+    if algorithm != PLUGIN_SIGNATURE_ALGORITHM:
+        raise PluginSignatureError("Plugin manifest signature_algorithm must be 'hmac-sha256'")
+
+    key_id = manifest_data.get("signature_key_id")
+    if not isinstance(key_id, str) or not key_id:
+        raise PluginSignatureError("Plugin manifest signature_key_id is required")
+
+    signature = manifest_data.get("signature")
+    if not isinstance(signature, str) or not signature:
+        raise PluginSignatureError("Plugin manifest signature is required")
+
+    trust_store = load_plugin_trust_store(trust_store_path)
+    secret = trust_store.get(key_id)
+    if secret is None:
+        raise PluginSignatureError(f"Plugin manifest signature_key_id {key_id!r} is not trusted")
+
+    expected = sign_manifest(manifest_data, secret=secret)
+    if not hmac.compare_digest(signature.strip().lower(), expected):
+        raise PluginSignatureError("Plugin manifest signature does not match trusted key")
+
+
+__all__ = [
+    "PLUGIN_SIGNATURE_ALGORITHM",
+    "PluginSignatureError",
+    "canonical_manifest_payload",
+    "load_plugin_trust_store",
+    "sign_manifest",
+    "verify_manifest_signature",
+]

--- a/src/transformation_portal/schemas/run_card/run_card.v1.schema.json
+++ b/src/transformation_portal/schemas/run_card/run_card.v1.schema.json
@@ -537,6 +537,69 @@
       ],
       "additionalProperties": false
     },
+    "licensing": {
+      "type": "object",
+      "required": [
+        "models",
+        "non_commercial_active",
+        "research_acknowledgement_required",
+        "schema_version",
+        "software_license_tier"
+      ],
+      "properties": {
+        "schema_version": {
+          "type": "string",
+          "const": "1.0"
+        },
+        "software_license_tier": {
+          "type": "string",
+          "minLength": 1
+        },
+        "models": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "id",
+              "license",
+              "runtime_role",
+              "requires_non_commercial_ok"
+            ],
+            "properties": {
+              "id": {
+                "type": "string",
+                "minLength": 1
+              },
+              "license": {
+                "type": "string",
+                "minLength": 1
+              },
+              "runtime_role": {
+                "type": "string",
+                "minLength": 1
+              },
+              "usage_class": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "requires_non_commercial_ok": {
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "non_commercial_active": {
+          "type": "boolean"
+        },
+        "research_acknowledgement_required": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
     "environment": {
       "type": "object",
       "required": [

--- a/src/transformation_portal/schemas/run_card/run_card.v2.schema.json
+++ b/src/transformation_portal/schemas/run_card/run_card.v2.schema.json
@@ -537,6 +537,69 @@
       ],
       "additionalProperties": false
     },
+    "licensing": {
+      "type": "object",
+      "required": [
+        "models",
+        "non_commercial_active",
+        "research_acknowledgement_required",
+        "schema_version",
+        "software_license_tier"
+      ],
+      "properties": {
+        "schema_version": {
+          "type": "string",
+          "const": "1.0"
+        },
+        "software_license_tier": {
+          "type": "string",
+          "minLength": 1
+        },
+        "models": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "id",
+              "license",
+              "runtime_role",
+              "requires_non_commercial_ok"
+            ],
+            "properties": {
+              "id": {
+                "type": "string",
+                "minLength": 1
+              },
+              "license": {
+                "type": "string",
+                "minLength": 1
+              },
+              "runtime_role": {
+                "type": "string",
+                "minLength": 1
+              },
+              "usage_class": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "requires_non_commercial_ok": {
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "non_commercial_active": {
+          "type": "boolean"
+        },
+        "research_acknowledgement_required": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
     "environment": {
       "type": "object",
       "required": [

--- a/tests/lux_depth_v3/test_orchestrator_run_card_provenance.py
+++ b/tests/lux_depth_v3/test_orchestrator_run_card_provenance.py
@@ -297,3 +297,23 @@ class TestRuntimeLicensingManifest:
 
         restored = CombinedManifest.load(manifest_path)
         assert restored.licensing == licensing
+
+    def test_combined_msgpack_manifest_round_trips_licensing(self, tmp_path: Path) -> None:
+        from transformation_portal.lux_depth_v3.manifest import MSGPACK_AVAILABLE, CombinedManifest
+
+        if not MSGPACK_AVAILABLE:
+            pytest.skip("msgpack is optional")
+
+        manifest_path = tmp_path / "licensing.manifest.msgpack"
+        licensing = {
+            "schema_version": "1.0",
+            "software_license_tier": "commercial",
+            "models": [],
+            "non_commercial_active": False,
+            "research_acknowledgement_required": False,
+        }
+
+        CombinedManifest(licensing=licensing).save_msgpack(manifest_path)
+
+        restored = CombinedManifest.load_msgpack(manifest_path)
+        assert restored.licensing == licensing

--- a/tests/lux_depth_v3/test_orchestrator_run_card_provenance.py
+++ b/tests/lux_depth_v3/test_orchestrator_run_card_provenance.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, Dict
 from unittest.mock import Mock, patch
 
@@ -113,6 +114,8 @@ class TestResolutionReasonField:
         """
         manifest = _get_manifest_data(tmp_path, "reason_success.png")
         assert "resolution_reason" in manifest["backend_selection"]
+        assert manifest["licensing"]["schema_version"] == "1.0"
+        assert "non_commercial_active" in manifest["licensing"]
 
 
 class TestFallbackPropagation:
@@ -235,3 +238,62 @@ class TestSchemaVersionGate:
         assert restored.resolution_status == "fallback"
         assert restored.requested_backend == "da3"
         assert restored.resolved_backend == "synthetic"
+
+
+class TestRuntimeLicensingManifest:
+    """Runtime licensing evidence must be emitted and legacy tolerant."""
+
+    def test_runtime_licensing_manifest_marks_research_model_active(self) -> None:
+        from transformation_portal.lux_depth_v3.run_card_contract import build_runtime_licensing_manifest
+
+        licensing = build_runtime_licensing_manifest(
+            model_contract={
+                "resolved_repo_id": "depth-anything/DA3NESTED-GIANT-LARGE-1.1",
+                "license_id": "cc-by-nc-4.0",
+                "backend_kind": "da3",
+                "usage_class": "non_commercial_only",
+                "requires_non_commercial_ok": True,
+            },
+            config=SimpleNamespace(non_commercial_ok=True),
+        )
+
+        assert licensing["software_license_tier"] == "research_or_non_commercial"
+        assert licensing["non_commercial_active"] is True
+        assert licensing["research_acknowledgement_required"] is True
+        assert licensing["models"][0]["license"] == "cc-by-nc-4.0"
+
+    def test_runtime_licensing_manifest_marks_commercial_model(self) -> None:
+        from transformation_portal.lux_depth_v3.run_card_contract import build_runtime_licensing_manifest
+
+        licensing = build_runtime_licensing_manifest(
+            model_contract={
+                "resolved_repo_id": "commercial/depth-model",
+                "license_id": "commercial",
+                "backend_kind": "depth",
+                "usage_class": "commercial",
+                "requires_non_commercial_ok": False,
+            },
+            config=SimpleNamespace(non_commercial_ok=False),
+        )
+
+        assert licensing["software_license_tier"] == "commercial"
+        assert licensing["non_commercial_active"] is False
+        assert licensing["research_acknowledgement_required"] is False
+        assert licensing["models"][0]["id"] == "commercial/depth-model"
+
+    def test_combined_manifest_round_trips_licensing(self, tmp_path: Path) -> None:
+        from transformation_portal.lux_depth_v3.manifest import CombinedManifest
+
+        manifest_path = tmp_path / "licensing.manifest.json"
+        licensing = {
+            "schema_version": "1.0",
+            "software_license_tier": "commercial",
+            "models": [],
+            "non_commercial_active": False,
+            "research_acknowledgement_required": False,
+        }
+
+        CombinedManifest(licensing=licensing).save(manifest_path)
+
+        restored = CombinedManifest.load(manifest_path)
+        assert restored.licensing == licensing

--- a/tests/spatial_ai/reconstruction/test_lazy_imports.py
+++ b/tests/spatial_ai/reconstruction/test_lazy_imports.py
@@ -192,6 +192,7 @@ class TestTorchLazyImportContract:
         assert scene_builder_cls is not None
         assert scene_builder_cls.__name__ == "SceneBuilder"
 
+    @pytest.mark.benchmark
     def test_lazy_import_performance_baseline(self):
         """Benchmark lazy import performance to detect regressions.
 

--- a/tests/test_app_orchestrator_contract_http.py
+++ b/tests/test_app_orchestrator_contract_http.py
@@ -4597,6 +4597,24 @@ def test_invalid_job_payload_returns_typed_invalid_argument(client: TestClient) 
     assert body["error"]["code"] == "INVALID_ARGUMENT"
 
 
+def test_malformed_job_args_return_typed_invalid_argument(client: TestClient) -> None:
+    response = client.post("/v1/jobs", json={"pipeline": "lux-depth-v3", "args": "not-a-dict"})
+    body = response.json()
+    assert response.status_code == 400
+    assert body["schema"] == "tp.orchestrator.error.v1"
+    assert body["success"] is False
+    assert body["error"]["code"] == "INVALID_ARGUMENT"
+    assert body["error"]["details"] == {"field": "input_dir", "reason": "required"}
+
+
+def test_job_create_request_adapter_rejects_non_dict_args() -> None:
+    response = orchestrator_app._validated_job_create_request({"pipeline": "lux-depth-v3", "args": "not-a-dict"})
+    assert isinstance(response, orchestrator_app.JSONResponse)
+    body = json.loads(response.body.decode("utf-8"))
+    assert body["error"]["code"] == "INVALID_ARGUMENT"
+    assert body["error"]["details"] == {"field": "args", "reason": "invalid_request"}
+
+
 def test_archive_gate_pipeline_submission_returns_job_envelope(
     client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
@@ -5480,6 +5498,64 @@ def test_job_events_stream_emits_state_log_progress_artifact_done(
     artifact_payload = next(payload for name, payload in events if name == "artifact")
     assert artifact_payload["artifact_type"] == "metadata"
     assert artifact_payload["relative_path"] == "report.json"
+
+
+def test_job_events_replays_persisted_events_from_last_event_id(client: TestClient) -> None:
+    now = orchestrator_app._now()
+    job = orchestrator_app.Job(
+        id="job_sse_replay",
+        created_at=now,
+        state="running",
+        progress=0,
+        request={"pipeline": "lux-depth-v3"},
+    )
+    _seed_job(job)
+
+    asyncio.run(orchestrator_app._publish_event(job.id, "state", {"id": job.id, "state": "running", "progress": 0}))
+    job.progress = 45
+    asyncio.run(orchestrator_app._publish_event(job.id, "progress", {"id": job.id, "progress": 45}))
+    job.state = "succeeded"
+    job.exit_code = 0
+    asyncio.run(
+        orchestrator_app._publish_event(
+            job.id,
+            "done",
+            {
+                "id": job.id,
+                "state": "succeeded",
+                "exit_code": 0,
+                "error": None,
+                "artifacts": {},
+            },
+        )
+    )
+    job.done_published_at = orchestrator_app._now()
+    job.finished_at = job.done_published_at
+
+    with client.stream("GET", f"/v1/jobs/{job.id}/events", headers={"Last-Event-ID": "1"}) as stream_response:
+        assert stream_response.status_code == 200
+        events = _collect_sse_events(stream_response)
+
+    assert [name for name, _payload in events] == ["progress", "done"]
+    assert events[0][1]["progress"] == 45
+
+
+def test_job_events_rejects_invalid_last_event_id(client: TestClient) -> None:
+    now = orchestrator_app._now()
+    job = orchestrator_app.Job(
+        id="job_sse_bad_last_event_id",
+        created_at=now,
+        state="running",
+        progress=0,
+        request={"pipeline": "lux-depth-v3"},
+    )
+    _seed_job(job)
+
+    response = client.get(f"/v1/jobs/{job.id}/events", headers={"Last-Event-ID": "not-a-seq"})
+    assert response.status_code == 400
+    body = response.json()
+    assert body["error"]["code"] == "INVALID_ARGUMENT"
+    assert body["error"]["details"] == {"field": "Last-Event-ID", "reason": "invalid_request"}
 
 
 def test_late_job_events_done_payload_includes_fastvlm_captioning_status(client: TestClient) -> None:

--- a/tests/test_app_orchestrator_contract_http.py
+++ b/tests/test_app_orchestrator_contract_http.py
@@ -4615,6 +4615,14 @@ def test_job_create_request_adapter_rejects_non_dict_args() -> None:
     assert body["error"]["details"] == {"field": "args", "reason": "invalid_request"}
 
 
+def test_job_create_request_adapter_keeps_required_reason_vocabulary() -> None:
+    response = orchestrator_app._validated_job_create_request({"args": {}})
+    assert isinstance(response, orchestrator_app.JSONResponse)
+    body = json.loads(response.body.decode("utf-8"))
+    assert body["error"]["code"] == "INVALID_ARGUMENT"
+    assert body["error"]["details"] == {"field": "pipeline", "reason": "required"}
+
+
 def test_archive_gate_pipeline_submission_returns_job_envelope(
     client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
@@ -5538,6 +5546,72 @@ def test_job_events_replays_persisted_events_from_last_event_id(client: TestClie
 
     assert [name for name, _payload in events] == ["progress", "done"]
     assert events[0][1]["progress"] == 45
+
+
+def test_job_events_replay_beyond_latest_seq_falls_back_to_state_first(client: TestClient) -> None:
+    now = orchestrator_app._now()
+    job = orchestrator_app.Job(
+        id="job_sse_replay_beyond_latest",
+        created_at=now,
+        state="running",
+        progress=12,
+        request={"pipeline": "lux-depth-v3"},
+    )
+    _seed_job(job)
+    asyncio.run(orchestrator_app._publish_event(job.id, "state", {"id": job.id, "state": "running", "progress": 12}))
+    job.state = "succeeded"
+    job.exit_code = 0
+    job.finished_at = orchestrator_app._now()
+    job.done_published_at = job.finished_at
+    _sync_seeded_job(job)
+
+    with client.stream("GET", f"/v1/jobs/{job.id}/events", headers={"Last-Event-ID": "999"}) as stream_response:
+        assert stream_response.status_code == 200
+        events = _collect_sse_events(stream_response)
+
+    assert [name for name, _payload in events] == ["state", "done"]
+    assert events[0][1]["state"] == "succeeded"
+    assert events[1][1]["state"] == "succeeded"
+
+
+def test_job_events_replay_failure_falls_back_to_state_first(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FailingAsyncIterator:
+        def __aiter__(self):  # noqa: ANN204
+            return self
+
+        async def __anext__(self):  # noqa: ANN204
+            raise RuntimeError("event store unavailable")
+
+    class FailingEventStore:
+        def events_since(self, _job_id: str, *, after_seq: int) -> FailingAsyncIterator:
+            return FailingAsyncIterator()
+
+    def failing_event_store() -> FailingEventStore:
+        return FailingEventStore()
+
+    now = orchestrator_app._now()
+    job = orchestrator_app.Job(
+        id="job_sse_replay_failure",
+        created_at=now,
+        state="succeeded",
+        progress=100,
+        finished_at=now,
+        done_published_at=now,
+        exit_code=0,
+        request={"pipeline": "lux-depth-v3"},
+    )
+    _seed_job(job)
+    monkeypatch.setattr(orchestrator_app, "_job_event_store", failing_event_store)
+
+    with client.stream("GET", f"/v1/jobs/{job.id}/events", headers={"Last-Event-ID": "1"}) as stream_response:
+        assert stream_response.status_code == 200
+        events = _collect_sse_events(stream_response)
+
+    assert [name for name, _payload in events] == ["state", "done"]
+    assert events[0][1]["progress"] == 100
 
 
 def test_job_events_rejects_invalid_last_event_id(client: TestClient) -> None:

--- a/tests/test_pbr_processor.py
+++ b/tests/test_pbr_processor.py
@@ -406,6 +406,8 @@ class TestPBRProcessorErrorHandling:
 class TestPBRProcessorPerformance:
     """Validate performance characteristics."""
 
+    pytestmark = pytest.mark.benchmark
+
     def test_memory_only_mode_faster_than_io(self, sample_depth, temp_workspace, standard_config):
         """Test that memory-only mode is faster than I/O mode."""
         import time

--- a/tests/test_run_card_schema.py
+++ b/tests/test_run_card_schema.py
@@ -35,7 +35,10 @@ from transformation_portal.lux_depth_v3.orchestrator import (
     _validate_run_card_backend_semantics,
     _validate_run_card_payload,
 )
-from transformation_portal.lux_depth_v3.run_card_contract import render_run_card_output_relative_path
+from transformation_portal.lux_depth_v3.run_card_contract import (
+    build_runtime_licensing_manifest,
+    render_run_card_output_relative_path,
+)
 from transformation_portal.lux_depth_v3.security import HashMode
 from transformation_portal.schemas.run_card import load_run_card_schema
 
@@ -175,6 +178,25 @@ def test_packaged_run_card_schemas_match_documented_copies() -> None:
     for version in ("v1", "v2"):
         documented_schema = json.loads(_run_card_schema_path(version).read_text(encoding="utf-8"))
         assert load_run_card_schema(version) == documented_schema
+
+
+def test_run_card_schema_accepts_runtime_licensing_block() -> None:
+    pytest.importorskip("jsonschema")
+    payload = _valid_run_card_payload()
+    model_contract = {
+        "resolved_repo_id": "depth-anything/DA3NESTED-GIANT-LARGE-1.1",
+        "license_id": "cc-by-nc-4.0",
+        "backend_kind": "da3",
+        "usage_class": "non_commercial_only",
+        "requires_non_commercial_ok": True,
+    }
+    payload["licensing"] = build_runtime_licensing_manifest(
+        model_contract=model_contract,
+        config=SimpleNamespace(non_commercial_ok=True),
+    )
+
+    _validate_run_card_payload(payload, _run_card_schema_path())
+    assert payload["licensing"]["non_commercial_active"] is True
 
 
 def test_run_card_schema_enforces_datetime_format() -> None:

--- a/tests/unit/plugins/loader_test_helpers.py
+++ b/tests/unit/plugins/loader_test_helpers.py
@@ -13,11 +13,13 @@ def isolated_loader(
     search_path: Path,
     *,
     auto_resolve_dependencies: bool = True,
+    plugin_trust_store_path: Path | None = None,
 ) -> PluginLoader:
     """Return a loader whose discovery paths are limited to one temp path."""
     loader = PluginLoader(
         allow_external_plugins=True,
         auto_resolve_dependencies=auto_resolve_dependencies,
+        plugin_trust_store_path=plugin_trust_store_path,
     )
     loader._search_paths.clear()  # noqa: SLF001 - tests need hermetic paths.
     loader.add_search_path(search_path)

--- a/tests/unit/plugins/test_loader_manifest_loading.py
+++ b/tests/unit/plugins/test_loader_manifest_loading.py
@@ -181,3 +181,25 @@ def test_tampered_external_plugin_json_is_rejected_before_load(tmp_path: Path):
     assert discovered[0].plugin is None
     assert discovered[0].is_valid is False
     assert "does not match trusted key" in discovered[0].load_errors[0]
+
+
+def test_pyproject_only_external_plugin_is_rejected_when_trust_store_is_configured(tmp_path: Path):
+    package_dir = tmp_path / "pyproject_only_package"
+    write_plugin_module(package_dir, "pyproject_only_plugin", plugin_name="pyproject_only_plugin")
+    write_pyproject_manifest(
+        package_dir,
+        name="pyproject_only_plugin",
+        module_name="pyproject_only_plugin",
+    )
+
+    discovered = isolated_loader(
+        tmp_path,
+        plugin_trust_store_path=_write_trust_store(tmp_path),
+    ).discover_all()
+
+    assert len(discovered) == 1
+    assert discovered[0].plugin is None
+    assert discovered[0].is_valid is False
+    assert discovered[0].load_errors == [
+        "External plugin packages require a signed plugin.json manifest when plugin trust is configured"
+    ]

--- a/tests/unit/plugins/test_loader_manifest_loading.py
+++ b/tests/unit/plugins/test_loader_manifest_loading.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -12,8 +13,23 @@ from tests.unit.plugins.loader_test_helpers import (
     write_plugin_module,
     write_pyproject_manifest,
 )
+from transformation_portal.plugins.signing import PLUGIN_SIGNATURE_ALGORITHM, sign_manifest
 
 pytestmark = [pytest.mark.unit]
+
+
+def _write_trust_store(tmp_path: Path, *, key_id: str = "local-dev", secret: str = "test-secret") -> Path:
+    trust_store_path = tmp_path / "plugin-trust.json"
+    trust_store_path.write_text(json.dumps({"keys": {key_id: secret}}, indent=2) + "\n", encoding="utf-8")
+    return trust_store_path
+
+
+def _sign_plugin_json(manifest_path: Path, *, key_id: str = "local-dev", secret: str = "test-secret") -> None:
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    payload["signature_algorithm"] = PLUGIN_SIGNATURE_ALGORITHM
+    payload["signature_key_id"] = key_id
+    payload["signature"] = sign_manifest(payload, secret=secret)
+    manifest_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
 
 
 def test_discovers_plugin_json_manifest(tmp_path: Path):
@@ -99,3 +115,69 @@ def test_manifest_without_entry_point_is_ignored(tmp_path: Path):
     )
 
     assert isolated_loader(tmp_path).discover_all() == []
+
+
+def test_signed_external_plugin_json_loads_with_configured_trust_store(tmp_path: Path):
+    package_dir = tmp_path / "signed_package"
+    write_plugin_module(
+        package_dir,
+        "signed_plugin",
+        class_name="SignedPlugin",
+        plugin_name="signed_plugin",
+        execute_result="signed-ok",
+    )
+    manifest_path = write_plugin_json(
+        package_dir,
+        name="signed_plugin",
+        module_name="signed_plugin",
+        class_name="SignedPlugin",
+    )
+    _sign_plugin_json(manifest_path)
+
+    discovered = isolated_loader(
+        tmp_path,
+        plugin_trust_store_path=_write_trust_store(tmp_path),
+    ).discover_all()
+
+    assert len(discovered) == 1
+    assert discovered[0].is_valid is True
+    assert discovered[0].manifest is not None
+    assert discovered[0].manifest.signature_key_id == "local-dev"
+    assert discovered[0].plugin.execute() == "signed-ok"
+
+
+def test_unsigned_external_plugin_json_is_rejected_when_trust_store_is_configured(tmp_path: Path):
+    package_dir = tmp_path / "unsigned_package"
+    write_plugin_module(package_dir, "unsigned_plugin", plugin_name="unsigned_plugin")
+    write_plugin_json(package_dir, name="unsigned_plugin", module_name="unsigned_plugin")
+
+    discovered = isolated_loader(
+        tmp_path,
+        plugin_trust_store_path=_write_trust_store(tmp_path),
+    ).discover_all()
+
+    assert len(discovered) == 1
+    assert discovered[0].plugin is None
+    assert discovered[0].is_valid is False
+    assert "signature verification failed" in discovered[0].load_errors[0]
+
+
+def test_tampered_external_plugin_json_is_rejected_before_load(tmp_path: Path):
+    package_dir = tmp_path / "tampered_package"
+    write_plugin_module(package_dir, "tampered_plugin", plugin_name="tampered_plugin")
+    manifest_path = write_plugin_json(package_dir, name="tampered_plugin", module_name="tampered_plugin")
+    _sign_plugin_json(manifest_path)
+
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    payload["version"] = "9.9.9"
+    manifest_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+    discovered = isolated_loader(
+        tmp_path,
+        plugin_trust_store_path=_write_trust_store(tmp_path),
+    ).discover_all()
+
+    assert len(discovered) == 1
+    assert discovered[0].plugin is None
+    assert discovered[0].is_valid is False
+    assert "does not match trusted key" in discovered[0].load_errors[0]


### PR DESCRIPTION
## Summary
- Implement the architecture cleanup plan as one reviewable governance/seam change.
- Keep jobs business logic in `app.py` while extracting only route decorators into an injected router factory.
- Address review follow-up directives for performance gating, SSE replay fallback, job validation vocabulary, plugin trust requirements, and runtime licensing evidence v1.

## Changes
- Added `docs/architecture/ARCHITECTURE_CLEANUP_BOARD.md` and updated current docs navigation.
- Added `create_jobs_router(JobRouteHandlers)` under `src/transformation_portal/api/routes/` and registered the existing `/v1/jobs...` and `/v2/jobs...` handlers through it.
- Added internal `JobCreateRequest` validation after existing unsupported-pipeline and field-error mapping, preserving `INVALID_ARGUMENT` envelopes and existing `reason: "required"` vocabulary.
- Wired `JobEventStore` append/replay into job SSE, including `Last-Event-ID` handling, optional SSE `id:` fields when persisted seq ids exist, and state-first fallback when replay fails or returns no events.
- Added additive runtime licensing evidence v1 to new run cards and combined manifests; preserved `licensing` through JSON and `.msgpack` manifest save/load paths with legacy reader tolerance.
- Added signed external `plugin.json` verification behind `TRANSFORMATION_PORTAL_PLUGIN_TRUST_STORE` / `PluginLoader(plugin_trust_store_path=...)`; trust-store mode now explicitly rejects pyproject-only external plugins.
- Added ADR-049 and `docs/performance/GATE_POLICY.md`; aligned benchmark markers and made the scheduled performance monitor fail on both `regression` and `failed` statuses.

## Validation
Proven green:
- `.venv/bin/pytest tests/test_app_orchestrator_contract_http.py::test_job_create_request_adapter_keeps_required_reason_vocabulary tests/test_app_orchestrator_contract_http.py::test_job_events_replay_beyond_latest_seq_falls_back_to_state_first tests/test_app_orchestrator_contract_http.py::test_job_events_replay_failure_falls_back_to_state_first -q` (`3 passed`)
- `.venv/bin/pytest tests/lux_depth_v3/test_orchestrator_run_card_provenance.py::TestRuntimeLicensingManifest::test_combined_msgpack_manifest_round_trips_licensing -q` (`1 passed`)
- `.venv/bin/pytest tests/unit/plugins/test_loader_manifest_loading.py::test_pyproject_only_external_plugin_is_rejected_when_trust_store_is_configured -q` (`1 passed`)
- `make validate-ci`
- `make test-orchestrator-http-contract` (`196 passed`)
- `./.venv/bin/pytest tests/test_app_orchestrator_contract_http.py tests/lux_depth_v3/test_orchestrator_run_card_provenance.py tests/test_run_card_schema.py tests/unit/plugins/test_loader_manifest_loading.py -q` (`291 passed`)
- `make ci-quick`

Still failing:
- None observed.

Classification:
- Product logic and stale-test validation are green for the touched surfaces.
- No Postgres/Redis/Docker service-backed lanes were required for this local closeout.

## Risk
- Route selector, path, method, response-model, auth, and API-envelope contracts are intended to stay stable; route inventory and orchestrator HTTP contract gates passed.
- SSE replay remains additive: clients without `Last-Event-ID` keep state-first/synthetic-terminal behavior, and replay clients now fall back to that behavior when durable replay is unavailable or empty.
- Runtime licensing remains additive and limited to v1 evidence; schemas and readers tolerate legacy payloads without `licensing`.
- Plugin signature enforcement is opt-in and bounded to configured trust stores, so existing local external plugin behavior is preserved unless operators enable the trust boundary.
- Revert-safe as scoped commits: removing the router include/signing/licensing/SSE additions restores previous behavior without data migration.
