### PR TITLE
test(orchestrator): cover cleanup seams and replay contracts

### DIFF
--- a/app.py
+++ b/app.py
@@ -18,6 +18,7 @@ import time
 import uuid
 from collections import deque
 from contextlib import asynccontextmanager, contextmanager, suppress
+from copy import deepcopy
 from dataclasses import dataclass
 from dataclasses import field as dataclass_field
 from email.parser import BytesParser
@@ -6410,11 +6411,12 @@ async def _publish_event(
 ) -> None:
     event_at = _now()
     event_seq: Optional[int] = None
+    event_data = deepcopy(data)
     try:
         stored_event = await _job_event_store().append(
             job_id,
             event,
-            dict(data),
+            event_data,
             created_at=event_at,
         )
         event_seq = stored_event.seq
@@ -6436,7 +6438,7 @@ async def _publish_event(
     if not subscribers:
         return
 
-    payload = {"event": event, "data": data}
+    payload = {"event": event, "data": event_data}
     if event_seq is not None:
         payload["id"] = event_seq
     stale_subscribers: List[str] = []
@@ -6447,7 +6449,7 @@ async def _publish_event(
             except asyncio.QueueEmpty:
                 pass
         try:
-            queue.put_nowait(payload)
+            queue.put_nowait(deepcopy(payload))
         except asyncio.QueueFull:
             continue
         except RuntimeError:
@@ -10036,23 +10038,26 @@ def _last_event_id_from_request(request: Request) -> Optional[int]:
     raw_value = headers.get("last-event-id")
     if raw_value is None or not str(raw_value).strip():
         return None
-    try:
-        last_event_id = int(str(raw_value).strip())
-    except ValueError as exc:
-        raise ValueError("Last-Event-ID must be a non-negative integer") from exc
-    if last_event_id < 0:
+    normalized = str(raw_value).strip()
+    if not normalized.isascii() or not normalized.isdecimal():
         raise ValueError("Last-Event-ID must be a non-negative integer")
-    return last_event_id
+    return int(normalized)
 
 
 def _event_queue_seq(event_payload: Mapping[str, Any]) -> Optional[int]:
     raw_value = event_payload.get("id")
     if raw_value is None:
         return None
-    try:
-        return int(raw_value)
-    except (TypeError, ValueError):
+    if isinstance(raw_value, bool):
         return None
+    if isinstance(raw_value, int):
+        return raw_value if raw_value > 0 else None
+    if isinstance(raw_value, str):
+        normalized = raw_value.strip()
+        if normalized.isascii() and normalized.isdecimal():
+            seq = int(normalized)
+            return seq if seq > 0 else None
+    return None
 
 
 def _terminal_done_payload(job: Job) -> Dict[str, Any]:

--- a/docs/schemas/run_card/run_card.v1.schema.json
+++ b/docs/schemas/run_card/run_card.v1.schema.json
@@ -553,7 +553,10 @@
         },
         "software_license_tier": {
           "type": "string",
-          "minLength": 1
+          "enum": [
+            "commercial",
+            "research_or_non_commercial"
+          ]
         },
         "models": {
           "type": "array",

--- a/docs/schemas/run_card/run_card.v2.schema.json
+++ b/docs/schemas/run_card/run_card.v2.schema.json
@@ -553,7 +553,10 @@
         },
         "software_license_tier": {
           "type": "string",
-          "minLength": 1
+          "enum": [
+            "commercial",
+            "research_or_non_commercial"
+          ]
         },
         "models": {
           "type": "array",

--- a/src/transformation_portal/api/routes/jobs.py
+++ b/src/transformation_portal/api/routes/jobs.py
@@ -20,6 +20,8 @@ from transformation_portal.api.v1 import (
     JobStatusEnvelope,
 )
 
+DEFAULT_JOB_LIST_LIMIT = 200
+
 
 @dataclass(frozen=True)
 class JobRouteHandlers:
@@ -41,7 +43,7 @@ class JobRouteHandlers:
     job_events_v2: Callable[[Request, str], Awaitable[Response]]
 
 
-def create_jobs_router(handlers: JobRouteHandlers, *, job_list_limit: int) -> APIRouter:
+def create_jobs_router(handlers: JobRouteHandlers, *, job_list_limit: int = DEFAULT_JOB_LIST_LIMIT) -> APIRouter:
     """Create the dual-version jobs router without owning route behavior."""
     router = APIRouter()
 

--- a/src/transformation_portal/lux_depth_v3/manifest.py
+++ b/src/transformation_portal/lux_depth_v3/manifest.py
@@ -556,6 +556,7 @@ class CombinedManifest:
             "input",
             "depth",
             "v2",
+            "materials_v3",
             "timing",
             "pbr_assets",
             "repro",
@@ -615,6 +616,8 @@ class CombinedManifest:
             manifest.depth = DepthMetadata(**data["depth"])
         if "v2" in data:
             manifest.v2 = V2Metadata(**data["v2"])
+        if "materials_v3" in data:
+            manifest.materials_v3 = MaterialsV3Metadata.from_dict(data["materials_v3"])
         if "timing" in data:
             manifest.timing = TimingMetadata(**data["timing"])
         if "repro" in data:
@@ -625,6 +628,8 @@ class CombinedManifest:
             manifest.pbr_assets = data["pbr_assets"]
         if "environment" in data:
             manifest.environment = data["environment"]
+        if "backend_selection" in data and data["backend_selection"] is not None:
+            manifest.backend_selection = BackendSelectionMetadata.from_dict(data["backend_selection"])
         if "licensing" in data and data["licensing"] is not None:
             manifest.licensing = dict(data["licensing"])
         if "start_time" in data:

--- a/src/transformation_portal/orchestrator/storage/memory.py
+++ b/src/transformation_portal/orchestrator/storage/memory.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 from collections import defaultdict, deque
+from copy import deepcopy
 from pathlib import Path
 from typing import Any, AsyncIterator, Deque, Dict, Iterable, List, Optional, Tuple
 
@@ -60,6 +61,10 @@ class MemoryJobRepository(JobRepository):
         return [r.copy() for r in ordered], total
 
     async def update(self, job_id: str, **fields: Any) -> JobRecord:
+        unknown = set(fields) - _UPDATABLE_FIELDS
+        if unknown:
+            raise RepositoryError(f"update received unknown fields: {sorted(unknown)}")
+        field_values = {key: deepcopy(value) for key, value in fields.items()}
         async with self._lock_for(job_id):
             existing = self._records.get(job_id)
             if existing is None:
@@ -69,10 +74,7 @@ class MemoryJobRepository(JobRepository):
             # backend persists it through a separate table). Forbidding
             # it here keeps both backends behavior-identical at the
             # ``update`` boundary.
-            unknown = set(fields) - _UPDATABLE_FIELDS
-            if unknown:
-                raise RepositoryError(f"update received unknown fields: {sorted(unknown)}")
-            for key, value in fields.items():
+            for key, value in field_values.items():
                 setattr(existing, key, value)
             return existing.copy()
 
@@ -107,12 +109,14 @@ class MemoryJobRepository(JobRepository):
         artifacts: Dict[str, Any],
         artifact_lookup: Dict[str, Path],
     ) -> None:
+        artifacts_snapshot = deepcopy(artifacts)
+        artifact_lookup_snapshot = dict(artifact_lookup)
         async with self._lock_for(job_id):
             existing = self._records.get(job_id)
             if existing is None:
                 raise JobNotFoundError(job_id)
-            existing.artifacts = dict(artifacts)
-            existing.artifact_lookup = dict(artifact_lookup)
+            existing.artifacts = artifacts_snapshot
+            existing.artifact_lookup = artifact_lookup_snapshot
 
     async def delete(self, job_id: str) -> None:
         self._records.pop(job_id, None)
@@ -182,6 +186,16 @@ class MemoryJobEventStore(JobEventStore):
         self._events: Dict[str, Deque[JobEvent]] = defaultdict(lambda: deque(maxlen=per_job_cap))
         self._next_seq: Dict[str, int] = defaultdict(lambda: 1)
 
+    @staticmethod
+    def _copy_event(event: JobEvent) -> JobEvent:
+        return JobEvent(
+            job_id=event.job_id,
+            seq=event.seq,
+            event_type=event.event_type,
+            payload=deepcopy(event.payload),
+            created_at=event.created_at,
+        )
+
     async def append(
         self,
         job_id: str,
@@ -196,11 +210,11 @@ class MemoryJobEventStore(JobEventStore):
             job_id=job_id,
             seq=seq,
             event_type=event_type,
-            payload=dict(payload),
+            payload=deepcopy(payload),
             created_at=created_at,
         )
         self._events[job_id].append(event)
-        return event
+        return self._copy_event(event)
 
     async def events_since(
         self,
@@ -211,7 +225,7 @@ class MemoryJobEventStore(JobEventStore):
         threshold = -1 if after_seq is None else after_seq
         for event in list(self._events.get(job_id, ())):
             if event.seq > threshold:
-                yield event
+                yield self._copy_event(event)
 
     async def reset(self) -> None:
         self._events.clear()

--- a/src/transformation_portal/orchestrator/storage/postgres.py
+++ b/src/transformation_portal/orchestrator/storage/postgres.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from contextlib import asynccontextmanager
+from copy import deepcopy
 from pathlib import Path
 from typing import Any, AsyncIterator, Dict, Iterable, List, Optional, Tuple, cast
 
@@ -108,13 +109,13 @@ def _record_from_model(model: JobModel) -> JobRecord:
         last_event_at=model.last_event_at,
         exit_code=model.exit_code,
         cancel_requested=model.cancel_requested,
-        request=dict(model.request or {}),
-        effective_request=dict(model.effective_request or {}),
+        request=deepcopy(model.request or {}),
+        effective_request=deepcopy(model.effective_request or {}),
         logs_tail=list(model.logs_tail or []),
-        artifacts=dict(model.artifacts or {}),
+        artifacts=deepcopy(model.artifacts or {}),
         artifact_lookup=artifact_lookup,
-        run_summary=dict(model.run_summary or {}),
-        error=None if model.error is None else dict(model.error),
+        run_summary=deepcopy(model.run_summary or {}),
+        error=None if model.error is None else deepcopy(model.error),
     )
 
 
@@ -140,32 +141,33 @@ class PostgresJobRepository(JobRepository):
             yield session
 
     async def create(self, record: JobRecord) -> None:
+        record_snapshot = record.copy()
         async with self._session() as session:
             session.add(
                 JobModel(
-                    id=record.id,
-                    created_at=record.created_at,
-                    state=record.state,
-                    progress=record.progress,
-                    started_at=record.started_at,
-                    finished_at=record.finished_at,
-                    done_published_at=record.done_published_at,
-                    last_event_at=record.last_event_at,
-                    exit_code=record.exit_code,
-                    cancel_requested=record.cancel_requested,
-                    request=dict(record.request),
-                    effective_request=dict(record.effective_request),
-                    logs_tail=list(record.logs_tail),
-                    artifacts=dict(record.artifacts),
-                    run_summary=dict(record.run_summary),
-                    error=None if record.error is None else dict(record.error),
+                    id=record_snapshot.id,
+                    created_at=record_snapshot.created_at,
+                    state=record_snapshot.state,
+                    progress=record_snapshot.progress,
+                    started_at=record_snapshot.started_at,
+                    finished_at=record_snapshot.finished_at,
+                    done_published_at=record_snapshot.done_published_at,
+                    last_event_at=record_snapshot.last_event_at,
+                    exit_code=record_snapshot.exit_code,
+                    cancel_requested=record_snapshot.cancel_requested,
+                    request=record_snapshot.request,
+                    effective_request=record_snapshot.effective_request,
+                    logs_tail=record_snapshot.logs_tail,
+                    artifacts=record_snapshot.artifacts,
+                    run_summary=record_snapshot.run_summary,
+                    error=record_snapshot.error,
                     version=1,
                 )
             )
-            for path_str, absolute in record.artifact_lookup.items():
+            for path_str, absolute in record_snapshot.artifact_lookup.items():
                 session.add(
                     JobArtifactModel(
-                        job_id=record.id,
+                        job_id=record_snapshot.id,
                         path=path_str,
                         absolute_path=str(absolute),
                     )
@@ -174,7 +176,7 @@ class PostgresJobRepository(JobRepository):
                 await session.commit()
             except IntegrityError as exc:
                 await session.rollback()
-                raise RepositoryError(f"job id already exists: {record.id}") from exc
+                raise RepositoryError(f"job id already exists: {record_snapshot.id}") from exc
 
     async def get(self, job_id: str) -> Optional[JobRecord]:
         async with self._session() as session:
@@ -207,13 +209,13 @@ class PostgresJobRepository(JobRepository):
             if existing is None:
                 raise JobNotFoundError(job_id)
             return existing
+        payload: Dict[str, Any] = {key: deepcopy(value) for key, value in fields.items()}
 
         async with self._session() as session:
             stmt = select(JobModel).where(JobModel.id == job_id).with_for_update()
             model = (await session.execute(stmt)).scalar_one_or_none()
             if model is None:
                 raise JobNotFoundError(job_id)
-            payload: Dict[str, Any] = dict(fields)
             # Normalize JSON-stored containers so SQLAlchemy detects the
             # mutation (asyncpg JSONB column).
             for key in (
@@ -223,11 +225,11 @@ class PostgresJobRepository(JobRepository):
                 "run_summary",
             ):
                 if key in payload and payload[key] is not None:
-                    payload[key] = dict(payload[key])
+                    payload[key] = deepcopy(payload[key])
             if "logs_tail" in payload and payload["logs_tail"] is not None:
                 payload["logs_tail"] = list(payload["logs_tail"])
             if "error" in payload and payload["error"] is not None:
-                payload["error"] = dict(payload["error"])
+                payload["error"] = deepcopy(payload["error"])
 
             for key, value in payload.items():
                 setattr(model, key, value)
@@ -266,6 +268,8 @@ class PostgresJobRepository(JobRepository):
         artifacts: Dict[str, Any],
         artifact_lookup: Dict[str, Path],
     ) -> None:
+        artifacts_snapshot = deepcopy(artifacts)
+        artifact_lookup_snapshot = dict(artifact_lookup)
         for attempt in range(_OPTIMISTIC_LOCK_RETRIES):
             async with self._session() as session:
                 model = await session.get(JobModel, job_id)
@@ -278,7 +282,7 @@ class PostgresJobRepository(JobRepository):
                         JobModel.id == job_id,
                         JobModel.version == current_version,
                     )
-                    .values(artifacts=dict(artifacts), version=current_version + 1)
+                    .values(artifacts=artifacts_snapshot, version=current_version + 1)
                 )
                 result = cast(CursorResult[Any], await session.execute(stmt))
                 if result.rowcount == 0:
@@ -288,7 +292,7 @@ class PostgresJobRepository(JobRepository):
                         continue
                     raise RepositoryError(f"optimistic-lock conflict on job {job_id} set_artifacts")
                 await session.execute(delete(JobArtifactModel).where(JobArtifactModel.job_id == job_id))
-                for path_str, absolute in artifact_lookup.items():
+                for path_str, absolute in artifact_lookup_snapshot.items():
                     session.add(
                         JobArtifactModel(
                             job_id=job_id,
@@ -426,6 +430,7 @@ class PostgresJobEventStore(JobEventStore):
         out-of-order overwrite. We retry on conflict so callers see the same
         monotonic-seq contract as the memory backend.
         """
+        payload_snapshot = deepcopy(payload)
         for attempt in range(_OPTIMISTIC_LOCK_RETRIES):
             try:
                 async with self._session() as session:
@@ -439,7 +444,7 @@ class PostgresJobEventStore(JobEventStore):
                             job_id=job_id,
                             seq=seq,
                             event_type=event_type,
-                            payload=dict(payload),
+                            payload=deepcopy(payload_snapshot),
                             created_at=created_at,
                         )
                     )
@@ -448,7 +453,7 @@ class PostgresJobEventStore(JobEventStore):
                         job_id=job_id,
                         seq=seq,
                         event_type=event_type,
-                        payload=dict(payload),
+                        payload=deepcopy(payload_snapshot),
                         created_at=created_at,
                     )
             except IntegrityError:
@@ -493,7 +498,7 @@ class PostgresJobEventStore(JobEventStore):
                     job_id=row.job_id,
                     seq=row.seq,
                     event_type=row.event_type,
-                    payload=dict(row.payload or {}),
+                    payload=deepcopy(row.payload or {}),
                     created_at=row.created_at,
                 )
 

--- a/src/transformation_portal/plugins/loader.py
+++ b/src/transformation_portal/plugins/loader.py
@@ -12,7 +12,7 @@ from threading import Lock
 from typing import Any, Dict, List, Optional
 
 from .interface import PluginInterface, PluginMetadata, PluginType
-from .signing import PluginSignatureError, verify_manifest_signature
+from .signing import verify_manifest_signature
 
 logger = logging.getLogger(__name__)
 
@@ -383,7 +383,7 @@ class PluginLoader:
                 manifest.raw_data,
                 trust_store_path=self._plugin_trust_store_path,  # type: ignore[arg-type]
             )
-        except (OSError, PluginSignatureError, json.JSONDecodeError) as exc:
+        except (OSError, ValueError) as exc:
             return f"Plugin manifest signature verification failed: {exc}"
         return None
 

--- a/src/transformation_portal/plugins/signing.py
+++ b/src/transformation_portal/plugins/signing.py
@@ -48,9 +48,11 @@ def load_plugin_trust_store(path: Path) -> dict[str, str]:
 
     trust_store: dict[str, str] = {}
     for key_id, secret in keys.items():
-        if not isinstance(key_id, str) or not key_id:
+        if not isinstance(key_id, str) or not key_id.strip():
             raise PluginSignatureError("Plugin trust store key ids must be non-empty strings")
-        if not isinstance(secret, str) or not secret:
+        if key_id != key_id.strip():
+            raise PluginSignatureError("Plugin trust store key ids must not contain leading or trailing whitespace")
+        if not isinstance(secret, str) or not secret.strip():
             raise PluginSignatureError(f"Plugin trust store secret for {key_id!r} must be a non-empty string")
         trust_store[key_id] = secret
     return trust_store
@@ -72,11 +74,13 @@ def verify_manifest_signature(manifest_data: Mapping[str, Any], *, trust_store_p
         raise PluginSignatureError("Plugin manifest signature_algorithm must be 'hmac-sha256'")
 
     key_id = manifest_data.get("signature_key_id")
-    if not isinstance(key_id, str) or not key_id:
+    if not isinstance(key_id, str) or not key_id.strip():
         raise PluginSignatureError("Plugin manifest signature_key_id is required")
+    if key_id != key_id.strip():
+        raise PluginSignatureError("Plugin manifest signature_key_id must not contain leading or trailing whitespace")
 
     signature = manifest_data.get("signature")
-    if not isinstance(signature, str) or not signature:
+    if not isinstance(signature, str) or not signature.strip():
         raise PluginSignatureError("Plugin manifest signature is required")
 
     trust_store = load_plugin_trust_store(trust_store_path)

--- a/src/transformation_portal/schemas/run_card/run_card.v1.schema.json
+++ b/src/transformation_portal/schemas/run_card/run_card.v1.schema.json
@@ -553,7 +553,10 @@
         },
         "software_license_tier": {
           "type": "string",
-          "minLength": 1
+          "enum": [
+            "commercial",
+            "research_or_non_commercial"
+          ]
         },
         "models": {
           "type": "array",

--- a/src/transformation_portal/schemas/run_card/run_card.v2.schema.json
+++ b/src/transformation_portal/schemas/run_card/run_card.v2.schema.json
@@ -553,7 +553,10 @@
         },
         "software_license_tier": {
           "type": "string",
-          "minLength": 1
+          "enum": [
+            "commercial",
+            "research_or_non_commercial"
+          ]
         },
         "models": {
           "type": "array",

--- a/tests/api/test_jobs_router_factory.py
+++ b/tests/api/test_jobs_router_factory.py
@@ -1,0 +1,275 @@
+"""Focused tests for the extracted jobs router factory seam."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+from starlette.responses import JSONResponse, Response
+
+from transformation_portal.api.routes.jobs import DEFAULT_JOB_LIST_LIMIT, JobRouteHandlers, create_jobs_router
+from transformation_portal.api.v1 import JobEnvelope, JobsListEnvelope, JobStatusEnvelope
+
+pytestmark = [pytest.mark.unit]
+
+
+@dataclass
+class _RecordingHandlers:
+    calls: list[tuple[str, dict[str, Any]]] = field(default_factory=list)
+
+    def _record(self, name: str, **kwargs: Any) -> Response:
+        self.calls.append((name, kwargs))
+        return JSONResponse({"handler": name, **kwargs})
+
+    async def create_job_http(self, request: Request, payload: dict[str, Any]) -> Response:
+        return self._record("create_job_http", path=request.url.path, payload=payload)
+
+    async def create_job_v2_http(self, request: Request, payload: dict[str, Any]) -> Response:
+        return self._record("create_job_v2_http", path=request.url.path, payload=payload)
+
+    async def list_jobs(self, limit: int) -> Response:
+        return self._record("list_jobs", limit=limit)
+
+    async def list_jobs_v2(self, limit: int) -> Response:
+        return self._record("list_jobs_v2", limit=limit)
+
+    async def get_job(self, job_id: str, include_logs: bool) -> Response:
+        return self._record("get_job", job_id=job_id, include_logs=include_logs)
+
+    async def get_job_v2(self, job_id: str, include_logs: bool) -> Response:
+        return self._record("get_job_v2", job_id=job_id, include_logs=include_logs)
+
+    async def get_job_artifact(self, job_id: str, artifact_path: str) -> Response:
+        return self._record("get_job_artifact", job_id=job_id, artifact_path=artifact_path)
+
+    async def get_job_artifact_v2(self, job_id: str, artifact_path: str) -> Response:
+        return self._record("get_job_artifact_v2", job_id=job_id, artifact_path=artifact_path)
+
+    async def delete_job_artifacts(self, job_id: str) -> Response:
+        return self._record("delete_job_artifacts", job_id=job_id)
+
+    async def delete_job_artifacts_v2(self, job_id: str) -> Response:
+        return self._record("delete_job_artifacts_v2", job_id=job_id)
+
+    async def cancel_job(self, job_id: str) -> Response:
+        return self._record("cancel_job", job_id=job_id)
+
+    async def cancel_job_v2(self, job_id: str) -> Response:
+        return self._record("cancel_job_v2", job_id=job_id)
+
+    async def job_events(self, request: Request, job_id: str) -> Response:
+        return self._record("job_events", path=request.url.path, job_id=job_id)
+
+    async def job_events_v2(self, request: Request, job_id: str) -> Response:
+        return self._record("job_events_v2", path=request.url.path, job_id=job_id)
+
+
+def _build_handlers(recording: _RecordingHandlers) -> JobRouteHandlers:
+    return JobRouteHandlers(
+        create_job_http=recording.create_job_http,
+        create_job_v2_http=recording.create_job_v2_http,
+        list_jobs=recording.list_jobs,
+        list_jobs_v2=recording.list_jobs_v2,
+        get_job=recording.get_job,
+        get_job_v2=recording.get_job_v2,
+        get_job_artifact=recording.get_job_artifact,
+        get_job_artifact_v2=recording.get_job_artifact_v2,
+        delete_job_artifacts=recording.delete_job_artifacts,
+        delete_job_artifacts_v2=recording.delete_job_artifacts_v2,
+        cancel_job=recording.cancel_job,
+        cancel_job_v2=recording.cancel_job_v2,
+        job_events=recording.job_events,
+        job_events_v2=recording.job_events_v2,
+    )
+
+
+def _build_test_app(*, job_list_limit: int = 37) -> tuple[TestClient, _RecordingHandlers, FastAPI]:
+    recording = _RecordingHandlers()
+    test_app = FastAPI(docs_url=None, redoc_url=None, openapi_url=None)
+    test_app.include_router(create_jobs_router(_build_handlers(recording), job_list_limit=job_list_limit))
+    return TestClient(test_app), recording, test_app
+
+
+def test_jobs_router_default_factory_call_uses_portal_list_limit_contract() -> None:
+    recording = _RecordingHandlers()
+    test_app = FastAPI(docs_url=None, redoc_url=None, openapi_url=None)
+    test_app.include_router(create_jobs_router(_build_handlers(recording)))
+    client = TestClient(test_app)
+
+    assert client.get("/v1/jobs").json() == {
+        "handler": "list_jobs",
+        "limit": DEFAULT_JOB_LIST_LIMIT,
+    }
+    assert client.get("/v2/jobs").json() == {
+        "handler": "list_jobs_v2",
+        "limit": DEFAULT_JOB_LIST_LIMIT,
+    }
+    assert recording.calls == [
+        ("list_jobs", {"limit": DEFAULT_JOB_LIST_LIMIT}),
+        ("list_jobs_v2", {"limit": DEFAULT_JOB_LIST_LIMIT}),
+    ]
+
+
+def test_jobs_router_pins_paths_methods_endpoint_names_and_response_models() -> None:
+    _client, _recording, test_app = _build_test_app()
+
+    tracked: dict[tuple[str, str], tuple[str, type[Any] | None]] = {}
+    for route in test_app.routes:
+        methods = getattr(route, "methods", None)
+        path = getattr(route, "path", None)
+        if not methods or not path:
+            continue
+        for method in methods:
+            if method in {"GET", "POST", "DELETE"}:
+                tracked[(method, path)] = (
+                    getattr(route, "name"),
+                    getattr(route, "response_model", None),
+                )
+
+    assert tracked == {
+        ("POST", "/v1/jobs"): ("create_job_http", JobEnvelope),
+        ("POST", "/v2/jobs"): ("create_job_v2_http", JobEnvelope),
+        ("GET", "/v1/jobs"): ("list_jobs", JobsListEnvelope),
+        ("GET", "/v2/jobs"): ("list_jobs_v2", JobsListEnvelope),
+        ("GET", "/v1/jobs/{job_id}"): ("get_job", JobStatusEnvelope),
+        ("GET", "/v2/jobs/{job_id}"): ("get_job_v2", JobStatusEnvelope),
+        ("GET", "/v1/jobs/{job_id}/artifacts/{artifact_path:path}"): ("get_job_artifact", None),
+        ("GET", "/v2/jobs/{job_id}/artifacts/{artifact_path:path}"): ("get_job_artifact_v2", None),
+        ("DELETE", "/v1/jobs/{job_id}/artifacts"): ("delete_job_artifacts", JobStatusEnvelope),
+        ("DELETE", "/v2/jobs/{job_id}/artifacts"): ("delete_job_artifacts_v2", JobStatusEnvelope),
+        ("POST", "/v1/jobs/{job_id}/cancel"): ("cancel_job", JobEnvelope),
+        ("POST", "/v2/jobs/{job_id}/cancel"): ("cancel_job_v2", JobEnvelope),
+        ("GET", "/v1/jobs/{job_id}/events"): ("job_events", None),
+        ("GET", "/v2/jobs/{job_id}/events"): ("job_events_v2", None),
+    }
+
+
+def test_jobs_router_delegates_list_limits_to_the_injected_handlers() -> None:
+    client, recording, _test_app = _build_test_app(job_list_limit=41)
+
+    assert client.get("/v1/jobs").json() == {"handler": "list_jobs", "limit": 41}
+    assert client.get("/v2/jobs", params={"limit": 9}).json() == {"handler": "list_jobs_v2", "limit": 9}
+    assert recording.calls == [
+        ("list_jobs", {"limit": 41}),
+        ("list_jobs_v2", {"limit": 9}),
+    ]
+
+
+@pytest.mark.parametrize("jobs_path", ["/v1/jobs", "/v2/jobs"])
+def test_jobs_router_rejects_non_object_create_body_before_handler(
+    jobs_path: str,
+) -> None:
+    client, recording, _test_app = _build_test_app()
+
+    response = client.post(jobs_path, json=["not", "an", "object"])
+
+    assert response.status_code == 422
+    assert recording.calls == []
+
+
+@pytest.mark.parametrize("jobs_path", ["/v1/jobs", "/v2/jobs"])
+def test_jobs_router_rejects_missing_create_body_before_handler(
+    jobs_path: str,
+) -> None:
+    client, recording, _test_app = _build_test_app()
+
+    response = client.post(jobs_path)
+
+    assert response.status_code == 422
+    assert recording.calls == []
+
+
+@pytest.mark.parametrize(
+    ("path", "params"),
+    [
+        ("/v1/jobs", {"limit": "not-an-int"}),
+        ("/v2/jobs", {"limit": "not-an-int"}),
+        ("/v1/jobs/job-1", {"include_logs": "not-a-bool"}),
+        ("/v2/jobs/job-2", {"include_logs": "not-a-bool"}),
+    ],
+)
+def test_jobs_router_rejects_invalid_query_parameters_before_handler(
+    path: str,
+    params: dict[str, str],
+) -> None:
+    client, recording, _test_app = _build_test_app()
+
+    response = client.get(path, params=params)
+
+    assert response.status_code == 422
+    assert recording.calls == []
+
+
+@pytest.mark.parametrize(
+    ("method", "path", "json_payload", "expected_handler", "expected_kwargs"),
+    [
+        (
+            "post",
+            "/v1/jobs",
+            {"pipeline": "lux-depth-v3", "args": {"input_dir": "in"}},
+            "create_job_http",
+            {"path": "/v1/jobs", "payload": {"pipeline": "lux-depth-v3", "args": {"input_dir": "in"}}},
+        ),
+        (
+            "post",
+            "/v2/jobs",
+            {"pipeline": "lux-depth-v3", "args": {"output_dir": "out"}},
+            "create_job_v2_http",
+            {"path": "/v2/jobs", "payload": {"pipeline": "lux-depth-v3", "args": {"output_dir": "out"}}},
+        ),
+        ("get", "/v1/jobs/job-1?include_logs=false", None, "get_job", {"job_id": "job-1", "include_logs": False}),
+        ("get", "/v2/jobs/job-2", None, "get_job_v2", {"job_id": "job-2", "include_logs": True}),
+        (
+            "get",
+            "/v1/jobs/job-1/artifacts/nested/report.json",
+            None,
+            "get_job_artifact",
+            {"job_id": "job-1", "artifact_path": "nested/report.json"},
+        ),
+        (
+            "get",
+            "/v2/jobs/job-2/artifacts/nested/report.json",
+            None,
+            "get_job_artifact_v2",
+            {"job_id": "job-2", "artifact_path": "nested/report.json"},
+        ),
+        ("delete", "/v1/jobs/job-1/artifacts", None, "delete_job_artifacts", {"job_id": "job-1"}),
+        ("delete", "/v2/jobs/job-2/artifacts", None, "delete_job_artifacts_v2", {"job_id": "job-2"}),
+        ("post", "/v1/jobs/job-1/cancel", None, "cancel_job", {"job_id": "job-1"}),
+        ("post", "/v2/jobs/job-2/cancel", None, "cancel_job_v2", {"job_id": "job-2"}),
+        (
+            "get",
+            "/v1/jobs/job-1/events",
+            None,
+            "job_events",
+            {"path": "/v1/jobs/job-1/events", "job_id": "job-1"},
+        ),
+        (
+            "get",
+            "/v2/jobs/job-2/events",
+            None,
+            "job_events_v2",
+            {"path": "/v2/jobs/job-2/events", "job_id": "job-2"},
+        ),
+    ],
+)
+def test_jobs_router_delegates_each_route_shape_without_rewriting_arguments(
+    method: str,
+    path: str,
+    json_payload: dict[str, Any] | None,
+    expected_handler: str,
+    expected_kwargs: dict[str, Any],
+) -> None:
+    client, recording, _test_app = _build_test_app()
+
+    if json_payload is None:
+        response = getattr(client, method)(path)
+    else:
+        response = getattr(client, method)(path, json=json_payload)
+
+    assert response.status_code == 200
+    assert response.json() == {"handler": expected_handler, **expected_kwargs}
+    assert recording.calls == [(expected_handler, expected_kwargs)]

--- a/tests/lux_depth_v3/test_orchestrator_run_card_provenance.py
+++ b/tests/lux_depth_v3/test_orchestrator_run_card_provenance.py
@@ -281,6 +281,74 @@ class TestRuntimeLicensingManifest:
         assert licensing["research_acknowledgement_required"] is False
         assert licensing["models"][0]["id"] == "commercial/depth-model"
 
+    def test_runtime_licensing_manifest_marks_research_ack_without_active_noncommercial(self) -> None:
+        from transformation_portal.lux_depth_v3.run_card_contract import build_runtime_licensing_manifest
+
+        licensing = build_runtime_licensing_manifest(
+            model_contract=None,
+            config=SimpleNamespace(
+                non_commercial_ok=False,
+                accept_apple_depth_pro_research_license=True,
+            ),
+        )
+
+        assert licensing["models"] == []
+        assert licensing["software_license_tier"] == "research_or_non_commercial"
+        assert licensing["research_acknowledgement_required"] is True
+        assert licensing["non_commercial_active"] is False
+
+    def test_runtime_licensing_manifest_uses_selector_fallbacks_and_defaults(self) -> None:
+        from transformation_portal.lux_depth_v3.run_card_contract import build_runtime_licensing_manifest
+
+        licensing = build_runtime_licensing_manifest(
+            model_contract={
+                "canonical_model_key": "da3-research",
+                "requested_model_selector": "depth-anything/DA3",
+                "license_id": "",
+                "backend_kind": "",
+                "usage_class": "non_commercial_only",
+                "requires_non_commercial_ok": False,
+            },
+            config=SimpleNamespace(non_commercial_ok=True),
+        )
+
+        assert licensing["software_license_tier"] == "research_or_non_commercial"
+        assert licensing["non_commercial_active"] is True
+        assert licensing["research_acknowledgement_required"] is True
+        assert licensing["models"] == [
+            {
+                "id": "da3-research",
+                "license": "unknown",
+                "runtime_role": "depth",
+                "usage_class": "non_commercial_only",
+                "requires_non_commercial_ok": False,
+            }
+        ]
+
+    def test_runtime_licensing_manifest_omits_empty_model_ids_but_keeps_research_ack(self) -> None:
+        from transformation_portal.lux_depth_v3.run_card_contract import build_runtime_licensing_manifest
+
+        licensing = build_runtime_licensing_manifest(
+            model_contract={
+                "resolved_repo_id": "",
+                "canonical_model_key": "",
+                "requested_model_selector": "   ",
+                "license_id": "cc-by-nc-4.0",
+                "backend_kind": "da3",
+                "usage_class": "non_commercial_only",
+                "requires_non_commercial_ok": True,
+            },
+            config=SimpleNamespace(
+                non_commercial_ok=True,
+                accept_research_tools_license=True,
+            ),
+        )
+
+        assert licensing["models"] == []
+        assert licensing["software_license_tier"] == "research_or_non_commercial"
+        assert licensing["research_acknowledgement_required"] is True
+        assert licensing["non_commercial_active"] is True
+
     def test_combined_manifest_round_trips_licensing(self, tmp_path: Path) -> None:
         from transformation_portal.lux_depth_v3.manifest import CombinedManifest
 
@@ -317,3 +385,262 @@ class TestRuntimeLicensingManifest:
 
         restored = CombinedManifest.load_msgpack(manifest_path)
         assert restored.licensing == licensing
+
+    def test_combined_msgpack_manifest_fallback_json_preserves_licensing(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from transformation_portal.lux_depth_v3 import manifest as manifest_module
+        from transformation_portal.lux_depth_v3.manifest import CombinedManifest
+
+        manifest_path = tmp_path / "licensing-fallback.manifest.msgpack"
+        licensing = {
+            "schema_version": "1.0",
+            "software_license_tier": "research_or_non_commercial",
+            "models": [{"id": "depth-anything/DA3", "license": "cc-by-nc-4.0"}],
+            "non_commercial_active": True,
+            "research_acknowledgement_required": True,
+        }
+        monkeypatch.setattr(manifest_module, "MSGPACK_AVAILABLE", False)
+
+        CombinedManifest(licensing=licensing).save_msgpack(manifest_path)
+
+        fallback_path = tmp_path / "licensing-fallback.manifest.json"
+        assert not manifest_path.exists()
+        assert CombinedManifest.load(fallback_path).licensing == licensing
+
+    def test_combined_msgpack_manifest_cleans_temp_file_when_pack_fails(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from transformation_portal.lux_depth_v3 import manifest as manifest_module
+        from transformation_portal.lux_depth_v3.manifest import MSGPACK_AVAILABLE, CombinedManifest
+
+        if not MSGPACK_AVAILABLE:
+            pytest.skip("msgpack is optional")
+
+        manifest_path = tmp_path / "pack-failure.manifest.msgpack"
+        temp_path = tmp_path / "pack-failure.manifest.msgpack.tmp"
+
+        def fail_pack(*_args: object, **_kwargs: object) -> None:
+            raise RuntimeError("pack failed")
+
+        monkeypatch.setattr(manifest_module.msgpack, "pack", fail_pack)
+
+        with pytest.raises(RuntimeError, match="pack failed"):
+            CombinedManifest(
+                licensing={
+                    "schema_version": "1.0",
+                    "software_license_tier": "commercial",
+                    "models": [],
+                    "non_commercial_active": False,
+                    "research_acknowledgement_required": False,
+                }
+            ).save_msgpack(manifest_path)
+
+        assert not manifest_path.exists()
+        assert not temp_path.exists()
+
+    def test_combined_msgpack_manifest_round_trips_stage_metadata_with_licensing(self, tmp_path: Path) -> None:
+        from transformation_portal.lux_depth_v3.manifest import (
+            MSGPACK_AVAILABLE,
+            BackendSelectionMetadata,
+            CombinedManifest,
+            MaterialsV3Metadata,
+        )
+
+        if not MSGPACK_AVAILABLE:
+            pytest.skip("msgpack is optional")
+
+        manifest_path = tmp_path / "stage-metadata-licensing.manifest.msgpack"
+        licensing = {
+            "schema_version": "1.0",
+            "software_license_tier": "research_or_non_commercial",
+            "models": [{"id": "depth-anything/DA3", "license": "cc-by-nc-4.0"}],
+            "non_commercial_active": True,
+            "research_acknowledgement_required": True,
+        }
+        backend_selection = BackendSelectionMetadata(
+            requested_backend="da3",
+            resolved_backend="da3",
+            resolution_status="success",
+            resolution_reason=None,
+            model_id="depth-anything/DA3",
+            device="cpu",
+        )
+        materials_v3 = MaterialsV3Metadata(
+            enabled=True,
+            response_plan={"finish": "premium"},
+            segmentation_metadata={"source": "fixture"},
+            output_bit_depth=16,
+        )
+
+        CombinedManifest(
+            backend_selection=backend_selection,
+            materials_v3=materials_v3,
+            licensing=licensing,
+        ).save_msgpack(manifest_path)
+
+        restored = CombinedManifest.load_msgpack(manifest_path)
+
+        assert restored.licensing == licensing
+        assert restored.backend_selection is not None
+        assert restored.backend_selection.resolved_backend == "da3"
+        assert restored.backend_selection.model_id == "depth-anything/DA3"
+        assert restored.materials_v3 is not None
+        assert restored.materials_v3.response_plan == {"finish": "premium"}
+        assert restored.materials_v3.segmentation_metadata == {"source": "fixture"}
+        assert restored.materials_v3.output_bit_depth == 16
+
+    def test_combined_msgpack_manifest_round_trips_full_serialized_metadata_surface(self, tmp_path: Path) -> None:
+        from transformation_portal.lux_depth_v3.manifest import (
+            MSGPACK_AVAILABLE,
+            CombinedManifest,
+            ConfigFingerprint,
+            DepthMetadata,
+            InputMetadata,
+            ReproMetadata,
+            TimingMetadata,
+            V2Metadata,
+        )
+
+        if not MSGPACK_AVAILABLE:
+            pytest.skip("msgpack is optional")
+
+        manifest_path = tmp_path / "full-surface.manifest.msgpack"
+        CombinedManifest(
+            input=InputMetadata(
+                image_path="input/source.tif",
+                image_sha256="a" * 64,
+                image_size_bytes=12345,
+                image_dimensions=(64, 32),
+            ),
+            depth=DepthMetadata(
+                model="depth-anything/DA3",
+                depth_path="depth/source_depth.npy",
+                runtime_seconds=1.25,
+                scaling={"min": 0.0, "max": 1.0},
+                stats={"mean": 0.42},
+            ),
+            v2=V2Metadata(
+                preset="premium",
+                status="ok",
+                runtime_seconds=2.5,
+                output_paths=["v2/source_enhanced.tif"],
+                strict_depth=True,
+                output_dir="v2",
+                report_path="v2/source_report.json",
+                input_bit_depth=16,
+                output_bit_depth=16,
+            ),
+            timing=TimingMetadata(
+                depth_seconds=1.25,
+                v2_seconds=2.5,
+                total_seconds=3.75,
+                timestamp_utc="2026-05-30T00:00:03Z",
+            ),
+            pbr_assets={"maps": [{"kind": "roughness", "path": "pbr/source_roughness.png"}]},
+            repro=ReproMetadata(
+                v3_git_revision="v3-rev",
+                v2_git_revision="v2-rev",
+                environment={"python": "3.12"},
+            ),
+            config_fingerprint=ConfigFingerprint(
+                model_variant="METRIC_LARGE",
+                depth_quantization="u16",
+                depth_device="cpu",
+                preset="premium",
+                depth_backend="da3",
+                quality_tier="premium",
+                materials_config={"enabled": True},
+                enable_v2=True,
+            ),
+            environment={"platform": "test"},
+            start_time="2026-05-30T00:00:00Z",
+            end_time="2026-05-30T00:00:04Z",
+        ).save_msgpack(manifest_path)
+
+        restored = CombinedManifest.load_msgpack(manifest_path)
+
+        assert restored.input is not None
+        assert restored.input.image_dimensions == (64, 32)
+        assert restored.depth is not None
+        assert restored.depth.scaling == {"min": 0.0, "max": 1.0}
+        assert restored.depth.stats == {"mean": 0.42}
+        assert restored.v2 is not None
+        assert restored.v2.output_paths == ["v2/source_enhanced.tif"]
+        assert restored.v2.strict_depth is True
+        assert restored.timing is not None
+        assert restored.timing.total_seconds == 3.75
+        assert restored.pbr_assets == {"maps": [{"kind": "roughness", "path": "pbr/source_roughness.png"}]}
+        assert restored.repro is not None
+        assert restored.repro.environment == {"python": "3.12"}
+        assert restored.config_fingerprint is not None
+        assert restored.config_fingerprint.materials_config == {"enabled": True}
+        assert restored.environment == {"platform": "test"}
+        assert restored.start_time == "2026-05-30T00:00:00Z"
+        assert restored.end_time == "2026-05-30T00:00:04Z"
+
+    def test_combined_manifest_load_auto_preserves_json_licensing(self, tmp_path: Path) -> None:
+        from transformation_portal.lux_depth_v3.manifest import CombinedManifest
+
+        manifest_path = tmp_path / "licensing-auto.manifest.json"
+        licensing = {
+            "schema_version": "1.0",
+            "software_license_tier": "commercial",
+            "models": [{"id": "commercial/depth-model", "license": "commercial"}],
+            "non_commercial_active": False,
+            "research_acknowledgement_required": False,
+        }
+
+        CombinedManifest(licensing=licensing).save(manifest_path)
+
+        restored = CombinedManifest.load_auto(manifest_path)
+        assert restored.licensing == licensing
+
+    def test_combined_manifest_load_auto_preserves_msgpack_licensing(self, tmp_path: Path) -> None:
+        from transformation_portal.lux_depth_v3.manifest import MSGPACK_AVAILABLE, CombinedManifest
+
+        if not MSGPACK_AVAILABLE:
+            pytest.skip("msgpack is optional")
+
+        manifest_path = tmp_path / "licensing-auto.manifest.msgpack"
+        licensing = {
+            "schema_version": "1.0",
+            "software_license_tier": "research_or_non_commercial",
+            "models": [{"id": "depth-anything/DA3", "license": "cc-by-nc-4.0"}],
+            "non_commercial_active": True,
+            "research_acknowledgement_required": True,
+        }
+
+        CombinedManifest(licensing=licensing).save_msgpack(manifest_path)
+
+        restored = CombinedManifest.load_auto(manifest_path)
+        assert restored.licensing == licensing
+
+    def test_combined_manifest_load_auto_tolerates_legacy_json_without_licensing(self, tmp_path: Path) -> None:
+        from transformation_portal.lux_depth_v3.manifest import CombinedManifest
+
+        manifest_path = tmp_path / "legacy-no-licensing.manifest.json"
+        manifest_path.write_text(json.dumps({"start_time": "2026-05-30T00:00:00Z"}), encoding="utf-8")
+
+        restored = CombinedManifest.load_auto(manifest_path)
+
+        assert restored.start_time == "2026-05-30T00:00:00Z"
+        assert restored.licensing is None
+
+    def test_combined_manifest_load_auto_tolerates_legacy_msgpack_without_licensing(self, tmp_path: Path) -> None:
+        from transformation_portal.lux_depth_v3.manifest import MSGPACK_AVAILABLE, CombinedManifest
+
+        if not MSGPACK_AVAILABLE:
+            pytest.skip("msgpack is optional")
+
+        manifest_path = tmp_path / "legacy-no-licensing.manifest.msgpack"
+        CombinedManifest(start_time="2026-05-30T00:00:00Z").save_msgpack(manifest_path)
+
+        restored = CombinedManifest.load_auto(manifest_path)
+
+        assert restored.start_time == "2026-05-30T00:00:00Z"
+        assert restored.licensing is None

--- a/tests/orchestrator/test_orchestrator_factories.py
+++ b/tests/orchestrator/test_orchestrator_factories.py
@@ -11,6 +11,7 @@ factory paths are exercised without live infrastructure.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Generator
 
 import pytest
@@ -98,6 +99,98 @@ class TestStorageFactory:
 
         assert isinstance(storage_factory.get_job_repository(), PostgresJobRepository)
         assert isinstance(storage_factory.get_job_event_store(), PostgresJobEventStore)
+
+    @pytest.mark.parametrize(
+        ("factory_name", "class_name"),
+        [
+            ("get_job_repository", "PostgresJobRepository"),
+            ("get_job_event_store", "PostgresJobEventStore"),
+        ],
+    )
+    def test_postgres_backend_missing_sql_dependencies_reports_install_guidance(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        factory_name: str,
+        class_name: str,
+    ) -> None:
+        import builtins
+
+        monkeypatch.setenv("TP_ORCHESTRATOR_STATE_BACKEND", "postgres")
+        monkeypatch.setenv("TP_DATABASE_URL", "postgresql+asyncpg://user:pw@host:5432/db")
+        real_import = builtins.__import__
+
+        def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):  # noqa: ANN001, ANN202
+            if name == "transformation_portal.orchestrator.storage.postgres" and class_name in fromlist:
+                raise ImportError("sqlalchemy unavailable")
+            return real_import(name, globals, locals, fromlist, level)
+
+        monkeypatch.setattr(builtins, "__import__", guarded_import)
+
+        with pytest.raises(RuntimeError) as exc_info:
+            getattr(storage_factory, factory_name)()
+
+        message = str(exc_info.value)
+        assert "requires sqlalchemy[asyncio] + asyncpg" in message
+        assert "make install-core" in message
+
+    def test_postgres_record_projection_isolates_nested_json_fields(self) -> None:
+        from transformation_portal.orchestrator.models import JobArtifactModel, JobModel
+        from transformation_portal.orchestrator.storage.postgres import _record_from_model
+
+        model = JobModel(
+            id="job-pg-projection",
+            created_at=1.0,
+            state="running",
+            progress=50,
+            request={"args": {"quality": "premium"}},
+            effective_request={"args": {"resolved_backend": "da3"}},
+            logs_tail=["line-1"],
+            artifacts={"items": [{"relative_path": "report.json"}]},
+            run_summary={"counts": {"succeeded": 1}},
+            error={"details": {"code": "original"}},
+            version=1,
+        )
+        model.artifact_index = [
+            JobArtifactModel(
+                job_id=model.id,
+                path="out/report.json",
+                absolute_path="/abs/out/report.json",
+            )
+        ]
+
+        record = _record_from_model(model)
+        record.request["args"]["quality"] = "record-mutated"
+        record.effective_request["args"]["resolved_backend"] = "record-mutated"
+        record.artifacts["items"][0]["relative_path"] = "record-mutated.json"
+        record.run_summary["counts"]["succeeded"] = 99
+        assert record.error is not None
+        record.error["details"]["code"] = "record-mutated"
+        record.logs_tail.append("record-mutated")
+
+        reprojected = _record_from_model(model)
+
+        assert reprojected.request == {"args": {"quality": "premium"}}
+        assert reprojected.effective_request == {"args": {"resolved_backend": "da3"}}
+        assert reprojected.artifacts == {"items": [{"relative_path": "report.json"}]}
+        assert reprojected.run_summary == {"counts": {"succeeded": 1}}
+        assert reprojected.error == {"details": {"code": "original"}}
+        assert reprojected.logs_tail == ["line-1"]
+        assert reprojected.artifact_lookup == {"out/report.json": Path("/abs/out/report.json")}
+
+        model.request["args"]["quality"] = "model-mutated"
+        model.effective_request["args"]["resolved_backend"] = "model-mutated"
+        model.artifacts["items"][0]["relative_path"] = "model-mutated.json"
+        model.run_summary["counts"]["succeeded"] = 100
+        assert model.error is not None
+        model.error["details"]["code"] = "model-mutated"
+        model.logs_tail.append("model-mutated")
+
+        assert reprojected.request == {"args": {"quality": "premium"}}
+        assert reprojected.effective_request == {"args": {"resolved_backend": "da3"}}
+        assert reprojected.artifacts == {"items": [{"relative_path": "report.json"}]}
+        assert reprojected.run_summary == {"counts": {"succeeded": 1}}
+        assert reprojected.error == {"details": {"code": "original"}}
+        assert reprojected.logs_tail == ["line-1"]
 
     def test_unsupported_backend_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("TP_ORCHESTRATOR_STATE_BACKEND", "cassandra")

--- a/tests/orchestrator/test_postgres_storage_offline.py
+++ b/tests/orchestrator/test_postgres_storage_offline.py
@@ -1,0 +1,157 @@
+"""Offline Postgres storage contract tests.
+
+These tests exercise persistence-boundary behavior without requiring a live
+Postgres service. The live repository contract still owns SQL integration; this
+file pins pure Python copy/snapshot guarantees that can regress before a query
+ever reaches the database.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, AsyncIterator, Iterable
+
+import pytest
+
+from transformation_portal.orchestrator import JobRecord
+from transformation_portal.orchestrator.models import JobEventModel, JobModel
+from transformation_portal.orchestrator.storage.postgres import PostgresJobEventStore, PostgresJobRepository
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+class _ScalarResult:
+    def __init__(self, value: int) -> None:
+        self._value = value
+
+    def scalar_one(self) -> int:
+        return self._value
+
+
+class _AsyncRows:
+    def __init__(self, rows: Iterable[Any]) -> None:
+        self._rows = iter(rows)
+
+    def __aiter__(self) -> "_AsyncRows":
+        return self
+
+    async def __anext__(self) -> Any:
+        try:
+            return next(self._rows)
+        except StopIteration as exc:
+            raise StopAsyncIteration from exc
+
+
+class _FakePostgresSession:
+    def __init__(self, *, current_max_seq: int = 0, rows: Iterable[Any] = ()) -> None:
+        self.current_max_seq = current_max_seq
+        self.rows = list(rows)
+        self.added: list[Any] = []
+        self.commits = 0
+        self.executed: list[Any] = []
+        self.streamed: list[Any] = []
+
+    def add(self, model: Any) -> None:
+        self.added.append(model)
+
+    async def execute(self, statement: Any) -> _ScalarResult:
+        self.executed.append(statement)
+        return _ScalarResult(self.current_max_seq)
+
+    async def stream_scalars(self, statement: Any) -> _AsyncRows:
+        self.streamed.append(statement)
+        return _AsyncRows(self.rows)
+
+    async def commit(self) -> None:
+        self.commits += 1
+
+
+def _install_fake_session(target: Any, session: _FakePostgresSession) -> None:
+    @asynccontextmanager
+    async def fake_session() -> AsyncIterator[_FakePostgresSession]:
+        yield session
+
+    target._session = fake_session  # type: ignore[method-assign]  # noqa: SLF001
+
+
+async def test_postgres_repository_create_snapshots_mutable_record_fields() -> None:
+    repo = PostgresJobRepository(database_url="postgresql+asyncpg://user:pw@host/db")
+    session = _FakePostgresSession()
+    _install_fake_session(repo, session)
+    record = JobRecord(
+        id="job-pg-create-copy",
+        created_at=1.0,
+        request={"args": {"quality": "premium"}},
+        effective_request={"args": {"resolved_backend": "da3"}},
+        logs_tail=["line-1"],
+        artifacts={"items": [{"relative_path": "report.json"}]},
+        artifact_lookup={"out/report.json": Path("/abs/out/report.json")},
+        run_summary={"counts": {"succeeded": 1}},
+        error={"details": {"code": "original"}},
+    )
+
+    await repo.create(record)
+    record.request["args"]["quality"] = "mutated"
+    record.effective_request["args"]["resolved_backend"] = "mutated"
+    record.logs_tail.append("mutated")
+    record.artifacts["items"][0]["relative_path"] = "mutated.json"
+    record.artifact_lookup["out/report.json"] = Path("/mutated/report.json")
+    record.run_summary["counts"]["succeeded"] = 99
+    assert record.error is not None
+    record.error["details"]["code"] = "mutated"
+
+    job_model = next(model for model in session.added if isinstance(model, JobModel))
+    artifact_model = next(model for model in session.added if not isinstance(model, JobModel))
+
+    assert session.commits == 1
+    assert job_model.request == {"args": {"quality": "premium"}}
+    assert job_model.effective_request == {"args": {"resolved_backend": "da3"}}
+    assert job_model.logs_tail == ["line-1"]
+    assert job_model.artifacts == {"items": [{"relative_path": "report.json"}]}
+    assert job_model.run_summary == {"counts": {"succeeded": 1}}
+    assert job_model.error == {"details": {"code": "original"}}
+    assert artifact_model.path == "out/report.json"
+    assert artifact_model.absolute_path == "/abs/out/report.json"
+
+
+async def test_postgres_event_append_snapshots_payload_for_db_and_return_value() -> None:
+    store = PostgresJobEventStore(database_url="postgresql+asyncpg://user:pw@host/db")
+    session = _FakePostgresSession(current_max_seq=41)
+    _install_fake_session(store, session)
+    payload = {"nested": {"state": "running"}, "items": [{"path": "out/report.json"}]}
+
+    event = await store.append("job-pg-event-copy", "state", payload, created_at=123.0)
+    payload["nested"]["state"] = "mutated"
+    payload["items"][0]["path"] = "mutated.json"
+
+    event_model = next(model for model in session.added if isinstance(model, JobEventModel))
+    assert session.commits == 1
+    assert event.seq == 42
+    assert event.payload == {"nested": {"state": "running"}, "items": [{"path": "out/report.json"}]}
+    assert event_model.payload == {"nested": {"state": "running"}, "items": [{"path": "out/report.json"}]}
+
+    event.payload["nested"]["state"] = "returned-mutated"
+    assert event_model.payload == {"nested": {"state": "running"}, "items": [{"path": "out/report.json"}]}
+
+
+async def test_postgres_events_since_yields_payload_copies() -> None:
+    row = SimpleNamespace(
+        job_id="job-pg-replay-copy",
+        seq=7,
+        event_type="progress",
+        payload={"nested": {"percent": 50}},
+        created_at=200.0,
+    )
+    store = PostgresJobEventStore(database_url="postgresql+asyncpg://user:pw@host/db")
+    session = _FakePostgresSession(rows=[row])
+    _install_fake_session(store, session)
+
+    events = [event async for event in store.events_since("job-pg-replay-copy", after_seq=6)]
+
+    assert len(events) == 1
+    assert events[0].seq == 7
+    assert events[0].payload == {"nested": {"percent": 50}}
+    events[0].payload["nested"]["percent"] = 99
+    assert row.payload == {"nested": {"percent": 50}}

--- a/tests/orchestrator/test_repository_contract.py
+++ b/tests/orchestrator/test_repository_contract.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
-from typing import Tuple
+from typing import Any, Tuple
 
 import pytest
 
@@ -31,6 +31,57 @@ def _new_record(job_id: str = "job-1", *, created_at: float = 1.0) -> JobRecord:
     return JobRecord(id=job_id, created_at=created_at)
 
 
+class _AppendLogOnlyRepository(JobRepository):
+    """Minimal concrete repository used to exercise the base append_logs default."""
+
+    def __init__(self) -> None:
+        self.appended: list[tuple[str, str, int]] = []
+
+    async def create(self, record: JobRecord) -> None:
+        return None
+
+    async def get(self, job_id: str) -> JobRecord | None:
+        return None
+
+    async def list(self, *, limit: int | None = None) -> tuple[list[JobRecord], int]:
+        return [], 0
+
+    async def update(self, job_id: str, **fields: Any) -> JobRecord:
+        raise JobNotFoundError(job_id)
+
+    async def append_log(self, job_id: str, line: str, *, tail_limit: int) -> None:
+        self.appended.append((job_id, line, tail_limit))
+
+    async def set_artifacts(
+        self,
+        job_id: str,
+        artifacts: dict[str, Any],
+        artifact_lookup: dict[str, Path],
+    ) -> None:
+        return None
+
+    async def delete(self, job_id: str) -> None:
+        return None
+
+    async def cleanup_expired(self, now: float, retention_seconds: float) -> list[str]:
+        return []
+
+    async def count_active(self) -> int:
+        return 0
+
+    async def sweep_orphaned(
+        self,
+        *,
+        live_job_ids: list[str] | None = None,
+        reason_code: str = "worker_lost_on_restart",
+        now: float | None = None,
+    ) -> list[str]:
+        return []
+
+    async def reset(self) -> None:
+        self.appended.clear()
+
+
 # ---------------------------------------------------------------------------
 # Lifecycle
 # ---------------------------------------------------------------------------
@@ -48,6 +99,48 @@ async def test_create_then_get_round_trip(repository_and_events: RepoAndEvents) 
     assert fetched.created_at == 1.0
     assert fetched.state == "queued"
     assert fetched.request == {"pipeline": "demo"}
+
+
+async def test_repository_isolates_nested_mutable_record_fields(
+    repository_and_events: RepoAndEvents,
+) -> None:
+    repo, _ = repository_and_events
+    record = _new_record("job-nested-copy")
+    record.request = {"args": {"quality": "premium"}}
+    record.effective_request = {"args": {"resolved_backend": "da3"}}
+    record.artifacts = {"items": [{"relative_path": "report.json"}]}
+    record.run_summary = {"counts": {"succeeded": 1}}
+    record.error = {"details": {"code": "original"}}
+
+    await repo.create(record)
+    record.request["args"]["quality"] = "mutated"
+    record.effective_request["args"]["resolved_backend"] = "mutated"
+    record.artifacts["items"][0]["relative_path"] = "mutated.json"
+    record.run_summary["counts"]["succeeded"] = 99
+    record.error["details"]["code"] = "mutated"
+
+    fetched = await repo.get("job-nested-copy")
+    assert fetched is not None
+    assert fetched.request == {"args": {"quality": "premium"}}
+    assert fetched.effective_request == {"args": {"resolved_backend": "da3"}}
+    assert fetched.artifacts == {"items": [{"relative_path": "report.json"}]}
+    assert fetched.run_summary == {"counts": {"succeeded": 1}}
+    assert fetched.error == {"details": {"code": "original"}}
+
+    fetched.request["args"]["quality"] = "fetched-mutated"
+    fetched.effective_request["args"]["resolved_backend"] = "fetched-mutated"
+    fetched.artifacts["items"][0]["relative_path"] = "fetched-mutated.json"
+    fetched.run_summary["counts"]["succeeded"] = 100
+    assert fetched.error is not None
+    fetched.error["details"]["code"] = "fetched-mutated"
+
+    refetched = await repo.get("job-nested-copy")
+    assert refetched is not None
+    assert refetched.request == {"args": {"quality": "premium"}}
+    assert refetched.effective_request == {"args": {"resolved_backend": "da3"}}
+    assert refetched.artifacts == {"items": [{"relative_path": "report.json"}]}
+    assert refetched.run_summary == {"counts": {"succeeded": 1}}
+    assert refetched.error == {"details": {"code": "original"}}
 
 
 async def test_get_missing_returns_none(repository_and_events: RepoAndEvents) -> None:
@@ -100,12 +193,89 @@ async def test_update_patches_named_fields(repository_and_events: RepoAndEvents)
     assert fetched.state == "running"
 
 
+async def test_update_without_fields_returns_isolated_current_record(
+    repository_and_events: RepoAndEvents,
+) -> None:
+    repo, _ = repository_and_events
+    record = _new_record("job-update-noop-copy")
+    record.request = {"args": {"quality": "premium"}}
+    record.run_summary = {"counts": {"succeeded": 1}}
+    await repo.create(record)
+
+    refreshed = await repo.update("job-update-noop-copy")
+
+    assert refreshed.request == {"args": {"quality": "premium"}}
+    assert refreshed.run_summary == {"counts": {"succeeded": 1}}
+
+    refreshed.request["args"]["quality"] = "mutated"
+    refreshed.run_summary["counts"]["succeeded"] = 99
+
+    refetched = await repo.get("job-update-noop-copy")
+    assert refetched is not None
+    assert refetched.request == {"args": {"quality": "premium"}}
+    assert refetched.run_summary == {"counts": {"succeeded": 1}}
+
+
+async def test_update_isolates_nested_mutable_fields(
+    repository_and_events: RepoAndEvents,
+) -> None:
+    repo, _ = repository_and_events
+    await repo.create(_new_record("job-update-nested-copy"))
+    request = {"args": {"quality": "premium"}}
+    effective_request = {"args": {"resolved_backend": "da3"}}
+    artifacts = {"items": [{"relative_path": "report.json"}]}
+    run_summary = {"counts": {"succeeded": 1}}
+    error = {"details": {"code": "original"}}
+    logs_tail = ["line-1"]
+
+    refreshed = await repo.update(
+        "job-update-nested-copy",
+        request=request,
+        effective_request=effective_request,
+        artifacts=artifacts,
+        run_summary=run_summary,
+        error=error,
+        logs_tail=logs_tail,
+    )
+    request["args"]["quality"] = "mutated"
+    effective_request["args"]["resolved_backend"] = "mutated"
+    artifacts["items"][0]["relative_path"] = "mutated.json"
+    run_summary["counts"]["succeeded"] = 99
+    error["details"]["code"] = "mutated"
+    logs_tail.append("mutated")
+    refreshed.request["args"]["quality"] = "refreshed-mutated"
+    refreshed.effective_request["args"]["resolved_backend"] = "refreshed-mutated"
+    refreshed.artifacts["items"][0]["relative_path"] = "refreshed-mutated.json"
+    refreshed.run_summary["counts"]["succeeded"] = 100
+    assert refreshed.error is not None
+    refreshed.error["details"]["code"] = "refreshed-mutated"
+    refreshed.logs_tail.append("refreshed-mutated")
+
+    refetched = await repo.get("job-update-nested-copy")
+
+    assert refetched is not None
+    assert refetched.request == {"args": {"quality": "premium"}}
+    assert refetched.effective_request == {"args": {"resolved_backend": "da3"}}
+    assert refetched.artifacts == {"items": [{"relative_path": "report.json"}]}
+    assert refetched.run_summary == {"counts": {"succeeded": 1}}
+    assert refetched.error == {"details": {"code": "original"}}
+    assert refetched.logs_tail == ["line-1"]
+
+
 async def test_update_missing_raises_job_not_found(
     repository_and_events: RepoAndEvents,
 ) -> None:
     repo, _ = repository_and_events
     with pytest.raises(JobNotFoundError):
         await repo.update("ghost", state="running")
+
+
+async def test_update_without_fields_missing_raises_job_not_found(
+    repository_and_events: RepoAndEvents,
+) -> None:
+    repo, _ = repository_and_events
+    with pytest.raises(JobNotFoundError):
+        await repo.update("ghost-noop")
 
 
 async def test_update_rejects_unknown_field(
@@ -126,6 +296,19 @@ async def test_update_rejects_id_and_created_at(
         await repo.update("job-locked", id="other")
     with pytest.raises(RepositoryError):
         await repo.update("job-locked", created_at=999.0)
+
+
+async def test_update_rejects_artifact_lookup_mutation(
+    repository_and_events: RepoAndEvents,
+) -> None:
+    repo, _ = repository_and_events
+    await repo.create(_new_record("job-artifact-lookup-locked"))
+
+    with pytest.raises(RepositoryError):
+        await repo.update(
+            "job-artifact-lookup-locked",
+            artifact_lookup={"out/report.json": Path("/abs/out/report.json")},
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -152,13 +335,95 @@ async def test_append_logs_rotates_tail(repository_and_events: RepoAndEvents) ->
     assert fetched.logs_tail == ["line-6", "line-7", "line-8", "line-9"]
 
 
+async def test_default_append_logs_delegates_to_append_log_for_compatibility() -> None:
+    repo = _AppendLogOnlyRepository()
+
+    await repo.append_logs("job-default-append", ["line-1", "line-2"], tail_limit=4)
+
+    assert repo.appended == [
+        ("job-default-append", "line-1", 4),
+        ("job-default-append", "line-2", 4),
+    ]
+
+
+@pytest.mark.parametrize("bad_tail_limit", [0, -1])
+async def test_default_append_logs_rejects_non_positive_tail_limit_before_delegation(
+    bad_tail_limit: int,
+) -> None:
+    repo = _AppendLogOnlyRepository()
+
+    with pytest.raises(RepositoryError):
+        await repo.append_logs("job-default-append", ["line"], tail_limit=bad_tail_limit)
+
+    assert repo.appended == []
+
+
+async def test_append_logs_under_limit_preserves_all_lines(
+    repository_and_events: RepoAndEvents,
+) -> None:
+    repo, _ = repository_and_events
+    await repo.create(_new_record("job-log-batch-under-limit"))
+
+    await repo.append_logs("job-log-batch-under-limit", ["line-1", "line-2"], tail_limit=4)
+
+    fetched = await repo.get("job-log-batch-under-limit")
+    assert fetched is not None
+    assert fetched.logs_tail == ["line-1", "line-2"]
+
+
+async def test_append_logs_rejects_zero_or_negative_limit(
+    repository_and_events: RepoAndEvents,
+) -> None:
+    repo, _ = repository_and_events
+    await repo.create(_new_record("job-log-batch-limit"))
+
+    with pytest.raises(RepositoryError):
+        await repo.append_logs("job-log-batch-limit", ["x"], tail_limit=0)
+    with pytest.raises(RepositoryError):
+        await repo.append_logs("job-log-batch-limit", ["x"], tail_limit=-1)
+
+
+async def test_append_logs_empty_batch_is_noop(
+    repository_and_events: RepoAndEvents,
+) -> None:
+    repo, _ = repository_and_events
+    await repo.create(_new_record("job-log-empty-batch"))
+    await repo.append_log("job-log-empty-batch", "existing", tail_limit=4)
+
+    await repo.append_logs("job-log-empty-batch", [], tail_limit=4)
+
+    fetched = await repo.get("job-log-empty-batch")
+    assert fetched is not None
+    assert fetched.logs_tail == ["existing"]
+
+
+async def test_append_logs_missing_job_raises_job_not_found(
+    repository_and_events: RepoAndEvents,
+) -> None:
+    repo, _ = repository_and_events
+
+    with pytest.raises(JobNotFoundError):
+        await repo.append_logs("missing-log-batch", ["line"], tail_limit=4)
+
+
+@pytest.mark.parametrize("bad_tail_limit", [0, -1])
 async def test_append_log_rejects_zero_or_negative_limit(
     repository_and_events: RepoAndEvents,
+    bad_tail_limit: int,
 ) -> None:
     repo, _ = repository_and_events
     await repo.create(_new_record("job-log0"))
     with pytest.raises(RepositoryError):
-        await repo.append_log("job-log0", "x", tail_limit=0)
+        await repo.append_log("job-log0", "x", tail_limit=bad_tail_limit)
+
+
+async def test_append_log_missing_job_raises_job_not_found(
+    repository_and_events: RepoAndEvents,
+) -> None:
+    repo, _ = repository_and_events
+
+    with pytest.raises(JobNotFoundError):
+        await repo.append_log("missing-log", "line", tail_limit=4)
 
 
 # ---------------------------------------------------------------------------
@@ -180,6 +445,43 @@ async def test_set_artifacts_replaces_index_and_lookup(
     assert fetched is not None
     assert fetched.artifacts == {"items": [{"path": "out/x.png"}]}
     assert fetched.artifact_lookup == {"out/x.png": Path("/abs/out/x.png")}
+
+
+async def test_set_artifacts_isolates_nested_mutable_artifacts(
+    repository_and_events: RepoAndEvents,
+) -> None:
+    repo, _ = repository_and_events
+    await repo.create(_new_record("job-artifact-nested-copy"))
+    artifacts = {"items": [{"path": "out/x.png", "metadata": {"kind": "preview"}}]}
+
+    await repo.set_artifacts(
+        "job-artifact-nested-copy",
+        artifacts=artifacts,
+        artifact_lookup={"out/x.png": Path("/abs/out/x.png")},
+    )
+    artifacts["items"][0]["metadata"]["kind"] = "mutated"
+
+    fetched = await repo.get("job-artifact-nested-copy")
+    assert fetched is not None
+    fetched.artifacts["items"][0]["metadata"]["kind"] = "fetched-mutated"
+
+    refetched = await repo.get("job-artifact-nested-copy")
+    assert refetched is not None
+    assert refetched.artifacts == {"items": [{"path": "out/x.png", "metadata": {"kind": "preview"}}]}
+    assert refetched.artifact_lookup == {"out/x.png": Path("/abs/out/x.png")}
+
+
+async def test_set_artifacts_missing_job_raises_job_not_found(
+    repository_and_events: RepoAndEvents,
+) -> None:
+    repo, _ = repository_and_events
+
+    with pytest.raises(JobNotFoundError):
+        await repo.set_artifacts(
+            "missing-artifacts",
+            artifacts={"items": []},
+            artifact_lookup={},
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -353,6 +655,46 @@ async def test_event_store_events_since_filters_by_seq(
     assert [e.payload["i"] for e in collected] == [1, 2]
 
 
+async def test_event_store_payload_is_stable_after_append(
+    repository_and_events: RepoAndEvents,
+) -> None:
+    _, events = repository_and_events
+    payload = {"state": "running", "nested": {"progress": 10}}
+
+    appended = await events.append("job-payload-copy", "state", payload, created_at=1.0)
+    payload["nested"]["progress"] = 88
+    payload["state"] = "mutated"
+    payload["nested"] = {"progress": 99}
+
+    replay = [event async for event in events.events_since("job-payload-copy")]
+
+    assert appended.payload == {"state": "running", "nested": {"progress": 10}}
+    assert [event.payload for event in replay] == [{"state": "running", "nested": {"progress": 10}}]
+
+    appended.payload["nested"]["progress"] = 77
+    replay[0].payload["nested"]["progress"] = 66
+    replay_again = [event async for event in events.events_since("job-payload-copy")]
+
+    assert [event.payload for event in replay_again] == [{"state": "running", "nested": {"progress": 10}}]
+
+
+async def test_event_store_replay_orders_by_assigned_seq_not_timestamp(
+    repository_and_events: RepoAndEvents,
+) -> None:
+    _, events = repository_and_events
+    await events.append("job-event-order", "latest-time", {"order": 1}, created_at=30.0)
+    await events.append("job-event-order", "earliest-time", {"order": 2}, created_at=10.0)
+    await events.append("job-event-order", "middle-time", {"order": 3}, created_at=20.0)
+
+    replay = [event async for event in events.events_since("job-event-order")]
+
+    assert [(event.seq, event.event_type, event.created_at) for event in replay] == [
+        (1, "latest-time", 30.0),
+        (2, "earliest-time", 10.0),
+        (3, "middle-time", 20.0),
+    ]
+
+
 async def test_event_store_isolates_jobs(
     repository_and_events: RepoAndEvents,
 ) -> None:
@@ -462,3 +804,40 @@ def test_memory_event_store_rejects_non_positive_per_job_cap(bad_cap: int) -> No
 
     with pytest.raises(RepositoryError):
         MemoryJobEventStore(per_job_cap=bad_cap)
+
+
+async def test_memory_event_store_cap_retains_latest_events_with_monotonic_seq() -> None:
+    """Bounded replay keeps newest events without resetting durable seq ids."""
+    from transformation_portal.orchestrator.storage.memory import MemoryJobEventStore
+
+    events = MemoryJobEventStore(per_job_cap=2)
+
+    first = await events.append("job-cap", "state", {"step": "queued"}, created_at=1.0)
+    second = await events.append("job-cap", "progress", {"step": "running"}, created_at=2.0)
+    third = await events.append("job-cap", "done", {"step": "succeeded"}, created_at=3.0)
+
+    assert [first.seq, second.seq, third.seq] == [1, 2, 3]
+
+    replay_all = [event async for event in events.events_since("job-cap")]
+    assert [(event.seq, event.event_type, event.payload["step"]) for event in replay_all] == [
+        (2, "progress", "running"),
+        (3, "done", "succeeded"),
+    ]
+
+    replay_after_oldest_retained = [event async for event in events.events_since("job-cap", after_seq=2)]
+    assert [(event.seq, event.event_type) for event in replay_after_oldest_retained] == [(3, "done")]
+
+
+async def test_memory_event_store_reset_clears_events_and_restarts_seq() -> None:
+    """Reset must fully clear event history for hermetic test/runtime restarts."""
+    from transformation_portal.orchestrator.storage.memory import MemoryJobEventStore
+
+    events = MemoryJobEventStore()
+    await events.append("job-reset", "state", {"state": "queued"}, created_at=1.0)
+
+    await events.reset()
+    replay_after_reset = [event async for event in events.events_since("job-reset")]
+    next_event = await events.append("job-reset", "state", {"state": "queued-again"}, created_at=2.0)
+
+    assert replay_after_reset == []
+    assert next_event.seq == 1

--- a/tests/structural/test_performance_monitor_gate_contract.py
+++ b/tests/structural/test_performance_monitor_gate_contract.py
@@ -1,0 +1,94 @@
+"""Structural contract for the scheduled performance gate."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.regression]
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_PATH = PROJECT_ROOT / ".github" / "workflows" / "performance-monitor.yml"
+POLICY_PATH = PROJECT_ROOT / "docs" / "performance" / "GATE_POLICY.md"
+
+
+def _workflow_step(workflow_text: str, step_name: str) -> str:
+    match = re.search(
+        rf"(?ms)^      - name: {re.escape(step_name)}\n(?P<body>.*?)(?=^      - name: |\Z)",
+        workflow_text,
+    )
+    assert match is not None, f"performance-monitor workflow must keep an explicit {step_name!r} step"
+    return match.group("body")
+
+
+def _performance_gate_step(workflow_text: str) -> str:
+    return _workflow_step(workflow_text, "Enforce nightly performance gate")
+
+
+def _workflow_on_block(workflow_text: str) -> str:
+    match = re.search(r"(?ms)^on:\n(?P<body>.*?)(?=^[A-Za-z_][\w-]*:|\Z)", workflow_text)
+    assert match is not None, "performance-monitor workflow must keep an explicit trigger block"
+    return match.group("body")
+
+
+def test_performance_monitor_stays_schedule_or_manual_only() -> None:
+    workflow_text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    policy_text = POLICY_PATH.read_text(encoding="utf-8")
+    on_block = _workflow_on_block(workflow_text)
+
+    assert "schedule:" in on_block
+    assert "workflow_dispatch:" in on_block
+    assert "pull_request:" not in on_block
+    assert "push:" not in on_block
+    assert "schedule/manual only" in policy_text
+
+
+def test_performance_monitor_blocks_regressions_and_benchmark_failures() -> None:
+    workflow_text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    step = _performance_gate_step(workflow_text)
+
+    assert "steps.benchmark.outputs.status == 'regression'" in step
+    assert "steps.benchmark.outputs.status == 'failed'" in step
+    assert "not product-green evidence" in step
+    assert "exit 1" in step
+
+
+def test_benchmark_step_keeps_status_output_contract_for_gate_consumers() -> None:
+    workflow_text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    benchmark_step = _workflow_step(workflow_text, "Run performance tests")
+    report_step = _workflow_step(workflow_text, "Generate performance report")
+    issue_step = _workflow_step(workflow_text, "Create issue on regression (deduplicated)")
+    gate_step = _performance_gate_step(workflow_text)
+
+    assert re.search(r"(?m)^        id: benchmark$", benchmark_step)
+    for status in ("no_tests", "passed", "regression", "failed"):
+        assert f'echo "status={status}" >> $GITHUB_OUTPUT' in benchmark_step
+
+    assert "${{ steps.benchmark.outputs.status }}" in report_step
+    assert "steps.benchmark.outputs.status == 'regression'" in issue_step
+    assert "steps.benchmark.outputs.status == 'regression'" in gate_step
+    assert "steps.benchmark.outputs.status == 'failed'" in gate_step
+
+
+def test_performance_gate_policy_matches_workflow_failure_modes() -> None:
+    workflow_text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    policy_text = POLICY_PATH.read_text(encoding="utf-8")
+    step = _performance_gate_step(workflow_text)
+
+    assert "status == 'failed'" in step
+    assert "regression beyond its documented threshold" in policy_text
+    assert "benchmark execution fails" in policy_text
+    assert "not valid evidence" in policy_text
+
+
+def test_invalid_benchmark_runs_fail_gate_without_opening_regression_issue() -> None:
+    workflow_text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    policy_text = POLICY_PATH.read_text(encoding="utf-8")
+    issue_step = _workflow_step(workflow_text, "Create issue on regression (deduplicated)")
+
+    assert "steps.benchmark.outputs.status == 'regression'" in issue_step
+    assert "steps.benchmark.outputs.status == 'failed'" not in issue_step
+    assert "Performance Regression Detected" in issue_step
+    assert "tooling/environment blockers" in policy_text

--- a/tests/test_app_orchestrator_contract_http.py
+++ b/tests/test_app_orchestrator_contract_http.py
@@ -91,6 +91,28 @@ def _collect_sse_events(response) -> List[Tuple[str, Dict[str, Any]]]:
     return events
 
 
+def _collect_sse_frames(response) -> List[Tuple[str | None, str, Dict[str, Any]]]:
+    frames: List[Tuple[str | None, str, Dict[str, Any]]] = []
+    current_id: str | None = None
+    current_event = ""
+    for line in response.iter_lines():
+        if not line:
+            continue
+        if line.startswith("id: "):
+            current_id = line.split("id: ", 1)[1].strip()
+            continue
+        if line.startswith("event: "):
+            current_event = line.split("event: ", 1)[1].strip()
+            continue
+        if line.startswith("data: "):
+            payload = json.loads(line.split("data: ", 1)[1])
+            frames.append((current_id, current_event, payload))
+            current_id = None
+            if current_event == "done":
+                break
+    return frames
+
+
 def _flag_value(argv: list[str], flag: str) -> str:
     try:
         index = argv.index(flag)
@@ -4595,6 +4617,7 @@ def test_invalid_job_payload_returns_typed_invalid_argument(client: TestClient) 
     assert body["schema"] == "tp.orchestrator.error.v1"
     assert body["success"] is False
     assert body["error"]["code"] == "INVALID_ARGUMENT"
+    assert body["error"]["details"] == {"field": "payload", "reason": "unsupported_pipeline"}
 
 
 def test_malformed_job_args_return_typed_invalid_argument(client: TestClient) -> None:
@@ -4607,12 +4630,131 @@ def test_malformed_job_args_return_typed_invalid_argument(client: TestClient) ->
     assert body["error"]["details"] == {"field": "input_dir", "reason": "required"}
 
 
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"pipeline": "not-allowed", "args": {}},
+        {"pipeline": "lux-depth-v3", "args": "not-a-dict"},
+        {"args": {"input_dir": "./in"}},
+    ],
+)
+def test_v2_job_create_validation_errors_match_v1_envelopes(
+    client: TestClient,
+    payload: Dict[str, Any],
+) -> None:
+    v1_response = client.post("/v1/jobs", json=payload)
+    v2_response = client.post("/v2/jobs", json=payload)
+
+    assert v1_response.status_code == 400
+    assert v2_response.status_code == 400
+    assert v2_response.json() == v1_response.json()
+
+
+def test_job_create_missing_pipeline_preserves_pre_adapter_unsupported_pipeline_mapping(
+    client: TestClient,
+) -> None:
+    response = client.post("/v1/jobs", json={"args": {"input_dir": "./in"}})
+
+    assert response.status_code == 400
+    body = response.json()
+    assert body["schema"] == "tp.orchestrator.error.v1"
+    assert body["success"] is False
+    assert body["error"]["code"] == "INVALID_ARGUMENT"
+    assert body["error"]["details"] == {"field": "payload", "reason": "unsupported_pipeline"}
+
+
+@pytest.mark.parametrize("jobs_path", ["/v1/jobs", "/v2/jobs"])
+def test_job_create_non_object_body_uses_versioned_request_validation_envelope(
+    client: TestClient,
+    jobs_path: str,
+) -> None:
+    response = client.post(jobs_path, json=["not", "an", "object"])
+
+    assert response.status_code == 400
+    body = response.json()
+    assert body["schema"] == "tp.orchestrator.error.v1"
+    assert body["success"] is False
+    assert body["error"]["code"] == "INVALID_ARGUMENT"
+    assert body["error"]["message"] == "request validation failed"
+    assert body["error"]["details"] == {
+        "path": jobs_path,
+        "reason": "request_validation_failed",
+    }
+
+
+@pytest.mark.parametrize("jobs_path", ["/v1/jobs", "/v2/jobs"])
+def test_job_create_missing_body_uses_versioned_request_validation_envelope(
+    client: TestClient,
+    jobs_path: str,
+) -> None:
+    response = client.post(jobs_path)
+
+    assert response.status_code == 400
+    body = response.json()
+    assert body["schema"] == "tp.orchestrator.error.v1"
+    assert body["success"] is False
+    assert body["error"]["code"] == "INVALID_ARGUMENT"
+    assert body["error"]["message"] == "request validation failed"
+    assert body["error"]["details"] == {
+        "path": jobs_path,
+        "reason": "request_validation_failed",
+    }
+
+
+@pytest.mark.parametrize("jobs_path", ["/v1/jobs", "/v2/jobs"])
+def test_job_create_malformed_json_uses_versioned_request_validation_envelope(
+    client: TestClient,
+    jobs_path: str,
+) -> None:
+    response = client.post(
+        jobs_path,
+        content='{"pipeline": "lux-depth-v3", "args": ',
+        headers={"content-type": "application/json"},
+    )
+
+    assert response.status_code == 400
+    body = response.json()
+    assert body["schema"] == "tp.orchestrator.error.v1"
+    assert body["success"] is False
+    assert body["error"]["code"] == "INVALID_ARGUMENT"
+    assert body["error"]["message"] == "request validation failed"
+    assert body["error"]["details"] == {
+        "path": jobs_path,
+        "reason": "request_validation_failed",
+    }
+
+
 def test_job_create_request_adapter_rejects_non_dict_args() -> None:
     response = orchestrator_app._validated_job_create_request({"pipeline": "lux-depth-v3", "args": "not-a-dict"})
     assert isinstance(response, orchestrator_app.JSONResponse)
     body = json.loads(response.body.decode("utf-8"))
     assert body["error"]["code"] == "INVALID_ARGUMENT"
     assert body["error"]["details"] == {"field": "args", "reason": "invalid_request"}
+
+
+def test_job_create_request_adapter_preserves_extra_fields_on_success() -> None:
+    response = orchestrator_app._validated_job_create_request(
+        {
+            "pipeline": "lux-depth-v3",
+            "args": {"input_dir": "./in"},
+            "overrides": {"quality_tier": "premium"},
+        }
+    )
+
+    assert isinstance(response, orchestrator_app.JobCreateRequest)
+    dumped = response.model_dump(mode="json")
+    assert dumped["pipeline"] == "lux-depth-v3"
+    assert dumped["args"] == {"input_dir": "./in"}
+    assert dumped["overrides"] == {"quality_tier": "premium"}
+
+
+def test_job_create_request_adapter_maps_bad_pipeline_type_to_invalid_request() -> None:
+    response = orchestrator_app._validated_job_create_request({"pipeline": None, "args": {}})
+
+    assert isinstance(response, orchestrator_app.JSONResponse)
+    body = json.loads(response.body.decode("utf-8"))
+    assert body["error"]["code"] == "INVALID_ARGUMENT"
+    assert body["error"]["details"] == {"field": "pipeline", "reason": "invalid_request"}
 
 
 def test_job_create_request_adapter_keeps_required_reason_vocabulary() -> None:
@@ -5508,10 +5650,334 @@ def test_job_events_stream_emits_state_log_progress_artifact_done(
     assert artifact_payload["relative_path"] == "report.json"
 
 
-def test_job_events_replays_persisted_events_from_last_event_id(client: TestClient) -> None:
+def _seed_running_event_job(job_id: str) -> Any:
     now = orchestrator_app._now()
     job = orchestrator_app.Job(
-        id="job_sse_replay",
+        id=job_id,
+        created_at=now,
+        state="running",
+        progress=0,
+        request={"pipeline": "lux-depth-v3"},
+    )
+    _seed_job(job)
+    return job
+
+
+def test_should_flush_last_event_at_always_flushes_state_artifact_and_done() -> None:
+    orchestrator_app._LAST_EVENT_PERSISTED_AT["job-flush-always"] = 100.0
+
+    for event_name in ("state", "artifact", "artifact_deleted", "artifact_deletion_failed", "done"):
+        assert orchestrator_app._should_flush_last_event_at("job-flush-always", event_name, 100.1) is True
+
+
+def test_should_flush_last_event_at_throttles_progress_until_interval(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(orchestrator_app, "JOB_LAST_EVENT_FLUSH_INTERVAL_SECONDS", 5.0)
+    orchestrator_app._LAST_EVENT_PERSISTED_AT["job-flush-progress"] = 100.0
+
+    assert orchestrator_app._should_flush_last_event_at("job-flush-progress", "progress", 104.9) is False
+    assert orchestrator_app._should_flush_last_event_at("job-flush-progress", "progress", 105.0) is True
+    assert orchestrator_app._should_flush_last_event_at("job-flush-new-job", "progress", 101.0) is True
+
+
+def test_should_flush_last_event_at_can_disable_throttling(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(orchestrator_app, "JOB_LAST_EVENT_FLUSH_INTERVAL_SECONDS", 0.0)
+    orchestrator_app._LAST_EVENT_PERSISTED_AT["job-flush-disabled"] = 100.0
+
+    assert orchestrator_app._should_flush_last_event_at("job-flush-disabled", "progress", 100.1) is True
+
+
+def test_publish_event_persists_seq_and_fans_out_id_to_live_subscribers() -> None:
+    async def replay_events(job_id: str) -> list[Any]:
+        return [event async for event in orchestrator_app._job_event_store().events_since(job_id)]
+
+    job = _seed_running_event_job("job_publish_seq_fanout")
+    subscriber_queue: asyncio.Queue[Dict[str, Any]] = asyncio.Queue()
+    orchestrator_app.EVENT_SUBSCRIBERS[job.id]["test-subscriber"] = subscriber_queue
+
+    asyncio.run(orchestrator_app._publish_event(job.id, "progress", {"id": job.id, "progress": 20}))
+
+    queued = subscriber_queue.get_nowait()
+    replayed_events = asyncio.run(replay_events(job.id))
+    persisted_record = asyncio.run(orchestrator_app._job_repository().get(job.id))
+
+    assert queued == {
+        "id": 1,
+        "event": "progress",
+        "data": {"id": job.id, "progress": 20},
+    }
+    assert [(event.seq, event.event_type, event.payload) for event in replayed_events] == [
+        (1, "progress", {"id": job.id, "progress": 20})
+    ]
+    assert persisted_record is not None
+    assert persisted_record.last_event_at == job.last_event_at
+    assert orchestrator_app._LAST_EVENT_PERSISTED_AT[job.id] == job.last_event_at
+
+
+def test_publish_event_snapshots_payload_for_live_fanout_and_replay() -> None:
+    async def replay_events(job_id: str) -> list[Any]:
+        return [event async for event in orchestrator_app._job_event_store().events_since(job_id)]
+
+    job = _seed_running_event_job("job_publish_payload_snapshot")
+    subscriber_queue: asyncio.Queue[Dict[str, Any]] = asyncio.Queue()
+    orchestrator_app.EVENT_SUBSCRIBERS[job.id]["test-subscriber"] = subscriber_queue
+    event_data = {"id": job.id, "progress": 20, "nested": {"stage": "before"}}
+
+    asyncio.run(orchestrator_app._publish_event(job.id, "progress", event_data))
+    event_data["progress"] = 99
+    event_data["nested"]["stage"] = "after"  # type: ignore[index]
+
+    queued = subscriber_queue.get_nowait()
+    replayed_events = asyncio.run(replay_events(job.id))
+
+    assert queued == {
+        "id": 1,
+        "event": "progress",
+        "data": {"id": job.id, "progress": 20, "nested": {"stage": "before"}},
+    }
+    assert [(event.seq, event.event_type, event.payload) for event in replayed_events] == [
+        (1, "progress", {"id": job.id, "progress": 20, "nested": {"stage": "before"}})
+    ]
+
+
+def test_publish_event_fanout_payloads_are_isolated_per_subscriber() -> None:
+    job = _seed_running_event_job("job_publish_subscriber_payload_isolation")
+    first_queue: asyncio.Queue[Dict[str, Any]] = asyncio.Queue()
+    second_queue: asyncio.Queue[Dict[str, Any]] = asyncio.Queue()
+    orchestrator_app.EVENT_SUBSCRIBERS[job.id]["first"] = first_queue
+    orchestrator_app.EVENT_SUBSCRIBERS[job.id]["second"] = second_queue
+
+    asyncio.run(
+        orchestrator_app._publish_event(
+            job.id,
+            "progress",
+            {"id": job.id, "nested": {"stage": "before"}},
+        )
+    )
+
+    first_payload = first_queue.get_nowait()
+    first_data = first_payload["data"]
+    assert isinstance(first_data, dict)
+    first_nested = first_data["nested"]
+    assert isinstance(first_nested, dict)
+    first_nested["stage"] = "after"
+
+    assert second_queue.get_nowait() == {
+        "id": 1,
+        "event": "progress",
+        "data": {"id": job.id, "nested": {"stage": "before"}},
+    }
+
+
+def test_publish_event_without_cached_job_still_persists_and_fans_out() -> None:
+    async def replay_events(job_id: str) -> list[Any]:
+        return [event async for event in orchestrator_app._job_event_store().events_since(job_id)]
+
+    job = _seed_running_event_job("job_publish_repository_only")
+    subscriber_queue: asyncio.Queue[Dict[str, Any]] = asyncio.Queue()
+    orchestrator_app.EVENT_SUBSCRIBERS[job.id]["test-subscriber"] = subscriber_queue
+    orchestrator_app.JOBS.pop(job.id)
+
+    asyncio.run(orchestrator_app._publish_event(job.id, "progress", {"id": job.id, "progress": 28}))
+
+    queued = subscriber_queue.get_nowait()
+    replayed_events = asyncio.run(replay_events(job.id))
+    persisted_record = asyncio.run(orchestrator_app._job_repository().get(job.id))
+
+    assert job.id not in orchestrator_app.JOBS
+    assert job.last_event_at is None
+    assert queued == {
+        "id": 1,
+        "event": "progress",
+        "data": {"id": job.id, "progress": 28},
+    }
+    assert [(event.seq, event.event_type, event.payload) for event in replayed_events] == [
+        (1, "progress", {"id": job.id, "progress": 28})
+    ]
+    assert persisted_record is not None
+    assert persisted_record.last_event_at is not None
+    assert orchestrator_app._LAST_EVENT_PERSISTED_AT[job.id] == persisted_record.last_event_at
+
+
+def test_publish_event_live_fanout_survives_event_store_append_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FailingEventStore:
+        async def append(self, *_args: object, **_kwargs: object) -> object:
+            raise RuntimeError("event store unavailable")
+
+    job = _seed_running_event_job("job_publish_append_failure")
+    subscriber_queue: asyncio.Queue[Dict[str, Any]] = asyncio.Queue()
+    orchestrator_app.EVENT_SUBSCRIBERS[job.id]["test-subscriber"] = subscriber_queue
+    monkeypatch.setattr(orchestrator_app, "_job_event_store", lambda: FailingEventStore())
+
+    asyncio.run(orchestrator_app._publish_event(job.id, "progress", {"id": job.id, "progress": 21}))
+
+    queued = subscriber_queue.get_nowait()
+    persisted_record = asyncio.run(orchestrator_app._job_repository().get(job.id))
+
+    assert queued == {
+        "event": "progress",
+        "data": {"id": job.id, "progress": 21},
+    }
+    assert persisted_record is not None
+    assert persisted_record.last_event_at == job.last_event_at
+    assert orchestrator_app._LAST_EVENT_PERSISTED_AT[job.id] == job.last_event_at
+
+
+def test_publish_event_live_fanout_survives_last_event_at_repository_update_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FailingLastEventRepository:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, dict[str, Any]]] = []
+
+        async def update(self, job_id: str, **fields: Any) -> object:
+            self.calls.append((job_id, fields))
+            raise RuntimeError("repository unavailable")
+
+    job = _seed_running_event_job("job_publish_last_event_update_failure")
+    subscriber_queue: asyncio.Queue[Dict[str, Any]] = asyncio.Queue()
+    orchestrator_app.EVENT_SUBSCRIBERS[job.id]["test-subscriber"] = subscriber_queue
+    failing_repo = FailingLastEventRepository()
+    monkeypatch.setattr(orchestrator_app, "_job_repository", lambda: failing_repo)
+
+    asyncio.run(orchestrator_app._publish_event(job.id, "progress", {"id": job.id, "progress": 24}))
+
+    assert failing_repo.calls == [(job.id, {"last_event_at": job.last_event_at})]
+    assert job.id not in orchestrator_app._LAST_EVENT_PERSISTED_AT
+    assert subscriber_queue.get_nowait() == {
+        "id": 1,
+        "event": "progress",
+        "data": {"id": job.id, "progress": 24},
+    }
+
+
+def test_publish_event_throttled_progress_skips_last_event_at_repository_update(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class RecordingRepository:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, dict[str, Any]]] = []
+
+        async def update(self, job_id: str, **fields: Any) -> object:
+            self.calls.append((job_id, fields))
+            return object()
+
+    job = _seed_running_event_job("job_publish_throttled_progress")
+    subscriber_queue: asyncio.Queue[Dict[str, Any]] = asyncio.Queue()
+    orchestrator_app.EVENT_SUBSCRIBERS[job.id]["test-subscriber"] = subscriber_queue
+    orchestrator_app._LAST_EVENT_PERSISTED_AT[job.id] = 100.0
+    recording_repo = RecordingRepository()
+    monkeypatch.setattr(orchestrator_app, "JOB_LAST_EVENT_FLUSH_INTERVAL_SECONDS", 5.0)
+    monkeypatch.setattr(orchestrator_app, "_now", lambda: 101.0)
+    monkeypatch.setattr(orchestrator_app, "_job_repository", lambda: recording_repo)
+
+    asyncio.run(orchestrator_app._publish_event(job.id, "progress", {"id": job.id, "progress": 25}))
+
+    assert recording_repo.calls == []
+    assert job.last_event_at == 101.0
+    assert orchestrator_app._LAST_EVENT_PERSISTED_AT[job.id] == 100.0
+    assert subscriber_queue.get_nowait() == {
+        "id": 1,
+        "event": "progress",
+        "data": {"id": job.id, "progress": 25},
+    }
+
+
+def test_publish_event_replaces_stale_buffered_event_when_subscriber_queue_is_full() -> None:
+    job = _seed_running_event_job("job_publish_full_queue")
+    subscriber_queue: asyncio.Queue[Dict[str, Any]] = asyncio.Queue(maxsize=1)
+    subscriber_queue.put_nowait({"event": "progress", "data": {"id": job.id, "progress": 1}})
+    orchestrator_app.EVENT_SUBSCRIBERS[job.id]["test-subscriber"] = subscriber_queue
+
+    asyncio.run(orchestrator_app._publish_event(job.id, "progress", {"id": job.id, "progress": 22}))
+
+    assert subscriber_queue.qsize() == 1
+    assert subscriber_queue.get_nowait() == {
+        "id": 1,
+        "event": "progress",
+        "data": {"id": job.id, "progress": 22},
+    }
+
+
+def test_publish_event_prunes_broken_subscriber_queue_and_keeps_healthy_fanout() -> None:
+    class BrokenSubscriberQueue:
+        def full(self) -> bool:
+            return False
+
+        def put_nowait(self, _payload: Dict[str, Any]) -> None:
+            raise RuntimeError("subscriber queue closed")
+
+    job = _seed_running_event_job("job_publish_broken_subscriber")
+    healthy_queue: asyncio.Queue[Dict[str, Any]] = asyncio.Queue()
+    orchestrator_app.EVENT_SUBSCRIBERS[job.id]["healthy"] = healthy_queue
+    orchestrator_app.EVENT_SUBSCRIBERS[job.id]["broken"] = BrokenSubscriberQueue()  # type: ignore[assignment]
+
+    asyncio.run(orchestrator_app._publish_event(job.id, "progress", {"id": job.id, "progress": 23}))
+
+    assert set(orchestrator_app.EVENT_SUBSCRIBERS[job.id]) == {"healthy"}
+    assert healthy_queue.get_nowait() == {
+        "id": 1,
+        "event": "progress",
+        "data": {"id": job.id, "progress": 23},
+    }
+
+
+def test_publish_event_handles_full_queue_drain_race_and_still_fans_out() -> None:
+    class RacyFullQueue:
+        def __init__(self) -> None:
+            self.payload: Dict[str, Any] | None = None
+
+        def full(self) -> bool:
+            return True
+
+        def get_nowait(self) -> object:
+            raise asyncio.QueueEmpty
+
+        def put_nowait(self, payload: Dict[str, Any]) -> None:
+            self.payload = payload
+
+    job = _seed_running_event_job("job_publish_full_queue_race")
+    subscriber_queue = RacyFullQueue()
+    orchestrator_app.EVENT_SUBSCRIBERS[job.id]["racy"] = subscriber_queue  # type: ignore[assignment]
+
+    asyncio.run(orchestrator_app._publish_event(job.id, "progress", {"id": job.id, "progress": 26}))
+
+    assert subscriber_queue.payload == {
+        "id": 1,
+        "event": "progress",
+        "data": {"id": job.id, "progress": 26},
+    }
+    assert "racy" in orchestrator_app.EVENT_SUBSCRIBERS[job.id]
+
+
+def test_publish_event_tolerates_queue_full_backpressure_without_pruning_subscriber() -> None:
+    class BackpressuredQueue:
+        def full(self) -> bool:
+            return False
+
+        def put_nowait(self, _payload: Dict[str, Any]) -> None:
+            raise asyncio.QueueFull
+
+    job = _seed_running_event_job("job_publish_queue_full_backpressure")
+    healthy_queue: asyncio.Queue[Dict[str, Any]] = asyncio.Queue()
+    orchestrator_app.EVENT_SUBSCRIBERS[job.id]["full"] = BackpressuredQueue()  # type: ignore[assignment]
+    orchestrator_app.EVENT_SUBSCRIBERS[job.id]["healthy"] = healthy_queue
+
+    asyncio.run(orchestrator_app._publish_event(job.id, "progress", {"id": job.id, "progress": 27}))
+
+    assert set(orchestrator_app.EVENT_SUBSCRIBERS[job.id]) == {"full", "healthy"}
+    assert healthy_queue.get_nowait() == {
+        "id": 1,
+        "event": "progress",
+        "data": {"id": job.id, "progress": 27},
+    }
+
+
+def _seed_job_with_sse_replay_events(job_id: str) -> Any:
+    now = orchestrator_app._now()
+    job = orchestrator_app.Job(
+        id=job_id,
         created_at=now,
         state="running",
         progress=0,
@@ -5519,9 +5985,21 @@ def test_job_events_replays_persisted_events_from_last_event_id(client: TestClie
     )
     _seed_job(job)
 
-    asyncio.run(orchestrator_app._publish_event(job.id, "state", {"id": job.id, "state": "running", "progress": 0}))
+    asyncio.run(
+        orchestrator_app._publish_event(
+            job.id,
+            "state",
+            {"id": job.id, "state": "running", "progress": 0},
+        )
+    )
     job.progress = 45
-    asyncio.run(orchestrator_app._publish_event(job.id, "progress", {"id": job.id, "progress": 45}))
+    asyncio.run(
+        orchestrator_app._publish_event(
+            job.id,
+            "progress",
+            {"id": job.id, "progress": 45},
+        )
+    )
     job.state = "succeeded"
     job.exit_code = 0
     asyncio.run(
@@ -5539,19 +6017,384 @@ def test_job_events_replays_persisted_events_from_last_event_id(client: TestClie
     )
     job.done_published_at = orchestrator_app._now()
     job.finished_at = job.done_published_at
+    return job
 
-    with client.stream("GET", f"/v1/jobs/{job.id}/events", headers={"Last-Event-ID": "1"}) as stream_response:
+
+@pytest.mark.parametrize(
+    ("jobs_prefix", "job_id"),
+    [
+        ("/v1/jobs", "job_sse_replay_v1"),
+        ("/v2/jobs", "job_sse_replay_v2"),
+    ],
+)
+def test_job_events_replays_persisted_events_from_last_event_id(
+    client: TestClient,
+    jobs_prefix: str,
+    job_id: str,
+) -> None:
+    job = _seed_job_with_sse_replay_events(job_id)
+
+    with client.stream("GET", f"{jobs_prefix}/{job.id}/events", headers={"Last-Event-ID": "1"}) as stream_response:
         assert stream_response.status_code == 200
-        events = _collect_sse_events(stream_response)
+        frames = _collect_sse_frames(stream_response)
 
+    events = [(event_name, payload) for _event_id, event_name, payload in frames]
     assert [name for name, _payload in events] == ["progress", "done"]
+    assert [event_id for event_id, _name, _payload in frames] == ["2", "3"]
     assert events[0][1]["progress"] == 45
 
 
-def test_job_events_replay_beyond_latest_seq_falls_back_to_state_first(client: TestClient) -> None:
+def test_job_events_terminal_replay_cleans_repository_only_subscriber(
+    client: TestClient,
+) -> None:
+    job = _seed_job_with_sse_replay_events("job_sse_replay_repository_only_cleanup")
+    _sync_seeded_job(job)
+    orchestrator_app.JOBS.pop(job.id)
+
+    with client.stream("GET", f"/v1/jobs/{job.id}/events", headers={"Last-Event-ID": "2"}) as stream_response:
+        assert stream_response.status_code == 200
+        frames = _collect_sse_frames(stream_response)
+
+    assert [(event_id, event_name) for event_id, event_name, _payload in frames] == [("3", "done")]
+    assert job.id not in orchestrator_app.JOBS
+    assert job.id not in orchestrator_app.EVENT_SUBSCRIBERS
+
+
+def test_job_events_active_disconnect_removes_subscriber_but_keeps_job_bucket() -> None:
+    class DisconnectingRequest:
+        headers: Dict[str, str] = {}
+
+        async def is_disconnected(self) -> bool:
+            return True
+
+    async def consume_initial_state_and_disconnect(job_id: str) -> str:
+        response = await orchestrator_app._job_events(DisconnectingRequest(), job_id)  # type: ignore[arg-type]
+        body_iterator = response.body_iterator
+        initial_state = await anext(body_iterator)
+        with pytest.raises(StopAsyncIteration):
+            await anext(body_iterator)
+        return initial_state
+
+    job = _seed_running_event_job("job_sse_active_disconnect_cleanup")
+
+    initial_state = asyncio.run(consume_initial_state_and_disconnect(job.id))
+    initial_payload = json.loads(initial_state.split("data: ", 1)[1])
+
+    assert "event: state" in initial_state
+    assert initial_payload == {"id": job.id, "state": "running", "progress": 0}
+    assert job.id in orchestrator_app.EVENT_SUBSCRIBERS
+    assert orchestrator_app.EVENT_SUBSCRIBERS[job.id] == {}
+
+
+def test_job_events_active_stream_emits_heartbeat_and_cleans_up(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class ConnectedRequest:
+        headers: Dict[str, str] = {}
+
+        async def is_disconnected(self) -> bool:
+            return False
+
+    async def consume_state_and_heartbeat(job_id: str) -> tuple[str, str]:
+        response = await orchestrator_app._job_events(ConnectedRequest(), job_id)  # type: ignore[arg-type]
+        body_iterator = response.body_iterator
+        initial_state = await anext(body_iterator)
+        heartbeat = await anext(body_iterator)
+        await body_iterator.aclose()
+        return initial_state, heartbeat
+
+    job = _seed_running_event_job("job_sse_active_heartbeat")
+    heartbeat_at = 100.0 + orchestrator_app.HEARTBEAT_SECONDS + 1.0
+    now_values = [100.0, heartbeat_at]
+    monkeypatch.setattr(
+        orchestrator_app,
+        "_now",
+        lambda: now_values.pop(0) if now_values else heartbeat_at,
+    )
+
+    initial_state, heartbeat = asyncio.run(consume_state_and_heartbeat(job.id))
+
+    assert json.loads(initial_state.split("data: ", 1)[1]) == {
+        "id": job.id,
+        "state": "running",
+        "progress": 0,
+    }
+    assert heartbeat == ": heartbeat\n\n"
+    assert job.id in orchestrator_app.EVENT_SUBSCRIBERS
+    assert orchestrator_app.EVENT_SUBSCRIBERS[job.id] == {}
+
+
+def test_job_events_finished_pending_done_waits_for_real_done_and_cleans_up() -> None:
+    class ConnectedRequest:
+        headers: Dict[str, str] = {}
+
+        async def is_disconnected(self) -> bool:
+            return False
+
+    async def consume_state_then_real_done(job_id: str) -> tuple[str, str]:
+        response = await orchestrator_app._job_events(ConnectedRequest(), job_id)  # type: ignore[arg-type]
+        body_iterator = response.body_iterator
+        initial_state = await anext(body_iterator)
+        subscribers = orchestrator_app.EVENT_SUBSCRIBERS[job_id]
+        assert len(subscribers) == 1
+        queue = next(iter(subscribers.values()))
+        queue.put_nowait(
+            {
+                "id": 9,
+                "event": "done",
+                "data": {
+                    "id": job_id,
+                    "state": "succeeded",
+                    "exit_code": 0,
+                    "error": None,
+                    "artifacts": {"report": {"relative_path": "report.json"}},
+                },
+            }
+        )
+        done_frame = await anext(body_iterator)
+        with pytest.raises(StopAsyncIteration):
+            await anext(body_iterator)
+        return initial_state, done_frame
+
     now = orchestrator_app._now()
     job = orchestrator_app.Job(
-        id="job_sse_replay_beyond_latest",
+        id="job_sse_finished_waits_for_real_done",
+        created_at=now,
+        state="succeeded",
+        progress=100,
+        finished_at=now,
+        done_published_at=None,
+        exit_code=0,
+        request={"pipeline": "lux-depth-v3"},
+    )
+    _seed_job(job)
+
+    initial_state, done_frame = asyncio.run(consume_state_then_real_done(job.id))
+
+    assert json.loads(initial_state.split("data: ", 1)[1]) == {
+        "id": job.id,
+        "state": "succeeded",
+        "progress": 100,
+    }
+    assert "id: 9" in done_frame
+    assert json.loads(done_frame.split("data: ", 1)[1]) == {
+        "id": job.id,
+        "state": "succeeded",
+        "exit_code": 0,
+        "error": None,
+        "artifacts": {"report": {"relative_path": "report.json"}},
+    }
+    assert job.id not in orchestrator_app.EVENT_SUBSCRIBERS
+
+
+def test_job_events_live_stream_omits_invalid_queued_event_id() -> None:
+    class ConnectedRequest:
+        headers: Dict[str, str] = {}
+
+        async def is_disconnected(self) -> bool:
+            return False
+
+    async def consume_state_then_invalid_id_done(job_id: str) -> tuple[str, str]:
+        response = await orchestrator_app._job_events(ConnectedRequest(), job_id)  # type: ignore[arg-type]
+        body_iterator = response.body_iterator
+        initial_state = await anext(body_iterator)
+        subscribers = orchestrator_app.EVENT_SUBSCRIBERS[job_id]
+        assert len(subscribers) == 1
+        queue = next(iter(subscribers.values()))
+        queue.put_nowait(
+            {
+                "id": "\uff11",
+                "event": "done",
+                "data": {
+                    "id": job_id,
+                    "state": "succeeded",
+                    "exit_code": 0,
+                    "error": None,
+                    "artifacts": {},
+                },
+            }
+        )
+        done_frame = await anext(body_iterator)
+        with pytest.raises(StopAsyncIteration):
+            await anext(body_iterator)
+        return initial_state, done_frame
+
+    now = orchestrator_app._now()
+    job = orchestrator_app.Job(
+        id="job_sse_invalid_live_event_id",
+        created_at=now,
+        state="succeeded",
+        progress=100,
+        finished_at=now,
+        done_published_at=None,
+        exit_code=0,
+        request={"pipeline": "lux-depth-v3"},
+    )
+    _seed_job(job)
+
+    initial_state, done_frame = asyncio.run(consume_state_then_invalid_id_done(job.id))
+
+    assert json.loads(initial_state.split("data: ", 1)[1]) == {
+        "id": job.id,
+        "state": "succeeded",
+        "progress": 100,
+    }
+    assert "id: " not in done_frame
+    assert "event: done" in done_frame
+    assert json.loads(done_frame.split("data: ", 1)[1]) == {
+        "id": job.id,
+        "state": "succeeded",
+        "exit_code": 0,
+        "error": None,
+        "artifacts": {},
+    }
+    assert job.id not in orchestrator_app.EVENT_SUBSCRIBERS
+
+
+def test_job_events_late_terminal_drain_omits_invalid_queued_event_id() -> None:
+    class ConnectedRequest:
+        headers: Dict[str, str] = {}
+
+        async def is_disconnected(self) -> bool:
+            return False
+
+    async def consume_state_then_drained_done(job_id: str) -> tuple[str, str]:
+        response = await orchestrator_app._job_events(ConnectedRequest(), job_id)  # type: ignore[arg-type]
+        body_iterator = response.body_iterator
+        initial_state = await anext(body_iterator)
+        subscribers = orchestrator_app.EVENT_SUBSCRIBERS[job_id]
+        assert len(subscribers) == 1
+        queue = next(iter(subscribers.values()))
+        queue.put_nowait(
+            {
+                "id": "\uff11",
+                "event": "done",
+                "data": {
+                    "id": job_id,
+                    "state": "succeeded",
+                    "exit_code": 0,
+                    "error": None,
+                    "artifacts": {},
+                },
+            }
+        )
+        done_frame = await anext(body_iterator)
+        with pytest.raises(StopAsyncIteration):
+            await anext(body_iterator)
+        return initial_state, done_frame
+
+    now = orchestrator_app._now()
+    job = orchestrator_app.Job(
+        id="job_sse_invalid_late_terminal_event_id",
+        created_at=now,
+        state="succeeded",
+        progress=100,
+        finished_at=now,
+        done_published_at=now,
+        exit_code=0,
+        request={"pipeline": "lux-depth-v3"},
+    )
+    _seed_job(job)
+
+    initial_state, done_frame = asyncio.run(consume_state_then_drained_done(job.id))
+
+    assert json.loads(initial_state.split("data: ", 1)[1]) == {
+        "id": job.id,
+        "state": "succeeded",
+        "progress": 100,
+    }
+    assert "id: " not in done_frame
+    assert "event: done" in done_frame
+    assert json.loads(done_frame.split("data: ", 1)[1]) == {
+        "id": job.id,
+        "state": "succeeded",
+        "exit_code": 0,
+        "error": None,
+        "artifacts": {},
+    }
+    assert job.id not in orchestrator_app.EVENT_SUBSCRIBERS
+
+
+@pytest.mark.parametrize(
+    ("jobs_prefix", "job_id"),
+    [
+        ("/v1/jobs", "job_sse_replay_from_zero_v1"),
+        ("/v2/jobs", "job_sse_replay_from_zero_v2"),
+    ],
+)
+def test_job_events_last_event_id_zero_replays_full_persisted_stream(
+    client: TestClient,
+    jobs_prefix: str,
+    job_id: str,
+) -> None:
+    job = _seed_job_with_sse_replay_events(job_id)
+
+    with client.stream("GET", f"{jobs_prefix}/{job.id}/events", headers={"Last-Event-ID": "0"}) as stream_response:
+        assert stream_response.status_code == 200
+        frames = _collect_sse_frames(stream_response)
+
+    events = [(event_name, payload) for _event_id, event_name, payload in frames]
+    assert [name for name, _payload in events] == ["state", "progress", "done"]
+    assert [event_id for event_id, _name, _payload in frames] == ["1", "2", "3"]
+    assert events[0][1]["state"] == "running"
+    assert events[-1][1]["state"] == "succeeded"
+
+
+def test_job_events_strips_padded_last_event_id_before_replay(client: TestClient) -> None:
+    job = _seed_job_with_sse_replay_events("job_sse_replay_padded_last_event_id")
+
+    with client.stream("GET", f"/v1/jobs/{job.id}/events", headers={"Last-Event-ID": " 1 "}) as stream_response:
+        assert stream_response.status_code == 200
+        frames = _collect_sse_frames(stream_response)
+
+    assert [(event_id, event_name) for event_id, event_name, _payload in frames] == [
+        ("2", "progress"),
+        ("3", "done"),
+    ]
+
+
+def test_job_events_blank_last_event_id_is_treated_as_absent(client: TestClient) -> None:
+    job = _seed_job_with_sse_replay_events("job_sse_blank_last_event_id")
+
+    with client.stream("GET", f"/v1/jobs/{job.id}/events", headers={"Last-Event-ID": "   "}) as stream_response:
+        assert stream_response.status_code == 200
+        frames = _collect_sse_frames(stream_response)
+
+    events = [(event_name, payload) for _event_id, event_name, payload in frames]
+    assert [name for name, _payload in events] == ["state", "done"]
+    assert [event_id for event_id, _name, _payload in frames] == [None, None]
+    assert events[0][1]["state"] == "succeeded"
+    assert events[-1][1]["state"] == "succeeded"
+
+
+def test_job_events_missing_job_returns_not_found_without_subscriber(
+    client: TestClient,
+) -> None:
+    response = client.get("/v1/jobs/missing-sse-job/events")
+
+    assert response.status_code == 404
+    body = response.json()
+    assert body["error"]["code"] == "NOT_FOUND"
+    assert body["error"]["message"] == "job not found"
+    assert body["error"]["details"] == {"job_id": "missing-sse-job"}
+    assert "missing-sse-job" not in orchestrator_app.EVENT_SUBSCRIBERS
+
+
+@pytest.mark.parametrize(
+    ("jobs_prefix", "job_id"),
+    [
+        ("/v1/jobs", "job_sse_replay_beyond_latest_v1"),
+        ("/v2/jobs", "job_sse_replay_beyond_latest_v2"),
+    ],
+)
+def test_job_events_replay_beyond_latest_seq_falls_back_to_state_first(
+    client: TestClient,
+    jobs_prefix: str,
+    job_id: str,
+) -> None:
+    now = orchestrator_app._now()
+    job = orchestrator_app.Job(
+        id=job_id,
         created_at=now,
         state="running",
         progress=12,
@@ -5565,18 +6408,29 @@ def test_job_events_replay_beyond_latest_seq_falls_back_to_state_first(client: T
     job.done_published_at = job.finished_at
     _sync_seeded_job(job)
 
-    with client.stream("GET", f"/v1/jobs/{job.id}/events", headers={"Last-Event-ID": "999"}) as stream_response:
+    with client.stream("GET", f"{jobs_prefix}/{job.id}/events", headers={"Last-Event-ID": "999"}) as stream_response:
         assert stream_response.status_code == 200
-        events = _collect_sse_events(stream_response)
+        frames = _collect_sse_frames(stream_response)
 
+    events = [(event_name, payload) for _event_id, event_name, payload in frames]
     assert [name for name, _payload in events] == ["state", "done"]
+    assert [event_id for event_id, _name, _payload in frames] == [None, None]
     assert events[0][1]["state"] == "succeeded"
     assert events[1][1]["state"] == "succeeded"
 
 
+@pytest.mark.parametrize(
+    ("jobs_prefix", "job_id"),
+    [
+        ("/v1/jobs", "job_sse_replay_failure_v1"),
+        ("/v2/jobs", "job_sse_replay_failure_v2"),
+    ],
+)
 def test_job_events_replay_failure_falls_back_to_state_first(
     client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
+    jobs_prefix: str,
+    job_id: str,
 ) -> None:
     class FailingAsyncIterator:
         def __aiter__(self):  # noqa: ANN204
@@ -5594,7 +6448,7 @@ def test_job_events_replay_failure_falls_back_to_state_first(
 
     now = orchestrator_app._now()
     job = orchestrator_app.Job(
-        id="job_sse_replay_failure",
+        id=job_id,
         created_at=now,
         state="succeeded",
         progress=100,
@@ -5606,18 +6460,305 @@ def test_job_events_replay_failure_falls_back_to_state_first(
     _seed_job(job)
     monkeypatch.setattr(orchestrator_app, "_job_event_store", failing_event_store)
 
-    with client.stream("GET", f"/v1/jobs/{job.id}/events", headers={"Last-Event-ID": "1"}) as stream_response:
+    with client.stream("GET", f"{jobs_prefix}/{job.id}/events", headers={"Last-Event-ID": "1"}) as stream_response:
         assert stream_response.status_code == 200
-        events = _collect_sse_events(stream_response)
+        frames = _collect_sse_frames(stream_response)
 
+    events = [(event_name, payload) for _event_id, event_name, payload in frames]
     assert [name for name, _payload in events] == ["state", "done"]
+    assert [event_id for event_id, _name, _payload in frames] == [None, None]
     assert events[0][1]["progress"] == 100
 
 
-def test_job_events_rejects_invalid_last_event_id(client: TestClient) -> None:
+def test_job_events_replay_failure_resets_seq_filter_for_live_events(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    job_id = "job_sse_replay_failure_live_lower_seq"
+
+    class ReplayFailureAfterQueuedLiveDone:
+        def events_since(self, observed_job_id: str, *, after_seq: int):
+            assert observed_job_id == job_id
+            assert after_seq == 9
+            return self._events()
+
+        async def _events(self):  # noqa: ANN202
+            subscribers = orchestrator_app.EVENT_SUBSCRIBERS[job_id]
+            assert len(subscribers) == 1
+            queue = next(iter(subscribers.values()))
+            queue.put_nowait(
+                {
+                    "id": 2,
+                    "event": "done",
+                    "data": {
+                        "id": job_id,
+                        "state": "succeeded",
+                        "exit_code": 0,
+                        "error": None,
+                        "artifacts": {},
+                    },
+                }
+            )
+            raise RuntimeError("event store unavailable")
+            yield  # pragma: no cover - keeps this method an async generator.
+
+    class NeverDisconnectedRequest:
+        headers = {"last-event-id": "9"}
+
+        async def is_disconnected(self) -> bool:
+            return False
+
+    async def consume_state_then_live_done() -> tuple[str, str]:
+        response = await orchestrator_app._job_events(NeverDisconnectedRequest(), job_id)
+        iterator = response.body_iterator
+        state_frame = await asyncio.wait_for(iterator.__anext__(), timeout=1.0)
+        done_frame = await asyncio.wait_for(iterator.__anext__(), timeout=1.0)
+        with pytest.raises(StopAsyncIteration):
+            await asyncio.wait_for(iterator.__anext__(), timeout=1.0)
+        return (
+            state_frame.decode("utf-8") if isinstance(state_frame, bytes) else state_frame,
+            done_frame.decode("utf-8") if isinstance(done_frame, bytes) else done_frame,
+        )
+
+    job = orchestrator_app.Job(
+        id=job_id,
+        created_at=orchestrator_app._now(),
+        state="running",
+        progress=42,
+        request={"pipeline": "lux-depth-v3"},
+    )
+    _seed_job(job)
+    monkeypatch.setattr(orchestrator_app, "_job_event_store", lambda: ReplayFailureAfterQueuedLiveDone())
+
+    state_frame, done_frame = asyncio.run(consume_state_then_live_done())
+
+    assert "event: state\n" in state_frame
+    assert '"progress":42' in state_frame
+    assert "id: " not in state_frame
+    assert "id: 2\n" in done_frame
+    assert "event: done\n" in done_frame
+
+
+def test_job_events_replay_skips_queued_duplicate_seq_before_live_done(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from transformation_portal.orchestrator.storage.base import JobEvent
+
+    job_id = "job_sse_replay_live_dedupe"
+
+    class ReplayStoreWithQueuedDuplicate:
+        def events_since(self, observed_job_id: str, *, after_seq: int):
+            assert observed_job_id == job_id
+            assert after_seq == 4
+            return self._events()
+
+        async def _events(self):  # noqa: ANN202
+            subscribers = orchestrator_app.EVENT_SUBSCRIBERS[job_id]
+            assert len(subscribers) == 1
+            queue = next(iter(subscribers.values()))
+            queue.put_nowait(
+                {
+                    "id": 5,
+                    "event": "progress",
+                    "data": {"id": job_id, "progress": 25},
+                }
+            )
+            queue.put_nowait(
+                {
+                    "id": 6,
+                    "event": "done",
+                    "data": {
+                        "id": job_id,
+                        "state": "succeeded",
+                        "exit_code": 0,
+                        "error": None,
+                        "artifacts": {},
+                    },
+                }
+            )
+            yield JobEvent(
+                job_id=job_id,
+                seq=5,
+                event_type="progress",
+                payload={"id": job_id, "progress": 25},
+                created_at=orchestrator_app._now(),
+            )
+
     now = orchestrator_app._now()
     job = orchestrator_app.Job(
-        id="job_sse_bad_last_event_id",
+        id=job_id,
+        created_at=now,
+        state="succeeded",
+        progress=100,
+        finished_at=now,
+        done_published_at=now,
+        exit_code=0,
+        request={"pipeline": "lux-depth-v3"},
+    )
+    _seed_job(job)
+    monkeypatch.setattr(orchestrator_app, "_job_event_store", lambda: ReplayStoreWithQueuedDuplicate())
+
+    with client.stream("GET", f"/v1/jobs/{job.id}/events", headers={"Last-Event-ID": "4"}) as stream_response:
+        assert stream_response.status_code == 200
+        frames = _collect_sse_frames(stream_response)
+
+    assert [(event_id, name) for event_id, name, _payload in frames] == [
+        ("5", "progress"),
+        ("6", "done"),
+    ]
+
+
+def test_job_events_replay_allows_live_done_without_persisted_seq(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from transformation_portal.orchestrator.storage.base import JobEvent
+
+    job_id = "job_sse_replay_live_done_without_seq"
+
+    class ReplayStoreWithUnpersistedLiveDone:
+        def events_since(self, observed_job_id: str, *, after_seq: int):
+            assert observed_job_id == job_id
+            assert after_seq == 4
+            return self._events()
+
+        async def _events(self):  # noqa: ANN202
+            yield JobEvent(
+                job_id=job_id,
+                seq=5,
+                event_type="progress",
+                payload={"id": job_id, "progress": 30},
+                created_at=orchestrator_app._now(),
+            )
+            subscribers = orchestrator_app.EVENT_SUBSCRIBERS[job_id]
+            assert len(subscribers) == 1
+            queue = next(iter(subscribers.values()))
+            queue.put_nowait(
+                {
+                    "event": "done",
+                    "data": {
+                        "id": job_id,
+                        "state": "succeeded",
+                        "exit_code": 0,
+                        "error": None,
+                        "artifacts": {},
+                    },
+                }
+            )
+
+    now = orchestrator_app._now()
+    job = orchestrator_app.Job(
+        id=job_id,
+        created_at=now,
+        state="succeeded",
+        progress=100,
+        finished_at=now,
+        done_published_at=now,
+        exit_code=0,
+        request={"pipeline": "lux-depth-v3"},
+    )
+    _seed_job(job)
+    monkeypatch.setattr(orchestrator_app, "_job_event_store", lambda: ReplayStoreWithUnpersistedLiveDone())
+
+    with client.stream("GET", f"/v1/jobs/{job.id}/events", headers={"Last-Event-ID": "4"}) as stream_response:
+        assert stream_response.status_code == 200
+        frames = _collect_sse_frames(stream_response)
+
+    assert [(event_id, name) for event_id, name, _payload in frames] == [
+        ("5", "progress"),
+        (None, "done"),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("event_payload", "expected_seq"),
+    [
+        ({}, None),
+        ({"id": None}, None),
+        ({"id": 7}, 7),
+        ({"id": "8"}, 8),
+        ({"id": " 9 "}, 9),
+        ({"id": "0010"}, 10),
+        ({"id": 0}, None),
+        ({"id": "0"}, None),
+        ({"id": " 0 "}, None),
+        ({"id": -1}, None),
+        ({"id": "-1"}, None),
+        ({"id": True}, None),
+        ({"id": False}, None),
+        ({"id": 1.2}, None),
+        ({"id": "\uff11"}, None),
+        ({"id": "not-a-seq"}, None),
+        ({"id": object()}, None),
+    ],
+)
+def test_event_queue_seq_parses_only_valid_persisted_event_ids(
+    event_payload: Dict[str, Any],
+    expected_seq: int | None,
+) -> None:
+    assert orchestrator_app._event_queue_seq(event_payload) == expected_seq
+
+
+@pytest.mark.parametrize(
+    ("header_value", "expected_seq"),
+    [
+        ("0", 0),
+        (" 12 ", 12),
+        ("+1", None),
+        ("1.2", None),
+        ("\uff11", None),
+    ],
+)
+def test_last_event_id_parser_accepts_only_ascii_decimal_text(
+    header_value: str,
+    expected_seq: int | None,
+) -> None:
+    request = SimpleNamespace(headers={"last-event-id": header_value})
+
+    if expected_seq is None:
+        with pytest.raises(ValueError, match="Last-Event-ID"):
+            orchestrator_app._last_event_id_from_request(request)
+    else:
+        assert orchestrator_app._last_event_id_from_request(request) == expected_seq
+
+
+@pytest.mark.parametrize(
+    "request_obj",
+    [
+        SimpleNamespace(),
+        SimpleNamespace(headers={}),
+        SimpleNamespace(headers={"last-event-id": None}),
+        SimpleNamespace(headers={"last-event-id": "   "}),
+    ],
+)
+def test_last_event_id_parser_treats_absent_and_blank_values_as_no_replay(
+    request_obj: SimpleNamespace,
+) -> None:
+    assert orchestrator_app._last_event_id_from_request(request_obj) is None
+
+
+@pytest.mark.parametrize(
+    ("jobs_prefix", "job_id", "last_event_id"),
+    [
+        ("/v1/jobs", "job_sse_bad_last_event_id_text_v1", "not-a-seq"),
+        ("/v1/jobs", "job_sse_bad_last_event_id_negative_v1", "-1"),
+        ("/v1/jobs", "job_sse_bad_last_event_id_plus_v1", "+1"),
+        ("/v1/jobs", "job_sse_bad_last_event_id_float_v1", "1.2"),
+        ("/v2/jobs", "job_sse_bad_last_event_id_text_v2", "not-a-seq"),
+        ("/v2/jobs", "job_sse_bad_last_event_id_negative_v2", "-1"),
+        ("/v2/jobs", "job_sse_bad_last_event_id_plus_v2", "+1"),
+        ("/v2/jobs", "job_sse_bad_last_event_id_float_v2", "1.2"),
+    ],
+)
+def test_job_events_rejects_invalid_last_event_id(
+    client: TestClient,
+    jobs_prefix: str,
+    job_id: str,
+    last_event_id: str,
+) -> None:
+    now = orchestrator_app._now()
+    job = orchestrator_app.Job(
+        id=job_id,
         created_at=now,
         state="running",
         progress=0,
@@ -5625,7 +6766,7 @@ def test_job_events_rejects_invalid_last_event_id(client: TestClient) -> None:
     )
     _seed_job(job)
 
-    response = client.get(f"/v1/jobs/{job.id}/events", headers={"Last-Event-ID": "not-a-seq"})
+    response = client.get(f"{jobs_prefix}/{job.id}/events", headers={"Last-Event-ID": last_event_id})
     assert response.status_code == 400
     body = response.json()
     assert body["error"]["code"] == "INVALID_ARGUMENT"

--- a/tests/test_run_card_schema.py
+++ b/tests/test_run_card_schema.py
@@ -36,11 +36,31 @@ from transformation_portal.lux_depth_v3.orchestrator import (
     _validate_run_card_payload,
 )
 from transformation_portal.lux_depth_v3.run_card_contract import (
+    RunCardPathValidationError,
     build_runtime_licensing_manifest,
+    get_run_card_schema_uri_for_payload,
+    infer_run_card_version,
+    normalize_run_card_relative_path,
     render_run_card_output_relative_path,
+    with_inferred_run_card_version,
 )
 from transformation_portal.lux_depth_v3.security import HashMode
-from transformation_portal.schemas.run_card import load_run_card_schema
+from transformation_portal.schemas.run_card import get_run_card_schema_uri, load_run_card_schema
+
+
+def _payload_for_run_card_schema_version(version: str) -> dict:
+    payload = _valid_run_card_payload()
+    payload["run_card_version"] = version
+    if version == "v2":
+        payload.pop("artifact_merkle_root", None)
+        payload["artifact_tree"] = {
+            "algorithm": "ct-sha256-v1",
+            "leaf_format": "tp.run_card.artifact_leaf.v1",
+            "leaf_count": 0,
+            "root_sha256": "e" * 64,
+            "artifacts": [],
+        }
+    return payload
 
 
 def test_apex_segmentation_dominance_warning_code_is_centralized() -> None:
@@ -180,6 +200,25 @@ def test_packaged_run_card_schemas_match_documented_copies() -> None:
         assert load_run_card_schema(version) == documented_schema
 
 
+@pytest.mark.parametrize("version", ["v3", "legacy", 2])
+def test_run_card_schema_loader_rejects_unsupported_versions(version: object) -> None:
+    with pytest.raises(ValueError, match="Unsupported run card schema version"):
+        load_run_card_schema(version)
+
+
+def test_run_card_contract_infers_version_and_schema_uri_without_mutating_payload() -> None:
+    v1_payload = {"run_card_version": "V1", "artifact_index": []}
+    v2_payload = {"artifact_tree": {"artifacts": []}}
+
+    assert infer_run_card_version(v1_payload) == "v1"
+    assert infer_run_card_version(v2_payload) == "v2"
+    assert get_run_card_schema_uri_for_payload(v2_payload) == get_run_card_schema_uri("v2")
+
+    hydrated = with_inferred_run_card_version(v2_payload)
+    assert hydrated["run_card_version"] == "v2"
+    assert "run_card_version" not in v2_payload
+
+
 def test_run_card_schema_accepts_runtime_licensing_block() -> None:
     pytest.importorskip("jsonschema")
     payload = _valid_run_card_payload()
@@ -197,6 +236,108 @@ def test_run_card_schema_accepts_runtime_licensing_block() -> None:
 
     _validate_run_card_payload(payload, _run_card_schema_path())
     assert payload["licensing"]["non_commercial_active"] is True
+
+
+@pytest.mark.parametrize("version", ["v1", "v2"])
+def test_run_card_schema_accepts_legacy_payload_without_runtime_licensing(version: str) -> None:
+    pytest.importorskip("jsonschema")
+    payload = _payload_for_run_card_schema_version(version)
+
+    _validate_run_card_payload(payload, _run_card_schema_path(version))
+
+    assert "licensing" not in payload
+
+
+@pytest.mark.parametrize("version", ["v1", "v2"])
+def test_run_card_schema_rejects_incomplete_runtime_licensing_block(version: str) -> None:
+    pytest.importorskip("jsonschema")
+    payload = _payload_for_run_card_schema_version(version)
+    payload["licensing"] = {
+        "schema_version": "1.0",
+        "software_license_tier": "commercial",
+        "models": [],
+        "non_commercial_active": False,
+    }
+
+    with pytest.raises(RuntimeError, match="licensing"):
+        _validate_run_card_payload(payload, _run_card_schema_path(version))
+
+
+@pytest.mark.parametrize("version", ["v1", "v2"])
+def test_run_card_schema_rejects_unknown_runtime_license_tier(version: str) -> None:
+    pytest.importorskip("jsonschema")
+    payload = _payload_for_run_card_schema_version(version)
+    payload["licensing"] = {
+        "schema_version": "1.0",
+        "software_license_tier": "multi_runtime_aggregate",
+        "models": [],
+        "non_commercial_active": False,
+        "research_acknowledgement_required": False,
+    }
+
+    with pytest.raises(RuntimeError, match="software_license_tier"):
+        _validate_run_card_payload(payload, _run_card_schema_path(version))
+
+
+@pytest.mark.parametrize("version", ["v1", "v2"])
+@pytest.mark.parametrize(
+    ("licensing_patch", "message"),
+    [
+        ({"approval_note": "signed off out of band"}, "approval_note"),
+        (
+            {
+                "models": [
+                    {
+                        "id": "commercial/depth-model",
+                        "license": "commercial",
+                        "runtime_role": "depth",
+                        "requires_non_commercial_ok": False,
+                        "approval_note": "signed off out of band",
+                    }
+                ]
+            },
+            "approval_note",
+        ),
+        (
+            {
+                "models": [
+                    {
+                        "id": "commercial/depth-model",
+                        "license": "commercial",
+                        "requires_non_commercial_ok": False,
+                    }
+                ]
+            },
+            "runtime_role",
+        ),
+    ],
+)
+def test_run_card_schema_rejects_ambiguous_runtime_licensing_evidence(
+    version: str,
+    licensing_patch: dict,
+    message: str,
+) -> None:
+    pytest.importorskip("jsonschema")
+    payload = _payload_for_run_card_schema_version(version)
+    licensing = {
+        "schema_version": "1.0",
+        "software_license_tier": "commercial",
+        "models": [
+            {
+                "id": "commercial/depth-model",
+                "license": "commercial",
+                "runtime_role": "depth",
+                "requires_non_commercial_ok": False,
+            }
+        ],
+        "non_commercial_active": False,
+        "research_acknowledgement_required": False,
+    }
+    licensing.update(licensing_patch)
+    payload["licensing"] = licensing
+
+    with pytest.raises(RuntimeError, match=message):
+        _validate_run_card_payload(payload, _run_card_schema_path(version))
 
 
 def test_run_card_schema_enforces_datetime_format() -> None:
@@ -284,6 +425,41 @@ def test_run_card_output_relative_path_handles_alias_equivalent_roots(tmp_path: 
     relative_path = render_run_card_output_relative_path(str(actual_manifest), alias_root)
 
     assert relative_path == "manifests/alpha.json"
+
+
+@pytest.mark.parametrize(
+    ("path_value", "message"),
+    [
+        (None, "invalid"),
+        ("", "invalid"),
+        (" ", "invalid"),
+        ("~/secret.txt", "invalid"),
+        ("nested\\secret.txt", "invalid"),
+        ("/absolute/secret.txt", "must not be absolute"),
+        (".", "invalid"),
+        ("../secret.txt", "must not contain traversal"),
+        ("nested/../secret.txt", "must not contain traversal"),
+    ],
+)
+def test_run_card_relative_path_rejects_empty_absolute_and_traversal_segments(
+    path_value: object,
+    message: str,
+) -> None:
+    with pytest.raises(RunCardPathValidationError, match=message):
+        normalize_run_card_relative_path(path_value)
+
+
+def test_run_card_relative_path_normalizes_valid_posix_path() -> None:
+    assert normalize_run_card_relative_path(" manifests/alpha.json ") == "manifests/alpha.json"
+
+
+def test_run_card_output_relative_path_falls_back_to_filename_for_external_paths(tmp_path: Path):
+    external_path = tmp_path / "outside" / "manifest.json"
+    output_root = tmp_path / "output"
+
+    assert render_run_card_output_relative_path(str(external_path), output_root) == "manifest.json"
+    assert render_run_card_output_relative_path("", output_root) is None
+    assert render_run_card_output_relative_path(None, output_root) is None
 
 
 def test_build_artifact_index_is_deterministic(tmp_path: Path):

--- a/tests/unit/plugins/test_loader_manifest_loading.py
+++ b/tests/unit/plugins/test_loader_manifest_loading.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 
 import pytest
@@ -104,6 +105,32 @@ def test_malformed_plugin_json_is_skipped(tmp_path: Path):
     assert isolated_loader(tmp_path).discover_all() == []
 
 
+def test_malformed_plugin_json_does_not_fall_back_to_pyproject_under_trust_store(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+):
+    package_dir = tmp_path / "malformed_json_with_pyproject_package"
+    write_plugin_module(package_dir, "fallback_plugin", plugin_name="fallback_plugin")
+    (package_dir / "plugin.json").write_text("{not valid json", encoding="utf-8")
+    write_pyproject_manifest(
+        package_dir,
+        name="fallback_plugin",
+        module_name="fallback_plugin",
+    )
+
+    with caplog.at_level(logging.WARNING):
+        discovered = isolated_loader(
+            tmp_path,
+            plugin_trust_store_path=_write_trust_store(tmp_path),
+        ).discover_all()
+
+    assert len(discovered) == 1
+    assert discovered[0].plugin is None
+    assert discovered[0].is_valid is False
+    assert "Failed to parse" in caplog.text
+    assert "signature verification failed" in discovered[0].load_errors[0]
+
+
 def test_manifest_without_entry_point_is_ignored(tmp_path: Path):
     package_dir = tmp_path / "missing_entry_point_package"
     write_plugin_module(package_dir, "missing_entry_plugin", plugin_name="missing_entry_plugin")
@@ -162,6 +189,140 @@ def test_unsigned_external_plugin_json_is_rejected_when_trust_store_is_configure
     assert "signature verification failed" in discovered[0].load_errors[0]
 
 
+def test_unsigned_external_plugin_json_is_rejected_before_module_import(tmp_path: Path):
+    package_dir = tmp_path / "unsigned_import_guard_package"
+    side_effect_path = tmp_path / "imported.txt"
+    package_dir.mkdir()
+    (package_dir / "unsigned_import_guard_plugin.py").write_text(
+        f"""from __future__ import annotations
+
+from pathlib import Path
+
+from transformation_portal.plugins.interface import PluginInterface, PluginMetadata, PluginType
+
+Path({str(side_effect_path)!r}).write_text("imported", encoding="utf-8")
+
+
+class UnsignedImportGuardPlugin(PluginInterface):
+    def _create_metadata(self):
+        return PluginMetadata(
+            name="unsigned_import_guard_plugin",
+            version="1.0.0",
+            plugin_type=PluginType.CUSTOM,
+            description="test plugin",
+            author="tests",
+        )
+
+    def execute(self, *args, **kwargs):
+        return "should-not-run"
+""",
+        encoding="utf-8",
+    )
+    write_plugin_json(
+        package_dir,
+        name="unsigned_import_guard_plugin",
+        module_name="unsigned_import_guard_plugin",
+        class_name="UnsignedImportGuardPlugin",
+    )
+
+    discovered = isolated_loader(
+        tmp_path,
+        plugin_trust_store_path=_write_trust_store(tmp_path),
+    ).discover_all()
+
+    assert len(discovered) == 1
+    assert discovered[0].plugin is None
+    assert discovered[0].is_valid is False
+    assert not side_effect_path.exists()
+
+
+def test_env_configured_trust_store_rejects_unsigned_plugin_json(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    package_dir = tmp_path / "env_unsigned_package"
+    write_plugin_module(package_dir, "env_unsigned_plugin", plugin_name="env_unsigned_plugin")
+    write_plugin_json(package_dir, name="env_unsigned_plugin", module_name="env_unsigned_plugin")
+    monkeypatch.setenv("TRANSFORMATION_PORTAL_PLUGIN_TRUST_STORE", str(_write_trust_store(tmp_path)))
+
+    discovered = isolated_loader(tmp_path).discover_all()
+
+    assert len(discovered) == 1
+    assert discovered[0].plugin is None
+    assert discovered[0].is_valid is False
+    assert "signature verification failed" in discovered[0].load_errors[0]
+
+
+def test_env_configured_trust_store_accepts_signed_plugin_json(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    package_dir = tmp_path / "env_signed_package"
+    write_plugin_module(
+        package_dir,
+        "env_signed_plugin",
+        class_name="EnvSignedPlugin",
+        plugin_name="env_signed_plugin",
+        execute_result="env-signed-ok",
+    )
+    manifest_path = write_plugin_json(
+        package_dir,
+        name="env_signed_plugin",
+        module_name="env_signed_plugin",
+        class_name="EnvSignedPlugin",
+    )
+    _sign_plugin_json(manifest_path)
+    monkeypatch.setenv("TRANSFORMATION_PORTAL_PLUGIN_TRUST_STORE", str(_write_trust_store(tmp_path)))
+
+    discovered = isolated_loader(tmp_path).discover_all()
+
+    assert len(discovered) == 1
+    assert discovered[0].is_valid is True
+    assert discovered[0].manifest is not None
+    assert discovered[0].manifest.signature_key_id == "local-dev"
+    assert discovered[0].plugin.execute() == "env-signed-ok"
+
+
+def test_explicit_trust_store_path_overrides_env_trust_store(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    package_dir = tmp_path / "explicit_trust_package"
+    write_plugin_module(
+        package_dir,
+        "explicit_trust_plugin",
+        class_name="ExplicitTrustPlugin",
+        plugin_name="explicit_trust_plugin",
+        execute_result="explicit-trust-ok",
+    )
+    manifest_path = write_plugin_json(
+        package_dir,
+        name="explicit_trust_plugin",
+        module_name="explicit_trust_plugin",
+        class_name="ExplicitTrustPlugin",
+    )
+    _sign_plugin_json(manifest_path, secret="explicit-secret")
+    env_trust_store = tmp_path / "env-trust.json"
+    env_trust_store.write_text(
+        json.dumps({"keys": {"local-dev": "wrong-secret"}}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    explicit_trust_store = tmp_path / "explicit-trust.json"
+    explicit_trust_store.write_text(
+        json.dumps({"keys": {"local-dev": "explicit-secret"}}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("TRANSFORMATION_PORTAL_PLUGIN_TRUST_STORE", str(env_trust_store))
+
+    discovered = isolated_loader(tmp_path, plugin_trust_store_path=explicit_trust_store).discover_all()
+
+    assert len(discovered) == 1
+    assert discovered[0].is_valid is True
+    assert discovered[0].manifest is not None
+    assert discovered[0].manifest.signature_key_id == "local-dev"
+    assert discovered[0].plugin.execute() == "explicit-trust-ok"
+
+
 def test_tampered_external_plugin_json_is_rejected_before_load(tmp_path: Path):
     package_dir = tmp_path / "tampered_package"
     write_plugin_module(package_dir, "tampered_plugin", plugin_name="tampered_plugin")
@@ -181,6 +342,100 @@ def test_tampered_external_plugin_json_is_rejected_before_load(tmp_path: Path):
     assert discovered[0].plugin is None
     assert discovered[0].is_valid is False
     assert "does not match trusted key" in discovered[0].load_errors[0]
+
+
+def test_non_canonical_signed_plugin_json_is_rejected_before_module_import(tmp_path: Path):
+    package_dir = tmp_path / "non_canonical_signed_package"
+    side_effect_path = tmp_path / "imported.txt"
+    package_dir.mkdir()
+    (package_dir / "non_canonical_plugin.py").write_text(
+        f"""from __future__ import annotations
+
+from pathlib import Path
+
+from transformation_portal.plugins.interface import PluginInterface, PluginMetadata, PluginType
+
+Path({str(side_effect_path)!r}).write_text("imported", encoding="utf-8")
+
+
+class NonCanonicalPlugin(PluginInterface):
+    def _create_metadata(self):
+        return PluginMetadata(
+            name="non_canonical_plugin",
+            version="1.0.0",
+            plugin_type=PluginType.CUSTOM,
+            description="test plugin",
+            author="tests",
+        )
+
+    def execute(self, *args, **kwargs):
+        return "should-not-run"
+""",
+        encoding="utf-8",
+    )
+    (package_dir / "plugin.json").write_text(
+        """{
+  "name": "non_canonical_plugin",
+  "version": "1.0.0",
+  "plugin_type": "custom",
+  "entry_point": "non_canonical_plugin:NonCanonicalPlugin",
+  "quality_score": NaN,
+  "signature_algorithm": "hmac-sha256",
+  "signature_key_id": "local-dev",
+  "signature": "not-a-valid-signature"
+}
+""",
+        encoding="utf-8",
+    )
+
+    discovered = isolated_loader(
+        tmp_path,
+        plugin_trust_store_path=_write_trust_store(tmp_path),
+    ).discover_all()
+
+    assert len(discovered) == 1
+    assert discovered[0].plugin is None
+    assert discovered[0].is_valid is False
+    assert not side_effect_path.exists()
+    assert "signature verification failed" in discovered[0].load_errors[0]
+    assert "Out of range" in discovered[0].load_errors[0]
+
+
+def test_malformed_trust_store_rejects_signed_plugin_before_load(tmp_path: Path):
+    package_dir = tmp_path / "bad_trust_store_package"
+    write_plugin_module(package_dir, "bad_trust_plugin", plugin_name="bad_trust_plugin")
+    manifest_path = write_plugin_json(package_dir, name="bad_trust_plugin", module_name="bad_trust_plugin")
+    _sign_plugin_json(manifest_path)
+    trust_store_path = tmp_path / "bad-trust-store.json"
+    trust_store_path.write_text("{not valid json", encoding="utf-8")
+
+    discovered = isolated_loader(
+        tmp_path,
+        plugin_trust_store_path=trust_store_path,
+    ).discover_all()
+
+    assert len(discovered) == 1
+    assert discovered[0].plugin is None
+    assert discovered[0].is_valid is False
+    assert "signature verification failed" in discovered[0].load_errors[0]
+
+
+def test_missing_trust_store_rejects_signed_plugin_before_load(tmp_path: Path):
+    package_dir = tmp_path / "missing_trust_store_package"
+    write_plugin_module(package_dir, "missing_trust_plugin", plugin_name="missing_trust_plugin")
+    manifest_path = write_plugin_json(package_dir, name="missing_trust_plugin", module_name="missing_trust_plugin")
+    _sign_plugin_json(manifest_path)
+
+    discovered = isolated_loader(
+        tmp_path,
+        plugin_trust_store_path=tmp_path / "missing-trust-store.json",
+    ).discover_all()
+
+    assert len(discovered) == 1
+    assert discovered[0].plugin is None
+    assert discovered[0].is_valid is False
+    assert "signature verification failed" in discovered[0].load_errors[0]
+    assert "missing-trust-store.json" in discovered[0].load_errors[0]
 
 
 def test_pyproject_only_external_plugin_is_rejected_when_trust_store_is_configured(tmp_path: Path):
@@ -203,3 +458,37 @@ def test_pyproject_only_external_plugin_is_rejected_when_trust_store_is_configur
     assert discovered[0].load_errors == [
         "External plugin packages require a signed plugin.json manifest when plugin trust is configured"
     ]
+
+
+def test_single_file_external_plugin_is_skipped_when_trust_store_is_configured(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+):
+    plugin_path = write_plugin_module(
+        tmp_path,
+        "single_file_plugin",
+        plugin_name="single_file_plugin",
+    )
+
+    with caplog.at_level(logging.WARNING):
+        discovered = isolated_loader(
+            tmp_path,
+            plugin_trust_store_path=_write_trust_store(tmp_path),
+        ).discover_all()
+
+    assert discovered == []
+    assert "requires signed plugin.json manifests" in caplog.text
+    assert str(plugin_path) in caplog.text
+
+
+def test_trust_store_signature_requirement_keeps_builtin_plugins_exempt(tmp_path: Path):
+    loader = isolated_loader(
+        tmp_path,
+        plugin_trust_store_path=_write_trust_store(tmp_path),
+    )
+
+    builtin_plugin = loader._builtin_plugins_root() / "processors.py"  # noqa: SLF001 - tests pin trust boundary.
+    external_plugin = tmp_path / "external_plugin.py"
+
+    assert loader._requires_manifest_signature(external_plugin) is True  # noqa: SLF001
+    assert loader._requires_manifest_signature(builtin_plugin) is False  # noqa: SLF001

--- a/tests/unit/plugins/test_signing.py
+++ b/tests/unit/plugins/test_signing.py
@@ -1,0 +1,202 @@
+"""Security-boundary tests for external plugin manifest signing."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from transformation_portal.plugins.signing import (
+    PLUGIN_SIGNATURE_ALGORITHM,
+    PluginSignatureError,
+    canonical_manifest_payload,
+    load_plugin_trust_store,
+    sign_manifest,
+    verify_manifest_signature,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.security]
+
+
+def _write_json(path: Path, payload: object) -> Path:
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def test_canonical_manifest_payload_excludes_signature_metadata_and_sorts_keys() -> None:
+    unsigned = {
+        "version": "1.0.0",
+        "entry_point": "demo:Plugin",
+        "name": "demo",
+        "config": {"z": 2, "a": 1},
+    }
+    signed = {
+        "signature": "ignored",
+        "signature_key_id": "ignored-key",
+        "signature_algorithm": PLUGIN_SIGNATURE_ALGORITHM,
+        "name": "demo",
+        "config": {"a": 1, "z": 2},
+        "entry_point": "demo:Plugin",
+        "version": "1.0.0",
+    }
+
+    assert canonical_manifest_payload(signed) == canonical_manifest_payload(unsigned)
+    assert json.loads(canonical_manifest_payload(signed).decode("utf-8")) == unsigned
+
+
+@pytest.mark.parametrize("bad_value", [float("nan"), float("inf"), float("-inf")])
+def test_canonical_manifest_payload_rejects_non_finite_numbers(bad_value: float) -> None:
+    manifest = {"name": "demo", "version": "1.0.0", "quality_score": bad_value}
+
+    with pytest.raises(ValueError, match="Out of range"):
+        canonical_manifest_payload(manifest)
+
+
+def test_sign_manifest_ignores_existing_signature_metadata() -> None:
+    unsigned = {"name": "demo", "version": "1.0.0", "entry_point": "demo:Plugin"}
+    signed_shape = {
+        **unsigned,
+        "signature_algorithm": PLUGIN_SIGNATURE_ALGORITHM,
+        "signature_key_id": "local-dev",
+        "signature": "stale-signature-value",
+    }
+
+    assert sign_manifest(signed_shape, secret="test-secret") == sign_manifest(unsigned, secret="test-secret")
+
+
+def test_verify_manifest_signature_accepts_nested_trust_store_and_normalized_signature(tmp_path: Path) -> None:
+    trust_store_path = _write_json(tmp_path / "trust.json", {"keys": {"local-dev": "test-secret"}})
+    manifest = {
+        "name": "demo",
+        "version": "1.0.0",
+        "entry_point": "demo:Plugin",
+        "signature_algorithm": PLUGIN_SIGNATURE_ALGORITHM,
+        "signature_key_id": "local-dev",
+    }
+    manifest["signature"] = f"  {sign_manifest(manifest, secret='test-secret').upper()}  "
+
+    verify_manifest_signature(manifest, trust_store_path=trust_store_path)
+
+
+def test_load_plugin_trust_store_accepts_flat_key_map(tmp_path: Path) -> None:
+    trust_store_path = _write_json(tmp_path / "flat-trust.json", {"local-dev": "test-secret"})
+
+    assert load_plugin_trust_store(trust_store_path) == {"local-dev": "test-secret"}
+
+
+def test_load_plugin_trust_store_uses_nested_keys_without_trusting_metadata(tmp_path: Path) -> None:
+    trust_store_path = _write_json(
+        tmp_path / "nested-trust.json",
+        {
+            "schema_version": "1.0",
+            "owner": "security",
+            "keys": {"local-dev": "test-secret"},
+        },
+    )
+
+    assert load_plugin_trust_store(trust_store_path) == {"local-dev": "test-secret"}
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        ([], "must be a JSON object"),
+        ({"keys": []}, "must be a JSON object"),
+        ({"keys": {"": "secret"}}, "key ids must be non-empty strings"),
+        ({"keys": {"   ": "secret"}}, "key ids must be non-empty strings"),
+        ({"keys": {" local-dev ": "secret"}}, "key ids must not contain leading or trailing whitespace"),
+        ({"keys": {"local-dev": 123}}, "secret for 'local-dev' must be a non-empty string"),
+        ({"keys": {"local-dev": ""}}, "secret for 'local-dev' must be a non-empty string"),
+        ({"keys": {"local-dev": "   "}}, "secret for 'local-dev' must be a non-empty string"),
+    ],
+)
+def test_load_plugin_trust_store_rejects_malformed_trust_sets(
+    tmp_path: Path,
+    payload: object,
+    message: str,
+) -> None:
+    trust_store_path = _write_json(tmp_path / "bad-trust.json", payload)
+
+    with pytest.raises(PluginSignatureError, match=message):
+        load_plugin_trust_store(trust_store_path)
+
+
+def test_verify_manifest_signature_rejects_unknown_key_id(tmp_path: Path) -> None:
+    trust_store_path = _write_json(tmp_path / "trust.json", {"keys": {"trusted": "test-secret"}})
+    manifest = {
+        "name": "demo",
+        "version": "1.0.0",
+        "entry_point": "demo:Plugin",
+        "signature_algorithm": PLUGIN_SIGNATURE_ALGORITHM,
+        "signature_key_id": "untrusted",
+    }
+    manifest["signature"] = sign_manifest(manifest, secret="test-secret")
+
+    with pytest.raises(PluginSignatureError, match="signature_key_id 'untrusted' is not trusted"):
+        verify_manifest_signature(manifest, trust_store_path=trust_store_path)
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"signature_key_id": 123}, "signature_key_id is required"),
+        ({"signature_key_id": ""}, "signature_key_id is required"),
+        ({"signature_key_id": "   "}, "signature_key_id is required"),
+        (
+            {"signature_key_id": " local-dev "},
+            "signature_key_id must not contain leading or trailing whitespace",
+        ),
+        ({"signature": 123}, "signature is required"),
+        ({"signature": ""}, "signature is required"),
+        ({"signature": "   "}, "signature is required"),
+        ({"signature": "0" * 64}, "signature does not match trusted key"),
+    ],
+)
+def test_verify_manifest_signature_rejects_missing_or_mismatched_signature_fields(
+    tmp_path: Path,
+    overrides: dict[str, object],
+    message: str,
+) -> None:
+    trust_store_path = _write_json(tmp_path / "trust.json", {"keys": {"local-dev": "test-secret"}})
+    manifest = {
+        "name": "demo",
+        "version": "1.0.0",
+        "entry_point": "demo:Plugin",
+        "signature_algorithm": PLUGIN_SIGNATURE_ALGORITHM,
+        "signature_key_id": "local-dev",
+    }
+    manifest["signature"] = sign_manifest(manifest, secret="test-secret")
+    manifest.update(overrides)
+
+    with pytest.raises(PluginSignatureError, match=message):
+        verify_manifest_signature(manifest, trust_store_path=trust_store_path)
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {},
+        {"signature_algorithm": None},
+        {"signature_algorithm": 123},
+        {"signature_algorithm": ""},
+        {"signature_algorithm": "   "},
+        {"signature_algorithm": "sha256"},
+    ],
+)
+def test_verify_manifest_signature_rejects_signature_algorithm_drift(
+    tmp_path: Path,
+    overrides: dict[str, object],
+) -> None:
+    trust_store_path = _write_json(tmp_path / "trust.json", {"keys": {"local-dev": "test-secret"}})
+    manifest = {
+        "name": "demo",
+        "version": "1.0.0",
+        "entry_point": "demo:Plugin",
+        "signature_key_id": "local-dev",
+        "signature": "not-a-valid-hmac",
+    }
+    manifest.update(overrides)
+
+    with pytest.raises(PluginSignatureError, match="signature_algorithm must be 'hmac-sha256'"):
+        verify_manifest_signature(manifest, trust_store_path=trust_store_path)


### PR DESCRIPTION
## Summary
- Add focused regression coverage for the architecture-cleanup seams that landed around jobs routing, typed job payload validation, durable SSE replay, runtime licensing evidence, plugin trust enforcement, and storage snapshot isolation.
- Make the jobs router factory callable as `create_jobs_router(JobRouteHandlers)` while preserving the app's explicit env-derived list limit override.

## Changes
- Added jobs-router factory tests for route parity, response models, handler delegation, validation short-circuiting, and the default factory API.
- Expanded orchestrator HTTP tests for typed job payload error envelopes, durable SSE replay/fallback, Last-Event-ID parsing, event ids, and live fanout isolation.
- Added repository contract coverage for mutable snapshot isolation, no-op update parity, append-log batching, event payload copies, ordering, caps, and reset.
- Added offline Postgres storage tests for create-time mutable snapshot isolation and event append/replay payload copies without requiring a live Postgres service.
- Added plugin signing/trust-store coverage and manifest-loader trust-mode import guards.
- Added runtime licensing/run-card schema coverage and MessagePack manifest round-trip preservation.
- Added performance-monitor structural tests for nightly gate failure modes and policy alignment.

## Validation
Proven green:
- `.venv/bin/pytest tests/api/test_jobs_router_factory.py tests/test_app_route_inventory.py -q` -> `28 passed`
- `.venv/bin/pytest tests/test_app_orchestrator_contract_http.py -k "replay_failure" -q` -> `3 passed, 269 deselected`
- `.venv/bin/pytest tests/test_app_orchestrator_contract_http.py -k "publish_event or job_events_replay or event_queue_seq or last_event_id" -q` -> `58 passed, 214 deselected`
- `.venv/bin/pytest tests/orchestrator/test_repository_contract.py tests/orchestrator/test_orchestrator_factories.py -q` -> `73 passed, 1 skipped`
- `.venv/bin/pytest tests/orchestrator/test_postgres_storage_offline.py -q` -> `3 passed`
- `.venv/bin/pytest tests/orchestrator/test_repository_contract.py tests/orchestrator/test_orchestrator_factories.py tests/orchestrator/test_postgres_storage_offline.py -q --cov=transformation_portal.orchestrator.storage.memory --cov=transformation_portal.orchestrator.storage.postgres --cov-report=term-missing` -> `76 passed, 1 skipped`; Postgres storage focused coverage rose to `29.87%` with memory storage still `100.00%`
- `.venv/bin/pytest tests/lux_depth_v3/test_orchestrator_run_card_provenance.py -q` -> `20 passed`
- `.venv/bin/pytest tests/api/test_jobs_router_factory.py tests/test_app_route_inventory.py tests/structural/test_performance_monitor_gate_contract.py tests/unit/plugins/test_signing.py tests/unit/plugins/test_loader_manifest_loading.py tests/orchestrator/test_repository_contract.py tests/orchestrator/test_orchestrator_factories.py tests/orchestrator/test_postgres_storage_offline.py tests/lux_depth_v3/test_orchestrator_run_card_provenance.py tests/test_run_card_schema.py tests/test_app_orchestrator_contract_http.py tests/test_phase3_advanced.py -k "not integration" -q` -> `577 passed, 4 skipped`
- `git diff --check -- . ':!AGENTS.md'` -> clean
- `git diff --cached --check` -> clean
- `make ci-quick` -> passed

Still failing:
- None observed.

## Risk
- Runtime changes are bounded to contract-preserving hardening: payload snapshots, stricter event-id parsing, internal router default, manifest round-trip fields, storage copy isolation, and plugin trust validation.
- Existing route shapes, selectors, API envelopes, auth behavior, v1/v2 jobs parity, and SSE payload names are preserved.
- Additive tests and schema/runtime compatibility checks make the change revert-safe; legacy run-card/manifest payloads without licensing remain tolerated.
