### PR TITLE
fix(portal): harden local launch runtime validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,6 +119,7 @@ web/secure-landing/.next/
 web/secure-landing/.next-build-verify/
 web/secure-landing/.next-smoke-*/
 web/secure-landing/.next-codex-*/
+web/secure-landing/tmp/
 web/secure-landing/node_modules/
 web/secure-landing/test-results/
 web/secure-landing/playwright-report/

--- a/Makefile
+++ b/Makefile
@@ -248,7 +248,7 @@ install-fastvlm-runtime:
 
 check-fastvlm-runtime:
 	@echo "Verifying governed FastVLM advisory captioning runtime..."
-	@"$(PY)" scripts/validation/validate_fastvlm_runtime.py --verify-only --models "$${TP_FASTVLM_VALIDATE_MODELS:-smoke,default}"
+	@"$(PY)" scripts/validation/validate_fastvlm_runtime.py --models "$${TP_FASTVLM_VALIDATE_MODELS:-smoke,default}"
 
 test-fast:
 	@"$(PY)" -m pytest -q $(FAST_TESTS) $(PHASE6_SMOKE_TESTS)

--- a/config/fastvlm_runtime_requirements.txt
+++ b/config/fastvlm_runtime_requirements.txt
@@ -17,7 +17,7 @@ dill==0.4.1
 fastapi==0.136.1
 filelock==3.29.0
 frozenlist==1.8.0
-fsspec==2026.4.0
+fsspec==2026.2.0
 gradio==6.14.0
 gradio_client==2.5.0
 groovy==0.1.2
@@ -38,7 +38,7 @@ mpmath==1.3.0
 multidict==6.7.1
 multiprocess==0.70.19
 networkx==3.6.1
-numpy==2.4.4
+numpy==2.2.6
 opencv-python==4.10.0.84
 orjson==3.11.9
 packaging==26.2
@@ -61,7 +61,7 @@ requests==2.34.2
 rich==15.0.0
 safehttpx==0.1.7
 safetensors==0.7.0
-scipy==1.15.0
+scipy==1.13.1
 semantic-version==2.10.0
 shellingham==1.5.4
 six==1.17.0

--- a/docs/runtimes/fastvlm.md
+++ b/docs/runtimes/fastvlm.md
@@ -197,6 +197,13 @@ TP_PORTAL_FASTVLM_CAPTIONING_ROLLOUT_PERCENT=100 \
 make validate-portal-fastvlm-captioning-live
 ```
 
+`make check-fastvlm-runtime` runs the import-smoke check and requires the local
+MLX/Metal runtime to be usable. In headless or sandboxed macOS sessions without
+a Metal device, use
+`./scripts/validation/validate_fastvlm_runtime.py --verify-only --models smoke,default`
+only for static manifest, source, Python,
+and checksum evidence; it is not enough to prove caption generation can run.
+
 ## Standalone Smoke Test
 
 Run the local command against one source image:

--- a/docs/schemas/run_card/run_card.v1.schema.json
+++ b/docs/schemas/run_card/run_card.v1.schema.json
@@ -360,6 +360,24 @@
         "operational_fallback_images": {
           "type": "integer",
           "minimum": 0
+        },
+        "requested_backend_status": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "honored",
+            "not_honored",
+            null
+          ]
+        },
+        "requested_backend_defect": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1
         }
       },
       "additionalProperties": false

--- a/docs/schemas/run_card/run_card.v2.schema.json
+++ b/docs/schemas/run_card/run_card.v2.schema.json
@@ -360,6 +360,24 @@
         "operational_fallback_images": {
           "type": "integer",
           "minimum": 0
+        },
+        "requested_backend_status": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "honored",
+            "not_honored",
+            null
+          ]
+        },
+        "requested_backend_defect": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1
         }
       },
       "additionalProperties": false

--- a/scripts/setup/run_frontdoor_local.sh
+++ b/scripts/setup/run_frontdoor_local.sh
@@ -9,6 +9,7 @@ FASTAPI_ORIGIN="${TP_FASTAPI_ORIGIN:-http://127.0.0.1:8000}"
 SESSION_DB="${TP_FRONTDOOR_SESSION_DB:-/tmp/transformation-portal-frontdoor-sessions.db}"
 BACKEND_API_KEY="${TP_BACKEND_API_KEY:-${TP_API_KEY:-}}"
 FRONTDOOR_DIST_DIR="${TP_FRONTDOOR_DIST_DIR:-}"
+FRONTDOOR_NEXT_DEV_ENGINE="${TP_FRONTDOOR_NEXT_DEV_ENGINE:-webpack}"
 DEFAULT_USERS_FILE="${TP_FRONTDOOR_USERS_FILE:-/tmp/tp-frontdoor-users.json}"
 DEFAULT_FRONTDOOR_USERNAME="${TP_FRONTDOOR_USERNAME:-smoke-admin}"
 DEFAULT_FRONTDOOR_PASSWORD="${TP_FRONTDOOR_PASSWORD:-correct horse battery staple}"
@@ -115,11 +116,34 @@ if [[ -n "${FRONTDOOR_DIST_DIR}" ]]; then
   export TP_NEXT_DIST_DIR="${FRONTDOOR_DIST_DIR}"
 fi
 
+NEXT_DEV_ARGS=(--hostname "${FRONTDOOR_HOST}" --port "${FRONTDOOR_PORT}")
+case "${FRONTDOOR_NEXT_DEV_ENGINE}" in
+  webpack)
+    NEXT_DEV_ARGS=(--webpack "${NEXT_DEV_ARGS[@]}")
+    ;;
+  turbopack|turbo)
+    NEXT_DEV_ARGS=(--turbo "${NEXT_DEV_ARGS[@]}")
+    ;;
+  auto|default|"")
+    FRONTDOOR_NEXT_DEV_ENGINE="auto"
+    ;;
+  *)
+    echo "TP_FRONTDOOR_NEXT_DEV_ENGINE must be one of: webpack, turbopack, auto."
+    exit 1
+    ;;
+esac
+
+if [[ "${TP_FRONTDOOR_WATCH_POLLING:-1}" != "0" ]]; then
+  export WATCHPACK_POLLING="${WATCHPACK_POLLING:-true}"
+  export CHOKIDAR_USEPOLLING="${CHOKIDAR_USEPOLLING:-true}"
+fi
+
 echo "Starting managed front door on http://${FRONTDOOR_HOST}:${FRONTDOOR_PORT}"
 echo "Using FastAPI origin ${TP_FASTAPI_ORIGIN}"
+echo "Using Next dev engine ${FRONTDOOR_NEXT_DEV_ENGINE}"
 if [[ -n "${FRONTDOOR_DIST_DIR}" ]]; then
   echo "Using isolated Next distDir ${TP_FRONTDOOR_DIST_DIR}"
 fi
 
 cd "${FRONTDOOR_ROOT}"
-npm run dev -- --hostname "${FRONTDOOR_HOST}" --port "${FRONTDOOR_PORT}"
+npm run dev -- "${NEXT_DEV_ARGS[@]}"

--- a/scripts/validation/fastvlm_runtime_manifest.py
+++ b/scripts/validation/fastvlm_runtime_manifest.py
@@ -311,6 +311,9 @@ def verify_python_imports(manifest: Mapping[str, Any], *, root: Path | None = No
         python_path = python_runtime_path(manifest, root=root)
     except ManifestError as exc:
         return [str(exc)]
+    python_errors = verify_python_runtime(manifest, root=root)
+    if python_errors:
+        return python_errors
     import_lines = (
         "import importlib, sys; "
         f"modules = {FASTVLM_RUNTIME_IMPORTS!r}; "

--- a/scripts/validation/fastvlm_runtime_manifest.py
+++ b/scripts/validation/fastvlm_runtime_manifest.py
@@ -312,18 +312,29 @@ def verify_python_imports(manifest: Mapping[str, Any], *, root: Path | None = No
     except ManifestError as exc:
         return [str(exc)]
     import_lines = (
-        "import importlib.util, sys; "
-        f"missing = [name for name in {FASTVLM_RUNTIME_IMPORTS!r} if importlib.util.find_spec(name) is None]; "
-        "print(','.join(missing), file=sys.stderr); "
+        "import importlib, sys; "
+        f"modules = {FASTVLM_RUNTIME_IMPORTS!r}; "
+        "missing = []; "
+        "\nfor name in modules:\n"
+        "    try:\n"
+        "        importlib.import_module(name)\n"
+        "    except Exception as exc:\n"
+        "        missing.append(f'{name}: {type(exc).__name__}: {exc}')\n"
+        "print('\\n'.join(missing), file=sys.stderr); "
         "sys.exit(1 if missing else 0)"
     )
-    completed = subprocess.run(
-        [str(python_path), "-c", import_lines],
-        check=False,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-    )
+    try:
+        completed = subprocess.run(
+            [str(python_path), "-c", import_lines],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=30,
+        )
+    except subprocess.TimeoutExpired as exc:
+        output = (exc.stderr if isinstance(exc.stderr, str) else "") or (exc.stdout if isinstance(exc.stdout, str) else "")
+        return ["FastVLM Python import smoke timed out after 30s: " + (output.strip() or str(python_path))]
     if completed.returncode == 0:
         return []
     return [

--- a/scripts/validation/validate_portal_fastvlm_captioning_live.py
+++ b/scripts/validation/validate_portal_fastvlm_captioning_live.py
@@ -16,6 +16,7 @@ from fastvlm_runtime_manifest import (
     load_manifest,
     runtime_root,
     selected_model_roles,
+    verify_python_imports,
     verify_runtime,
 )
 from validate_portal_lux_materials_live import (
@@ -69,6 +70,7 @@ def _validate_runtime_ready(model_role: str) -> None:
     root = runtime_root(manifest)
     roles = selected_model_roles(manifest, models=model_role)
     errors = verify_runtime(manifest, roles=roles, root=root)
+    errors.extend(verify_python_imports(manifest, root=root))
     if errors:
         raise SmokeFailure(
             "FastVLM runtime prerequisites are not ready:\n" + "\n".join(f"- {error}" for error in errors),

--- a/scripts/validation/validate_portal_fastvlm_captioning_live.py
+++ b/scripts/validation/validate_portal_fastvlm_captioning_live.py
@@ -70,7 +70,8 @@ def _validate_runtime_ready(model_role: str) -> None:
     root = runtime_root(manifest)
     roles = selected_model_roles(manifest, models=model_role)
     errors = verify_runtime(manifest, roles=roles, root=root)
-    errors.extend(verify_python_imports(manifest, root=root))
+    if not errors:
+        errors.extend(verify_python_imports(manifest, root=root))
     if errors:
         raise SmokeFailure(
             "FastVLM runtime prerequisites are not ready:\n" + "\n".join(f"- {error}" for error in errors),

--- a/src/transformation_portal/lux_depth_v3/orchestrator.py
+++ b/src/transformation_portal/lux_depth_v3/orchestrator.py
@@ -5083,6 +5083,10 @@ class EnhanceOrchestrator:
 
         self._enforce_apex_depth_png_uniqueness(results)
         batch_backend_summary = self._compute_backend_summary(results)
+        batch_requested_backend_defect = self._requested_backend_fulfillment_defect(
+            results,
+            batch_backend_summary,
+        )
         batch_backend_selection = self._build_backend_selection_payload(
             results,
             batch_backend_summary,
@@ -5122,7 +5126,11 @@ class EnhanceOrchestrator:
                 runtime_stats,
                 outliers,
                 batch_manifest_path=batch_manifest_path,
+                requested_backend_defect=batch_requested_backend_defect,
             )
+
+        if batch_requested_backend_defect is not None:
+            raise RuntimeError(batch_requested_backend_defect)
 
         return results
 
@@ -6633,6 +6641,7 @@ class EnhanceOrchestrator:
         runtime_stats: Dict[str, Any],
         outliers: List[Dict[str, Any]],
         batch_manifest_path: Optional[Path] = None,
+        requested_backend_defect: Optional[str] = None,
     ) -> None:
         """Emit run card for batch reproducibility.
 
@@ -6677,12 +6686,18 @@ class EnhanceOrchestrator:
         else:
             artifact_merkle_root = _compute_artifact_merkle_root(artifact_index)
         backend_summary = self._compute_backend_summary(results)
-        requested_backend_defect = self._requested_backend_fulfillment_defect(
-            results,
-            backend_summary,
-        )
+        if requested_backend_defect is None:
+            requested_backend_defect = self._requested_backend_fulfillment_defect(
+                results,
+                backend_summary,
+            )
         if requested_backend_defect is not None:
             logger.error(requested_backend_defect)
+            backend_summary = {
+                **backend_summary,
+                "requested_backend_status": "not_honored",
+                "requested_backend_defect": requested_backend_defect,
+            }
         backend_selection = self._build_backend_selection_payload(
             results,
             backend_summary,

--- a/src/transformation_portal/lux_depth_v3/pipeline_coordinator.py
+++ b/src/transformation_portal/lux_depth_v3/pipeline_coordinator.py
@@ -546,10 +546,10 @@ def infer_operational_error_code(
     message = str(error).lower()
     if "torch not compiled with cuda enabled" in message:
         return "CUDA_HARDCODED_IN_BACKEND"
-    if "cuda" in message and "not available" in message:
-        return "CUDA_UNAVAILABLE"
     if "mps" in message and "not available" in message:
         return "MPS_UNAVAILABLE"
+    if "cuda" in message and "not available" in message:
+        return "CUDA_UNAVAILABLE"
     return "BACKEND_RUNTIME_ERROR"
 
 

--- a/src/transformation_portal/lux_depth_v3/validators/run_card_backend_semantics.py
+++ b/src/transformation_portal/lux_depth_v3/validators/run_card_backend_semantics.py
@@ -49,6 +49,13 @@ def collect_run_card_backend_semantic_errors(payload: dict[str, Any]) -> list[st
 
     requested_backend = backend_selection.get("requested") or backend_summary.get("requested_backend")
     fallback_images = backend_summary.get("fallback_images")
+    requested_backend_defect = backend_summary.get("requested_backend_defect")
+    requested_backend_status = backend_summary.get("requested_backend_status")
+    explicit_requested_backend_defect = (
+        requested_backend_status == "not_honored"
+        and isinstance(requested_backend_defect, str)
+        and bool(requested_backend_defect.strip())
+    )
     total_images = payload.get("total_images")
     error_count = payload.get("error_count")
     run_failed = (
@@ -61,6 +68,7 @@ def collect_run_card_backend_semantic_errors(payload: dict[str, Any]) -> list[st
         and fallback_images == success_count
         and primary_backend != requested_backend
         and not run_failed
+        and not explicit_requested_backend_defect
     ):
         errors.append(
             "requested backend 'depth_pro' was not honored: "

--- a/src/transformation_portal/schemas/run_card/run_card.v1.schema.json
+++ b/src/transformation_portal/schemas/run_card/run_card.v1.schema.json
@@ -360,6 +360,24 @@
         "operational_fallback_images": {
           "type": "integer",
           "minimum": 0
+        },
+        "requested_backend_status": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "honored",
+            "not_honored",
+            null
+          ]
+        },
+        "requested_backend_defect": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1
         }
       },
       "additionalProperties": false

--- a/src/transformation_portal/schemas/run_card/run_card.v2.schema.json
+++ b/src/transformation_portal/schemas/run_card/run_card.v2.schema.json
@@ -360,6 +360,24 @@
         "operational_fallback_images": {
           "type": "integer",
           "minimum": 0
+        },
+        "requested_backend_status": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "honored",
+            "not_honored",
+            null
+          ]
+        },
+        "requested_backend_defect": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1
         }
       },
       "additionalProperties": false

--- a/src/transformation_portal/vlm_captioning/fastvlm_runtime.py
+++ b/src/transformation_portal/vlm_captioning/fastvlm_runtime.py
@@ -268,6 +268,14 @@ def _failure_result(
     )
 
 
+def _classify_nonzero_fastvlm_status(stdout: str, stderr: str) -> str:
+    """Classify non-zero FastVLM exits that represent unavailable runtime state."""
+    text = f"{stdout}\n{stderr}".lower()
+    if "no metal device available" in text or "metal::load_device" in text:
+        return "missing_runtime"
+    return "error"
+
+
 def run_fastvlm_caption(
     config: FastVLMRuntimeConfig,
     image_path: Path,
@@ -361,7 +369,7 @@ def run_fastvlm_caption(
     runtime_seconds = time.monotonic() - start
     parsed = parse_fastvlm_caption(completed.stdout)
     success = completed.returncode == 0
-    status = "ok" if success else "error"
+    status = "ok" if success else _classify_nonzero_fastvlm_status(completed.stdout, completed.stderr)
     error = None if success else f"FastVLM subprocess exited with code {completed.returncode}."
     result = FastVLMRuntimeResult(
         success=success,

--- a/tests/lux_depth_v3/test_pipeline_coordinator.py
+++ b/tests/lux_depth_v3/test_pipeline_coordinator.py
@@ -410,6 +410,16 @@ class TestRuntimeBackendStateHelpers:
         assert infer_operational_error_code(FileNotFoundError("missing")) == "BACKEND_RESOURCE_MISSING"
         assert infer_operational_error_code(RuntimeError("cuda not available")) == "CUDA_UNAVAILABLE"
         assert infer_operational_error_code(RuntimeError("mps not available")) == "MPS_UNAVAILABLE"
+        assert (
+            infer_operational_error_code(
+                RuntimeError(
+                    '{"cuda_available": false, "device": "mps", '
+                    '"mps_available": false, '
+                    '"reason": "PyTorch MPS backend is not available in this runtime."}'
+                )
+            )
+            == "MPS_UNAVAILABLE"
+        )
 
     def test_seed_depth_attempts_from_selection_fallback_records_depth_pro_failure(self):
         """Test startup fallback is materialized into per-image attempt history."""

--- a/tests/lux_depth_v3/validators/test_run_card_backend_semantics.py
+++ b/tests/lux_depth_v3/validators/test_run_card_backend_semantics.py
@@ -133,6 +133,19 @@ class TestDepthProFallbackPolicy:
         errors = collect_run_card_backend_semantic_errors(payload)
         assert any("'depth_pro' was not honored" in e for e in errors)
 
+    def test_full_fallback_with_explicit_defect_is_auditable(self):
+        payload = _base_payload(success_count=2, total_images=2, error_count=0)
+        payload["backend_selection"]["requested"] = "depth_pro"
+        payload["backend_selection"]["resolved"] = "da3"
+        payload["backend_summary"]["requested_backend"] = "depth_pro"
+        payload["backend_summary"]["primary_backend"] = "da3"
+        payload["backend_summary"]["final_backends_used"] = ["da3"]
+        payload["backend_summary"]["fallback_images"] = 2
+        payload["backend_summary"]["requested_backend_status"] = "not_honored"
+        payload["backend_summary"]["requested_backend_defect"] = "Depth Pro MPS runtime unavailable."
+
+        assert collect_run_card_backend_semantic_errors(payload) == []
+
     def test_partial_fallback_is_tolerated(self):
         payload = _base_payload(success_count=4, total_images=4, error_count=0)
         payload["backend_selection"]["requested"] = "depth_pro"

--- a/tests/test_run_card_schema.py
+++ b/tests/test_run_card_schema.py
@@ -2020,6 +2020,76 @@ def test_emit_run_card_respects_run_card_include_proofs_flag(tmp_path: Path):
     assert build_tree.call_args.kwargs["include_proofs"] is False
 
 
+def test_emit_run_card_preserves_requested_backend_defect(tmp_path: Path):
+    config = EnhanceConfig(
+        model_variant=ModelVariant.METRIC_LARGE,
+        model_key="da3-metric",
+        run_card_version="v1",
+    )
+    orch = EnhanceOrchestrator(config, tmp_path)
+
+    artifact_path = tmp_path / "depth" / "image_01_depth.png"
+    source_path = tmp_path / "inputs" / "image_01.png"
+    artifact_path.parent.mkdir(parents=True, exist_ok=True)
+    source_path.parent.mkdir(parents=True, exist_ok=True)
+    artifact_path.write_bytes(b"depth")
+    source_path.write_bytes(b"image")
+    defect = "Requested backend 'depth_pro' was not honored."
+
+    with (
+        patch.object(orch, "_collect_run_card_artifact_paths", return_value=[artifact_path]),
+        patch.object(
+            orch,
+            "_compute_backend_summary",
+            return_value={
+                "requested_backend": "depth_pro",
+                "primary_backend": "da3",
+                "final_backends_used": ["da3"],
+                "fallback_images": 1,
+                "semantic_fallback_images": 0,
+                "operational_fallback_images": 1,
+            },
+        ),
+        patch.object(
+            orch,
+            "_resolve_run_card_backend_model_artifact",
+            return_value={"model_artifact_filename": None, "model_artifact_sha256": None},
+        ),
+        patch.object(orch, "_resolve_run_card_backend_model_id", return_value="depth-anything/DA3"),
+    ):
+        orch._emit_run_card(
+            batch_id="2026-04-10_120000",
+            start_time="2026-04-10T12:00:00Z",
+            end_time="2026-04-10T12:05:00Z",
+            results=[
+                {
+                    "status": "ok",
+                    "image": str(source_path),
+                    "backend": "da3",
+                    "runtime_s": 1.0,
+                    "attempts": [
+                        {"backend": "depth_pro", "status": "failed", "failure_kind": "operational"},
+                        {"backend": "da3", "status": "success"},
+                    ],
+                }
+            ],
+            runtime_stats={
+                "count": 1,
+                "min": 1.0,
+                "max": 1.0,
+                "mean": 1.0,
+                "median": 1.0,
+                "total": 1.0,
+            },
+            outliers=[],
+            requested_backend_defect=defect,
+        )
+
+    run_card = json.loads((tmp_path / "run_card_2026-04-10_120000.json").read_text(encoding="utf-8"))
+    assert run_card["backend_summary"]["requested_backend_status"] == "not_honored"
+    assert run_card["backend_summary"]["requested_backend_defect"] == defect
+
+
 def test_emit_run_card_skips_legacy_merkle_root_for_v2(tmp_path: Path):
     config = EnhanceConfig(
         model_variant=ModelVariant.METRIC_LARGE,

--- a/tests/test_verify_run_card_integrity.py
+++ b/tests/test_verify_run_card_integrity.py
@@ -512,6 +512,29 @@ def test_verify_run_card_integrity_rejects_requested_depth_pro_full_fallback(tmp
     assert any("requested backend 'depth_pro' was not honored" in error for error in errors)
 
 
+def test_verify_run_card_integrity_accepts_explicit_requested_backend_defect(tmp_path: Path):
+    module = _load_script_module(
+        "verify_run_card_integrity_script_depth_pro_fallback_audited",
+        "scripts/verify_run_card_integrity.py",
+    )
+    run_card_path = tmp_path / "run_card_depth_pro_fallback_audited.json"
+    payload = _valid_run_card_payload(module)
+    payload["backend_selection"]["requested"] = "depth_pro"
+    payload["backend_selection"]["resolved"] = "da3"
+    payload["backend_summary"]["requested_backend"] = "depth_pro"
+    payload["backend_summary"]["primary_backend"] = "da3"
+    payload["backend_summary"]["final_backends_used"] = ["da3"]
+    payload["backend_summary"]["fallback_images"] = 2
+    payload["backend_summary"]["requested_backend_status"] = "not_honored"
+    payload["backend_summary"]["requested_backend_defect"] = "Depth Pro MPS runtime unavailable."
+    payload["total_images"] = 2
+    payload["success_count"] = 2
+    payload["error_count"] = 0
+    _write_json(run_card_path, payload)
+
+    assert module.verify_run_card_integrity(run_card_path) == []
+
+
 def test_verify_run_card_integrity_and_validator_share_depth_pro_fallback_semantics(tmp_path: Path):
     module = _load_script_module("verify_run_card_integrity_script_depth_pro_shared", "scripts/verify_run_card_integrity.py")
     from transformation_portal.lux_depth_v3.validators import validate_run_card_backend_semantics

--- a/tests/validation/test_portal_smoke_scripts.py
+++ b/tests/validation/test_portal_smoke_scripts.py
@@ -697,6 +697,31 @@ def test_portal_fastvlm_captioning_runtime_check_is_local_backend_scoped():
     )
 
 
+def test_portal_fastvlm_captioning_runtime_ready_skips_import_when_static_runtime_fails(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    module = _load_portal_fastvlm_captioning_module("tests_validate_portal_fastvlm_captioning_runtime_missing_python")
+    manifest = {"schema_version": "fastvlm-runtime.v1"}
+    runtime_root = Path("/tmp/fastvlm")
+    static_errors = [f"FastVLM Python executable missing: {runtime_root}/.venv-fastvlm/bin/python"]
+
+    monkeypatch.setattr(module, "load_manifest", lambda: manifest)
+    monkeypatch.setattr(module, "runtime_root", lambda _manifest: runtime_root)
+    monkeypatch.setattr(module, "selected_model_roles", lambda _manifest, *, models: [models])
+    monkeypatch.setattr(module, "verify_runtime", lambda *_args, **_kwargs: list(static_errors))
+
+    def fail_import_smoke(*_args, **_kwargs):  # noqa: ANN001
+        raise AssertionError("import smoke must be skipped when static runtime checks already failed")
+
+    monkeypatch.setattr(module, "verify_python_imports", fail_import_smoke)
+
+    with pytest.raises(module.SmokeFailure) as exc_info:
+        module._validate_runtime_ready("smoke")
+
+    assert exc_info.value.kind == "environment"
+    assert static_errors[0] in str(exc_info.value)
+
+
 def test_portal_lux_materials_sam2_prerequisite_reports_missing_checkpoint(tmp_path: Path):
     module = _load_module(PORTAL_LUX_MATERIALS_SCRIPT_PATH, "tests_validate_portal_lux_materials_sam2_prereq")
 

--- a/tests/vlm_captioning/test_fastvlm_runtime.py
+++ b/tests/vlm_captioning/test_fastvlm_runtime.py
@@ -264,6 +264,23 @@ def test_runtime_nonzero_exit(tmp_path: Path) -> None:
     assert "boom" in result.raw_stderr
 
 
+def test_runtime_classifies_headless_metal_failure_as_missing_runtime(tmp_path: Path) -> None:
+    runtime_dir = tmp_path / "runtime"
+    _write_fake_mlx_module(
+        runtime_dir,
+        "import sys\n"
+        "print('RuntimeError: [metal::load_device] No Metal device available.', file=sys.stderr)\n"
+        "sys.exit(1)\n",
+    )
+    config, image = _config(tmp_path, runtime_dir)
+
+    result = run_fastvlm_caption(config, image)
+
+    assert result.success is False
+    assert result.status == "missing_runtime"
+    assert "No Metal device available" in result.raw_stderr
+
+
 def test_runtime_malformed_output_returns_partial_parse(tmp_path: Path) -> None:
     runtime_dir = tmp_path / "runtime"
     _write_fake_mlx_module(runtime_dir, "print('SCENE=Patio; MATERIALS=stone.')\n")

--- a/tests/vlm_captioning/test_fastvlm_runtime_manifest.py
+++ b/tests/vlm_captioning/test_fastvlm_runtime_manifest.py
@@ -242,6 +242,30 @@ def test_fastvlm_import_smoke_imports_modules_and_reports_metal_failures(
     assert "No Metal device available" in errors[0]
 
 
+def test_fastvlm_import_smoke_reports_missing_python_without_spawning(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_script_module(
+        "fastvlm_runtime_manifest_import_smoke_missing_python_test",
+        "scripts/validation/fastvlm_runtime_manifest.py",
+    )
+    runtime_root = tmp_path / "fastvlm"
+    manifest = _manifest(tmp_path)
+    _write_fixture_runtime(runtime_root)
+    (runtime_root / ".venv-fastvlm" / "bin" / "python").unlink()
+
+    def fail_run(*_args, **_kwargs):  # noqa: ANN001
+        raise AssertionError("missing Python must be reported before subprocess.run")
+
+    monkeypatch.setattr(module.subprocess, "run", fail_run)
+
+    errors = module.verify_python_imports(manifest, root=runtime_root)
+
+    assert len(errors) == 1
+    assert "FastVLM Python executable missing" in errors[0]
+
+
 def test_validate_fastvlm_runtime_json_reports_static_and_import_checks(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],

--- a/tests/vlm_captioning/test_fastvlm_runtime_manifest.py
+++ b/tests/vlm_captioning/test_fastvlm_runtime_manifest.py
@@ -213,6 +213,35 @@ def test_validate_fastvlm_runtime_verify_only_skips_import_smoke(
     assert not import_smoke_calls
 
 
+def test_fastvlm_import_smoke_imports_modules_and_reports_metal_failures(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_script_module(
+        "fastvlm_runtime_manifest_import_smoke_test",
+        "scripts/validation/fastvlm_runtime_manifest.py",
+    )
+    runtime_root = tmp_path / "fastvlm"
+    manifest = _manifest(tmp_path)
+    _write_fixture_runtime(runtime_root)
+
+    def fake_run(args, **kwargs):  # noqa: ANN001
+        assert "importlib.import_module(name)" in args[-1]
+        return module.subprocess.CompletedProcess(
+            args,
+            returncode=1,
+            stdout="",
+            stderr="mlx_vlm: RuntimeError: [metal::load_device] No Metal device available.",
+        )
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    errors = module.verify_python_imports(manifest, root=runtime_root)
+
+    assert len(errors) == 1
+    assert "No Metal device available" in errors[0]
+
+
 def test_validate_fastvlm_runtime_json_reports_static_and_import_checks(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],

--- a/web/secure-landing/next.config.js
+++ b/web/secure-landing/next.config.js
@@ -1,18 +1,31 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import nextConstants from "next/constants.js";
 
 const appRoot = fileURLToPath(new URL(".", import.meta.url));
 const repoRoot = path.resolve(appRoot, "../..");
 const requestedDistDir = String(process.env.TP_NEXT_DIST_DIR || "").trim();
+const { PHASE_DEVELOPMENT_SERVER } = nextConstants;
 
 /** @type {import('next').NextConfig} */
-const nextConfig = {
-  output: "standalone",
-  distDir: requestedDistDir || ".next",
-  outputFileTracingRoot: repoRoot,
-  outputFileTracingIncludes: {
-    "/portal/assets/[...path]": ["../../config/portal_asset_manifest.json"]
-  }
-};
+function nextConfig(phase) {
+  const standaloneConfig = phase === PHASE_DEVELOPMENT_SERVER
+    ? {}
+    : {
+        output: "standalone",
+        outputFileTracingRoot: repoRoot,
+        outputFileTracingIncludes: {
+          "/portal/assets/[...path]": ["../../config/portal_asset_manifest.json"]
+        }
+      };
+
+  return {
+    distDir: requestedDistDir || ".next",
+    turbopack: {
+      root: repoRoot
+    },
+    ...standaloneConfig
+  };
+}
 
 export default nextConfig;

--- a/web/secure-landing/playwright.config.mjs
+++ b/web/secure-landing/playwright.config.mjs
@@ -130,7 +130,7 @@ export default defineConfig({
       // mock FastAPI origin above. Auth bypass for Cloudflare Access is
       // enabled via TP_ALLOW_LOCAL_ACCESS_BYPASS=1 +
       // NODE_ENV=development (lib/config.js:10-12).
-      command: `npm run dev -- --port ${webServerPort}`,
+      command: `npm run dev -- --webpack --port ${webServerPort}`,
       url: baseURL,
       reuseExistingServer: !isCi,
       timeout: 120_000,
@@ -141,6 +141,7 @@ export default defineConfig({
         TP_FRONTDOOR_USERS_JSON: frontdoorSmokeUsersJson,
         TP_ALLOW_LOCAL_ACCESS_BYPASS: "1",
         WATCHPACK_POLLING: "true",
+        CHOKIDAR_USEPOLLING: "true",
       },
     },
   ],

--- a/web/secure-landing/tests/routes.test.mjs
+++ b/web/secure-landing/tests/routes.test.mjs
@@ -199,10 +199,17 @@ test("next config honors TP_NEXT_DIST_DIR for isolated local frontdoor runs", as
 
   try {
     const configModule = await importFresh("../next.config.js");
-    assert.equal(configModule.default.distDir, ".next-smoke-test");
-    assert.equal(configModule.default.turbopack, undefined);
+    const productionConfig = configModule.default("phase-production-build");
+    const developmentConfig = configModule.default("phase-development-server");
+
+    assert.equal(productionConfig.distDir, ".next-smoke-test");
+    assert.equal(developmentConfig.distDir, ".next-smoke-test");
+    assert.equal(path.resolve(productionConfig.turbopack.root), REPO_ROOT);
+    assert.equal(path.resolve(developmentConfig.turbopack.root), REPO_ROOT);
+    assert.equal(developmentConfig.output, undefined);
+    assert.equal(developmentConfig.outputFileTracingRoot, undefined);
     assert.equal(
-      path.resolve(configModule.default.outputFileTracingRoot),
+      path.resolve(productionConfig.outputFileTracingRoot),
       REPO_ROOT,
       "standalone tracing must still include repo-root files such as the portal asset manifest"
     );
@@ -269,12 +276,13 @@ test("playwright frontdoor smoke config uses local preflight-safe fixtures", asy
     const env = frontdoor.env;
     const users = JSON.parse(env.TP_FRONTDOOR_USERS_JSON);
 
-    assert.equal(frontdoor.command, "npm run dev -- --port 3000");
+    assert.equal(frontdoor.command, "npm run dev -- --webpack --port 3000");
     assert.equal(env.NODE_ENV, "development");
     assert.equal(env.TP_ALLOW_LOCAL_ACCESS_BYPASS, "1");
     assert.equal(env.TP_FASTAPI_ORIGIN, "http://127.0.0.1:9999");
     assert.equal(env.TP_BACKEND_API_KEY, "frontdoor-browser-smoke");
     assert.equal(env.WATCHPACK_POLLING, "true");
+    assert.equal(env.CHOKIDAR_USEPOLLING, "true");
     assert.equal(users.length, 1);
     assert.equal(users[0].username, "smoke-admin");
     assert.equal(users[0].access_email, "smoke-admin@local.invalid");
@@ -304,7 +312,7 @@ test("playwright frontdoor smoke config derives webServer port from PLAYWRIGHT_B
 
     assert.equal(configModule.default.use.baseURL, "http://127.0.0.1:3017");
     assert.equal(frontdoor.url, "http://127.0.0.1:3017");
-    assert.equal(frontdoor.command, "npm run dev -- --port 3017");
+    assert.equal(frontdoor.command, "npm run dev -- --webpack --port 3017");
   } finally {
     restorePlaywrightConfigEnv(snapshot);
   }
@@ -335,6 +343,11 @@ test("run_frontdoor_local launcher supports isolated port, distdir, and local us
   assert.match(script, /TP_FRONTDOOR_PORT/);
   assert.match(script, /TP_FRONTDOOR_DIST_DIR/);
   assert.match(script, /TP_NEXT_DIST_DIR/);
+  assert.match(script, /TP_FRONTDOOR_NEXT_DEV_ENGINE:-webpack/);
+  assert.match(script, /TP_FRONTDOOR_WATCH_POLLING:-1/);
+  assert.match(script, /WATCHPACK_POLLING:-true/);
+  assert.match(script, /CHOKIDAR_USEPOLLING:-true/);
+  assert.match(script, /npm run dev -- "\$\{NEXT_DEV_ARGS\[@\]\}"/);
   assert.match(script, /TP_FRONTDOOR_USERS_FILE:-\/tmp\/tp-frontdoor-users\.json/);
   assert.match(script, /TP_FRONTDOOR_USERNAME:-smoke-admin/);
   assert.match(script, /TP_FRONTDOOR_PASSWORD:-correct horse battery staple/);


### PR DESCRIPTION
## Summary
- Hardens the local all-on portal/frontdoor launch path and optional runtime checks without changing public routes, auth flow, query parameters, or backend API envelopes.
- Makes runtime failures observable: FastVLM validation now imports the runtime stack, headless Metal failures classify as missing runtime, and full requested Depth Pro fallback is captured in run-card evidence before the batch fails.

## Changes
- Default the local managed frontdoor launcher and Playwright web server to Next dev `--webpack` with file watching polling enabled, while keeping an explicit `TP_FRONTDOOR_NEXT_DEV_ENGINE` override.
- Make `next.config.js` phase-aware so development avoids standalone output while production keeps standalone tracing; set Turbopack root consistently with the repo tracing root.
- Tighten FastVLM runtime requirements and make `make check-fastvlm-runtime` run import-smoke validation instead of static manifest-only checks.
- Extend the live FastVLM portal smoke prerequisite check with runtime import validation.
- Classify FastVLM subprocess Metal-device failures as `missing_runtime`.
- Add audited run-card fields for requested backend defects when Depth Pro is fully not honored, and keep backend semantic validation aligned with that evidence.
- Add `web/secure-landing/tmp/` to `.gitignore` for local Next dev output.

Contract notes:
- No route, auth, selector, query parameter, or public API shape changes.
- Run-card schema change is additive optional metadata: `requested_backend_status` and `requested_backend_defect`.
- Make target behavior changes intentionally make unusable FastVLM runtimes fail closed instead of passing static checks.

## Validation
Proven green:
- `.venv/bin/pytest tests/lux_depth_v3/test_pipeline_coordinator.py::TestRuntimeBackendStateHelpers::test_infer_operational_error_code_classifies_known_failures tests/vlm_captioning/test_fastvlm_runtime.py::test_runtime_classifies_headless_metal_failure_as_missing_runtime tests/vlm_captioning/test_fastvlm_runtime_manifest.py::test_fastvlm_import_smoke_imports_modules_and_reports_metal_failures tests/lux_depth_v3/validators/test_run_card_backend_semantics.py::TestDepthProFallbackPolicy::test_full_fallback_with_explicit_defect_is_auditable tests/test_verify_run_card_integrity.py::test_verify_run_card_integrity_accepts_explicit_requested_backend_defect -q`
- `.venv/bin/python -m py_compile scripts/validation/fastvlm_runtime_manifest.py scripts/validation/validate_portal_fastvlm_captioning_live.py`
- `.venv/bin/pytest tests/lux_depth_v3/test_pipeline_coordinator.py tests/vlm_captioning/test_fastvlm_runtime.py tests/vlm_captioning/test_fastvlm_runtime_manifest.py tests/lux_depth_v3/validators/test_run_card_backend_semantics.py tests/lux_depth_v3/validators/test_run_card_validator.py tests/test_verify_run_card_integrity.py tests/test_run_card_schema.py tests/validation/test_portal_smoke_scripts.py::test_portal_fastvlm_captioning_runtime_check_is_local_backend_scoped -q` (`268 passed`)
- `jq empty docs/schemas/run_card/run_card.v1.schema.json docs/schemas/run_card/run_card.v2.schema.json src/transformation_portal/schemas/run_card/run_card.v1.schema.json src/transformation_portal/schemas/run_card/run_card.v2.schema.json`
- `env PATH=/Users/richardcheetham/.nvm/versions/node/v22.22.2/bin:/usr/bin:/bin:/usr/sbin:/sbin npm run build:portal`
- `env PATH=/Users/richardcheetham/.nvm/versions/node/v22.22.2/bin:/usr/bin:/bin:/usr/sbin:/sbin npm run lint:css`
- `/Users/richardcheetham/.nvm/versions/node/v22.22.2/bin/node --experimental-specifier-resolution=node --test tests/routes.test.mjs` (`86 passed`)
- `env PATH=/Users/richardcheetham/.nvm/versions/node/v22.22.2/bin:/usr/bin:/bin:/usr/sbin:/sbin make test-frontdoor-contract` (`255 passed`, Next production build passed)
- `make check-portal-asset-budgets`
- `git diff --check`
- `git diff --cached --check`

Still failing / environment-only:
- `make check-fastvlm-runtime` fails locally because MLX reports `[metal::load_device] No Metal device available`; this is the intended fail-closed behavior for an unusable headless/sandboxed Metal runtime, not a product regression.
- Running `node --experimental-specifier-resolution=node --test tests/routes.test.mjs` with ambient Node `v25.9.0` fails on the existing `better-sqlite3` native addon ABI. The required Node `v22.22.2` path above passes.

## Risk
- Compatibility risk is bounded to local development launch and optional runtime validation.
- Production route/auth/proxy contracts are unchanged and covered by the frontdoor contract suite.
- Runtime behavior is intentionally stricter for FastVLM and full requested Depth Pro fallback; the change is fail-closed and revert-safe.
