### PR TITLE
chore(schemas): codify schema contract topology

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -43,6 +43,7 @@ for `docs/cli`.
 | TODO governance | [TODO Inventory](analysis/TODO_INVENTORY.md), [TODO Action Plan](analysis/TODO_ACTION_PLAN.md), [TODO Quick Reference](architecture/TODO_INVENTORY_QUICK_REF.md), [TODO Priority Schema](governance/todo_priority_schema.yaml) | Current scanner-governed baseline: 24 governed `NotImplementedError` items, 0 ungoverned TODOs, snapshot refreshed May 11, 2026. |
 | Archive gates | [Archive Machine Contract](api/ARCHIVE_MACHINE_MODE_CONTRACT.md), [2026-04-27 Archive Gates Audit](governance/audit/archive-gates-2026-04-27.md) | Gates A/B/C are documented with the April 27 readiness audit and normalized JSON evidence. |
 | APEX / Materials | [APEX Governance Status](apex/GOVERNANCE_STATUS.md), [APEX Workflow Design](architecture/APEX_WORKFLOW_DESIGN.md), [APEX Model Family Characterization](validation/APEX_MODEL_FAMILY_CHARACTERIZATION_PROTOCOL.md) | Recent merges added offline model-family characterization, failure-code surfacing, confidence-only pixel-op passthrough, V2 fallback, and SAM2 tile-merge regression coverage. |
+| Schema contracts | [Schema Contracts](../schemas/README.md), [Metadata Schema](schemas/METADATA_SCHEMA.md) | Root `schemas/` holds live machine-readable runtime contracts/profiles; `docs/schemas/` holds published schema contracts and schema documentation. |
 | CLI references | [CLI Index](cli/README.md), [CLI Reference](cli/CLI_REFERENCE.md), [Lux Depth V3 CLI Guide](cli/LUX_DEPTH_V3_CLI_GUIDE.md), [PBR CLI Testing Guide](cli/PBR_CLI_TESTING_GUIDE.md) | Maintained CLI docs use repo-governed `.venv` and Make targets; old PBR coverage/checklist and CLI v1.3 notes are historical evidence. |
 | Advisory captioning | [FastVLM Runtime](runtimes/fastvlm.md) | Optional subprocess-isolated sidecars only; captions are advisory and never satisfy APEX or Materials V3 gates. |
 | Portal UX/UI planning | [Portal UX/UI Status Snapshot](architecture/DNA_UX_UI_STRATEGY_REBASELINE_2026-04-08.md) | Current planning context through #1721; status snapshot only, not a next-PR selector. |
@@ -95,4 +96,4 @@ make check-doc-heading-links
 python3 scripts/governance/check_docs_structure.py --all
 ```
 
-**Last Updated:** 2026-05-15
+**Last Updated:** 2026-06-01

--- a/docs/governance/DOCUMENTATION_MAP.md
+++ b/docs/governance/DOCUMENTATION_MAP.md
@@ -3,7 +3,7 @@
 **Purpose:** Current source of truth for finding maintained Transformation
 Portal documentation.
 
-**Last Updated:** 2026-05-15
+**Last Updated:** 2026-06-01
 **Maintainer:** Repository Architect
 **Current baseline:** repo-wide refresh audit dated May 11, 2026, building on
 `main` through PR #1721, with the May 12 architecture triage overlay for
@@ -93,6 +93,7 @@ operator guidance unless they are linked here as canonical documents.
 | Portal UX/UI status snapshot | [Portal UX/UI Status Snapshot](../architecture/DNA_UX_UI_STRATEGY_REBASELINE_2026-04-08.md) | Current planning-context snapshot; does not choose the next implementation PR |
 | APEX workflow design | [APEX_WORKFLOW_DESIGN.md](../architecture/APEX_WORKFLOW_DESIGN.md) | Maintained |
 | Deterministic RAW ingest | [ADR-030](../architecture/ADR-030-phase2-deterministic-raw-ingest.md) | Maintained |
+| Schema contracts and topology | [Schema Contracts](../../schemas/README.md), [docs/schemas](../schemas/) | Maintained boundary for root runtime schema/profile contracts versus published schema contracts under docs |
 | Plugin manifest trust | [ADR-049](../architecture/ADR-049-plugin-manifest-trust.md) | Maintained in-process external plugin trust boundary |
 | Determinism harness spec | [SPEC-DH-001](../architecture/specifications/SPEC-DH-001.md) | Locked |
 

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,0 +1,39 @@
+# Schema Contracts
+
+This directory contains repo-owned machine-readable contracts and versioned
+runtime profiles that code loads directly from the repository root. It is a
+live contract surface, not historical material.
+
+## Placement
+
+- `schemas/phase4/*.schema.json` are the authoritative JSON Schema contracts
+  for Phase 4 capture metadata, manifests, provenance, Merkle roots, and
+  verification reports. ADR-035 and the Phase 4 tools intentionally reference
+  this root-level location.
+- `schemas/profiles/*.json` are versioned runtime projection profiles. They
+  are not JSON Schema contracts and must not use the `.schema.json` suffix.
+- Published schema contracts, schema docs, and externally linked schema copies
+  that are not runtime defaults belong under `docs/schemas/`.
+
+Do not add another top-level schema tree. Use root `schemas/` only when the
+runtime, validation tools, or tests intentionally load the file from the repo
+root. Use `docs/schemas/` for published documentation contracts.
+
+## Naming
+
+- JSON Schema files use `*.schema.json`, declare Draft 2020-12 with `$schema`,
+  and keep stable `$id` values that match their repo path.
+- Runtime profile files use a fully qualified versioned contract id as the
+  filename, for example `tp.projection.machine_to_evidence.v1.json`.
+- Runtime profile payloads include a `schema` field matching the filename stem
+  and a `source_schema` field for the input contract they project.
+
+## Validation
+
+Run the focused topology and contract checks after moving, adding, or editing
+schema files:
+
+```bash
+.venv/bin/python -m pytest tests/test_schema_topology_contract.py
+.venv/bin/python tools/validate_evalsuite_contract_schemas.py
+```

--- a/schemas/profiles/tp.projection.machine_to_evidence.v1.json
+++ b/schemas/profiles/tp.projection.machine_to_evidence.v1.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "schema": "tp.projection.machine_to_evidence.v1",
   "description": "Projection profile for deriving reproducible evidence hashes from tp.meta.machine.v1 envelopes.",
   "source_schema": "tp.meta.machine.v1",

--- a/tests/test_schema_topology_contract.py
+++ b/tests/test_schema_topology_contract.py
@@ -1,0 +1,84 @@
+"""Contract tests for repo schema/profile placement and naming."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+import pytest
+
+from transformation_portal.ingest.evidence import (
+    DEFAULT_PROJECTION_PROFILE,
+    DEFAULT_PROJECTION_PROFILE_PATH,
+    MACHINE_SCHEMA_VERSION,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+]
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DRAFT_2020_12 = "https://json-schema.org/draft/2020-12/schema"
+
+PHASE4_SCHEMA_CONTRACT_FIELDS = {
+    "metadata.schema.json": ("metadata_contract_version", "tp.meta.capture.v1"),
+    "metadata_manifest.schema.json": ("metadata_manifest_contract_version", "tp.meta.capture_manifest.v1"),
+    "provenance_manifest.schema.json": ("provenance_contract_version", "tp.meta.provenance.v1"),
+    "provenance_merkle.schema.json": ("provenance_merkle_contract_version", "tp.meta.provenance_merkle.v1"),
+    "verification_report.schema.json": ("verification_contract_version", "tp.meta.verification_report.v1"),
+}
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict), f"{path} must contain a JSON object"
+    return payload
+
+
+def test_phase4_schemas_remain_authoritative_root_contracts() -> None:
+    phase4_root = REPO_ROOT / "schemas" / "phase4"
+    schema_paths = sorted(phase4_root.glob("*.schema.json"))
+
+    assert [path.name for path in schema_paths] == sorted(PHASE4_SCHEMA_CONTRACT_FIELDS)
+
+    for path in schema_paths:
+        payload = _load_json(path)
+        jsonschema.Draft202012Validator.check_schema(payload)
+
+        assert payload["$schema"] == DRAFT_2020_12
+        assert payload["$id"].endswith(path.relative_to(REPO_ROOT).as_posix())
+
+        version_field, contract_version = PHASE4_SCHEMA_CONTRACT_FIELDS[path.name]
+        assert payload["properties"][version_field]["const"] == contract_version
+
+
+def test_docs_schema_tree_contains_published_json_schema_contracts() -> None:
+    docs_schema_paths = sorted((REPO_ROOT / "docs" / "schemas").rglob("*.schema.json"))
+
+    assert docs_schema_paths
+    for path in docs_schema_paths:
+        payload = _load_json(path)
+        jsonschema.Draft202012Validator.check_schema(payload)
+
+        assert payload["$schema"] == DRAFT_2020_12
+        assert "$id" in payload
+        assert "title" in payload
+
+
+def test_runtime_projection_profiles_are_not_json_schema_contracts() -> None:
+    profile_root = REPO_ROOT / "schemas" / "profiles"
+    profile_paths = sorted(profile_root.glob("*.json"))
+
+    assert [path.name for path in profile_paths] == [f"{DEFAULT_PROJECTION_PROFILE}.json"]
+    assert DEFAULT_PROJECTION_PROFILE_PATH == profile_paths[0]
+
+    for path in profile_paths:
+        assert not path.name.endswith(".schema.json")
+        payload = _load_json(path)
+
+        assert "$schema" not in payload
+        assert payload["schema"] == path.stem == DEFAULT_PROJECTION_PROFILE
+        assert payload["source_schema"] == MACHINE_SCHEMA_VERSION
+        assert all(isinstance(pointer, str) and pointer.startswith("/") for pointer in payload["drop_paths"])


### PR DESCRIPTION
## Summary
- Clarifies the schema-topology boundary after auditing root `schemas/` and `docs/schemas/` usage.
- Keeps authoritative Phase 4 runtime schemas in root `schemas/phase4` and documents when root schema/profile files are allowed.

## Changes
- Added `schemas/README.md` with placement, naming, and validation rules for runtime schemas/profiles versus published docs schemas.
- Linked the schema-topology boundary from `docs/README.md` and `docs/governance/DOCUMENTATION_MAP.md`.
- Removed the misleading JSON Schema `$schema` marker from the runtime projection profile `schemas/profiles/tp.projection.machine_to_evidence.v1.json`.
- Added `tests/test_schema_topology_contract.py` to lock Phase 4 schema placement, docs schema metadata, and projection-profile naming.
- No API routes, selectors, CLI flags, env vars, Make targets, or runtime envelopes change.

## Validation
Proven green:
- `.venv/bin/python -m pytest tests/test_schema_topology_contract.py tests/ingest/test_evidence_artifact.py tests/ingest/test_build_machine_evidence_cli.py -q`
- `.venv/bin/python tools/validate_evalsuite_contract_schemas.py`
- `make check-doc-heading-links`
- `python3 scripts/governance/check_docs_structure.py --all`
- `git diff --check`
- `make ci-quick`

Still failing:
- None observed locally.

Failure classification:
- No product logic, stale test, or environment/tooling failures remain from the local validation run.

## Risk
- Low compatibility risk: authoritative Phase 4 schema paths stay unchanged and the evidence projection profile still carries the same `schema`, `source_schema`, and `drop_paths` values.
- Bounded and revert-safe: the change is limited to schema-boundary docs, one profile metadata cleanup, and topology tests.