### PR TITLE
fix(lint): align pylint config authority

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,10 +1,10 @@
 [MASTER]
 ignore=build,dist,.venv,.eggs
 ignore-paths=
-    ^tools/deprecated/.*$,
-    ^src/transformation_portal/.*$,
-    ^src/luxury_tiff_batch_processor/.*$,
-    ^scripts/.*$
+    ^tools/deprecated(?:/.*)?$,
+    ^src/transformation_portal(?:/.*)?$,
+    ^src/luxury_tiff_batch_processor(?:/.*)?$,
+    ^scripts(?:/.*)?$
 jobs=1
 persistent=no
 

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,6 +1,11 @@
 [MASTER]
-ignore=build,dist,.venv,.eggs,tools/deprecated,src/transformation_portal,src/luxury_tiff_batch_processor,scripts
-jobs=0
+ignore=build,dist,.venv,.eggs
+ignore-paths=
+    ^tools/deprecated/.*$,
+    ^src/transformation_portal/.*$,
+    ^src/luxury_tiff_batch_processor/.*$,
+    ^scripts/.*$
+jobs=1
 persistent=no
 
 [MESSAGES CONTROL]
@@ -21,7 +26,6 @@ disable=
     C0411, C0412,         # wrong-import-order, ungrouped-imports (not critical)
     C0325,                # superfluous-parens (readability preference)
     R1735, R1705,         # use-dict-literal, no-else-return (style preference)
-    W0611,                # unused-import (managed by flake8)
     C0209,                # consider-using-f-string (not critical)
     W1514,                # unspecified-encoding (acceptable for most cases)
     E1123,                # unexpected-keyword-arg (false positives with optional deps)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,26 +175,6 @@ exclude = ["tests*", "data*", "docs*", "scripts"]
 [tool.setuptools.package-data]
 "transformation_portal.schemas.run_card" = ["*.json"]
 
-[tool.pylint.main]
-# Increase limits for complex image/video processing functions
-max-args = 8
-max-locals = 20
-max-branches = 15
-max-statements = 60
-max-line-length = 127
-max-module-lines = 1500
-
-[tool.pylint.messages_control]
-# Disable specific checks that are overly strict for this codebase
-disable = [
-    "too-few-public-methods",
-    "missing-module-docstring",
-    "missing-function-docstring",
-    "missing-class-docstring",
-    "duplicate-code",
-    "fixme",
-]
-
 [tool.pytest.ini_options]
 minversion = "8.0"
 addopts = "--strict-markers --tb=short -p no:warnings"

--- a/tests/validation/test_pylint_config_contract.py
+++ b/tests/validation/test_pylint_config_contract.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import configparser
+import re
 import tomllib
 from pathlib import Path
 
@@ -44,11 +45,28 @@ def test_pylintrc_path_exclusions_use_ignore_paths() -> None:
 
     assert all("/" not in ignored_name for ignored_name in ignored_names)
     assert ignored_paths == {
-        "^tools/deprecated/.*$",
-        "^src/transformation_portal/.*$",
-        "^src/luxury_tiff_batch_processor/.*$",
-        "^scripts/.*$",
+        "^tools/deprecated(?:/.*)?$",
+        "^src/transformation_portal(?:/.*)?$",
+        "^src/luxury_tiff_batch_processor(?:/.*)?$",
+        "^scripts(?:/.*)?$",
     }
+
+    expected_matches = {
+        "^tools/deprecated(?:/.*)?$": ("tools/deprecated", "tools/deprecated/legacy.py"),
+        "^src/transformation_portal(?:/.*)?$": (
+            "src/transformation_portal",
+            "src/transformation_portal/__init__.py",
+        ),
+        "^src/luxury_tiff_batch_processor(?:/.*)?$": (
+            "src/luxury_tiff_batch_processor",
+            "src/luxury_tiff_batch_processor/__init__.py",
+        ),
+        "^scripts(?:/.*)?$": ("scripts", "scripts/lint_runner.sh"),
+    }
+    for pattern, excluded_targets in expected_matches.items():
+        compiled = re.compile(pattern)
+        for excluded_target in excluded_targets:
+            assert compiled.match(excluded_target)
 
 
 def test_pylintrc_keeps_unused_import_signal_enabled() -> None:

--- a/tests/validation/test_pylint_config_contract.py
+++ b/tests/validation/test_pylint_config_contract.py
@@ -1,0 +1,65 @@
+"""Contract tests for the repository Pylint configuration."""
+
+from __future__ import annotations
+
+import configparser
+import tomllib
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+PYLINTRC_PATH = PROJECT_ROOT / ".pylintrc"
+PYPROJECT_PATH = PROJECT_ROOT / "pyproject.toml"
+
+
+def _load_pylintrc() -> configparser.ConfigParser:
+    config = configparser.ConfigParser()
+    read_files = config.read(PYLINTRC_PATH, encoding="utf-8")
+    assert read_files == [str(PYLINTRC_PATH)]
+    return config
+
+
+def _config_list(value: str) -> set[str]:
+    items: set[str] = set()
+    for part in value.replace("\n", ",").split(","):
+        item = part.split("#", 1)[0].strip()
+        if item:
+            items.add(item)
+    return items
+
+
+def test_pylintrc_uses_single_process_for_direct_pylint_runs() -> None:
+    config = _load_pylintrc()
+
+    assert config["MASTER"].getint("jobs") == 1
+
+
+def test_pylintrc_path_exclusions_use_ignore_paths() -> None:
+    config = _load_pylintrc()
+    ignored_names = _config_list(config["MASTER"]["ignore"])
+    ignored_paths = _config_list(config["MASTER"]["ignore-paths"])
+
+    assert all("/" not in ignored_name for ignored_name in ignored_names)
+    assert ignored_paths == {
+        "^tools/deprecated/.*$",
+        "^src/transformation_portal/.*$",
+        "^src/luxury_tiff_batch_processor/.*$",
+        "^scripts/.*$",
+    }
+
+
+def test_pylintrc_keeps_unused_import_signal_enabled() -> None:
+    config = _load_pylintrc()
+    disabled_messages = _config_list(config["MESSAGES CONTROL"]["disable"])
+
+    assert "W0611" not in disabled_messages
+    assert "unused-import" not in disabled_messages
+
+
+def test_pyproject_does_not_define_shadow_pylint_config() -> None:
+    pyproject = tomllib.loads(PYPROJECT_PATH.read_text(encoding="utf-8"))
+
+    assert "pylint" not in pyproject.get("tool", {})


### PR DESCRIPTION
## Summary
- Pylint direct runs were nondeterministic because .pylintrc used jobs=0, and path-like ignore entries did not actually exclude explicit path targets.
- Make .pylintrc the single authoritative Pylint config and add contract tests for the lint-policy invariants.

## Changes
- Set .pylintrc to single-process direct Pylint execution.
- Move excluded repo trees from ignore to ignore-paths so direct path targets are skipped.
- Re-enable unused-import signal by removing W0611 from the disabled messages.
- Remove the stale pyproject.toml Pylint blocks.
- Add validation tests for config authority, path filtering, jobs, and unused-import signal.

## Validation
Proven green:
- .venv/bin/pytest tests/validation/test_pylint_config_contract.py tests/validation/test_lint_runner.py -q
- .venv-lint/bin/python -m pylint --verbose --score=n tests/test_depth_tools.py
- .venv-lint/bin/python -m pylint --verbose --score=n tools/deprecated/ad_editorial_post_pipeline_v2.py
- .venv-lint/bin/python -m pylint --score=n --reports=n tests/validation/test_pylint_config_contract.py
- make lint-parity
- make ci-quick

Still failing:
- None. make ci-quick reports the existing TODO/FIXME warning count but exits green.

## Risk
- Bounded to lint configuration and focused validation tests.
- No route, API, selector, auth, schema, or runtime behavior changes.
- Revert-safe because the change only restores deterministic lint-policy authority.