### PR TITLE
chore(repo): tighten gitattributes contracts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,87 +1,142 @@
 # .gitattributes
-# Git attributes for Transformation Portal repository
-# Ensures consistent file handling and line endings across platforms
+# Git attributes for deterministic checkout, diff, and archive behavior.
 
-# Auto detect text files and normalize line endings to LF
+# Normalize text unless a more specific rule marks the path binary.
 * text=auto eol=lf
 
-# Explicitly declare text files
+# Source, scripts, and repository text
 *.py text eol=lf
+*.pyi text eol=lf
 *.sh text eol=lf
+*.bash text eol=lf
 *.md text eol=lf
+*.rst text eol=lf
 *.txt text eol=lf
+*.csv text eol=lf
+*.tsv text eol=lf
+*.in text eol=lf
+*.example text eol=lf
+*.sha256 text eol=lf
+*.asc text eol=lf
+*.c text eol=lf
+*.h text eol=lf
+*.sol text eol=lf
+*.mako text eol=lf
+
+# Config and structured data
+*.json text eol=lf
+*.jsonc text eol=lf
+*.jsonl text eol=lf
+*.ndjson text eol=lf
 *.yml text eol=lf
 *.yaml text eol=lf
-*.json text eol=lf
 *.toml text eol=lf
 *.ini text eol=lf
 *.cfg text eol=lf
 *.conf text eol=lf
+*.lock text eol=lf
+*.sql text eol=lf
+
+# Web assets that are still text
 *.xml text eol=lf
 *.html text eol=lf
 *.css text eol=lf
 *.js text eol=lf
+*.mjs text eol=lf
+*.cjs text eol=lf
 *.ts text eol=lf
 *.jsx text eol=lf
 *.tsx text eol=lf
+*.svg text eol=lf
 *.cube text eol=lf
 
-# Scripts should always use LF
-*.sh text eol=lf
+# Root and dotfile contracts without reliable extensions
+Makefile text eol=lf
+Dockerfile text eol=lf
+LICENSE text eol=lf
+CODEOWNERS text eol=lf
+.dockerignore text eol=lf
+.env.example text eol=lf
+.git-blame-ignore-revs text eol=lf
+.nvmrc text eol=lf
+.pylintrc text eol=lf
 
-# Windows scripts use CRLF
+# Windows command scripts keep Windows-native endings.
 *.bat text eol=crlf
 *.cmd text eol=crlf
 *.ps1 text eol=crlf
 
-# Binary files
+# Raster, raw, HDR, and icon assets
 *.jpg binary
+*.JPG binary
 *.jpeg binary
+*.JPEG binary
 *.png binary
 *.gif binary
 *.ico binary
-*.mov binary
-*.mp4 binary
-*.mp3 binary
-*.flv binary
-*.fla binary
-*.swf binary
-*.gz binary
-*.zip binary
-*.7z binary
-*.ttf binary
-*.eot binary
-*.woff binary
-*.woff2 binary
-*.pyc binary
-*.pyd binary
-*.so binary
-*.dll binary
-*.exe binary
-*.o binary
-*.a binary
-*.lib binary
-*.dylib binary
-
-# Image formats (high-end processing)
+*.bmp binary
+*.webp binary
+*.avif binary
+*.heic binary
+*.heif binary
 *.tif binary
+*.TIF binary
 *.tiff binary
+*.TIFF binary
 *.exr binary
 *.hdr binary
 *.dng binary
+*.DNG binary
 *.cr2 binary
+*.CR2 binary
+*.cr3 binary
+*.CR3 binary
 *.nef binary
+*.NEF binary
 *.arw binary
+*.ARW binary
+*.raf binary
+*.RAF binary
+*.rw2 binary
+*.RW2 binary
+*.orf binary
+*.ORF binary
 
-# Video formats
+# Audio and video
 *.avi binary
 *.mov binary
+*.MOV binary
 *.mp4 binary
 *.mkv binary
 *.webm binary
 *.prores binary
+*.mp3 binary
+*.wav binary
+*.flac binary
+*.flv binary
+*.fla binary
+*.swf binary
 
-# Model files
+# Fonts
+*.ttf binary
+*.otf binary
+*.eot binary
+*.woff binary
+*.woff2 binary
+
+# Python/native build outputs and shared libraries
+*.pyc binary
+*.pyo binary
+*.pyd binary
+*.so binary
+*.dll binary
+*.dylib binary
+*.exe binary
+*.o binary
+*.a binary
+*.lib binary
+
+# Model, numeric, and local database artifacts
 *.pth binary
 *.pt binary
 *.ckpt binary
@@ -92,14 +147,25 @@
 *.mlpackage binary
 *.tflite binary
 *.bin binary
+*.npy binary
+*.npz binary
+*.pkl binary
+*.pickle binary
+*.parquet binary
+*.db binary
+*.sqlite binary
+*.sqlite3 binary
 
-# Archives
+# Archives and compressed fixtures
 *.tar binary
 *.tar.gz binary
 *.tgz binary
+*.gz binary
 *.zip binary
 *.7z binary
 *.rar binary
+*.bz2 binary
+*.xz binary
 
 # Documents
 *.pdf binary
@@ -110,14 +176,10 @@
 *.ppt binary
 *.pptx binary
 
-# Git attributes for specific files
-.gitattributes export-ignore
-.gitignore export-ignore
+# Exclude repository-only metadata from source archives.
+.gitattributes text eol=lf export-ignore
+.gitignore text eol=lf export-ignore
 .github/ export-ignore
 
-# LFS tracking for large files (if Git LFS is enabled)
-# Uncomment if using Git LFS:
-# *.pth filter=lfs diff=lfs merge=lfs -text
-# *.safetensors filter=lfs diff=lfs merge=lfs -text
-# *.onnx filter=lfs diff=lfs merge=lfs -text
-# *.mlpackage filter=lfs diff=lfs merge=lfs -text
+# Large model and media files are binary only. Do not enable Git LFS here
+# without updating checkout workflows that currently use lfs: false.

--- a/tests/validation/test_gitattributes_contract.py
+++ b/tests/validation/test_gitattributes_contract.py
@@ -1,0 +1,89 @@
+"""Contract tests for repository Git attributes."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+GITATTRIBUTES_PATH = PROJECT_ROOT / ".gitattributes"
+
+
+TEXT_FIXTURES = [
+    ".gitattributes",
+    ".gitignore",
+    ".github/CODEOWNERS",
+    ".env.example",
+    "Dockerfile",
+    "Makefile",
+    "README.md",
+    "wrangler.jsonc",
+    "migrations/script.py.mako",
+    "docs/contracts/SCHEMA_LOCKS.sha256",
+    "docs/contracts/presence/PresenceCompiler.sol",
+    "policy/dataset_signing_public.asc",
+    "src/transformation_portal/determinism/_fpstate.c",
+    "tools/verify_merkle_signature.py",
+]
+
+BINARY_FIXTURES = [
+    "public/portal-assets/fonts/portal-sans.woff2",
+    "src/transformation_portal/lux_depth_v3_precision_arch_fixes_plus_upgrades_files.zip",
+    "tests/fixtures/archive_small/archive_index_normalized.csv.gz",
+    "tests/fixtures/archive_small/archive_root/DriveA/Part1/bravo.bin",
+    "tests/fixtures/ingest/batch_inputs/raw/DJI_0001.DNG",
+    "tests/fixtures/ingest/batch_inputs/stills/INT_1001.JPG",
+    "tests/fixtures/ingest/batch_inputs/video/clip_0001.MOV",
+    "tests/fixtures/pipelines/750_picacho_lane/input/750Picacho_Pool_UltraQuality.tif",
+]
+
+
+def _git_attrs(path: str) -> dict[str, str]:
+    result = subprocess.run(
+        ["git", "check-attr", "--all", "--", path],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    attrs: dict[str, str] = {}
+    for line in result.stdout.splitlines():
+        _path, attr, value = line.split(": ", 2)
+        attrs[attr] = value
+    return attrs
+
+
+def test_gitattributes_has_no_duplicate_exact_patterns() -> None:
+    seen: dict[str, int] = {}
+
+    for line_number, line in enumerate(GITATTRIBUTES_PATH.read_text(encoding="utf-8").splitlines(), start=1):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        pattern = stripped.split()[0]
+        assert pattern not in seen, f"duplicate pattern {pattern!r} at lines {seen[pattern]} and {line_number}"
+        seen[pattern] = line_number
+
+
+@pytest.mark.parametrize("path", TEXT_FIXTURES)
+def test_representative_text_files_are_lf_normalized(path: str) -> None:
+    assert (PROJECT_ROOT / path).exists(), path
+    attrs = _git_attrs(path)
+
+    assert attrs["text"] == "set"
+    assert attrs["eol"] == "lf"
+
+
+@pytest.mark.parametrize("path", BINARY_FIXTURES)
+def test_representative_binary_files_are_not_text_normalized(path: str) -> None:
+    assert (PROJECT_ROOT / path).exists(), path
+    attrs = _git_attrs(path)
+
+    assert attrs["binary"] == "set"
+    assert attrs["text"] == "unset"
+    assert attrs["diff"] == "unset"
+    assert attrs["merge"] == "unset"


### PR DESCRIPTION
## Summary
- Refine .gitattributes from a broad template into repo-specific checkout, diff, and archive rules.
- Add contract coverage that verifies representative tracked text and binary files through git check-attr.

## Changes
- Reorganized .gitattributes into explicit groups for source/text, config/data, web text assets, dotfiles, Windows scripts, media/raw files, fonts, native/model artifacts, archives, and documents.
- Added explicit rules for tracked repo surfaces including .mjs, .jsonc, .rst, .csv, .in, .example, .mako, .sol, .c, .asc, uppercase media fixtures, compressed fixtures, and numeric/model artifacts.
- Consolidated duplicate metadata patterns and kept .gitattributes/.gitignore LF-normalized while export-ignored.
- Kept Git LFS disabled and documented that enabling it requires checkout workflow updates.
- Added tests/validation/test_gitattributes_contract.py for duplicate-pattern checks and git check-attr text/binary assertions.

## Validation
Proven green:
- .venv/bin/pytest tests/validation/test_gitattributes_contract.py tests/test_organization_system.py -q
- .venv-lint/bin/python -m pylint --score=n --reports=n tests/validation/test_gitattributes_contract.py
- git diff --check -- .gitattributes tests/validation/test_gitattributes_contract.py
- make ci-quick
- make lint-parity

Still failing:
- None. make ci-quick reports the existing TODO/FIXME warning count but exits green.

## Risk
- Bounded to Git attribute metadata and validation coverage.
- No route, API, selector, auth, schema, runtime, or package behavior changes.
- Revert-safe because the change only affects checkout/diff/archive classification and is covered with git check-attr assertions.