### PR TITLE
ci(mypy): align policy whitelist across workflows

### DIFF
--- a/.github/workflows/ci-quality-firewall.yml
+++ b/.github/workflows/ci-quality-firewall.yml
@@ -153,9 +153,20 @@ jobs:
           pip install -e . --no-deps
 
       - name: Type check with mypy (critical modules)
+        # Advisory mirror of the canonical PR gate whitelist in build.yml.
+        # Keep this list in sync with docs/ci/TYPE_CHECKING_POLICY.md.
         continue-on-error: true
         run: |
-          mypy src/transformation_portal/lux_depth_v3/ --config-file=mypy.ini
+          mypy --config-file=mypy.ini \
+            src/transformation_portal/api/ \
+            src/transformation_portal/lux_depth_v3/ \
+            src/transformation_portal/orchestrator/queue/ \
+            src/transformation_portal/orchestrator/storage/ \
+            src/transformation_portal/orchestrator/artifact_store/ \
+            src/transformation_portal/core/geometry/ \
+            src/transformation_portal/core/processing/ \
+            src/transformation_portal/core/ml_dependency_health.py \
+            src/transformation_portal/core/da3_runtime.py
 
   security:
     name: Security Scans

--- a/.github/workflows/ci-quality-firewall.yml
+++ b/.github/workflows/ci-quality-firewall.yml
@@ -149,7 +149,9 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install mypy types-PyYAML
+          # The API whitelist imports pydantic; editable install uses --no-deps,
+          # so install the same pinned runtime dependency as build.yml.
+          pip install mypy types-PyYAML "pydantic==2.13.3"
           pip install -e . --no-deps
 
       - name: Type check with mypy (critical modules)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,9 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install mypy types-PyYAML
+          # The API whitelist imports pydantic; editable install uses --no-deps,
+          # so install the same pinned runtime dependency as build.yml.
+          pip install mypy types-PyYAML "pydantic==2.13.3"
           pip install -e . --no-deps
 
       - name: Type check with mypy (critical modules)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,9 +106,19 @@ jobs:
 
       - name: Type check with mypy (critical modules)
         # ADR-044: mypy now hard-fails for critical modules (was soft-fail)
-        # This enforces type safety as a blocking gate
+        # This mirrors the canonical PR gate whitelist in build.yml.
+        # Keep this list in sync with docs/ci/TYPE_CHECKING_POLICY.md.
         run: |
-          mypy src/transformation_portal/lux_depth_v3/ --config-file=mypy.ini
+          mypy --config-file=mypy.ini \
+            src/transformation_portal/api/ \
+            src/transformation_portal/lux_depth_v3/ \
+            src/transformation_portal/orchestrator/queue/ \
+            src/transformation_portal/orchestrator/storage/ \
+            src/transformation_portal/orchestrator/artifact_store/ \
+            src/transformation_portal/core/geometry/ \
+            src/transformation_portal/core/processing/ \
+            src/transformation_portal/core/ml_dependency_health.py \
+            src/transformation_portal/core/da3_runtime.py
 
   security:
     name: Security Scans

--- a/docs/ci/TYPE_CHECKING_POLICY.md
+++ b/docs/ci/TYPE_CHECKING_POLICY.md
@@ -2,16 +2,18 @@
 
 **Status**: DRAFT (requires architect approval)
 **Owner**: Transformation Portal Architect
-**Last Updated**: 2026-05-24
+**Last Updated**: 2026-06-02
 
 ---
 
 ## Actively Enforced mypy Whitelist (current)
 
-This is the authoritative list of paths that the **blocking** mypy gate in
-`.github/workflows/build.yml` (`Type check with mypy (critical modules)`)
-enforces. Each path passes `mypy --config-file=mypy.ini <path>` cleanly;
-additions must do the same before being appended to the workflow list.
+This is the authoritative list of paths enforced by the **blocking** mypy gate
+in `.github/workflows/build.yml` (`Type check with mypy (critical modules)`).
+The post-merge hard-fail workflow (`.github/workflows/ci.yml`) and the
+post-CI soft-fail firewall (`.github/workflows/ci-quality-firewall.yml`) mirror
+the same whitelist. Each path passes `mypy --config-file=mypy.ini <path>`
+cleanly; additions must do the same before being appended to workflow lists.
 
 **Enforced as of 2026-05-24:**
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,8 +1,12 @@
 [mypy]
 python_version = 3.11
 warn_unused_configs = True
+show_error_codes = True
 disallow_untyped_defs = True
 disallow_incomplete_defs = True
 check_untyped_defs = True
 ignore_missing_imports = True
 follow_imports = silent
+warn_redundant_casts = True
+no_implicit_optional = True
+strict_equality = True

--- a/scripts/validate_ci_config.py
+++ b/scripts/validate_ci_config.py
@@ -35,6 +35,7 @@ class CIValidator:
     """Validate GitHub Actions workflow configurations."""
 
     MIN_CHECKOUT_MAJOR = 4
+    MYPY_POLICY_WORKFLOWS = frozenset({"build.yml", "ci.yml", "ci-quality-firewall.yml"})
     REQUIRED_FLAKE8_FATAL_CODES = {"E9", "F63", "F7", "F82"}
     ML_NO_COV_BLOCK_PATTERN = re.compile(
         r'if\s+\[\s*"\$\{\{\s*matrix\.test-type\s*\}\}"\s*=\s*"ml"\s*\]\s*;\s*then\s*\n\s*' r'COV_FLAGS="--no-cov"'
@@ -305,6 +306,47 @@ class CIValidator:
 
         return valid
 
+    def validate_mypy_policy_contract(self, workflow_path: Path, config: Dict) -> bool:
+        """Validate mypy workflow whitelists against the current policy doc."""
+        if workflow_path.name not in self.MYPY_POLICY_WORKFLOWS:
+            return True
+
+        valid = True
+        expected_paths = self._mypy_policy_doc_paths()
+        if not expected_paths:
+            self.log_error("docs/ci/TYPE_CHECKING_POLICY.md: Missing actively enforced mypy whitelist paths")
+            return False
+
+        jobs = config.get("jobs", {})
+        typecheck_job = jobs.get("typecheck") if isinstance(jobs, dict) else None
+        if not isinstance(typecheck_job, dict):
+            self.log_error(f"{workflow_path.name}:typecheck: Missing typecheck job for mypy policy contract")
+            return False
+
+        steps = typecheck_job.get("steps", [])
+        if not isinstance(steps, list):
+            self.log_error(f"{workflow_path.name}:typecheck: Steps must be a list for mypy policy contract")
+            return False
+
+        typecheck_step = self._find_step_by_name(steps, "Type check with mypy (critical modules)")
+        if typecheck_step is None:
+            self.log_error(f"{workflow_path.name}:typecheck: Missing mypy typecheck step")
+            return False
+
+        actual_paths, has_config = self._mypy_step_paths(typecheck_step.get("run"))
+        if not has_config:
+            self.log_error(f"{workflow_path.name}:typecheck: mypy command must use --config-file=mypy.ini")
+            valid = False
+
+        if actual_paths != expected_paths:
+            self.log_error(
+                f"{workflow_path.name}:typecheck: mypy whitelist must match docs/ci/TYPE_CHECKING_POLICY.md "
+                f"(expected {expected_paths}, found {actual_paths})"
+            )
+            valid = False
+
+        return valid
+
     def _validate_run_tests_coverage_contract(self, run_script: object) -> bool:
         """Validate coverage flag scoping in the build.yml Run tests shell script."""
         valid = True
@@ -365,6 +407,45 @@ class CIValidator:
             valid = False
 
         return valid
+
+    def _mypy_policy_doc_paths(self) -> List[str]:
+        """Return the live mypy whitelist from docs/ci/TYPE_CHECKING_POLICY.md."""
+        policy_path = self.repo_root / "docs" / "ci" / "TYPE_CHECKING_POLICY.md"
+        try:
+            text = policy_path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            return []
+
+        try:
+            start = text.index("**Enforced as of")
+            end = text.index("**N-1 tranche notes", start)
+        except ValueError:
+            return []
+
+        return re.findall(r"^- `([^`]+)`", text[start:end], flags=re.MULTILINE)
+
+    @staticmethod
+    def _mypy_step_paths(run_script: object) -> Tuple[List[str], bool]:
+        """Return src paths and config-file usage from a mypy workflow step."""
+        if not isinstance(run_script, str):
+            return [], False
+
+        logical_script = run_script.replace("\\\n", " ")
+        try:
+            tokens = shlex.split(logical_script, comments=True, posix=True)
+        except ValueError:
+            tokens = logical_script.split()
+
+        if "mypy" not in tokens:
+            return [], False
+
+        has_inline_config = "--config-file=mypy.ini" in tokens
+        has_split_config = any(
+            token == "--config-file" and index + 1 < len(tokens) and tokens[index + 1] == "mypy.ini"
+            for index, token in enumerate(tokens)
+        )
+        paths = [token for token in tokens if token.startswith("src/")]
+        return paths, has_inline_config or has_split_config
 
     @classmethod
     def _branch_coverage_checker_commands(cls, run_script: str) -> List[List[str]]:
@@ -448,6 +529,7 @@ class CIValidator:
             self.validate_common_issues(workflow_path, config),
             self.validate_flake8_config(workflow_path, config),
             self.validate_build_coverage_contract(workflow_path, config),
+            self.validate_mypy_policy_contract(workflow_path, config),
         ]
 
         return all(validations)

--- a/scripts/validate_ci_config.py
+++ b/scripts/validate_ci_config.py
@@ -36,6 +36,7 @@ class CIValidator:
 
     MIN_CHECKOUT_MAJOR = 4
     MYPY_POLICY_WORKFLOWS = frozenset({"build.yml", "ci.yml", "ci-quality-firewall.yml"})
+    REQUIRED_MYPY_PYDANTIC_DEPENDENCY = "pydantic==2.13.3"
     REQUIRED_FLAKE8_FATAL_CODES = {"E9", "F63", "F7", "F82"}
     ML_NO_COV_BLOCK_PATTERN = re.compile(
         r'if\s+\[\s*"\$\{\{\s*matrix\.test-type\s*\}\}"\s*=\s*"ml"\s*\]\s*;\s*then\s*\n\s*' r'COV_FLAGS="--no-cov"'
@@ -328,6 +329,17 @@ class CIValidator:
             self.log_error(f"{workflow_path.name}:typecheck: Steps must be a list for mypy policy contract")
             return False
 
+        if "src/transformation_portal/api/" in expected_paths:
+            install_step = self._find_step_by_name(steps, "Install dependencies")
+            install_tokens = self._shell_tokens(install_step.get("run") if isinstance(install_step, dict) else None)
+            if self.REQUIRED_MYPY_PYDANTIC_DEPENDENCY not in install_tokens:
+                self.log_error(
+                    f"{workflow_path.name}:typecheck: API mypy whitelist requires "
+                    f"{self.REQUIRED_MYPY_PYDANTIC_DEPENDENCY!r} in the Install dependencies step because "
+                    "editable install uses --no-deps"
+                )
+                valid = False
+
         typecheck_step = self._find_step_by_name(steps, "Type check with mypy (critical modules)")
         if typecheck_step is None:
             self.log_error(f"{workflow_path.name}:typecheck: Missing mypy typecheck step")
@@ -427,14 +439,7 @@ class CIValidator:
     @staticmethod
     def _mypy_step_paths(run_script: object) -> Tuple[List[str], bool]:
         """Return src paths and config-file usage from a mypy workflow step."""
-        if not isinstance(run_script, str):
-            return [], False
-
-        logical_script = run_script.replace("\\\n", " ")
-        try:
-            tokens = shlex.split(logical_script, comments=True, posix=True)
-        except ValueError:
-            tokens = logical_script.split()
+        tokens = CIValidator._shell_tokens(run_script)
 
         if "mypy" not in tokens:
             return [], False
@@ -446,6 +451,18 @@ class CIValidator:
         )
         paths = [token for token in tokens if token.startswith("src/")]
         return paths, has_inline_config or has_split_config
+
+    @staticmethod
+    def _shell_tokens(run_script: object) -> List[str]:
+        """Return shell tokens from a workflow run script."""
+        if not isinstance(run_script, str):
+            return []
+
+        logical_script = run_script.replace("\\\n", " ")
+        try:
+            return shlex.split(logical_script, comments=True, posix=True)
+        except ValueError:
+            return logical_script.split()
 
     @classmethod
     def _branch_coverage_checker_commands(cls, run_script: str) -> List[List[str]]:

--- a/tests/test_validate_ci_config.py
+++ b/tests/test_validate_ci_config.py
@@ -10,6 +10,8 @@ pytestmark = pytest.mark.unit
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 TOOL_PATH = PROJECT_ROOT / "scripts" / "validate_ci_config.py"
 BUILD_WORKFLOW_PATH = PROJECT_ROOT / ".github" / "workflows" / "build.yml"
+CI_WORKFLOW_PATH = PROJECT_ROOT / ".github" / "workflows" / "ci.yml"
+FIREWALL_WORKFLOW_PATH = PROJECT_ROOT / ".github" / "workflows" / "ci-quality-firewall.yml"
 SPEC = importlib.util.spec_from_file_location("validate_ci_config", TOOL_PATH)
 assert SPEC is not None and SPEC.loader is not None
 validate_ci_config = importlib.util.module_from_spec(SPEC)
@@ -24,9 +26,13 @@ def _load_config(path: Path) -> tuple[object, dict]:
 
 
 def _mutated_build_workflow(tmp_path: Path, old: str, new: str) -> Path:
-    source = BUILD_WORKFLOW_PATH.read_text(encoding="utf-8")
+    return _mutated_workflow(BUILD_WORKFLOW_PATH, tmp_path, old, new)
+
+
+def _mutated_workflow(source_path: Path, tmp_path: Path, old: str, new: str) -> Path:
+    source = source_path.read_text(encoding="utf-8")
     assert old in source
-    path = tmp_path / "build.yml"
+    path = tmp_path / source_path.name
     path.write_text(source.replace(old, new, 1), encoding="utf-8")
     return path
 
@@ -46,6 +52,58 @@ def test_build_workflow_coverage_contract_passes_repo_config() -> None:
 
     assert validator.validate_build_coverage_contract(BUILD_WORKFLOW_PATH, config) is True
     assert validator.errors == []
+
+
+def test_mypy_config_remains_root_linting_config() -> None:
+    mypy_config = PROJECT_ROOT / "mypy.ini"
+    assert mypy_config.exists()
+    assert not (PROJECT_ROOT / "src" / "mypy.ini").exists()
+
+    mypy_config_text = mypy_config.read_text(encoding="utf-8")
+    for required_option in (
+        "show_error_codes = True",
+        "warn_redundant_casts = True",
+        "no_implicit_optional = True",
+        "strict_equality = True",
+    ):
+        assert required_option in mypy_config_text
+
+    organization_doc = (PROJECT_ROOT / "docs" / "governance" / "REPO_ORGANIZATION.md").read_text(encoding="utf-8")
+    assert "- **Linting configuration**: `.pylintrc`, `.flake8`, `mypy.ini`" in organization_doc
+
+
+def test_mypy_policy_contract_passes_repo_workflows() -> None:
+    for workflow_path in (BUILD_WORKFLOW_PATH, CI_WORKFLOW_PATH, FIREWALL_WORKFLOW_PATH):
+        validator, config = _load_config(workflow_path)
+
+        assert validator.validate_mypy_policy_contract(workflow_path, config) is True
+        assert validator.errors == []
+
+
+def test_mypy_policy_contract_rejects_workflow_whitelist_drift(tmp_path: Path) -> None:
+    workflow_path = _mutated_workflow(
+        CI_WORKFLOW_PATH,
+        tmp_path,
+        "            src/transformation_portal/api/ \\\n",
+        "",
+    )
+    validator, config = _load_config(workflow_path)
+
+    assert validator.validate_mypy_policy_contract(workflow_path, config) is False
+    assert any("mypy whitelist must match" in error for error in validator.errors)
+
+
+def test_mypy_policy_contract_requires_root_mypy_ini_config(tmp_path: Path) -> None:
+    workflow_path = _mutated_workflow(
+        BUILD_WORKFLOW_PATH,
+        tmp_path,
+        "          mypy --config-file=mypy.ini \\\n",
+        "          mypy --config-file=pyproject.toml \\\n",
+    )
+    validator, config = _load_config(workflow_path)
+
+    assert validator.validate_mypy_policy_contract(workflow_path, config) is False
+    assert any("must use --config-file=mypy.ini" in error for error in validator.errors)
 
 
 def test_build_workflow_coverage_upload_must_be_core_only(tmp_path: Path) -> None:

--- a/tests/test_validate_ci_config.py
+++ b/tests/test_validate_ci_config.py
@@ -93,6 +93,19 @@ def test_mypy_policy_contract_rejects_workflow_whitelist_drift(tmp_path: Path) -
     assert any("mypy whitelist must match" in error for error in validator.errors)
 
 
+def test_mypy_policy_contract_requires_api_runtime_dependency(tmp_path: Path) -> None:
+    workflow_path = _mutated_workflow(
+        CI_WORKFLOW_PATH,
+        tmp_path,
+        ' types-PyYAML "pydantic==2.13.3"',
+        " types-PyYAML",
+    )
+    validator, config = _load_config(workflow_path)
+
+    assert validator.validate_mypy_policy_contract(workflow_path, config) is False
+    assert any("API mypy whitelist requires 'pydantic==2.13.3'" in error for error in validator.errors)
+
+
 def test_mypy_policy_contract_requires_root_mypy_ini_config(tmp_path: Path) -> None:
     workflow_path = _mutated_workflow(
         BUILD_WORKFLOW_PATH,


### PR DESCRIPTION
## Summary
- `mypy.ini` was root-level and correctly placed, but the mypy policy was split across CI surfaces.
- Keep the existing root config location, tighten non-disruptive mypy diagnostics, and make workflow whitelist drift contract-visible.

## Changes
- Added `show_error_codes`, `warn_redundant_casts`, `no_implicit_optional`, and `strict_equality` to `mypy.ini`.
- Aligned `.github/workflows/ci.yml` and `.github/workflows/ci-quality-firewall.yml` with the canonical `build.yml` mypy whitelist.
- Updated `docs/ci/TYPE_CHECKING_POLICY.md` to name the blocking, post-merge, and advisory workflow ownership rule.
- Extended `scripts/validate_ci_config.py` so `build.yml`, `ci.yml`, and `ci-quality-firewall.yml` must match the policy doc whitelist and use `--config-file=mypy.ini`.
- Added focused tests for whitelist drift and root `mypy.ini` placement.

## Validation
Proven green:
- `.venv/bin/pytest tests/test_validate_ci_config.py -q`
- `.venv/bin/mypy --config-file=mypy.ini src/transformation_portal/api/ src/transformation_portal/lux_depth_v3/ src/transformation_portal/orchestrator/queue/ src/transformation_portal/orchestrator/storage/ src/transformation_portal/orchestrator/artifact_store/ src/transformation_portal/core/geometry/ src/transformation_portal/core/processing/ src/transformation_portal/core/ml_dependency_health.py src/transformation_portal/core/da3_runtime.py`
- `make validate-ci`
- `./.auto-organize.sh --check`
- `make ci-quick`
- `git diff --check -- .github/workflows/ci.yml .github/workflows/ci-quality-firewall.yml docs/ci/TYPE_CHECKING_POLICY.md mypy.ini scripts/validate_ci_config.py tests/test_validate_ci_config.py`

Still failing:
- Experimental `warn_unused_ignores` run reports 33 stale `type: ignore` comments in 12 already-whitelisted files. This is existing cleanup debt, so this PR does not enable that option.

Failure classification:
- No product logic, stale test logic, or environment/tooling failures observed in the validation path above.

## Risk
- CI behavior becomes stricter for post-merge/advisory mypy coverage because those workflows now mirror the already-blocking PR whitelist.
- No route, selector, API envelope, auth, schema, or runtime contract changes.
- Revert-safe: changes are limited to mypy config, CI workflow command scope, policy docs, and the validator contract.