### PR TITLE
test(tp): codify import surface and phase4 coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,10 @@ actionable; use the linked docs and `Makefile` for exhaustive inventories.
   without evidence.
 - Pair behavior changes with focused tests in the same pass. Prefer tests that
   prove a real contract or regression risk over tests that only raise counts.
+- Keep `src/tp` as the separate public import surface for contract, fixity, and
+  Phase 4 tooling (`tp.crypto`, `tp.merkle`, `tp.phase4`). Do not collapse it
+  into `transformation_portal`; tracked file and package names stay lowercase
+  snake_case Python source.
 - Treat Postgres, Redis, Docker, browser, and external-model failures as
   environment/tooling blockers until evidence shows a product regression. Do
   not weaken product contracts to hide missing services.

--- a/src/tp/__init__.py
+++ b/src/tp/__init__.py
@@ -1,1 +1,9 @@
-"""Top-level helpers for contract-focused tooling modules."""
+"""Public contract, fixity, and Phase 4 tooling import surface.
+
+The ``tp`` package is intentionally separate from
+``transformation_portal``. Keep this surface lightweight, deterministic, and
+limited to contract-bearing helpers such as ``tp.crypto``, ``tp.merkle``, and
+``tp.phase4``.
+"""
+
+__all__ = ["crypto", "merkle", "phase4"]

--- a/tests/crypto/test_merkle_properties.py
+++ b/tests/crypto/test_merkle_properties.py
@@ -253,6 +253,32 @@ _JSON_VALUES = st.recursive(
 )
 
 
+def _json_structural_bytes(encoded: bytes) -> bytes:
+    """Return encoded JSON with string literal contents removed."""
+    structural = bytearray()
+    in_string = False
+    escaped = False
+
+    for byte in encoded:
+        if in_string:
+            if escaped:
+                escaped = False
+                continue
+            if byte == ord("\\"):
+                escaped = True
+                continue
+            if byte == ord('"'):
+                in_string = False
+                structural.append(byte)
+            continue
+
+        structural.append(byte)
+        if byte == ord('"'):
+            in_string = True
+
+    return bytes(structural)
+
+
 class TestCanonicalJsonProperties:
     """Canonical-JSON invariants: round-trip, key-order independence, determinism."""
 
@@ -291,10 +317,11 @@ class TestCanonicalJsonProperties:
         # incidental whitespace. Pinning this prevents a careless
         # ``indent=2`` from sneaking in and silently changing every hash.
         encoded = canonicalize_json(payload)
-        # The encoded bytes must not contain ``", "`` or ``": "``
-        # separator pairs (with the space) anywhere.
-        assert b", " not in encoded
-        assert b": " not in encoded
+        # Separator whitespace is structural. User-provided string content
+        # may legitimately contain comma-space or colon-space bytes.
+        structural = _json_structural_bytes(encoded)
+        assert b", " not in structural
+        assert b": " not in structural
 
     def test_canonicalize_rejects_nan_and_infinity(self):
         # Both NaN and Infinity break JSON-strict consumers and would

--- a/tests/test_build_metadata_manifest.py
+++ b/tests/test_build_metadata_manifest.py
@@ -17,6 +17,7 @@ from tp.phase4.hash_capture_metadata import (
     MetadataSchemaValidationError,
     build_metadata_manifest_payload,
     compute_metadata_sha256,
+    serialize_metadata_manifest,
 )
 from tp.phase4.validation_helpers import validate_records_with_schema
 
@@ -129,6 +130,22 @@ def _deepcopy_record(record: dict[str, Any]) -> dict[str, Any]:
     return json.loads(json.dumps(record))
 
 
+def test_phase4d_build_payload_direct_success_with_fingerprint() -> None:
+    pytest.importorskip("jsonschema")
+    records = _load_golden_capture_records()
+    fingerprint = records[0]["extractor"]["config_fingerprint_sha256"]
+
+    payload = build_metadata_manifest_payload(
+        records,
+        metadata_schema={},
+        manifest_schema={},
+        required_config_fingerprint_sha256=fingerprint,
+    )
+
+    assert payload == json.loads(GOLDEN_MANIFEST.read_text(encoding="utf-8"))
+    assert serialize_metadata_manifest(payload).endswith(b"\n")
+
+
 def test_phase4d_metadata_hash_is_whitespace_and_key_order_independent() -> None:
     record = _load_golden_capture_records()[0]
     reordered = {key: record[key] for key in reversed(list(record.keys()))}
@@ -166,6 +183,51 @@ def test_phase4d_build_payload_reports_missing_relative_path_without_keyerror() 
     ]
 
     with pytest.raises(MetadataManifestInputError, match=r"input metadata array record\[0\] missing relative_path"):
+        build_metadata_manifest_payload(records, metadata_schema={}, manifest_schema={})
+
+
+def test_phase4d_build_payload_rejects_contract_version_mismatch() -> None:
+    pytest.importorskip("jsonschema")
+    records = _load_golden_capture_records()
+    records[0]["metadata_contract_version"] = "tp.meta.capture.v999"
+
+    with pytest.raises(MetadataManifestInputError, match="contract mismatch"):
+        build_metadata_manifest_payload(records, metadata_schema={}, manifest_schema={})
+
+
+def test_phase4d_build_payload_rejects_fingerprint_mismatch() -> None:
+    pytest.importorskip("jsonschema")
+    records = _load_golden_capture_records()
+
+    with pytest.raises(MetadataManifestInputError, match="fingerprint mismatch"):
+        build_metadata_manifest_payload(
+            records,
+            metadata_schema={},
+            manifest_schema={},
+            required_config_fingerprint_sha256="0" * 64,
+        )
+
+
+def test_phase4d_build_payload_rejects_missing_extractor_when_fingerprint_required() -> None:
+    pytest.importorskip("jsonschema")
+    records = _load_golden_capture_records()
+    del records[0]["extractor"]
+
+    with pytest.raises(MetadataManifestInputError, match="missing extractor object"):
+        build_metadata_manifest_payload(
+            records,
+            metadata_schema={},
+            manifest_schema={},
+            required_config_fingerprint_sha256="0" * 64,
+        )
+
+
+def test_phase4d_build_payload_wraps_canonical_serialization_errors() -> None:
+    pytest.importorskip("jsonschema")
+    records = _load_golden_capture_records()
+    records[0]["non_jsonable"] = object()
+
+    with pytest.raises(MetadataSchemaValidationError, match="canonical serialization failed"):
         build_metadata_manifest_payload(records, metadata_schema={}, manifest_schema={})
 
 

--- a/tests/test_build_provenance_manifest.py
+++ b/tests/test_build_provenance_manifest.py
@@ -19,8 +19,10 @@ from tp.phase4.hash_capture_metadata import (
 from tp.phase4.provenance_capture import (
     PROVENANCE_CONTRACT_VERSION,
     ProvenanceInputError,
+    ProvenanceSchemaValidationError,
     build_provenance_manifest_payload,
     compute_provenance_entry_sha256,
+    serialize_provenance_manifest,
 )
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
@@ -107,6 +109,26 @@ def _build_two_record_artifacts() -> tuple[list[dict[str, Any]], dict[str, Any]]
     return [record_a, record_b], manifest_payload
 
 
+def test_phase4e_build_manifest_direct_success_with_fingerprint() -> None:
+    pytest.importorskip("jsonschema")
+    records, manifest_payload = _build_two_record_artifacts()
+    fingerprint = records[0]["extractor"]["config_fingerprint_sha256"]
+
+    payload = build_provenance_manifest_payload(
+        records,
+        manifest_payload,
+        metadata_schema={},
+        metadata_manifest_schema={},
+        provenance_manifest_schema={},
+        required_config_fingerprint_sha256=fingerprint,
+    )
+
+    assert payload["provenance_contract_version"] == PROVENANCE_CONTRACT_VERSION
+    assert payload["metadata_contract_version"] == METADATA_CONTRACT_VERSION
+    assert [entry["relative_path"] for entry in payload["entries"]] == ["a/sample_01.dng", "b/sample_01.dng"]
+    assert serialize_provenance_manifest(payload).endswith(b"\n")
+
+
 def test_phase4e_golden_provenance_manifest_matches_expected(tmp_path: Path) -> None:
     pytest.importorskip("jsonschema")
     out_path = tmp_path / "provenance_manifest.tp.meta.provenance.v1.json"
@@ -191,6 +213,141 @@ def test_phase4e_build_manifest_reports_missing_relative_path_without_keyerror()
         build_provenance_manifest_payload(
             capture_records,
             metadata_manifest_payload,
+            metadata_schema={},
+            metadata_manifest_schema={},
+            provenance_manifest_schema={},
+        )
+
+
+def test_phase4e_build_manifest_rejects_non_object_metadata_manifest() -> None:
+    pytest.importorskip("jsonschema")
+    records, _manifest_payload = _build_two_record_artifacts()
+
+    with pytest.raises(ProvenanceInputError, match="metadata manifest payload must be a JSON object"):
+        build_provenance_manifest_payload(
+            records,
+            [],
+            metadata_schema={},
+            metadata_manifest_schema={},
+            provenance_manifest_schema={},
+        )
+
+
+def test_phase4e_build_manifest_rejects_capture_contract_mismatch() -> None:
+    pytest.importorskip("jsonschema")
+    records, manifest_payload = _build_two_record_artifacts()
+    records[0]["metadata_contract_version"] = "tp.meta.capture.v999"
+
+    with pytest.raises(ProvenanceInputError, match="capture record\\[0\\] contract mismatch"):
+        build_provenance_manifest_payload(
+            records,
+            manifest_payload,
+            metadata_schema={},
+            metadata_manifest_schema={},
+            provenance_manifest_schema={},
+        )
+
+
+def test_phase4e_build_manifest_rejects_metadata_manifest_contract_mismatch() -> None:
+    pytest.importorskip("jsonschema")
+    records, manifest_payload = _build_two_record_artifacts()
+    manifest_payload["metadata_manifest_contract_version"] = "tp.meta.capture_manifest.v999"
+
+    with pytest.raises(ProvenanceInputError, match="metadata manifest contract mismatch"):
+        build_provenance_manifest_payload(
+            records,
+            manifest_payload,
+            metadata_schema={},
+            metadata_manifest_schema={},
+            provenance_manifest_schema={},
+        )
+
+
+def test_phase4e_build_manifest_rejects_metadata_manifest_entries_that_are_not_array() -> None:
+    pytest.importorskip("jsonschema")
+    records, manifest_payload = _build_two_record_artifacts()
+    manifest_payload["entries"] = {"not": "an array"}
+
+    with pytest.raises(ProvenanceInputError, match="metadata manifest entries must be an array"):
+        build_provenance_manifest_payload(
+            records,
+            manifest_payload,
+            metadata_schema={},
+            metadata_manifest_schema={},
+            provenance_manifest_schema={},
+        )
+
+
+def test_phase4e_build_manifest_rejects_missing_extractor_when_fingerprint_required() -> None:
+    pytest.importorskip("jsonschema")
+    records, manifest_payload = _build_two_record_artifacts()
+    del records[0]["extractor"]
+
+    with pytest.raises(ProvenanceInputError, match="missing extractor object"):
+        build_provenance_manifest_payload(
+            records,
+            manifest_payload,
+            metadata_schema={},
+            metadata_manifest_schema={},
+            provenance_manifest_schema={},
+            required_config_fingerprint_sha256="0" * 64,
+        )
+
+
+def test_phase4e_build_manifest_rejects_alignment_mismatch_directly() -> None:
+    pytest.importorskip("jsonschema")
+    records, manifest_payload = _build_two_record_artifacts()
+    manifest_payload["entries"] = manifest_payload["entries"][:1]
+
+    with pytest.raises(ProvenanceInputError, match="relative_path alignment mismatch"):
+        build_provenance_manifest_payload(
+            records,
+            manifest_payload,
+            metadata_schema={},
+            metadata_manifest_schema={},
+            provenance_manifest_schema={},
+        )
+
+
+def test_phase4e_build_manifest_rejects_file_sha256_mismatch_directly() -> None:
+    pytest.importorskip("jsonschema")
+    records, manifest_payload = _build_two_record_artifacts()
+    manifest_payload["entries"][0]["file_sha256"] = "f" * 64
+
+    with pytest.raises(ProvenanceInputError, match="file_sha256 mismatch"):
+        build_provenance_manifest_payload(
+            records,
+            manifest_payload,
+            metadata_schema={},
+            metadata_manifest_schema={},
+            provenance_manifest_schema={},
+        )
+
+
+def test_phase4e_build_manifest_rejects_metadata_sha256_mismatch_directly() -> None:
+    pytest.importorskip("jsonschema")
+    records, manifest_payload = _build_two_record_artifacts()
+    manifest_payload["entries"][0]["metadata_sha256"] = "f" * 64
+
+    with pytest.raises(ProvenanceInputError, match="metadata_sha256 mismatch"):
+        build_provenance_manifest_payload(
+            records,
+            manifest_payload,
+            metadata_schema={},
+            metadata_manifest_schema={},
+            provenance_manifest_schema={},
+        )
+
+
+def test_phase4e_build_manifest_wraps_canonical_serialization_errors() -> None:
+    pytest.importorskip("jsonschema")
+    records, manifest_payload = _build_two_record_artifacts()
+    records[0]["non_jsonable"] = object()
+
+    with pytest.raises(ProvenanceSchemaValidationError, match="canonical metadata serialization failed"):
+        build_provenance_manifest_payload(
+            records,
+            manifest_payload,
             metadata_schema={},
             metadata_manifest_schema={},
             provenance_manifest_schema={},

--- a/tests/test_build_provenance_merkle.py
+++ b/tests/test_build_provenance_merkle.py
@@ -12,7 +12,14 @@ from typing import Any
 import pytest
 
 from tp.phase4.hash_capture_metadata import METADATA_CONTRACT_VERSION, compute_metadata_sha256
-from tp.phase4.provenance_capture import PROVENANCE_CONTRACT_VERSION, compute_provenance_entry_sha256
+from tp.phase4.provenance_capture import (
+    PROVENANCE_CONTRACT_VERSION,
+    PROVENANCE_MERKLE_CONTRACT_VERSION,
+    ProvenanceInputError,
+    build_provenance_merkle_payload,
+    compute_provenance_entry_sha256,
+    serialize_provenance_merkle,
+)
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 EXTRACT_TOOL = PROJECT_ROOT / "tools" / "extract_capture_metadata.py"
@@ -150,6 +157,131 @@ def _build_two_entry_provenance_manifest() -> dict[str, Any]:
             },
         ],
     }
+
+
+def test_phase4e_build_merkle_payload_direct_success() -> None:
+    pytest.importorskip("jsonschema")
+    provenance_manifest = _build_two_entry_provenance_manifest()
+
+    payload = build_provenance_merkle_payload(
+        provenance_manifest,
+        provenance_manifest_schema={},
+        provenance_merkle_schema={},
+    )
+
+    assert payload["provenance_merkle_contract_version"] == PROVENANCE_MERKLE_CONTRACT_VERSION
+    assert payload["provenance_contract_version"] == PROVENANCE_CONTRACT_VERSION
+    assert payload["leaf_count"] == 2
+    assert serialize_provenance_merkle(payload).endswith(b"\n")
+
+
+def test_phase4e_build_merkle_payload_rejects_non_object_manifest() -> None:
+    pytest.importorskip("jsonschema")
+
+    with pytest.raises(ProvenanceInputError, match="provenance manifest payload must be a JSON object"):
+        build_provenance_merkle_payload(
+            [],
+            provenance_manifest_schema={},
+            provenance_merkle_schema={},
+        )
+
+
+def test_phase4e_build_merkle_payload_rejects_contract_mismatch() -> None:
+    pytest.importorskip("jsonschema")
+    provenance_manifest = _build_two_entry_provenance_manifest()
+    provenance_manifest["provenance_contract_version"] = "tp.meta.provenance.v999"
+
+    with pytest.raises(ProvenanceInputError, match="provenance manifest contract mismatch"):
+        build_provenance_merkle_payload(
+            provenance_manifest,
+            provenance_manifest_schema={},
+            provenance_merkle_schema={},
+        )
+
+
+def test_phase4e_build_merkle_payload_rejects_entries_that_are_not_array() -> None:
+    pytest.importorskip("jsonschema")
+    provenance_manifest = _build_two_entry_provenance_manifest()
+    provenance_manifest["entries"] = {"not": "an array"}
+
+    with pytest.raises(ProvenanceInputError, match="provenance manifest entries must be an array"):
+        build_provenance_merkle_payload(
+            provenance_manifest,
+            provenance_manifest_schema={},
+            provenance_merkle_schema={},
+        )
+
+
+def test_phase4e_build_merkle_payload_rejects_duplicate_relative_path_directly() -> None:
+    pytest.importorskip("jsonschema")
+    provenance_manifest = _build_two_entry_provenance_manifest()
+    provenance_manifest["entries"] = [provenance_manifest["entries"][0], _deepcopy(provenance_manifest["entries"][0])]
+
+    with pytest.raises(ProvenanceInputError, match="duplicate relative_path"):
+        build_provenance_merkle_payload(
+            provenance_manifest,
+            provenance_manifest_schema={},
+            provenance_merkle_schema={},
+        )
+
+
+def test_phase4e_build_merkle_payload_rejects_unsorted_entries_directly() -> None:
+    pytest.importorskip("jsonschema")
+    provenance_manifest = _build_two_entry_provenance_manifest()
+    provenance_manifest["entries"] = list(reversed(provenance_manifest["entries"]))
+
+    with pytest.raises(ProvenanceInputError, match="must be sorted by relative_path"):
+        build_provenance_merkle_payload(
+            provenance_manifest,
+            provenance_manifest_schema={},
+            provenance_merkle_schema={},
+        )
+
+
+def test_phase4e_build_merkle_payload_can_sort_when_strict_order_disabled() -> None:
+    pytest.importorskip("jsonschema")
+    provenance_manifest = _build_two_entry_provenance_manifest()
+    expected = build_provenance_merkle_payload(
+        provenance_manifest,
+        provenance_manifest_schema={},
+        provenance_merkle_schema={},
+    )
+    provenance_manifest["entries"] = list(reversed(provenance_manifest["entries"]))
+
+    relaxed = build_provenance_merkle_payload(
+        provenance_manifest,
+        provenance_manifest_schema={},
+        provenance_merkle_schema={},
+        strict_input_order=False,
+    )
+
+    assert relaxed == expected
+
+
+def test_phase4e_build_merkle_payload_rejects_invalid_leaf_digest_directly() -> None:
+    pytest.importorskip("jsonschema")
+    provenance_manifest = _build_two_entry_provenance_manifest()
+    provenance_manifest["entries"][0]["provenance_entry_sha256"] = "not-a-sha256"
+
+    with pytest.raises(ProvenanceInputError, match="provenance_entry_sha256"):
+        build_provenance_merkle_payload(
+            provenance_manifest,
+            provenance_manifest_schema={},
+            provenance_merkle_schema={},
+        )
+
+
+def test_phase4e_build_merkle_payload_rejects_empty_entries_directly() -> None:
+    pytest.importorskip("jsonschema")
+    provenance_manifest = _build_two_entry_provenance_manifest()
+    provenance_manifest["entries"] = []
+
+    with pytest.raises(ProvenanceInputError, match="entries must be non-empty"):
+        build_provenance_merkle_payload(
+            provenance_manifest,
+            provenance_manifest_schema={},
+            provenance_merkle_schema={},
+        )
 
 
 def test_phase4e_golden_provenance_merkle_matches_expected(tmp_path: Path) -> None:

--- a/tests/test_extract_capture_metadata.py
+++ b/tests/test_extract_capture_metadata.py
@@ -12,6 +12,7 @@ import pytest
 
 from tp.phase4.canonicalize_capture_metadata import (
     EXIFTOOL_TIMEOUT_SECONDS,
+    ConfigValidationError,
     ExtractionFailure,
     PathNormalizationError,
     _run_exiftool,
@@ -231,6 +232,38 @@ def test_phase4c_records_embed_config_fingerprint() -> None:
     assert payload
     for record in payload:
         assert record["extractor"]["config_fingerprint_sha256"] == expected_fingerprint
+
+
+def _write_config(tmp_path: Path, payload: dict) -> Path:
+    config_path = tmp_path / "capture_metadata_config.json"
+    config_path.write_text(json.dumps(payload), encoding="utf-8")
+    return config_path
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (lambda payload: payload.pop("tag_whitelist"), "config missing required key"),
+        (lambda payload: payload.update({"unexpected": True}), "config contains unknown key"),
+        (lambda payload: payload.update({"metadata_contract_version": "tp.meta.capture.v999"}), "metadata_contract_version"),
+        (lambda payload: payload.update({"tag_whitelist": ["Make", "Make"]}), "tag_whitelist must not contain duplicates"),
+        (
+            lambda payload: payload.update({"datetime_precedence": ["UnsupportedDateSource"]}),
+            "datetime_precedence contains unsupported source",
+        ),
+        (lambda payload: payload["rounding_rules"].update({"gps_decimal_places": True}), "gps_decimal_places"),
+        (lambda payload: payload["rounding_rules"].update({"rounding_mode": "half_up"}), "rounding_mode"),
+        (lambda payload: payload["orientation_mapping"].pop("8"), "orientation_mapping keys must be 1..8"),
+        (lambda payload: payload.update({"warning_codes": ["WARN_DATETIME_NO_TZ"]}), "warning_codes missing"),
+        (lambda payload: payload["path_normalization"].update({"forbid_dotdot": "yes"}), "forbid_dotdot"),
+    ],
+)
+def test_phase4c_config_validation_rejects_common_shape_errors(tmp_path: Path, mutate, message: str) -> None:
+    payload = json.loads(CAPTURE_CONFIG_PATH.read_text(encoding="utf-8"))
+    mutate(payload)
+
+    with pytest.raises(ConfigValidationError, match=message):
+        load_capture_metadata_config(_write_config(tmp_path, payload))
 
 
 def test_phase4c_path_normalization_rejects_unsafe_inputs() -> None:

--- a/tests/test_tp_import_surface_contract.py
+++ b/tests/test_tp_import_surface_contract.py
@@ -1,0 +1,89 @@
+"""Contract tests for the public ``tp`` import surface."""
+
+from __future__ import annotations
+
+import importlib
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO_ROOT / "src"
+TP_ROOT = SRC_ROOT / "tp"
+SNAKE_CASE_MODULE_RE = re.compile(r"(?:__init__|[a-z][a-z0-9]*(?:_[a-z0-9]+)*)")
+GENERATED_SUFFIXES = {".pyc", ".pyo"}
+
+PUBLIC_TP_MODULES = (
+    "tp",
+    "tp.crypto",
+    "tp.crypto.ct_merkle",
+    "tp.crypto.merkle",
+    "tp.merkle",
+    "tp.phase4",
+    "tp.phase4.canonicalize_capture_metadata",
+    "tp.phase4.exceptions",
+    "tp.phase4.hash_capture_metadata",
+    "tp.phase4.provenance_capture",
+    "tp.phase4.schema_validation",
+    "tp.phase4.types",
+    "tp.phase4.validation_helpers",
+    "tp.phase4.verify_phase4_chain",
+)
+
+
+def _tracked_tp_files() -> list[Path]:
+    result = subprocess.run(
+        ["git", "ls-files", "src/tp"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [Path(line) for line in result.stdout.splitlines() if line]
+
+
+def test_tp_remains_separate_public_import_surface() -> None:
+    assert TP_ROOT.is_dir()
+    assert (SRC_ROOT / "transformation_portal").is_dir()
+
+    tp_module = importlib.import_module("tp")
+    portal_module = importlib.import_module("transformation_portal")
+
+    assert Path(tp_module.__file__).resolve() == TP_ROOT / "__init__.py"
+    assert Path(portal_module.__file__).resolve().parent == SRC_ROOT / "transformation_portal"
+
+
+def test_public_tp_modules_remain_importable() -> None:
+    for module_name in PUBLIC_TP_MODULES:
+        assert importlib.import_module(module_name)
+
+
+def test_tp_merkle_reexport_remains_backward_compatible() -> None:
+    from tp.crypto.merkle import merkle_root_sha256
+    from tp.merkle import merkle_root_sha256 as reexported_merkle_root_sha256
+
+    assert reexported_merkle_root_sha256 is merkle_root_sha256
+
+
+def test_tracked_tp_files_are_source_only_and_consistently_named() -> None:
+    tracked_files = _tracked_tp_files()
+
+    assert tracked_files
+    assert tracked_files == sorted(tracked_files)
+
+    generated_files = [path for path in tracked_files if "__pycache__" in path.parts or path.suffix in GENERATED_SUFFIXES]
+    assert generated_files == []
+
+    non_python_files = [path for path in tracked_files if path.suffix != ".py"]
+    assert non_python_files == []
+
+    invalid_module_names = [path for path in tracked_files if not SNAKE_CASE_MODULE_RE.fullmatch(path.stem)]
+    assert invalid_module_names == []
+
+    package_dirs = {part for path in tracked_files for part in path.relative_to("src/tp").parts[:-1]}
+    invalid_package_dirs = [dirname for dirname in sorted(package_dirs) if not SNAKE_CASE_MODULE_RE.fullmatch(dirname)]
+    assert invalid_package_dirs == []

--- a/tests/test_verify_phase4_chain.py
+++ b/tests/test_verify_phase4_chain.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import subprocess
@@ -23,10 +24,17 @@ from tp.phase4.provenance_capture import (
     compute_provenance_entry_sha256,
 )
 from tp.phase4.verify_phase4_chain import (
+    FAILURE_CODE_LABEL_MAX_LENGTH,
     FAILURE_MESSAGE_MAX_LENGTH,
     Phase4AlignmentError,
+    Phase4SchemaValidationError,
+    Phase4VerificationInputError,
     build_verification_report_payload,
+    collect_report_inputs_from_paths,
     default_failure_computed_block,
+    serialize_verification_report_payload,
+    validate_verification_report_payload,
+    verify_phase4_chain_from_paths,
     verify_phase4_chain_payloads,
 )
 
@@ -216,6 +224,86 @@ def test_phase4f_report_validates_against_schema(tmp_path: Path) -> None:
     schema = _load_json(REPORT_SCHEMA_PATH)
     payload = _load_json(report_path)
     jsonschema.Draft202012Validator(schema).validate(payload)
+
+
+def test_phase4f_verify_from_paths_returns_inputs_and_computed_blocks() -> None:
+    verification = verify_phase4_chain_from_paths(
+        capture_metadata_path=GOLDEN_CAPTURE,
+        metadata_manifest_path=GOLDEN_METADATA_MANIFEST,
+        provenance_manifest_path=GOLDEN_PROVENANCE_MANIFEST,
+        provenance_merkle_path=GOLDEN_PROVENANCE_MERKLE,
+        metadata_schema_path=METADATA_SCHEMA_PATH,
+        metadata_manifest_schema_path=METADATA_MANIFEST_SCHEMA_PATH,
+        provenance_manifest_schema_path=PROVENANCE_MANIFEST_SCHEMA_PATH,
+        provenance_merkle_schema_path=PROVENANCE_MERKLE_SCHEMA_PATH,
+    )
+    golden_report = _load_json(GOLDEN_VERIFICATION_REPORT)
+
+    assert verification["inputs"] == golden_report["inputs"]
+    assert verification["computed"] == golden_report["computed"]
+
+
+def test_phase4f_verify_from_paths_rejects_malformed_input_json(tmp_path: Path) -> None:
+    bad_capture = tmp_path / "capture_bad.json"
+    bad_capture.write_text("{bad-json", encoding="utf-8")
+
+    with pytest.raises(Phase4VerificationInputError, match="unable to parse capture metadata artifact"):
+        verify_phase4_chain_from_paths(
+            capture_metadata_path=bad_capture,
+            metadata_manifest_path=GOLDEN_METADATA_MANIFEST,
+            provenance_manifest_path=GOLDEN_PROVENANCE_MANIFEST,
+            provenance_merkle_path=GOLDEN_PROVENANCE_MERKLE,
+            metadata_schema_path=METADATA_SCHEMA_PATH,
+            metadata_manifest_schema_path=METADATA_MANIFEST_SCHEMA_PATH,
+            provenance_manifest_schema_path=PROVENANCE_MANIFEST_SCHEMA_PATH,
+            provenance_merkle_schema_path=PROVENANCE_MERKLE_SCHEMA_PATH,
+        )
+
+
+def test_phase4f_verify_from_paths_rejects_non_object_schema(tmp_path: Path) -> None:
+    bad_schema = tmp_path / "metadata_schema_array.json"
+    bad_schema.write_text("[]", encoding="utf-8")
+
+    with pytest.raises(Phase4SchemaValidationError, match="metadata schema must be a JSON object"):
+        verify_phase4_chain_from_paths(
+            capture_metadata_path=GOLDEN_CAPTURE,
+            metadata_manifest_path=GOLDEN_METADATA_MANIFEST,
+            provenance_manifest_path=GOLDEN_PROVENANCE_MANIFEST,
+            provenance_merkle_path=GOLDEN_PROVENANCE_MERKLE,
+            metadata_schema_path=bad_schema,
+            metadata_manifest_schema_path=METADATA_MANIFEST_SCHEMA_PATH,
+            provenance_manifest_schema_path=PROVENANCE_MANIFEST_SCHEMA_PATH,
+            provenance_merkle_schema_path=PROVENANCE_MERKLE_SCHEMA_PATH,
+        )
+
+
+def test_phase4f_collect_report_inputs_handles_missing_and_malformed_files(tmp_path: Path) -> None:
+    bad_capture = tmp_path / "capture_bad.json"
+    bad_capture.write_text("{bad-json", encoding="utf-8")
+    provenance_manifest = tmp_path / "provenance_manifest.json"
+    _write_json(
+        provenance_manifest,
+        {
+            "provenance_contract_version": PROVENANCE_CONTRACT_VERSION,
+            "metadata_contract_version": METADATA_CONTRACT_VERSION,
+        },
+    )
+    merkle_array = tmp_path / "provenance_merkle_array.json"
+    _write_json(merkle_array, [])
+
+    inputs = collect_report_inputs_from_paths(
+        capture_metadata_path=bad_capture,
+        metadata_manifest_path=tmp_path / "missing_metadata_manifest.json",
+        provenance_manifest_path=provenance_manifest,
+        provenance_merkle_path=merkle_array,
+    )
+
+    assert inputs["capture_metadata"]["file_sha256"] == hashlib.sha256(b"{bad-json").hexdigest()
+    assert inputs["capture_metadata"]["metadata_contract_version"] is None
+    assert inputs["metadata_manifest"]["file_sha256"] is None
+    assert inputs["provenance_manifest"]["provenance_contract_version"] == PROVENANCE_CONTRACT_VERSION
+    assert inputs["provenance_merkle"]["file_sha256"] == hashlib.sha256(b"[]").hexdigest()
+    assert inputs["provenance_merkle"]["provenance_merkle_contract_version"] is None
 
 
 def test_phase4f_report_has_no_nondeterministic_fields(tmp_path: Path) -> None:
@@ -632,6 +720,55 @@ def test_phase4f_failure_report_truncates_long_failure_messages() -> None:
 
     schema = _load_json(REPORT_SCHEMA_PATH)
     jsonschema.Draft202012Validator(schema).validate(payload)
+
+
+def test_phase4f_failure_report_defaults_and_truncates_labels() -> None:
+    jsonschema = pytest.importorskip("jsonschema")
+    golden_report_payload = _load_json(GOLDEN_VERIFICATION_REPORT)
+    payload = build_verification_report_payload(
+        inputs=dict(golden_report_payload["inputs"]),
+        computed=default_failure_computed_block(),
+        passed=False,
+        failure_code_label="",
+        failure_message="",
+    )
+    assert payload["verification_status"]["failure_code_label"] == "UNSPECIFIED_FAILURE"
+    assert payload["verification_status"]["failure_message"] == "verification failed"
+
+    long_label = "LABEL_" + ("x" * (FAILURE_CODE_LABEL_MAX_LENGTH + 32))
+    payload = build_verification_report_payload(
+        inputs=dict(golden_report_payload["inputs"]),
+        computed=default_failure_computed_block(),
+        passed=False,
+        failure_code_label=long_label,
+        failure_message="failure",
+    )
+    failure_code_label = payload["verification_status"]["failure_code_label"]
+    assert isinstance(failure_code_label, str)
+    assert len(failure_code_label) == FAILURE_CODE_LABEL_MAX_LENGTH
+    assert failure_code_label.endswith("... [truncated]")
+
+    schema = _load_json(REPORT_SCHEMA_PATH)
+    jsonschema.Draft202012Validator(schema).validate(payload)
+
+
+def test_phase4f_report_validation_rejects_non_object_payload() -> None:
+    with pytest.raises(Phase4SchemaValidationError, match="verification report payload must be a JSON object"):
+        validate_verification_report_payload([], report_schema={})
+
+
+def test_phase4f_report_validation_rejects_schema_mismatch() -> None:
+    with pytest.raises(Phase4SchemaValidationError, match="verification_report schema validation failed"):
+        validate_verification_report_payload({}, report_schema={"type": "array"})
+
+
+def test_phase4f_report_serialization_is_canonical_with_trailing_newline() -> None:
+    payload = _load_json(GOLDEN_VERIFICATION_REPORT)
+    serialized = serialize_verification_report_payload(payload)
+
+    assert serialized.endswith(b"\n")
+    assert not serialized.endswith(b"\n\n")
+    assert json.loads(serialized) == payload
 
 
 def test_phase4f_report_schema_rejects_inconsistent_pass_fail_fields() -> None:


### PR DESCRIPTION
## Summary
- Audited `src/tp` and preserved it as the separate public contract/fixity/Phase 4 import surface instead of relocating it into `transformation_portal`.
- Added the smallest contract-backed guard for that boundary: maintainer guidance, package-surface documentation, and a focused import/naming/source-only test.
- Added test-only Phase 4 coverage for direct contract-helper success/failure branches in metadata, provenance manifest, provenance merkle, and verification report flows.
- Fixed a stale canonical JSON property test that treated comma-space or colon-space inside user string content as structural separator whitespace.

## Changes
- Documents the `src/tp` boundary in `AGENTS.md` and `src/tp/__init__.py`.
- Adds `tests/test_tp_import_surface_contract.py` to verify public `tp.*` imports, `tp.merkle` compatibility, source-only tracked files, and lowercase snake_case package/module names.
- Updates `tests/crypto/test_merkle_properties.py` so the whitespace property checks structural JSON bytes outside string literals.
- Adds direct tests for `build_metadata_manifest_payload()` success, required fingerprint matching, contract mismatch, fingerprint mismatch, missing extractor, and canonical serialization errors.
- Adds direct tests for `build_provenance_manifest_payload()` and `build_provenance_merkle_payload()` success, contract mismatch, malformed payload shapes, alignment/hash mismatches, duplicate/unsorted entries, relaxed sorting, invalid leaf digests, and empty entries.
- Adds direct tests for `verify_phase4_chain_from_paths()`, report input collection from missing/malformed files, failure defaulting/truncation, malformed report payload validation, and canonical report serialization.
- Adds a compact config-validation parameterization for common `canonicalize_capture_metadata.py` config shape errors.
- Removed ignored `src/tp` `__pycache__` artifacts locally; no generated artifacts are committed.
- No route, selector, API envelope, schema, CLI flag, or runtime contract shape changed.

## Validation
Proven green:
- `.venv/bin/pytest tests/crypto/test_merkle_properties.py::TestCanonicalJsonProperties::test_canonicalize_uses_no_whitespace -q`
- `.venv/bin/pytest tests/test_tp_import_surface_contract.py tests/crypto/test_ct_merkle.py tests/crypto/test_merkle_properties.py tests/test_phase4_validation_helpers.py tests/test_phase4_exceptions.py tests/test_build_metadata_manifest.py tests/test_build_provenance_manifest.py tests/test_build_provenance_merkle.py tests/test_verify_phase4_chain.py -q`
- `.venv/bin/python -m black tests/test_build_metadata_manifest.py tests/test_build_provenance_manifest.py tests/test_build_provenance_merkle.py tests/test_verify_phase4_chain.py tests/test_extract_capture_metadata.py`
- `env PYTHONDONTWRITEBYTECODE=1 .venv/bin/pytest tests/test_build_metadata_manifest.py tests/test_build_provenance_manifest.py tests/test_build_provenance_merkle.py tests/test_verify_phase4_chain.py tests/test_extract_capture_metadata.py -q` (`127 passed`)
- `env COVERAGE_FILE=/private/tmp/tp_phase4.coverage PYTHONDONTWRITEBYTECODE=1 .venv/bin/pytest tests/test_extract_capture_metadata.py tests/test_build_metadata_manifest.py tests/test_build_provenance_manifest.py tests/test_build_provenance_merkle.py tests/test_verify_phase4_chain.py tests/test_phase4_validation_helpers.py tests/test_phase4_exceptions.py tests/test_capture_metadata_fingerprint.py tests/test_tp_import_surface_contract.py --cov=tp.phase4 --cov-branch --cov-report=term-missing --cov-report=json:/private/tmp/tp_phase4_coverage_after.json --no-cov-on-fail -q` (`182 passed`; scoped `tp.phase4` total coverage `60.72% -> 79.21%`, branch coverage `47.80% -> 67.31%`)
- `make check-doc-heading-links`
- `make ci-quick`
- `make test-fast`
- `make pre-commit`
- `make check-worktree`
- `git diff --check`
- `git diff --cached --check`
- Commit pre-commit hooks

Still failing:
- None.

Notes:
- `make ci-quick` still reports advisory pylint messages in `tests/crypto/test_merkle_properties.py`, but the repository lint runner treats those as advisory and the target passed.
- The discovered canonical JSON assertion was stale test logic, not product logic: it matched separator-like bytes inside JSON string content.

## Risk
- Compatibility risk is low: existing `tp.*` files were not moved, so public imports remain intact.
- Phase 4 changes are test-only and exercise existing helper/report contracts without changing schemas, CLIs, selectors, or runtime behavior.
- Import contract stability and Phase 4 failure-path coverage are strengthened.
- The change is revert-safe and bounded to documentation, package metadata, and focused tests.
