### PR TITLE
chore(root): harden governance contracts

### DIFF
--- a/.auto-organize.sh
+++ b/.auto-organize.sh
@@ -504,7 +504,7 @@ main() {
             failed_steps=$((failed_steps + 1))
         fi
 
-        # Step 5: Validate documentation structure
+        # Step 5: Validate script topology
         total_steps=$((total_steps + 1))
         if validate_script_topology; then
             passed_steps=$((passed_steps + 1))

--- a/.dockerignore
+++ b/.dockerignore
@@ -7,6 +7,7 @@
 .mypy_cache/
 .ruff_cache/
 .hypothesis/
+.pyre/
 .coverage
 .coverage.*
 coverage.xml
@@ -14,6 +15,7 @@ coverage.json
 htmlcov/
 requirements/.pip-tools-cache/
 requirements/.hash-pilot/
+.rag_cache/
 
 # Local secrets / credentials
 .env
@@ -31,6 +33,7 @@ web/secure-landing/node_modules/
 web/secure-landing/.next/
 web/secure-landing/.next-*/
 web/secure-landing/.metafiles/
+web/secure-landing/tmp/
 web/secure-landing/test-results/
 web/secure-landing/playwright-report/
 web/secure-landing/blob-report/
@@ -38,6 +41,10 @@ web/secure-landing/.playwright/
 cloudflare/transformationportal-worker/node_modules/
 cloudflare/transformationportal-worker/.wrangler/
 
+build/
+dist/
+downloads/
+docs/api/_build/
 output/
 output_*/
 outputs/
@@ -45,17 +52,30 @@ processed_images/
 processed_output/
 test_output/
 test_artifacts/
+extracted_context/
 logs/
 artifacts/
 trial_runs/
 archive_reports/
 local_artifacts/
+depth_maps_apex/
+artifact_store/
+archive/experiments/
+archive/deprecated/
+archive/legacy/
 
 input_images/
+data/sample_images/
+Architectural_Plans/
 checkpoints/
 models/
 weights/
 pretrained/
+external/
+.cas/
+.local_backup/
+.backup_local/
+.branch_cleanup_backup/
 
 *.log
 *.tmp
@@ -78,3 +98,7 @@ __pycache__/
 *.mlpackage
 *.tif
 *.tiff
+*.xlsx
+*.xls
+tmp_tensor.npy
+uv.lock

--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,7 @@
 # Shared secret for protected /v1 endpoints. When unset AND
 # TP_ENFORCE_JOB_API_KEY is true (the default), the orchestrator returns
 # 503 AUTH_CONFIGURATION_ERROR for protected routes. Generate with:
-#   python -c "import secrets; print(secrets.token_urlsafe(32))"
+#   .venv/bin/python -c "import secrets; print(secrets.token_urlsafe(32))"
 TP_API_KEY=
 
 # Whether protected /v1 endpoints enforce the API key. Default in app.py: true.
@@ -26,6 +26,59 @@ TP_API_KEY=
 
 # HTTP header carrying the API key. Default: x-api-key. Lower-case, single token.
 # TP_API_KEY_HEADER=x-api-key
+
+# ---------------------------------------------------------------------------
+# HTTP trust, path boundaries, and request limits
+# ---------------------------------------------------------------------------
+
+# Comma-separated CORS origins accepted by the FastAPI origin. Defaults in
+# app.py: http://localhost,http://localhost:3000,http://127.0.0.1:8000.
+# TP_ALLOWED_ORIGINS=http://localhost,http://localhost:3000,http://127.0.0.1:8000
+
+# TrustedHost middleware allowlist. Append tunnel or deployment hostnames before
+# backend startup; keep TP_ENABLE_TRUSTED_HOSTS=true outside exceptional local
+# troubleshooting.
+# TP_TRUSTED_HOSTS=localhost,127.0.0.1,::1,testserver
+# TP_ENABLE_TRUSTED_HOSTS=true
+
+# Only enable forwarded-client-IP trust behind a controlled proxy, then list the
+# trusted proxy IPs explicitly.
+# TP_TRUST_X_FORWARDED_FOR=false
+# TP_TRUSTED_PROXY_IPS=
+
+# Request and admission limits. Defaults in app.py: 1 MiB request/upload cap,
+# 256 upload files, 32 multipart fields, 60 requests/minute, 4 concurrent jobs.
+# TP_MAX_REQUEST_BYTES=1048576
+# TP_PORTAL_MAX_UPLOAD_REQUEST_BYTES=1048576
+# TP_PORTAL_UPLOAD_MAX_FILES=256
+# TP_PORTAL_UPLOAD_MAX_FIELDS=32
+# TP_PORTAL_UPLOAD_MAX_PART_BYTES=1048576
+# TP_RATE_LIMIT_PER_MINUTE=60
+# TP_MAX_CONCURRENT_JOBS=4
+
+# Comma-separated filesystem roots the backend may read from or write to. Defaults
+# are the repo root plus platform temp aliases. Keep TP_PORTAL_UPLOAD_ROOT inside
+# TP_ALLOWED_INPUT_ROOTS.
+# TP_ALLOWED_INPUT_ROOTS=.
+# TP_ALLOWED_OUTPUT_ROOTS=.
+
+# Job retention and worker lease tunables. Canonical worker names are TP_WORKER_*;
+# legacy TP_ORCHESTRATOR_WORKER_* names are only fallback compatibility.
+# TP_JOB_RETENTION_SECONDS=3600
+# TP_CLEANUP_INTERVAL_SECONDS=60
+# TP_JOB_CLEANUP_SCAN_LIMIT=1000
+# TP_CANCEL_GRACE_SECONDS=5
+# TP_JOB_LIST_LIMIT=200
+# TP_MAX_INDEXED_ARTIFACTS=200
+# TP_WORKER_LEASE_SECONDS=300
+# TP_WORKER_HEARTBEAT_SECONDS=30
+# TP_WORKER_POLL_SECONDS=0.05
+# TP_ORCHESTRATOR_WORKER_SHUTDOWN_GRACE_SECONDS=5
+# TP_ORCHESTRATOR_RECLAIM_SWEEP_INTERVAL_SECONDS=5
+
+# Local diagnostics. Leave disabled in normal local/production runs.
+# TP_ENABLE_API_DOCS=false
+# TP_READY_VERBOSE=false
 
 # ---------------------------------------------------------------------------
 # Docker Compose runtime
@@ -42,9 +95,15 @@ TP_GID=10001
 # backend exposes a separate device selector.
 DEVICE=cpu
 
-# Override interpreter used to launch the DA3 depth subprocess. Most deploys
-# leave this unset and the orchestrator picks `python3` from PATH.
+# Optional subprocess runtime interpreter overrides. Most deploys leave these
+# unset and let Lux Depth V3 auto-discover the repo-local runtime contract paths
+# when present:
+#   ./.runtime/Depth-Anything-3/.venv-da3/bin/python
+#   ./.venv-depth-pro/bin/python
+#   ./.venv-raw/bin/python
 # TRANSFORMATION_PORTAL_DA3_PYTHON=
+# TRANSFORMATION_PORTAL_DEPTH_PRO_PYTHON=
+# TRANSFORMATION_PORTAL_RAW_PYTHON=
 
 # ---------------------------------------------------------------------------
 # Backend storage, queue, and artifact backends

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,12 +44,12 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install PyYAML>=6.0
-          pip install -r requirements.txt
+          python -m pip install "PyYAML>=6.0"
+          python -m pip install -r requirements.txt
           # sphinx-autodoc-typehints currently fails under Sphinx 9.x in this workflow;
           # keep docs build on the stable Sphinx 8 line until upstream compatibility lands.
-          pip install "sphinx>=7.2,<9" "sphinx-rtd-theme>=2.0,<3" "sphinx-autodoc-typehints>=2.0,<4"
-          pip install -e .
+          python -m pip install "sphinx>=7.2,<9" "sphinx-rtd-theme>=2.0,<3" "sphinx-autodoc-typehints>=2.0,<4"
+          python -m pip install -e .
 
       - name: Build documentation
         run: |

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -7,7 +7,7 @@ useDefault = true
 # gitleaks v8.21.x and does not support global allowlist targetRules.
 [allowlist]
 description = "Ignore generated local artifact directories already excluded from version control"
-paths = ['''(^|/)(output|output_[^/]*|test_output|test_artifacts|processed_images|processed_output|extracted_context|docs/api/_build|__pycache__|\.pytest_cache|\.mypy_cache|\.ruff_cache|\.pyre|\.rag_cache|web/secure-landing/(?:\.next|\.next-build-verify|\.next-smoke-[^/]*|\.next-codex-[^/]*|\.metafiles))(/|$)''']
+paths = ['''(^|/)(\.venv(?:-[^/]*)?|\.runtime|\.cache|\.pytest_cache|\.mypy_cache|\.ruff_cache|\.hypothesis|\.pyre|\.rag_cache|\.coverage(?:\..*)?|coverage\.(?:xml|json)|htmlcov|node_modules|build|dist|downloads|docs/api/_build|output|output_[^/]*|outputs|test_output|test_artifacts|processed_images|processed_output|extracted_context|logs|artifacts|trial_runs|archive_reports|local_artifacts|depth_maps_apex|artifact_store|archive/(?:experiments|deprecated|legacy)|__pycache__|web/secure-landing/(?:node_modules|\.next|\.next-build-verify|\.next-smoke-[^/]*|\.next-codex-[^/]*|\.metafiles|tmp|test-results|playwright-report|blob-report|\.playwright)|cloudflare/transformationportal-worker/(?:node_modules|\.wrangler))(/|$)''']
 
 [[rules]]
 id = "generic-api-key"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,18 +8,14 @@
 #
 # Install:
 #   make install-hooks
-#   # or
-#   pre-commit install -f
 #
 # Manual run:
 #   make pre-commit
-#   # or
-#   pre-commit run --all-files
 #
 # For the unified quality gate without the pre-commit framework:
 #   ./scripts/pre_commit_hook.sh
 
-# `pre-commit install -f` (invoked by `make install-hooks`) installs exactly
+# `make install-hooks` invokes the repo-managed `.venv` pre-commit and installs exactly
 # the hook types listed here. The gitleaks hook below declares a `pre-push`
 # stage, so pre-push must be installed by default — otherwise `git push` would
 # bypass the secrets check when a caller used `git commit --no-verify`.
@@ -67,6 +63,13 @@ repos:
         name: Check Root File Placement
         entry: scripts/setup/pre-commit-check.sh
         language: system
+        pass_filenames: false
+
+      - id: check-script-topology
+        name: Check Script Topology
+        entry: scripts/setup/run_repo_python.sh scripts/governance/check_script_topology.py
+        language: system
+        files: ^(scripts/.*|src/transformation_portal/(perceptual|pipelines)/.*|archive/scripts/legacy-organization/.*)$
         pass_filenames: false
 
       - id: check-ml-test-isolation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,8 @@ actionable; use the linked docs and `Makefile` for exhaustive inventories.
 - Branch hygiene closeout: confirm PR state, local `main...origin/main`, no
   stale local branch for the PR, and no stale remote-tracking branch after
   prune.
+- Hook setup is `make install-hooks`; it installs both pre-commit and pre-push
+  hooks through the repo-managed `.venv` pre-commit binary.
 
 ## Authority And Navigation
 
@@ -108,12 +110,19 @@ actionable; use the linked docs and `Makefile` for exhaustive inventories.
   `make test-paid-pilot-services-contract`. Start only the services required by
   the lane and report missing services as environment blockers.
 - Governance/docs gates:
+  `make validate-ci`,
   `make check-stale-docs`, `make check-doc-heading-links`,
   `make check-todo-governance`, `make check-ci-sync`,
   `make check-requirements-lock-contract`, `make check-dependency-pinning`,
   `make check-json-serialization`, `make check-yaml-governance`,
   `make check-python-headers`, and
-  `python3 scripts/governance/check_docs_structure.py --all`.
+  `python3 scripts/governance/check_docs_structure.py --all`. For direct
+  source-contract checks use
+  `./scripts/setup/run_repo_python.sh scripts/governance/check_script_topology.py`
+  and
+  `./scripts/setup/run_repo_python.sh scripts/validation/check_gitleaks_workflow_contract.py`.
+- Root metadata contract tests:
+  `./.venv/bin/pytest tests/validation/test_cloudflare_worker_root_shim_contract.py tests/validation/test_git_blame_ignore_revs_contract.py tests/validation/test_gitattributes_contract.py tests/validation/test_pylint_config_contract.py -v`.
 - Coverage/cold-zone:
   `make coverage-report`, `make coverage-diff`, `make coverage-package`,
   `python3 scripts/ci/check_per_package_coverage.py coverage.xml`,
@@ -158,8 +167,8 @@ actionable; use the linked docs and `Makefile` for exhaustive inventories.
 - `make install-ml` and `make install-ml-raw` are intentionally disabled until
   trusted umbrella/raw lock contracts exist.
 - Supported ML installs:
-  `make install-ml-core`, `make install-ml-sam2`, and
-  `make install-ml-coreml` on macOS when the trusted lock exists.
+  `make install-ml-core`, `make install-ml-sam2` on native macOS Apple
+  Silicon, and `make install-ml-coreml` on macOS when the trusted lock exists.
 - Target-owned lock lanes:
   `make compile-ml-darwin-arm64`, `make update-ml-darwin-arm64`, and
   `make check-ml-darwin-arm64`. Linux x86_64 and Darwin x86_64 ML lock lanes
@@ -188,6 +197,21 @@ actionable; use the linked docs and `Makefile` for exhaustive inventories.
   `./scripts/validate_dependency_constraints.sh`,
   `./scripts/setup/ensure_node_version.sh`, and
   `./scripts/setup/run_repo_python.sh scripts/validation/check_unsafe_torch_load.py --fix-suggestions`.
+- Script topology:
+  canonical implementations live under governed `scripts/setup`,
+  `scripts/pipelines`, `scripts/utilities`, or `src/transformation_portal`
+  paths. Public compatibility wrappers in `scripts/` must delegate to the
+  canonical module, bootstrap the right import root, and propagate exit status.
+  Validate with
+  `./scripts/setup/run_repo_python.sh scripts/governance/check_script_topology.py`.
+- Cloudflare Worker root shim:
+  root `package.json` is only a Workers Builds deploy shim. Use
+  `npm run worker:dry-run` or `npm run worker:deploy`; keep versions and
+  scripts aligned with `cloudflare/transformationportal-worker`.
+- Presence Security CLI:
+  `.venv/bin/presence-security params`, `anchor`, and `watermark` are the
+  current helpers for sessionized Presence Compiler parameters, SHA3 anchor
+  payloads, and manifest/session watermarks.
 - Frontdoor source bundle:
   from `web/secure-landing`, use `npm run build:portal`,
   `npm run check:utility-ownership`, and `npm run check:css-layer-parity`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ make install-fastvlm-runtime    # optional FastVLM advisory captioning subproces
 make check-fastvlm-runtime      # verify FastVLM runtime + selected model roles (TP_FASTVLM_VALIDATE_MODELS=smoke,default by default)
 make check-environment          # pre-flight (Python/Node/Chrome/ports/dep-health)
 ```
-The umbrella `make install-ml` is **disabled** until a trusted umbrella ML lockfile exists. `install-ml-raw` is also fail-closed pending a trusted target-correct lockfile. Use the layered targets (`install-ml-core`, `install-ml-sam2`, `install-ml-coreml`) or `./scripts/bootstrap/install_ml_stack.sh --profile <core-cpu|core-mps|...>`. All current core profiles (`core-cpu`, `core-mps`) are Apple Silicon (`darwin-arm64`) only; `core-cuda` and the Linux/Intel macOS lanes are retired and fail closed.
+The umbrella `make install-ml` is **disabled** until a trusted umbrella ML lockfile exists. `install-ml-raw` is also fail-closed pending a trusted target-correct lockfile. Use the layered Make targets (`install-ml-core`, `install-ml-sam2`, `install-ml-coreml`) for current operator setup. Advanced Apple Silicon bootstrap-profile work can call `./scripts/bootstrap/install_ml_stack.sh --profile <core-cpu|core-mps|...>` directly. All current core profiles (`core-cpu`, `core-mps`) are Apple Silicon (`darwin-arm64`) only; `core-cuda` and the Linux/Intel macOS lanes are retired and fail closed.
 
 ### Tests
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,7 +166,7 @@ Tests must be **deterministic** and **reliable**. Flaky tests (intermittent fail
 - Tests with >3% flake rate are quarantined
 
 **If you encounter a flaky test:**
-1. Check ledger: `python scripts/analyze_flakes.py`
+1. Check ledger: `.venv/bin/python scripts/analyze_flakes.py`
 2. Reproduce locally (run 20+ times)
 3. Fix root cause (see ADR-033 for common patterns)
 4. **Do not** just re-run CI hoping it passes
@@ -278,20 +278,18 @@ The following checks run after merge and do not block PRs:
 
 ### Quick Check (before committing)
 ```bash
-# Lint and format
-black --check --line-length=127 src/ tests/
-isort --check-only --profile=black --line-length=127 src/ tests/
-flake8 src/ tests/ --max-line-length=127
+# CI-pinned lint parity (Black, isort, flake8, and pylint)
+make lint-parity
 
 # Core tests
-pytest -v tests/ -m "(unit or security or regression or golden or integration) and not slow" --maxfail=3
+make test-fast
 ```
 
 ### Full Pre-PR Check
 ```bash
-# Format code
-black --line-length=127 src/ tests/
-isort --profile=black --line-length=127 src/ tests/
+# Format code with the CI-pinned lint toolchain
+./scripts/setup/run_lint_tool.sh black src/ tests/
+./scripts/setup/run_lint_tool.sh isort src/ tests/
 
 # Run security scans
 ./scripts/security_scan.sh  # Uses CI-aligned flags: -ll -ii
@@ -306,8 +304,8 @@ pytest -v tests/ -m "not slow" \
 coverage report --fail-under=25
 
 # Build package
-python -m build
-twine check dist/*
+.venv/bin/python -m build
+.venv/bin/twine check dist/*
 ```
 
 ## CI/CD Control Plane
@@ -361,12 +359,13 @@ The `main` branch is protected to ensure code quality and stability. All changes
    - `CI Quality Firewall (post-CI) / Flake Rate Analysis`
    - `Nightly Deep Checks / Nightly Summary`
 
-3. **Resolve all review conversations** (recommended)
+3. **Resolve all review conversations** (required)
+   - Branch protection requires conversation resolution before merge
    - Address all reviewer comments before merge
 
-4. **Maintain linear history**
-   - Use "Squash and merge" or "Rebase and merge"
-   - Merge commits are allowed but squash is preferred
+4. **Maintain reviewable history**
+   - Use exact-head "Squash and merge" by default
+   - Merge commits are allowed by repository settings, but squash remains the preferred project convention
 
 5. **Keep branch up to date**
    - Strict status checks enabled: must be up-to-date with main before merge
@@ -375,7 +374,7 @@ The `main` branch is protected to ensure code quality and stability. All changes
 
 ---
 
-### Current Branch Protection Rules (Verified 2026-02-10)
+### Current Branch Protection Rules (Verified 2026-06-03)
 
 ### Required Status Checks (✅ ENFORCED)
 - **CI Gate** (GitHub App ID: 15368) must pass
@@ -388,15 +387,15 @@ The `main` branch is protected to ensure code quality and stability. All changes
 - **Code owner reviews**: Not required
 - **Last push approval**: Not required
 
-### History and Force Push Protection (✅ ENFORCED)
+### History and Force Push Protection
 - **Force pushes**: ❌ Disabled (history is immutable)
 - **Branch deletions**: ❌ Disabled (main cannot be deleted)
-- **Linear history**: ✅ Required (merge commits or squash merges only)
+- **Linear history**: Not required by branch protection; use exact-head squash by project convention
 
-### Additional Protections (NOT ENABLED)
-- **Enforce for admins**: ❌ Not enabled (admins can bypass)
+### Additional Protections
+- **Enforce for admins**: ✅ Enabled
 - **Require signed commits**: ❌ Not enabled
-- **Require conversation resolution**: ❌ Not enabled
+- **Require conversation resolution**: ✅ Enabled
 - **Lock branch**: ❌ Not enabled
 
 ### Recommended Improvements
@@ -408,15 +407,12 @@ Based on governance best practices, consider enabling:
      -f required_approving_review_count=1
    ```
 
-2. **Enforce for admins**: Prevent accidental bypasses
-   ```bash
-   gh api -X POST repos/RC219805/Transformation_Portal/branches/main/protection/enforce_admins
-   ```
-
-3. **Require signed commits**: For supply chain security (optional)
+2. **Require signed commits**: For supply chain security (optional)
    ```bash
    gh api -X POST repos/RC219805/Transformation_Portal/branches/main/protection/required_signatures
    ```
+
+3. **Require linear history**: Optional only if merge-commit workflows are intentionally retired
 
 ### Current Configuration Summary
 ```json
@@ -429,10 +425,11 @@ Based on governance best practices, consider enabling:
     "required_approving_review_count": 0,
     "dismiss_stale_reviews": true
   },
-  "enforce_admins": false,
-  "required_linear_history": true,
+  "enforce_admins": true,
+  "required_linear_history": false,
   "allow_force_pushes": false,
   "allow_deletions": false,
+  "required_conversation_resolution": true,
   "required_signatures": false
 }
 ```
@@ -517,11 +514,11 @@ We use a **ratcheting coverage strategy**:
 ### Lint Failures
 ```bash
 # Auto-fix most issues
-black --line-length=127 src/ tests/
-isort --profile=black --line-length=127 src/ tests/
+./scripts/setup/run_lint_tool.sh black src/ tests/
+./scripts/setup/run_lint_tool.sh isort src/ tests/
 
 # Check remaining issues
-flake8 src/ tests/ --max-line-length=127
+make lint-parity
 ```
 
 ### Test Failures
@@ -553,10 +550,10 @@ diff-cover coverage.xml --compare-branch=origin/main --fail-under=85
 rm -rf dist/ build/ *.egg-info
 
 # Build fresh
-python -m build
+.venv/bin/python -m build
 
 # Test wheel
-pip install dist/*.whl --force-reinstall
+.venv/bin/python -m pip install dist/*.whl --force-reinstall
 ```
 
 ## Dependency Management
@@ -571,7 +568,7 @@ Transformation Portal uses `pip-compile` for dependency management. All dependen
 |--------------------|-----------------|---------------------------------------------------|------------------------------------------|
 | **Range Pin**      | `>=X.Y,<Z`      | Production dependencies (`base.in`, ML layer `.in` files) | `numpy>=1.24,<2.5.0`                     |
 | **Strict Pin**     | `==X.Y.Z`       | Deterministic builds, known incompatibilities     | `rawpy==0.26.0  # RAW demosaic`          |
-| **Lower-bound**    | `>=X.Y`         | Dev tools with stable CLI (dev.in, ci.in only)    | `black>=24.8  # Formatter`               |
+| **Lower-bound**    | `>=X.Y`         | Dev tools with stable CLI (dev.in, ci.in only)    | `mypy>=1.10  # Type checker`             |
 | **Unpinned**       | (none)          | **NEVER ALLOWED** (causes non-deterministic builds) | ❌                                       |
 
 **Decision tree:**
@@ -708,7 +705,7 @@ Certain packages require minimum versions due to CVEs:
 
 | Package                 | Minimum Version | Reason                              |
 |-------------------------|-----------------|-------------------------------------|
-| `cryptography`          | >=46.0.5        | CVE-2026-26007 / GHSA-r6ph-v2qm-q3c2 |
+| `cryptography`          | >=47.0.0        | Governed lock baseline includes the CVE-2026-26007 / GHSA-r6ph-v2qm-q3c2 fix |
 | `sentence-transformers` | >=3.1.0         | CVE-73169 (arbitrary code execution) |
 | `Pillow`                | >=10.3.0        | CVE-2024-28219 and multiple 9.x CVEs |
 | `starlette`             | >=1.0.1         | CVE-2026-48710 / PYSEC-2026-161      |

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,10 +75,10 @@ EXPOSE 8000
 # Uses Python stdlib so we don't have to install curl in the slim base.
 # start-period gives uvicorn time to bind before failures count.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
-    CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/healthz', timeout=3).read()" || exit 1
+    CMD python3.11 -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/healthz', timeout=3).read()" || exit 1
 
 USER tp
-CMD ["python", "-m", "transformation_portal.cli"]
+CMD ["python3.11", "-m", "transformation_portal.cli"]
 
 # Stage 4: GPU runtime base (CUDA support)
 FROM nvidia/cuda:12.1.0-runtime-ubuntu22.04 AS gpu-runtime-base
@@ -146,27 +146,13 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
 USER tp
 CMD ["python3.11", "-m", "transformation_portal.cli"]
 
-# Stage 7: Apple Silicon builder (M-series chips)
-FROM python-build AS apple-silicon-build
+# Stage 7: Apple Silicon compatibility target.
+#
+# Docker on Apple Silicon still runs a Linux container, so this target cannot
+# consume the governed native Darwin arm64 ML lock or provide MPS/CoreML
+# acceleration. Keep the historical target name as a CPU image alias and route
+# native Apple Silicon ML installs through `make install-ml-core` or
+# `scripts/bootstrap/install_ml_stack.sh --profile core-mps`.
+FROM cpu AS apple-silicon
 
-# Install Apple Silicon optimized dependencies
-RUN python -m pip install --no-cache-dir coremltools
-RUN python -m pip install --no-cache-dir -e ".[ml]"
-
-# Stage 8: Apple Silicon optimized (M-series chips)
-FROM python-runtime-base AS apple-silicon
-
-ENV VIRTUAL_ENV=/opt/venv
-ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
-
-COPY --from=apple-silicon-build --chown=tp:tp /opt/venv /opt/venv
-COPY --from=apple-silicon-build --chown=tp:tp /app /app
-
-ENV DEVICE=mps
-EXPOSE 8000
-
-HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
-    CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/healthz', timeout=3).read()" || exit 1
-
-USER tp
-CMD ["python", "-m", "transformation_portal.cli"]
+ENV DEVICE=cpu

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ SHELL := /bin/sh
 BOOTSTRAP_PY = $$(./scripts/setup/resolve_python_311.sh)
 PY = $$(./scripts/setup/resolve_python_311.sh)
 PRE_COMMIT_BIN := $(shell if [ -x .venv/bin/pre-commit ]; then printf '%s' .venv/bin/pre-commit; elif [ -x .venv/Scripts/pre-commit.exe ]; then printf '%s' .venv/Scripts/pre-commit.exe; fi)
+DOCS_TOOL_REQUIREMENTS := "sphinx>=7.2,<9" "sphinx-rtd-theme>=2.0,<3" "sphinx-autodoc-typehints>=2.0,<4"
 
 # Common subsets (fast tests avoid heavy/optional paths)
 FAST_TESTS := \
@@ -37,7 +38,7 @@ PHASE6_SMOKE_TESTS := \
 
 help:
 	@echo "Targets:"
-	@echo "  setup              Install package in editable mode (pip install -e .)"
+	@echo "  setup              Install package in editable mode into the repo .venv"
 	@echo "  install-core       Install pinned core runtime + dev tooling dependencies into .venv"
 	@echo "  repair-core-venv   Recreate .venv and reinstall the pinned core environment"
 	@echo "  install-ml         Disabled: no trusted umbrella ML lockfile contract"
@@ -567,7 +568,7 @@ coverage-report:
 coverage-diff:
 	@echo "Running diff coverage comparison against main branch..."
 	@if ! "$(PY)" -m pip show diff-cover >/dev/null 2>&1; then \
-		echo "Error: diff-cover not installed. Run 'make install-core' or 'pip install diff-cover'"; \
+		echo "Error: diff-cover not installed. Run 'make install-core' to install the repo-managed tooling"; \
 		exit 1; \
 	fi
 	@if [ ! -f coverage.xml ]; then \
@@ -809,7 +810,7 @@ check-ml-darwin-x86_64:
 
 docs:
 	@echo "Building API documentation with Sphinx..."
-	@"$(PY)" -m pip install -q sphinx sphinx-rtd-theme sphinx-autodoc-typehints
+	@"$(PY)" -m pip install -q $(DOCS_TOOL_REQUIREMENTS)
 	@"$(PY)" -m sphinx -b html -W --keep-going docs/api docs/api/_build/html
 	@echo "✓ Documentation built in docs/api/_build/html"
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Quick discovery:
 lux-depth-v3 --help
 
 # If console scripts aren't on PATH, run as module:
-python -m transformation_portal.lux_depth_v3 --help
+.venv/bin/python -m transformation_portal.lux_depth_v3 --help
 
 # Portal/orchestrator contract gate:
 make test-orchestrator-contract
@@ -49,7 +49,7 @@ make test-orchestrator-contract
 
 Install a pinned release:
 ```bash
-pip install "git+https://github.com/RC219805/Transformation_Portal.git@<release-tag>"
+.venv/bin/python -m pip install "git+https://github.com/RC219805/Transformation_Portal.git@<release-tag>"
 ```
 
 Replace `<release-tag>` with a tag from [GitHub Releases](https://github.com/RC219805/Transformation_Portal/releases).
@@ -119,7 +119,7 @@ Transformation Portal supports depth models across two tiers with different lice
 ### Production Path
 - **DA3 (`da3` backend):** Primary production backend for Lux Depth V3
 - **Use for:** The governed depth workflow surface. Select `model_key="da3-metric"` for the Apache-2.0 DA3 path, or `model_key="da3"` / `model_key="da3-research"` for the research-default selector.
-- **Requirement:** Install a trusted ML core profile for actual DA3 inference. The checked-in ML core lock is currently target-owned for macOS Apple Silicon (`darwin-arm64`) only; Linux and macOS Intel ML lanes are retired unsupported lanes that fail closed until a governed lane is re-established. For example: `make install-ml-core` or, on Apple Silicon, `./scripts/bootstrap/install_ml_stack.sh --profile core-cpu`.
+- **Requirement:** Install a trusted ML core profile for actual DA3 inference. The checked-in ML core lock is currently target-owned for macOS Apple Silicon (`darwin-arm64`) only; Linux and macOS Intel ML lanes are retired unsupported lanes that fail closed until a governed lane is re-established. Use `make install-ml-core` for current operator setup; advanced Apple Silicon bootstrap-profile work can run `./scripts/bootstrap/install_ml_stack.sh --profile core-cpu` directly.
 - **Default:** Standard CLI flows resolve here unless a research-only backend is explicitly requested
 
 ### Research & Non-Commercial
@@ -162,7 +162,7 @@ The orchestrator also contains an internal `synthetic` fallback path used for ex
 
 **Default (DA3):**
 ```bash
-lux-depth-v3 --input-dir ./input --output-dir ./output
+lux-depth-v3 --input-dir ./input_images --output-dir ./output
 ```
 
 If `./.runtime/Depth-Anything-3/.venv-da3/bin/python` exists, Lux Depth V3
@@ -181,7 +181,7 @@ gate. Install or verify the manifest-pinned local runtime with
 ```bash
 ./scripts/setup/install_da3_runtime.sh
 
-lux-depth-v3 --input-dir ./input --output-dir ./output
+lux-depth-v3 --input-dir ./input_images --output-dir ./output
 ```
 
 The repo-local DA3 setup script pins the upstream checkout to a validated ref under
@@ -201,7 +201,7 @@ instead of silently downgrading to DA2.
 **Depth Pro (requires license acceptance):**
 ```bash
 lux-depth-v3 \
-  --input-dir ./input \
+  --input-dir ./input_images \
   --output-dir ./output \
   --depth-backend depth_pro \
   --depth-pro-python ./.venv-depth-pro/bin/python \
@@ -258,7 +258,7 @@ Enable direct ingestion of professional camera RAW formats such as CR2, NEF, ARW
 ```bash
 ./scripts/setup/install_raw_runtime.sh
 
-lux-depth-v3 --input-dir ./input --output-dir ./output
+lux-depth-v3 --input-dir ./input_images --output-dir ./output
 ```
 
 RAW inputs are auto-detected and converted into pipeline-ready RGB using LibRaw via `rawpy`. If `./.venv-raw/bin/python` exists, Lux Depth V3 auto-discovers that repo-local RAW runtime before falling back to the main repo environment.
@@ -270,7 +270,7 @@ main repo environment for operator workflows.
 Use `--raw-python` only when you want to override that repo-local runtime explicitly:
 
 ```bash
-lux-depth-v3 --input-dir ./input --output-dir ./output --raw-python ~/venvs/raw/bin/python
+lux-depth-v3 --input-dir ./input_images --output-dir ./output --raw-python ~/venvs/raw/bin/python
 ```
 
 See [SETUP_GUIDE.md](docs/guides/SETUP_GUIDE.md) for environment details.
@@ -296,7 +296,7 @@ hosts.
 Required CLI wiring:
 ```bash
 lux-depth-v3 \
-  --input-dir ./input \
+  --input-dir ./input_images \
   --output-dir ./output \
   --depth-backend depth_pro \
   --depth-pro-python ./.venv-depth-pro/bin/python \
@@ -318,7 +318,7 @@ Lux Depth V3 can generate physically based rendering maps directly from the full
 Fast PBR-only run:
 ```bash
 lux-depth-v3 \
-  --input-dir ./input \
+  --input-dir ./input_images \
   --output-dir ./output/pbr \
   --quality-tier apex \
   --pbr "on" \
@@ -355,7 +355,7 @@ Add a trusted ML profile when you need DA3 depth inference, research backends, s
 
 ```bash
 make install-ml-core
-# or use the target-specific bootstrap flow on macOS Apple Silicon:
+# advanced Apple Silicon bootstrap-profile work only:
 ./scripts/bootstrap/install_ml_stack.sh --profile core-cpu
 make test-fast
 ```
@@ -371,7 +371,7 @@ For a more guided environment bring-up, see [SETUP_GUIDE.md](docs/guides/SETUP_G
 The metadata extraction tooling supports deterministic machine-mode JSON for CI/CD and automation.
 
 ```bash
-python scripts/test_metadata_extraction.py --json extract /input/image.CR2
+.venv/bin/python scripts/test_metadata_extraction.py --json extract input_images/image.CR2
 ```
 
 Key properties:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -179,13 +179,13 @@ Security features may impact performance:
 ### Deployment
 
 ```bash
-# Run with minimal privileges (recommended)
-sudo -u nobody python -m transformation_portal.cli
+# Run with minimal privileges from the repo-managed environment (recommended)
+sudo -u tp .venv/bin/python -m transformation_portal.cli serve --host 127.0.0.1 --port 8000
 
 # Or use systemd service with User directive:
 # [Service]
-# User=nobody
-# Group=nogroup
+# User=tp
+# Group=tp
 
 # Use read-only filesystem where possible
 docker run --read-only --tmpfs /tmp transformation_portal:latest
@@ -234,13 +234,13 @@ make quality-check
 make test-full
 
 # Install governed security tools from requirements/security.txt
-pip install -r requirements/security.txt
+.venv/bin/python -m pip install -r requirements/security.txt
 
 # Run static security analysis
-bandit -r src/ -ll
+.venv/bin/bandit -r src/ -ll
 
 # Run dependency vulnerability scan
-pip-audit
+.venv/bin/pip-audit
 ```
 
 ## Incident Response
@@ -307,20 +307,20 @@ Security scanning tools are governed in CI via `requirements/security.txt`:
 
 ```bash
 # Install governed security tools (bandit, pip-audit)
-pip install -r requirements/security.txt
+.venv/bin/python -m pip install -r requirements/security.txt
 
 # Run dependency vulnerability scan
-pip-audit
+.venv/bin/pip-audit
 
 # Run static security analysis
-bandit -r src/
+.venv/bin/bandit -r src/
 
-# Additional optional tools (not governed)
-pip install semgrep
-semgrep --config=auto
+# Additional optional tools (install into an isolated security tooling env)
+# python -m pip install semgrep
+# semgrep --config=auto
 
 # Existing project tools
-pylint --enable=security
+make lint-parity
 
 # Container scanning (if using Docker)
 # Install trivy: https://github.com/aquasecurity/trivy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,7 @@ services:
     ports:
       - "8000:8000"
     volumes:
-      - ./input:/app/input:ro
+      - ./input_images:/app/input:ro
       - ./output:/app/output
       - ./config:/app/config:ro
       # State persists in named volume `tp_state` — Docker-managed ownership
@@ -74,7 +74,7 @@ services:
     environment:
       - DEVICE=cpu
       - PYTHONUNBUFFERED=1
-    command: python -m transformation_portal.cli serve --host 0.0.0.0 --port 8000
+    command: python3.11 -m transformation_portal.cli serve --host 0.0.0.0 --port 8000
 
   # GPU-enabled service (CUDA)
   transformation-portal-gpu:
@@ -93,7 +93,7 @@ services:
     ports:
       - "8001:8000"
     volumes:
-      - ./input:/app/input:ro
+      - ./input_images:/app/input:ro
       - ./output:/app/output
       - ./config:/app/config:ro
       # State persists in named volume `tp_state` — see cpu service for rationale.
@@ -130,7 +130,7 @@ services:
       tp-init:
         condition: service_completed_successfully
     volumes:
-      - ./input:/app/input:ro
+      - ./input_images:/app/input:ro
       - ./output:/app/output
       - ./config:/app/config:ro
       # State persists in named volume `tp_state` — see cpu service for rationale.
@@ -141,7 +141,7 @@ services:
     environment:
       - DEVICE=cpu
       - PYTHONUNBUFFERED=1
-    command: python -m transformation_portal.cli batch-process /app/input /app/output --preset golden_hour
+    command: python3.11 -m transformation_portal.cli batch-process /app/input /app/output --preset golden_hour
 
   # Monitoring dashboard (optional). No I/O bind mounts → no tp-init dependency.
   transformation-portal-monitor:
@@ -164,12 +164,16 @@ services:
     environment:
       - PYTHONUNBUFFERED=1
     healthcheck:
-      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8080/', timeout=3).read()"]
+      test:
+        - CMD
+        - python3.11
+        - -c
+        - "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8080/', timeout=3).read()"
       interval: 30s
       timeout: 5s
       retries: 3
       start_period: 20s
-    command: python -m transformation_portal.monitoring.dashboard --port 8080
+    command: python3.11 -m transformation_portal.monitoring.dashboard --port 8080
 
   # Durable orchestrator state backend (Phase 1.B).
   #

--- a/docs/api/MACHINE_MODE_CONTRACT.md
+++ b/docs/api/MACHINE_MODE_CONTRACT.md
@@ -208,9 +208,9 @@ Single-image metadata extraction with provenance sidecar generation.
   "success": true,
   "exit_code": 0,
   "data": {
-    "input_path": "/input/IMG_1234.CR2",
+    "input_path": "input_images/IMG_1234.CR2",
     "success": true,
-    "output_path": "/output/IMG_1234.provenance.json",
+    "output_path": "output/IMG_1234.provenance.json",
     "elapsed_seconds": 1.234,
     "preset": "luxury",
     "error": null
@@ -228,14 +228,14 @@ Single-image metadata extraction with provenance sidecar generation.
   "success": false,
   "exit_code": 5,
   "data": {
-    "input_path": "/input/missing.CR2",
+    "input_path": "input_images/missing.CR2",
     "success": false,
     "output_path": null,
     "elapsed_seconds": 0.001,
     "preset": "luxury",
     "error": {
       "type": "OtherIngestFailure",
-      "message": "Input file does not exist: /input/missing.CR2",
+      "message": "Input file does not exist: input_images/missing.CR2",
       "exit_code": {"name": "OTHER_FAILURE", "value": 5},
       "priority": 10
     }
@@ -272,7 +272,7 @@ Schema validation of an existing provenance sidecar.
   "success": true,
   "exit_code": 0,
   "data": {
-    "sidecar_path": "/output/IMG_1234.provenance.json",
+    "sidecar_path": "output/IMG_1234.provenance.json",
     "strict": true,
     "success": true,
     "errors": [],
@@ -291,7 +291,7 @@ Schema validation of an existing provenance sidecar.
   "success": false,
   "exit_code": 4,
   "data": {
-    "sidecar_path": "/output/IMG_1234.provenance.json",
+    "sidecar_path": "output/IMG_1234.provenance.json",
     "strict": true,
     "success": false,
     "errors": [
@@ -340,16 +340,16 @@ Batch metadata extraction for multiple images.
   "success": false,
   "exit_code": 5,
   "data": {
-    "input_root": "/input",
-    "output_dir": "/output",
+    "input_root": "input_images",
+    "output_dir": "output",
     "fail_fast": false,
     "preserve_structure": false,
     "success": false,
     "items": [
       {
-        "path": "/input/IMG_1234.CR2",
+        "path": "input_images/IMG_1234.CR2",
         "success": true,
-        "output_path": "/output/IMG_1234.provenance.json",
+        "output_path": "output/IMG_1234.provenance.json",
         "elapsed_seconds": 1.234,
         "error": null
       },
@@ -497,27 +497,27 @@ Aggregate summary of sidecar validation results in a directory.
 
 ```bash
 # Emit machine JSON to stdout
-python scripts/test_metadata_extraction.py --json extract /input/image.CR2
+.venv/bin/python scripts/test_metadata_extraction.py --json extract input_images/image.CR2
 
 # Pretty-printed JSON to stdout
-python scripts/test_metadata_extraction.py --json --json-pretty extract /input/image.CR2
+.venv/bin/python scripts/test_metadata_extraction.py --json --json-pretty extract input_images/image.CR2
 
 # Write JSON to file, keep stdout clean
-python scripts/test_metadata_extraction.py --json --json-output result.json extract /input/image.CR2
+.venv/bin/python scripts/test_metadata_extraction.py --json --json-output result.json extract input_images/image.CR2
 
 # Pretty JSON to file
-python scripts/test_metadata_extraction.py --json --json-pretty --json-output result.json extract /input/image.CR2
+.venv/bin/python scripts/test_metadata_extraction.py --json --json-pretty --json-output result.json extract input_images/image.CR2
 ```
 
 ### Exit Code Handling
 
 ```bash
 # Exit code reflects operation status
-python scripts/test_metadata_extraction.py --json extract /input/image.CR2
+.venv/bin/python scripts/test_metadata_extraction.py --json extract input_images/image.CR2
 echo $?  # 0 = success, 1-5 = specific failure modes
 
 # Route by exit code in CI
-if python scripts/test_metadata_extraction.py --json validate sidecar.json; then
+if .venv/bin/python scripts/test_metadata_extraction.py --json validate sidecar.json; then
   echo "Validation passed"
 else
   exit_code=$?
@@ -640,13 +640,13 @@ if __name__ == "__main__":
 
 ```bash
 # Parse from file
-python parse_machine_json.py result.json
+.venv/bin/python tools/parse_machine_json.py result.json
 
 # Parse from stdin
-python scripts/test_metadata_extraction.py --json extract /input/image.CR2 | python parse_machine_json.py
+.venv/bin/python scripts/test_metadata_extraction.py --json extract input_images/image.CR2 | .venv/bin/python tools/parse_machine_json.py
 
 # Exit code forwarding
-python scripts/test_metadata_extraction.py --json validate sidecar.json | python parse_machine_json.py
+.venv/bin/python scripts/test_metadata_extraction.py --json validate sidecar.json | .venv/bin/python tools/parse_machine_json.py
 echo $?  # Parser exits with same code as CLI
 ```
 
@@ -662,7 +662,7 @@ For bash automation without Python:
 #!/bin/bash
 set -euo pipefail
 
-result=$(python scripts/test_metadata_extraction.py --json extract "$1")
+result=$(.venv/bin/python scripts/test_metadata_extraction.py --json extract "$1")
 exit_code=$?
 
 # Validate schema
@@ -692,7 +692,7 @@ fi
 #!/bin/bash
 set -euo pipefail
 
-result=$(python scripts/test_metadata_extraction.py --json validate "$1")
+result=$(.venv/bin/python scripts/test_metadata_extraction.py --json validate "$1")
 exit_code=$?
 
 success=$(echo "$result" | jq -r '.success')
@@ -718,7 +718,7 @@ fi
 #!/bin/bash
 set -euo pipefail
 
-result=$(python scripts/test_metadata_extraction.py --json extract-batch "$1")
+result=$(.venv/bin/python scripts/test_metadata_extraction.py --json extract-batch "$1")
 exit_code=$?
 
 total=$(echo "$result" | jq '.data.summary_counts.total')
@@ -757,10 +757,10 @@ exit $exit_code
 
 ```bash
 # Separate JSON (stdout) from diagnostics (stderr)
-python scripts/test_metadata_extraction.py --json extract /input/image.CR2 > result.json 2> diagnostics.log
+.venv/bin/python scripts/test_metadata_extraction.py --json extract input_images/image.CR2 > result.json 2> diagnostics.log
 
 # Interactive debugging: see diagnostics, capture JSON
-python scripts/test_metadata_extraction.py --json extract /input/image.CR2 2>&1 | tee full_output.log | jq .
+.venv/bin/python scripts/test_metadata_extraction.py --json extract input_images/image.CR2 2>&1 | tee full_output.log | jq .
 ```
 
 **DO NOT parse stderr in automation.** It may contain:

--- a/docs/architecture/ADR-032-dependency-pinning-strategy.md
+++ b/docs/architecture/ADR-032-dependency-pinning-strategy.md
@@ -111,7 +111,7 @@ pydantic>=2.0,<3           # Major version boundary
 **Examples:**
 ```
 mypy>=1.10                 # Type checker: CLI stable, benefits from latest rules
-black>=24.8                # Formatter: deterministic output, auto-updates OK
+pylint>=3.0                # Linter: CLI stable, benefits from latest diagnostics
 flake8>=7.0                # Linter: new rules are improvements
 ```
 
@@ -197,7 +197,7 @@ Exceptions to pinning rules require explicit approval via one of:
 | Package       | File    | Constraint      | Rationale                                  |
 |---------------|---------|-----------------|------------------------------------------- |
 | `mypy`        | dev.in  | `>=1.10`        | Type checker: benefits from latest rules   |
-| `black`       | dev.in  | `>=24.8`        | Formatter: deterministic, auto-updates OK  |
+| `black`       | dev.in  | `>=26.3.1`      | Formatter: deterministic, auto-updates OK  |
 | `flake8`      | dev.in  | `>=7.0`         | Linter: new rules are improvements         |
 | `pylint`      | dev.in  | `>=3.0`         | Linter: CLI stable across minor versions   |
 | `PyYAML`      | ml.in   | `>=6.0`         | Config parser: strong backward compat      |

--- a/docs/architecture/ADR-033-test-flake-management.md
+++ b/docs/architecture/ADR-033-test-flake-management.md
@@ -277,7 +277,7 @@ def test_foo(value):
 ### For Developers
 
 **When you see a flaky test:**
-1. Check flake ledger: `python scripts/analyze_flakes.py`
+1. Check flake ledger: `.venv/bin/python scripts/analyze_flakes.py`
 2. Reproduce locally: Run test 20+ times
 3. Identify root cause (use debugger, add logging)
 4. Fix or quarantine (with issue tracking)

--- a/docs/ci/BRANCH_PROTECTION_COMMANDS.md
+++ b/docs/ci/BRANCH_PROTECTION_COMMANDS.md
@@ -1,5 +1,11 @@
 # Branch Protection Configuration Commands
 
+> **Historical record. Do not run these commands as current configuration.**
+> The required branch-protection check is now the stable `CI Gate` aggregator,
+> and live settings must be verified from GitHub before any change. Use
+> [BRANCH_PROTECTION_SETUP.md](./BRANCH_PROTECTION_SETUP.md) for maintained
+> setup and troubleshooting guidance.
+
 **Generated**: 2026-02-01
 **Purpose**: Complete quality firewall implementation with automated branch protection
 
@@ -298,9 +304,9 @@ gh auth status
 ## 📚 Related Documentation
 
 - [BRANCH_PROTECTION_SETUP.md](./BRANCH_PROTECTION_SETUP.md) - Original setup guide
-- [CI Workflow](../.github/workflows/ci.yml) - Quality gates implementation
-- [CONTRIBUTING.md](../CONTRIBUTING.md) - Developer workflow
-- [CODE_QUALITY_SYSTEM.md](./CODE_QUALITY_SYSTEM.md) - Quality standards
+- [CI Workflow](../../.github/workflows/build.yml) - Quality gates implementation
+- [CONTRIBUTING.md](../../CONTRIBUTING.md) - Developer workflow
+- [CODE_QUALITY_SYSTEM.md](../guides/CODE_QUALITY_SYSTEM.md) - Quality standards
 
 ---
 

--- a/docs/ci/BRANCH_PROTECTION_SETUP.md
+++ b/docs/ci/BRANCH_PROTECTION_SETUP.md
@@ -1,6 +1,15 @@
 # Branch Protection Setup Guide
 
-This guide documents the required branch protection rules for the `main` branch to enforce CI quality gates.
+This guide documents the current and recommended branch protection rules for the
+`main` branch to enforce CI quality gates.
+
+Current live settings were verified with:
+
+```bash
+gh api repos/RC219805/Transformation_Portal/branches/main/protection
+```
+
+Last verified: 2026-06-03.
 
 ## Required Branch Protection Rules
 
@@ -17,40 +26,40 @@ main
 
 #### ✅ Require Pull Request Reviews
 - **Enable**: ✓ Require a pull request before merging
-- **Required approving reviews**: 1
-- **Dismiss stale pull request approvals**: ✓ (recommended)
-- **Require review from Code Owners**: Optional (if using CODEOWNERS)
+- **Required approving reviews**: 0 currently, 1+ recommended for governance-sensitive work
+- **Dismiss stale pull request approvals**: ✓ enabled
+- **Require review from Code Owners**: Disabled
 
 #### ✅ Require Status Checks to Pass
 - **Enable**: ✓ Require status checks to pass before merging
-- **Require branches to be up to date**: ✓ (recommended)
+- **Require branches to be up to date**: ✓ enabled
 
-**Required Status Checks** (add these):
+**Required Status Checks**:
 ```
-lint (3.12)
-security
-test-core (3.10)
-test-core (3.12)
-test-ml (3.11)
-coverage-gate
-build
-repo-hygiene
-quality-summary
+CI Gate
 ```
 
-**Note**: GitHub will auto-discover these check names after the first CI run. You may need to type them manually if they haven't run yet.
+**Note**: `CI Gate` is the stable branch-protection aggregator from
+`.github/workflows/build.yml`. Do not add individual matrix jobs such as
+`lint`, `test (3.11, cpu, core)`, or `generate-manifest` as separate required
+checks unless the CI gate contract is intentionally changed.
 
 #### ✅ Require Conversation Resolution
-- **Enable**: ✓ Require conversation resolution before merging
+- **Enable**: ✓ enabled
 - Ensures all review comments are addressed
 
 #### ✅ Restrict Force Pushes
-- **Enable**: ✓ Do not allow force pushes
+- **Enable**: ✓ force pushes are disabled
 - Preserves commit history integrity
 
-#### ✅ Require Linear History (Optional but Recommended)
-- **Enable**: ✓ Require linear history
-- Enforces clean, linear commit history via rebase or squash merges
+#### ⚠️ Require Linear History (Optional)
+- **Current**: Disabled
+- Exact-head squash merges remain the preferred project convention, but branch
+  protection does not currently require linear history.
+
+#### ✅ Enforce for Administrators
+- **Current**: Enabled
+- Admins are subject to the same branch protection rules.
 
 #### ⚠️ Do Not Require Signed Commits (Optional)
 - **Leave disabled** unless you have organizational policy
@@ -123,19 +132,21 @@ Create `.github/CODEOWNERS` for automated review assignment:
 
 ## Enforcement in CI
 
-The CI workflow (`.github/workflows/ci.yml`) enforces quality gates automatically. The `quality-summary` job aggregates all results and blocks merge if critical gates fail.
+The canonical PR workflow (`.github/workflows/build.yml`) enforces quality
+gates automatically. Its `CI Gate` job aggregates the blocking upstream jobs and
+is the only status check currently required by branch protection.
 
 ### Critical Gates (BLOCKING)
+- Lightweight checks
 - Lint
-- Security scans
-- Core tests
-- Build verification
-- Repo hygiene
+- Test matrix
+- Montecito manifest build
+- CI contract validation
 
 ### Advisory Gates (NON-BLOCKING but reported)
-- Type checking
-- Coverage warnings (diff coverage is enforced)
-- ML tests (informational)
+- Post-merge quality firewall signals
+- Nightly and scheduled deep checks
+- Advisory security/dependency reports not aggregated into `CI Gate`
 
 ## Troubleshooting
 
@@ -156,17 +167,21 @@ git checkout -b safety/backup-main
 ```
 
 ### Need to bypass protection (emergency)
-**Admin override**: Repository admins can bypass protection rules if absolutely necessary. This is logged and should be rare. Document the reason in an issue or post-incident review.
+**Admin override**: Admin enforcement is currently enabled, so emergency bypasses
+require an explicit repository-settings change or an approved alternative
+recovery path. Document the reason in an issue or post-incident review.
 
 ## Enforcement Checklist
 
 Before considering this complete:
 
 - [ ] Branch protection rule created for `main`
-- [ ] All required status checks added
-- [ ] Pull request reviews required (1+ approver)
+- [ ] `CI Gate` is the only required status check
+- [ ] Pull request review policy intentionally set (currently 0 approvers; 1+ recommended)
+- [ ] Conversation resolution required
+- [ ] Admin enforcement enabled
 - [ ] Force push disabled
-- [ ] Linear history enabled (optional but recommended)
+- [ ] Linear history setting intentionally chosen (currently disabled; exact-head squash remains preferred)
 - [ ] Verified by attempting to merge failing PR (blocks correctly)
 - [ ] Verified by attempting force push (blocks correctly)
 - [ ] CODEOWNERS file created (optional)
@@ -174,9 +189,9 @@ Before considering this complete:
 
 ## Related Documentation
 
-- [CONTRIBUTING.md](../CONTRIBUTING.md) - Developer workflow
-- [CI Workflow](../.github/workflows/ci.yml) - Quality gates implementation
-- [Production Readiness](./PRODUCTION_READINESS.md) - Overall quality status
+- [CONTRIBUTING.md](../../CONTRIBUTING.md) - Developer workflow
+- [CI Workflow](../../.github/workflows/build.yml) - Quality gates implementation
+- [Production Readiness](../deployment/PRODUCTION_READINESS.md) - Overall quality status
 
 ---
 

--- a/docs/decisions/ADR_019_INTEGRATION_COMPLETE.md
+++ b/docs/decisions/ADR_019_INTEGRATION_COMPLETE.md
@@ -239,13 +239,13 @@ None. Implementation follows ADR-019 specification exactly.
 
 ### Default (DA3)
 ```bash
-lux-depth-v3 --input-dir ./input --output-dir ./output
+lux-depth-v3 --input-dir ./input_images --output-dir ./output
 ```
 
 ### Explicit DA3
 ```bash
 lux-depth-v3 \
-  --input-dir ./input \
+  --input-dir ./input_images \
   --output-dir ./output \
   --depth-backend da3
 ```
@@ -253,7 +253,7 @@ lux-depth-v3 \
 ### Depth Pro (Research)
 ```bash
 lux-depth-v3 \
-  --input-dir ./input \
+  --input-dir ./input_images \
   --output-dir ./output \
   --depth-backend depth_pro \
   --accept-apple-depth-pro-research-license true \
@@ -277,7 +277,7 @@ config = EnhanceConfig(
 )
 
 orchestrator = EnhanceOrchestrator(config, Path("./output"))
-results = orchestrator.enhance_batch(Path("./input"))
+results = orchestrator.enhance_batch(Path("./input_images"))
 ```
 
 ---

--- a/docs/deployment/PRODUCTION_READINESS.md
+++ b/docs/deployment/PRODUCTION_READINESS.md
@@ -20,14 +20,14 @@ Transformation Portal v2.0.0 has achieved "**conditional go**" status with produ
   - Linting: ✅ Enforced
   - Security scans: ✅ Active
   - Test gates: ✅ Running
-  - Coverage ratcheting: 🟡 Diff coverage being enforced
-  - Branch protection: 📝 Needs configuration
+  - Coverage ratcheting: 🟡 Diff and cold-zone gates active where scoped
+  - Branch protection: ✅ Current required check is `CI Gate` with admin enforcement and conversation resolution enabled
 
 ### Production Readiness Checklist
 
 Before deploying to production, verify:
 
-- [ ] **Tests passing** on clean environment (Python 3.10, 3.11, 3.12)
+- [ ] **Tests passing** on clean environment (Python 3.11 and 3.12; Python 3.10 is retired)
 - [ ] **Coverage gates** met (global minimum + diff coverage)
 - [ ] **Security scans** clean (bandit, gitleaks, pip-audit)
 - [ ] **Build verification** (wheel builds and installs successfully)
@@ -49,11 +49,11 @@ We use a **ratcheting quality approach**:
 
 Our CI pipeline enforces quality gates on every PR:
 
-```
-PR → Lint → Type Check → Security Scan → Tests → Coverage Gate → Build Check → Repo Hygiene → Merge
+```text
+PR → Lint → Type Check → Security Scan → Tests → Coverage Gate → Build Check → Repo Hygiene → CI Gate → Merge
 ```
 
-All checks must pass before merge to `main`. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
+All required checks must pass before merge to `main`. See [CONTRIBUTING.md](../../CONTRIBUTING.md) and [Branch Protection Setup](../ci/BRANCH_PROTECTION_SETUP.md) for details.
 
 ### Nightly Deep Checks
 
@@ -71,16 +71,16 @@ Check current quality metrics:
 
 ```bash
 # Run core test suite
-pytest -v tests/ -m "not ml and not slow"
+make test-fast
 
 # Check coverage
-pytest --cov=src/transformation_portal --cov-report=term
+make coverage-report
 
 # Security scan
-bandit -r src/ -ll
+make validate-ci
 
 # Build verification
-python -m build && twine check dist/*
+make ci-quick
 ```
 
 ---
@@ -92,16 +92,16 @@ If upgrading from earlier versions:
 1. **Contracts**: API payloads are now versioned. Update client code to use schema-aligned requests.
 2. **Presets**: Use `--list-stable` to discover production-ready presets. Experimental presets are clearly marked.
 3. **Dependencies**: Check `requirements/constraints.txt` for banned dependencies (e.g., `realesrgan`).
-4. **Environment**: Validate on Python 3.10+ (3.11 recommended for ML workloads).
+4. **Environment**: Validate on Python 3.11+; the supported CI matrix covers Python 3.11 and 3.12.
 
 ---
 
 ## Support & Escalation
 
 - **Issues**: Report bugs via GitHub Issues
-- **Security**: See [SECURITY.md](SECURITY.md) for vulnerability reporting
-- **Contribution**: See [CONTRIBUTING.md](CONTRIBUTING.md) for development guidelines
-- **Architecture**: See `docs/architecture/` for design decisions (ADRs)
+- **Security**: See [SECURITY.md](../../SECURITY.md) for vulnerability reporting
+- **Contribution**: See [CONTRIBUTING.md](../../CONTRIBUTING.md) for development guidelines
+- **Architecture**: See [Architecture docs](../architecture/) for design decisions (ADRs)
 
 ---
 

--- a/docs/deployment/ROLLBACK_PROCEDURES.md
+++ b/docs/deployment/ROLLBACK_PROCEDURES.md
@@ -87,7 +87,7 @@ python -c "import transformation_portal; print(transformation_portal.__version__
 pytest tests/test_core_functionality.py -v --maxfail=1
 
 # Verify PBR processing (if applicable)
-python -m transformation_portal.lux_depth_v3.pbr_cli --help
+.venv/bin/python -m transformation_portal.lux_depth_v3.pbr_cli --help
 ```
 
 **Step 5: Restart services** (if applicable)
@@ -100,7 +100,7 @@ docker-compose down
 docker-compose up -d
 
 # Verify service is healthy
-curl http://localhost:8000/health || python scripts/verification/verify_core.py
+curl http://localhost:8000/health || .venv/bin/python scripts/verification/verify_core.py
 ```
 
 **Step 6: Monitor and communicate**
@@ -351,7 +351,7 @@ echo "## [2.2.1] - $(date +%Y-%m-%d)
 " >> CHANGELOG.md
 
 # Build distribution packages
-python -m build
+.venv/bin/python -m build
 ls -lh dist/  # Verify wheel and sdist created
 
 # Verify package contents
@@ -478,15 +478,14 @@ pip freeze >> rollback-report.md
 If dependency conflicts occur during rollback:
 
 ```bash
-# Option 1: Use pip's dependency resolver (default in pip >=20.3)
-pip install -r requirements.txt --use-feature=2020-resolver
+# Option 1: Rebuild the governed core environment
+make repair-core-venv
 
-# Option 2: Use constraints file to force specific versions
-pip install -r requirements.txt --constraint requirements-rollback-YYYYMMDD.txt
+# Option 2: Use a rollback constraints file for the editable package install
+.venv/bin/python -m pip install --constraint requirements-rollback-YYYYMMDD.txt -e .
 
-# Option 3: Install packages individually if conflicts persist
-# (Use this as last resort)
-cat requirements/core.txt | grep -v '^#' | xargs -n1 pip install
+# Option 3: Regenerate and reinstall the governed core lane
+make install-core
 ```
 
 **Known Compatibility Issues**:
@@ -542,7 +541,7 @@ mkdir -p archive/output-v2.2.0-$(date +%Y%m%d)/
 mv output_*/ archive/output-v2.2.0-$(date +%Y%m%d)/
 
 # Verify older version can process fresh inputs
-python -m transformation_portal.cli depth-estimation \
+.venv/bin/python -m transformation_portal.cli depth-estimation \
   --input tests/fixtures/test_image.jpg \
   --output /tmp/verify-rollback/
 ```

--- a/docs/deployment/STAGING_VALIDATION.md
+++ b/docs/deployment/STAGING_VALIDATION.md
@@ -36,14 +36,14 @@ This document provides a comprehensive validation checklist for staging environm
 cd /opt/transformation-portal-staging
 git fetch --tags
 git checkout v2.0.0  # Or target version
-pip install --force-reinstall -e .
+make install-core
 
 # Verify version
-python -c "import transformation_portal; print(transformation_portal.__version__)"
+.venv/bin/python -c "import transformation_portal; print(transformation_portal.__version__)"
 # Expected output: 2.0.0
 
 # Verify environment
-python scripts/verification/verify_core.py
+.venv/bin/python scripts/verification/verify_core.py
 ```
 
 ---
@@ -56,16 +56,12 @@ python scripts/verification/verify_core.py
 
 #### 1.1 Installation Verification
 ```bash
-# Fresh install in isolated environment
-python3 -m venv staging_test_venv
-source staging_test_venv/bin/activate
-
-pip install --upgrade pip
-pip install -r requirements.txt
-pip install -e .
+# Fresh repo-managed install
+make venv
+make install-core
 
 # Verify imports
-python -c "
+.venv/bin/python -c "
 from transformation_portal.lux_depth_v3 import PBRProcessor, EnhanceConfig
 from transformation_portal.lux_depth_v3.pbr_presets import get_preset
 print('✅ All imports successful')
@@ -98,7 +94,7 @@ print('✅ Configuration valid')
 which transform-process || echo "Warning: transform-process not in PATH"
 
 # Test CLI help
-python -m transformation_portal.lux_depth_v3.pbr_cli --help
+.venv/bin/python -m transformation_portal.lux_depth_v3.pbr_cli --help
 
 # Expected output: Usage information, no errors
 ```
@@ -176,7 +172,7 @@ for name in ['default', 'premium', 'balanced', 'performance']:
 #### 2.4 Batch Processing
 ```bash
 # Test batch processing with 5 images
-python -m transformation_portal.lux_depth_v3.pbr_cli \
+.venv/bin/python -m transformation_portal.lux_depth_v3.pbr_cli \
   --input-dir data/sample_images/ \
   --output-dir /tmp/staging_batch_test \
   --preset balanced \
@@ -343,7 +339,7 @@ assert mem_increase < 1000, f'Memory leak suspected: {mem_increase} MB'
 # Test with 4 concurrent processes (if supported)
 # (Skip if single-process only)
 for i in {1..4}; do
-  python -m transformation_portal.lux_depth_v3.pbr_cli \
+  .venv/bin/python -m transformation_portal.lux_depth_v3.pbr_cli \
     --input data/sample_$i.jpg \
     --output /tmp/staging_concurrent_$i \
     --preset balanced &
@@ -459,9 +455,8 @@ except KeyError:
 # (Manual or automated with doctest)
 
 # Example: Quick Start
-pip install -r requirements.txt
-pip install -e .
-python scripts/verification/verify_core.py
+make install-core
+.venv/bin/python scripts/verification/verify_core.py
 
 # Expected: All commands execute successfully
 ```
@@ -515,7 +510,7 @@ make html
 
 # run_smoke_tests.sh:
 #!/bin/bash
-python -m transformation_portal.lux_depth_v3.pbr_cli \
+.venv/bin/python -m transformation_portal.lux_depth_v3.pbr_cli \
   --input data/smoke_test_image.jpg \
   --output /tmp/smoke_test_$(date +%s) \
   --preset balanced

--- a/docs/governance/PRODUCTION_HARDENING_GAP_2026-05-13.md
+++ b/docs/governance/PRODUCTION_HARDENING_GAP_2026-05-13.md
@@ -150,8 +150,10 @@ Still net-new after Phase 4 closeout:
 
 **Updated 2026-05-15: Phase 5.A local Compose validation has landed.**
 
-- `Dockerfile` provides `base`, `cpu`, `gpu`, and `apple-silicon` stages with
-  health probes.
+- `Dockerfile` provides `base`, `cpu`, and `gpu` runtime stages with health
+  probes. The `apple-silicon` target remains as a CPU-image compatibility alias;
+  native Apple Silicon ML installs are governed by the Darwin arm64 ML lock, not
+  by ad hoc Docker `.[ml]` installs.
 - `docker-compose.yml` provides CPU, GPU, worker, and monitor services.
 - `make test-paid-pilot-services-contract` exists as the opt-in managed
   services smoke gate.

--- a/docs/governance/REPO_ORGANIZATION.md
+++ b/docs/governance/REPO_ORGANIZATION.md
@@ -152,10 +152,9 @@ The `.auto-organize.sh` script is the canonical entry point for repository organ
 Only these files should remain in the repository root:
 
 - **Core documentation**: `README.md`, `LICENSE`, `CONTRIBUTING.md`, `SECURITY.md`, `CHANGELOG.md`
-- **Build configuration**: `Makefile`, `pyproject.toml`, `setup.py`, root Cloudflare Workers Builds shim files (`package.json`, `package-lock.json`, `wrangler.jsonc`)
-- **Dependency management**: `requirements*.txt`, `requirements-lint.txt`, `Pipfile`, `poetry.lock`
-- **Testing configuration**: `pytest.ini`, `tox.ini`, `.coveragerc`
-- **Linting configuration**: `.pylintrc`, `.flake8`, `mypy.ini`
+- **Build configuration**: `Makefile`, `pyproject.toml`, root Cloudflare Workers Builds shim files (`package.json`, `package-lock.json`, `wrangler.jsonc`)
+- **Dependency management**: `requirements.txt`, `requirements-dev.txt`, `requirements-ci.txt`, `requirements-lint.txt`
+- **Testing and linting configuration**: `pyproject.toml`, `.pylintrc`, `mypy.ini`
 - **Docker**: `Dockerfile`, `docker-compose.yml`
 - **Git**: `.gitignore`, `.gitattributes`, `.git-blame-ignore-revs`, `.pre-commit-config.yaml`
 - **Governance metadata**: `.architect_directive_status.yml`, `AGENTS.md`, `CLAUDE.md`

--- a/docs/governance/audit/PORTAL_AUDIT_2026-05-18_backlog.md
+++ b/docs/governance/audit/PORTAL_AUDIT_2026-05-18_backlog.md
@@ -45,7 +45,7 @@ Each item carries severity, effort, the files to touch, observable acceptance cr
 
 ### I-3. Add non-root `USER` to Dockerfile and harden compose defaults
 
-**Status:** Done — landed in PR #1808 (`f54d3eea`), with follow-ups PR #1809 (`03b600f8`, restore non-root image smoke build) and PR #1813 (`24f9df88`, harden runtime image construction). Runtime stages (`cpu`/`gpu`/`apple-silicon`) end with `USER tp` via a multi-stage builder that drops compiler toolchains from runtime images; compose uses a `tp-init` bootstrap + `tp_state` named volume with read-only `./input`/`./config`. Contract enforced by `tests/validation/test_dockerfile_contract.py`.
+**Status:** Done — landed in PR #1808 (`f54d3eea`), with follow-ups PR #1809 (`03b600f8`, restore non-root image smoke build) and PR #1813 (`24f9df88`, harden runtime image construction). Runtime stages (`cpu`/`gpu`/`apple-silicon`) end with `USER tp` via a multi-stage builder that drops compiler toolchains from runtime images; compose uses a `tp-init` bootstrap + `tp_state` named volume with read-only `./input_images`/`./config`. Contract enforced by `tests/validation/test_dockerfile_contract.py`.
 
 **Severity / Effort:** Medium / S
 **Tracks finding:** [#6](../PORTAL_AUDIT_REPO_WIDE_2026-05-18.md#63-security) — container default is root

--- a/docs/guides/AI_ENHANCEMENT_GUIDE.md
+++ b/docs/guides/AI_ENHANCEMENT_GUIDE.md
@@ -593,7 +593,7 @@ validator = QualityValidator()
 lpips_metric = LPIPSMetric()
 
 # Process batch
-input_images = glob.glob("input/*.jpg")
+input_images = glob.glob("input_images/*.jpg")
 results = []
 
 for img_path in input_images:

--- a/docs/guides/FLUX_INTEGRATION.md
+++ b/docs/guides/FLUX_INTEGRATION.md
@@ -216,7 +216,7 @@ flux = FLUXPipeline(variant="schnell")  # Fast variant for batch
 prompt_builder = ArchitecturalPromptBuilder()
 
 # Process all images
-input_images = glob.glob("input/*.jpg")
+input_images = glob.glob("input_images/*.jpg")
 
 for img_path in input_images:
     print(f"Processing {img_path}...")

--- a/docs/guides/LUX_DEPTH_V3_TROUBLESHOOTING.md
+++ b/docs/guides/LUX_DEPTH_V3_TROUBLESHOOTING.md
@@ -59,7 +59,7 @@ ERROR: V2 enhancement script not found: scripts/enhance_image.py
 **Example - Simple Commercial Workflow (Recommended):**
 ```bash
 lux-depth-v3 \
-  --input-dir "./input" \
+  --input-dir "./input_images" \
   --output-dir "./output" \
   --quality-tier "apex" \
   --depth-device "mps" \
@@ -70,7 +70,7 @@ lux-depth-v3 \
 **Example - Research Workflow (Advanced):**
 ```bash
 lux-depth-v3 \
-  --input-dir "./input" \
+  --input-dir "./input_images" \
   --output-dir "./output" \
   --quality-tier "apex" \
   --preset "depth-anything-v3.1-research-m4" \
@@ -544,7 +544,7 @@ The CLI **enforces license compliance** at startup:
 
 ```bash
 lux-depth-v3 \
-  --input-dir "./input" \
+  --input-dir "./input_images" \
   --output-dir "./output/commercial" \
   --quality-tier "apex" \
   --depth-device "mps" \
@@ -569,7 +569,7 @@ lux-depth-v3 \
 
 ```bash
 lux-depth-v3 \
-  --input-dir "./input" \
+  --input-dir "./input_images" \
   --output-dir "./output/research" \
   --preset "depth-anything-v3.1-research-m4" \
   --non-commercial-ok "true" \
@@ -591,7 +591,7 @@ lux-depth-v3 \
 
 ```bash
 lux-depth-v3 \
-  --input-dir "./input" \
+  --input-dir "./input_images" \
   --output-dir "./output/dev" \
   --quality-tier "standard" \
   --depth-device "cpu" \

--- a/docs/guides/PBR_ENHANCE_CONFIG_GUIDE.md
+++ b/docs/guides/PBR_ENHANCE_CONFIG_GUIDE.md
@@ -203,8 +203,8 @@ output_root = Path("./output")
 orchestrator = EnhanceOrchestrator(config, output_root)
 
 # Process image
-image_input = ImageInput(path=Path("./input/luxury_interior.jpg"))
-result = orchestrator.enhance_image(image_input, input_root=Path("./input"))
+image_input = ImageInput(path=Path("./input_images/luxury_interior.jpg"))
+result = orchestrator.enhance_image(image_input, input_root=Path("./input_images"))
 
 # Expected outputs in output_root:
 # - luxury_interior_depth.png (16-bit depth visualization)

--- a/docs/guides/SETUP_GUIDE.md
+++ b/docs/guides/SETUP_GUIDE.md
@@ -66,7 +66,7 @@ For AI-powered features such as DA3 depth inference, use a trusted target-specif
 # Supported checked-in Apple Silicon baseline
 make install-ml-core
 
-# Or use the Apple Silicon bootstrap profiles directly:
+# Advanced Apple Silicon bootstrap-profile work only:
 ./scripts/bootstrap/install_ml_stack.sh --profile core-cpu
 ./scripts/bootstrap/install_ml_stack.sh --profile core-mps    # macOS Apple Silicon only
 ```
@@ -77,7 +77,7 @@ The `core-cuda` profile and all Linux ML lock lanes are retired unsupported lane
 
 **Platform-specific notes:**
 
-- **Apple Silicon macOS (M1/M2/M3/M4):** use `make install-ml-core` or `./scripts/bootstrap/install_ml_stack.sh --profile core-mps`
+- **Apple Silicon macOS (M1/M2/M3/M4):** use `make install-ml-core`; reserve `./scripts/bootstrap/install_ml_stack.sh --profile core-mps` for bootstrap-profile work
 - **Linux with NVIDIA GPU:** retired unsupported ML lane; `core-cuda` fails closed until a governed Linux lockfile contract exists
 - **CPU only:** supported through the checked-in Apple Silicon baseline; Linux/macOS Intel ML lanes are retired unsupported lanes
 
@@ -102,7 +102,7 @@ For depth-aware processing, use the governed isolated runtime installers instead
 Use the provided script to print Depth Anything CoreML setup instructions and verify local artifact status:
 
 ```bash
-python scripts/setup/download_depth_models.py --model depth
+.venv/bin/python scripts/setup/download_depth_models.py --model depth
 ```
 
 Options:
@@ -168,7 +168,7 @@ ZoeD_M12_N.pt: 0% | 703k/1.44G [00:30<10:48:36, 37.1kB/s]
 
 **Solutions:**
 - Use a faster internet connection
-- Use `python scripts/setup/download_depth_models.py --verify-only` to verify local artifacts
+- Use `.venv/bin/python scripts/setup/download_depth_models.py --verify-only` to verify local artifacts
 - HuggingFace models are still downloaded automatically on first model use
 - Use cached models: Set `TRANSFORMERS_CACHE` environment variable
   ```bash
@@ -204,7 +204,7 @@ FileNotFoundError: [Errno 2] No such file or directory: 'depth_pipeline/pipeline
 **Current usage:**
 ```bash
 # Use the lux-depth-v3 CLI
-lux-depth-v3 --input-dir ./input --output-dir ./output
+lux-depth-v3 --input-dir ./input_images --output-dir ./output
 ```
 
 ```python
@@ -222,13 +222,13 @@ See [Lux Depth V3 CLI Guide](../cli/LUX_DEPTH_V3_CLI_GUIDE.md) for detailed usag
 ### Run Verification Script
 
 ```bash
-python scripts/verification/verify_core.py
+.venv/bin/python scripts/verification/verify_core.py
 ```
 
 Or for ML dependencies:
 
 ```bash
-python scripts/verification/verify_ml_deps.py
+.venv/bin/python scripts/verification/verify_ml_deps.py
 ```
 
 **Example Output:**
@@ -305,7 +305,7 @@ lux-depth-v3 --list-stable
 ### Apple Silicon (M1/M2/M3/M4)
 
 1. **Use the checked-in Apple Silicon ML baseline**: `make install-ml-core`
-2. **Use MPS bootstrap only on native arm64 macOS**: `./scripts/bootstrap/install_ml_stack.sh --profile core-mps`
+2. **Reserve MPS bootstrap for native arm64 macOS bootstrap-profile work**: `./scripts/bootstrap/install_ml_stack.sh --profile core-mps`
 3. **Enable Metal**: Ensure macOS 13+ for best performance
 
 **Expected performance**:

--- a/docs/guides/TROUBLESHOOTING.md
+++ b/docs/guides/TROUBLESHOOTING.md
@@ -34,7 +34,7 @@ TypeError: expected str, bytes or os.PathLike object, not OptionInfo
 
 **Verification**:
 ```bash
-python lux_render_pipeline.py --help
+.venv/bin/python scripts/pipelines/lux_render_pipeline.py --help
 # Should display help without errors
 ```
 
@@ -83,7 +83,7 @@ validate_sd_dimensions(1024, 770, auto_correct=False)
 **Manual fix**:
 Always use dimensions that are multiples of 64:
 ```bash
-python lux_render_pipeline.py \
+.venv/bin/python scripts/pipelines/lux_render_pipeline.py \
   --width 768 \    # ✓ 768 = 64 × 12
   --height 512 \   # ✓ 512 = 64 × 8
   --input 'images/*.png'
@@ -105,19 +105,21 @@ FileNotFoundError: [Errno 2] No such file or directory:
 
 **Option 1: Use PyTorch Depth Model** (Recommended for cross-platform)
 ```bash
-# Install transformers
-pip install transformers torch
+# Install the governed ML dependency lane
+make install-ml-core
 
 # Model downloads automatically on first use
+.venv/bin/python - <<'PY'
 from transformers import pipeline
 depth_estimator = pipeline("depth-estimation",
                           model="depth-anything/Depth-Anything-V2-Small")
+PY
 ```
 
 **Option 2: Convert to CoreML** (Apple Silicon only)
 ```bash
 # Install CoreML tools (macOS only)
-pip install coremltools
+make install-ml-coreml
 
 # Follow CoreML conversion guide
 # See: https://apple.github.io/coremltools/docs-guides/source/convert-pytorch.html
@@ -126,7 +128,7 @@ pip install coremltools
 **Option 3: Skip Depth Processing**
 ```bash
 # Use --no-depth flag to skip depth guidance
-python lux_render_pipeline.py \
+.venv/bin/python scripts/pipelines/lux_render_pipeline.py \
   --no-depth \
   --input 'images/*.png'
 ```
@@ -148,15 +150,18 @@ python lux_render_pipeline.py \
 
 **Solution** (now with helpful error messages):
 
-**Step 1: Install package**
+**Step 1: Confirm optional upscaling policy**
 ```bash
-pip install realesrgan basicsr facexlib gfpgan
+# External realesrgan packages are intentionally not part of the default setup.
+# Keep using the built-in Lanczos fallback unless a project-specific optional
+# runtime policy explicitly permits external upscaling dependencies.
+make install-ml-core
 ```
 
 **Step 2: Download model weights**
 ```bash
 # Automatic download (recommended)
-python scripts/setup/download_depth_models.py --model depth
+.venv/bin/python scripts/setup/download_depth_models.py --model depth
 
 # Or manual download
 mkdir -p weights
@@ -166,7 +171,7 @@ mv RealESRGAN_x4plus.pth weights/
 
 **Step 3: Verify installation**
 ```bash
-python scripts/verify_setup.py
+.venv/bin/python scripts/verify_setup.py
 ```
 
 **Fallback**: If Real-ESRGAN is unavailable, the pipeline automatically uses Pillow's Lanczos resampling (lower quality but functional).
@@ -192,7 +197,7 @@ ZoeD_M12_N.pt: 0% | 703k/1.44G [00:30<10:48:36, 37.1kB/s]
 **Option 1: Pre-download models**
 ```bash
 # Use download script with progress bar
-python scripts/setup/download_depth_models.py
+.venv/bin/python scripts/setup/download_depth_models.py
 ```
 
 **Option 2: Use model cache**
@@ -201,8 +206,8 @@ python scripts/setup/download_depth_models.py
 export TRANSFORMERS_CACHE=/path/to/fast/storage
 export HF_HOME=/path/to/fast/storage
 
-# Models download to this location
-python your_script.py
+# Models download to this location from repo-managed commands
+.venv/bin/python your_script.py
 ```
 
 **Option 3: Use smaller models**
@@ -216,7 +221,7 @@ depth_estimator = pipeline("depth-estimation",
 
 **Option 4: Skip depth processing**
 ```bash
-python lux_render_pipeline.py --no-depth --input 'images/*.png'
+.venv/bin/python scripts/pipelines/lux_render_pipeline.py --no-depth --input 'images/*.png'
 ```
 
 ---
@@ -231,11 +236,11 @@ Cannot initialize model with low cpu memory usage because `accelerate`
 was not found in the environment.
 ```
 
-**Solution**: Now included in requirements.txt (as of November 2025)
+**Solution**: Install the governed ML dependency lane.
 
 **Install manually** (if needed):
 ```bash
-pip install accelerate
+make install-ml-core
 ```
 
 **Benefits**:
@@ -264,30 +269,26 @@ ImportError: cannot import name 'pipeline' from 'transformers'
 
 **Step 1: Verify Python version**
 ```bash
-python --version  # Must be 3.10+
+.venv/bin/python --version  # Must be 3.11 or 3.12
 ```
 
-**Step 2: Install all dependencies**
+**Step 2: Install core dependencies**
 ```bash
-# Core dependencies
-pip install -r requirements.txt
-
-# Development dependencies (optional)
-pip install -r requirements-dev.txt
+make install-core
 ```
 
-**Step 3: Install package in editable mode**
+**Step 3: Install development hooks when needed**
 ```bash
-pip install -e .
+make install-hooks
 ```
 
 **Step 4: Verify installation**
 ```bash
-python scripts/verify_setup.py
+.venv/bin/python scripts/verify_setup.py
 ```
 
 **Common fixes**:
-- **Wrong Python version**: Use Python 3.10+
+- **Wrong Python version**: Use Python 3.11 or 3.12
 - **Wrong virtual environment**: Activate correct venv
 - **Cached packages**: Clear pip cache: `pip cache purge`
 - **Conflicting packages**: Create fresh venv
@@ -336,7 +337,7 @@ python -c "import torch; print(torch.backends.mps.is_available())"
 
 **Check installation status**:
 ```bash
-python scripts/verify_setup.py --verbose
+.venv/bin/python scripts/verify_setup.py --verbose
 ```
 
 **Test dimension validation**:
@@ -399,7 +400,7 @@ top -l 1 | grep PhysMem  # macOS
 
 2. **Run diagnostics**:
    ```bash
-   python scripts/verify_setup.py --verbose
+   .venv/bin/python scripts/verify_setup.py --verbose
    ```
 
 3. **Check existing issues**:
@@ -419,10 +420,10 @@ top -l 1 | grep PhysMem  # macOS
 | Problem | Quick Fix |
 |---------|-----------|
 | Tensor dimension mismatch | Use dimensions that are multiples of 64 (auto-corrected) |
-| Real-ESRGAN not found | `pip install realesrgan && python scripts/setup/install_models.py --dry-run` |
-| Slow model downloads | `python scripts/setup/download_depth_models.py` |
-| Missing accelerate | `pip install accelerate` (now in requirements.txt) |
-| Import errors | `pip install -r requirements.txt && pip install -e .` |
+| Real-ESRGAN not found | Use the built-in Lanczos fallback, or validate an approved optional upscaler with `.venv/bin/python scripts/setup/install_models.py --dry-run` |
+| Slow model downloads | `.venv/bin/python scripts/setup/download_depth_models.py` |
+| Missing accelerate | `make install-ml-core` |
+| Import errors | `make install-core && .venv/bin/python scripts/verify_setup.py --verbose` |
 | GPU not detected | Install CUDA or MPS-enabled PyTorch |
 | Out of memory | Reduce dimensions or use --no-depth flag |
 | CoreML model missing | Use PyTorch models (cross-platform) |

--- a/docs/investigations/PHASE2_16BIT_QUICKREF.md
+++ b/docs/investigations/PHASE2_16BIT_QUICKREF.md
@@ -50,7 +50,7 @@ Materials V3 Output:
 
 ```bash
 python -m transformation_portal.lux_depth_v3 \
-  --input-dir ./input \
+  --input-dir ./input_images \
   --output-dir ./output_16bit \
   --materials-v3 on \
   --enable-v2 on \
@@ -67,7 +67,7 @@ python -m transformation_portal.lux_depth_v3 \
 
 ```bash
 python -m transformation_portal.lux_depth_v3 \
-  --input-dir ./input \
+  --input-dir ./input_images \
   --output-dir ./output_8bit \
   --materials-v3 on \
   --enable-v2 on

--- a/docs/quick_references/MACHINE_MODE_JSON.md
+++ b/docs/quick_references/MACHINE_MODE_JSON.md
@@ -8,13 +8,13 @@
 
 ```bash
 # Emit JSON to stdout
-python scripts/test_metadata_extraction.py --json extract /input/image.CR2
+.venv/bin/python scripts/test_metadata_extraction.py --json extract input_images/image.CR2
 
 # Write JSON to file
-python scripts/test_metadata_extraction.py --json --json-output result.json extract /input/image.CR2
+.venv/bin/python scripts/test_metadata_extraction.py --json --json-output result.json extract input_images/image.CR2
 
 # Pretty-printed JSON
-python scripts/test_metadata_extraction.py --json --json-pretty extract /input/image.CR2
+.venv/bin/python scripts/test_metadata_extraction.py --json --json-pretty extract input_images/image.CR2
 ```
 
 ---
@@ -56,15 +56,15 @@ python scripts/test_metadata_extraction.py --json --json-pretty extract /input/i
 ### `extract` - Single Image
 
 ```bash
-python scripts/test_metadata_extraction.py --json extract /input/IMG_1234.CR2
+.venv/bin/python scripts/test_metadata_extraction.py --json extract input_images/IMG_1234.CR2
 ```
 
 **Success:**
 ```json
 {
   "data": {
-    "input_path": "/input/IMG_1234.CR2",
-    "output_path": "/output/IMG_1234.provenance.json",
+    "input_path": "input_images/IMG_1234.CR2",
+    "output_path": "output/IMG_1234.provenance.json",
     "elapsed_seconds": 1.234,
     "preset": "luxury",
     "success": true,
@@ -77,7 +77,7 @@ python scripts/test_metadata_extraction.py --json extract /input/IMG_1234.CR2
 ```json
 {
   "data": {
-    "input_path": "/input/missing.CR2",
+    "input_path": "input_images/missing.CR2",
     "success": false,
     "error": {
       "type": "OtherIngestFailure",
@@ -90,14 +90,14 @@ python scripts/test_metadata_extraction.py --json extract /input/IMG_1234.CR2
 ### `validate` - Schema Check
 
 ```bash
-python scripts/test_metadata_extraction.py --json validate /output/sidecar.json
+.venv/bin/python scripts/test_metadata_extraction.py --json validate output/sidecar.json
 ```
 
 **Success:**
 ```json
 {
   "data": {
-    "sidecar_path": "/output/sidecar.json",
+    "sidecar_path": "output/sidecar.json",
     "strict": true,
     "success": true,
     "errors": [],
@@ -122,19 +122,19 @@ python scripts/test_metadata_extraction.py --json validate /output/sidecar.json
 ### `extract-batch` - Multiple Images
 
 ```bash
-python scripts/test_metadata_extraction.py --json extract-batch /input --output /output
+.venv/bin/python scripts/test_metadata_extraction.py --json extract-batch input_images --output output
 ```
 
 **Result:**
 ```json
 {
   "data": {
-    "input_root": "/input",
-    "output_dir": "/output",
+    "input_root": "input_images",
+    "output_dir": "output",
     "success": false,
     "items": [
-      {"path": "/input/a.CR2", "success": true, ...},
-      {"path": "/input/b.CR2", "success": false, "error": {...}}
+      {"path": "input_images/a.CR2", "success": true, ...},
+      {"path": "input_images/b.CR2", "success": false, "error": {...}}
     ],
     "summary_counts": {
       "total": 2,
@@ -150,7 +150,7 @@ python scripts/test_metadata_extraction.py --json extract-batch /input --output 
 ### `check-system` - Readiness
 
 ```bash
-python scripts/test_metadata_extraction.py --json check-system
+.venv/bin/python scripts/test_metadata_extraction.py --json check-system
 ```
 
 **Result:**
@@ -172,8 +172,8 @@ python scripts/test_metadata_extraction.py --json check-system
 
 ```bash
 # Parse from file or stdin
-python tools/parse_machine_json.py result.json
-python scripts/test_metadata_extraction.py --json extract /input/image.CR2 | python tools/parse_machine_json.py
+.venv/bin/python tools/parse_machine_json.py result.json
+.venv/bin/python scripts/test_metadata_extraction.py --json extract input_images/image.CR2 | .venv/bin/python tools/parse_machine_json.py
 
 # Exit code forwarded
 echo $?
@@ -185,7 +185,7 @@ echo $?
 
 ```bash
 # Extract with exit code routing
-result=$(python scripts/test_metadata_extraction.py --json extract /input/image.CR2)
+result=$(.venv/bin/python scripts/test_metadata_extraction.py --json extract input_images/image.CR2)
 exit_code=$?
 
 if [[ $exit_code -eq 0 ]]; then
@@ -200,7 +200,7 @@ fi
 
 ```bash
 # Validate with error details
-result=$(python scripts/test_metadata_extraction.py --json validate /output/sidecar.json)
+result=$(.venv/bin/python scripts/test_metadata_extraction.py --json validate output/sidecar.json)
 
 if [[ $(echo "$result" | jq -r '.success') == "true" ]]; then
   echo "✅ Valid"
@@ -212,7 +212,7 @@ fi
 
 ```bash
 # Batch summary
-result=$(python scripts/test_metadata_extraction.py --json extract-batch /input --output /output)
+result=$(.venv/bin/python scripts/test_metadata_extraction.py --json extract-batch input_images --output output)
 
 total=$(echo "$result" | jq '.data.summary_counts.total')
 success=$(echo "$result" | jq '.data.summary_counts.success')
@@ -257,7 +257,7 @@ echo "Result: $success/$total succeeded"
 **Problem:** Exit code always 0
 **Fix:** Don't use `set -e` before capturing JSON; capture exit code explicitly:
 ```bash
-result=$(python scripts/test_metadata_extraction.py --json ...)
+result=$(.venv/bin/python scripts/test_metadata_extraction.py --json ...)
 exit_code=$?  # Capture before any other commands
 ```
 

--- a/docs/quick_references/PHASE_3_7_METADATA_EXTRACTION_TEST_COMMANDS.md
+++ b/docs/quick_references/PHASE_3_7_METADATA_EXTRACTION_TEST_COMMANDS.md
@@ -15,7 +15,7 @@ brew install exiftool        # macOS
 apt-get install libimage-exiftool-perl  # Linux
 
 # Check system readiness
-python scripts/test_metadata_extraction.py check-system
+.venv/bin/python scripts/test_metadata_extraction.py check-system
 ```
 
 ## Test Commands for `<project_root>/input_images`
@@ -26,13 +26,13 @@ Use these flags before the subcommand when you need deterministic machine output
 
 ```bash
 # Emit machine JSON to stdout
-python scripts/test_metadata_extraction.py --json <command> ...
+.venv/bin/python scripts/test_metadata_extraction.py --json <command> ...
 
 # Pretty-print machine JSON
-python scripts/test_metadata_extraction.py --json --json-pretty <command> ...
+.venv/bin/python scripts/test_metadata_extraction.py --json --json-pretty <command> ...
 
 # Write machine JSON to file (stdout remains clean)
-python scripts/test_metadata_extraction.py --json --json-output /tmp/metadata_result.json <command> ...
+.venv/bin/python scripts/test_metadata_extraction.py --json --json-output /tmp/metadata_result.json <command> ...
 ```
 
 ### Machine JSON Envelope Structure
@@ -78,10 +78,10 @@ This envelope structure is versioned and stable. Any breaking change to the enve
 ### 1. Check System Readiness
 
 ```bash
-python scripts/test_metadata_extraction.py check-system
+.venv/bin/python scripts/test_metadata_extraction.py check-system
 
 # Machine JSON output
-python scripts/test_metadata_extraction.py --json check-system
+.venv/bin/python scripts/test_metadata_extraction.py --json check-system
 ```
 
 Expected output includes:
@@ -95,19 +95,19 @@ Extract metadata from a single image:
 
 ```bash
 # Basic extraction (output to <image>.provenance.json)
-python scripts/test_metadata_extraction.py extract /path/to/input_images/your_image.tif
+.venv/bin/python scripts/test_metadata_extraction.py extract /path/to/input_images/your_image.tif
 
 # Custom output path
-python scripts/test_metadata_extraction.py extract /path/to/input_images/your_image.tif -o /tmp/test_provenance.json
+.venv/bin/python scripts/test_metadata_extraction.py extract /path/to/input_images/your_image.tif -o /tmp/test_provenance.json
 
 # With durable write (fsync)
-python scripts/test_metadata_extraction.py extract /path/to/input_images/your_image.tif --fsync
+.venv/bin/python scripts/test_metadata_extraction.py extract /path/to/input_images/your_image.tif --fsync
 
 # Debug mode (full tracebacks on errors)
-python scripts/test_metadata_extraction.py --debug extract /path/to/input_images/your_image.tif
+.venv/bin/python scripts/test_metadata_extraction.py --debug extract /path/to/input_images/your_image.tif
 
 # Machine JSON output
-python scripts/test_metadata_extraction.py --json extract /path/to/input_images/your_image.tif
+.venv/bin/python scripts/test_metadata_extraction.py --json extract /path/to/input_images/your_image.tif
 ```
 
 ### 3. Batch Extraction (Entire Directory)
@@ -116,22 +116,22 @@ Extract metadata from all images in the input_images directory:
 
 ```bash
 # Default: sidecars saved to input_images/provenance_sidecars/
-python scripts/test_metadata_extraction.py extract-batch /path/to/input_images/
+.venv/bin/python scripts/test_metadata_extraction.py extract-batch /path/to/input_images/
 
 # Custom output directory
-python scripts/test_metadata_extraction.py extract-batch /path/to/input_images/ -o /tmp/metadata_sidecars/
+.venv/bin/python scripts/test_metadata_extraction.py extract-batch /path/to/input_images/ -o /tmp/metadata_sidecars/
 
 # Non-recursive (only top-level images)
-python scripts/test_metadata_extraction.py extract-batch /path/to/input_images/ --no-recursive
+.venv/bin/python scripts/test_metadata_extraction.py extract-batch /path/to/input_images/ --no-recursive
 
 # Stop on first error
-python scripts/test_metadata_extraction.py extract-batch /path/to/input_images/ --fail-fast
+.venv/bin/python scripts/test_metadata_extraction.py extract-batch /path/to/input_images/ --fail-fast
 
 # Verbose output (show per-file status)
-python scripts/test_metadata_extraction.py extract-batch /path/to/input_images/ -v
+.venv/bin/python scripts/test_metadata_extraction.py extract-batch /path/to/input_images/ -v
 
 # Machine JSON output
-python scripts/test_metadata_extraction.py --json extract-batch /path/to/input_images/
+.venv/bin/python scripts/test_metadata_extraction.py --json extract-batch /path/to/input_images/
 ```
 
 ### 4. Validate Sidecar Files
@@ -140,16 +140,16 @@ Validate provenance sidecars for schema compliance:
 
 ```bash
 # Basic validation
-python scripts/test_metadata_extraction.py validate /path/to/input_images/provenance_sidecars/your_image_provenance.json
+.venv/bin/python scripts/test_metadata_extraction.py validate /path/to/input_images/provenance_sidecars/your_image_provenance.json
 
 # Verbose output (show sidecar summary)
-python scripts/test_metadata_extraction.py validate /path/to/input_images/provenance_sidecars/your_image_provenance.json -v
+.venv/bin/python scripts/test_metadata_extraction.py validate /path/to/input_images/provenance_sidecars/your_image_provenance.json -v
 
 # Non-strict mode (legacy compatibility)
-python scripts/test_metadata_extraction.py validate /path/to/input_images/provenance_sidecars/your_image_provenance.json --no-strict
+.venv/bin/python scripts/test_metadata_extraction.py validate /path/to/input_images/provenance_sidecars/your_image_provenance.json --no-strict
 
 # Machine JSON output
-python scripts/test_metadata_extraction.py --json validate /path/to/input_images/provenance_sidecars/your_image_provenance.json
+.venv/bin/python scripts/test_metadata_extraction.py --json validate /path/to/input_images/provenance_sidecars/your_image_provenance.json
 ```
 
 ### 5. Summarize Extraction Results
@@ -157,10 +157,10 @@ python scripts/test_metadata_extraction.py --json validate /path/to/input_images
 Get aggregate statistics from extracted sidecars:
 
 ```bash
-python scripts/test_metadata_extraction.py summarize /path/to/input_images/provenance_sidecars/
+.venv/bin/python scripts/test_metadata_extraction.py summarize /path/to/input_images/provenance_sidecars/
 
 # Machine JSON output
-python scripts/test_metadata_extraction.py --json summarize /path/to/input_images/provenance_sidecars/
+.venv/bin/python scripts/test_metadata_extraction.py --json summarize /path/to/input_images/provenance_sidecars/
 ```
 
 Output includes:

--- a/docs/reference/PBR_PRESETS_QUICK_REFERENCE.md
+++ b/docs/reference/PBR_PRESETS_QUICK_REFERENCE.md
@@ -46,8 +46,8 @@ from pathlib import Path
 output_root = Path("./pbr_output")
 orchestrator = EnhanceOrchestrator(STANDARD_QUALITY, output_root)
 
-for img_path in Path("./input").glob("*.jpg"):
-    result = orchestrator.enhance_image(img_path, input_root=Path("./input"))
+for img_path in Path("./input_images").glob("*.jpg"):
+    result = orchestrator.enhance_image(img_path, input_root=Path("./input_images"))
     print(f"✓ {img_path.name}")
 ```
 

--- a/docs/status/READY_TO_PROCESS.md
+++ b/docs/status/READY_TO_PROCESS.md
@@ -1,163 +1,97 @@
-# Quick Answer: Are We Ready to Process Images? ✅
+# Image Processing Readiness Status
 
-## YES! The Transformation Portal is ready to process images right now.
+This status note is a quick pointer for local image-processing readiness. The
+authoritative setup and tier details live in
+[Image Processing Readiness Guide](../guides/IMAGE_PROCESSING_READINESS.md).
 
-### Current Status: **MINIMAL TIER READY** ✓
+## Current Status
 
-```
-✓ Python 3.12.3
-✓ Core packages installed (numpy, Pillow, typer)
-✓ 14.9GB disk space available
-✓ Test images created and processed
-✓ All tests passing
-```
+The repository supports a minimal local image-processing tier through the
+repo-managed Python environment. Do not rely on a fixed historical machine
+snapshot here; verify the current checkout before processing client images.
 
-## What You Can Do Right Now
-
-### 1. Check Your Setup
 ```bash
-python scripts/check_image_processing_readiness.py
+make venv
+make install-core
+.venv/bin/python scripts/check_image_processing_readiness.py
+.venv/bin/python scripts/check_image_processing_readiness.py --quick-start
 ```
 
-### 2. Process Images Immediately
+The readiness checker reports installed packages, disk capacity, FFmpeg
+availability, sample-image availability, available operations, and the next
+governed setup command for missing optional tiers.
+
+## Immediate Minimal Processing
+
+Use the minimal processor for basic local adjustments:
+
 ```bash
-# Basic processing with simple adjustments
-python scripts/simple_image_processor.py input_images/test_render.jpg \
-  --brightness 1.1 --contrast 1.05 --saturation 1.1 --verbose
-
-# Resize for web
-python scripts/simple_image_processor.py input_images/test_render.jpg \
-  --width 1280 --height 720 --output web_preview.jpg
-
-# Format conversion
-python scripts/simple_image_processor.py input_images/image.png \
-  --output converted.jpg --quality 95
+.venv/bin/python scripts/simple_image_processor.py input_images/test_render.jpg \
+  --brightness 1.1 \
+  --contrast 1.05 \
+  --saturation 1.1 \
+  --output output/test_render_processed.jpg \
+  --verbose
 ```
 
-### 3. Explore Available Tools
+Resize or convert formats with the same entrypoint:
 
-**New Tools Added:**
-- ✅ `scripts/check_image_processing_readiness.py` - Comprehensive setup checker
-- ✅ `scripts/simple_image_processor.py` - Minimal-dependency processor
-- ✅ `docs/guides/IMAGE_PROCESSING_READINESS.md` - Complete readiness guide
-
-**Example Output:**
-```
-Processing: test_render.jpg
-Loading: input_images/test_render.jpg
-  Original: 1920x1080 RGB
-  Adjusting brightness: 1.10
-  Adjusting contrast: 1.05
-  Adjusting saturation: 1.10
-  Saved: input_images/test_render_processed.jpg
-  Final: 1920x1080
-✓ Successfully processed: input_images/test_render_processed.jpg
-```
-
-## Three Capability Tiers
-
-### 📦 Tier 1: MINIMAL (✓ Current Status)
-**What's included:**
-- Image format conversion
-- Resize and crop
-- Brightness, contrast, saturation
-- Basic metadata reading
-
-**Requirements:** numpy, Pillow ✅ Installed
-
-### 📦 Tier 2: STANDARD
-**What's added:**
-- LUT-based color grading
-- 16-bit TIFF workflows
-- Professional metadata preservation
-- Advanced filters
-
-**To upgrade:**
 ```bash
-pip install scipy tifffile imagecodecs scikit-image
+.venv/bin/python scripts/simple_image_processor.py input_images/test_render.jpg \
+  --width 1280 \
+  --height 720 \
+  --output output/web_preview.jpg
+
+.venv/bin/python scripts/simple_image_processor.py input_images/image.png \
+  --output output/converted.jpg \
+  --quality 95
 ```
 
-### 📦 Tier 3: FULL (AI-Powered)
-**What's added:**
-- Depth Anything V2 depth estimation
-- Stable Diffusion enhancement
-- Real-ESRGAN upscaling
-- ControlNet refinement
-- Material Response processing
+## Capability Tiers
 
-**To upgrade:**
+| Tier | Setup command | Typical workflows |
+|------|---------------|-------------------|
+| Minimal | `make install-core` | Format conversion, resize/crop, brightness, contrast, saturation, basic metadata |
+| Standard | `make install-core` | Minimal tier plus TIFF/LUT-oriented workflows when optional image packages are present |
+| Full ML | `make install-ml-core` plus target runtime installers | Governed ML, depth, segmentation, and rendering workflows |
+
+Optional runtimes are explicit and isolated:
+
 ```bash
-pip install -r requirements.txt
-python scripts/download_depth_models.py
+make install-ml-core
+make install-ml-sam2
+./scripts/setup/install_raw_runtime.sh
+./scripts/setup/install_da3_runtime.sh --profile baseline
+./scripts/setup/install_depth_pro_runtime.sh
+./scripts/setup/install_fastvlm_runtime.sh
+.venv/bin/python scripts/setup/download_depth_models.py
 ```
 
-## Next Steps
+## Maintained Processing Entrypoints
 
-### Option 1: Start Processing Now (Recommended)
-Use the minimal tier tools to process images immediately:
+Use the maintained console scripts after the relevant setup tier is installed:
+
 ```bash
-# Process your images
-python scripts/simple_image_processor.py input_images/my_image.jpg \
-  --brightness 1.1 --contrast 1.08 --output enhanced.jpg
+.venv/bin/luxury-tiff-batch input_images/tiff output/tiff_lux \
+  --preset signature \
+  --profile balanced \
+  --recursive
+
+.venv/bin/lux-depth-v3 \
+  --input-dir ./input_images \
+  --output-dir ./output/lux_depth_v3 \
+  --model-key da3-metric \
+  --quality-tier standard
+
+.venv/bin/lux_render \
+  --input-glob 'input_images/*.png' \
+  --out output/lux_render \
+  --prompt 'luxury interior, natural light'
 ```
 
-### Option 2: Upgrade to Standard Tier
-Add professional features:
-```bash
-pip install scipy tifffile imagecodecs
-```
+## Related Documentation
 
-### Option 3: Upgrade to Full Tier (when disk space permits)
-Get all AI features:
-```bash
-pip install -r requirements.txt
-```
-
-## Documentation
-
-- **Quick Reference:** This file
-- **Complete Guide:** `docs/guides/IMAGE_PROCESSING_READINESS.md`
-- **Main README:** `README.md`
-- **Pipeline Guide:** `docs/pipeline_docs/PIPELINE_OPERATIONS_GUIDE.md`
-
-## Test Results ✅
-
-All tests passing:
-```
-✓ All readiness check tests passed!
-✓ All processor tests passed!
-✓ Image processing verified working
-```
-
-## Examples of What's Possible
-
-**Current Minimal Tier:**
-```python
-from PIL import Image, ImageEnhance
-
-# Load and enhance
-img = Image.open('input_images/test_render.jpg')
-enhancer = ImageEnhance.Brightness(img)
-bright_img = enhancer.enhance(1.1)
-bright_img.save('enhanced.jpg', quality=95)
-```
-
-**With Standard Tier:**
-```bash
-# Professional TIFF batch processing
-python scripts/utilities/luxury_tiff_batch_processor.py \
-  input_images/ output/ --preset golden_hour
-```
-
-**With Full Tier:**
-```bash
-# AI-powered enhancement
-python scripts/pipelines/lux_render_pipeline.py \
-  input_images/render.tiff --ai-enhance --upscale
-```
-
----
-
-**Bottom Line:** Yes, we're ready! The system can process images right now, and you can upgrade to more advanced features as needed.
-
-**Get Started:** `python scripts/check_image_processing_readiness.py`
+- [Image Processing Readiness Guide](../guides/IMAGE_PROCESSING_READINESS.md)
+- [Supported File Formats](../guides/SUPPORTED_FILE_FORMATS.md)
+- [Pipeline Operations Guide](../pipeline_docs/PIPELINE_OPERATIONS_GUIDE.md)
+- [Repository README](../../README.md)

--- a/docs/workflows/PBR_ONLY_WORKFLOW.md
+++ b/docs/workflows/PBR_ONLY_WORKFLOW.md
@@ -179,7 +179,7 @@ FileNotFoundError: V2 enhancement script not found: scripts/enhance_image.py
 
 1. **Disable V2 via CLI** (easiest):
 ```bash
-lux-depth-v3 --input-dir ./input --output-dir ./output --enable-v2 "off" --pbr "on"
+lux-depth-v3 --input-dir ./input_images --output-dir ./output --enable-v2 "off" --pbr "on"
 ```
 
 2. **Disable V2 via Python API**:

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
       "name": "transformation-portal-worker-build",
       "devDependencies": {
         "wrangler": "4.95.0"
+      },
+      "engines": {
+        "node": ">=22 <23"
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
     "worker:dry-run": "wrangler deploy --dry-run",
     "worker:deploy": "wrangler deploy"
   },
+  "engines": {
+    "node": ">=22 <23"
+  },
+  "packageManager": "npm@11.12.1",
   "devDependencies": {
     "wrangler": "4.95.0"
   }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,18 +107,19 @@ ml = [
 # NVDiffRec requires manual install of nvdiffrast compiled CUDA extensions:
 #   ./scripts/bootstrap/install_ml_stack.sh --profile nvdiffrec
 # 3DGS (graphdeco-inria/gaussian-splatting) requires SHA verification:
-#   python scripts/validation/verify_3dgs_artifacts.py
+#   .venv/bin/python scripts/validation/verify_3dgs_artifacts.py
 spatial-ai = [
     "transformation-portal[ml-core]",
     "huggingface-hub>=0.19",
     # SAM2: pip install sam2 (requires scripted bootstrap for weights)
     "sam2>=1.0; python_version >= '3.11'",
     # nvdiffrast (compiled CUDA extension) must be installed separately:
-    # git clone https://github.com/NVlabs/nvdiffrast && pip install -e .
+    # git clone https://github.com/NVlabs/nvdiffrast external/nvdiffrast
+    # .venv/bin/python -m pip install -e external/nvdiffrast
 ]
 # Optional detached signing support for archive attestation CLIs
 archive-signing = [
-    "cryptography>=46.0,<48",
+    "cryptography>=47.0.0,<48",
 ]
 # Development tools - see requirements/dev.in for pinned versions
 dev = [
@@ -132,12 +133,12 @@ dev = [
     "httpx>=0.28,<1",  # required for FastAPI/Starlette TestClient in HTTP contract tests
     "hypothesis>=6.0,<7",
     "jsonschema>=4.21.0,<5",  # required for machine-mode contract schema validation tests
-    "cryptography>=46.0,<48",  # required for Phase 3.1 signing CLI tests
+    "cryptography>=47.0.0,<48",  # required for Phase 3.1 signing CLI tests
     "moto[s3]>=5.0,<6",  # required for moto-backed S3 ArtifactStore contract tests
     "mypy>=1.10",
     "flake8>=7.0",
     "pylint>=3.0",
-    "black>=24.8",
+    "black>=26.3.1",
     "isort>=5.13,<9",
     "autopep8>=2.0,<3",
     "libcst>=1.2,<2",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -33,6 +33,6 @@ libcst>=1.2,<2
 pre-commit>=4.0,<5
 
 # Documentation generation
-sphinx>=7.2,<10
-sphinx-rtd-theme>=3.1.0,<4
-sphinx-autodoc-typehints>=3.6.1,<4
+sphinx>=7.2,<9
+sphinx-rtd-theme>=2.0,<3
+sphinx-autodoc-typehints>=2.0,<4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,13 @@
 # Transformation Portal - Core Runtime Dependencies
 # ==================================================
-# This is the main requirements file for production installations.
-# For a complete development environment, see requirements/ directory.
+# This is the root aggregate requirements file for core runtime dependencies.
+# Local repository setup should use the Make targets below so the pinned
+# dependency lanes, editable package install, and pip check stay in sync.
 #
 # Installation options:
-#   pip install -r requirements.txt           # Core functionality only (lightweight)
-#   pip install -r requirements/all.txt       # Development aggregate (generic locks)
+#   make install-core                         # Repo-managed core .venv (recommended)
 #   make install-ml-core                      # Supported target-owned ML core install
-#   pip install -e ".[ml]"                    # Editable metadata extras, not pinned locks
+#   make repair-core-venv                     # Recreate and validate the core .venv
 #
 # For CI/CD environments, use requirements-ci.txt
 # For development, use requirements-dev.txt

--- a/requirements/tools-archive.in
+++ b/requirements/tools-archive.in
@@ -5,6 +5,6 @@
 numpy>=2.2,<2.5
 pandas>=2.2,<3.1
 jsonschema>=4.23,<5
-cryptography>=46.0,<48
+cryptography>=47.0.0,<48
 bagit>=1.8,<2
 pyyaml>=6.0,<7

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -46,7 +46,7 @@ Most scripts can be run directly:
 ./scripts/setup/install_da3_runtime.sh
 
 # Python scripts
-python scripts/setup/install_models.py --dry-run
+.venv/bin/python scripts/setup/install_models.py --dry-run
 ```
 
 ## Contributing

--- a/scripts/analyze_flakes.py
+++ b/scripts/analyze_flakes.py
@@ -3,7 +3,7 @@
 Analyze flake ledger and generate reports.
 
 Usage:
-    python scripts/analyze_flakes.py [--format=text|json|markdown]
+    .venv/bin/python scripts/analyze_flakes.py [--format=text|json|markdown]
 """
 
 from __future__ import annotations

--- a/scripts/check_image_processing_readiness.py
+++ b/scripts/check_image_processing_readiness.py
@@ -237,7 +237,7 @@ def print_tier_status(capabilities: Dict) -> None:
         ml_count = sum(capabilities["ml_packages"].values())
         print(f"   → {ml_count}/{len(capabilities['ml_packages'])} supported ML packages installed")
         print("   → Install: make install-ml-core")
-        print("   → Apple Silicon bootstrap: ./scripts/bootstrap/install_ml_stack.sh --profile core-cpu")
+        print("   → Advanced Apple Silicon bootstrap: ./scripts/bootstrap/install_ml_stack.sh --profile core-cpu")
         print("   → Note: Requires ~5GB disk space")
 
 
@@ -347,7 +347,7 @@ def print_quick_start_guide(capabilities: Dict, images: Dict) -> None:
         print("   ")
         print("   Upgrade to Full tier for AI-powered processing:")
         print("   make install-ml-core")
-        print("   # Apple Silicon CPU fallback: ./scripts/bootstrap/install_ml_stack.sh --profile core-cpu")
+        print("   # Advanced Apple Silicon bootstrap: ./scripts/bootstrap/install_ml_stack.sh --profile core-cpu")
 
     elif capabilities["full_ready"]:
         print("   With current setup (Full), you can use all pipelines:")
@@ -403,7 +403,7 @@ def print_recommendations(disk: Dict, capabilities: Dict) -> None:
             recommendations.append(
                 (
                     "→",
-                    "Apple Silicon ML bootstrap: ./scripts/bootstrap/install_ml_stack.sh --profile core-cpu",
+                    "Advanced Apple Silicon ML bootstrap: ./scripts/bootstrap/install_ml_stack.sh --profile core-cpu",
                     Colors.OKCYAN,
                 )
             )

--- a/scripts/governance/check_script_topology.py
+++ b/scripts/governance/check_script_topology.py
@@ -37,6 +37,10 @@ COMPATIBILITY_WRAPPERS = {
         "src/transformation_portal/perceptual/synthetic_viewer.py",
         "from transformation_portal.perceptual.synthetic_viewer import",
     ),
+    "scripts/pipelines/lux_render_pipeline.py": (
+        "src/transformation_portal/pipelines/lux_render_pipeline.py",
+        "from transformation_portal.pipelines.lux_render_pipeline import",
+    ),
     "scripts/visualize_material_assignments.py": (
         "scripts/utilities/visualize_material_assignments.py",
         "from scripts.utilities.visualize_material_assignments import",
@@ -94,6 +98,15 @@ def _git_ls_files() -> list[str]:
 
 def _read_repo_text(path: str) -> str:
     return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def _repo_root_parent_expression(wrapper_path: str) -> str:
+    wrapper_parent_depth = len(Path(wrapper_path).parent.parts)
+    return f"Path(__file__).resolve().parents[{wrapper_parent_depth}]"
+
+
+def _src_root_bootstrap_expression(wrapper_path: str) -> str:
+    return f'{_repo_root_parent_expression(wrapper_path)} / "src"'
 
 
 def validate_script_topology(
@@ -178,23 +191,32 @@ def validate_script_topology(
                     suggestion="call the canonical main through raise SystemExit(...)",
                 )
             )
-        if wrapper in SCRIPT_PACKAGE_COMPATIBILITY_WRAPPERS and "Path(__file__).resolve().parents[1]" not in wrapper_text:
+        if (
+            wrapper in SCRIPT_PACKAGE_COMPATIBILITY_WRAPPERS
+            and _repo_root_parent_expression(wrapper) not in wrapper_text
+        ):
             violations.append(
                 TopologyViolation(
                     path=wrapper,
                     reason="script-package compatibility wrapper does not bootstrap repository root",
-                    suggestion="insert the repository root into sys.path before importing scripts.*",
+                    suggestion=(
+                        f"insert the repository root ({_repo_root_parent_expression(wrapper)}) into sys.path "
+                        "before importing scripts.*"
+                    ),
                 )
             )
         if (
             wrapper in SOURCE_PACKAGE_COMPATIBILITY_WRAPPERS
-            and 'Path(__file__).resolve().parents[1] / "src"' not in wrapper_text
+            and _src_root_bootstrap_expression(wrapper) not in wrapper_text
         ):
             violations.append(
                 TopologyViolation(
                     path=wrapper,
                     reason="source-package compatibility wrapper does not bootstrap src package root",
-                    suggestion="insert the src root into sys.path before importing transformation_portal.*",
+                    suggestion=(
+                        f"insert the src root ({_src_root_bootstrap_expression(wrapper)}) into sys.path "
+                        "before importing transformation_portal.*"
+                    ),
                 )
             )
 

--- a/scripts/pipelines/lux_render_pipeline.py
+++ b/scripts/pipelines/lux_render_pipeline.py
@@ -7,18 +7,18 @@ module imports. The real implementation now lives in
 ``src/transformation_portal/pipelines/lux_render_pipeline.py``.
 
 For module imports, all functions are re-exported from the new location.
-For CLI usage, run: python lux_render_pipeline.py [options]
+For CLI usage, run:
+    .venv/bin/python scripts/pipelines/lux_render_pipeline.py [options]
 
-NOTE: Requires package installation (pip install -e .) or running from
-repository root with src/ in Python path.
+The wrapper bootstraps the repo-local ``src/`` package root for raw checkouts.
 """
 import sys
 from pathlib import Path
 
 # Add src/ to path if package not installed (for development/testing)
-_repo_root = Path(__file__).parent
-if (_repo_root / "src").exists():
-    _src_path = str(_repo_root / "src")
+_src_root = Path(__file__).resolve().parents[2] / "src"
+if _src_root.exists():
+    _src_path = str(_src_root)
     if _src_path not in sys.path:
         sys.path.insert(0, _src_path)
 

--- a/scripts/security_scan.sh
+++ b/scripts/security_scan.sh
@@ -1,13 +1,18 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Security scan script matching CI policy
 # Run this locally to verify security gate before pushing
-set -e
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PYTHON_BIN="$("$SCRIPT_DIR/setup/resolve_python_311.sh")"
 
 echo "Running Bandit security scan with CI flags..."
 echo "Policy: severity >= LOW, confidence >= MEDIUM"
 echo ""
 
-python -m bandit -r src/ -ll -ii
+cd "$REPO_ROOT"
+"$PYTHON_BIN" -m bandit -r src/ -ll -ii
 
 echo ""
 echo "✅ Security scan passed"

--- a/scripts/setup/README.md
+++ b/scripts/setup/README.md
@@ -50,12 +50,12 @@ contract and by explicit `--da3-python` overrides.
 
 **Stable contract:**
 ```bash
-lux-depth-v3 --input-dir ./input --output-dir ./output
+lux-depth-v3 --input-dir ./input_images --output-dir ./output
 ```
 
 If you need a non-default interpreter, override it explicitly:
 ```bash
-lux-depth-v3 --input-dir ./input --output-dir ./output --da3-python ~/venvs/da3/bin/python
+lux-depth-v3 --input-dir ./input_images --output-dir ./output --da3-python ~/venvs/da3/bin/python
 ```
 
 **Requirements:**
@@ -86,7 +86,7 @@ curl -L https://ml-site.cdn-apple.com/models/depth-pro/depth_pro.pt -o checkpoin
 
 **Stable contract:**
 ```bash
-lux-depth-v3 --input-dir ./input --output-dir ./output --depth-pro-python ./.venv-depth-pro/bin/python
+lux-depth-v3 --input-dir ./input_images --output-dir ./output --depth-pro-python ./.venv-depth-pro/bin/python
 ```
 
 Use `--verify-device cpu` when you only need a CPU-safe contract. The default
@@ -112,7 +112,7 @@ auto-discovered `./.venv-raw/bin/python` contract and by explicit
 
 **Stable contract:**
 ```bash
-lux-depth-v3 --input-dir ./input --output-dir ./output --raw-python ./.venv-raw/bin/python
+lux-depth-v3 --input-dir ./input_images --output-dir ./output --raw-python ./.venv-raw/bin/python
 ```
 
 If you want the repo-local runtime to be used automatically for RAW batches,
@@ -170,7 +170,7 @@ Downloads and installs AI/ML models required by the Transformation Portal pipeli
 
 **Usage:**
 ```bash
-python scripts/setup/install_models.py [--all] [--dry-run] [--force]
+.venv/bin/python scripts/setup/install_models.py [--all] [--dry-run] [--force]
 ```
 
 **Options:**
@@ -180,17 +180,19 @@ python scripts/setup/install_models.py [--all] [--dry-run] [--force]
 
 **Models:**
 - Depth Anything V2 (depth estimation)
-- Real-ESRGAN (upscaling)
+- Governed upscaling model assets where configured; the external `realesrgan`
+  package remains unsupported
 - Stable Diffusion XL (AI enhancement)
 - ControlNet models (edge-preserving processing)
 
 ### `download_depth_models.py`
 
-Downloads depth estimation models for the Depth Pipeline.
+Prints Depth Anything CoreML setup instructions and verifies local Lux Depth V3
+artifact status.
 
 **Usage:**
 ```bash
-python scripts/setup/download_depth_models.py
+.venv/bin/python scripts/setup/download_depth_models.py
 ```
 
 **What it does:**
@@ -207,14 +209,15 @@ python scripts/setup/download_depth_models.py
 git clone https://github.com/RC219805/Transformation_Portal.git
 cd Transformation_Portal
 
-# 2. Install Python dependencies
-pip install -r requirements.txt
+# 2. Install pinned core runtime and dev tooling
+make venv
+make install-core
 
 # 3. Install organization system
 ./scripts/setup/auto-organize-install.sh
 
 # 4. (Optional) Install ML models
-python scripts/setup/install_models.py --all
+.venv/bin/python scripts/setup/install_models.py --all
 ```
 
 ### Organization System Only
@@ -296,7 +299,7 @@ sed -i 's/\r$//' .auto-organize.sh
 **Solution:**
 ```bash
 # Try downloading specific models one at a time
-python scripts/setup/install_models.py --model depth_anything_v2
+.venv/bin/python scripts/setup/install_models.py --model depth_anything_v2
 
 # Check disk space
 df -h

--- a/scripts/setup/download_depth_models.py
+++ b/scripts/setup/download_depth_models.py
@@ -8,14 +8,14 @@ This script downloads required models for depth-aware processing:
 - Alternative depth models for non-Apple platforms
 
 Usage:
-    python scripts/setup/download_depth_models.py [--model depth] [--output-dir DIR] [--verify-only]
+    .venv/bin/python scripts/setup/download_depth_models.py [--model depth] [--output-dir DIR] [--verify-only]
 
 Examples:
     # Download default Depth Anything V2 Small model
-    python scripts/setup/download_depth_models.py
+    .venv/bin/python scripts/setup/download_depth_models.py
 
     # Download to custom location
-    python scripts/setup/download_depth_models.py --output-dir ./models/depth
+    .venv/bin/python scripts/setup/download_depth_models.py --output-dir ./models/depth
 """
 
 import argparse
@@ -172,8 +172,8 @@ def download_depth_anything_v2_coreml(output_dir: Path) -> bool:
 
     print("\nOption 2: Use PyTorch model directly")
     print("-" * 70)
-    print("The repository can use Depth Anything V2 via transformers library:")
-    print("  pip install transformers torch")
+    print("The repository can use Depth Anything V2 through the governed ML baseline:")
+    print("  make install-ml-core")
     print("The model will download automatically on first use.")
     print("Note: PyTorch is slower than CoreML on Apple Silicon but works cross-platform.")
 
@@ -276,12 +276,12 @@ def main():
     print("\n" + "=" * 70)
     print("NEXT STEPS")
     print("=" * 70)
-    print("1. Install required packages:")
-    print("   pip install -r requirements.txt")
-    print("\n2. For depth processing, install transformers:")
-    print("   pip install transformers torch")
+    print("1. Install pinned core runtime and dev tooling:")
+    print("   make install-core")
+    print("\n2. Install the supported ML baseline when you need live model execution:")
+    print("   make install-ml-core")
     print("\n3. Test your installation:")
-    print("   python scripts/verification/verify_core.py")
+    print("   .venv/bin/python scripts/verification/verify_core.py")
 
     return 0 if success else 1
 

--- a/scripts/setup/install_da3_runtime.sh
+++ b/scripts/setup/install_da3_runtime.sh
@@ -220,7 +220,7 @@ BASE_DEPS=(
     "torch==2.11.0"
     "torchvision==0.26.0"
     "transformers==5.5.0"
-    "cryptography==46.0.6"
+    "cryptography==47.0.0"
     "moviepy==1.0.3"
     "einops==0.8.2"
     "huggingface_hub==1.9.0"
@@ -293,5 +293,5 @@ cat <<EOF
 [INFO] DA3 runtime ready.
 [INFO] Stable executable: ./.runtime/Depth-Anything-3/.venv-da3/bin/python
 [INFO] Example:
-lux-depth-v3 --input-dir ./input --output-dir ./output --da3-python ./.runtime/Depth-Anything-3/.venv-da3/bin/python
+lux-depth-v3 --input-dir ./input_images --output-dir ./output --da3-python ./.runtime/Depth-Anything-3/.venv-da3/bin/python
 EOF

--- a/scripts/setup/install_depth_pro_runtime.sh
+++ b/scripts/setup/install_depth_pro_runtime.sh
@@ -193,5 +193,5 @@ cat <<EOF
 [INFO] Stable executable: ./.venv-depth-pro/bin/python
 [INFO] Pinned refs: torch==2.7.1 torchvision==0.22.1 numpy==1.26.4 depth_pro@${REF}
 [INFO] Example:
-lux-depth-v3 --input-dir ./input --output-dir ./output --depth-pro-python ./.venv-depth-pro/bin/python
+lux-depth-v3 --input-dir ./input_images --output-dir ./output --depth-pro-python ./.venv-depth-pro/bin/python
 EOF

--- a/scripts/setup/install_models.py
+++ b/scripts/setup/install_models.py
@@ -20,20 +20,20 @@ Features:
 - Dry-run mode
 
 Usage:
-    python scripts/setup/install_models.py [--all] [--dry-run] [--force]
+    .venv/bin/python scripts/setup/install_models.py [--all] [--dry-run] [--force]
 
 Examples:
     # Install essential models only (Depth, Real-ESRGAN-compatible weights)
-    python scripts/setup/install_models.py
+    .venv/bin/python scripts/setup/install_models.py
 
     # Install all models including Stable Diffusion
-    python scripts/setup/install_models.py --all
+    .venv/bin/python scripts/setup/install_models.py --all
 
     # Check what would be downloaded without downloading
-    python scripts/setup/install_models.py --all --dry-run
+    .venv/bin/python scripts/setup/install_models.py --all --dry-run
 
     # Force re-download even if files exist
-    python scripts/setup/install_models.py --force
+    .venv/bin/python scripts/setup/install_models.py --force
 
 Author: Transformation Portal Team
 License: Attribution (see LICENSE)
@@ -330,7 +330,7 @@ def install_depth_models(install_all: bool = False, dry_run: bool = False) -> in
 
     except ImportError:
         print("\n✗ transformers not installed")
-        print("  Install with: pip install transformers torch")
+        print("  Install the governed ML baseline with: make install-ml-core")
         return 0
 
     return installed
@@ -493,16 +493,16 @@ def main():
         epilog="""
 Examples:
   # Install essential models (Depth, Real-ESRGAN-compatible weights)
-  python scripts/setup/install_models.py
+  .venv/bin/python scripts/setup/install_models.py
 
   # Install all models including Stable Diffusion
-  python scripts/setup/install_models.py --all
+  .venv/bin/python scripts/setup/install_models.py --all
 
   # Preview what would be downloaded
-  python scripts/setup/install_models.py --all --dry-run
+  .venv/bin/python scripts/setup/install_models.py --all --dry-run
 
   # Force re-download existing models
-  python scripts/setup/install_models.py --force
+  .venv/bin/python scripts/setup/install_models.py --force
         """,
     )
 

--- a/scripts/setup/install_models_auto.py
+++ b/scripts/setup/install_models_auto.py
@@ -17,7 +17,7 @@ Features (upgraded from basic version):
 - Graceful error handling
 
 Usage:
-    python scripts/setup/install_models_auto.py [--skip-optional] [--force]
+    .venv/bin/python scripts/setup/install_models_auto.py [--skip-optional] [--force]
 
 Performance: ~5-10 minutes total for required models (depends on connection)
 

--- a/scripts/setup/install_raw_runtime.sh
+++ b/scripts/setup/install_raw_runtime.sh
@@ -132,5 +132,5 @@ cat <<EOF
 [INFO] RAW runtime ready.
 [INFO] Stable executable: ./.venv-raw/bin/python
 [INFO] Example:
-lux-depth-v3 --input-dir ./input --output-dir ./output --raw-python ./.venv-raw/bin/python
+lux-depth-v3 --input-dir ./input_images --output-dir ./output --raw-python ./.venv-raw/bin/python
 EOF

--- a/scripts/setup/pre-commit-check.sh
+++ b/scripts/setup/pre-commit-check.sh
@@ -28,26 +28,16 @@ ALLOWED_ROOT_FILES=(
     "package.json"
     "package-lock.json"
     "pyproject.toml"
-    "setup.py"
-    "setup.cfg"
     "requirements.txt"
     "requirements-dev.txt"
     "requirements-ci.txt"
-    "requirements-test.txt"
     "requirements-lint.txt"
-    "Pipfile"
-    "Pipfile.lock"
-    "poetry.lock"
-    "pytest.ini"
-    "tox.ini"
-    ".coveragerc"
     ".pylintrc"
-    ".flake8"
     "mypy.ini"
     "Dockerfile"
     "docker-compose.yml"
-    "docker-compose.yaml"
     ".gitignore"
+    ".gitleaks.toml"
     ".dockerignore"
     ".gitattributes"
     ".gitmodules"
@@ -57,18 +47,11 @@ ALLOWED_ROOT_FILES=(
     ".auto-organize.sh"
     ".architect_directive_status.yml"
     ".env.example"
-    "PKG-INFO"
-    "MANIFEST.in"
-    "__init__.py"
     "app.py"
     "portal.html"
 )
 
-ALLOWED_ROOT_PATTERNS=(
-    '^requirements.*\.txt$'
-    '^\.git.*$'
-    '^\..*rc$'
-)
+ALLOWED_ROOT_PATTERNS=()
 
 ALLOWED_ROOT_DIRECTORIES=(
     ".github"

--- a/scripts/test_metadata_extraction.py
+++ b/scripts/test_metadata_extraction.py
@@ -9,24 +9,24 @@ capabilities, including:
 - Batch processing (multiple images)
 
 Requirements:
-- Package must be installed: pip install -e .
+- Package must be installed through the repo-managed setup path (`make install-core`)
 - exiftool must be installed (brew install exiftool / apt-get install libimage-exiftool-perl)
 
 Usage:
     # Single image extraction
-    python scripts/test_metadata_extraction.py extract /path/to/image.tif
+    .venv/bin/python scripts/test_metadata_extraction.py extract /path/to/image.tif
 
     # Batch extraction (entire directory)
-    python scripts/test_metadata_extraction.py extract-batch /path/to/images/ --output ./output_sidecars/
+    .venv/bin/python scripts/test_metadata_extraction.py extract-batch /path/to/images/ --output ./output_sidecars/
 
     # Validate existing sidecar
-    python scripts/test_metadata_extraction.py validate /path/to/provenance.json
+    .venv/bin/python scripts/test_metadata_extraction.py validate /path/to/provenance.json
 
     # Check system readiness
-    python scripts/test_metadata_extraction.py check-system
+    .venv/bin/python scripts/test_metadata_extraction.py check-system
 
     # Summary of extraction results
-    python scripts/test_metadata_extraction.py summarize /path/to/sidecars/
+    .venv/bin/python scripts/test_metadata_extraction.py summarize /path/to/sidecars/
 
 Exit Codes:
     0: Success

--- a/scripts/validation/check_gitleaks_workflow_contract.py
+++ b/scripts/validation/check_gitleaks_workflow_contract.py
@@ -15,9 +15,14 @@ FIREWALL_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "ci-quality-firew
 EXPECTED_RULE_ID = "generic-api-key"
 EXPECTED_PATH_REGEX = r"(^|/)public/portal-assets/portal\.js$"
 EXPECTED_ARTIFACT_PATH_REGEX = (
-    r"(^|/)(output|output_[^/]*|test_output|test_artifacts|processed_images|processed_output|"
-    r"extracted_context|docs/api/_build|__pycache__|\.pytest_cache|\.mypy_cache|\.ruff_cache|\.pyre|"
-    r"\.rag_cache|web/secure-landing/(?:\.next|\.next-build-verify|\.next-smoke-[^/]*|\.next-codex-[^/]*|\.metafiles))(/|$)"
+    r"(^|/)(\.venv(?:-[^/]*)?|\.runtime|\.cache|\.pytest_cache|\.mypy_cache|\.ruff_cache|\.hypothesis|"
+    r"\.pyre|\.rag_cache|\.coverage(?:\..*)?|coverage\.(?:xml|json)|htmlcov|node_modules|build|dist|"
+    r"downloads|docs/api/_build|output|output_[^/]*|outputs|test_output|test_artifacts|processed_images|"
+    r"processed_output|extracted_context|logs|artifacts|trial_runs|archive_reports|local_artifacts|"
+    r"depth_maps_apex|artifact_store|archive/(?:experiments|deprecated|legacy)|"
+    r"__pycache__|web/secure-landing/(?:node_modules|\.next|\.next-build-verify|\.next-smoke-[^/]*|"
+    r"\.next-codex-[^/]*|\.metafiles|tmp|test-results|playwright-report|blob-report|\.playwright)|"
+    r"cloudflare/transformationportal-worker/(?:node_modules|\.wrangler))(/|$)"
 )
 EXPECTED_REGEX_TARGET = "line"
 EXPECTED_MATCH_REGEX = r'return normalizedReason==="auth_failure"\|\|normalizedReason==="auth"\|\|normalizedStatus===401\|\|normalizedStatus===403\?\{reason:"auth_failure"'

--- a/tests/structural/test_pre_commit_runtime_contract.py
+++ b/tests/structural/test_pre_commit_runtime_contract.py
@@ -17,7 +17,14 @@ PRE_COMMIT_CONFIG = REPO_ROOT / ".pre-commit-config.yaml"
 MAKEFILE = REPO_ROOT / "Makefile"
 CLAUDE_GUIDE = REPO_ROOT / "CLAUDE.md"
 REPO_PYTHON_RUNNER = "scripts/setup/run_repo_python.sh"
-PYTHON_HOOK_IDS = {"auto-format-staged", "check-test-markers", "ban-tautological-tests"}
+PYTHON_HOOK_IDS = {
+    "auto-format-staged",
+    "check-design-tokens-doc",
+    "check-script-topology",
+    "check-test-markers",
+    "check-unsafe-torch-load",
+    "ban-tautological-tests",
+}
 
 
 def _load_pre_commit_config() -> dict:
@@ -63,6 +70,17 @@ def test_install_hooks_target_documents_all_installed_hook_types() -> None:
     assert "make install-hooks         # install git pre-commit hook" not in claude_guide
 
 
+def test_pre_commit_config_operator_guidance_prefers_make_targets() -> None:
+    config_text = PRE_COMMIT_CONFIG.read_text(encoding="utf-8")
+
+    assert "#   make install-hooks" in config_text
+    assert "#   make pre-commit" in config_text
+    assert "`make install-hooks` invokes the repo-managed `.venv` pre-commit" in config_text
+    assert "#   pre-commit install -f" not in config_text
+    assert "#   pre-commit run --all-files" not in config_text
+    assert "`pre-commit install -f` (invoked by `make install-hooks`)" not in config_text
+
+
 def test_dependency_constraints_hook_runs_for_root_dependency_metadata() -> None:
     config = _load_pre_commit_config()
     hooks = {str(hook.get("id")): hook for repo in config.get("repos", []) for hook in repo.get("hooks", [])}
@@ -82,3 +100,27 @@ def test_dependency_constraints_hook_runs_for_root_dependency_metadata() -> None
 
     for path in ("README.md", "CONTRIBUTING.md", "scripts/validation/other_check.py"):
         assert not pattern.fullmatch(path), f"dependency constraints hook should not run for {path}"
+
+
+def test_script_topology_hook_runs_for_wrapper_and_canonical_surfaces() -> None:
+    config = _load_pre_commit_config()
+    hooks = {str(hook.get("id")): hook for repo in config.get("repos", []) for hook in repo.get("hooks", [])}
+    hook = hooks["check-script-topology"]
+    pattern = re.compile(str(hook["files"]))
+
+    assert hook["entry"] == "scripts/setup/run_repo_python.sh scripts/governance/check_script_topology.py"
+    assert hook["pass_filenames"] is False
+
+    expected_matches = {
+        "scripts/install_models.py",
+        "scripts/setup/install_models.py",
+        "scripts/pipelines/lux_render_pipeline.py",
+        "src/transformation_portal/pipelines/lux_render_pipeline.py",
+        "src/transformation_portal/perceptual/synthetic_viewer.py",
+        "archive/scripts/legacy-organization/organize_outputs.sh",
+    }
+    for path in expected_matches:
+        assert pattern.fullmatch(path), f"script topology hook must run for {path}"
+
+    for path in ("README.md", "docs/guides/SETUP_GUIDE.md", "src/transformation_portal/app.py"):
+        assert not pattern.fullmatch(path), f"script topology hook should not run for {path}"

--- a/tests/test_check_gitleaks_workflow_contract.py
+++ b/tests/test_check_gitleaks_workflow_contract.py
@@ -1,4 +1,5 @@
 import importlib.util
+import re
 from pathlib import Path
 
 import pytest
@@ -140,6 +141,32 @@ def test_broad_generated_artifact_allowlist_is_reported() -> None:
         firewall_workflow_text=valid_firewall_workflow_text(),
     )
     assert "gitleaks global allowlist must be scoped only to ignored generated artifact directories" in errors
+
+
+def test_generated_artifact_allowlist_matches_frontdoor_tmp_output() -> None:
+    pattern = re.compile(gitleaks_contract.EXPECTED_ARTIFACT_PATH_REGEX)
+
+    assert pattern.search("web/secure-landing/tmp/dev-auth-state.json")
+    assert pattern.search("/repo/web/secure-landing/tmp/preview-keys.json")
+    assert pattern.search(".runtime/fastvlm/runtime.json")
+    assert pattern.search(".venv/lib/python3.11/site-packages/generated.py")
+    assert pattern.search(".venv-da3/lib/python3.11/site-packages/generated.py")
+    assert pattern.search(".coverage")
+    assert pattern.search(".coverage.core-py3.12")
+    assert pattern.search("coverage.xml")
+    assert pattern.search("coverage.json")
+    assert pattern.search("htmlcov/index.html")
+    assert pattern.search("node_modules/example/index.js")
+    assert pattern.search("web/secure-landing/node_modules/example/index.js")
+    assert pattern.search("cloudflare/transformationportal-worker/.wrangler/state/v3/cache")
+    assert pattern.search("archive_reports/fixity/hash_manifest.csv.gz")
+    assert pattern.search("archive/experiments/local-run/report.json")
+    assert pattern.search("artifact_store/local/blob.bin")
+    assert not pattern.search("web/secure-landing/portal-src/tmp/dev-auth-state.json")
+    assert not pattern.search("input_images/client/secret.txt")
+    assert not pattern.search("data/sample_images/README.md")
+    assert not pattern.search("Architectural_Plans/client.pdf")
+    assert not pattern.search("external/vendor/secret.txt")
 
 
 def test_broad_rule_path_allowlist_is_reported() -> None:

--- a/tests/test_codebase_structure.py
+++ b/tests/test_codebase_structure.py
@@ -139,6 +139,42 @@ class TestRootGovernanceMetadata:
     def _make_targets(makefile: Path) -> set[str]:
         return {match.group(1) for match in re.finditer(r"(?m)^([A-Za-z0-9_.%/+@-]+):", makefile.read_text())}
 
+    @staticmethod
+    def _relative_markdown_links(markdown_path: Path) -> list[tuple[int, str, Path]]:
+        links: list[tuple[int, str, Path]] = []
+        text = markdown_path.read_text(encoding="utf-8")
+        for match in re.finditer(r"\[[^\]]+\]\(([^)]+)\)", text):
+            raw_target = match.group(1).strip()
+            link_target = raw_target.split("#", 1)[0].split("?", 1)[0].strip("<>")
+            if not link_target or link_target.startswith("#") or re.match(r"^[A-Za-z][A-Za-z0-9+.-]*:", link_target):
+                continue
+            line_number = text.count("\n", 0, match.start()) + 1
+            links.append((line_number, raw_target, markdown_path.parent / link_target))
+        return links
+
+    def test_root_operator_markdown_links_resolve_to_tracked_targets(self):
+        """Root-facing operator docs should not carry broken relative links."""
+        relative_docs = [
+            "README.md",
+            "AGENTS.md",
+            "CLAUDE.md",
+            "CONTRIBUTING.md",
+            "SECURITY.md",
+            "CHANGELOG.md",
+            "docs/ci/BRANCH_PROTECTION_SETUP.md",
+            "docs/ci/BRANCH_PROTECTION_COMMANDS.md",
+            "docs/deployment/PRODUCTION_READINESS.md",
+        ]
+        broken_links = []
+
+        for relative_path in relative_docs:
+            markdown_path = _repo_root / relative_path
+            for line_number, raw_target, target_path in self._relative_markdown_links(markdown_path):
+                if not target_path.exists():
+                    broken_links.append(f"{relative_path}:{line_number}: {raw_target}")
+
+        assert not broken_links, "Broken root-facing Markdown links:\n" + "\n".join(sorted(broken_links))
+
     def test_root_readme_status_points_to_current_documentation_navigation(self):
         """Root status prose should not depend on stale PR-specific snapshots."""
         readme = (_repo_root / "README.md").read_text()
@@ -153,6 +189,232 @@ class TestRootGovernanceMetadata:
         for expected in required_navigation:
             assert expected in readme
         assert "Last Updated: 2026-05-11" not in readme
+
+    def test_operator_guides_use_governed_local_input_surface(self):
+        """Current CLI examples should not create untracked input directories."""
+        readme = (_repo_root / "README.md").read_text()
+        setup_readme = (_repo_root / "scripts" / "setup" / "README.md").read_text()
+        setup_guide = (_repo_root / "docs" / "guides" / "SETUP_GUIDE.md").read_text()
+        current_workflow_guides = [
+            (_repo_root / "docs" / "decisions" / "ADR_019_INTEGRATION_COMPLETE.md").read_text(),
+            (_repo_root / "docs" / "investigations" / "PHASE2_16BIT_QUICKREF.md").read_text(),
+            (_repo_root / "docs" / "workflows" / "PBR_ONLY_WORKFLOW.md").read_text(),
+        ]
+        runtime_installers = [
+            (_repo_root / "scripts" / "setup" / "install_da3_runtime.sh").read_text(),
+            (_repo_root / "scripts" / "setup" / "install_depth_pro_runtime.sh").read_text(),
+            (_repo_root / "scripts" / "setup" / "install_raw_runtime.sh").read_text(),
+        ]
+        compose = (_repo_root / "docker-compose.yml").read_text()
+        active_input_guidance = {
+            "docs/decisions/ADR_019_INTEGRATION_COMPLETE.md": (
+                _repo_root / "docs" / "decisions" / "ADR_019_INTEGRATION_COMPLETE.md"
+            ).read_text(),
+            "docs/guides/AI_ENHANCEMENT_GUIDE.md": (_repo_root / "docs" / "guides" / "AI_ENHANCEMENT_GUIDE.md").read_text(),
+            "docs/guides/FLUX_INTEGRATION.md": (_repo_root / "docs" / "guides" / "FLUX_INTEGRATION.md").read_text(),
+            "docs/guides/LUX_DEPTH_V3_TROUBLESHOOTING.md": (
+                _repo_root / "docs" / "guides" / "LUX_DEPTH_V3_TROUBLESHOOTING.md"
+            ).read_text(),
+            "docs/guides/PBR_ENHANCE_CONFIG_GUIDE.md": (
+                _repo_root / "docs" / "guides" / "PBR_ENHANCE_CONFIG_GUIDE.md"
+            ).read_text(),
+            "docs/reference/PBR_PRESETS_QUICK_REFERENCE.md": (
+                _repo_root / "docs" / "reference" / "PBR_PRESETS_QUICK_REFERENCE.md"
+            ).read_text(),
+        }
+
+        for guide in (readme, setup_readme, setup_guide, *current_workflow_guides, *runtime_installers):
+            assert "--input-dir ./input_images" in guide
+            assert "--input-dir ./input " not in guide
+            assert "--input-dir ./input\n" not in guide
+        stale_input_snippets = [
+            '--input-dir "./input"',
+            'Path("./input/',
+            "Path('./input/",
+            'Path("./input")',
+            "Path('./input')",
+            'input_root=Path("./input")',
+            "input_root=Path('./input')",
+            'glob.glob("input/*.jpg")',
+            "glob.glob('input/*.jpg')",
+        ]
+        for guide_name, guide in active_input_guidance.items():
+            assert "input_images" in guide, guide_name
+            for stale_snippet in stale_input_snippets:
+                assert stale_snippet not in guide, f"{guide_name} contains {stale_snippet}"
+        assert "./input_images:/app/input:ro" in compose
+        assert "./input:/app/input" not in compose
+
+    def test_root_ml_setup_guidance_prefers_make_targets(self):
+        """Root/current setup guidance should not present bootstrap profiles as the primary install path."""
+        guides = {
+            "README.md": (_repo_root / "README.md").read_text(),
+            "CLAUDE.md": (_repo_root / "CLAUDE.md").read_text(),
+            "docs/guides/SETUP_GUIDE.md": (_repo_root / "docs" / "guides" / "SETUP_GUIDE.md").read_text(),
+        }
+
+        for guide_name, guide in guides.items():
+            assert "make install-ml-core" in guide, guide_name
+            assert "Advanced Apple Silicon" in guide or "bootstrap-profile work" in guide, guide_name
+
+        stale_primary_guidance = [
+            "For example: `make install-ml-core` or, on Apple Silicon,",
+            "or use the target-specific bootstrap flow on macOS Apple Silicon",
+            "Or use the Apple Silicon bootstrap profiles directly",
+            "use `make install-ml-core` or `./scripts/bootstrap/install_ml_stack.sh --profile core-mps`",
+        ]
+        combined = "\n".join(guides.values())
+        for stale_fragment in stale_primary_guidance:
+            assert stale_fragment not in combined
+
+    def test_active_setup_guidance_uses_repo_managed_python(self):
+        """Active setup docs should not depend on ambient Python or raw requirements installs."""
+        guidance = {
+            "README.md": (_repo_root / "README.md").read_text(),
+            "CONTRIBUTING.md": (_repo_root / "CONTRIBUTING.md").read_text(),
+            "SECURITY.md": (_repo_root / "SECURITY.md").read_text(),
+            "docs/architecture/ADR-033-test-flake-management.md": (
+                _repo_root / "docs" / "architecture" / "ADR-033-test-flake-management.md"
+            ).read_text(),
+            "docs/deployment/ROLLBACK_PROCEDURES.md": (
+                _repo_root / "docs" / "deployment" / "ROLLBACK_PROCEDURES.md"
+            ).read_text(),
+            "docs/deployment/STAGING_VALIDATION.md": (
+                _repo_root / "docs" / "deployment" / "STAGING_VALIDATION.md"
+            ).read_text(),
+            "docs/guides/SETUP_GUIDE.md": (_repo_root / "docs" / "guides" / "SETUP_GUIDE.md").read_text(),
+            "docs/guides/TROUBLESHOOTING.md": (_repo_root / "docs" / "guides" / "TROUBLESHOOTING.md").read_text(),
+            "docs/status/READY_TO_PROCESS.md": (_repo_root / "docs" / "status" / "READY_TO_PROCESS.md").read_text(),
+            "pyproject.toml": (_repo_root / "pyproject.toml").read_text(),
+            "requirements.txt": (_repo_root / "requirements.txt").read_text(),
+            "Makefile": (_repo_root / "Makefile").read_text(),
+            "scripts/analyze_flakes.py": (_repo_root / "scripts" / "analyze_flakes.py").read_text(),
+            "scripts/README.md": (_repo_root / "scripts" / "README.md").read_text(),
+            "scripts/setup/download_depth_models.py": (
+                _repo_root / "scripts" / "setup" / "download_depth_models.py"
+            ).read_text(),
+            "scripts/setup/install_models.py": (_repo_root / "scripts" / "setup" / "install_models.py").read_text(),
+            "scripts/setup/install_models_auto.py": (_repo_root / "scripts" / "setup" / "install_models_auto.py").read_text(),
+            "scripts/setup/README.md": (_repo_root / "scripts" / "setup" / "README.md").read_text(),
+        }
+        combined = "\n".join(guidance.values())
+
+        forbidden_fragments = [
+            "pip install -r requirements.txt",
+            "pip install transformers torch",
+            "Real-ESRGAN (upscaling)",
+            "git clone https://github.com/NVlabs/nvdiffrast && pip install -e .",
+        ]
+        for forbidden_fragment in forbidden_fragments:
+            assert forbidden_fragment not in combined
+
+        forbidden_ambient_python = [
+            r"(?<![/\w.-])python scripts/analyze_flakes\.py",
+            r"(?<![/\w.-])python scripts/setup/download_depth_models\.py",
+            r"(?<![/\w.-])python scripts/setup/install_models\.py",
+            r"(?<![/\w.-])python scripts/setup/install_models_auto\.py",
+            r"(?<![/\w.-])python scripts/test_metadata_extraction\.py",
+            r"(?<![/\w.-])python scripts/verification/verify_core\.py",
+            r"(?<![/\w.-])python scripts/verification/verify_ml_deps\.py",
+            r"(?<![/\w.-])python scripts/check_image_processing_readiness\.py",
+            r"(?<![/\w.-])python scripts/simple_image_processor\.py",
+            r"(?<![/\w.-])python scripts/validation/verify_3dgs_artifacts\.py",
+            r"(?<![/\w.-])python -m transformation_portal\.",
+            r"(?m)^python -m build$",
+            r"(?m)^twine check dist/\*$",
+            r"(?m)^pip install dist/\*\.whl --force-reinstall$",
+            r"(?<!python -m )(?<![/\w.-])pip install -r requirements/security\.txt",
+            r"(?<!python -m )(?<![/\w.-])pip install diff-cover",
+            r"pylint --enable=security",
+            r"(?m)^black --(?:check --)?line-length=127 src/ tests/$",
+            r"(?m)^isort --(?:check-only --)?profile=black --line-length=127 src/ tests/$",
+            r"(?m)^flake8 src/ tests/ --max-line-length=127$",
+        ]
+        for forbidden_pattern in forbidden_ambient_python:
+            assert re.search(forbidden_pattern, combined) is None
+
+        required_fragments = [
+            "make install-core",
+            "make repair-core-venv",
+            ".venv/bin/python scripts/analyze_flakes.py",
+            ".venv/bin/python scripts/setup/download_depth_models.py",
+            ".venv/bin/python scripts/setup/install_models.py",
+            ".venv/bin/python scripts/setup/install_models_auto.py",
+            ".venv/bin/python scripts/test_metadata_extraction.py",
+            ".venv/bin/python scripts/verification/verify_core.py",
+            ".venv/bin/python scripts/verification/verify_ml_deps.py",
+            ".venv/bin/python scripts/check_image_processing_readiness.py",
+            ".venv/bin/python scripts/simple_image_processor.py",
+            ".venv/bin/python scripts/validation/verify_3dgs_artifacts.py",
+            ".venv/bin/python -m transformation_portal.lux_depth_v3 --help",
+            ".venv/bin/python -m transformation_portal.lux_depth_v3.pbr_cli --help",
+            ".venv/bin/python -m transformation_portal.cli depth-estimation",
+            '.venv/bin/python -m pip install "git+https://github.com/RC219805/Transformation_Portal.git@<release-tag>"',
+            ".venv/bin/python -m build",
+            ".venv/bin/twine check dist/*",
+            ".venv/bin/python -m pip install dist/*.whl --force-reinstall",
+            ".venv/bin/python -m pip install -r requirements/security.txt",
+            ".venv/bin/bandit -r src/ -ll",
+            ".venv/bin/pip-audit",
+            ".venv/bin/bandit -r src/",
+            "make lint-parity",
+            "make test-fast",
+            "./scripts/setup/run_lint_tool.sh black src/ tests/",
+            "./scripts/setup/run_lint_tool.sh isort src/ tests/",
+            "Run 'make install-core' to install the repo-managed tooling",
+            "git clone https://github.com/NVlabs/nvdiffrast external/nvdiffrast",
+            ".venv/bin/python -m pip install -e external/nvdiffrast",
+            "input_images/image.CR2",
+            "external `realesrgan`",
+        ]
+        for required_fragment in required_fragments:
+            assert required_fragment in combined
+
+        assert "/input/image.CR2" not in combined
+
+    def test_machine_mode_guidance_uses_repo_managed_python_and_local_paths(self):
+        """Machine-mode examples should mirror the repo-managed local execution contract."""
+        guidance = {
+            "README.md": (_repo_root / "README.md").read_text(),
+            "docs/api/MACHINE_MODE_CONTRACT.md": (_repo_root / "docs" / "api" / "MACHINE_MODE_CONTRACT.md").read_text(),
+            "docs/quick_references/MACHINE_MODE_JSON.md": (
+                _repo_root / "docs" / "quick_references" / "MACHINE_MODE_JSON.md"
+            ).read_text(),
+            "tools/parse_machine_json.py": (_repo_root / "tools" / "parse_machine_json.py").read_text(),
+            "tools/parse_machine_json_examples.sh": (_repo_root / "tools" / "parse_machine_json_examples.sh").read_text(),
+        }
+        combined = "\n".join(guidance.values())
+
+        forbidden_patterns = [
+            r"(?<![/\w.-])python scripts/test_metadata_extraction\.py",
+            r"(?<![/\w.-])python tools/parse_machine_json\.py",
+            r"(?<![/\w.-])python parse_machine_json\.py",
+        ]
+        for pattern in forbidden_patterns:
+            assert re.search(pattern, combined) is None
+
+        forbidden_fragments = [
+            "/input/image.CR2",
+            "/input/IMG_1234.CR2",
+            "/input/missing.CR2",
+            '"/input"',
+            '"/output"',
+            "extract-batch /input",
+            "validate /output/sidecar.json",
+        ]
+        for fragment in forbidden_fragments:
+            assert fragment not in combined
+
+        required_fragments = [
+            ".venv/bin/python scripts/test_metadata_extraction.py",
+            ".venv/bin/python tools/parse_machine_json.py",
+            "input_images/image.CR2",
+            "input_images/IMG_1234.CR2",
+            "extract-batch input_images --output output",
+            "validate output/sidecar.json",
+        ]
+        for fragment in required_fragments:
+            assert fragment in combined
 
     def test_root_changelog_keeps_pr1562_snapshot_historical(self):
         """Root changelog should not present the PR #1562 snapshot as current state."""
@@ -266,6 +528,26 @@ class TestRootGovernanceMetadata:
             assert relative_path in security_policy
             assert (_repo_root / relative_path).exists()
 
+    def test_security_policy_deployment_guidance_uses_repo_runtime_contract(self):
+        """Root security deployment guidance should not advertise stale runtime commands."""
+        security_policy = (_repo_root / "SECURITY.md").read_text()
+
+        stale_fragments = [
+            "sudo -u nobody python -m transformation_portal.cli",
+            "# User=nobody",
+            "# Group=nogroup",
+        ]
+        for stale_fragment in stale_fragments:
+            assert stale_fragment not in security_policy
+
+        required_fragments = [
+            "sudo -u tp .venv/bin/python -m transformation_portal.cli serve --host 127.0.0.1 --port 8000",
+            "# User=tp",
+            "# Group=tp",
+        ]
+        for required_fragment in required_fragments:
+            assert required_fragment in security_policy
+
     def test_retired_pygments_exception_stays_removed_from_security_scans(self):
         """The root security policy and CI scanners should agree on retired CVE exceptions."""
         security_policy = (_repo_root / "SECURITY.md").read_text()
@@ -316,11 +598,27 @@ class TestRootGovernanceMetadata:
         assert "cryptography>=47.0.0,<48" in requirements_dev
         assert "cryptography>=46.0,<48" not in requirements_ci
         assert "cryptography>=46.0,<48" not in requirements_dev
-        assert "`cryptography`          | >=46.0.5" in contributing
+        assert "`cryptography`          | >=47.0.0" in contributing
+        assert "`cryptography`          | >=46.0.5" not in contributing
         assert "`starlette`             | >=1.0.1" in contributing
         assert "Starlette==1.0.1" in security_policy
         assert "current governed lock baseline is pillow==12.2.0" in requirements_lint
         assert "allows pillow==12.1.1 in lockfiles" not in requirements_lint
+
+    def test_pyproject_security_extras_track_current_cryptography_floor(self):
+        """Public optional metadata should not expose retired cryptography floors."""
+        pyproject = tomllib.loads((_repo_root / "pyproject.toml").read_text())
+        optional_dependencies = pyproject["project"]["optional-dependencies"]
+        tools_archive_in = (_repo_root / "requirements" / "tools-archive.in").read_text()
+        tools_archive_lock = (_repo_root / "requirements" / "tools-archive.txt").read_text()
+
+        for extra_name in ("archive-signing", "dev"):
+            assert "cryptography>=47.0.0,<48" in optional_dependencies[extra_name]
+            assert "cryptography>=46.0,<48" not in optional_dependencies[extra_name]
+
+        assert "cryptography>=47.0.0,<48" in tools_archive_in
+        assert "cryptography>=46.0,<48" not in tools_archive_in
+        assert "cryptography==47.0.0" in tools_archive_lock
 
     def test_pyproject_core_dependencies_track_governed_base_requirements(self):
         """Installable package metadata should not trail the governed core dependency surface."""
@@ -362,6 +660,8 @@ class TestRootGovernanceMetadata:
         pyproject = tomllib.loads((_repo_root / "pyproject.toml").read_text())
         dev_extra = pyproject["project"]["optional-dependencies"]["dev"]
         requirements_dev_in = (_repo_root / "requirements" / "dev.in").read_text().splitlines()
+        requirements_dev = (_repo_root / "requirements-dev.txt").read_text()
+        contributing = (_repo_root / "CONTRIBUTING.md").read_text()
 
         def package_names(lines: list[str]) -> set[str]:
             names: set[str] = set()
@@ -378,6 +678,17 @@ class TestRootGovernanceMetadata:
         metadata_dev_packages = package_names(dev_extra)
 
         assert governed_dev_packages <= metadata_dev_packages
+        assert "black>=26.3.1" in dev_extra
+        assert "black>=24.8" not in dev_extra
+        assert "black>=26.3.1" in requirements_dev
+        assert "black>=24.8" not in contributing
+        assert "mypy>=1.10  # Type checker" in contributing
+
+        adr_032 = (_repo_root / "docs" / "architecture" / "ADR-032-dependency-pinning-strategy.md").read_text()
+        assert "black>=24.8" not in adr_032
+        assert "| `black`       | dev.in  | `>=24.8`" not in adr_032
+        assert "| `black`       | dev.in  | `>=26.3.1`" in adr_032
+        assert "pylint>=3.0" in adr_032
 
     def test_contributing_dependency_audit_schedule_is_current(self):
         """Canonical contribution guidance should not point to a past audit date."""
@@ -531,6 +842,71 @@ class TestRootGovernanceMetadata:
             assert relative_path in content
             assert (_repo_root / relative_path).exists()
 
+    def test_root_branch_protection_guidance_matches_current_contract(self):
+        """Root branch-protection prose should not preserve stale setup snapshots."""
+        contributing = (_repo_root / "CONTRIBUTING.md").read_text()
+        setup_doc = (_repo_root / "docs" / "ci" / "BRANCH_PROTECTION_SETUP.md").read_text()
+        historical_commands_doc = (_repo_root / "docs" / "ci" / "BRANCH_PROTECTION_COMMANDS.md").read_text()
+
+        required_current_claims = [
+            "Current Branch Protection Rules (Verified 2026-06-03)",
+            '"enforce_admins": true',
+            '"required_linear_history": false',
+            '"required_conversation_resolution": true',
+            "Linear history**: Not required by branch protection",
+            "Require conversation resolution**: ✅ Enabled",
+            "**Resolve all review conversations** (required)",
+        ]
+        for claim in required_current_claims:
+            assert claim in contributing
+
+        stale_claims = [
+            "Verified 2026-02-10",
+            '"enforce_admins": false',
+            '"required_linear_history": true',
+            "Require conversation resolution**: ❌ Not enabled",
+            "Linear history**: ✅ Required",
+            "**Resolve all review conversations** (recommended)",
+        ]
+        for stale_claim in stale_claims:
+            assert stale_claim not in contributing
+
+        assert "Last verified: 2026-06-03." in setup_doc
+        assert "CI Gate" in setup_doc
+        assert "lint (3.12)" not in setup_doc
+        assert "test-core (3.10)" not in setup_doc
+        assert "quality-summary" not in setup_doc
+        assert "Admin enforcement is currently enabled" in setup_doc
+        assert "[CONTRIBUTING.md](../../CONTRIBUTING.md)" in setup_doc
+        assert "[Production Readiness](../deployment/PRODUCTION_READINESS.md)" in setup_doc
+        assert "[CONTRIBUTING.md](../CONTRIBUTING.md)" not in setup_doc
+        assert "[Production Readiness](./PRODUCTION_READINESS.md)" not in setup_doc
+
+        assert "Historical record. Do not run these commands as current configuration." in historical_commands_doc
+        assert "[BRANCH_PROTECTION_SETUP.md](./BRANCH_PROTECTION_SETUP.md)" in historical_commands_doc
+        assert "[CI Workflow](../../.github/workflows/build.yml)" in historical_commands_doc
+        assert "[CONTRIBUTING.md](../../CONTRIBUTING.md)" in historical_commands_doc
+        assert "[CODE_QUALITY_SYSTEM.md](../guides/CODE_QUALITY_SYSTEM.md)" in historical_commands_doc
+        assert "[CI Workflow](../.github/workflows/ci.yml)" not in historical_commands_doc
+        assert "[CONTRIBUTING.md](../CONTRIBUTING.md)" not in historical_commands_doc
+        assert "[CODE_QUALITY_SYSTEM.md](./CODE_QUALITY_SYSTEM.md)" not in historical_commands_doc
+
+    def test_production_readiness_guidance_tracks_current_runtime_and_gate_contract(self):
+        """Deployment readiness guidance should not advertise retired runtime or branch-protection state."""
+        readiness_doc = (_repo_root / "docs" / "deployment" / "PRODUCTION_READINESS.md").read_text()
+
+        assert "Python 3.11 and 3.12; Python 3.10 is retired" in readiness_doc
+        assert "Python 3.11+; the supported CI matrix covers Python 3.11 and 3.12" in readiness_doc
+        assert "CI Gate" in readiness_doc
+        assert "Branch protection: ✅" in readiness_doc
+        assert "Branch protection: 📝 Needs configuration" not in readiness_doc
+        assert "Python 3.10, 3.11, 3.12" not in readiness_doc
+        assert "Python 3.10+" not in readiness_doc
+        assert "make test-fast" in readiness_doc
+        assert "make ci-quick" in readiness_doc
+        assert "[CONTRIBUTING.md](../../CONTRIBUTING.md)" in readiness_doc
+        assert "[SECURITY.md](../../SECURITY.md)" in readiness_doc
+
     def test_ci_hygiene_checks_cover_split_coverage_artifacts(self):
         """CI hygiene checks should track every ignored root coverage artifact."""
         gitignore = (_repo_root / ".gitignore").read_text()
@@ -613,6 +989,40 @@ class TestRootGovernanceMetadata:
         assert "check-quality" in self._make_targets(_repo_root / "Makefile")
         assert "fix-quality check-quality validate-ci" in makefile
         assert "check-quality      Dry-run common quality issue fixes" in makefile
+
+    def test_docs_build_tooling_uses_bounded_repo_contract(self):
+        """Local and hosted docs builds should share the same bounded Sphinx lane."""
+        makefile = (_repo_root / "Makefile").read_text()
+        requirements_dev = (_repo_root / "requirements-dev.txt").read_text()
+        docs_workflow = (_repo_root / ".github" / "workflows" / "docs.yml").read_text()
+
+        docs_specs = [
+            "sphinx>=7.2,<9",
+            "sphinx-rtd-theme>=2.0,<3",
+            "sphinx-autodoc-typehints>=2.0,<4",
+        ]
+        expected_make_var = (
+            'DOCS_TOOL_REQUIREMENTS := "sphinx>=7.2,<9" ' '"sphinx-rtd-theme>=2.0,<3" "sphinx-autodoc-typehints>=2.0,<4"'
+        )
+
+        assert expected_make_var in makefile
+        assert '"$(PY)" -m pip install -q $(DOCS_TOOL_REQUIREMENTS)' in makefile
+        assert "pip install -q sphinx sphinx-rtd-theme sphinx-autodoc-typehints" not in makefile
+
+        for spec in docs_specs:
+            assert spec in requirements_dev
+            assert f'"{spec}"' in docs_workflow
+
+        stale_specs = [
+            "sphinx>=7.2,<10",
+            "sphinx-rtd-theme>=3.1.0,<4",
+            "sphinx-autodoc-typehints>=3.6.1,<4",
+        ]
+        for spec in stale_specs:
+            assert spec not in requirements_dev
+            assert spec not in docs_workflow
+
+        assert re.search(r"(?m)^\s+pip install ", docs_workflow) is None
 
 
 class TestReferenceQuickstartGuidance:
@@ -858,6 +1268,33 @@ class TestRootEnvironmentTemplate:
 
         expected_variables = [
             "TP_API_KEY",
+            "TP_ALLOWED_ORIGINS",
+            "TP_TRUSTED_HOSTS",
+            "TP_ENABLE_TRUSTED_HOSTS",
+            "TP_TRUST_X_FORWARDED_FOR",
+            "TP_TRUSTED_PROXY_IPS",
+            "TP_MAX_REQUEST_BYTES",
+            "TP_PORTAL_MAX_UPLOAD_REQUEST_BYTES",
+            "TP_PORTAL_UPLOAD_MAX_FILES",
+            "TP_PORTAL_UPLOAD_MAX_FIELDS",
+            "TP_PORTAL_UPLOAD_MAX_PART_BYTES",
+            "TP_RATE_LIMIT_PER_MINUTE",
+            "TP_MAX_CONCURRENT_JOBS",
+            "TP_ALLOWED_INPUT_ROOTS",
+            "TP_ALLOWED_OUTPUT_ROOTS",
+            "TP_JOB_RETENTION_SECONDS",
+            "TP_CLEANUP_INTERVAL_SECONDS",
+            "TP_JOB_CLEANUP_SCAN_LIMIT",
+            "TP_CANCEL_GRACE_SECONDS",
+            "TP_JOB_LIST_LIMIT",
+            "TP_MAX_INDEXED_ARTIFACTS",
+            "TP_WORKER_LEASE_SECONDS",
+            "TP_WORKER_HEARTBEAT_SECONDS",
+            "TP_WORKER_POLL_SECONDS",
+            "TP_ORCHESTRATOR_WORKER_SHUTDOWN_GRACE_SECONDS",
+            "TP_ORCHESTRATOR_RECLAIM_SWEEP_INTERVAL_SECONDS",
+            "TP_ENABLE_API_DOCS",
+            "TP_READY_VERBOSE",
             "TP_UID",
             "TP_GID",
             "DEVICE",
@@ -883,9 +1320,25 @@ class TestRootEnvironmentTemplate:
             "TP_TEST_REDIS_URL",
             "TP_TEST_S3_URL",
             "TP_TEST_S3_BUCKET",
+            "TRANSFORMATION_PORTAL_DA3_PYTHON",
+            "TRANSFORMATION_PORTAL_DEPTH_PRO_PYTHON",
+            "TRANSFORMATION_PORTAL_RAW_PYTHON",
         ]
         for variable in expected_variables:
             assert variable in content
+
+        expected_runtime_claims = [
+            "Lux Depth V3 auto-discover the repo-local runtime contract paths",
+            '.venv/bin/python -c "import secrets; print(secrets.token_urlsafe(32))"',
+            "./.runtime/Depth-Anything-3/.venv-da3/bin/python",
+            "./.venv-depth-pro/bin/python",
+            "./.venv-raw/bin/python",
+            "keep TP_ENABLE_TRUSTED_HOSTS=true outside exceptional local",
+            "Keep TP_PORTAL_UPLOAD_ROOT inside",
+            "Canonical worker names are TP_WORKER_*",
+        ]
+        for claim in expected_runtime_claims:
+            assert claim in content
 
         expected_authorities = [
             "web/secure-landing/.env.example",
@@ -899,6 +1352,9 @@ class TestRootEnvironmentTemplate:
             "Inventory below covers Python-orchestrator env vars sourced from",
             "grep -oE",
             "app.py. Run this",
+            "orchestrator picks `python3` from PATH",
+            '#   python -c "import secrets; print(secrets.token_urlsafe(32))"',
+            "TP_ORCHESTRATOR_USE_QUEUE_BROKER",
         ]
         for stale_claim in stale_claims:
             assert stale_claim not in content
@@ -1019,6 +1475,7 @@ class TestGitignore:
             "web/secure-landing/.next-smoke-*/",
             "web/secure-landing/.next-codex-*/",
             "web/secure-landing/.metafiles/",
+            "web/secure-landing/tmp/",
         ]
 
         for pattern in temp_dir_patterns:

--- a/tests/test_image_processing_readiness.py
+++ b/tests/test_image_processing_readiness.py
@@ -106,7 +106,7 @@ class TestReadinessCheck:
 
         output = capsys.readouterr().out
         assert "make install-ml-core" in output
-        assert "Apple Silicon" in output
+        assert "Advanced Apple Silicon" in output
         assert "./scripts/bootstrap/install_ml_stack.sh --profile core-cpu" in output
         assert ".venv/bin/python scripts/setup/download_depth_models.py" in output
         assert "Linux/CPU" not in output

--- a/tests/test_pre_commit_check.py
+++ b/tests/test_pre_commit_check.py
@@ -89,6 +89,121 @@ def test_cloudflare_workers_build_root_shim_files_are_allowed(tmp_path: Path) ->
     assert result.returncode == 0, result.stdout + result.stderr
 
 
+def test_known_root_requirement_shims_are_allowed(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    _init_repo(repo_root)
+    _copy_repo_script(repo_root)
+
+    for path in ("requirements.txt", "requirements-ci.txt", "requirements-dev.txt", "requirements-lint.txt"):
+        _write(repo_root / path, "# governed root requirement shim\n")
+
+    add_result = _run(
+        [
+            "git",
+            "add",
+            "requirements.txt",
+            "requirements-ci.txt",
+            "requirements-dev.txt",
+            "requirements-lint.txt",
+            "scripts/setup/pre-commit-check.sh",
+        ],
+        repo_root,
+    )
+    assert add_result.returncode == 0, add_result.stdout + add_result.stderr
+
+    result = _run(["bash", "scripts/setup/pre-commit-check.sh", "--staged"], repo_root)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_governed_root_dotfile_configs_are_allowed(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    _init_repo(repo_root)
+    _copy_repo_script(repo_root)
+
+    governed_dotfiles = [
+        ".dockerignore",
+        ".env.example",
+        ".gitattributes",
+        ".git-blame-ignore-revs",
+        ".gitignore",
+        ".gitleaks.toml",
+        ".pre-commit-config.yaml",
+        ".pylintrc",
+    ]
+    for path in governed_dotfiles:
+        _write(repo_root / path)
+
+    add_result = _run(["git", "add", *governed_dotfiles, "scripts/setup/pre-commit-check.sh"], repo_root)
+    assert add_result.returncode == 0, add_result.stdout + add_result.stderr
+
+    result = _run(["bash", "scripts/setup/pre-commit-check.sh", "--staged"], repo_root)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_broad_root_allowlist_patterns_do_not_allow_new_clutter(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    _init_repo(repo_root)
+    _copy_repo_script(repo_root)
+
+    unexpected_root_files = [
+        ".envrc",
+        ".gitlab-ci.yml",
+        "requirements-local.txt",
+    ]
+    for path in unexpected_root_files:
+        _write(repo_root / path)
+
+    add_result = _run(["git", "add", *unexpected_root_files, "scripts/setup/pre-commit-check.sh"], repo_root)
+    assert add_result.returncode == 0, add_result.stdout + add_result.stderr
+
+    result = _run(["bash", "scripts/setup/pre-commit-check.sh", "--staged"], repo_root)
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    for path in unexpected_root_files:
+        assert path in result.stdout
+    assert "an approved project subdirectory" in result.stdout
+
+
+def test_retired_root_config_files_are_rejected(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    _init_repo(repo_root)
+    _copy_repo_script(repo_root)
+
+    retired_root_configs = [
+        "setup.py",
+        "setup.cfg",
+        "requirements-test.txt",
+        "Pipfile",
+        "Pipfile.lock",
+        "poetry.lock",
+        "pytest.ini",
+        "tox.ini",
+        ".coveragerc",
+        ".flake8",
+        "docker-compose.yaml",
+        "PKG-INFO",
+        "MANIFEST.in",
+        "__init__.py",
+    ]
+    for path in retired_root_configs:
+        _write(repo_root / path)
+
+    add_result = _run(["git", "add", *retired_root_configs, "scripts/setup/pre-commit-check.sh"], repo_root)
+    assert add_result.returncode == 0, add_result.stdout + add_result.stderr
+
+    result = _run(["bash", "scripts/setup/pre-commit-check.sh", "--staged"], repo_root)
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    for path in retired_root_configs:
+        assert path in result.stdout
+
+
 def test_allowed_top_level_directories_are_accepted(tmp_path: Path) -> None:
     repo_root = tmp_path / "repo"
     repo_root.mkdir()

--- a/tests/test_script_topology.py
+++ b/tests/test_script_topology.py
@@ -27,6 +27,8 @@ COMPATIBILITY_WRAPPERS = CHECKER.COMPATIBILITY_WRAPPERS
 CLI_COMPATIBILITY_WRAPPERS = CHECKER.CLI_COMPATIBILITY_WRAPPERS
 SCRIPT_PACKAGE_COMPATIBILITY_WRAPPERS = CHECKER.SCRIPT_PACKAGE_COMPATIBILITY_WRAPPERS
 SOURCE_PACKAGE_COMPATIBILITY_WRAPPERS = CHECKER.SOURCE_PACKAGE_COMPATIBILITY_WRAPPERS
+src_root_bootstrap_expression = CHECKER._src_root_bootstrap_expression
+repo_root_parent_expression = CHECKER._repo_root_parent_expression
 validate_script_topology = CHECKER.validate_script_topology
 
 
@@ -44,7 +46,7 @@ def _valid_wrapper_text(wrapper: str, marker: str) -> str:
             [
                 "import sys",
                 "from pathlib import Path",
-                "REPO_ROOT = Path(__file__).resolve().parents[1]",
+                f"REPO_ROOT = {repo_root_parent_expression(wrapper)}",
                 "sys.path.insert(0, str(REPO_ROOT))",
             ]
         )
@@ -53,7 +55,7 @@ def _valid_wrapper_text(wrapper: str, marker: str) -> str:
             [
                 "import sys",
                 "from pathlib import Path",
-                'SRC_ROOT = Path(__file__).resolve().parents[1] / "src"',
+                f"SRC_ROOT = {src_root_bootstrap_expression(wrapper)}",
                 "sys.path.insert(0, str(SRC_ROOT))",
             ]
         )
@@ -182,6 +184,31 @@ def test_script_topology_requires_source_package_wrappers_to_bootstrap_src_root(
     assert "does not bootstrap src package root" in violations[0].reason
 
 
+def test_script_topology_requires_nested_source_package_wrappers_to_bootstrap_repo_src_root() -> None:
+    violations = validate_script_topology(
+        {
+            "scripts/pipelines/lux_render_pipeline.py",
+            "src/transformation_portal/pipelines/lux_render_pipeline.py",
+        },
+        read_text=_reader(
+            {
+                "scripts/pipelines/lux_render_pipeline.py": (
+                    "from pathlib import Path\n"
+                    'SRC_ROOT = Path(__file__).resolve().parents[1] / "src"\n'
+                    "from transformation_portal.pipelines.lux_render_pipeline import main\n"
+                    "if __name__ == '__main__':\n"
+                    "    raise SystemExit(main())\n"
+                )
+            }
+        ),
+    )
+
+    assert len(violations) == 1
+    assert violations[0].path == "scripts/pipelines/lux_render_pipeline.py"
+    assert "does not bootstrap src package root" in violations[0].reason
+    assert 'parents[2] / "src"' in violations[0].suggestion
+
+
 def test_repository_compatibility_wrappers_reference_canonical_modules() -> None:
     for wrapper, (_canonical, marker) in COMPATIBILITY_WRAPPERS.items():
         wrapper_path = REPO_ROOT / wrapper
@@ -198,13 +225,15 @@ def test_repository_cli_wrappers_propagate_exit_status() -> None:
 def test_repository_script_package_wrappers_bootstrap_repo_root() -> None:
     for wrapper in SCRIPT_PACKAGE_COMPATIBILITY_WRAPPERS:
         wrapper_text = (REPO_ROOT / wrapper).read_text(encoding="utf-8")
-        assert "Path(__file__).resolve().parents[1]" in wrapper_text, f"Wrapper must bootstrap repo root: {wrapper}"
+        expected = repo_root_parent_expression(wrapper)
+        assert expected in wrapper_text, f"Wrapper must bootstrap repo root via {expected}: {wrapper}"
 
 
 def test_repository_source_package_wrappers_bootstrap_src_root() -> None:
     for wrapper in SOURCE_PACKAGE_COMPATIBILITY_WRAPPERS:
         wrapper_text = (REPO_ROOT / wrapper).read_text(encoding="utf-8")
-        assert 'Path(__file__).resolve().parents[1] / "src"' in wrapper_text, f"Wrapper must bootstrap src root: {wrapper}"
+        expected = src_root_bootstrap_expression(wrapper)
+        assert expected in wrapper_text, f"Wrapper must bootstrap src root via {expected}: {wrapper}"
 
 
 def test_synthetic_viewer_wrapper_imports_from_raw_checkout() -> None:

--- a/tests/test_validate_ci_config.py
+++ b/tests/test_validate_ci_config.py
@@ -69,7 +69,8 @@ def test_mypy_config_remains_root_linting_config() -> None:
         assert required_option in mypy_config_text
 
     organization_doc = (PROJECT_ROOT / "docs" / "governance" / "REPO_ORGANIZATION.md").read_text(encoding="utf-8")
-    assert "- **Linting configuration**: `.pylintrc`, `.flake8`, `mypy.ini`" in organization_doc
+    assert "- **Testing and linting configuration**: `pyproject.toml`, `.pylintrc`, `mypy.ini`" in organization_doc
+    assert ".flake8" not in organization_doc
 
 
 def test_mypy_policy_contract_passes_repo_workflows() -> None:

--- a/tests/validation/test_cloudflare_worker_root_shim_contract.py
+++ b/tests/validation/test_cloudflare_worker_root_shim_contract.py
@@ -26,6 +26,8 @@ def test_root_worker_build_package_is_minimal_deploy_shim() -> None:
         "worker:dry-run": worker_package["scripts"]["dry-run"],
         "worker:deploy": worker_package["scripts"]["deploy"],
     }
+    assert root_package["engines"] == worker_package["engines"]
+    assert root_package["packageManager"] == worker_package["packageManager"]
     assert root_package["devDependencies"] == {
         "wrangler": worker_package["devDependencies"]["wrangler"],
     }
@@ -44,6 +46,7 @@ def test_root_worker_build_lock_matches_package_contract() -> None:
     assert root_lock["requires"] is True
     assert root_lock_package["name"] == root_package["name"]
     assert root_lock_package["devDependencies"] == root_package["devDependencies"]
+    assert root_lock_package["engines"] == root_package["engines"]
     assert "dependencies" not in root_lock_package
     assert root_lock["packages"]["node_modules/wrangler"]["version"] == wrangler_spec
     assert root_lock["packages"]["node_modules/wrangler"]["bin"] == {

--- a/tests/validation/test_dockerfile_contract.py
+++ b/tests/validation/test_dockerfile_contract.py
@@ -55,20 +55,53 @@ def test_runtime_stages_do_not_install_compiler_tooling() -> None:
     assert "build-essential" in stages["gpu-build"]
 
 
-def test_gpu_image_invokes_python_311_explicitly() -> None:
+def test_runtime_images_invoke_python_311_explicitly() -> None:
     stages = _dockerfile_stages()
+    cpu_runtime = stages["cpu"]
     gpu_build = stages["gpu-build"]
     gpu_runtime = stages["gpu"]
     compose = COMPOSE_PATH.read_text(encoding="utf-8")
 
     assert "pip3" not in gpu_build
     assert "python3.11 -m pip install" in gpu_build
+    assert "CMD python3.11 -c" in cpu_runtime
+    assert 'CMD ["python3.11", "-m", "transformation_portal.cli"]' in cpu_runtime
     assert "CMD python3.11 -c" in gpu_runtime
     assert 'CMD ["python3.11", "-m", "transformation_portal.cli"]' in gpu_runtime
+    assert 'CMD ["python", "-m", "transformation_portal.cli"]' not in cpu_runtime
     assert re.search(r"(?<![\w.])python3(?!\.11|\w)", gpu_runtime) is None
 
     assert "command: python3.11 -m transformation_portal.cli serve --host 0.0.0.0 --port 8000" in compose
+    assert (
+        "command: python3.11 -m transformation_portal.cli batch-process " "/app/input /app/output --preset golden_hour"
+    ) in compose
+    assert "command: python3.11 -m transformation_portal.monitoring.dashboard --port 8080" in compose
+    assert "        - python3.11" in compose
+    assert "command: python -m transformation_portal" not in compose
     assert "command: python3 -m transformation_portal.cli serve --host 0.0.0.0 --port 8000" not in compose
+
+
+def test_compose_mounts_governed_local_input_surface() -> None:
+    """Compose should not create untracked root input directories."""
+    compose = COMPOSE_PATH.read_text(encoding="utf-8")
+
+    assert "./input_images:/app/input:ro" in compose
+    assert "./input:/app/input:ro" not in compose
+
+
+def test_docker_targets_do_not_bypass_governed_ml_lock_contract() -> None:
+    """Docker targets must not install broad or platform-wrong ML extras."""
+    dockerfile = _dockerfile_text()
+    stages = _dockerfile_stages()
+    apple_silicon_stage = stages["apple-silicon"]
+
+    assert 'pip install --no-cache-dir -e ".[ml]"' not in dockerfile
+    assert "pip install --no-cache-dir coremltools" not in dockerfile
+    assert re.search(r"^FROM cpu AS apple-silicon$", dockerfile, flags=re.MULTILINE)
+    assert "Docker on Apple Silicon still runs a Linux container" in dockerfile
+    assert "make install-ml-core" in dockerfile
+    assert "ENV DEVICE=cpu" in apple_silicon_stage
+    assert "ENV DEVICE=mps" not in apple_silicon_stage
 
 
 def test_dockerignore_excludes_heavy_local_context() -> None:
@@ -82,21 +115,50 @@ def test_dockerignore_excludes_heavy_local_context() -> None:
         ".git",
         ".venv",
         ".runtime",
+        ".pyre",
         ".coverage",
         ".coverage.*",
         "node_modules",
         "coverage.xml",
         "coverage.json",
         "htmlcov",
+        ".rag_cache",
+        "build",
+        "dist",
+        "downloads",
+        "docs/api/_build",
         "output",
+        "outputs",
+        "processed_images",
+        "processed_output",
+        "extracted_context",
+        "artifacts",
+        "archive_reports",
+        "local_artifacts",
+        "depth_maps_apex",
+        "artifact_store",
+        "archive/experiments",
+        "archive/deprecated",
+        "archive/legacy",
         "input_images",
+        "data/sample_images",
+        "Architectural_Plans",
         "checkpoints",
+        "models",
+        "weights",
+        "pretrained",
         ".env",
         ".env.*",
         "!.env.example",
+        "external",
+        ".cas",
+        ".local_backup",
+        ".backup_local",
+        ".branch_cleanup_backup",
         ".npmrc",
         ".pypirc",
         "web/secure-landing/.metafiles",
+        "web/secure-landing/tmp",
         "*.pem",
         "*.key",
         "*.p12",
@@ -104,4 +166,8 @@ def test_dockerignore_excludes_heavy_local_context() -> None:
         "*.safetensors",
         "*.pt",
         "*.pth",
+        "*.xlsx",
+        "*.xls",
+        "tmp_tensor.npy",
+        "uv.lock",
     } <= ignored_entries

--- a/tests/validation/test_python_bootstrap_scripts.py
+++ b/tests/validation/test_python_bootstrap_scripts.py
@@ -20,6 +20,7 @@ DA3_RUNTIME_INSTALLER_PATH = PROJECT_ROOT / "scripts" / "setup" / "install_da3_r
 RAW_RUNTIME_INSTALLER_PATH = PROJECT_ROOT / "scripts" / "setup" / "install_raw_runtime.sh"
 VALIDATION_SUITE_PATH = PROJECT_ROOT / "scripts" / "validation" / "run_full_validation_suite.sh"
 ML_STACK_INSTALLER_PATH = PROJECT_ROOT / "scripts" / "bootstrap" / "install_ml_stack.sh"
+SECURITY_SCAN_PATH = PROJECT_ROOT / "scripts" / "security_scan.sh"
 
 
 def _write_executable(path: Path, content: str) -> Path:
@@ -237,6 +238,14 @@ def test_make_venv_accepts_supported_windows_repo_venv_layout(tmp_path: Path) ->
 
     assert result.returncode == 0, result.stdout + result.stderr
     assert ".venv already present" in result.stdout
+
+
+def test_security_scan_uses_repo_python_resolver() -> None:
+    script = SECURITY_SCAN_PATH.read_text(encoding="utf-8")
+
+    assert 'PYTHON_BIN="$("$SCRIPT_DIR/setup/resolve_python_311.sh")"' in script
+    assert '"$PYTHON_BIN" -m bandit -r src/ -ll -ii' in script
+    assert "python -m bandit" not in script
 
 
 def test_make_install_ml_core_selects_darwin_arm64_lockfile(tmp_path: Path) -> None:
@@ -551,6 +560,8 @@ def test_install_da3_runtime_baseline_profile_omits_optional_deps(tmp_path: Path
     assert result.returncode == 0, result.stdout + result.stderr
     pip_install_lines = "\n".join(_dry_run_pip_install_lines(result.stdout))
     assert "DA3 NumPy spec: numpy>=2.0,<3" in result.stdout
+    assert "cryptography==47.0.0" in pip_install_lines
+    assert "cryptography==46.0.6" not in pip_install_lines
     assert "numpy==1.26.4" not in pip_install_lines
     assert "pycolmap==" not in pip_install_lines
     assert "xformers" not in pip_install_lines

--- a/tools/parse_machine_json.py
+++ b/tools/parse_machine_json.py
@@ -9,13 +9,13 @@ contract itself (schema + field semantics), not this parser's stdout text.
 
 Usage:
     # Parse from file
-    python tools/parse_machine_json.py result.json
+    .venv/bin/python tools/parse_machine_json.py result.json
 
     # Parse from stdin
-    python scripts/test_metadata_extraction.py --json extract /input/image.CR2 | python tools/parse_machine_json.py
+    .venv/bin/python scripts/test_metadata_extraction.py --json extract input_images/image.CR2 | .venv/bin/python tools/parse_machine_json.py
 
     # Exit code forwarding
-    python scripts/test_metadata_extraction.py --json validate sidecar.json | python tools/parse_machine_json.py
+    .venv/bin/python scripts/test_metadata_extraction.py --json validate sidecar.json | .venv/bin/python tools/parse_machine_json.py
     echo $?  # Parser exits with same code as CLI
 
 See docs/api/MACHINE_MODE_CONTRACT.md for full contract specification.

--- a/tools/parse_machine_json_examples.sh
+++ b/tools/parse_machine_json_examples.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 extract_with_routing() {
     local input_path="$1"
 
-    if result=$(python scripts/test_metadata_extraction.py --json extract "$input_path"); then
+    if result=$(.venv/bin/python scripts/test_metadata_extraction.py --json extract "$input_path"); then
         exit_code=0
     else
         exit_code=$?
@@ -46,7 +46,7 @@ extract_with_routing() {
 validate_with_error_handling() {
     local sidecar_path="$1"
 
-    if result=$(python scripts/test_metadata_extraction.py --json validate "$sidecar_path"); then
+    if result=$(.venv/bin/python scripts/test_metadata_extraction.py --json validate "$sidecar_path"); then
         exit_code=0
     else
         exit_code=$?
@@ -83,7 +83,7 @@ batch_extract_with_summary() {
     local input_root="$1"
     local output_dir="$2"
 
-    if result=$(python scripts/test_metadata_extraction.py --json extract-batch "$input_root" --output "$output_dir"); then
+    if result=$(.venv/bin/python scripts/test_metadata_extraction.py --json extract-batch "$input_root" --output "$output_dir"); then
         exit_code=0
     else
         exit_code=$?
@@ -112,7 +112,7 @@ batch_extract_with_summary() {
 # ==============================================================================
 
 check_system_readiness() {
-    if result=$(python scripts/test_metadata_extraction.py --json check-system); then
+    if result=$(.venv/bin/python scripts/test_metadata_extraction.py --json check-system); then
         exit_code=0
     else
         exit_code=$?
@@ -147,7 +147,7 @@ check_system_readiness() {
 ci_safe_validate() {
     local sidecar_path="$1"
 
-    if result=$(python scripts/test_metadata_extraction.py --json validate "$sidecar_path"); then
+    if result=$(.venv/bin/python scripts/test_metadata_extraction.py --json validate "$sidecar_path"); then
         exit_code=0
     else
         exit_code=$?
@@ -196,7 +196,7 @@ ci_safe_validate() {
 compact_status_check() {
     local sidecar_path="$1"
 
-    python scripts/test_metadata_extraction.py --json validate "$sidecar_path" | \
+    .venv/bin/python scripts/test_metadata_extraction.py --json validate "$sidecar_path" | \
         jq -r 'if .success then "✅ \(.data.sidecar_path)" else "❌ \(.data.sidecar_path): \(.data.dominant_error.type)" end'
 }
 
@@ -213,7 +213,7 @@ extract_multiple_with_error_collection() {
     local successes=0
 
     for file in "${files[@]}"; do
-        if result=$(python scripts/test_metadata_extraction.py --json extract "$file" --output "$output_dir"); then
+        if result=$(.venv/bin/python scripts/test_metadata_extraction.py --json extract "$file" --output "$output_dir"); then
             exit_code=0
         else
             exit_code=$?


### PR DESCRIPTION
## Summary
- Tighten root governance and setup contracts so allowed root files, runtime guidance, Docker/Compose metadata, and active operator docs match the current architecture.
- Keep the change contract-preserving: no API route, response envelope, selector, auth, or frontend route changes.

## Changes
- Harden root placement validation by removing retired root-file allowances such as setup.py, .flake8, pytest.ini, tox.ini, PKG-INFO, and root __init__.py.
- Align active setup and operator guidance with repo-managed Python, governed input_images usage, current branch-protection metadata, and target-owned ML/runtime lanes.
- Add script-topology validation to auto-organize and pre-commit, including wrapper bootstrap depth handling.
- Align Docker/Compose runtime commands with explicit python3.11, use input_images bind mounts, and make the historical Apple Silicon Docker target a CPU compatibility alias instead of installing broad ML extras.
- Update root dependency/tooling metadata for Node 22, bounded docs build tooling, current cryptography floors, and Cloudflare Worker shim contract coverage.
- Expand focused tests for root governance metadata, root placement, Docker contracts, script topology, gitleaks workflow contracts, Python bootstrap scripts, and pre-commit runtime behavior.

## Validation
Proven green:
- make ci-quick
- ./.auto-organize.sh --check --verbose
- .venv/bin/pytest tests/test_codebase_structure.py::TestRootGovernanceMetadata tests/test_codebase_structure.py::TestDocumentationOrganization::test_no_excessive_root_markdown_files tests/test_pre_commit_check.py tests/test_validate_ci_config.py tests/validation/test_dockerfile_contract.py tests/validation/test_python_bootstrap_scripts.py tests/test_script_topology.py tests/structural/test_pre_commit_runtime_contract.py tests/test_check_gitleaks_workflow_contract.py -q
- .venv/bin/pytest tests/test_codebase_structure.py::TestRootGovernanceMetadata tests/validation/test_dockerfile_contract.py -q
- make validate-ci
- make check-doc-heading-links
- docker compose config
- git diff --check
- git diff --cached --check
- git ls-files --others --exclude-standard produced no output
- Commit pre-commit hooks passed: Black/isort CI parity, root placement, script topology, dependency constraints, ML test isolation, test markers, unsafe torch.load check, tautological assertion ban, and gitleaks.

Still failing:
- None known locally.

Failure classification:
- No product, stale-test, or environment/tooling failures observed in the validation above.

## Risk
- Compatibility risk is bounded to root governance, local setup guidance, Docker/Compose runtime invocation, and validation contracts.
- The root placement checker now fails closed on retired conventional root config names; this is intentional and covered by tests.
- Docker/Compose changes are contract-visible for local container users: commands now invoke python3.11 explicitly and mount input_images at /app/input.
- Revert-safe as a single root-governance commit with focused tests and no route/API/frontend selector changes.