### PR TITLE
chore(root): align governance contracts

### DIFF
--- a/.auto-organize.sh
+++ b/.auto-organize.sh
@@ -17,14 +17,15 @@
 #   --dry-run       Show what would be done without making changes
 #   --check         Validate current organization (exit 1 if violations found)
 #   --verbose       Show detailed output including skipped files
-#   --docs-only     Only organize documentation files
+#   --docs-only     Only run documentation organization and docs topology validation
 #   --skip-root     Skip root file placement validation
 #   -h, --help      Show this help message
 #
-# Helper Scripts (executed in sequence when running full organization):
-#   1. scripts/organize_docs.sh         - Classify docs into approved locations
+# Helper scripts and validators:
+#   1. scripts/organize_docs.sh - Classify docs into approved locations
 #   2. scripts/setup/pre-commit-check.sh - Validate root file placement
 #   3. scripts/governance/check_script_topology.py - Validate script placement
+#   4. scripts/governance/check_docs_structure.py - Validate docs topology
 #
 # Documentation:
 #   See docs/governance/REPO_ORGANIZATION.md for organization rules.
@@ -72,7 +73,7 @@ Options:
   --dry-run       Show what would be done without making changes
   --check         Validate current organization (exit 1 if violations)
   --verbose       Show detailed output including skipped files
-  --docs-only     Only organize documentation files
+  --docs-only     Only run documentation organization and docs topology validation
   --skip-root     Skip root file placement validation
   -h, --help      Show this help message
 
@@ -80,7 +81,7 @@ Examples:
   $0 --dry-run              # Preview organization changes
   $0                        # Apply organization changes
   $0 --check                # CI validation mode (fail if violations)
-  $0 --docs-only --dry-run  # Preview documentation moves only
+  $0 --docs-only --dry-run  # Preview docs moves and validate docs topology
 
 Documentation:
   docs/governance/REPO_ORGANIZATION.md - Organization rules and guidelines
@@ -270,9 +271,11 @@ check_root_scripts() {
 
         local basename="$file"
 
-        # Skip allowed root Python files
+        # Skip allowed root Python files. Root placement policy allows app.py as
+        # the FastAPI origin; package/build/test config files belong in governed
+        # package, tool, or test locations instead of the repository root.
         case "$basename" in
-            app.py|__init__.py|setup.py|conftest.py)
+            app.py)
                 continue
                 ;;
         esac
@@ -298,11 +301,15 @@ check_root_scripts() {
             example_*.py|*_example*.py)
                 dest="examples/"
                 ;;
+            setup.py|conftest.py|__init__.py)
+                dest="governed package, tool, or test location"
+                ;;
+            *)
+                dest="scripts/ or src/transformation_portal/"
+                ;;
         esac
 
-        if [[ -n "$dest" ]]; then
-            misplaced+=("$basename → $dest")
-        fi
+        misplaced+=("$basename → $dest")
 
     done < <(git -C "$REPO_ROOT" ls-files -z)
 
@@ -512,13 +519,15 @@ main() {
             failed_steps=$((failed_steps + 1))
         fi
 
-        # Step 6: Validate documentation structure
-        total_steps=$((total_steps + 1))
-        if validate_docs_structure; then
-            passed_steps=$((passed_steps + 1))
-        else
-            failed_steps=$((failed_steps + 1))
-        fi
+    fi
+
+    # Final documentation topology validation always runs. In --docs-only mode
+    # this is the second docs-specific gate; in full mode it remains step 6.
+    total_steps=$((total_steps + 1))
+    if validate_docs_structure; then
+        passed_steps=$((passed_steps + 1))
+    else
+        failed_steps=$((failed_steps + 1))
     fi
 
     # Summary
@@ -547,7 +556,12 @@ main() {
             echo ""
         fi
     else
-        if [[ "$DRY_RUN" == "true" ]]; then
+        if [[ "$CHECK_MODE" == "true" ]]; then
+            log_success "Organization validation completed successfully"
+            echo ""
+            echo "No organization changes are required."
+            echo ""
+        elif [[ "$DRY_RUN" == "true" ]]; then
             log_success "Dry run completed successfully"
             echo ""
             echo "To apply changes, run without --dry-run:"

--- a/.env.example
+++ b/.env.example
@@ -62,17 +62,23 @@ TP_API_KEY=
 # TP_ALLOWED_INPUT_ROOTS=.
 # TP_ALLOWED_OUTPUT_ROOTS=.
 
-# Job retention and worker lease tunables. Canonical worker names are TP_WORKER_*;
-# legacy TP_ORCHESTRATOR_WORKER_* names are only fallback compatibility.
+# Job retention and worker tunables. Canonical worker names are TP_WORKER_*;
+# legacy TP_ORCHESTRATOR_WORKER_* names are only fallback compatibility. The
+# lease, heartbeat, and poll values below preserve the in-process FastAPI worker
+# pool defaults; the standalone `python -m transformation_portal.orchestrator.worker`
+# CLI uses lower built-in defaults unless these same variables are set.
 # TP_JOB_RETENTION_SECONDS=3600
 # TP_CLEANUP_INTERVAL_SECONDS=60
 # TP_JOB_CLEANUP_SCAN_LIMIT=1000
 # TP_CANCEL_GRACE_SECONDS=5
 # TP_JOB_LIST_LIMIT=200
 # TP_MAX_INDEXED_ARTIFACTS=200
+# TP_WORKER_ID=worker-local-1
 # TP_WORKER_LEASE_SECONDS=300
 # TP_WORKER_HEARTBEAT_SECONDS=30
 # TP_WORKER_POLL_SECONDS=0.05
+# TP_WORKER_MAX_BACKOFF_SECONDS=5.0
+# TP_WORKER_LOG_LEVEL=INFO
 # TP_ORCHESTRATOR_WORKER_SHUTDOWN_GRACE_SECONDS=5
 # TP_ORCHESTRATOR_RECLAIM_SWEEP_INTERVAL_SECONDS=5
 

--- a/.gitignore
+++ b/.gitignore
@@ -81,8 +81,12 @@ venv_py311/
 .sh_history
 *.pem
 *.key
+*.p12
+*.pfx
 id_rsa
 id_dsa
+.npmrc
+.pypirc
 PKG-INFO
 
 # -----------------------------------------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,7 +171,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Coverage Quality Gate:** Adjusted baseline threshold from 33% to 25% to reflect actual combined coverage
   - PR #832 fixed coverage artifact consolidation, revealing accurate combined coverage of 25.44%
   - Previous 33% threshold was aspirational, not historical
-  - Added [Coverage Improvement Plan](docs/guides/coverage-improvement-plan.md) with roadmap to 33% by Q2 2026
+  - Maintained coverage ratchet guidance now lives in
+    [Test Coverage Improvement Plan](docs/testing/test_coverage_improvement_plan.md)
+    and [Cold-Zone Coverage Program](docs/testing/COLD_ZONE_COVERAGE_PROGRAM.md).
   - Baseline gate now prevents regression while allowing incremental improvement
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -220,10 +220,12 @@ All pull requests must pass these automated gates before merge:
 
 #### Global Minimum
 - Combined coverage must stay **≥25%** (enforced via `coverage report --fail-under=25`)
-- Current baseline: **25.44%** (Q2 2026 target: 28%)
+- Coverage ratchet targets and current baseline evidence live in
+  [`docs/testing/test_coverage_improvement_plan.md`](docs/testing/test_coverage_improvement_plan.md)
+  and [`docs/testing/COLD_ZONE_COVERAGE_PROGRAM.md`](docs/testing/COLD_ZONE_COVERAGE_PROGRAM.md).
 
 #### Diff Coverage (KEY METRIC)
-- **New/changed lines must be 80%+ covered**
+- **New/changed lines must be 85%+ covered**
 - This is the primary quality ratchet mechanism
 - Enforced via `diff-cover` tool
 
@@ -491,7 +493,7 @@ Use draft PRs for:
 We use a **ratcheting coverage strategy**:
 
 1. **Never decrease global coverage** (enforced in CI)
-2. **New code must be well-tested** (80% diff coverage)
+2. **New code must be well-tested** (85% diff coverage)
 3. **Critical modules** have floor thresholds (coming soon)
 4. **Incremental improvement** over time
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -216,7 +216,7 @@ All pull requests must pass these automated gates before merge:
 - **All tests must pass**
 - **No skipped tests without justification**
 
-### 4. Coverage Gates (ENFORCED)
+### 4. Coverage Gates and Targets
 
 #### Global Minimum
 - Combined coverage must stay **≥25%** (enforced via `coverage report --fail-under=25`)
@@ -224,10 +224,11 @@ All pull requests must pass these automated gates before merge:
   [`docs/testing/test_coverage_improvement_plan.md`](docs/testing/test_coverage_improvement_plan.md)
   and [`docs/testing/COLD_ZONE_COVERAGE_PROGRAM.md`](docs/testing/COLD_ZONE_COVERAGE_PROGRAM.md).
 
-#### Diff Coverage (KEY METRIC)
-- **New/changed lines must be 85%+ covered**
-- This is the primary quality ratchet mechanism
-- Enforced via `diff-cover` tool
+#### Diff Coverage (LOCAL TARGET / PR REVIEW SIGNAL)
+- **New/changed lines should target 85%+ covered**
+- This is the primary local quality ratchet and PR-review signal.
+- Check it with `make coverage-diff`; required PR CI currently enforces the
+  global 25% floor and package/cold-zone checks in `build.yml`, not `diff-cover`.
 
 #### Critical Module Floors
 Future enforcement (not yet active):
@@ -493,7 +494,7 @@ Use draft PRs for:
 We use a **ratcheting coverage strategy**:
 
 1. **Never decrease global coverage** (enforced in CI)
-2. **New code must be well-tested** (85% diff coverage)
+2. **New code should be well-tested** (85% diff coverage target)
 3. **Critical modules** have floor thresholds (coming soon)
 4. **Incremental improvement** over time
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -62,7 +62,13 @@ This repository uses:
 Given our image/video processing nature, special attention is required for:
 
 - **File Upload Security**:
-  - Maximum file size limits (default: 500MB for images, 5GB for videos)
+  - Bounded request and upload sizes. Current backend defaults are
+    `TP_MAX_REQUEST_BYTES=1048576` and
+    `TP_PORTAL_MAX_UPLOAD_REQUEST_BYTES=1048576`; raise them deliberately per
+    deployment instead of assuming large media uploads are accepted by default.
+  - Multipart guardrails: `TP_PORTAL_UPLOAD_MAX_FILES=256`,
+    `TP_PORTAL_UPLOAD_MAX_FIELDS=32`, and
+    `TP_PORTAL_UPLOAD_MAX_PART_BYTES=1048576` by default.
   - Strict MIME type validation
   - Magic number verification for file formats
   - Filename sanitization to prevent path traversal
@@ -143,10 +149,12 @@ Given our image/video processing nature, special attention is required for:
 
 If exposing Transformation Portal as a service:
 
-- **Authentication**: Implement API key or OAuth 2.0
+- **Authentication**: Protected `/v1` endpoints enforce API-key auth by
+  default. Set `TP_API_KEY`, keep `TP_ENFORCE_JOB_API_KEY=true`, and only
+  override `TP_API_KEY_HEADER` when the proxy/client contract requires it.
 - **Rate Limiting**:
-  - Default: 100 requests/minute per IP
-  - Heavy operations: 10 requests/hour
+  - Default: 60 requests/minute per client via `TP_RATE_LIMIT_PER_MINUTE`
+  - Admission cap: 4 concurrent jobs via `TP_MAX_CONCURRENT_JOBS`
 - **Input Sanitization**: All user inputs must be validated
 - **Output Filtering**: Ensure no metadata leakage in processed files
 
@@ -198,21 +206,20 @@ Content-Security-Policy: default-src 'self'
 
 ### Configuration
 
-**Note**: The project currently uses `config/default_config.yaml` for depth pipeline settings (see actual structure with `depth_model.variant`, `processing.zone_tone_mapping`, `optimization.memory_limit_gb`, etc.). The following represents recommended security-related configuration fields that should be implemented for production deployments:
+Security-sensitive runtime controls are environment-backed and documented in
+the root [`.env.example`](.env.example). Depth-pipeline defaults still live in
+`config/default_config.yaml`, but API protection, request limits, filesystem
+boundaries, and artifact-store controls are backend environment contracts:
 
-```yaml
-# Recommended security configuration (not currently implemented)
-# These settings should be added to application configuration for production use
-security:
-  max_file_size: 524288000  # 500 MiB (500 * 1024 * 1024 bytes)
-  allowed_extensions: ['.jpg', '.png', '.tiff', '.mp4', '.mov']
-  temp_directory: '/tmp/transformation_portal'
-  cleanup_interval: 3600  # seconds
-
-  depth_processing:
-    max_input_dimension: 4096
-    max_vertices: 10000000
-    memory_limit_gb: 8  # GB (see: optimization.memory_limit_gb in default_config.yaml)
+```bash
+TP_API_KEY=<strong-token>
+TP_ENFORCE_JOB_API_KEY=true
+TP_MAX_REQUEST_BYTES=1048576
+TP_PORTAL_MAX_UPLOAD_REQUEST_BYTES=1048576
+TP_RATE_LIMIT_PER_MINUTE=60
+TP_MAX_CONCURRENT_JOBS=4
+TP_ALLOWED_INPUT_ROOTS=.
+TP_ALLOWED_OUTPUT_ROOTS=.
 ```
 
 ### Sensitive Data

--- a/docs/governance/REPO_ORGANIZATION.md
+++ b/docs/governance/REPO_ORGANIZATION.md
@@ -50,26 +50,12 @@ Transformation_Portal/
 ├── .github/                    # GitHub workflows and actions
 │   ├── workflows/              # CI/CD workflow definitions
 │   └── agents/                 # Custom GitHub Copilot agents
-├── assets/                     # Media and static resources
-│   ├── brand/                  # Brand assets (logos, colors)
-│   ├── luts/                   # Color grading LUTs
-│   │   ├── film_emulation/     # Film stock emulations
-│   │   ├── location_aesthetic/ # Location-specific profiles
-│   │   └── material_response/  # Material Response LUTs
-│   ├── textures/               # Material texture maps
-│   │   └── board_materials/    # MBAR board-material texture plates
-│   ├── images/                 # Sample and reference images
-│   ├── videos/                 # Sample videos
-│   ├── renders/                # Sample renders
-│   └── models/                 # 3D models
-├── config/                     # Configuration files
-│   ├── presets/                # Processing presets (YAML)
-│   └── profiles/               # User profiles
-├── data/                       # Data files
-│   ├── input/                  # Input data
-│   ├── output/                 # Output data
-│   ├── cache/                  # Cached results
-│   └── sample_images/          # Sample images for testing
+├── archive/                    # Retired code, legacy scripts, historical bundles
+├── artifacts/                  # Tracked artifact metadata and governed evidence
+├── assets/                     # Brand assets, LUTs, project assets, texture plates
+├── cloudflare/                 # Cloudflare Worker source owned by the root shim
+├── config/                     # Runtime config, presets, manifests, feature gates
+├── data/                       # Tracked sample images and fixture-like data
 ├── docs/                       # Maintained docs plus historical records
 │   ├── README.md               # Current documentation entry point
 │   ├── governance/             # Documentation map, policy, organization
@@ -79,21 +65,30 @@ Transformation_Portal/
 │   ├── ci/                     # CI governance and workflow matrix
 │   ├── historical/             # Point-in-time records
 │   └── _archive/               # Retired or consolidated documentation
+├── evalsets/                   # Evaluation fixtures and governed benchmark inputs
+├── examples/                   # Example inputs, configs, and demos
+├── input_images/               # Local/sample input image root
+├── migrations/                 # Alembic migrations for durable orchestrator state
+├── policy/                     # Policy-as-data and governance policy assets
+├── public/                     # FastAPI-served portal assets, shared assets, video
+├── requirements/               # Layered .in/.txt lock sources and lock governance
+├── schemas/                    # Contract schemas
 ├── scripts/                    # All scripts
 │   ├── setup/                  # Installation and setup scripts
-│   ├── automation/             # Automation scripts
-│   └── utilities/              # Utility scripts
+│   ├── pipelines/              # Pipeline runners/processors
+│   ├── governance/             # Organization and policy validators
+│   ├── validation/             # Runtime/contract validation checks
+│   └── utilities/              # Focused utility scripts
 ├── src/                        # Source code (installable package)
 │   ├── transformation_portal/  # Main package
+│   ├── tp/                     # Separate public contract/fixity import surface
 │   └── luxury_tiff_batch_processor/  # TIFF processing module
-├── tests/                      # Test suite
-│   ├── unit/                   # Unit tests
-│   ├── integration/            # Integration tests
-│   └── fixtures/               # Test fixtures
-├── archive/                    # Historical and temporary files
-│   ├── deprecated/             # Deprecated code
-│   ├── experiments/            # Experimental features
-│   └── legacy/                 # Legacy code
+├── tests/                      # Contract, unit, integration, fixture, and smoke tests
+├── tools/                      # Governed CLIs for archive/performance/evidence
+├── web/                        # Managed Next.js frontdoor and shared web assets
+│   ├── secure-landing/         # Node 22 managed browser entry point
+│   └── shared/                 # Shared web tokens/assets
+├── workflows/                  # Repo-level workflow metadata and supporting files
 └── [root files]                # Configuration and build files only
     ├── README.md
     ├── Makefile
@@ -121,7 +116,7 @@ The `.auto-organize.sh` script is the canonical entry point for repository organ
 | `--dry-run` | Show what would be done without making changes |
 | `--check` | CI validation mode - exit 1 if violations found |
 | `--verbose` | Show detailed output including skipped files |
-| `--docs-only` | Only organize documentation files |
+| `--docs-only` | Only run documentation organization and docs topology validation |
 | `--skip-root` | Skip root file placement validation |
 | `-h, --help` | Show help message |
 
@@ -131,7 +126,7 @@ The `.auto-organize.sh` script is the canonical entry point for repository organ
 ./.auto-organize.sh --dry-run              # Preview organization changes
 ./.auto-organize.sh                        # Apply organization changes
 ./.auto-organize.sh --check                # CI validation mode (fail if violations)
-./.auto-organize.sh --docs-only --dry-run  # Preview documentation moves only
+./.auto-organize.sh --docs-only --dry-run  # Preview docs moves and validate docs topology
 ```
 
 ### What Gets Organized
@@ -155,11 +150,29 @@ Only these files should remain in the repository root:
 - **Build configuration**: `Makefile`, `pyproject.toml`, root Cloudflare Workers Builds shim files (`package.json`, `package-lock.json`, `wrangler.jsonc`)
 - **Dependency management**: `requirements.txt`, `requirements-dev.txt`, `requirements-ci.txt`, `requirements-lint.txt`
 - **Testing and linting configuration**: `pyproject.toml`, `.pylintrc`, `mypy.ini`
-- **Docker**: `Dockerfile`, `docker-compose.yml`
-- **Git**: `.gitignore`, `.gitattributes`, `.git-blame-ignore-revs`, `.pre-commit-config.yaml`
+- **Docker and local environment templates**: `Dockerfile`, `docker-compose.yml`, `.dockerignore`, `.env.example`
+- **Git and security metadata**: `.gitignore`, `.gitattributes`, `.gitmodules`, `.git-blame-ignore-revs`, `.gitleaks.toml`, `.pre-commit-config.yaml`
 - **Governance metadata**: `.architect_directive_status.yml`, `AGENTS.md`, `CLAUDE.md`
 - **Runtime entrypoints**: `app.py`, `portal.html`
 - **Organization system**: `.auto-organize.sh`
+
+Current allowed root files are:
+`README.md`, `LICENSE`, `CONTRIBUTING.md`, `SECURITY.md`, `CHANGELOG.md`,
+`AGENTS.md`, `CLAUDE.md`, `Makefile`, `package.json`, `package-lock.json`,
+`pyproject.toml`, `requirements.txt`, `requirements-dev.txt`,
+`requirements-ci.txt`, `requirements-lint.txt`, `.pylintrc`, `mypy.ini`,
+`Dockerfile`, `docker-compose.yml`, `.gitignore`, `.gitleaks.toml`,
+`.dockerignore`, `.gitattributes`, `.gitmodules`, `.git-blame-ignore-revs`,
+`.pre-commit-config.yaml`, `wrangler.jsonc`, `.auto-organize.sh`,
+`.architect_directive_status.yml`, `.env.example`, `app.py`, and
+`portal.html`.
+
+The root Cloudflare Workers files are not a general JavaScript application
+root. They are a minimal Workers Builds deploy shim for
+`cloudflare/transformationportal-worker`; keep scripts, Node engine metadata,
+Wrangler version, and the delegated entrypoint aligned with that governed
+worker package. The contract is enforced by
+`tests/validation/test_cloudflare_worker_root_shim_contract.py`.
 
 ### Root Directory Limits
 
@@ -169,11 +182,18 @@ bundle is archived under `docs/historical/productivity-suite-2025/`, with its
 retired placeholder script under `archive/scripts/productivity/`.
 
 Approved tracked top-level directories are enforced by
-`scripts/setup/pre-commit-check.sh`. Contract-sensitive roots such as
-`public/portal-assets`, `public/video`, `schemas`, `config`, `input_images`,
-and `web/secure-landing` remain stable. Retired roots such as `dashboard/`,
-`data/luts/`, `linear_ingest_demo/`, `projects/`, `test_sky_fix/`, and
-`textures/` must not be recreated; use `assets/luts/`,
+`scripts/setup/pre-commit-check.sh`.
+
+Current allowed top-level directories are:
+`.github/`, `archive/`, `artifacts/`, `assets/`, `cloudflare/`, `config/`,
+`data/`, `docs/`, `evalsets/`, `examples/`, `input_images/`, `migrations/`,
+`policy/`, `public/`, `requirements/`, `schemas/`, `scripts/`, `src/`,
+`tests/`, `tools/`, `web/`, and `workflows/`.
+
+Contract-sensitive nested roots such as `public/portal-assets`,
+`public/video`, and `web/secure-landing` remain stable. Retired roots such as
+`dashboard/`, `data/luts/`, `linear_ingest_demo/`, `projects/`,
+`test_sky_fix/`, and `textures/` must not be recreated; use `assets/luts/`,
 `assets/textures/board_materials/`, `assets/projects/`, `docs/projects/`, or
 ignored `output/...` paths instead.
 
@@ -205,6 +225,9 @@ ignored `output/...` paths instead.
 6. **Documentation Structure Validation** (`scripts/governance/check_docs_structure.py`)
    - Validates that documentation follows the approved directory structure
 
+`--docs-only` runs steps 1 and 6 only. It skips root placement and script
+topology checks, but still validates documentation topology.
+
 ### Running in CI
 
 Use `--check` mode for CI validation:
@@ -231,16 +254,20 @@ This guarantees a consistent ordering of operations and a single point of contro
 
 ## Pre-Commit Hook
 
-The pre-commit hook (`scripts/setup/pre-commit-check.sh`) prevents commits with misplaced files.
+The repository hook set is installed through the pre-commit framework. Its
+root-placement hook calls `scripts/setup/pre-commit-check.sh` to prevent commits
+with misplaced files, and `.pre-commit-config.yaml` installs both `pre-commit`
+and `pre-push` hook types so push-time checks such as gitleaks are active too.
 
 Repo-wide audits use the same checker in `--all` mode with no grandfathered root-file baseline.
 
 ### How It Works
 
-1. Runs automatically before each commit
-2. Checks for files in the root directory that should be elsewhere
-3. Provides helpful error messages with suggested destinations
-4. Allows bypass with `git commit --no-verify` (not recommended)
+1. Runs automatically before each commit through the configured pre-commit hook set
+2. Runs configured push-time checks before `git push`
+3. Checks for files in the root directory that should be elsewhere
+4. Provides helpful error messages with suggested destinations
+5. Allows bypass with `git commit --no-verify` or `git push --no-verify` (not recommended)
 
 ## Installation
 
@@ -251,7 +278,8 @@ Repo-wide audits use the same checker in `--all` mode with no grandfathered root
 git clone https://github.com/RC219805/Transformation_Portal.git
 cd Transformation_Portal
 
-# 2. Install the organization system
+# 2. Install the repo-managed hook tooling and organization system
+make install-core
 ./scripts/setup/auto-organize-install.sh
 
 # 3. Run initial organization (dry-run first)
@@ -266,13 +294,12 @@ cd Transformation_Portal
 If you prefer manual setup:
 
 ```bash
-# Make scripts executable
-chmod +x .auto-organize.sh
-chmod +x scripts/setup/pre-commit-check.sh
-chmod +x scripts/setup/auto-organize-install.sh
+# Install the repo-managed pre-commit and pre-push hooks
+make install-core
+make install-hooks
 
-# Create symbolic link for pre-commit hook
-ln -sf ../../scripts/setup/pre-commit-check.sh .git/hooks/pre-commit
+# Verify root placement directly when needed
+./scripts/setup/pre-commit-check.sh --all
 ```
 
 ## Usage
@@ -381,7 +408,7 @@ The organization system uses these rules to classify files:
 
 ### For CI/CD
 
-1. Validate organization: add a CI check that runs `.auto-organize.sh --dry-run`.
+1. Validate organization: add a CI check that runs `.auto-organize.sh --check`.
 2. Fail on violations: fail the build if organization is needed.
 3. Report violations: provide clear error messages about misplaced files.
 
@@ -401,15 +428,15 @@ sed -i 's/\r$//' .auto-organize.sh
 ### Pre-Commit Hook Not Working
 
 ```bash
-# Check if hook exists
+# Check if hooks exist
 ls -la .git/hooks/pre-commit
+ls -la .git/hooks/pre-push
 
-# Reinstall hook
-./scripts/setup/auto-organize-install.sh
+# Reinstall hooks through the repo-managed target
+make install-hooks
 
-# Check hook is executable
-chmod +x .git/hooks/pre-commit
-chmod +x scripts/setup/pre-commit-check.sh
+# Run the root-placement check directly
+./scripts/setup/pre-commit-check.sh --all
 ```
 
 ### Files Not Being Moved

--- a/docs/guides/coverage-improvement-plan.md
+++ b/docs/guides/coverage-improvement-plan.md
@@ -87,7 +87,8 @@ Low-priority modules (can defer):
 
 ### CI Integration
 - **Baseline gate** (`--fail-under=25`): Prevents regression
-- **Diff coverage gate** (`diff-cover --fail-under=85`): New code must be well-tested
+- **Diff coverage target** (`make coverage-diff`): Local PR-review signal for new code;
+  not a required PR CI gate until `build.yml` wires in `diff-cover`
 - **Ratchet mechanism**: As coverage improves, baseline gate increases
 
 ### Ownership
@@ -113,7 +114,9 @@ Update this document quarterly with:
 A: This is a legacy codebase with ~25K statements. Reaching 80% would require ~12,000 new test assertions. We're taking an incremental, pragmatic approach.
 
 **Q: Can I merge code with <85% diff coverage?**
-A: No. The diff-cover gate ensures all *new* code is well-tested, even if legacy code has gaps.
+A: Required PR CI may still pass today, but expect review scrutiny. Target 85%
+diff coverage locally with `make coverage-diff`; wiring this into `build.yml`
+is the tracked step that would make it a blocking PR gate.
 
 **Q: What if coverage drops unexpectedly?**
 A: The CI gate will fail. Investigate whether:
@@ -127,7 +130,7 @@ A: The CI gate will fail. Investigate whether:
 make coverage-report
 open htmlcov/index.html
 
-# Diff coverage check against main branch (≥85% required for new code)
+# Diff coverage check against main branch (85% local target for new code)
 make coverage-diff
 
 # Package-level baseline report for ratcheting
@@ -138,8 +141,8 @@ make coverage-fast-scope
 ```
 
 **Q: What are the coverage targets?**
-- **Diff coverage**: 85% on new/changed lines (required for PRs)
-- **Global floor**: 25% (prevents regression)
+- **Diff coverage**: 85% on new/changed lines (local target / future PR gate)
+- **Global floor**: 25% (required PR gate; prevents regression)
 - **Long-horizon target**: 70% overall
 
 See `docs/testing/test_coverage_improvement_plan.md` for the full phased plan.

--- a/docs/testing/test_coverage_improvement_plan.md
+++ b/docs/testing/test_coverage_improvement_plan.md
@@ -25,8 +25,18 @@ The repository has substantial test volume, but high-risk areas remain under-cov
 | Offline integration tests | pytest | Pass |
 | Contract tests | pytest | Pass |
 | Security boundary tests | pytest | Pass |
-| **Diff coverage** | diff-cover | ≥85% |
 | **Global floor** | coverage | ≥25% |
+
+### Local / Review Targets (non-blocking today)
+
+| Check | Tool | Threshold |
+|-------|------|-----------|
+| **Diff coverage** | `make coverage-diff` / diff-cover | Target ≥85% |
+
+The diff-coverage target is a local quality ratchet and PR-review signal today.
+The required PR test job in `build.yml` does not invoke `diff-cover`; the
+push-only `ci.yml` workflow keeps an intended gate stub that must be wired into
+`build.yml` before this becomes a blocking PR check.
 
 ### Optional / Nightly Lane (non-blocking)
 
@@ -55,9 +65,11 @@ its `app.py` milestone targets below are actually enforced, not aspirational.
 ### Immediate Gate (Active)
 
 ```bash
-# Enforced in CI today
-diff-cover coverage.xml --compare-branch=origin/main --fail-under=85
+# Enforced in required PR CI today
 coverage report --fail-under=25
+
+# Local target / intended future PR gate
+make coverage-diff
 ```
 
 ### Ratcheted Package Gates (Future Milestones)
@@ -98,10 +110,10 @@ coverage report --fail-under=25
 
 - [x] `pytest-cov` HTML, XML, terminal, and branch reports configured
 - [x] `make coverage-report` — comprehensive local coverage
-- [x] `make coverage-diff` — diff coverage vs main branch
+- [x] `make coverage-diff` — local diff coverage vs main branch
 - [x] `make coverage-package` — package-level baseline report
 - [x] CI artifact upload for coverage outputs
-- [x] Diff coverage reporting in CI (85% threshold)
+- [ ] Wire diff coverage into the required `build.yml` PR gate (85% threshold)
 - [x] `diff-cover` added to dev dependencies
 
 ### Phase 1 — Highest-Gap, Highest-Yield Coverage

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,9 @@
 # 2. Supported ML core install:
 #    - Uses the checked-in target-owned Apple Silicon ML lock when available
 #    - Enables governed depth/ML workflows on supported runtimes
-#    - To enable: run `make install-ml-core` or use pyproject.toml extras
+#    - To enable: run `make install-ml-core` or see requirements/README.md
+#      for target-owned flows; pyproject.toml extras are metadata pointers,
+#      not the governed operator install surface
 #
 # 3. For development: use requirements-dev.txt or requirements/all.txt
 #

--- a/requirements/README.md
+++ b/requirements/README.md
@@ -99,17 +99,20 @@ Dependencies are organized into logical layers:
 
 ### Relationship to Root Requirements Files
 
-The repository has **root-level** requirements files that reference this layered system:
+The repository has **root-level** requirements files that reference or complement
+this layered system:
 
 | Root File | Purpose | Structure |
 |-----------|---------|-----------|
 | `requirements.txt` | Core runtime | References `requirements/base.txt` |
 | `requirements-ci.txt` | CI test runs | References `requirements.txt` + inline test deps |
 | `requirements-dev.txt` | Development | References `requirements-ci.txt` + dev tools |
+| `requirements-lint.txt` | CI/local lint parity | Hand-authored lean lint toolchain consumed by `scripts/setup/run_lint_tool.sh` |
 
 **Important distinctions:**
 - `requirements-ci.txt` (root) contains **test runner and test-support** deps (pytest, hypothesis, moto, etc.)
 - `requirements/ci.in` contains **CI pipeline tools** (bandit, safety, build, twine, etc.)
+- `requirements-lint.txt` is a separate root lint-tool parity surface, not a generated layered lock
 - Core test deps in root `requirements-ci.txt` must match `requirements/dev.in`. The enforced set is defined as `CORE_TEST_DEPS` in `scripts/validation/check_ci_dep_sync.py` (currently: pytest, pytest-cov, pytest-asyncio, pytest-json-report, pytest-xdist, hypothesis, httpx, moto)
 - Dev-only test tools in `requirements/dev.in` must also be available from root `requirements-dev.txt` without entering lean CI installs. The enforced set is defined as `DEV_ONLY_DEPS` in `scripts/validation/check_ci_dep_sync.py` (currently: pytest-rerunfailures for ADR-033 flaky-test quarantine support)
 - Run `make check-ci-sync` to verify no drift for the enforced core-test and dev-only dependency sets across the root and layered files
@@ -156,8 +159,9 @@ pinned-without-hashes unless a later policy decision promotes broader
   and are treated as evidence, not as the default install surface.
 - The checked-in layered locks remain the primary deployment contract and
   continue to be consumed without mandatory hash enforcement.
-- Root wrapper files such as `requirements.txt`, `requirements-ci.txt`, and
-  `requirements-dev.txt` remain outside this hash-enforced policy decision.
+- Root wrapper files such as `requirements.txt`, `requirements-ci.txt`,
+  `requirements-dev.txt`, and `requirements-lint.txt` remain outside this
+  hash-enforced policy decision.
 - ML platform locks remain outside this policy decision until the simpler
   non-ML layered surface has a reason to absorb broader enforcement cost.
 - Promotion to mandatory `--require-hashes` enforcement requires a separate
@@ -184,11 +188,11 @@ These files are emitted into `HASH_PILOT_OUT_DIR` (default:
 
 ### Why the policy excludes root wrappers
 
-Root wrapper files such as `requirements.txt`, `requirements-ci.txt`, and
-`requirements-dev.txt` remain hand-authored convenience entry points and are
-used broadly across CI and local setup flows. The pilot deliberately avoids
-changing those interfaces until the team decides whether hash enforcement is
-worth the operational cost.
+Root wrapper files such as `requirements.txt`, `requirements-ci.txt`,
+`requirements-dev.txt`, and `requirements-lint.txt` remain hand-authored
+convenience entry points and are used broadly across CI and local setup flows.
+The pilot deliberately avoids changing those interfaces until the team decides
+whether hash enforcement is worth the operational cost.
 
 ### Why ML platform locks remain deferred
 

--- a/requirements/README.md
+++ b/requirements/README.md
@@ -159,9 +159,9 @@ pinned-without-hashes unless a later policy decision promotes broader
   and are treated as evidence, not as the default install surface.
 - The checked-in layered locks remain the primary deployment contract and
   continue to be consumed without mandatory hash enforcement.
-- Root wrapper files such as `requirements.txt`, `requirements-ci.txt`,
-  `requirements-dev.txt`, and `requirements-lint.txt` remain outside this
-  hash-enforced policy decision.
+- `requirements.txt`, `requirements-ci.txt`, and
+  `requirements-dev.txt` remain outside this hash-enforced policy decision.
+  `requirements-lint.txt` is also outside the hash-enforced pilot scope.
 - ML platform locks remain outside this policy decision until the simpler
   non-ML layered surface has a reason to absorb broader enforcement cost.
 - Promotion to mandatory `--require-hashes` enforcement requires a separate
@@ -188,11 +188,11 @@ These files are emitted into `HASH_PILOT_OUT_DIR` (default:
 
 ### Why the policy excludes root wrappers
 
-Root wrapper files such as `requirements.txt`, `requirements-ci.txt`,
-`requirements-dev.txt`, and `requirements-lint.txt` remain hand-authored
-convenience entry points and are used broadly across CI and local setup flows.
-The pilot deliberately avoids changing those interfaces until the team decides
-whether hash enforcement is worth the operational cost.
+`requirements.txt`, `requirements-ci.txt`, and `requirements-dev.txt` remain
+outside this hash-enforced policy decision. `requirements-lint.txt` is also a
+hand-authored convenience entry point outside the pilot scope. The pilot
+deliberately avoids changing those interfaces until the team decides whether
+hash enforcement is worth the operational cost.
 
 ### Why ML platform locks remain deferred
 

--- a/scripts/README_QUALITY_CONTROL.md
+++ b/scripts/README_QUALITY_CONTROL.md
@@ -38,8 +38,8 @@ make pre-commit
 
 ### 1. Pre-commit Hooks
 
-The default git hook is installed with `make install-hooks`, which runs
-`pre-commit install -f` against this repository's `.pre-commit-config.yaml`.
+The default git hooks are installed with `make install-hooks`, which uses the
+repo-managed pre-commit binary and `.pre-commit-config.yaml` default hook types.
 The legacy `scripts/pre_commit_hook.sh` entrypoint remains available as a
 compatibility wrapper for running `scripts/utilities/pre-commit-quality-check.py`
 directly.
@@ -252,7 +252,7 @@ make fix-quality       # Auto-fix all issues
 make check-quality     # Dry-run (show what would be fixed)
 
 # Tools
-make install-hooks     # Install git pre-commit hook
+make install-hooks     # Install git pre-commit and pre-push hooks
 make validate-ci       # Validate GitHub Actions configs
 make organize-docs     # Organize markdown files
 make check-docs        # Preview documentation organization

--- a/scripts/setup/README.md
+++ b/scripts/setup/README.md
@@ -6,7 +6,8 @@ This directory contains installation and setup scripts for the Transformation Po
 
 ### `auto-organize-install.sh`
 
-Installs the automated repository organization system, including the standard repository pre-commit hook.
+Installs the automated repository organization system, including the
+repo-managed pre-commit and pre-push hook set.
 
 **Usage:**
 ```bash
@@ -14,9 +15,9 @@ Installs the automated repository organization system, including the standard re
 ```
 
 **What it does:**
-- Installs the standard repository pre-commit hook at `.git/hooks/pre-commit`
+- Delegates to `make install-hooks` so `.git/hooks/pre-commit` and
+  `.git/hooks/pre-push` match `.pre-commit-config.yaml`
 - Makes the `.auto-organize.sh` script executable
-- Validates the repository structure
 
 ### `install_da3_runtime.sh`
 
@@ -267,9 +268,10 @@ make install-hooks
 
 # Verify installation
 ls -la .git/hooks/pre-commit
+ls -la .git/hooks/pre-push
 
-# Make sure it's executable
-chmod +x .git/hooks/pre-commit
+# Run the root-placement check directly
+./scripts/setup/pre-commit-check.sh --all
 ```
 
 ### Line Ending Issues (Windows)

--- a/scripts/setup/auto-organize-install.sh
+++ b/scripts/setup/auto-organize-install.sh
@@ -3,7 +3,8 @@
 # auto-organize-install.sh
 # Installation script for the automated repository organization system
 #
-# This script installs the pre-commit hook and configures the organization system.
+# This script installs the repo-managed pre-commit framework hook set and
+# configures the organization system.
 #
 
 set -euo pipefail
@@ -24,16 +25,12 @@ fi
 echo "Repository root: $REPO_ROOT"
 echo ""
 
-# Install pre-commit hook
-echo "Installing pre-commit hook..."
-if ! command -v pre-commit >/dev/null 2>&1; then
-    echo "ERROR: 'pre-commit' is required but not installed."
-    echo "Install it with: python3 -m pip install pre-commit"
-    exit 1
-fi
-
-(cd "$REPO_ROOT" && pre-commit install -f)
-echo "  ✓ Pre-commit hook installed"
+# Install the configured pre-commit framework hook set. The Make target uses
+# the repo-managed .venv pre-commit binary and .pre-commit-config.yaml's
+# default_install_hook_types, so pre-commit and pre-push stay in sync.
+echo "Installing pre-commit and pre-push hooks..."
+(cd "$REPO_ROOT" && make install-hooks)
+echo "  ✓ Pre-commit and pre-push hooks installed"
 
 # Make organization script executable
 ORGANIZE_SCRIPT="$REPO_ROOT/.auto-organize.sh"
@@ -58,7 +55,8 @@ echo ""
 echo "3. View organization documentation:"
 echo "   cat docs/governance/REPO_ORGANIZATION.md"
 echo ""
-echo "The pre-commit hook will now run the repository hook set before each commit."
-echo "That includes misplaced-file detection as one of its checks. To bypass (not recommended):"
+echo "The repository hook set now runs before each commit and push."
+echo "That includes misplaced-file detection and push-time secrets checks. To bypass (not recommended):"
 echo "   git commit --no-verify"
+echo "   git push --no-verify"
 echo ""

--- a/tests/test_codebase_structure.py
+++ b/tests/test_codebase_structure.py
@@ -453,6 +453,10 @@ class TestRootGovernanceMetadata:
         assert "torchvision: 0.19.1" not in changelog
         assert "diffusers: 0.31.0" not in changelog
         assert "transformers: 4.53.0" not in changelog
+        assert "docs/guides/coverage-improvement-plan.md" not in changelog
+        assert "33% by Q2 2026" not in changelog
+        assert "docs/testing/test_coverage_improvement_plan.md" in changelog
+        assert "docs/testing/COLD_ZONE_COVERAGE_PROGRAM.md" in changelog
 
     def test_root_readme_performance_links_use_current_authorities(self):
         """README performance navigation should point to maintained policy docs."""
@@ -697,6 +701,18 @@ class TestRootGovernanceMetadata:
         assert "Next audit: **2026-05-16 (Q2 2026)**" not in contributing
         assert "Next audit: **2026-08-16 (Q3 2026)**" in contributing
 
+    def test_contributing_coverage_guidance_matches_active_gates(self):
+        """Root contribution guidance should match current coverage gate policy."""
+        contributing = (_repo_root / "CONTRIBUTING.md").read_text()
+
+        assert "coverage report --fail-under=25" in contributing
+        assert "**New/changed lines must be 85%+ covered**" in contributing
+        assert "docs/testing/test_coverage_improvement_plan.md" in contributing
+        assert "docs/testing/COLD_ZONE_COVERAGE_PROGRAM.md" in contributing
+        assert "**New/changed lines must be 80%+ covered**" not in contributing
+        assert "80% diff coverage" not in contributing
+        assert "Q2 2026 target: 28%" not in contributing
+
     def test_contributing_dependency_workflow_matches_requirements_contract(self):
         """Root contribution guidance should not route dependency edits through retired ML flows."""
         contributing = (_repo_root / "CONTRIBUTING.md").read_text()
@@ -752,6 +768,18 @@ class TestRootGovernanceMetadata:
         assert "Install via: make install-ml-coreml" not in requirements_ml_coreml
         assert "Reserved metadata only" in requirements_ml_research
         assert "make install-ml-research" not in requirements_ml_research
+
+    def test_root_requirements_guidance_preserves_target_owned_ml_install_contract(self):
+        """Root requirements entrypoint should not advertise metadata extras as ML install support."""
+        root_requirements = (_repo_root / "requirements.txt").read_text()
+        pyproject = (_repo_root / "pyproject.toml").read_text()
+
+        assert "make install-ml-core" in root_requirements
+        assert "requirements/README.md" in root_requirements
+        assert "pyproject.toml extras are metadata pointers" in root_requirements
+        assert "not the governed operator install surface" in root_requirements
+        assert "or use pyproject.toml extras" not in root_requirements
+        assert "pyproject.toml extras are metadata/convenience pointers, not install support" in pyproject
 
     def test_contributing_setup_uses_repo_managed_environment(self):
         """Root contribution setup should use the current Makefile-managed .venv contract."""
@@ -1268,6 +1296,8 @@ class TestRootEnvironmentTemplate:
 
         expected_variables = [
             "TP_API_KEY",
+            "TP_ENFORCE_JOB_API_KEY",
+            "TP_API_KEY_HEADER",
             "TP_ALLOWED_ORIGINS",
             "TP_TRUSTED_HOSTS",
             "TP_ENABLE_TRUSTED_HOSTS",
@@ -1288,9 +1318,12 @@ class TestRootEnvironmentTemplate:
             "TP_CANCEL_GRACE_SECONDS",
             "TP_JOB_LIST_LIMIT",
             "TP_MAX_INDEXED_ARTIFACTS",
+            "TP_WORKER_ID",
             "TP_WORKER_LEASE_SECONDS",
             "TP_WORKER_HEARTBEAT_SECONDS",
             "TP_WORKER_POLL_SECONDS",
+            "TP_WORKER_MAX_BACKOFF_SECONDS",
+            "TP_WORKER_LOG_LEVEL",
             "TP_ORCHESTRATOR_WORKER_SHUTDOWN_GRACE_SECONDS",
             "TP_ORCHESTRATOR_RECLAIM_SWEEP_INTERVAL_SECONDS",
             "TP_ENABLE_API_DOCS",
@@ -1305,8 +1338,12 @@ class TestRootEnvironmentTemplate:
             "TP_REDIS_KEY_PREFIX",
             "TP_ARTIFACT_STORE",
             "TP_ARTIFACT_LOCAL_ROOT",
+            "TP_ARTIFACT_PREFIX",
+            "TP_ARTIFACT_PRESIGN_EXPIRES_SECONDS",
+            "TP_ARTIFACT_RETENTION_SECONDS",
             "TP_ARTIFACT_BUCKET",
             "TP_ARTIFACT_ENDPOINT_URL",
+            "TP_ARTIFACT_REGION",
             "POSTGRES_DB",
             "POSTGRES_USER",
             "POSTGRES_PASSWORD",
@@ -1316,6 +1353,8 @@ class TestRootEnvironmentTemplate:
             "MINIO_ROOT_PASSWORD",
             "TP_MINIO_API_PUBLIC_PORT",
             "TP_MINIO_CONSOLE_PUBLIC_PORT",
+            "TP_MINIO_IMAGE",
+            "TP_MINIO_MC_IMAGE",
             "TP_TEST_POSTGRES_URL",
             "TP_TEST_REDIS_URL",
             "TP_TEST_S3_URL",
@@ -1336,6 +1375,7 @@ class TestRootEnvironmentTemplate:
             "keep TP_ENABLE_TRUSTED_HOSTS=true outside exceptional local",
             "Keep TP_PORTAL_UPLOAD_ROOT inside",
             "Canonical worker names are TP_WORKER_*",
+            "standalone `python -m transformation_portal.orchestrator.worker`",
         ]
         for claim in expected_runtime_claims:
             assert claim in content
@@ -1355,6 +1395,44 @@ class TestRootEnvironmentTemplate:
             "orchestrator picks `python3` from PATH",
             '#   python -c "import secrets; print(secrets.token_urlsafe(32))"',
             "TP_ORCHESTRATOR_USE_QUEUE_BROKER",
+        ]
+        for stale_claim in stale_claims:
+            assert stale_claim not in content
+
+
+class TestRootSecurityPolicy:
+    """Tests for the root security policy's live runtime claims."""
+
+    def test_security_policy_matches_current_backend_runtime_defaults(self):
+        """Root security guidance should describe current backend controls."""
+        security_policy = _repo_root / "SECURITY.md"
+        content = security_policy.read_text()
+
+        expected_claims = [
+            "TP_MAX_REQUEST_BYTES=1048576",
+            "TP_PORTAL_MAX_UPLOAD_REQUEST_BYTES=1048576",
+            "TP_PORTAL_UPLOAD_MAX_FILES=256",
+            "TP_PORTAL_UPLOAD_MAX_FIELDS=32",
+            "TP_PORTAL_UPLOAD_MAX_PART_BYTES=1048576",
+            "Protected `/v1` endpoints enforce API-key auth by",
+            "TP_ENFORCE_JOB_API_KEY=true",
+            "Default: 60 requests/minute per client via `TP_RATE_LIMIT_PER_MINUTE`",
+            "Admission cap: 4 concurrent jobs via `TP_MAX_CONCURRENT_JOBS`",
+            "[`.env.example`](.env.example)",
+            "TP_ALLOWED_INPUT_ROOTS=.",
+            "TP_ALLOWED_OUTPUT_ROOTS=.",
+        ]
+        for claim in expected_claims:
+            assert claim in content
+
+        stale_claims = [
+            "Maximum file size limits (default: 500MB for images, 5GB for videos)",
+            "Implement API key or OAuth 2.0",
+            "Default: 100 requests/minute per IP",
+            "Heavy operations: 10 requests/hour",
+            "Recommended security configuration (not currently implemented)",
+            "These settings should be added to application configuration for production use",
+            "max_file_size: 524288000",
         ]
         for stale_claim in stale_claims:
             assert stale_claim not in content
@@ -1489,6 +1567,23 @@ class TestGitignore:
         assert ".env" in content
         assert ".env.*" in content
         assert "!.env.example" in content
+
+    def test_gitignore_covers_local_credential_files(self):
+        """Test that local package-manager credentials and certificate bundles stay ignored."""
+        gitignore = _repo_root / ".gitignore"
+        content = gitignore.read_text()
+
+        sensitive_patterns = [
+            ".npmrc",
+            ".pypirc",
+            "*.pem",
+            "*.key",
+            "*.p12",
+            "*.pfx",
+        ]
+
+        for pattern in sensitive_patterns:
+            assert pattern in content, f".gitignore should include local credential pattern: {pattern}"
 
     def test_gitignore_does_not_hide_tracked_files(self):
         """Tracked governance docs and fixtures should not be masked by ignore rules."""

--- a/tests/test_codebase_structure.py
+++ b/tests/test_codebase_structure.py
@@ -704,9 +704,20 @@ class TestRootGovernanceMetadata:
     def test_contributing_coverage_guidance_matches_active_gates(self):
         """Root contribution guidance should match current coverage gate policy."""
         contributing = (_repo_root / "CONTRIBUTING.md").read_text()
+        testing_plan = (_repo_root / "docs" / "testing" / "test_coverage_improvement_plan.md").read_text()
+        guide_plan = (_repo_root / "docs" / "guides" / "coverage-improvement-plan.md").read_text()
 
         assert "coverage report --fail-under=25" in contributing
-        assert "**New/changed lines must be 85%+ covered**" in contributing
+        assert "**New/changed lines should target 85%+ covered**" in contributing
+        assert "required PR CI currently enforces the" in contributing
+        assert "`build.yml`, not `diff-cover`" in contributing
+        assert "Coverage Gates (ENFORCED)" not in contributing
+        assert "Enforced via `diff-cover` tool" not in contributing
+        assert "| **Diff coverage** | diff-cover | ≥85% |" not in testing_plan
+        assert "### Local / Review Targets (non-blocking today)" in testing_plan
+        assert "Wire diff coverage into the required `build.yml` PR gate" in testing_plan
+        assert "Required PR CI may still pass today" in guide_plan
+        assert "local target / future PR gate" in guide_plan
         assert "docs/testing/test_coverage_improvement_plan.md" in contributing
         assert "docs/testing/COLD_ZONE_COVERAGE_PROGRAM.md" in contributing
         assert "**New/changed lines must be 80%+ covered**" not in contributing

--- a/tests/test_organization_system.py
+++ b/tests/test_organization_system.py
@@ -10,6 +10,9 @@ This test verifies that:
 """
 
 import os
+import re
+import shutil
+import stat
 import subprocess
 from pathlib import Path
 
@@ -18,9 +21,48 @@ import pytest
 pytestmark = pytest.mark.unit
 
 
+REPO_ROOT = Path(__file__).parent.parent
+
+
+def _run(cmd: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=str(cwd), capture_output=True, text=True, check=False)
+
+
+def _write(path: Path, content: str = "test\n") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _copy_executable(source: Path, destination: Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, destination)
+    destination.chmod(destination.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _shell_array_values(array_name: str) -> list[str]:
+    script = (REPO_ROOT / "scripts" / "setup" / "pre-commit-check.sh").read_text(encoding="utf-8")
+    pattern = rf"{array_name}=\(\n(?P<body>.*?)\n\)"
+    match = re.search(pattern, script, flags=re.DOTALL)
+    assert match, f"{array_name} block not found"
+    values = []
+    for line in match.group("body").splitlines():
+        candidate = line.strip().strip('"')
+        if candidate:
+            values.append(candidate)
+    return values
+
+
+def _allowed_root_files() -> list[str]:
+    return _shell_array_values("ALLOWED_ROOT_FILES")
+
+
+def _allowed_root_directories() -> list[str]:
+    return _shell_array_values("ALLOWED_ROOT_DIRECTORIES")
+
+
 def test_organization_scripts_exist():
     """Test that all organization scripts exist and are executable."""
-    repo_root = Path(__file__).parent.parent
+    repo_root = REPO_ROOT
 
     scripts = [
         ".auto-organize.sh",
@@ -35,9 +77,23 @@ def test_organization_scripts_exist():
         assert os.access(script_path, os.X_OK), f"Script not executable: {script}"
 
 
+def test_auto_organize_header_lists_governed_validators():
+    """The root organization entrypoint should document the validators it runs."""
+    script = (REPO_ROOT / ".auto-organize.sh").read_text(encoding="utf-8")
+
+    required_helpers = [
+        "scripts/organize_docs.sh",
+        "scripts/setup/pre-commit-check.sh",
+        "scripts/governance/check_script_topology.py",
+        "scripts/governance/check_docs_structure.py",
+    ]
+    for helper in required_helpers:
+        assert helper in script
+
+
 def test_documentation_exists():
     """Test that organization documentation exists."""
-    repo_root = Path(__file__).parent.parent
+    repo_root = REPO_ROOT
 
     docs = [
         "docs/governance/REPO_ORGANIZATION.md",
@@ -49,16 +105,92 @@ def test_documentation_exists():
         assert doc_path.exists(), f"Documentation not found: {doc}"
 
 
+def test_repo_organization_doc_uses_check_mode_for_ci():
+    """CI guidance should use the fail-closed organization validation mode."""
+    doc = (REPO_ROOT / "docs" / "governance" / "REPO_ORGANIZATION.md").read_text(encoding="utf-8")
+
+    assert ".auto-organize.sh --check" in doc
+    assert "CI check that runs `.auto-organize.sh --dry-run`" not in doc
+
+
+def test_docs_only_guidance_mentions_topology_validation():
+    """Docs-only mode should be documented as docs validation, not just move planning."""
+    script = (REPO_ROOT / ".auto-organize.sh").read_text(encoding="utf-8")
+    doc = (REPO_ROOT / "docs" / "governance" / "REPO_ORGANIZATION.md").read_text(encoding="utf-8")
+    combined = script + "\n" + doc
+
+    assert "Only run documentation organization and docs topology validation" in combined
+    assert "Preview docs moves and validate docs topology" in combined
+    assert "Only organize documentation files" not in combined
+    assert "Preview documentation moves only" not in combined
+
+
+def test_organization_hook_installation_guidance_uses_repo_managed_hooks():
+    """Current organization guidance should not teach direct hook symlinks."""
+    doc = (REPO_ROOT / "docs" / "governance" / "REPO_ORGANIZATION.md").read_text(encoding="utf-8")
+    setup_readme = (REPO_ROOT / "scripts" / "setup" / "README.md").read_text(encoding="utf-8")
+    quality_readme = (REPO_ROOT / "scripts" / "README_QUALITY_CONTROL.md").read_text(encoding="utf-8")
+    installer = (REPO_ROOT / "scripts" / "setup" / "auto-organize-install.sh").read_text(encoding="utf-8")
+    combined = "\n".join([doc, setup_readme, quality_readme, installer])
+
+    assert "make install-hooks" in combined
+    assert "pre-commit and pre-push" in combined
+    assert ".git/hooks/pre-push" in combined
+    assert "ln -sf ../../scripts/setup/pre-commit-check.sh .git/hooks/pre-commit" not in combined
+    assert "chmod +x .git/hooks/pre-commit" not in combined
+    assert "pre-commit install -f" not in combined
+    assert "command -v pre-commit" not in installer
+
+
+def test_repo_organization_doc_lists_allowed_root_files():
+    """The governance doc should mirror the root-placement file allowlist."""
+    doc = (REPO_ROOT / "docs" / "governance" / "REPO_ORGANIZATION.md").read_text(encoding="utf-8")
+
+    assert "Current allowed root files" in doc
+    for filename in _allowed_root_files():
+        assert f"`{filename}`" in doc
+
+
+def test_requirements_readme_documents_allowed_root_requirement_files():
+    """The dependency README should describe every allowed root requirements file."""
+    doc = (REPO_ROOT / "requirements" / "README.md").read_text(encoding="utf-8")
+    root_requirement_files = sorted(
+        filename for filename in _allowed_root_files() if filename.startswith("requirements") and filename.endswith(".txt")
+    )
+
+    assert root_requirement_files
+    for filename in root_requirement_files:
+        assert f"`{filename}`" in doc
+
+
+def test_repo_organization_doc_documents_cloudflare_root_shim_boundary():
+    """Root Node files should be documented as Cloudflare Worker deploy shims only."""
+    doc = (REPO_ROOT / "docs" / "governance" / "REPO_ORGANIZATION.md").read_text(encoding="utf-8")
+
+    assert "minimal Workers Builds deploy shim" in doc
+    assert "`cloudflare/transformationportal-worker`" in doc
+    assert "`tests/validation/test_cloudflare_worker_root_shim_contract.py`" in doc
+
+
+def test_repo_organization_doc_lists_allowed_top_level_directories():
+    """The governance doc should mirror the root-placement directory allowlist."""
+    doc = (REPO_ROOT / "docs" / "governance" / "REPO_ORGANIZATION.md").read_text(encoding="utf-8")
+
+    assert "Current allowed top-level directories" in doc
+    for directory in _allowed_root_directories():
+        assert f"`{directory}/`" in doc
+
+
 def test_gitattributes_exists():
     """Test that .gitattributes file exists."""
-    repo_root = Path(__file__).parent.parent
+    repo_root = REPO_ROOT
     gitattributes = repo_root / ".gitattributes"
     assert gitattributes.exists(), ".gitattributes not found"
 
 
 def test_directory_structure():
     """Test that the organized directory structure exists."""
-    repo_root = Path(__file__).parent.parent
+    repo_root = REPO_ROOT
 
     directories = [
         "docs/guides",
@@ -81,7 +213,7 @@ def test_directory_structure():
 
 def test_organization_script_dry_run():
     """Test that the organization script runs in dry-run mode."""
-    repo_root = Path(__file__).parent.parent
+    repo_root = REPO_ROOT
     script = repo_root / ".auto-organize.sh"
 
     result = subprocess.run([str(script), "--dry-run"], cwd=str(repo_root), capture_output=True, text=True, check=False)
@@ -90,9 +222,106 @@ def test_organization_script_dry_run():
     assert "DRY RUN" in result.stdout, "Dry run mode not detected"
 
 
+def test_organization_script_check_mode_uses_validation_messaging():
+    """Check mode should not tell CI users to apply organization changes."""
+    result = _run(["./.auto-organize.sh", "--check"], REPO_ROOT)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Mode: CHECK" in result.stdout
+    assert "Organization validation completed successfully" in result.stdout
+    assert "No organization changes are required." in result.stdout
+    assert "To apply changes, run without --dry-run" not in result.stdout
+
+
+def test_organization_script_docs_only_check_validates_docs_structure():
+    """Docs-only check mode should still run documentation topology validation."""
+    result = _run(["./.auto-organize.sh", "--docs-only", "--check"], REPO_ROOT)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Organizing Documentation Files" in result.stdout
+    assert "Validating Documentation Structure" in result.stdout
+    assert "Summary: 2/2 steps passed" in result.stdout
+    assert "Validating Root File Placement" not in result.stdout
+    assert "Checking for Misplaced Root Scripts" not in result.stdout
+    assert "Validating Script Topology" not in result.stdout
+
+
+def test_organization_script_skip_root_check_only_skips_root_placement():
+    """Skip-root mode should retain non-placement organization validators."""
+    result = _run(["./.auto-organize.sh", "--skip-root", "--check"], REPO_ROOT)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Skipping root file validation (--skip-root)" in result.stdout
+    assert "Checking for Misplaced Root Scripts" in result.stdout
+    assert "Checking for Misplaced Shell Scripts in Root" in result.stdout
+    assert "Validating Script Topology" in result.stdout
+    assert "Validating Documentation Structure" in result.stdout
+    assert "Summary: 6/6 steps passed" in result.stdout
+
+
+def test_auto_organize_flags_retired_root_python_files(tmp_path: Path):
+    """Root setup/conftest/package markers should not bypass root script checks."""
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    assert _run(["git", "init", "-q"], repo_root).returncode == 0
+
+    _copy_executable(REPO_ROOT / ".auto-organize.sh", repo_root / ".auto-organize.sh")
+    _copy_executable(REPO_ROOT / "scripts" / "setup" / "pre-commit-check.sh", repo_root / "scripts/setup/pre-commit-check.sh")
+
+    _write(
+        repo_root / "scripts" / "organize_docs.sh",
+        "#!/usr/bin/env bash\nset -euo pipefail\necho 'No candidate documentation files found.'\n",
+    )
+    _write(
+        repo_root / "scripts" / "governance" / "check_script_topology.py",
+        "#!/usr/bin/env python3\nprint('Script topology check passed.')\n",
+    )
+    _write(
+        repo_root / "scripts" / "governance" / "check_docs_structure.py",
+        "#!/usr/bin/env python3\nprint('Documentation structure check passed.')\n",
+    )
+    for helper in (
+        repo_root / "scripts" / "organize_docs.sh",
+        repo_root / "scripts" / "governance" / "check_script_topology.py",
+        repo_root / "scripts" / "governance" / "check_docs_structure.py",
+    ):
+        helper.chmod(helper.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+    for root_python in ("app.py", "setup.py", "conftest.py", "__init__.py", "helper.py"):
+        _write(repo_root / root_python, "print('placeholder')\n")
+
+    add_result = _run(
+        [
+            "git",
+            "add",
+            ".auto-organize.sh",
+            "scripts/setup/pre-commit-check.sh",
+            "scripts/organize_docs.sh",
+            "scripts/governance/check_script_topology.py",
+            "scripts/governance/check_docs_structure.py",
+            "app.py",
+            "setup.py",
+            "conftest.py",
+            "__init__.py",
+            "helper.py",
+        ],
+        repo_root,
+    )
+    assert add_result.returncode == 0, add_result.stdout + add_result.stderr
+
+    result = _run(["./.auto-organize.sh", "--check"], repo_root)
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "app.py →" not in result.stdout
+    assert "setup.py → governed package, tool, or test location" in result.stdout
+    assert "conftest.py → governed package, tool, or test location" in result.stdout
+    assert "__init__.py → governed package, tool, or test location" in result.stdout
+    assert "helper.py → scripts/ or src/transformation_portal/" in result.stdout
+
+
 def test_files_organized():
     """Test that specific files were moved to correct locations."""
-    repo_root = Path(__file__).parent.parent
+    repo_root = REPO_ROOT
 
     # Files that should have been moved to docs/guides/
     moved_to_guides = [


### PR DESCRIPTION
## Summary
- Root governance guidance had drifted from current organization, hook, dependency, coverage, security, and runtime contracts.
- This patch keeps the change bounded to root-facing policy/config/docs plus regression tests for those contracts.

## Changes
- Hardened `.auto-organize.sh` validation messaging, docs-only behavior, root script checks, and organization success output.
- Updated root operator guidance in `REPO_ORGANIZATION.md`, `CONTRIBUTING.md`, `SECURITY.md`, `CHANGELOG.md`, `requirements.txt`, and `requirements/README.md` to match current codebase contracts.
- Added missing `.env.example` knobs for current backend/auth/worker/artifact defaults and extended `.gitignore` credential coverage.
- Aligned hook setup docs and `scripts/setup/auto-organize-install.sh` with the repo-managed `make install-hooks` pre-commit/pre-push contract.
- Added regression coverage for root allowlists, hook setup guidance, coverage/security/dependency claims, env coverage, ignored credentials, and organization validator behavior.

## Validation
Proven green:
- `git diff --check`
- `bash -n .auto-organize.sh`
- `bash -n scripts/setup/auto-organize-install.sh`
- `.venv/bin/pytest tests/test_codebase_structure.py tests/test_organization_system.py tests/test_pre_commit_check.py tests/structural/test_pre_commit_runtime_contract.py tests/structural/test_gitleaks_hook_registered.py tests/validation/test_cloudflare_worker_root_shim_contract.py tests/validation/test_dockerfile_contract.py tests/validation/test_git_blame_ignore_revs_contract.py tests/validation/test_gitattributes_contract.py tests/validation/test_pylint_config_contract.py tests/test_validate_ci_config.py -q` (`169 passed`)
- `./.auto-organize.sh --check --verbose`
- `python3 scripts/governance/check_docs_structure.py --all`
- `make check-stale-docs`
- `make check-doc-heading-links`
- `make ci-quick`

Still failing:
- None locally. `make ci-quick` reports the existing non-blocking `106 TODO/FIXME` warning count while exiting green.

## Risk
- No route, API envelope, selector, schema, runtime CLI, or frontend behavior changes.
- Risk is documentation/governance drift only; regressions are bounded by focused root-structure, hook, docs, and validation contract tests.
- Revert-safe: the patch is limited to root-facing governance/config/docs and matching tests.
