### PR TITLE
perf(pipelines): add opt-in parallel io batch path

### DIFF
--- a/docs/analysis/PERFORMANCE_OPTIMIZATION_PLAN.md
+++ b/docs/analysis/PERFORMANCE_OPTIMIZATION_PLAN.md
@@ -1,383 +1,186 @@
-# Performance Bottleneck Analysis & Optimization Strategy
+# Performance Optimization Plan
 
-## Critical Bottleneck Identified: I/O Operations in Batch Processing
+## Status
 
-### Problem Statement
-**Current Throughput**: 5-8 images/minute for 4K TIFF processing
-**Target Throughput**: 30-50 images/minute (6-10x improvement)
-**Root Cause**: Sequential I/O operations blocking GPU/CPU compute
+Phase 1 is partially implemented as a bounded parallel I/O primitive and an
+explicit opt-in path for the compatibility Unified Luxury Pipeline.
 
----
+Implemented:
 
-## Profiling Results
+- `transformation_portal.pipelines.parallel_io.ParallelIOPipeline`
+- deterministic per-item results for `load`, `process`, and `save` failures
+- bounded prefetch and save queues
+- background input loading and background output writing
+- TIFF inputs use a `tifffile` pixel-load path with PIL fallback
+- explicit Unified Luxury Pipeline config controls:
+  - `parallel_io`
+  - `io_prefetch_size`
+  - `io_saver_workers`
+- focused unit coverage for ordering, failure isolation, and background-save
+  overlap
 
-### Current Pipeline Breakdown (Single 4K Image)
+Not implemented:
+
+- a new public `--parallel-io` CLI flag
+- default-on behavior for existing batch callers
+- benchmark gate changes
+- GPU/backend acceleration changes
+- memory-mapped TIFF loading
+
+The CLI flag from the earlier draft was intentionally not added because there
+is no active Unified Luxury Pipeline CLI surface. The live CLIs already expose
+their own parallel controls: `transformation-portal process --parallel` for the
+recipe pipeline and `luxury_tiff_batch_processor --workers` for the TIFF batch
+processor. Adding a new flag without a live command would create documentation
+drift rather than an operator feature.
+
+## Current Bottleneck Hypothesis
+
+Large TIFF and multi-format finishing jobs can spend a meaningful share of wall
+time in image load and output writes. The highest-leverage safe change is to
+overlap I/O with compute without changing output formats, color transforms,
+metadata handling, or existing CLI defaults.
+
+Earlier drafts claimed specific throughput targets such as 30-50 images/minute.
+Those numbers should be treated as hypotheses until measured on a current
+fixture set with real benchmark artifacts. Prior performance audits found that
+green benchmark workflows can still produce empty or schema-incompatible
+benchmark output, so optimization claims must be backed by inspected benchmark
+JSON and logs.
+
+## Implemented Architecture
+
+`ParallelIOPipeline` is a generic producer/consumer helper:
+
+```text
+input paths
+  -> loader thread and bounded prefetch queue
+  -> caller-thread processor
+  -> bounded save queue and background saver workers
+  -> ordered per-input results
 ```
-Total Time: 12.5 seconds per image
 
-Breakdown:
-1. File I/O (Load)           4.2s  (34%) ← BOTTLENECK #1
-2. Depth Estimation          2.8s  (22%)
-3. Material Processing       1.5s  (12%)
-4. Color Grading             0.8s  (6%)
-5. File I/O (Save)           2.9s  (23%) ← BOTTLENECK #2
-6. Misc Overhead             0.3s  (3%)
-```
+The primitive is intentionally independent of PIL, tifffile, model runtimes, and
+pipeline-specific state. Callers supply the loader, processor, and saver
+functions. This keeps it reusable for future TIFF, depth, and export workflows
+without coupling the helper to one image representation.
 
-**Key Insight**: 57% of pipeline time is spent on I/O, not computation!
+Failure behavior is fail-isolated:
 
-### Why I/O is Slow
-1. **TIFF Format**: 16-bit uncompressed = 48MB per 4K image
-2. **Sequential Processing**: Load → Process → Save (no parallelism)
-3. **Cold Cache**: Each image read from disk (no prefetching)
-4. **Sync Writes**: `PIL.Image.save()` blocks until disk write complete
-5. **No Buffering**: Single-threaded I/O queue
+- load failures produce a failed item with `stage="load"`
+- process failures produce a failed item with `stage="process"`
+- save failures produce a failed item with `stage="save"`
+- other inputs continue processing
+- returned results preserve the original input order
 
----
+## Unified Luxury Pipeline Integration
 
-## Optimization Strategy: Parallel I/O Pipeline
+The compatibility Unified Luxury Pipeline now supports explicit batch I/O
+overlap:
 
-### Solution Overview
-Implement **producer-consumer pattern** with separate I/O threads:
-
-```
-Input Queue → [Loader Thread] → Processing Queue → [Compute] → Output Queue → [Saver Thread]
-                    ↓                                                ↓
-              Prefetch N+1                                     Async Write
-```
-
-### Architecture
 ```python
-# File: src/transformation_portal/pipelines/parallel_io.py
+from pathlib import Path
 
-from concurrent.futures import ThreadPoolExecutor
-from queue import Queue
-import threading
+from transformation_portal.pipelines import (
+    OutputFormat,
+    ProcessingProfile,
+    UnifiedLuxuryPipeline,
+    UnifiedPipelineConfig,
+)
 
-class ParallelIOPipeline:
-    """
-    Parallel I/O pipeline for batch image processing.
+config = UnifiedPipelineConfig(
+    profile=ProcessingProfile.BALANCED,
+    output_dir=Path("output"),
+    output_formats=[OutputFormat.MASTER_TIFF, OutputFormat.WEB_4K],
+    parallel_io=True,
+    io_prefetch_size=2,
+    io_saver_workers=2,
+)
 
-    Separates I/O operations into background threads:
-    - Loader thread: Prefetches next N images
-    - Saver thread: Asynchronous disk writes
-    - Main thread: Focus on GPU/CPU compute
-
-    Expected speedup: 3-5x for I/O-bound workloads
-    """
-
-    def __init__(self, prefetch_size=2, num_savers=2):
-        self.prefetch_size = prefetch_size
-        self.load_queue = Queue(maxsize=prefetch_size)
-        self.save_queue = Queue(maxsize=prefetch_size * 2)
-        self.loader_pool = ThreadPoolExecutor(max_workers=1)
-        self.saver_pool = ThreadPoolExecutor(max_workers=num_savers)
-
-    def process_batch(self, input_paths, processor_fn):
-        """
-        Process batch with parallel I/O.
-
-        Args:
-            input_paths: List of image file paths
-            processor_fn: Function that takes image, returns processed image
-
-        Returns:
-            List of output paths
-        """
-        # Start loader thread
-        loader_future = self.loader_pool.submit(
-            self._loader_worker, input_paths
-        )
-
-        # Start saver threads
-        saver_futures = [
-            self.saver_pool.submit(self._saver_worker)
-            for _ in range(self.num_savers)
-        ]
-
-        # Main processing loop
-        for i, path in enumerate(input_paths):
-            # Get prefetched image (blocking if not ready)
-            image = self.load_queue.get()
-
-            # Process (GPU/CPU compute)
-            processed = processor_fn(image)
-
-            # Queue for async save (non-blocking)
-            output_path = self._get_output_path(path, i)
-            self.save_queue.put((processed, output_path))
-
-        # Cleanup
-        loader_future.result()
-        self._shutdown_savers()
-
-    def _loader_worker(self, paths):
-        """Background thread: prefetch images."""
-        for path in paths:
-            image = self._load_image(path)
-            self.load_queue.put(image)
-
-    def _saver_worker(self):
-        """Background thread: async save images."""
-        while True:
-            item = self.save_queue.get()
-            if item is None:  # Shutdown signal
-                break
-            image, path = item
-            self._save_image(image, path)
+pipeline = UnifiedLuxuryPipeline(config)
+results = pipeline.batch_process(list(Path("renders").glob("*.tif")))
 ```
 
-### Implementation Steps (Phase 1: High Impact)
+The convenience function exposes the same controls:
 
-#### Step 1: Add Parallel I/O Module (30 minutes)
+```python
+from pathlib import Path
+
+from transformation_portal.pipelines import batch_process_luxury_renders
+
+results = batch_process_luxury_renders(
+    input_dir=Path("renders"),
+    output_dir=Path("output"),
+    parallel_io=True,
+    io_prefetch_size=2,
+    io_saver_workers=2,
+)
+```
+
+Existing behavior is preserved because `parallel_io` defaults to `False`.
+
+## Why The Integration Is Opt-In
+
+The Unified Luxury Pipeline keeps mutable per-call stage state for timing and
+graceful-degradation reporting. The new batch path avoids cross-thread mutation
+by running load and compute in a single ordered path and deferring only output
+generation to background saver workers. That is safe and testable, but it is a
+contract-visible execution-mode change, so it remains explicit rather than
+default-on.
+
+Default-on optimization should wait for:
+
+- benchmark evidence on representative TIFF and JPEG batches
+- memory profiling for high-resolution batches
+- confirmation that optional depth/material stages do not regress due to
+  changed I/O scheduling
+- confirmation that the `tifffile` loader improves wall time on the target
+  storage medium versus the PIL fallback
+- production operator approval for changed batch timing and logging semantics
+
+## Benchmark Requirements
+
+Any future performance claim should include:
+
+- fixture set name and image dimensions
+- storage medium and host hardware
+- pipeline profile and enabled stages
+- prefetch and saver worker settings
+- wall time and images/minute
+- p50/p95 per-image latency
+- peak RSS
+- output quality/hash comparison when deterministic output is expected
+- benchmark artifact path and schema verification
+
+Minimum local measurement command shape:
+
 ```bash
-# Create new module
-touch src/transformation_portal/pipelines/parallel_io.py
-
-# Implement ParallelIOPipeline class (see above)
-# Add tests
-touch tests/test_parallel_io.py
+.venv/bin/python -m pytest tests/test_parallel_io.py tests/test_unified_luxury_pipeline.py -q
 ```
 
-#### Step 2: Integrate with Batch Processor (15 minutes)
-```python
-# File: src/transformation_portal/pipelines/unified_luxury_pipeline.py
+For real throughput measurement, add or reuse a benchmark that writes a non-empty
+artifact with a schema that the consuming workflow validates. Do not treat a
+green workflow as performance evidence unless the artifact contains real
+measurements.
 
-from transformation_portal.pipelines.parallel_io import ParallelIOPipeline
+## Remaining Work
 
-class UnifiedLuxuryPipeline:
-    def __init__(self, use_parallel_io=True):
-        if use_parallel_io:
-            self.io_pipeline = ParallelIOPipeline(
-                prefetch_size=2,  # Load 2 images ahead
-                num_savers=2      # 2 async write threads
-            )
+1. Add a dedicated benchmark harness for Unified Luxury Pipeline batch I/O.
+2. Evaluate whether `parallel_io=True` should become the default after measured
+   evidence and memory limits are understood.
+3. Reassess the recipe pipeline and TIFF batch processor for shared reuse of
+   `ParallelIOPipeline`; both already have existing parallel execution controls,
+   so changes should be evidence-driven.
+4. Keep GPU/backend acceleration work separate from I/O scheduling; it has
+   different dependencies, hardware assumptions, and failure modes.
 
-    def process_batch(self, input_paths):
-        """Process batch with parallel I/O."""
-        return self.io_pipeline.process_batch(
-            input_paths,
-            processor_fn=self._process_single_image
-        )
-```
+## Validation
 
-#### Step 3: Optimize TIFF Loading (10 minutes)
-```python
-# File: src/transformation_portal/utils/tiff_io.py
+Focused validation for this phase:
 
-import tifffile  # Faster than PIL for TIFF
-
-def load_tiff_fast(path, use_mmap=True):
-    """
-    Fast TIFF loading with memory mapping.
-
-    Speedup: 2-3x faster than PIL.Image.open()
-    """
-    if use_mmap:
-        # Memory-mapped read (lazy loading)
-        with tifffile.TiffFile(path) as tif:
-            return tif.asarray(out='memmap')
-    else:
-        return tifffile.imread(path)
-```
-
-#### Step 4: Optimize TIFF Saving (10 minutes)
-```python
-def save_tiff_fast(image, path, compression='lzw', quality=95):
-    """
-    Fast TIFF saving with compression.
-
-    Speedup: 3-4x faster than PIL with LZW compression
-    File size: 50-70% smaller (48MB → 15MB for 4K)
-    """
-    tifffile.imwrite(
-        path,
-        image,
-        compression=compression,  # 'lzw' or 'jpeg'
-        compressionargs={'level': quality},
-        photometric='rgb',
-        planarconfig='contig',
-        metadata={'Software': 'Transformation Portal'}
-    )
-```
-
----
-
-## Expected Performance Improvements
-
-### Before Optimization (Baseline)
-```
-Single Image Processing Time: 12.5s
-  - Load TIFF:  4.2s
-  - Process:    5.4s
-  - Save TIFF:  2.9s
-
-Batch Throughput: 4.8 images/minute (60s / 12.5s)
-```
-
-### After Phase 1 Optimization
-```
-Single Image Processing Time: 6.2s (-50%)
-  - Load TIFF:  0.8s (prefetched, -81%)
-  - Process:    5.4s (unchanged)
-  - Save TIFF:  0.0s (async, non-blocking)
-
-Batch Throughput: 11.1 images/minute (+131%)
-```
-
-### After Phase 2: GPU Optimization (V2-Large + CUDA)
-```
-Single Image Processing Time: 3.5s (-72% from baseline)
-  - Load TIFF:  0.8s
-  - Process:    2.7s (V2-Large on CUDA, -50%)
-  - Save TIFF:  0.0s (async)
-
-Batch Throughput: 30-50 images/minute (+525-940%)
-```
-
----
-
-## Cost-Benefit Analysis
-
-### Phase 1: Parallel I/O (RECOMMENDED - Highest ROI)
-- **Development Time**: 2 hours
-- **Testing Time**: 1 hour
-- **Speedup**: 2-3x
-- **Risk**: Low (isolated module, easy rollback)
-- **Dependencies**: None (stdlib only)
-- **Impact**: Immediate 130% throughput increase
-
-### Phase 2: TIFF Optimization
-- **Development Time**: 1 hour
-- **Testing Time**: 30 minutes
-- **Speedup**: Additional 1.5x
-- **Risk**: Low (tifffile is battle-tested)
-- **Dependencies**: tifffile (already installed)
-- **Impact**: 50% faster I/O
-
-### Phase 3: GPU Acceleration
-- **Development Time**: 4 hours (see DEPTH_ANYTHING_V2_ANALYSIS.md)
-- **Testing Time**: 2 hours
-- **Speedup**: Additional 2x
-- **Risk**: Medium (GPU availability, CUDA setup)
-- **Dependencies**: CUDA toolkit, NVIDIA GPU
-- **Impact**: 100% faster compute
-
----
-
-## Implementation Roadmap
-
-### Week 1: Parallel I/O (HIGH PRIORITY)
-**Monday**
-- [ ] Create `parallel_io.py` module
-- [ ] Implement `ParallelIOPipeline` class
-- [ ] Add unit tests
-
-**Tuesday**
-- [ ] Integrate with `UnifiedLuxuryPipeline`
-- [ ] Add CLI flag `--parallel-io / --no-parallel-io`
-- [ ] Benchmark on 100-image test set
-
-**Wednesday**
-- [ ] Optimize TIFF loading with `tifffile`
-- [ ] Optimize TIFF saving with LZW compression
-- [ ] Update documentation
-
-**Thursday**
-- [ ] Code review and refinements
-- [ ] Performance regression tests
-- [ ] Merge to main
-
-**Friday**
-- [ ] Monitor production metrics
-- [ ] Write blog post on optimization techniques
-
-### Week 2: GPU Acceleration (if available)
-- See DEPTH_ANYTHING_V2_ANALYSIS.md for detailed plan
-
----
-
-## Monitoring & Validation
-
-### Metrics to Track
-1. **Throughput**: Images processed per minute
-2. **Latency**: Time per image (p50, p95, p99)
-3. **I/O Wait**: % time blocked on disk
-4. **GPU Utilization**: % time GPU is active
-5. **Memory Usage**: Peak RAM/VRAM consumption
-
-### Benchmark Script
 ```bash
-# Run performance benchmark
-python -m transformation_portal.tools.benchmark_pipeline \
-    --input-dir tests/fixtures/4k_batch/ \
-    --num-images 100 \
-    --parallel-io \
-    --output-report reports/perf_$(date +%Y%m%d).json
-
-# Compare before/after
-python -m transformation_portal.tools.compare_benchmarks \
-    reports/perf_baseline.json \
-    reports/perf_optimized.json
+.venv/bin/pytest tests/test_parallel_io.py tests/test_unified_luxury_pipeline.py -q
+git diff --check
 ```
 
-### Success Criteria
-- ✅ Throughput increases by 100%+ (2x)
-- ✅ I/O wait time < 20% (currently 57%)
-- ✅ GPU utilization > 70% (currently ~40%)
-- ✅ No quality regression (PSNR, SSIM)
-- ✅ Memory usage stays under 16GB
-
----
-
-## Alternative Bottlenecks (Lower Priority)
-
-### 2. Material Processing (1.5s, 12% of time)
-**Current**: K-means clustering in Python
-**Optimization**: Numba JIT compilation or Rust extension
-**Expected Speedup**: 2-3x
-**Effort**: High (2-3 days)
-**ROI**: Low (only 12% of total time)
-
-### 3. Color Grading (0.8s, 6% of time)
-**Current**: Sequential LUT application
-**Optimization**: Vectorized NumPy operations
-**Expected Speedup**: 1.5x
-**Effort**: Medium (4 hours)
-**ROI**: Low (only 6% of total time)
-
-### 4. Depth Estimation (2.8s, 22% of time)
-**Current**: V2-Small on MPS
-**Optimization**: V2-Large on CUDA + FP16
-**Expected Speedup**: 2x (see DEPTH_ANYTHING_V2_ANALYSIS.md)
-**Effort**: Medium (2-4 hours)
-**ROI**: High (22% of total time + quality improvement)
-
----
-
-## Conclusion
-
-**Immediate Action**: Implement parallel I/O pipeline
-**Impact**: 130% throughput increase (4.8 → 11.1 images/min)
-**Effort**: 3 hours development + testing
-**Risk**: Low (isolated module, easy rollback)
-
-**Follow-Up Actions**:
-1. TIFF optimization (+50% I/O speed)
-2. Depth model upgrade (+quality + 2x compute speed)
-3. Material processing JIT (+50% material speed)
-
-**Total Expected Improvement**: 5-10x faster batch processing
-
----
-
-## References
-
-- [Python Threading Best Practices](https://docs.python.org/3/library/threading.html)
-- [tifffile Documentation](https://pypi.org/project/tifffile/)
-- [Producer-Consumer Pattern](https://en.wikipedia.org/wiki/Producer%E2%80%93consumer_problem)
-- [Profiling Python Code](https://docs.python.org/3/library/profile.html)
-
-**Last Updated**: 2025-11-11
-**Author**: Performance Engineering Team
-**Status**: Ready for Implementation ✅
+Broader validation should include `make ci-quick` before merging into `main`.

--- a/docs/guides/UNIFIED_LUXURY_PIPELINE.md
+++ b/docs/guides/UNIFIED_LUXURY_PIPELINE.md
@@ -106,11 +106,19 @@ from transformation_portal.pipelines import batch_process_luxury_renders
 results = batch_process_luxury_renders(
     input_dir=Path("renders"),
     output_dir=Path("output"),
-    profile=ProcessingProfile.BALANCED
+    profile=ProcessingProfile.BALANCED,
+    parallel_io=True,
+    io_prefetch_size=2,
+    io_saver_workers=2,
 )
 
 print(f"Processed {len(results)} images")
 ```
+
+`parallel_io` is opt-in for compatibility. It overlaps input loading and output
+writing for batch runs while preserving result ordering and per-image failure
+isolation. Keep it disabled when comparing against older timing baselines or
+when debugging per-stage behavior.
 
 ## Configuration Guide
 
@@ -170,6 +178,10 @@ config = UnifiedPipelineConfig(
 config = UnifiedPipelineConfig(
     device="auto",              # auto, cpu, cuda, mps
     preserve_metadata=True,     # Preserve EXIF/IPTC/XMP
+    parallel_outputs=True,      # Generate requested output formats in parallel
+    parallel_io=False,          # Opt in to overlapped batch load/save I/O
+    io_prefetch_size=2,         # Images to prefetch when parallel_io=True
+    io_saver_workers=2,         # Background output workers when parallel_io=True
     save_intermediates=False    # Save depth maps, etc.
 )
 ```

--- a/src/transformation_portal/pipelines/__init__.py
+++ b/src/transformation_portal/pipelines/__init__.py
@@ -13,6 +13,8 @@ __all__ = [
     "OutputFormat",
     "PipelineStage",
     "PipelineStatistics",
+    "ParallelIOItemResult",
+    "ParallelIOPipeline",
     "process_luxury_render",
     "batch_process_luxury_renders",
     # 4K Rendering Pipeline
@@ -53,9 +55,16 @@ def __getattr__(name: str):
         "OutputFormat",
         "PipelineStage",
         "PipelineStatistics",
+        "ParallelIOItemResult",
+        "ParallelIOPipeline",
         "process_luxury_render",
         "batch_process_luxury_renders",
     ):
+        if name in ("ParallelIOItemResult", "ParallelIOPipeline"):
+            from .parallel_io import ParallelIOItemResult, ParallelIOPipeline
+
+            return locals()[name]
+
         from .unified_luxury_pipeline import (
             OutputFormat,
             PipelineStage,

--- a/src/transformation_portal/pipelines/parallel_io.py
+++ b/src/transformation_portal/pipelines/parallel_io.py
@@ -1,0 +1,248 @@
+"""Bounded producer/consumer helpers for image batch I/O.
+
+The pipeline overlaps three phases while preserving deterministic result order:
+load in a background thread, process on the caller thread, and save in one or
+more background threads. Callers provide the actual load/process/save functions
+so this module remains independent of PIL, tifffile, and model runtimes.
+"""
+
+from __future__ import annotations
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from pathlib import Path
+from queue import Queue
+from typing import Callable, Generic, Literal, Sequence, TypeVar, cast
+
+LoadedT = TypeVar("LoadedT")
+ProcessedT = TypeVar("ProcessedT")
+SavedT = TypeVar("SavedT")
+
+ParallelIOStage = Literal["load", "process", "save", "internal"]
+
+
+@dataclass(frozen=True)
+class ParallelIOItemResult(Generic[SavedT]):
+    """Per-input result emitted by :class:`ParallelIOPipeline`."""
+
+    input_path: Path
+    output: SavedT | None = None
+    error: Exception | None = None
+    stage: ParallelIOStage | None = None
+
+    @property
+    def succeeded(self) -> bool:
+        """Return True when load, process, and save all completed."""
+
+        return self.error is None
+
+
+@dataclass(frozen=True)
+class _LoadedItem(Generic[LoadedT]):
+    index: int
+    input_path: Path
+    payload: LoadedT
+
+
+@dataclass(frozen=True)
+class _SaveItem(Generic[ProcessedT]):
+    index: int
+    input_path: Path
+    payload: ProcessedT
+
+
+@dataclass(frozen=True)
+class _Failure:
+    index: int
+    input_path: Path
+    stage: ParallelIOStage
+    error: Exception
+
+
+_SENTINEL = object()
+
+
+class ParallelIOPipeline(Generic[LoadedT, ProcessedT, SavedT]):
+    """Overlap load, process, and save stages for bounded batch work."""
+
+    def __init__(
+        self,
+        *,
+        loader: Callable[[Path], LoadedT],
+        saver: Callable[[Path, ProcessedT], SavedT],
+        prefetch_size: int = 2,
+        num_savers: int = 2,
+        save_queue_size: int | None = None,
+        thread_name_prefix: str = "parallel_io",
+    ) -> None:
+        if prefetch_size < 1:
+            raise ValueError("prefetch_size must be >= 1")
+        if num_savers < 1:
+            raise ValueError("num_savers must be >= 1")
+        if save_queue_size is not None and save_queue_size < 1:
+            raise ValueError("save_queue_size must be >= 1 when provided")
+
+        self._loader = loader
+        self._saver = saver
+        self.prefetch_size = prefetch_size
+        self.num_savers = num_savers
+        self.save_queue_size = save_queue_size or max(
+            prefetch_size * num_savers,
+            1,
+        )
+        self.thread_name_prefix = thread_name_prefix
+
+    def process_batch(
+        self,
+        input_paths: Sequence[Path | str],
+        processor_fn: Callable[[Path, LoadedT], ProcessedT],
+    ) -> list[ParallelIOItemResult[SavedT]]:
+        """Process *input_paths* while preserving caller order.
+
+        Individual item failures are returned as failed results instead of
+        aborting the entire batch. Unexpected worker failures still surface as
+        ``internal`` item errors for inputs that never produced a result.
+        """
+
+        paths = [Path(path) for path in input_paths]
+        if not paths:
+            return []
+
+        load_queue: Queue[_LoadedItem[LoadedT] | _Failure | object] = Queue(
+            maxsize=self.prefetch_size,
+        )
+        save_queue: Queue[_SaveItem[ProcessedT] | object] = Queue(
+            maxsize=self.save_queue_size,
+        )
+        results: list[ParallelIOItemResult[SavedT] | None] = [None] * len(paths)
+        result_lock = threading.Lock()
+
+        def record(index: int, result: ParallelIOItemResult[SavedT]) -> None:
+            with result_lock:
+                results[index] = result
+
+        def loader_worker() -> None:
+            try:
+                for index, input_path in enumerate(paths):
+                    try:
+                        payload = self._loader(input_path)
+                    except Exception as exc:
+                        load_queue.put(
+                            _Failure(index, input_path, "load", exc),
+                        )
+                    else:
+                        load_queue.put(_LoadedItem(index, input_path, payload))
+            finally:
+                load_queue.put(_SENTINEL)
+
+        def saver_worker() -> None:
+            while True:
+                item = save_queue.get()
+                try:
+                    if item is _SENTINEL:
+                        return
+
+                    save_item = cast(_SaveItem[ProcessedT], item)
+                    try:
+                        output = self._saver(
+                            save_item.input_path,
+                            save_item.payload,
+                        )
+                    except Exception as exc:
+                        record(
+                            save_item.index,
+                            ParallelIOItemResult(
+                                input_path=save_item.input_path,
+                                error=exc,
+                                stage="save",
+                            ),
+                        )
+                    else:
+                        record(
+                            save_item.index,
+                            ParallelIOItemResult(
+                                input_path=save_item.input_path,
+                                output=output,
+                            ),
+                        )
+                finally:
+                    save_queue.task_done()
+
+        with ThreadPoolExecutor(
+            max_workers=1 + self.num_savers,
+            thread_name_prefix=self.thread_name_prefix,
+        ) as executor:
+            loader_future = executor.submit(loader_worker)
+            saver_futures = [executor.submit(saver_worker) for _ in range(self.num_savers)]
+
+            while True:
+                loaded = load_queue.get()
+                try:
+                    if loaded is _SENTINEL:
+                        break
+
+                    if isinstance(loaded, _Failure):
+                        record(
+                            loaded.index,
+                            ParallelIOItemResult(
+                                input_path=loaded.input_path,
+                                error=loaded.error,
+                                stage=loaded.stage,
+                            ),
+                        )
+                        continue
+
+                    loaded_item = cast(_LoadedItem[LoadedT], loaded)
+                    try:
+                        processed = processor_fn(
+                            loaded_item.input_path,
+                            loaded_item.payload,
+                        )
+                    except Exception as exc:
+                        record(
+                            loaded_item.index,
+                            ParallelIOItemResult(
+                                input_path=loaded_item.input_path,
+                                error=exc,
+                                stage="process",
+                            ),
+                        )
+                    else:
+                        save_queue.put(
+                            _SaveItem(
+                                loaded_item.index,
+                                loaded_item.input_path,
+                                processed,
+                            ),
+                        )
+                finally:
+                    load_queue.task_done()
+
+            loader_future.result()
+            for _ in range(self.num_savers):
+                save_queue.put(_SENTINEL)
+            for saver_future in saver_futures:
+                saver_future.result()
+
+        return [
+            (
+                result
+                if result is not None
+                else ParallelIOItemResult(
+                    input_path=paths[index],
+                    error=RuntimeError(
+                        "parallel I/O worker finished without producing a result",
+                    ),
+                    stage="internal",
+                )
+            )
+            for index, result in enumerate(results)
+        ]
+
+
+__all__ = [
+    "ParallelIOItemResult",
+    "ParallelIOPipeline",
+    "ParallelIOStage",
+]

--- a/src/transformation_portal/pipelines/unified_luxury_pipeline.py
+++ b/src/transformation_portal/pipelines/unified_luxury_pipeline.py
@@ -66,6 +66,8 @@ import numpy as np
 from PIL import Image
 from tqdm import tqdm
 
+from transformation_portal.pipelines.parallel_io import ParallelIOPipeline
+
 # Optional imports with graceful fallback
 try:
     import tifffile
@@ -137,6 +139,9 @@ class UnifiedPipelineConfig:
         device: Processing device (auto/cpu/cuda/mps)
         preserve_metadata: Preserve EXIF/IPTC/XMP metadata
         parallel_outputs: Generate output formats in parallel
+        parallel_io: Overlap batch input loading and output writing
+        io_prefetch_size: Number of input images to prefetch during batch work
+        io_saver_workers: Number of background workers for batch output writes
         save_intermediates: Save intermediate processing stages
     """
 
@@ -171,6 +176,9 @@ class UnifiedPipelineConfig:
     # Advanced options
     preserve_metadata: bool = True
     parallel_outputs: bool = True
+    parallel_io: bool = False
+    io_prefetch_size: int = 2
+    io_saver_workers: int = 2
     save_intermediates: bool = False
 
     def __post_init__(self):
@@ -193,6 +201,8 @@ class UnifiedPipelineConfig:
         self.saturation = max(0.0, min(2.0, self.saturation))
         self.clarity = max(0.0, min(1.0, self.clarity))
         self.lut_strength = max(0.0, min(1.0, self.lut_strength))
+        self.io_prefetch_size = max(1, int(self.io_prefetch_size))
+        self.io_saver_workers = max(1, int(self.io_saver_workers))
 
 
 @dataclass
@@ -257,6 +267,30 @@ class PipelineStatistics:
 
         lines.append("=" * 70)
         return "\n".join(lines)
+
+
+@dataclass(frozen=True)
+class _LoadedBatchImage:
+    image: Image.Image
+    metadata: Dict[str, Any]
+    elapsed_time: float
+
+
+@dataclass(frozen=True)
+class _OutputGenerationWork:
+    image: Image.Image
+    input_path: Path
+    metadata: Dict[str, Any]
+    config: UnifiedPipelineConfig
+    started_at: float
+    stage_times: Dict[str, float]
+
+
+@dataclass(frozen=True)
+class _SavedBatchOutputs:
+    outputs: Dict[str, Path]
+    total_time: float
+    stage_times: Dict[str, float]
 
 
 class UnifiedLuxuryPipeline:
@@ -469,6 +503,9 @@ class UnifiedLuxuryPipeline:
         """
         log.info(f"Batch processing {len(input_paths)} images")
 
+        if self.config.parallel_io and len(input_paths) > 1:
+            return self._batch_process_parallel_io(input_paths, show_progress=show_progress)
+
         results = {}
         iterator = tqdm(input_paths, desc="Processing") if show_progress else input_paths
 
@@ -483,6 +520,145 @@ class UnifiedLuxuryPipeline:
         log.info(self.stats.summary())
 
         return results
+
+    def _batch_process_parallel_io(
+        self,
+        input_paths: List[Path],
+        *,
+        show_progress: bool = True,
+    ) -> Dict[Path, Dict[str, Path]]:
+        """Process a batch with overlapped input prefetching and output writes."""
+
+        log.info(
+            "Parallel I/O enabled: prefetch=%s, savers=%s",
+            self.config.io_prefetch_size,
+            self.config.io_saver_workers,
+        )
+
+        started = time.time()
+        aggregate_stage_times: Dict[str, float] = {}
+
+        io_pipeline: ParallelIOPipeline[_LoadedBatchImage, _OutputGenerationWork, _SavedBatchOutputs] = ParallelIOPipeline(
+            loader=self._load_batch_image,
+            saver=self._save_batch_outputs,
+            prefetch_size=self.config.io_prefetch_size,
+            num_savers=self.config.io_saver_workers,
+            thread_name_prefix="unified_luxury_io",
+        )
+
+        io_results = io_pipeline.process_batch(input_paths, self._prepare_batch_output_work)
+
+        results: Dict[Path, Dict[str, Path]] = {}
+        result_iterator = tqdm(io_results, desc="Processing") if show_progress else io_results
+        for item in result_iterator:
+            if item.succeeded and item.output is not None:
+                saved = item.output
+                results[item.input_path] = saved.outputs
+                self.stats.images_processed += 1
+                self.stats.total_time += saved.total_time
+                self.stats.output_files[str(item.input_path)] = list(saved.outputs.values())
+                for stage_name, elapsed in saved.stage_times.items():
+                    aggregate_stage_times[stage_name] = aggregate_stage_times.get(stage_name, 0.0) + elapsed
+                continue
+
+            error = item.error or RuntimeError("unknown parallel I/O failure")
+            stage = item.stage or "unknown"
+            log.error("Failed to process %s during %s stage: %s", item.input_path.name, stage, error)
+            results[item.input_path] = {}
+            self.stats.images_failed += 1
+
+        self.stats.stage_times = aggregate_stage_times
+        log.info("Parallel I/O batch wall time: %.2fs", time.time() - started)
+        log.info(self.stats.summary())
+
+        return results
+
+    def _load_batch_image(self, input_path: Path) -> _LoadedBatchImage:
+        """Load an image for a parallel-I/O batch item."""
+
+        start = time.time()
+        image, metadata = self._load_image(input_path)
+        return _LoadedBatchImage(
+            image=image,
+            metadata=metadata,
+            elapsed_time=time.time() - start,
+        )
+
+    def _prepare_batch_output_work(
+        self,
+        input_path: Path,
+        loaded: _LoadedBatchImage,
+    ) -> _OutputGenerationWork:
+        """Run compute stages for a loaded batch item and defer output I/O."""
+
+        started_at = time.time() - loaded.elapsed_time
+        temp_config = self._apply_overrides({})
+        temp_config.output_dir.mkdir(parents=True, exist_ok=True)
+        self._configure_stage_state(temp_config)
+        self.stats.stage_times["Load & Validate"] = loaded.elapsed_time
+        self.stages["load"].success = True
+        self.stages["load"].elapsed_time = loaded.elapsed_time
+
+        image = loaded.image
+        metadata = loaded.metadata
+
+        if self.stages["scene_detect"].enabled:
+            scene_type = self._execute_stage("scene_detect", self._detect_scene_type, image)
+            temp_config.scene_type = scene_type
+            log.info(f"  Detected scene type: {scene_type.value}")
+
+        params = self._optimize_parameters(temp_config)
+
+        if self.stages["depth"].enabled:
+            image = self._execute_stage("depth", self._apply_depth_processing, image, params, temp_config)
+
+        if self.stages["material"].enabled:
+            image = self._execute_stage(
+                "material",
+                self._apply_material_response,
+                image,
+                params,
+                temp_config.scene_type,
+            )
+
+        if self.stages["vfx"].enabled:
+            image = self._execute_stage("vfx", self._apply_vfx_effects, image, params)
+
+        if self.stages["color_grade"].enabled:
+            image = self._execute_stage(
+                "color_grade",
+                self._apply_color_grading,
+                image,
+                params,
+                temp_config,
+            )
+
+        return _OutputGenerationWork(
+            image=image,
+            input_path=input_path,
+            metadata=metadata,
+            config=temp_config,
+            started_at=started_at,
+            stage_times=self.stats.stage_times.copy(),
+        )
+
+    def _save_batch_outputs(
+        self,
+        input_path: Path,
+        work: _OutputGenerationWork,
+    ) -> _SavedBatchOutputs:
+        """Write outputs for a prepared batch item."""
+
+        start = time.time()
+        outputs = self._generate_outputs(work.image, input_path, work.metadata, work.config)
+        elapsed = time.time() - start
+        stage_times = work.stage_times.copy()
+        stage_times["Output Generation"] = elapsed
+        return _SavedBatchOutputs(
+            outputs=outputs,
+            total_time=time.time() - work.started_at,
+            stage_times=stage_times,
+        )
 
     def get_statistics(self) -> Dict[str, Any]:
         """
@@ -507,6 +683,9 @@ class UnifiedLuxuryPipeline:
                 "scene_type": self.config.scene_type.value,
                 "device": self.device,
                 "output_formats": [fmt.value for fmt in self.config.output_formats],
+                "parallel_io": self.config.parallel_io,
+                "io_prefetch_size": self.config.io_prefetch_size,
+                "io_saver_workers": self.config.io_saver_workers,
             },
         }
 
@@ -598,26 +777,105 @@ class UnifiedLuxuryPipeline:
 
         log.info(f"Loading: {input_path.name}")
 
-        # Load image
         image = Image.open(input_path)
+        metadata = self._extract_image_metadata(image)
 
-        # Extract metadata
-        metadata = {
-            "format": image.format,
-            "mode": image.mode,
-            "size": image.size,
-            "info": image.info.copy() if hasattr(image, "info") else {},
-        }
+        if self._is_tiff_path(input_path) and HAS_TIFFFILE:
+            tiff_image = self._load_tiff_with_tifffile(input_path, metadata)
+            if tiff_image is not None:
+                image.close()
+                image = tiff_image
 
-        # Convert to RGB if needed
         if image.mode != "RGB":
             log.info(f"  Converting {image.mode} → RGB")
             image = image.convert("RGB")
+
+        image.load()
 
         log.info(f"  Size: {image.size[0]}x{image.size[1]}")
         log.info(f"  Format: {metadata['format']}")
 
         return image, metadata
+
+    @staticmethod
+    def _is_tiff_path(input_path: Path) -> bool:
+        """Return True for TIFF extensions supported by the fast loader."""
+
+        return input_path.suffix.lower() in {".tif", ".tiff"}
+
+    @staticmethod
+    def _extract_image_metadata(image: Image.Image) -> Dict[str, Any]:
+        """Extract the metadata contract used by downstream output generation."""
+
+        return {
+            "format": image.format,
+            "mode": image.mode,
+            "size": image.size,
+            "info": image.info.copy() if hasattr(image, "info") else {},
+            "load_backend": "PIL",
+        }
+
+    def _load_tiff_with_tifffile(
+        self,
+        input_path: Path,
+        metadata: Dict[str, Any],
+    ) -> Optional[Image.Image]:
+        """Load TIFF pixel data through tifffile with PIL fallback on failure."""
+
+        try:
+            array = tifffile.imread(input_path)
+        except Exception as exc:  # noqa: BLE001 - fallback is deliberate
+            log.warning("  tifffile load failed for %s, falling back to PIL: %s", input_path.name, exc)
+            return None
+
+        try:
+            image = self._array_to_rgb_image(array)
+        except Exception as exc:  # noqa: BLE001 - fallback is deliberate
+            log.warning("  tifffile array conversion failed for %s, falling back to PIL: %s", input_path.name, exc)
+            return None
+
+        metadata["load_backend"] = "tifffile"
+        metadata["source_dtype"] = str(getattr(array, "dtype", "unknown"))
+        return image
+
+    @staticmethod
+    def _array_to_rgb_image(array: np.ndarray) -> Image.Image:
+        """Convert TIFF array data to an RGB PIL image for compatibility stages."""
+
+        arr = np.asarray(array)
+        if arr.ndim == 3 and arr.shape[0] in {3, 4} and arr.shape[-1] not in {3, 4}:
+            arr = np.moveaxis(arr, 0, -1)
+
+        if arr.dtype == np.uint8:
+            arr8 = arr
+        elif arr.dtype == np.uint16:
+            arr8 = (arr.astype(np.float32) / 65535.0 * 255.0).round().astype(np.uint8)
+        elif np.issubdtype(arr.dtype, np.floating):
+            arr8 = (np.clip(arr.astype(np.float32), 0.0, 1.0) * 255.0).round().astype(np.uint8)
+        else:
+            arr_min = float(np.min(arr))
+            arr_max = float(np.max(arr))
+            if arr_max <= arr_min:
+                arr8 = np.zeros_like(arr, dtype=np.uint8)
+            else:
+                arr8 = ((arr.astype(np.float32) - arr_min) / (arr_max - arr_min) * 255.0).round().astype(np.uint8)
+
+        if arr8.ndim == 2:
+            return Image.fromarray(arr8, mode="L").convert("RGB")
+
+        if arr8.ndim != 3:
+            raise ValueError(f"Unsupported TIFF array shape: {arr8.shape}")
+
+        channels = arr8.shape[-1]
+        if channels == 1:
+            return Image.fromarray(arr8[:, :, 0], mode="L").convert("RGB")
+        if channels in {3, 4}:
+            mode = "RGBA" if channels == 4 else "RGB"
+            return Image.fromarray(arr8, mode=mode).convert("RGB")
+        if channels > 4:
+            return Image.fromarray(arr8[:, :, :3], mode="RGB")
+
+        raise ValueError(f"Unsupported TIFF channel count: {channels}")
 
     def _detect_scene_type(self, image: Image.Image) -> SceneType:
         """
@@ -1462,6 +1720,9 @@ class UnifiedLuxuryPipeline:
                 "scene_type": self.config.scene_type.value,
                 "device": self.device,
                 "output_formats": [fmt.value for fmt in self.config.output_formats],
+                "parallel_io": self.config.parallel_io,
+                "io_prefetch_size": self.config.io_prefetch_size,
+                "io_saver_workers": self.config.io_saver_workers,
             },
         }
 
@@ -1546,6 +1807,9 @@ def batch_process_luxury_renders(
     output_dir: Path = Path("output"),
     profile: ProcessingProfile = ProcessingProfile.BALANCED,
     pattern: str = DEFAULT_BATCH_PATTERN,
+    parallel_io: bool = False,
+    io_prefetch_size: int = 2,
+    io_saver_workers: int = 2,
 ) -> Dict[Path, Dict[str, Path]]:
     """
     Convenience function for batch processing luxury renders.
@@ -1555,6 +1819,9 @@ def batch_process_luxury_renders(
         output_dir: Output directory
         profile: Processing quality profile
         pattern: Glob pattern for input files
+        parallel_io: Overlap image loading and output writing during batch processing
+        io_prefetch_size: Number of input images to prefetch when parallel_io is enabled
+        io_saver_workers: Number of background output workers when parallel_io is enabled
 
     Returns:
         Dictionary mapping input paths to output dictionaries
@@ -1582,6 +1849,9 @@ def batch_process_luxury_renders(
         enable_depth=True,
         enable_material_response=True,
         enable_color_grading=True,
+        parallel_io=parallel_io,
+        io_prefetch_size=io_prefetch_size,
+        io_saver_workers=io_saver_workers,
     )
 
     pipeline = UnifiedLuxuryPipeline(config)

--- a/src/transformation_portal/pipelines/unified_luxury_pipeline.py
+++ b/src/transformation_portal/pipelines/unified_luxury_pipeline.py
@@ -823,7 +823,18 @@ class UnifiedLuxuryPipeline:
         """Load TIFF pixel data through tifffile with PIL fallback on failure."""
 
         try:
-            array = tifffile.imread(input_path)
+            with tifffile.TiffFile(input_path) as tiff:
+                page = tiff.pages[0]
+                photometric = self._tiff_photometric_name(page)
+                metadata["tiff_photometric"] = photometric
+                if photometric not in {"MINISBLACK", "RGB"}:
+                    metadata["tifffile_skip_reason"] = "unsupported_photometric"
+                    log.info(
+                        "  TIFF photometric %s requires PIL interpretation; skipping tifffile fast path",
+                        photometric,
+                    )
+                    return None
+                array = page.asarray()
         except Exception as exc:  # noqa: BLE001 - fallback is deliberate
             log.warning("  tifffile load failed for %s, falling back to PIL: %s", input_path.name, exc)
             return None
@@ -837,6 +848,16 @@ class UnifiedLuxuryPipeline:
         metadata["load_backend"] = "tifffile"
         metadata["source_dtype"] = str(getattr(array, "dtype", "unknown"))
         return image
+
+    @staticmethod
+    def _tiff_photometric_name(page: Any) -> str:
+        """Return a stable TIFF photometric label for fast-path allowlisting."""
+
+        photometric = getattr(page, "photometric", None)
+        name = getattr(photometric, "name", None)
+        if name:
+            return str(name).upper()
+        return str(photometric).upper()
 
     @staticmethod
     def _array_to_rgb_image(array: np.ndarray) -> Image.Image:

--- a/tests/test_parallel_io.py
+++ b/tests/test_parallel_io.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+import pytest
+
+from transformation_portal.pipelines.parallel_io import ParallelIOPipeline
+
+pytestmark = pytest.mark.unit
+
+
+def test_parallel_io_preserves_input_order_and_writes_outputs(
+    tmp_path: Path,
+) -> None:
+    input_paths = [tmp_path / f"input_{index}.txt" for index in range(3)]
+    for index, input_path in enumerate(input_paths):
+        input_path.write_text(str(index), encoding="utf-8")
+
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+
+    def loader(path: Path) -> int:
+        return int(path.read_text(encoding="utf-8"))
+
+    def processor(path: Path, value: int) -> tuple[Path, int]:
+        return output_dir / path.name, value * 10
+
+    def saver(_path: Path, payload: tuple[Path, int]) -> Path:
+        output_path, value = payload
+        output_path.write_text(str(value), encoding="utf-8")
+        return output_path
+
+    pipeline = ParallelIOPipeline(
+        loader=loader,
+        saver=saver,
+        prefetch_size=2,
+        num_savers=2,
+    )
+
+    results = pipeline.process_batch(input_paths, processor)
+
+    assert [result.input_path for result in results] == input_paths
+    assert [result.succeeded for result in results] == [True, True, True]
+    assert [result.output.name for result in results if result.output is not None] == [path.name for path in input_paths]
+    assert [(output_dir / path.name).read_text(encoding="utf-8") for path in input_paths] == ["0", "10", "20"]
+
+
+def test_parallel_io_reports_load_process_and_save_failures(
+    tmp_path: Path,
+) -> None:
+    input_paths = [
+        tmp_path / "load_fail.txt",
+        tmp_path / "process_fail.txt",
+        tmp_path / "save_fail.txt",
+        tmp_path / "ok.txt",
+    ]
+    for input_path in input_paths:
+        input_path.write_text(input_path.stem, encoding="utf-8")
+
+    def loader(path: Path) -> str:
+        if path.name == "load_fail.txt":
+            raise OSError("load failed")
+        return path.read_text(encoding="utf-8")
+
+    def processor(path: Path, value: str) -> str:
+        if path.name == "process_fail.txt":
+            raise RuntimeError("process failed")
+        return value.upper()
+
+    def saver(path: Path, value: str) -> str:
+        if path.name == "save_fail.txt":
+            raise ValueError("save failed")
+        return f"{path.name}:{value}"
+
+    pipeline = ParallelIOPipeline(
+        loader=loader,
+        saver=saver,
+        prefetch_size=2,
+        num_savers=2,
+    )
+
+    results = pipeline.process_batch(input_paths, processor)
+
+    assert [(result.input_path.name, result.succeeded, result.stage) for result in results] == [
+        ("load_fail.txt", False, "load"),
+        ("process_fail.txt", False, "process"),
+        ("save_fail.txt", False, "save"),
+        ("ok.txt", True, None),
+    ]
+    assert results[-1].output == "ok.txt:OK"
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"prefetch_size": 0},
+        {"num_savers": 0},
+        {"save_queue_size": 0},
+    ],
+)
+def test_parallel_io_rejects_invalid_bounds(kwargs: dict[str, int]) -> None:
+    with pytest.raises(ValueError):
+        ParallelIOPipeline(
+            loader=lambda path: path,
+            saver=lambda _path, payload: payload,
+            **kwargs,
+        )
+
+
+def test_parallel_io_overlaps_processing_with_background_save(
+    tmp_path: Path,
+) -> None:
+    first = tmp_path / "first.txt"
+    second = tmp_path / "second.txt"
+    first.write_text("first", encoding="utf-8")
+    second.write_text("second", encoding="utf-8")
+
+    first_save_started = threading.Event()
+    release_first_save = threading.Event()
+    events: list[str] = []
+    events_lock = threading.Lock()
+
+    def append_event(value: str) -> None:
+        with events_lock:
+            events.append(value)
+
+    def loader(path: Path) -> str:
+        return path.read_text(encoding="utf-8")
+
+    def processor(path: Path, value: str) -> str:
+        if path == second:
+            assert first_save_started.wait(timeout=2.0)
+            append_event("process-second")
+            release_first_save.set()
+        return value
+
+    def saver(path: Path, value: str) -> str:
+        if path == first:
+            append_event("save-first-start")
+            first_save_started.set()
+            assert release_first_save.wait(timeout=2.0)
+        append_event(f"save-{path.stem}-end")
+        return value
+
+    pipeline = ParallelIOPipeline(
+        loader=loader,
+        saver=saver,
+        prefetch_size=2,
+        num_savers=1,
+    )
+
+    results = pipeline.process_batch([first, second], processor)
+
+    assert [result.succeeded for result in results] == [True, True]
+    assert events.index("process-second") < events.index("save-first-end")

--- a/tests/test_unified_luxury_pipeline.py
+++ b/tests/test_unified_luxury_pipeline.py
@@ -478,6 +478,26 @@ class TestMetadataPreservation:
         assert metadata["load_backend"] == "tifffile"
         assert metadata["source_dtype"] == "uint16"
 
+    @pytest.mark.skipif(not HAS_TIFFFILE, reason="CMYK TIFF regression requires tifffile")
+    def test_tiff_loading_preserves_cmyk_interpretation(self, temp_dir):
+        """Test CMYK TIFF inputs keep PIL color interpretation."""
+
+        tiff_path = temp_dir / "cmyk.tif"
+        source = Image.new("CMYK", (2, 1), (255, 0, 0, 0))
+        source.save(tiff_path)
+        expected_pixel = source.convert("RGB").getpixel((0, 0))
+
+        config = UnifiedPipelineConfig(output_dir=temp_dir, output_formats=[OutputFormat.MASTER_TIFF])
+        pipeline = UnifiedLuxuryPipeline(config)
+
+        image, metadata = pipeline._load_image(tiff_path)
+
+        assert image.mode == "RGB"
+        assert image.getpixel((0, 0)) == expected_pixel
+        assert metadata["load_backend"] == "PIL"
+        assert metadata["tiff_photometric"] == "SEPARATED"
+        assert metadata["tifffile_skip_reason"] == "unsupported_photometric"
+
 
 class TestGracefulDegradation:
     """Test graceful failure handling for optional stages."""

--- a/tests/test_unified_luxury_pipeline.py
+++ b/tests/test_unified_luxury_pipeline.py
@@ -100,6 +100,9 @@ class TestUnifiedPipelineConfig:
         assert config.enable_depth is True
         assert config.enable_material_response is True
         assert config.device == "auto"
+        assert config.parallel_io is False
+        assert config.io_prefetch_size == 2
+        assert config.io_saver_workers == 2
 
     def test_custom_config(self, temp_dir):
         """Test custom configuration."""
@@ -454,6 +457,27 @@ class TestMetadataPreservation:
         assert "size" in metadata
         assert metadata["mode"] == "RGB"
 
+    @pytest.mark.skipif(not HAS_TIFFFILE, reason="tifffile fast TIFF path requires tifffile")
+    def test_tiff_loading_uses_tifffile_fast_path_for_16bit_rgb(self, temp_dir):
+        """Test 16-bit TIFF inputs use the tifffile loader path."""
+        import tifffile
+
+        arr = np.zeros((4, 5, 3), dtype=np.uint16)
+        arr[..., 0] = 65535
+        arr[..., 1] = 32768
+        tiff_path = temp_dir / "sixteen_bit.tif"
+        tifffile.imwrite(tiff_path, arr, photometric="rgb")
+
+        config = UnifiedPipelineConfig(output_dir=temp_dir, output_formats=[OutputFormat.MASTER_TIFF])
+        pipeline = UnifiedLuxuryPipeline(config)
+
+        image, metadata = pipeline._load_image(tiff_path)
+
+        assert image.mode == "RGB"
+        assert image.size == (5, 4)
+        assert metadata["load_backend"] == "tifffile"
+        assert metadata["source_dtype"] == "uint16"
+
 
 class TestGracefulDegradation:
     """Test graceful failure handling for optional stages."""
@@ -664,6 +688,61 @@ class TestBatchProcessing:
         # Invalid image should have empty results
         assert len(results[invalid_path]) == 0
 
+    def test_batch_process_parallel_io_multiple_images(self, temp_dir, sample_image):
+        """Test explicit parallel I/O batch processing of multiple images."""
+        image_paths = []
+        for i in range(3):
+            image_path = temp_dir / f"parallel_input_{i}.jpg"
+            sample_image.save(image_path)
+            image_paths.append(image_path)
+
+        config = UnifiedPipelineConfig(
+            scene_type=SceneType.INTERIOR,
+            output_dir=temp_dir / "parallel_output",
+            output_formats=[OutputFormat.MASTER_TIFF],
+            enable_depth=False,
+            enable_material_response=False,
+            enable_color_grading=False,
+            parallel_io=True,
+            io_prefetch_size=2,
+            io_saver_workers=2,
+        )
+        pipeline = UnifiedLuxuryPipeline(config)
+
+        results = pipeline.batch_process(image_paths, show_progress=False)
+
+        assert list(results) == image_paths
+        assert all("master" in outputs for outputs in results.values())
+        assert all(outputs["master"].exists() for outputs in results.values())
+        assert pipeline.stats.images_processed == 3
+        assert pipeline.stats.images_failed == 0
+        assert "Load & Validate" in pipeline.stats.stage_times
+        assert "Output Generation" in pipeline.stats.stage_times
+
+    def test_batch_process_parallel_io_continues_on_load_failure(self, temp_dir, sample_image):
+        """Test parallel I/O batch failures retain existing empty-result semantics."""
+        valid_path = temp_dir / "valid_parallel.jpg"
+        sample_image.save(valid_path)
+        invalid_path = temp_dir / "missing_parallel.jpg"
+
+        config = UnifiedPipelineConfig(
+            scene_type=SceneType.INTERIOR,
+            output_dir=temp_dir / "parallel_failure_output",
+            output_formats=[OutputFormat.MASTER_TIFF],
+            enable_depth=False,
+            enable_material_response=False,
+            enable_color_grading=False,
+            parallel_io=True,
+        )
+        pipeline = UnifiedLuxuryPipeline(config)
+
+        results = pipeline.batch_process([valid_path, invalid_path], show_progress=False)
+
+        assert results[valid_path]["master"].exists()
+        assert results[invalid_path] == {}
+        assert pipeline.stats.images_processed == 1
+        assert pipeline.stats.images_failed == 1
+
 
 class TestStatisticsSaving:
     """Test statistics tracking and saving."""
@@ -758,6 +837,30 @@ class TestConvenienceFunctions:
 
         input_paths = mock_instance.batch_process.call_args.args[0]
         assert input_paths == [input_dir / "keep.png"]
+
+    @patch("transformation_portal.pipelines.unified_luxury_pipeline.UnifiedLuxuryPipeline")
+    def test_batch_process_luxury_renders_accepts_parallel_io_options(self, mock_pipeline_class, sample_image, temp_dir):
+        """Test batch convenience function forwards parallel I/O configuration."""
+        input_dir = temp_dir / "inputs"
+        input_dir.mkdir()
+        sample_image.save(input_dir / "keep.jpg")
+
+        mock_instance = MagicMock()
+        mock_instance.batch_process.return_value = {}
+        mock_pipeline_class.return_value = mock_instance
+
+        batch_process_luxury_renders(
+            input_dir,
+            output_dir=temp_dir / "output",
+            parallel_io=True,
+            io_prefetch_size=3,
+            io_saver_workers=4,
+        )
+
+        config = mock_pipeline_class.call_args.args[0]
+        assert config.parallel_io is True
+        assert config.io_prefetch_size == 3
+        assert config.io_saver_workers == 4
 
     @pytest.mark.parametrize("pattern", ["*.{jpg,png", "*.}jpg{", "*.{jpg,}", "*.{}"])
     @patch("transformation_portal.pipelines.unified_luxury_pipeline.UnifiedLuxuryPipeline")


### PR DESCRIPTION
## Summary
- Implements the safe Phase 1 surface from `docs/analysis/PERFORMANCE_OPTIMIZATION_PLAN.md`.
- Adds a bounded producer/consumer I/O helper and wires it into the compatibility Unified Luxury Pipeline as an explicit opt-in batch mode.

## Changes
- Added `ParallelIOPipeline` with deterministic result ordering and per-item `load` / `process` / `save` failure isolation.
- Added `UnifiedPipelineConfig.parallel_io`, `io_prefetch_size`, and `io_saver_workers`.
- Added opt-in Unified Luxury Pipeline batch I/O overlap for input loading and output writes.
- Added a `tifffile` TIFF pixel-load path with PIL fallback for TIFF inputs.
- Exported the new helper through `transformation_portal.pipelines`.
- Rewrote the performance plan to remove unverified throughput promises and document implemented vs remaining work.
- Updated the Unified Luxury Pipeline guide and focused tests.

## Validation
Proven green:
- `.venv/bin/pytest tests/test_parallel_io.py tests/test_unified_luxury_pipeline.py -q`
- `git diff --check`
- `git diff --cached --check`
- `make check-doc-heading-links`
- `python3 scripts/governance/check_docs_structure.py --all`
- `make ci-quick`
- commit hooks: Black, isort, root placement, script topology, ML isolation, test markers, unsafe torch.load guard, gitleaks

Still failing:
- None known.

## Risk
- Existing batch behavior is preserved because `parallel_io` defaults to `False`.
- No route, selector, API envelope, CLI flag, or Make target contract changes.
- Performance claims remain bounded to implementation mechanics; throughput uplift still requires benchmark evidence.