### PR TITLE
feat(pilot): add managed paid-pilot control plane

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ PHASE6_SMOKE_TESTS := \
 	tests/test_lux_render_pipeline_smoke.py \
 	tests/lux_depth_v3/test_orchestrator_smoke.py
 
-.PHONY: help test-fast test-novideo test-full test-integration test-structure test-utils test-orchestrator-contract test-orchestrator-http-contract test-artifact-s3-contract test-orchestrator-postgres-contract test-orchestrator-postgres-app-contract test-worker-redis-contract test-frontdoor-redis-contract test-paid-pilot-services-contract run-managed-paid-pilot-gate test-portal-contract test-frontdoor-contract test-archive-gate-contract db-upgrade db-revision seed-frontdoor-user run-frontdoor-local run-backend-local run-backend-local-noreload dev-write-env dev-start dev-stop check-vercel-env validate-orchestrator-http validate-portal-lux-materials-live validate-portal-fastvlm-captioning-live validate-portal-css-layer-parity validate-portal-browser validate-frontdoor-browser validate-frontdoor-deployment-gate audit-pipeline-readiness coverage-fast-scope coverage-report coverage-diff coverage-package venv repair-core-venv setup clean \
+.PHONY: help test-fast test-novideo test-full test-integration test-structure test-utils test-orchestrator-contract test-orchestrator-http-contract test-artifact-s3-contract test-orchestrator-postgres-contract test-orchestrator-postgres-app-contract test-worker-redis-contract test-frontdoor-redis-contract test-paid-pilot-services-contract run-managed-paid-pilot-gate run-orchestrator-worker test-portal-contract test-frontdoor-contract test-archive-gate-contract db-upgrade db-revision seed-frontdoor-user run-frontdoor-local run-backend-local run-backend-local-noreload dev-write-env dev-start dev-stop check-vercel-env validate-orchestrator-http validate-portal-lux-materials-live validate-portal-fastvlm-captioning-live validate-portal-css-layer-parity validate-portal-browser validate-frontdoor-browser validate-frontdoor-deployment-gate audit-pipeline-readiness coverage-fast-scope coverage-report coverage-diff coverage-package venv repair-core-venv setup clean \
         lint lint-parity ci ci-full pre-commit install-hooks quality-check fix-quality check-quality validate-ci organize-docs check-json-serialization check-piptools-cache \
         check-python-headers check-yaml-governance check-stale-docs check-doc-heading-links lock lock-prod lock-ci lock-dev install-core install-ml install-ml-core install-ml-raw install-ml-sam2 install-ml-coreml install-fastvlm-runtime check-fastvlm-runtime docs docs-clean \
         check check-test-markers check-ci-sync check-todo-governance check-environment check-portal-asset-budgets check-dependency-pinning validate-full validate-quick clean-frontdoor clean-all check-worktree \
@@ -57,6 +57,7 @@ help:
 	@echo "  test-frontdoor-redis-contract  Run managed frontdoor Redis SessionStore contract"
 	@echo "  test-paid-pilot-services-contract  Run opt-in Postgres + Redis + S3 pilot service gate"
 	@echo "  run-managed-paid-pilot-gate  Run provider paid-pilot gate from a clean env file"
+	@echo "  run-orchestrator-worker  Run an external Redis/Postgres orchestrator worker"
 	@echo "  test-portal-contract  Run portal runtime/browser contract tests"
 	@echo "  test-frontdoor-contract  Run managed frontdoor Node contract/build checks"
 	@echo "  test-archive-gate-contract  Run archive gate readiness + HTTP contract tests (Gates A, B, C)"
@@ -393,6 +394,22 @@ test-paid-pilot-services-contract:
 
 run-managed-paid-pilot-gate:
 	@./scripts/validation/run_managed_paid_pilot_gate.sh --env-file "$${TP_MANAGED_PAID_PILOT_ENV_FILE:-/tmp/tp-managed-staging.env}" $(MANAGED_PAID_PILOT_GATE_ARGS)
+
+run-orchestrator-worker:
+	@echo "Starting external orchestrator worker..."
+	@if [ "$(TP_ORCHESTRATOR_STATE_BACKEND)" != "postgres" ]; then \
+		echo "ERROR: TP_ORCHESTRATOR_STATE_BACKEND must be postgres."; \
+		exit 1; \
+	fi
+	@if [ "$(TP_ORCHESTRATOR_QUEUE_BACKEND)" != "redis" ]; then \
+		echo "ERROR: TP_ORCHESTRATOR_QUEUE_BACKEND must be redis."; \
+		exit 1; \
+	fi
+	@if [ -z "$(TP_DATABASE_URL)" ] || [ -z "$(TP_REDIS_URL)" ]; then \
+		echo "ERROR: TP_DATABASE_URL and TP_REDIS_URL must be set."; \
+		exit 1; \
+	fi
+	@"$(PY)" -m transformation_portal.orchestrator.worker_process
 
 # Apply orchestrator schema migrations against TP_DATABASE_URL.
 db-upgrade:

--- a/app.py
+++ b/app.py
@@ -58,6 +58,7 @@ from transformation_portal.api.v1 import (
     ReadyResponse,
     UploadStagingEnvelope,
 )
+from transformation_portal.core.security.tenant import TenantContext, TenantError, TenantManager, TenantPolicy
 from transformation_portal.determinism.trace import get_or_create_trace_context
 from transformation_portal.ingest.upload_staging import (
     DEFAULT_CAPTURE_METADATA_CONFIG_PATH,
@@ -73,8 +74,10 @@ from transformation_portal.orchestrator import (
     JobNotFoundError,
     JobRecord,
     JobRepository,
+    OperationalAuditRecord,
     get_job_event_store,
     get_job_repository,
+    get_operational_audit_store,
 )
 from transformation_portal.orchestrator.artifact_store import ArtifactNotFoundError as StoreArtifactNotFoundError
 from transformation_portal.orchestrator.artifact_store import ArtifactPathValidationError as StoreArtifactPathValidationError
@@ -140,6 +143,7 @@ from transformation_portal.vlm_captioning.fastvlm_runtime import (
 LOGGER = logging.getLogger(__name__)
 _PORTAL_EVENT_LOG_WRITE_LOCK = threading.Lock()
 _MANAGED_SAM2_CHECKSUM_CACHE_LOCK = threading.Lock()
+_PILOT_TENANT_MANAGER: Optional[TenantManager] = None
 
 # Optionally suppress successful /healthz and /ready access-log lines so
 # operator log streams stay focused on actionable failures. Errors are never
@@ -663,6 +667,17 @@ PORTAL_UPLOAD_MAX_FIELDS = _env_int("TP_PORTAL_UPLOAD_MAX_FIELDS", 32, minimum=1
 PORTAL_UPLOAD_MAX_PART_BYTES = _env_int("TP_PORTAL_UPLOAD_MAX_PART_BYTES", MAX_UPLOAD_REQUEST_BYTES, minimum=1024)
 RATE_LIMIT_PER_MINUTE = _env_int("TP_RATE_LIMIT_PER_MINUTE", 60, minimum=0)
 MAX_CONCURRENT_JOBS = _env_int("TP_MAX_CONCURRENT_JOBS", 4, minimum=1)
+PILOT_CONTROL_PLANE_ENABLED = _env_bool("TP_PILOT_CONTROL_PLANE_ENABLED", False)
+PILOT_TENANT_HEADER = os.getenv("TP_PILOT_TENANT_HEADER", "x-tp-tenant-id").strip().lower() or "x-tp-tenant-id"
+PILOT_ALLOWED_TENANTS = set(_env_csv("TP_PILOT_ALLOWED_TENANTS", []))
+PILOT_ALLOWED_PIPELINES = set(_env_csv("TP_PILOT_ALLOWED_PIPELINES", ["lux-depth-v3"]))
+PILOT_MAX_ACTIVE_JOBS_PER_TENANT = _env_int("TP_PILOT_MAX_ACTIVE_JOBS_PER_TENANT", 0, minimum=0)
+PILOT_TENANT_WORKSPACE_ROOT = Path(
+    os.getenv("TP_PILOT_TENANT_WORKSPACE_ROOT", str(Path(tempfile.gettempdir()) / "tp-pilot-tenants" / "workspaces"))
+)
+PILOT_TENANT_CAS_ROOT = Path(
+    os.getenv("TP_PILOT_TENANT_CAS_ROOT", str(Path(tempfile.gettempdir()) / "tp-pilot-tenants" / "cas"))
+)
 RATE_LIMIT_WINDOW_SECONDS = 60.0
 # Default Retry-After (seconds) returned when the job-admission concurrency cap
 # (MAX_CONCURRENT_JOBS) rejects a request. Not tied to a deterministic schedule
@@ -704,6 +719,7 @@ WORKER_HEARTBEAT_INTERVAL_SECONDS = _worker_env_float(
 WORKER_POLL_INTERVAL_SECONDS = _worker_env_float(
     "TP_WORKER_POLL_SECONDS", "TP_ORCHESTRATOR_WORKER_POLL_SECONDS", 0.05, minimum=0.001
 )
+ORCHESTRATOR_IN_PROCESS_WORKERS_ENABLED = _env_bool("TP_ORCHESTRATOR_IN_PROCESS_WORKERS_ENABLED", True)
 # Grace period the lifespan shutdown waits for the worker pool to drain
 # cleanly before escalating to ``task.cancel()``. Bounded so a stuck
 # executor cannot block the broker / repository close paths.
@@ -1142,6 +1158,230 @@ def _job_repository() -> JobRepository:
 
 def _job_event_store():
     return get_job_event_store()
+
+
+def _pilot_tenant_policy() -> TenantPolicy:
+    return TenantPolicy(allowed_node_types=set(PILOT_ALLOWED_PIPELINES))
+
+
+def _pilot_tenant_manager() -> TenantManager:
+    global _PILOT_TENANT_MANAGER
+    if _PILOT_TENANT_MANAGER is None:
+        _PILOT_TENANT_MANAGER = TenantManager(
+            workspace_root=PILOT_TENANT_WORKSPACE_ROOT,
+            cas_root=PILOT_TENANT_CAS_ROOT,
+            default_policy=_pilot_tenant_policy(),
+        )
+    return _PILOT_TENANT_MANAGER
+
+
+def _job_tenant_id(job: Job) -> Optional[str]:
+    effective_request = job.effective_request if isinstance(job.effective_request, dict) else {}
+    tenant_id = effective_request.get("tenant_id")
+    if isinstance(tenant_id, str) and tenant_id.strip():
+        return tenant_id.strip()
+    return None
+
+
+def _record_tenant_id(record: JobRecord) -> Optional[str]:
+    effective_request = record.effective_request if isinstance(record.effective_request, dict) else {}
+    tenant_id = effective_request.get("tenant_id")
+    if isinstance(tenant_id, str) and tenant_id.strip():
+        return tenant_id.strip()
+    return None
+
+
+def _artifact_storage_job_id(job: Job) -> str:
+    tenant_id = _job_tenant_id(job)
+    if tenant_id:
+        return f"{tenant_id}__{job.id}"
+    return job.id
+
+
+def _pilot_actor_summary(actor: Optional[Mapping[str, Any]] = None) -> Dict[str, Any]:
+    if not isinstance(actor, Mapping):
+        return {}
+    summary: Dict[str, Any] = {}
+    for key in ("username", "role", "accessEmail"):
+        value = actor.get(key)
+        if isinstance(value, str) and value.strip():
+            summary[key] = value.strip().lower()
+    return summary
+
+
+def _pilot_request_context(request: Optional[Request] = None) -> Dict[str, Any]:
+    if request is None:
+        return {}
+    trace_context = getattr(request.state, "trace_context", None)
+    context: Dict[str, Any] = {
+        "method": request.method,
+        "path": request.url.path,
+    }
+    if trace_context is not None:
+        context["trace_id"] = trace_context.trace_id
+    return context
+
+
+async def _record_pilot_audit(
+    *,
+    action: str,
+    decision: str,
+    tenant_id: Optional[str] = None,
+    job_id: Optional[str] = None,
+    actor: Optional[Mapping[str, Any]] = None,
+    request: Optional[Request] = None,
+    details: Optional[Mapping[str, Any]] = None,
+) -> Optional[JSONResponse]:
+    if not PILOT_CONTROL_PLANE_ENABLED:
+        return None
+    try:
+        store = get_operational_audit_store()
+        await store.append(
+            OperationalAuditRecord(
+                created_at=_now(),
+                action=action,
+                decision=decision,
+                tenant_id=tenant_id,
+                job_id=job_id,
+                actor=_pilot_actor_summary(actor),
+                request_context=_pilot_request_context(request),
+                details=dict(details or {}),
+            )
+        )
+    except Exception:  # noqa: BLE001 - pilot mode must not mutate without audit
+        LOGGER.exception("pilot operational audit unavailable for action=%s", action)
+        return _error_response(
+            503,
+            code="AUDIT_UNAVAILABLE",
+            message="operational audit log unavailable",
+            details={"action": action},
+            retriable=True,
+        )
+    return None
+
+
+async def _pilot_tenant_error(
+    *,
+    action: str,
+    reason: str,
+    request: Optional[Request],
+    tenant_id: Optional[str] = None,
+    status_code: int = 400,
+) -> JSONResponse:
+    audit_response = await _record_pilot_audit(
+        action="tenant_admission",
+        decision="rejected",
+        tenant_id=tenant_id,
+        request=request,
+        details={"action": action, "reason": reason},
+    )
+    if audit_response is not None:
+        return audit_response
+    return _error_response(
+        status_code,
+        code=_http_status_error_code(status_code),
+        message="tenant admission failed",
+        details={"field": PILOT_TENANT_HEADER, "reason": reason},
+    )
+
+
+async def _pilot_tenant_from_request(
+    request: Optional[Request],
+    *,
+    action: str,
+) -> Tuple[Optional[TenantContext], Optional[JSONResponse]]:
+    if not PILOT_CONTROL_PLANE_ENABLED:
+        return None, None
+    if request is None:
+        return None, await _pilot_tenant_error(action=action, reason="tenant_required", request=request)
+
+    tenant_id = str(request.headers.get(PILOT_TENANT_HEADER) or "").strip()
+    if not tenant_id:
+        return None, await _pilot_tenant_error(action=action, reason="tenant_required", request=request)
+
+    try:
+        manager = _pilot_tenant_manager()
+        tenant = manager.get_tenant(tenant_id)
+        if tenant is None:
+            tenant = manager.create_tenant(tenant_id, policy=_pilot_tenant_policy())
+    except TenantError:
+        return None, await _pilot_tenant_error(
+            action=action,
+            reason="invalid_tenant_id",
+            request=request,
+            tenant_id=None,
+        )
+
+    if PILOT_ALLOWED_TENANTS and tenant.tenant_id not in PILOT_ALLOWED_TENANTS:
+        return None, await _pilot_tenant_error(
+            action=action,
+            reason="tenant_not_allowed",
+            request=request,
+            tenant_id=tenant.tenant_id,
+            status_code=403,
+        )
+
+    return tenant, None
+
+
+async def _pilot_enforce_pipeline(
+    tenant: Optional[TenantContext],
+    *,
+    pipeline: str,
+    action: str,
+    request: Optional[Request],
+) -> Optional[JSONResponse]:
+    if tenant is None or not PILOT_CONTROL_PLANE_ENABLED:
+        return None
+    try:
+        _pilot_tenant_manager().enforce_node_type(tenant.tenant_id, pipeline)
+    except TenantError:
+        return await _pilot_tenant_error(
+            action=action,
+            reason="pipeline_not_allowed",
+            request=request,
+            tenant_id=tenant.tenant_id,
+            status_code=403,
+        )
+    return None
+
+
+async def _pilot_enforce_job_tenant(
+    tenant: Optional[TenantContext],
+    job: Job,
+    *,
+    action: str,
+    request: Optional[Request] = None,
+) -> Optional[JSONResponse]:
+    if tenant is None or not PILOT_CONTROL_PLANE_ENABLED:
+        return None
+    if _job_tenant_id(job) == tenant.tenant_id:
+        return None
+    audit_response = await _record_pilot_audit(
+        action="tenant_admission",
+        decision="rejected",
+        tenant_id=tenant.tenant_id,
+        job_id=job.id,
+        request=request,
+        details={"action": action, "reason": "tenant_job_mismatch"},
+    )
+    if audit_response is not None:
+        return audit_response
+    return _error_response(
+        404,
+        code="NOT_FOUND",
+        message="job not found",
+        details={"job_id": job.id},
+    )
+
+
+async def _pilot_active_job_count_for_tenant(repo: JobRepository, tenant_id: str) -> int:
+    records, _total = await repo.list(limit=None)
+    return sum(
+        1
+        for record in records
+        if record.state in ACTIVE_JOB_STATES and _record_tenant_id(record) == tenant_id
+    )
 
 
 def _record_from_job(job: Job) -> JobRecord:
@@ -3180,7 +3420,7 @@ async def _delete_job_artifacts_for_job(
 
     lifecycle = _ensure_artifact_lifecycle(job, backend=store.backend)
     try:
-        store_deleted_count = await store.delete(job.id)
+        store_deleted_count = await store.delete(_artifact_storage_job_id(job))
         legacy_deleted_count = await asyncio.to_thread(_delete_legacy_job_artifact_files, job)
     except Exception as exc:  # noqa: BLE001 - cleanup/deletion must be observable and non-fatal
         lifecycle.update(
@@ -7197,13 +7437,14 @@ async def _mirror_job_artifacts_to_store(job: Job, *, fail_closed_on_repository:
 
     mirrored = 0
     failures: List[str] = []
+    storage_job_id = _artifact_storage_job_id(job)
     for relative_path, source_path in sorted(job.artifact_lookup.items()):
         try:
             _, resolved_artifact, normalized_relative_path = _validate_resolved_job_artifact_path(job, source_path)
             if not resolved_artifact.is_file():
                 continue
             await store.write_file(
-                job.id,
+                storage_job_id,
                 normalized_relative_path,
                 resolved_artifact,
                 content_type=_artifact_content_type(resolved_artifact),
@@ -8722,23 +8963,26 @@ async def _orchestrator_lifespan(app: "FastAPI") -> "AsyncGenerator[None, None]"
         app.state.queue_broker = broker
         stop_event = asyncio.Event()
         app.state.worker_stop_event = stop_event
-        for slot in range(MAX_CONCURRENT_JOBS):
-            worker_config = WorkerConfig(
-                worker_id=f"inproc-worker-{slot}",
-                lease_seconds=WORKER_LEASE_SECONDS,
-                heartbeat_interval_seconds=WORKER_HEARTBEAT_INTERVAL_SECONDS,
-                poll_interval_seconds=WORKER_POLL_INTERVAL_SECONDS,
-            )
-            app.state.worker_tasks.append(
-                asyncio.create_task(
-                    run_worker_forever(
-                        broker=broker,
-                        config=worker_config,
-                        executor=_orchestrator_job_executor,
-                        stop_event=stop_event,
+        if ORCHESTRATOR_IN_PROCESS_WORKERS_ENABLED:
+            for slot in range(MAX_CONCURRENT_JOBS):
+                worker_config = WorkerConfig(
+                    worker_id=f"inproc-worker-{slot}",
+                    lease_seconds=WORKER_LEASE_SECONDS,
+                    heartbeat_interval_seconds=WORKER_HEARTBEAT_INTERVAL_SECONDS,
+                    poll_interval_seconds=WORKER_POLL_INTERVAL_SECONDS,
+                )
+                app.state.worker_tasks.append(
+                    asyncio.create_task(
+                        run_worker_forever(
+                            broker=broker,
+                            config=worker_config,
+                            executor=_orchestrator_job_executor,
+                            stop_event=stop_event,
+                        )
                     )
                 )
-            )
+        else:
+            LOGGER.info("in-process worker pool disabled; expecting external orchestrator worker process")
         # Phase 2.D — periodic broker-reclaim reconciler. Shares
         # ``stop_event`` with the worker pool so a single signal
         # winds down the whole broker-dispatch substrate.
@@ -8853,6 +9097,7 @@ app.add_middleware(
         "Accept",
         "Authorization",
         API_KEY_HEADER,
+        PILOT_TENANT_HEADER,
     ],
 )
 
@@ -9170,10 +9415,19 @@ async def ready() -> Dict[str, Any]:
 
 
 @app.get("/v1/readiness", response_model=ReadinessEnvelope)
-async def readiness() -> JSONResponse:
+async def readiness(request: Request) -> JSONResponse:
     pipeline_data: Dict[str, Any] = {}
     for pipeline_name in ("lux-depth-v3", "archive-gate-a", "archive-gate-b", "archive-gate-c"):
         pipeline_data[pipeline_name] = _evaluate_pipeline_readiness(pipeline_name)
+
+    audit_response = await _record_pilot_audit(
+        action="readiness",
+        decision="accepted",
+        request=request,
+        details={"pipelines": sorted(pipeline_data)},
+    )
+    if audit_response is not None:
+        return audit_response
 
     return JSONResponse(
         _api_envelope(
@@ -9256,18 +9510,49 @@ async def config_metadata(pipeline: str) -> JSONResponse:
 
 @app.post("/v1/config-preview", response_model=ConfigPreviewEnvelope)
 async def config_preview(request: Request, payload: Dict[str, Any]) -> JSONResponse:
+    tenant, tenant_error = await _pilot_tenant_from_request(request, action="config_preview")
+    if tenant_error is not None:
+        return tenant_error
     try:
         preview = await _build_config_preview_threaded(
             payload,
             portal_actor=_portal_actor_from_request(request),
         )
     except ValueError:
+        audit_response = await _record_pilot_audit(
+            action="config_preview",
+            decision="rejected",
+            tenant_id=tenant.tenant_id if tenant is not None else None,
+            request=request,
+            details={"reason": "unsupported_pipeline"},
+        )
+        if audit_response is not None:
+            return audit_response
         return _error_response(
             400,
             code="INVALID_ARGUMENT",
             message="invalid config preview request",
             details={"field": "payload", "reason": "unsupported_pipeline"},
         )
+
+    pipeline = str(preview.get("pipeline") or payload.get("pipeline") or "").strip()
+    pipeline_error = await _pilot_enforce_pipeline(
+        tenant,
+        pipeline=pipeline,
+        action="config_preview",
+        request=request,
+    )
+    if pipeline_error is not None:
+        return pipeline_error
+    audit_response = await _record_pilot_audit(
+        action="config_preview",
+        decision="accepted",
+        tenant_id=tenant.tenant_id if tenant is not None else None,
+        request=request,
+        details={"pipeline": pipeline},
+    )
+    if audit_response is not None:
+        return audit_response
 
     return JSONResponse(
         _api_envelope(
@@ -9407,11 +9692,15 @@ async def create_job(
     payload: Dict[str, Any],
     *,
     portal_actor: Optional[Mapping[str, Any]] = None,
+    pilot_tenant: Optional[TenantContext] = None,
+    request: Optional[Request] = None,
 ) -> JSONResponse:
     return await _create_job(
         payload,
         api_version="v1",
         portal_actor=portal_actor,
+        pilot_tenant=pilot_tenant,
+        request=request,
     )
 
 
@@ -9419,20 +9708,40 @@ async def create_job_v2(
     payload: Dict[str, Any],
     *,
     portal_actor: Optional[Mapping[str, Any]] = None,
+    pilot_tenant: Optional[TenantContext] = None,
+    request: Optional[Request] = None,
 ) -> JSONResponse:
     return await _create_job(
         payload,
         api_version="v2",
         portal_actor=portal_actor,
+        pilot_tenant=pilot_tenant,
+        request=request,
     )
 
 
 async def create_job_http(request: Request, payload: Dict[str, Any]) -> JSONResponse:
-    return await create_job(payload, portal_actor=_portal_actor_from_request(request))
+    tenant, tenant_error = await _pilot_tenant_from_request(request, action="job_create")
+    if tenant_error is not None:
+        return tenant_error
+    return await create_job(
+        payload,
+        portal_actor=_portal_actor_from_request(request),
+        pilot_tenant=tenant,
+        request=request,
+    )
 
 
 async def create_job_v2_http(request: Request, payload: Dict[str, Any]) -> JSONResponse:
-    return await create_job_v2(payload, portal_actor=_portal_actor_from_request(request))
+    tenant, tenant_error = await _pilot_tenant_from_request(request, action="job_create")
+    if tenant_error is not None:
+        return tenant_error
+    return await create_job_v2(
+        payload,
+        portal_actor=_portal_actor_from_request(request),
+        pilot_tenant=tenant,
+        request=request,
+    )
 
 
 async def _create_job(
@@ -9440,6 +9749,8 @@ async def _create_job(
     *,
     api_version: str = "v1",
     portal_actor: Optional[Mapping[str, Any]] = None,
+    pilot_tenant: Optional[TenantContext] = None,
+    request: Optional[Request] = None,
 ) -> JSONResponse:
     try:
         preview_kwargs: Dict[str, Any] = {"archive_index_scan_mode": "full"}
@@ -9455,6 +9766,14 @@ async def _create_job(
         )
 
     pipeline = str(preview.get("pipeline") or payload.get("pipeline") or "").strip()
+    pipeline_error = await _pilot_enforce_pipeline(
+        pilot_tenant,
+        pipeline=pipeline,
+        action="job_create",
+        request=request,
+    )
+    if pipeline_error is not None:
+        return pipeline_error
 
     preview_errors = preview.get("field_errors") or []
     if preview_errors:
@@ -9570,6 +9889,44 @@ async def _create_job(
                 },
                 headers=job_admission_headers,
             )
+        if pilot_tenant is not None and PILOT_MAX_ACTIVE_JOBS_PER_TENANT > 0:
+            try:
+                tenant_active_jobs = await _pilot_active_job_count_for_tenant(repo, pilot_tenant.tenant_id)
+            except Exception:  # noqa: BLE001 - admission must not fall back to stale tenant counts
+                LOGGER.exception("tenant active-count check failed for %s", pilot_tenant.tenant_id)
+                return _repository_unavailable_response()
+            if tenant_active_jobs >= PILOT_MAX_ACTIVE_JOBS_PER_TENANT:
+                audit_response = await _record_pilot_audit(
+                    action="tenant_admission",
+                    decision="rejected",
+                    tenant_id=pilot_tenant.tenant_id,
+                    actor=portal_actor,
+                    request=request,
+                    details={
+                        "action": "job_create",
+                        "reason": "tenant_active_job_quota_exceeded",
+                        "active_jobs": tenant_active_jobs,
+                        "max_active_jobs": PILOT_MAX_ACTIVE_JOBS_PER_TENANT,
+                    },
+                )
+                if audit_response is not None:
+                    return audit_response
+                tenant_admission_headers = _rate_limit_response_headers(
+                    limit=PILOT_MAX_ACTIVE_JOBS_PER_TENANT,
+                    remaining=0,
+                    retry_after=JOB_ADMISSION_RETRY_AFTER_SECONDS,
+                    reset_epoch=int(_now()) + JOB_ADMISSION_RETRY_AFTER_SECONDS,
+                )
+                return _error_response(
+                    429,
+                    code="RATE_LIMITED",
+                    message="too many active jobs for tenant; try again later",
+                    details={
+                        "active_jobs": tenant_active_jobs,
+                        "max_active_jobs": PILOT_MAX_ACTIVE_JOBS_PER_TENANT,
+                    },
+                    headers=tenant_admission_headers,
+                )
         # Materialise output_dir only after admission succeeds so 429-rejected
         # requests never leave behind directories on disk. Track whether the
         # directory existed before we materialised it so the dispatch
@@ -9591,6 +9948,22 @@ async def _create_job(
             )
         jid = "job_" + uuid.uuid4().hex[:8]
         effective_request = {"pipeline": pipeline, "args": dict(execution_args)}
+        if pilot_tenant is not None:
+            effective_request["tenant_id"] = pilot_tenant.tenant_id
+        audit_response = await _record_pilot_audit(
+            action="job_create",
+            decision="accepted",
+            tenant_id=pilot_tenant.tenant_id if pilot_tenant is not None else None,
+            job_id=jid,
+            actor=portal_actor,
+            request=request,
+            details={"pipeline": pipeline},
+        )
+        if audit_response is not None:
+            if trusted_output_dir is not None and not output_dir_existed_pre_dispatch:
+                with suppress(OSError):
+                    trusted_output_dir.rmdir()
+            return audit_response
         job = Job(id=jid, created_at=_now(), request=payload, effective_request=effective_request)
         try:
             await repo.create(_record_from_job(job))
@@ -9662,14 +10035,34 @@ async def list_jobs_v2(limit: int = JOB_LIST_LIMIT) -> JSONResponse:
     return await _list_jobs(limit=limit, api_version="v2")
 
 
-async def _list_jobs(*, limit: int = JOB_LIST_LIMIT, api_version: str = "v1") -> JSONResponse:
+async def list_jobs_http(request: Request, limit: int = JOB_LIST_LIMIT) -> JSONResponse:
+    return await _list_jobs(request=request, limit=limit, api_version="v1")
+
+
+async def list_jobs_v2_http(request: Request, limit: int = JOB_LIST_LIMIT) -> JSONResponse:
+    return await _list_jobs(request=request, limit=limit, api_version="v2")
+
+
+async def _list_jobs(
+    *,
+    request: Optional[Request] = None,
+    limit: int = JOB_LIST_LIMIT,
+    api_version: str = "v1",
+) -> JSONResponse:
     await _cleanup_expired_jobs(_now(), force=False)
     bounded_limit = max(1, min(limit, JOB_LIST_LIMIT))
+    tenant, tenant_error = await _pilot_tenant_from_request(request, action="job_list")
+    if tenant_error is not None:
+        return tenant_error
     try:
-        records, total = await _job_repository().list(limit=bounded_limit)
+        records, total = await _job_repository().list(limit=None if tenant is not None else bounded_limit)
     except Exception:  # noqa: BLE001 - never fall back to stale runtime cache
         LOGGER.exception("job repository list failed")
         return _repository_unavailable_response()
+    if tenant is not None:
+        records = [record for record in records if _record_tenant_id(record) == tenant.tenant_id]
+        total = len(records)
+        records = records[:bounded_limit]
 
     jobs = [_overlay_runtime_state(_job_from_record(record), JOBS.get(record.id)) for record in records]
     serialized = [_serialize_job(job, include_logs=False, api_version=api_version) for job in jobs]
@@ -9700,8 +10093,25 @@ async def get_job_v2(job_id: str, include_logs: bool = True) -> JSONResponse:
     return await _get_job(job_id, include_logs=include_logs, api_version="v2")
 
 
-async def _get_job(job_id: str, *, include_logs: bool = True, api_version: str = "v1") -> JSONResponse:
+async def get_job_http(request: Request, job_id: str, include_logs: bool = True) -> JSONResponse:
+    return await _get_job(job_id, request=request, include_logs=include_logs, api_version="v1")
+
+
+async def get_job_v2_http(request: Request, job_id: str, include_logs: bool = True) -> JSONResponse:
+    return await _get_job(job_id, request=request, include_logs=include_logs, api_version="v2")
+
+
+async def _get_job(
+    job_id: str,
+    *,
+    request: Optional[Request] = None,
+    include_logs: bool = True,
+    api_version: str = "v1",
+) -> JSONResponse:
     await _cleanup_expired_jobs(_now(), force=False)
+    tenant, tenant_error = await _pilot_tenant_from_request(request, action="job_read")
+    if tenant_error is not None:
+        return tenant_error
     try:
         job = await _load_job_view(job_id)
     except _JobRepositoryUnavailable:
@@ -9713,6 +10123,9 @@ async def _get_job(job_id: str, *, include_logs: bool = True, api_version: str =
             message="job not found",
             details={"job_id": job_id},
         )
+    tenant_access_error = await _pilot_enforce_job_tenant(tenant, job, action="job_read", request=request)
+    if tenant_access_error is not None:
+        return tenant_access_error
     # Phase 1.D: construct via Pydantic for runtime validation, then
     # serialize with ``exclude_unset=True`` so the optional
     # ``logs_tail`` default (None) is omitted when the legacy
@@ -9735,6 +10148,14 @@ async def get_job_artifact_v2(job_id: str, artifact_path: str) -> Response:
     return await _get_job_artifact(job_id, artifact_path)
 
 
+async def get_job_artifact_http(request: Request, job_id: str, artifact_path: str) -> Response:
+    return await _get_job_artifact(job_id, artifact_path, request=request)
+
+
+async def get_job_artifact_v2_http(request: Request, job_id: str, artifact_path: str) -> Response:
+    return await _get_job_artifact(job_id, artifact_path, request=request)
+
+
 async def delete_job_artifacts(job_id: str) -> JSONResponse:
     return await _delete_job_artifacts(job_id, api_version="v1")
 
@@ -9743,8 +10164,24 @@ async def delete_job_artifacts_v2(job_id: str) -> JSONResponse:
     return await _delete_job_artifacts(job_id, api_version="v2")
 
 
-async def _get_job_artifact(job_id: str, artifact_path: str) -> Response:
+async def delete_job_artifacts_http(request: Request, job_id: str) -> JSONResponse:
+    return await _delete_job_artifacts(job_id, request=request, api_version="v1")
+
+
+async def delete_job_artifacts_v2_http(request: Request, job_id: str) -> JSONResponse:
+    return await _delete_job_artifacts(job_id, request=request, api_version="v2")
+
+
+async def _get_job_artifact(
+    job_id: str,
+    artifact_path: str,
+    *,
+    request: Optional[Request] = None,
+) -> Response:
     await _cleanup_expired_jobs(_now(), force=False)
+    tenant, tenant_error = await _pilot_tenant_from_request(request, action="artifact_fetch")
+    if tenant_error is not None:
+        return tenant_error
     try:
         job = await _load_job_view(job_id)
     except _JobRepositoryUnavailable:
@@ -9756,6 +10193,9 @@ async def _get_job_artifact(job_id: str, artifact_path: str) -> Response:
             message="job not found",
             details={"job_id": job_id},
         )
+    tenant_access_error = await _pilot_enforce_job_tenant(tenant, job, action="artifact_fetch", request=request)
+    if tenant_access_error is not None:
+        return tenant_access_error
 
     try:
         requested_relative_path = _normalize_artifact_relative_path(artifact_path)
@@ -9810,6 +10250,18 @@ async def _get_job_artifact(job_id: str, artifact_path: str) -> Response:
             details={"job_id": job_id, "path": requested_relative_path},
         )
 
+    storage_job_id = _artifact_storage_job_id(job)
+    audit_response = await _record_pilot_audit(
+        action="artifact_fetch",
+        decision="accepted",
+        tenant_id=tenant.tenant_id if tenant is not None else _job_tenant_id(job),
+        job_id=job.id,
+        request=request,
+        details={"path": requested_relative_path},
+    )
+    if audit_response is not None:
+        return audit_response
+
     if not job.artifact_store_mirrored:
         try:
             await _mirror_job_artifacts_to_store(job, fail_closed_on_repository=True)
@@ -9830,10 +10282,10 @@ async def _get_job_artifact(job_id: str, artifact_path: str) -> Response:
 
     if store.backend == "s3":
         try:
-            metadata = await store.head(job.id, requested_relative_path)
+            metadata = await store.head(storage_job_id, requested_relative_path)
             response_headers = _artifact_response_headers_for_relative_path(requested_relative_path)
             presigned_url = await store.presign_get(
-                job.id,
+                storage_job_id,
                 requested_relative_path,
                 expires_seconds=ARTIFACT_PRESIGN_EXPIRES_SECONDS,
                 content_type=metadata.content_type,
@@ -9889,8 +10341,8 @@ async def _get_job_artifact(job_id: str, artifact_path: str) -> Response:
         )
 
     try:
-        metadata = await store.head(job.id, requested_relative_path)
-        stream = await store.open_bytes(job.id, requested_relative_path)
+        metadata = await store.head(storage_job_id, requested_relative_path)
+        stream = await store.open_bytes(storage_job_id, requested_relative_path)
         return StreamingResponse(
             stream,
             media_type=metadata.content_type,
@@ -9933,8 +10385,16 @@ async def _get_job_artifact(job_id: str, artifact_path: str) -> Response:
     )
 
 
-async def _delete_job_artifacts(job_id: str, *, api_version: str = "v1") -> JSONResponse:
+async def _delete_job_artifacts(
+    job_id: str,
+    *,
+    request: Optional[Request] = None,
+    api_version: str = "v1",
+) -> JSONResponse:
     await _cleanup_expired_jobs(_now(), force=False)
+    tenant, tenant_error = await _pilot_tenant_from_request(request, action="artifact_delete")
+    if tenant_error is not None:
+        return tenant_error
     try:
         job = await _load_job_view(job_id)
     except _JobRepositoryUnavailable:
@@ -9946,6 +10406,9 @@ async def _delete_job_artifacts(job_id: str, *, api_version: str = "v1") -> JSON
             message="job not found",
             details={"job_id": job_id},
         )
+    tenant_access_error = await _pilot_enforce_job_tenant(tenant, job, action="artifact_delete", request=request)
+    if tenant_access_error is not None:
+        return tenant_access_error
     if job.state not in _TERMINAL_JOB_STATES:
         return _error_response(
             409,
@@ -9954,6 +10417,16 @@ async def _delete_job_artifacts(job_id: str, *, api_version: str = "v1") -> JSON
             details={"job_id": job_id, "state": job.state},
         )
     if not _artifacts_deleted(job):
+        audit_response = await _record_pilot_audit(
+            action="artifact_delete",
+            decision="accepted",
+            tenant_id=tenant.tenant_id if tenant is not None else _job_tenant_id(job),
+            job_id=job.id,
+            request=request,
+            details={"reason": "explicit_delete"},
+        )
+        if audit_response is not None:
+            return audit_response
         try:
             await _persist_job_artifact_metadata(job, fail_closed=True)
             deleted = await _delete_job_artifacts_for_job(
@@ -9989,7 +10462,18 @@ async def cancel_job_v2(job_id: str) -> JSONResponse:
     return await _cancel_job(job_id)
 
 
-async def _cancel_job(job_id: str) -> JSONResponse:
+async def cancel_job_http(request: Request, job_id: str) -> JSONResponse:
+    return await _cancel_job(job_id, request=request)
+
+
+async def cancel_job_v2_http(request: Request, job_id: str) -> JSONResponse:
+    return await _cancel_job(job_id, request=request)
+
+
+async def _cancel_job(job_id: str, *, request: Optional[Request] = None) -> JSONResponse:
+    tenant, tenant_error = await _pilot_tenant_from_request(request, action="job_cancel")
+    if tenant_error is not None:
+        return tenant_error
     try:
         job = await _load_job_view(job_id)
     except _JobRepositoryUnavailable:
@@ -10001,6 +10485,19 @@ async def _cancel_job(job_id: str) -> JSONResponse:
             message="job not found",
             details={"job_id": job_id},
         )
+    tenant_access_error = await _pilot_enforce_job_tenant(tenant, job, action="job_cancel", request=request)
+    if tenant_access_error is not None:
+        return tenant_access_error
+    audit_response = await _record_pilot_audit(
+        action="job_cancel",
+        decision="accepted",
+        tenant_id=tenant.tenant_id if tenant is not None else _job_tenant_id(job),
+        job_id=job.id,
+        request=request,
+        details={"state": job.state},
+    )
+    if audit_response is not None:
+        return audit_response
     try:
         await _request_cancel(job)
     except _JobRepositoryUnavailable:
@@ -10075,6 +10572,9 @@ async def _job_events(
     request: Request,
     job_id: str,
 ) -> Response:
+    tenant, tenant_error = await _pilot_tenant_from_request(request, action="job_events")
+    if tenant_error is not None:
+        return tenant_error
     try:
         job = await _load_job_view(job_id)
     except _JobRepositoryUnavailable:
@@ -10086,6 +10586,9 @@ async def _job_events(
             message="job not found",
             details={"job_id": job_id},
         )
+    tenant_access_error = await _pilot_enforce_job_tenant(tenant, job, action="job_events", request=request)
+    if tenant_access_error is not None:
+        return tenant_access_error
     if job.state not in ACTIVE_JOB_STATES and job.state != "canceled":
         _refresh_job_run_summary(job)
 
@@ -10211,16 +10714,16 @@ app.include_router(
         JobRouteHandlers(
             create_job_http=create_job_http,
             create_job_v2_http=create_job_v2_http,
-            list_jobs=list_jobs,
-            list_jobs_v2=list_jobs_v2,
-            get_job=get_job,
-            get_job_v2=get_job_v2,
-            get_job_artifact=get_job_artifact,
-            get_job_artifact_v2=get_job_artifact_v2,
-            delete_job_artifacts=delete_job_artifacts,
-            delete_job_artifacts_v2=delete_job_artifacts_v2,
-            cancel_job=cancel_job,
-            cancel_job_v2=cancel_job_v2,
+            list_jobs=list_jobs_http,
+            list_jobs_v2=list_jobs_v2_http,
+            get_job=get_job_http,
+            get_job_v2=get_job_v2_http,
+            get_job_artifact=get_job_artifact_http,
+            get_job_artifact_v2=get_job_artifact_v2_http,
+            delete_job_artifacts=delete_job_artifacts_http,
+            delete_job_artifacts_v2=delete_job_artifacts_v2_http,
+            cancel_job=cancel_job_http,
+            cancel_job_v2=cancel_job_v2_http,
             job_events=job_events,
             job_events_v2=job_events_v2,
         ),

--- a/docs/deployment/managed_paid_pilot_staging_runbook.md
+++ b/docs/deployment/managed_paid_pilot_staging_runbook.md
@@ -35,9 +35,10 @@ This runbook validates the currently landed paid-pilot service composition:
 ## Non-Goals
 
 This runbook does not add or validate Terraform, Helm, Kubernetes manifests,
-durable SSE replay, globally atomic multi-instance admission, tenancy, billing,
-metrics, audit events, or a separate multi-host worker deployment. Those remain
-separate follow-up phases.
+globally atomic multi-instance admission, billing, metrics dashboards, or
+provider-specific worker deployment manifests. Durable job-event replay is part
+of the landed orchestrator surface and is covered by the integrated gate.
+Multi-host workers and tenant/audit mode are opt-in runtime surfaces.
 
 ## Managed-Service Topology
 
@@ -221,11 +222,17 @@ The launcher runs `make db-upgrade` against staging `TP_DATABASE_URL`, not
 `TP_TEST_POSTGRES_URL`, before invoking `make test-paid-pilot-services-contract`.
 Do not point `TP_DATABASE_URL` at the disposable test database.
 
+Add `--evidence-out /tmp/tp-managed-paid-pilot-acceptance.md` through
+`MANAGED_PAID_PILOT_GATE_ARGS` when a redacted acceptance note is needed. The
+output must live outside the repository. Use
+[`managed_provider_acceptance_note_template.md`](managed_provider_acceptance_note_template.md)
+as the manual review template before promoting evidence into docs.
+
 The integrated gate must prove `/v1/jobs` creation through Redis broker
 enqueue, worker subprocess completion, Postgres-backed terminal state after
-`app.JOBS.clear()`, S3-compatible artifact redirect, artifact delete lifecycle,
-`410 ARTIFACT_DELETED` after delete, and abandoned active-row recovery to
-`worker_lost`.
+`app.JOBS.clear()`, durable SSE replay with `Last-Event-ID`, S3-compatible
+artifact redirect, artifact delete lifecycle, `410 ARTIFACT_DELETED` after
+delete, and abandoned active-row recovery to `worker_lost`.
 
 ## Evidence Capture
 
@@ -305,10 +312,13 @@ or its environment configuration.
 - Local Phase 5.A validation is complete; provider validation is pending.
 - No Terraform, Helm, Kubernetes manifests, or deployment pipeline are added by
   this runbook.
-- Durable SSE replay remains a separate event-store cutover.
-- Separate multi-host worker deployment remains a Phase 5.C follow-up.
-- Observability, audit events, tenancy, billing, and entitlement models remain
-  future phases.
+- Durable SSE replay is landed and must remain covered by the integrated gate.
+- Multi-host worker execution is available as an opt-in worker process;
+  provider deployment manifests remain follow-up work.
+- Tenant admission, artifact-prefix isolation, per-tenant quota, and Postgres
+  audit logging are opt-in pilot runtime surfaces.
+- Observability dashboards, billing, and provider-specific IaC remain future
+  phases.
 
 ## Follow-Up Gates
 

--- a/docs/deployment/managed_provider_acceptance_note_template.md
+++ b/docs/deployment/managed_provider_acceptance_note_template.md
@@ -1,0 +1,52 @@
+# Managed Provider Paid-Pilot Acceptance Note Template
+
+Use this template for redacted provider acceptance evidence. The managed gate
+can generate a starter note with:
+
+```bash
+TP_MANAGED_PAID_PILOT_ENV_FILE=/tmp/tp-managed-staging.env \
+MANAGED_PAID_PILOT_GATE_ARGS="--evidence-out /tmp/tp-managed-paid-pilot-acceptance.md" \
+make run-managed-paid-pilot-gate
+```
+
+Keep the note outside the repository unless it has been reviewed and scrubbed.
+
+## Provider Surface
+
+- Validation date:
+- Git commit:
+- Backend host:
+- Frontdoor host:
+- Provider Postgres: configured / not configured
+- Provider Redis queue: configured / not configured
+- Provider Redis frontdoor sessions: configured / not configured
+- Provider S3-compatible artifacts: configured / not configured
+
+Do not include secrets, private hostnames, customer identifiers, usernames, or
+bucket names. Use provider/environment labels instead.
+
+## Gate Evidence
+
+- Clean env preflight:
+- `make db-upgrade`:
+- `make test-orchestrator-postgres-contract`:
+- `make test-orchestrator-postgres-app-contract`:
+- `make test-worker-redis-contract`:
+- `make test-artifact-s3-contract`:
+- `make test-frontdoor-redis-contract`:
+- `make test-paid-pilot-services-contract`:
+
+The integrated gate must prove `/v1/jobs` creation through Redis broker
+enqueue, worker completion, terminal state from Postgres after
+`app.JOBS.clear()`, persisted SSE replay with `Last-Event-ID`, S3-compatible
+artifact fetch/delete lifecycle, `410 ARTIFACT_DELETED` after delete, and
+abandoned active-row recovery to `worker_lost`.
+
+## Follow-Ups
+
+- Provider validation:
+- Multi-host worker rollout:
+- Tenant/admission/audit mode:
+- Observability:
+- Billing/entitlements:
+- Infrastructure-as-code:

--- a/docs/deployment/paid_pilot_services.md
+++ b/docs/deployment/paid_pilot_services.md
@@ -98,7 +98,57 @@ TP_MANAGED_PAID_PILOT_ENV_FILE=/tmp/tp-managed-staging.env \
 make run-managed-paid-pilot-gate
 ```
 
-The integrated smoke submits a real `/v1/jobs` request, enqueues through Redis, executes through the in-process worker pool with a tiny generated subprocess, persists terminal state in Postgres, mirrors artifacts to S3-compatible storage, verifies repository-backed artifact fetch/delete semantics after `app.JOBS.clear()`, and proves a separate abandoned active row sweeps to `worker_lost`.
+The integrated smoke submits a real `/v1/jobs` request, enqueues through
+Redis, executes through the in-process worker pool with a tiny generated
+subprocess, persists terminal state in Postgres, mirrors artifacts to
+S3-compatible storage, verifies repository-backed artifact fetch/delete
+semantics after `app.JOBS.clear()`, and proves a separate abandoned active row
+sweeps to `worker_lost`.
+It also proves persisted SSE replay with `Last-Event-ID: 0` after the runtime
+job cache is cleared.
+
+## Multi-Host Worker Mode
+
+Local/default backend operation keeps the in-process worker pool enabled.
+Managed pilot deployments that run workers on separate hosts can disable that
+pool on backend hosts and start explicit worker processes:
+
+```bash
+TP_ORCHESTRATOR_IN_PROCESS_WORKERS_ENABLED=0 make run-backend-local-noreload
+TP_ORCHESTRATOR_STATE_BACKEND=postgres \
+TP_ORCHESTRATOR_QUEUE_BACKEND=redis \
+TP_DATABASE_URL=postgresql+asyncpg://... \
+TP_REDIS_URL=redis://... \
+make run-orchestrator-worker
+```
+
+The worker process consumes the existing Redis broker, uses the existing
+Postgres job repository and event store, finalizes artifacts through the
+configured artifact store, and drains on `SIGINT`/`SIGTERM`.
+
+## Pilot Tenant, Admission, And Audit Mode
+
+Tenant mode is opt-in and preserves the single-tenant compatibility path when
+disabled:
+
+```text
+TP_PILOT_CONTROL_PLANE_ENABLED=1
+TP_PILOT_TENANT_HEADER=x-tp-tenant-id
+TP_PILOT_ALLOWED_TENANTS=pilot_acme,pilot_beta
+TP_PILOT_ALLOWED_PIPELINES=lux-depth-v3
+TP_PILOT_MAX_ACTIVE_JOBS_PER_TENANT=2
+```
+
+When enabled, job admission and config preview require the tenant header. Job
+list/detail/events/artifact/cancel surfaces are tenant-filtered, artifact store
+keys are prefixed with the tenant id, active-job quota is enforced per tenant,
+and pipeline entitlement uses `TenantPolicy.allowed_node_types`.
+
+Audit v1 writes append-only operational events to the same Postgres database as
+job state. Run `make db-upgrade` before enabling tenant/audit mode so the
+`operational_audit_events` table exists. Audited actions currently include
+tenant admission decisions, job create/cancel, artifact fetch/delete, and config
+preview, plus the protected `/v1/readiness` operator readiness surface.
 
 ## Startup Order
 
@@ -147,4 +197,8 @@ Rotate in this order:
 
 ## Non-Goals
 
-This gate does not add Terraform, Helm, durable SSE replay, globally atomic multi-instance admission, metrics, audit events, tenancy, billing, or production secret management. Those remain separate follow-up phases.
+This gate does not add Terraform, Helm, globally atomic multi-instance
+admission, metrics dashboards, billing, or production secret management.
+Durable SSE replay is a supported `Last-Event-ID` job-events contract.
+Multi-host workers and tenant/audit mode are opt-in runtime surfaces;
+provider-specific deployment manifests remain separate follow-up work.

--- a/docs/deployment/phase5a_paid_pilot_live_acceptance_2026-05-14.md
+++ b/docs/deployment/phase5a_paid_pilot_live_acceptance_2026-05-14.md
@@ -95,7 +95,7 @@ Phase 5.A is locally validated on the follow-up fix branch. The gate proves the 
 
 ## Known Limits
 
-This is local Compose validation only. Managed-service validation must rerun the same gate with provider Postgres, Redis, and S3-compatible endpoints. The gate is still manual and opt-in; it does not add Terraform, Helm, durable SSE replay, globally atomic multi-instance admission, broad observability, operational audit events, tenancy, billing, or production secret management.
+This is local Compose validation only. Managed-service validation must rerun the same gate with provider Postgres, Redis, and S3-compatible endpoints. The gate is still manual and opt-in; durable SSE replay is now a supported `Last-Event-ID` job-events contract and must remain covered by the integrated gate. Provider-specific Terraform, Helm, globally atomic multi-instance admission, broad observability, billing, and production secret management remain follow-up work. Multi-host workers and tenant/audit mode are opt-in runtime surfaces.
 
 ## Merged Baseline
 

--- a/migrations/versions/0002_operational_audit_events.py
+++ b/migrations/versions/0002_operational_audit_events.py
@@ -1,0 +1,71 @@
+"""add operational audit events
+
+Revision ID: 0002_operational_audit_events
+Revises: 0001_initial
+Create Date: 2026-06-04
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0002_operational_audit_events"
+down_revision: Union[str, None] = "0001_initial"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "operational_audit_events",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("created_at", sa.Float(), nullable=False),
+        sa.Column("action", sa.String(length=64), nullable=False),
+        sa.Column("decision", sa.String(length=32), nullable=False),
+        sa.Column("tenant_id", sa.String(length=64), nullable=True),
+        sa.Column("job_id", sa.String(length=64), nullable=True),
+        sa.Column(
+            "actor",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column(
+            "request_context",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column(
+            "details",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_operational_audit_events_action", "operational_audit_events", ["action"], unique=False)
+    op.create_index("ix_operational_audit_events_created_at", "operational_audit_events", ["created_at"], unique=False)
+    op.create_index("ix_operational_audit_events_decision", "operational_audit_events", ["decision"], unique=False)
+    op.create_index("ix_operational_audit_events_job_id", "operational_audit_events", ["job_id"], unique=False)
+    op.create_index("ix_operational_audit_events_tenant_id", "operational_audit_events", ["tenant_id"], unique=False)
+    op.create_index(
+        "ix_operational_audit_events_tenant_created",
+        "operational_audit_events",
+        ["tenant_id", "created_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_operational_audit_events_tenant_created", table_name="operational_audit_events")
+    op.drop_index("ix_operational_audit_events_tenant_id", table_name="operational_audit_events")
+    op.drop_index("ix_operational_audit_events_job_id", table_name="operational_audit_events")
+    op.drop_index("ix_operational_audit_events_decision", table_name="operational_audit_events")
+    op.drop_index("ix_operational_audit_events_created_at", table_name="operational_audit_events")
+    op.drop_index("ix_operational_audit_events_action", table_name="operational_audit_events")
+    op.drop_table("operational_audit_events")

--- a/scripts/validation/run_managed_paid_pilot_gate.sh
+++ b/scripts/validation/run_managed_paid_pilot_gate.sh
@@ -13,6 +13,7 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 DEFAULT_ENV_FILE="/tmp/tp-managed-staging.env"
 
 ENV_FILE="${DEFAULT_ENV_FILE}"
+EVIDENCE_OUT=""
 PREFLIGHT_ONLY=0
 CLEAN_PROCESS=0
 
@@ -22,11 +23,13 @@ Usage: scripts/validation/run_managed_paid_pilot_gate.sh [options]
 
 Options:
   --env-file PATH      Provider env file to source (default: /tmp/tp-managed-staging.env)
+  --evidence-out PATH  Write a redacted managed-provider acceptance note outside the repository
   --preflight-only     Validate the clean env and stop before migrations/tests
   -h, --help           Show this help
 
 The env file must be outside the repository, mode 0600 or stricter, and contain
 real provider-managed Postgres, Redis, frontdoor Redis, and S3-compatible values.
+The evidence output is optional and must also live outside the repository.
 EOF
 }
 
@@ -41,6 +44,11 @@ while (($#)); do
             shift
             [[ $# -gt 0 ]] || die "--env-file requires a path"
             ENV_FILE="$1"
+            ;;
+        --evidence-out)
+            shift
+            [[ $# -gt 0 ]] || die "--evidence-out requires a path"
+            EVIDENCE_OUT="$1"
             ;;
         --preflight-only)
             PREFLIGHT_ONLY=1
@@ -72,6 +80,9 @@ if [[ "${CLEAN_PROCESS}" != "1" ]]; then
         CLEAN_PATH="${PYTHON_DIR}:${CLEAN_PATH}"
     fi
     REEXEC_ARGS=(--env-file "${ENV_FILE}")
+    if [[ -n "${EVIDENCE_OUT}" ]]; then
+        REEXEC_ARGS+=(--evidence-out "${EVIDENCE_OUT}")
+    fi
     if [[ "${PREFLIGHT_ONLY}" == "1" ]]; then
         REEXEC_ARGS+=(--preflight-only)
     fi
@@ -136,6 +147,105 @@ set -a
 # shellcheck disable=SC1090
 . "${ENV_FILE}"
 set +a
+
+write_evidence_note() {
+    [[ -n "${EVIDENCE_OUT}" ]] || return 0
+    "${PYTHON_BIN}" - "${EVIDENCE_OUT}" "$1" <<'PY'
+from __future__ import annotations
+
+import datetime as _dt
+import os
+import subprocess
+import sys
+from pathlib import Path
+from urllib.parse import urlsplit
+
+evidence_path = Path(sys.argv[1])
+gate_status = sys.argv[2]
+repo_root = Path.cwd().resolve()
+
+resolved = evidence_path.expanduser().resolve()
+try:
+    resolved.relative_to(repo_root)
+except ValueError:
+    pass
+else:
+    print("ERROR: managed paid-pilot evidence output must live outside the repository", file=sys.stderr)
+    raise SystemExit(1)
+
+resolved.parent.mkdir(parents=True, exist_ok=True)
+
+selectors = {
+    "TP_ORCHESTRATOR_STATE_BACKEND": os.getenv("TP_ORCHESTRATOR_STATE_BACKEND", ""),
+    "TP_ORCHESTRATOR_QUEUE_BACKEND": os.getenv("TP_ORCHESTRATOR_QUEUE_BACKEND", ""),
+    "TP_FRONTDOOR_SESSION_STORE": os.getenv("TP_FRONTDOOR_SESSION_STORE", ""),
+    "TP_ARTIFACT_STORE": os.getenv("TP_ARTIFACT_STORE", ""),
+}
+
+def _url_summary(name: str) -> str:
+    raw = os.getenv(name, "").strip()
+    if not raw:
+        return "unset"
+    parsed = urlsplit(raw)
+    scheme = parsed.scheme or "unknown"
+    database_or_path = "set" if parsed.path.strip("/") else "unset"
+    tls = "yes" if scheme.endswith("s") or scheme in {"https", "rediss"} else "no"
+    return f"scheme={scheme}; tls={tls}; path={database_or_path}"
+
+def _set_summary(name: str) -> str:
+    return "set" if os.getenv(name, "").strip() else "unset"
+
+try:
+    commit = subprocess.check_output(["git", "rev-parse", "--verify", "HEAD"], text=True).strip()
+except Exception:
+    commit = "unknown"
+
+generated_at = _dt.datetime.now(_dt.timezone.utc).replace(microsecond=0).isoformat()
+lines = [
+    "# Managed Provider Paid-Pilot Acceptance Note",
+    "",
+    f"- generated_at_utc: `{generated_at}`",
+    f"- git_commit: `{commit}`",
+    f"- gate_status: `{gate_status}`",
+    "",
+    "## Redacted Selector Summary",
+    "",
+]
+for name, value in selectors.items():
+    lines.append(f"- `{name}`: `{value or 'unset'}`")
+
+lines.extend(
+    [
+        "",
+        "## Redacted Endpoint Summary",
+        "",
+        f"- `TP_DATABASE_URL`: `{_url_summary('TP_DATABASE_URL')}`",
+        f"- `TP_TEST_POSTGRES_URL`: `{_url_summary('TP_TEST_POSTGRES_URL')}`",
+        f"- `TP_REDIS_URL`: `{_url_summary('TP_REDIS_URL')}`",
+        f"- `TP_TEST_REDIS_URL`: `{_url_summary('TP_TEST_REDIS_URL')}`",
+        f"- `TP_FRONTDOOR_REDIS_URL`: `{_url_summary('TP_FRONTDOOR_REDIS_URL')}`",
+        f"- `TP_ARTIFACT_ENDPOINT_URL`: `{_url_summary('TP_ARTIFACT_ENDPOINT_URL')}`",
+        f"- `TP_TEST_S3_URL`: `{_url_summary('TP_TEST_S3_URL')}`",
+        f"- `TP_ARTIFACT_BUCKET`: `{_set_summary('TP_ARTIFACT_BUCKET')}`",
+        f"- `TP_TEST_S3_BUCKET`: `{_set_summary('TP_TEST_S3_BUCKET')}`",
+        f"- `TP_ARTIFACT_REGION`: `{_set_summary('TP_ARTIFACT_REGION')}`",
+        "",
+        "## Evidence Checklist",
+        "",
+        "- Clean env preflight: captured by this note status.",
+        "- `make db-upgrade`: record exact result for full gate runs.",
+        "- Component gates: record exact result for full gate runs.",
+        "- `make test-paid-pilot-services-contract`: record exact result for full gate runs.",
+        "- Cleanup result: record validation Postgres/Redis/S3 cleanup confirmation.",
+        "",
+        "Do not add secrets, private hostnames, customer identifiers, real usernames, or bucket names to this note.",
+        "",
+    ]
+)
+resolved.write_text("\n".join(lines), encoding="utf-8")
+print(f"Managed paid-pilot evidence note written: {resolved}")
+PY
+}
 
 "${PYTHON_BIN}" - <<'PY'
 from __future__ import annotations
@@ -228,9 +338,11 @@ raise SystemExit(1 if missing or placeholder or wrong or leaked or unsafe_overla
 PY
 
 if [[ "${PREFLIGHT_ONLY}" == "1" ]]; then
+    write_evidence_note "preflight_passed"
     printf '%s\n' "Managed paid-pilot clean-env preflight passed."
     exit 0
 fi
 
 make db-upgrade
 make test-paid-pilot-services-contract
+write_evidence_note "gate_passed"

--- a/src/transformation_portal/api/routes/jobs.py
+++ b/src/transformation_portal/api/routes/jobs.py
@@ -29,16 +29,16 @@ class JobRouteHandlers:
 
     create_job_http: Callable[[Request, dict[str, Any]], Awaitable[Response]]
     create_job_v2_http: Callable[[Request, dict[str, Any]], Awaitable[Response]]
-    list_jobs: Callable[[int], Awaitable[Response]]
-    list_jobs_v2: Callable[[int], Awaitable[Response]]
-    get_job: Callable[[str, bool], Awaitable[Response]]
-    get_job_v2: Callable[[str, bool], Awaitable[Response]]
-    get_job_artifact: Callable[[str, str], Awaitable[Response]]
-    get_job_artifact_v2: Callable[[str, str], Awaitable[Response]]
-    delete_job_artifacts: Callable[[str], Awaitable[Response]]
-    delete_job_artifacts_v2: Callable[[str], Awaitable[Response]]
-    cancel_job: Callable[[str], Awaitable[Response]]
-    cancel_job_v2: Callable[[str], Awaitable[Response]]
+    list_jobs: Callable[[Request, int], Awaitable[Response]]
+    list_jobs_v2: Callable[[Request, int], Awaitable[Response]]
+    get_job: Callable[[Request, str, bool], Awaitable[Response]]
+    get_job_v2: Callable[[Request, str, bool], Awaitable[Response]]
+    get_job_artifact: Callable[[Request, str, str], Awaitable[Response]]
+    get_job_artifact_v2: Callable[[Request, str, str], Awaitable[Response]]
+    delete_job_artifacts: Callable[[Request, str], Awaitable[Response]]
+    delete_job_artifacts_v2: Callable[[Request, str], Awaitable[Response]]
+    cancel_job: Callable[[Request, str], Awaitable[Response]]
+    cancel_job_v2: Callable[[Request, str], Awaitable[Response]]
     job_events: Callable[[Request, str], Awaitable[Response]]
     job_events_v2: Callable[[Request, str], Awaitable[Response]]
 
@@ -56,44 +56,44 @@ def create_jobs_router(handlers: JobRouteHandlers, *, job_list_limit: int = DEFA
         return await handlers.create_job_v2_http(request, payload)
 
     @router.get("/v1/jobs", response_model=JobsListEnvelope)
-    async def list_jobs(limit: int = job_list_limit) -> Response:
-        return await handlers.list_jobs(limit)
+    async def list_jobs(request: Request, limit: int = job_list_limit) -> Response:
+        return await handlers.list_jobs(request, limit)
 
     @router.get("/v2/jobs", response_model=JobsListEnvelope)
-    async def list_jobs_v2(limit: int = job_list_limit) -> Response:
-        return await handlers.list_jobs_v2(limit)
+    async def list_jobs_v2(request: Request, limit: int = job_list_limit) -> Response:
+        return await handlers.list_jobs_v2(request, limit)
 
     @router.get("/v1/jobs/{job_id}", response_model=JobStatusEnvelope)
-    async def get_job(job_id: str, include_logs: bool = True) -> Response:
-        return await handlers.get_job(job_id, include_logs)
+    async def get_job(request: Request, job_id: str, include_logs: bool = True) -> Response:
+        return await handlers.get_job(request, job_id, include_logs)
 
     @router.get("/v2/jobs/{job_id}", response_model=JobStatusEnvelope)
-    async def get_job_v2(job_id: str, include_logs: bool = True) -> Response:
-        return await handlers.get_job_v2(job_id, include_logs)
+    async def get_job_v2(request: Request, job_id: str, include_logs: bool = True) -> Response:
+        return await handlers.get_job_v2(request, job_id, include_logs)
 
     @router.get("/v1/jobs/{job_id}/artifacts/{artifact_path:path}")
-    async def get_job_artifact(job_id: str, artifact_path: str) -> Response:
-        return await handlers.get_job_artifact(job_id, artifact_path)
+    async def get_job_artifact(request: Request, job_id: str, artifact_path: str) -> Response:
+        return await handlers.get_job_artifact(request, job_id, artifact_path)
 
     @router.get("/v2/jobs/{job_id}/artifacts/{artifact_path:path}")
-    async def get_job_artifact_v2(job_id: str, artifact_path: str) -> Response:
-        return await handlers.get_job_artifact_v2(job_id, artifact_path)
+    async def get_job_artifact_v2(request: Request, job_id: str, artifact_path: str) -> Response:
+        return await handlers.get_job_artifact_v2(request, job_id, artifact_path)
 
     @router.delete("/v1/jobs/{job_id}/artifacts", response_model=JobStatusEnvelope)
-    async def delete_job_artifacts(job_id: str) -> Response:
-        return await handlers.delete_job_artifacts(job_id)
+    async def delete_job_artifacts(request: Request, job_id: str) -> Response:
+        return await handlers.delete_job_artifacts(request, job_id)
 
     @router.delete("/v2/jobs/{job_id}/artifacts", response_model=JobStatusEnvelope)
-    async def delete_job_artifacts_v2(job_id: str) -> Response:
-        return await handlers.delete_job_artifacts_v2(job_id)
+    async def delete_job_artifacts_v2(request: Request, job_id: str) -> Response:
+        return await handlers.delete_job_artifacts_v2(request, job_id)
 
     @router.post("/v1/jobs/{job_id}/cancel", response_model=JobEnvelope)
-    async def cancel_job(job_id: str) -> Response:
-        return await handlers.cancel_job(job_id)
+    async def cancel_job(request: Request, job_id: str) -> Response:
+        return await handlers.cancel_job(request, job_id)
 
     @router.post("/v2/jobs/{job_id}/cancel", response_model=JobEnvelope)
-    async def cancel_job_v2(job_id: str) -> Response:
-        return await handlers.cancel_job_v2(job_id)
+    async def cancel_job_v2(request: Request, job_id: str) -> Response:
+        return await handlers.cancel_job_v2(request, job_id)
 
     @router.get("/v1/jobs/{job_id}/events")
     async def job_events(request: Request, job_id: str) -> Response:

--- a/src/transformation_portal/orchestrator/__init__.py
+++ b/src/transformation_portal/orchestrator/__init__.py
@@ -7,6 +7,7 @@ Phase 1 of the production hardening roadmap. See
 from transformation_portal.orchestrator.storage import (
     get_job_event_store,
     get_job_repository,
+    get_operational_audit_store,
     reset_singletons,
 )
 from transformation_portal.orchestrator.storage.base import (
@@ -15,6 +16,8 @@ from transformation_portal.orchestrator.storage.base import (
     JobNotFoundError,
     JobRecord,
     JobRepository,
+    OperationalAuditRecord,
+    OperationalAuditStore,
     RepositoryError,
 )
 
@@ -24,8 +27,11 @@ __all__ = [
     "JobNotFoundError",
     "JobRecord",
     "JobRepository",
+    "OperationalAuditRecord",
+    "OperationalAuditStore",
     "RepositoryError",
     "get_job_event_store",
     "get_job_repository",
+    "get_operational_audit_store",
     "reset_singletons",
 ]

--- a/src/transformation_portal/orchestrator/models.py
+++ b/src/transformation_portal/orchestrator/models.py
@@ -11,6 +11,7 @@ Schema notes:
 - ``job_events``: append-only, per-job monotonic ``seq`` for SSE replay.
 - ``job_artifacts``: keyed by ``(job_id, artifact_path)`` to match the
   legacy ``Job.artifact_lookup`` semantic.
+- ``operational_audit_events``: append-only pilot control-plane audit log.
 
 All complex fields (``request``, ``effective_request``, ``run_summary``,
 ``error``, the artifact item dict) use JSONB so they can be queried in
@@ -122,4 +123,29 @@ class JobEventModel(Base):
     created_at: Mapped[float] = mapped_column(Float, nullable=False)
 
 
-__all__ = ["Base", "JobArtifactModel", "JobEventModel", "JobModel"]
+class OperationalAuditEventModel(Base):
+    """Append-only pilot control-plane audit event.
+
+    ``job_id`` deliberately has no SQL-level foreign key so job retention and
+    artifact deletion cannot erase the operational audit history.
+    """
+
+    __tablename__ = "operational_audit_events"
+    __table_args__ = (
+        Index("ix_operational_audit_events_created_at", "created_at"),
+        Index("ix_operational_audit_events_tenant_created", "tenant_id", "created_at"),
+        Index("ix_operational_audit_events_job_id", "job_id"),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    created_at: Mapped[float] = mapped_column(Float, nullable=False)
+    action: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    decision: Mapped[str] = mapped_column(String(32), nullable=False, index=True)
+    tenant_id: Mapped[Optional[str]] = mapped_column(String(64), nullable=True, index=True)
+    job_id: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
+    actor: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+    request_context: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+    details: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+
+
+__all__ = ["Base", "JobArtifactModel", "JobEventModel", "JobModel", "OperationalAuditEventModel"]

--- a/src/transformation_portal/orchestrator/storage/__init__.py
+++ b/src/transformation_portal/orchestrator/storage/__init__.py
@@ -19,6 +19,7 @@ from typing import Optional
 from transformation_portal.orchestrator.storage.base import (
     JobEventStore,
     JobRepository,
+    OperationalAuditStore,
 )
 
 _BACKEND_ENV = "TP_ORCHESTRATOR_STATE_BACKEND"
@@ -26,6 +27,7 @@ _DATABASE_URL_ENV = "TP_DATABASE_URL"
 
 _repository: Optional[JobRepository] = None
 _event_store: Optional[JobEventStore] = None
+_audit_store: Optional[OperationalAuditStore] = None
 
 
 def _selected_backend() -> str:
@@ -114,11 +116,48 @@ def get_job_event_store() -> JobEventStore:
     raise RuntimeError(f"Unsupported {_BACKEND_ENV}={backend!r}; expected 'memory' or 'postgres'.")
 
 
+def get_operational_audit_store() -> OperationalAuditStore:
+    """Return the singleton pilot audit store.
+
+    Audit v1 is intentionally Postgres-only so operational history lives in
+    the same managed database as durable job state.
+    """
+    global _audit_store
+    if _audit_store is not None:
+        return _audit_store
+
+    backend = _selected_backend()
+    if backend != "postgres":
+        raise RuntimeError(f"operational audit requires {_BACKEND_ENV}=postgres; got {backend!r}.")
+
+    try:
+        from transformation_portal.orchestrator.storage.postgres import (
+            PostgresOperationalAuditStore,
+        )
+    except ImportError as exc:
+        raise RuntimeError(
+            f"{_BACKEND_ENV}=postgres requires sqlalchemy[asyncio] + "
+            "asyncpg from requirements/base.txt. Install the pinned "
+            "base requirements (make install-core) and retry. (Alembic "
+            "is only needed for `make db-upgrade` / `make db-revision`.)"
+        ) from exc
+
+    database_url = os.getenv(_DATABASE_URL_ENV, "").strip()
+    if not database_url:
+        raise RuntimeError(
+            f"operational audit requires {_DATABASE_URL_ENV} to " "be set (e.g. postgresql+asyncpg://user:pw@host:5432/db)."
+        )
+
+    _audit_store = PostgresOperationalAuditStore(database_url=database_url)
+    return _audit_store
+
+
 def reset_singletons() -> None:
     """Drop the cached singletons. Tests call this between cases."""
-    global _repository, _event_store
+    global _repository, _event_store, _audit_store
     _repository = None
     _event_store = None
+    _audit_store = None
 
 
-__all__ = ["get_job_event_store", "get_job_repository", "reset_singletons"]
+__all__ = ["get_job_event_store", "get_job_repository", "get_operational_audit_store", "reset_singletons"]

--- a/src/transformation_portal/orchestrator/storage/base.py
+++ b/src/transformation_portal/orchestrator/storage/base.py
@@ -288,3 +288,37 @@ class JobEventStore(ABC):
     async def close(self) -> None:
         """Optional shutdown hook for backends that hold connections."""
         return None
+
+
+@dataclass
+class OperationalAuditRecord:
+    """One append-only pilot control-plane audit event."""
+
+    created_at: float
+    action: str
+    decision: str
+    tenant_id: Optional[str] = None
+    job_id: Optional[str] = None
+    actor: Dict[str, Any] = field(default_factory=dict)
+    request_context: Dict[str, Any] = field(default_factory=dict)
+    details: Dict[str, Any] = field(default_factory=dict)
+
+    def copy(self) -> "OperationalAuditRecord":
+        return replace(
+            self,
+            actor=deepcopy(self.actor),
+            request_context=deepcopy(self.request_context),
+            details=deepcopy(self.details),
+        )
+
+
+class OperationalAuditStore(ABC):
+    """Append-only operational audit surface for managed pilot mode."""
+
+    @abstractmethod
+    async def append(self, record: OperationalAuditRecord) -> None:
+        """Persist one audit event."""
+
+    async def close(self) -> None:
+        """Optional shutdown hook for backends that hold connections."""
+        return None

--- a/src/transformation_portal/orchestrator/storage/postgres.py
+++ b/src/transformation_portal/orchestrator/storage/postgres.py
@@ -39,6 +39,7 @@ from transformation_portal.orchestrator.models import (
     JobArtifactModel,
     JobEventModel,
     JobModel,
+    OperationalAuditEventModel,
 )
 from transformation_portal.orchestrator.storage.base import UPDATABLE_FIELDS as _UPDATABLE_FIELDS
 from transformation_portal.orchestrator.storage.base import (
@@ -47,6 +48,8 @@ from transformation_portal.orchestrator.storage.base import (
     JobNotFoundError,
     JobRecord,
     JobRepository,
+    OperationalAuditRecord,
+    OperationalAuditStore,
     RepositoryError,
 )
 
@@ -513,4 +516,46 @@ class PostgresJobEventStore(JobEventStore):
         self._session_factory = None
 
 
-__all__ = ["PostgresJobEventStore", "PostgresJobRepository"]
+class PostgresOperationalAuditStore(OperationalAuditStore):
+    """Append-only operational audit log backed by the orchestrator database."""
+
+    def __init__(self, *, database_url: str) -> None:
+        if not database_url:
+            raise RepositoryError("database_url must be a non-empty string")
+        self._database_url = database_url
+        self._session_factory: Optional[async_sessionmaker[AsyncSession]] = None
+
+    async def _ensure_session_factory(self) -> async_sessionmaker[AsyncSession]:
+        if self._session_factory is None:
+            _, self._session_factory = await _SharedEngine.get(self._database_url)
+        return self._session_factory
+
+    @asynccontextmanager
+    async def _session(self) -> AsyncIterator[AsyncSession]:
+        factory = await self._ensure_session_factory()
+        async with factory() as session:
+            yield session
+
+    async def append(self, record: OperationalAuditRecord) -> None:
+        snapshot = record.copy()
+        async with self._session() as session:
+            session.add(
+                OperationalAuditEventModel(
+                    created_at=snapshot.created_at,
+                    action=snapshot.action,
+                    decision=snapshot.decision,
+                    tenant_id=snapshot.tenant_id,
+                    job_id=snapshot.job_id,
+                    actor=snapshot.actor,
+                    request_context=snapshot.request_context,
+                    details=snapshot.details,
+                )
+            )
+            await session.commit()
+
+    async def close(self) -> None:
+        # The shared engine is disposed by ``PostgresJobRepository.close``.
+        self._session_factory = None
+
+
+__all__ = ["PostgresJobEventStore", "PostgresJobRepository", "PostgresOperationalAuditStore"]

--- a/src/transformation_portal/orchestrator/worker.py
+++ b/src/transformation_portal/orchestrator/worker.py
@@ -1,17 +1,14 @@
 """Worker runner that consumes jobs from the ``QueueBroker``.
 
-Phase 2.A ships the consumer skeleton. The worker is **not yet
-wired** as the actual job executor: ``app.py``'s
-``asyncio.create_subprocess_exec`` call still happens in-band
-(orchestrator process) and the real cut-over to "orchestrator
-enqueues, worker consumes" is the Phase 2.C deliverable.
+The FastAPI lifespan uses ``WorkerRunner`` with the app-owned
+``_orchestrator_job_executor`` for the default in-process worker pool.
+Multi-host deployments can run the same executor through
+``python -m transformation_portal.orchestrator.worker_process`` while
+the backend keeps broker admission as the single execution seam.
 
-This module exists in 2.A so the contract is reviewable end-to-end:
-the worker loop, the heartbeat cadence, the cancellation handling,
-and the lease release are all in one place. Phase 2.C will replace
-the ``_default_executor`` placeholder with the real subprocess
-dispatch (the same code path ``_run_job`` uses today, factored out
-of ``app.py``).
+The ``_default_executor`` remains a lightweight test/CLI fallback for
+this module's generic ``python -m transformation_portal.orchestrator.worker``
+entrypoint; production execution should use the app-wired executor.
 
 Layout:
 
@@ -22,9 +19,9 @@ Layout:
   the executor.
 - ``run_worker_forever`` — the supervisor loop. Runs ``WorkerRunner
   .step`` repeatedly with backoff when the queue is empty.
-- ``main`` — the CLI entry point (``python -m
-  transformation_portal.orchestrator.worker``); reads
-  ``TP_WORKER_*`` env vars and spawns ``run_worker_forever``.
+- ``main`` — the generic CLI entry point (``python -m
+  transformation_portal.orchestrator.worker``); reads ``TP_WORKER_*``
+  env vars and spawns ``run_worker_forever`` with the default executor.
 """
 
 from __future__ import annotations
@@ -104,11 +101,9 @@ async def _default_executor(
     request: JobEnqueueRequest,
     cancellation_event: asyncio.Event,
 ) -> int:
-    """Phase 2.A placeholder executor.
+    """Lightweight fallback executor for this generic runner module.
 
-    Logs that a job was received, sleeps briefly to simulate work,
-    and exits 0. Phase 2.C replaces this with the real subprocess
-    dispatch carved out of ``app.py:_run_job``.
+    Production workers pass the app-owned orchestrator executor instead.
     """
     logger.info(
         "phase2a placeholder executor processing job_id=%s argv=%s",

--- a/src/transformation_portal/orchestrator/worker_process.py
+++ b/src/transformation_portal/orchestrator/worker_process.py
@@ -1,0 +1,53 @@
+"""External orchestrator worker process entrypoint.
+
+This module runs the same executor that the FastAPI lifespan uses for the
+default in-process worker pool, but in a standalone process for multi-host
+paid-pilot deployments.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import logging
+import os
+import signal
+
+from transformation_portal.orchestrator.worker import run_worker_forever
+
+logger = logging.getLogger(__name__)
+
+
+def _load_app_executor():
+    app_module = importlib.import_module("app")
+    return getattr(app_module, "_orchestrator_job_executor")
+
+
+async def run_external_worker(*, stop_event: asyncio.Event | None = None) -> None:
+    """Consume broker leases with the app-owned orchestrator job executor."""
+    await run_worker_forever(executor=_load_app_executor(), stop_event=stop_event)
+
+
+def main() -> None:
+    """``python -m transformation_portal.orchestrator.worker_process`` entry point."""
+    logging.basicConfig(
+        level=os.getenv("TP_WORKER_LOG_LEVEL", "INFO"),
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+    stop_event = asyncio.Event()
+
+    def _request_stop(_signum: int, _frame: object) -> None:
+        logger.info("received signal; requesting external worker drain")
+        stop_event.set()
+
+    signal.signal(signal.SIGINT, _request_stop)
+    signal.signal(signal.SIGTERM, _request_stop)
+
+    asyncio.run(run_external_worker(stop_event=stop_event))
+
+
+if __name__ == "__main__":  # pragma: no cover - executed via `python -m ...`
+    main()
+
+
+__all__ = ["main", "run_external_worker"]

--- a/tests/api/test_jobs_router_factory.py
+++ b/tests/api/test_jobs_router_factory.py
@@ -30,34 +30,34 @@ class _RecordingHandlers:
     async def create_job_v2_http(self, request: Request, payload: dict[str, Any]) -> Response:
         return self._record("create_job_v2_http", path=request.url.path, payload=payload)
 
-    async def list_jobs(self, limit: int) -> Response:
+    async def list_jobs(self, request: Request, limit: int) -> Response:  # noqa: ARG002
         return self._record("list_jobs", limit=limit)
 
-    async def list_jobs_v2(self, limit: int) -> Response:
+    async def list_jobs_v2(self, request: Request, limit: int) -> Response:  # noqa: ARG002
         return self._record("list_jobs_v2", limit=limit)
 
-    async def get_job(self, job_id: str, include_logs: bool) -> Response:
+    async def get_job(self, request: Request, job_id: str, include_logs: bool) -> Response:  # noqa: ARG002
         return self._record("get_job", job_id=job_id, include_logs=include_logs)
 
-    async def get_job_v2(self, job_id: str, include_logs: bool) -> Response:
+    async def get_job_v2(self, request: Request, job_id: str, include_logs: bool) -> Response:  # noqa: ARG002
         return self._record("get_job_v2", job_id=job_id, include_logs=include_logs)
 
-    async def get_job_artifact(self, job_id: str, artifact_path: str) -> Response:
+    async def get_job_artifact(self, request: Request, job_id: str, artifact_path: str) -> Response:  # noqa: ARG002
         return self._record("get_job_artifact", job_id=job_id, artifact_path=artifact_path)
 
-    async def get_job_artifact_v2(self, job_id: str, artifact_path: str) -> Response:
+    async def get_job_artifact_v2(self, request: Request, job_id: str, artifact_path: str) -> Response:  # noqa: ARG002
         return self._record("get_job_artifact_v2", job_id=job_id, artifact_path=artifact_path)
 
-    async def delete_job_artifacts(self, job_id: str) -> Response:
+    async def delete_job_artifacts(self, request: Request, job_id: str) -> Response:  # noqa: ARG002
         return self._record("delete_job_artifacts", job_id=job_id)
 
-    async def delete_job_artifacts_v2(self, job_id: str) -> Response:
+    async def delete_job_artifacts_v2(self, request: Request, job_id: str) -> Response:  # noqa: ARG002
         return self._record("delete_job_artifacts_v2", job_id=job_id)
 
-    async def cancel_job(self, job_id: str) -> Response:
+    async def cancel_job(self, request: Request, job_id: str) -> Response:  # noqa: ARG002
         return self._record("cancel_job", job_id=job_id)
 
-    async def cancel_job_v2(self, job_id: str) -> Response:
+    async def cancel_job_v2(self, request: Request, job_id: str) -> Response:  # noqa: ARG002
         return self._record("cancel_job_v2", job_id=job_id)
 
     async def job_events(self, request: Request, job_id: str) -> Response:

--- a/tests/orchestrator/test_orchestrator_factories.py
+++ b/tests/orchestrator/test_orchestrator_factories.py
@@ -64,6 +64,10 @@ class TestStorageFactory:
         events = storage_factory.get_job_event_store()
         assert isinstance(events, MemoryJobEventStore)
 
+    def test_operational_audit_requires_postgres_backend(self) -> None:
+        with pytest.raises(RuntimeError, match="operational audit requires"):
+            storage_factory.get_operational_audit_store()
+
     def test_explicit_memory_backend(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("TP_ORCHESTRATOR_STATE_BACKEND", "MEMORY")  # case-insensitive
         from transformation_portal.orchestrator.storage.memory import MemoryJobRepository
@@ -95,16 +99,19 @@ class TestStorageFactory:
         from transformation_portal.orchestrator.storage.postgres import (
             PostgresJobEventStore,
             PostgresJobRepository,
+            PostgresOperationalAuditStore,
         )
 
         assert isinstance(storage_factory.get_job_repository(), PostgresJobRepository)
         assert isinstance(storage_factory.get_job_event_store(), PostgresJobEventStore)
+        assert isinstance(storage_factory.get_operational_audit_store(), PostgresOperationalAuditStore)
 
     @pytest.mark.parametrize(
         ("factory_name", "class_name"),
         [
             ("get_job_repository", "PostgresJobRepository"),
             ("get_job_event_store", "PostgresJobEventStore"),
+            ("get_operational_audit_store", "PostgresOperationalAuditStore"),
         ],
     )
     def test_postgres_backend_missing_sql_dependencies_reports_install_guidance(

--- a/tests/orchestrator/test_paid_pilot_services_contract.py
+++ b/tests/orchestrator/test_paid_pilot_services_contract.py
@@ -10,6 +10,7 @@ performs the fail-closed environment validation before invoking it.
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 import sys
 import time
@@ -262,6 +263,28 @@ def _wait_for_durable_artifacts(client: TestClient, job_id: str, *, timeout: flo
     raise AssertionError(f"job {job_id} did not persist terminal artifacts; last body={last_body!r}")
 
 
+def _collect_sse_frames(response: Any) -> list[tuple[str | None, str, dict[str, Any]]]:
+    frames: list[tuple[str | None, str, dict[str, Any]]] = []
+    current_id: str | None = None
+    current_event = ""
+    for line in response.iter_lines():
+        if not line:
+            continue
+        if line.startswith("id: "):
+            current_id = line.split("id: ", 1)[1].strip()
+            continue
+        if line.startswith("event: "):
+            current_event = line.split("event: ", 1)[1].strip()
+            continue
+        if line.startswith("data: "):
+            payload = json.loads(line.split("data: ", 1)[1])
+            frames.append((current_id, current_event, payload))
+            current_id = None
+            if current_event == "done":
+                break
+    return frames
+
+
 def test_paid_pilot_backend_services_compose_end_to_end(
     paid_pilot_stack: dict[str, Any],
     monkeypatch: pytest.MonkeyPatch,
@@ -307,6 +330,15 @@ def test_paid_pilot_backend_services_compose_end_to_end(
         orchestrator_app.JOBS.clear()
         durable_body = _wait_for_durable_artifacts(client, job_id)
         assert durable_body["artifacts"]["items"], "terminal artifact metadata should persist in Postgres"
+
+        orchestrator_app.JOBS.clear()
+        with client.stream("GET", f"/v1/jobs/{job_id}/events", headers={"Last-Event-ID": "0"}) as stream_response:
+            assert stream_response.status_code == 200
+            replayed_frames = _collect_sse_frames(stream_response)
+        replayed_events = [(event_id, event_name, payload.get("id")) for event_id, event_name, payload in replayed_frames]
+        assert replayed_events[-1][1:] == ("done", job_id)
+        assert [event_name for _event_id, event_name, _payload_id in replayed_events][:2] == ["state", "log"]
+        assert all(event_id is not None for event_id, _event_name, _payload_id in replayed_events)
 
         artifact_response = client.get(
             f"/v1/jobs/{job_id}/artifacts/result.txt",

--- a/tests/orchestrator/test_pilot_control_plane_contract.py
+++ b/tests/orchestrator/test_pilot_control_plane_contract.py
@@ -1,0 +1,112 @@
+"""Focused contracts for opt-in managed pilot control-plane behavior."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from transformation_portal.orchestrator import reset_singletons
+from transformation_portal.orchestrator.queue import reset_singleton as reset_queue_singleton
+
+orchestrator_app = importlib.import_module("app")
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def _reset_pilot_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(orchestrator_app, "API_KEY_SECRET", "contract-secret")
+    monkeypatch.setattr(orchestrator_app, "ENFORCE_JOB_API_KEY", True)
+    monkeypatch.setattr(orchestrator_app, "PILOT_CONTROL_PLANE_ENABLED", False)
+    monkeypatch.setattr(orchestrator_app, "PILOT_ALLOWED_TENANTS", set())
+    monkeypatch.setattr(orchestrator_app, "PILOT_ALLOWED_PIPELINES", {"lux-depth-v3"})
+    monkeypatch.setattr(orchestrator_app, "PILOT_MAX_ACTIVE_JOBS_PER_TENANT", 0)
+    monkeypatch.setattr(orchestrator_app, "_PILOT_TENANT_MANAGER", None)
+    reset_singletons()
+    reset_queue_singleton()
+    orchestrator_app.app.state.job_repository = None
+    orchestrator_app.app.state.job_repository_unavailable = False
+    orchestrator_app.JOBS.clear()
+    orchestrator_app.EVENT_SUBSCRIBERS.clear()
+    yield
+    reset_singletons()
+    reset_queue_singleton()
+    orchestrator_app.app.state.job_repository = None
+    orchestrator_app.app.state.job_repository_unavailable = False
+    orchestrator_app.JOBS.clear()
+    orchestrator_app.EVENT_SUBSCRIBERS.clear()
+
+
+async def _audit_noop(**_kwargs: Any) -> None:
+    return None
+
+
+def _seed_job(job: Any) -> None:
+    asyncio.run(orchestrator_app._job_repository().create(orchestrator_app._record_from_job(job)))
+
+
+def test_pilot_tenant_mode_requires_tenant_for_config_preview(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(orchestrator_app, "PILOT_CONTROL_PLANE_ENABLED", True)
+    monkeypatch.setattr(orchestrator_app, "_record_pilot_audit", _audit_noop)
+
+    with TestClient(orchestrator_app.app, headers={"x-api-key": "contract-secret"}) as client:
+        response = client.post("/v1/config-preview", json={"pipeline": "lux-depth-v3", "args": {}})
+
+    assert response.status_code == 400
+    body = response.json()
+    assert body["error"]["code"] == "INVALID_ARGUMENT"
+    assert body["error"]["details"] == {
+        "field": "x-tp-tenant-id",
+        "reason": "tenant_required",
+    }
+
+
+def test_pilot_tenant_mode_filters_job_namespace(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(orchestrator_app, "PILOT_CONTROL_PLANE_ENABLED", True)
+    monkeypatch.setattr(orchestrator_app, "PILOT_ALLOWED_TENANTS", {"tenant_a", "tenant_b"})
+    monkeypatch.setattr(orchestrator_app, "_record_pilot_audit", _audit_noop)
+
+    with TestClient(orchestrator_app.app, headers={"x-api-key": "contract-secret"}) as client:
+        _seed_job(
+            orchestrator_app.Job(
+                id="job_tenant_a",
+                created_at=1.0,
+                state="succeeded",
+                request={"pipeline": "lux-depth-v3"},
+                effective_request={"pipeline": "lux-depth-v3", "args": {}, "tenant_id": "tenant_a"},
+            )
+        )
+        _seed_job(
+            orchestrator_app.Job(
+                id="job_tenant_b",
+                created_at=2.0,
+                state="succeeded",
+                request={"pipeline": "lux-depth-v3"},
+                effective_request={"pipeline": "lux-depth-v3", "args": {}, "tenant_id": "tenant_b"},
+            )
+        )
+
+        list_response = client.get("/v1/jobs", headers={"x-tp-tenant-id": "tenant_a"})
+        cross_tenant_response = client.get("/v1/jobs/job_tenant_b", headers={"x-tp-tenant-id": "tenant_a"})
+
+    assert list_response.status_code == 200
+    body = list_response.json()
+    assert body["data"]["total"] == 1
+    assert [job["id"] for job in body["data"]["jobs"]] == ["job_tenant_a"]
+    assert cross_tenant_response.status_code == 404
+    assert cross_tenant_response.json()["error"]["code"] == "NOT_FOUND"
+
+
+def test_pilot_artifact_storage_job_id_uses_tenant_prefix() -> None:
+    job = orchestrator_app.Job(
+        id="job_artifacts",
+        created_at=1.0,
+        request={"pipeline": "lux-depth-v3"},
+        effective_request={"pipeline": "lux-depth-v3", "args": {}, "tenant_id": "tenant_a"},
+    )
+
+    assert orchestrator_app._artifact_storage_job_id(job) == "tenant_a__job_artifacts"

--- a/tests/orchestrator/test_postgres_storage_offline.py
+++ b/tests/orchestrator/test_postgres_storage_offline.py
@@ -15,9 +15,13 @@ from typing import Any, AsyncIterator, Iterable
 
 import pytest
 
-from transformation_portal.orchestrator import JobRecord
-from transformation_portal.orchestrator.models import JobEventModel, JobModel
-from transformation_portal.orchestrator.storage.postgres import PostgresJobEventStore, PostgresJobRepository
+from transformation_portal.orchestrator import JobRecord, OperationalAuditRecord
+from transformation_portal.orchestrator.models import JobEventModel, JobModel, OperationalAuditEventModel
+from transformation_portal.orchestrator.storage.postgres import (
+    PostgresJobEventStore,
+    PostgresJobRepository,
+    PostgresOperationalAuditStore,
+)
 
 pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
 
@@ -155,3 +159,35 @@ async def test_postgres_events_since_yields_payload_copies() -> None:
     assert events[0].payload == {"nested": {"percent": 50}}
     events[0].payload["nested"]["percent"] = 99
     assert row.payload == {"nested": {"percent": 50}}
+
+
+async def test_postgres_operational_audit_append_snapshots_record_fields() -> None:
+    store = PostgresOperationalAuditStore(database_url="postgresql+asyncpg://user:pw@host/db")
+    session = _FakePostgresSession()
+    _install_fake_session(store, session)
+    record = OperationalAuditRecord(
+        created_at=300.0,
+        action="job_create",
+        decision="accepted",
+        tenant_id="tenant_a",
+        job_id="job_audit",
+        actor={"username": "operator"},
+        request_context={"path": "/v1/jobs"},
+        details={"nested": {"pipeline": "lux-depth-v3"}},
+    )
+
+    await store.append(record)
+    record.actor["username"] = "mutated"
+    record.request_context["path"] = "/mutated"
+    record.details["nested"]["pipeline"] = "mutated"
+
+    audit_model = next(model for model in session.added if isinstance(model, OperationalAuditEventModel))
+    assert session.commits == 1
+    assert audit_model.created_at == 300.0
+    assert audit_model.action == "job_create"
+    assert audit_model.decision == "accepted"
+    assert audit_model.tenant_id == "tenant_a"
+    assert audit_model.job_id == "job_audit"
+    assert audit_model.actor == {"username": "operator"}
+    assert audit_model.request_context == {"path": "/v1/jobs"}
+    assert audit_model.details == {"nested": {"pipeline": "lux-depth-v3"}}

--- a/tests/orchestrator/test_worker_process_contract.py
+++ b/tests/orchestrator/test_worker_process_contract.py
@@ -1,0 +1,41 @@
+"""Contracts for the external orchestrator worker process entrypoint."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from transformation_portal.orchestrator import worker_process
+
+pytestmark = pytest.mark.unit
+
+
+def test_external_worker_uses_app_owned_executor(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    async def fake_executor(_request: Any, _cancel: asyncio.Event) -> int:
+        return 0
+
+    async def fake_run_worker_forever(
+        *,
+        executor: Any,
+        stop_event: asyncio.Event | None = None,
+        **_kwargs: Any,
+    ) -> None:
+        captured["executor"] = executor
+        captured["stop_event"] = stop_event
+
+    monkeypatch.setattr(
+        worker_process.importlib,
+        "import_module",
+        lambda name: SimpleNamespace(_orchestrator_job_executor=fake_executor) if name == "app" else None,
+    )
+    monkeypatch.setattr(worker_process, "run_worker_forever", fake_run_worker_forever)
+    stop_event = asyncio.Event()
+
+    asyncio.run(worker_process.run_external_worker(stop_event=stop_event))
+
+    assert captured == {"executor": fake_executor, "stop_event": stop_event}

--- a/tests/validation/test_managed_paid_pilot_gate_script.py
+++ b/tests/validation/test_managed_paid_pilot_gate_script.py
@@ -42,7 +42,12 @@ def _write_env_file(path: Path, *, extra: str = "") -> Path:
     return path
 
 
-def _run_preflight(env_file: Path, *, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+def _run_preflight(
+    env_file: Path,
+    *,
+    env: dict[str, str] | None = None,
+    evidence_out: Path | None = None,
+) -> subprocess.CompletedProcess[str]:
     fake_bin = env_file.parent / "fake-bin"
     fake_bin.mkdir(exist_ok=True)
     fake_node = fake_bin / "node"
@@ -52,8 +57,12 @@ def _run_preflight(env_file: Path, *, env: dict[str, str] | None = None) -> subp
     run_env = dict(os.environ) if env is None else dict(env)
     run_env["PATH"] = f"{fake_bin}{os.pathsep}{run_env.get('PATH', '')}"
 
+    args = ["bash", str(SCRIPT_PATH), "--env-file", str(env_file), "--preflight-only"]
+    if evidence_out is not None:
+        args.extend(["--evidence-out", str(evidence_out)])
+
     return subprocess.run(
-        ["bash", str(SCRIPT_PATH), "--env-file", str(env_file), "--preflight-only"],
+        args,
         cwd=REPO_ROOT,
         env=run_env,
         text=True,
@@ -82,6 +91,33 @@ def test_managed_paid_pilot_preflight_runs_from_clean_env(tmp_path: Path) -> Non
     assert "leaked local-dev vars: []" in result.stdout
     assert "unsafe managed/test overlap: {}" in result.stdout
     assert "Managed paid-pilot clean-env preflight passed." in result.stdout
+
+
+def test_managed_paid_pilot_preflight_writes_redacted_evidence_note(tmp_path: Path) -> None:
+    env_file = _write_env_file(tmp_path / "managed.env")
+    evidence_out = tmp_path / "acceptance-note.md"
+
+    result = _run_preflight(env_file, evidence_out=evidence_out)
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    note = evidence_out.read_text(encoding="utf-8")
+    assert "# Managed Provider Paid-Pilot Acceptance Note" in note
+    assert "gate_status: `preflight_passed`" in note
+    assert "`TP_ORCHESTRATOR_STATE_BACKEND`: `postgres`" in note
+    assert "`TP_DATABASE_URL`: `scheme=postgresql+asyncpg; tls=no; path=set`" in note
+    assert "staging_user" not in note
+    assert "staging-db.example.test" not in note
+    assert "tp-staging-artifacts" not in note
+    assert "test-secret-value" not in note
+
+
+def test_managed_paid_pilot_preflight_rejects_repo_local_evidence_note(tmp_path: Path) -> None:
+    env_file = _write_env_file(tmp_path / "managed.env")
+
+    result = _run_preflight(env_file, evidence_out=REPO_ROOT / "managed-acceptance.md")
+
+    assert result.returncode == 1
+    assert "evidence output must live outside the repository" in result.stderr
 
 
 def test_managed_paid_pilot_preflight_rejects_local_dev_vars_in_env_file(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Add opt-in managed paid-pilot control-plane surfaces on top of the existing Postgres job state, Redis broker, S3 artifact store, and durable SSE replay seams.
- Keep public route shapes, response envelopes, selectors, auth behavior, and default single-tenant/local-compatible operation intact.

## Changes
- Add redacted managed-provider acceptance evidence output for `run_managed_paid_pilot_gate.sh` plus an acceptance note template.
- Update paid-pilot docs so `Last-Event-ID` durable SSE replay is documented as supported and covered by the integrated gate.
- Extend the paid-pilot services contract to prove persisted SSE replay after `app.JOBS.clear()`.
- Add an external orchestrator worker process entrypoint and `make run-orchestrator-worker`; backend in-process workers remain enabled by default and can be disabled with `TP_ORCHESTRATOR_IN_PROCESS_WORKERS_ENABLED=0`.
- Add opt-in pilot tenant mode using the existing tenant policy surface: tenant header validation, tenant-filtered job reads/events/artifacts/cancel, artifact-store tenant prefixes, pipeline entitlement, and per-tenant active-job quota.
- Add the `operational_audit_events` Postgres migration/store and audit writes for tenant admission, job create/cancel, artifact fetch/delete, config preview, and protected `/v1/readiness`.

## Validation
Proven green:
- `.venv/bin/pytest -q tests/validation/test_managed_paid_pilot_gate_script.py tests/orchestrator/test_postgres_storage_offline.py tests/orchestrator/test_worker_process_contract.py tests/orchestrator/test_pilot_control_plane_contract.py tests/api/test_jobs_router_factory.py -m unit`
- `.venv/bin/pytest -q tests/orchestrator/test_paid_pilot_services_contract.py -m unit` (1 passed, 1 skipped; live service branch skipped without service env)
- `.venv/bin/pytest -q tests/test_app_orchestrator_contract_http.py -m unit`
- `.venv/bin/pytest -q tests/orchestrator/test_broker_dispatch.py -m unit`
- `.venv/bin/pytest -q tests/test_app_orchestrator_runtime.py -m unit -k "list_jobs or get_job or broker or artifact"`
- `.venv/bin/pytest -q tests/orchestrator/test_orchestrator_factories.py -m unit`
- `make validate-ci`
- `make check-doc-heading-links`
- `make ci-quick`
- `make test-frontdoor-contract`
- `git diff --check`
- pre-commit hooks during `git commit`

Still failing:
- `make test-paid-pilot-services-contract` stops at preflight: `TP_ORCHESTRATOR_STATE_BACKEND must be postgres.`

Failure classification:
- The `make test-paid-pilot-services-contract` failure is an environment/service selector blocker. It requires Postgres/Redis/S3 paid-pilot env and did not reach product logic.

## Risk
- Contract risk is bounded by preserving public routes, envelopes, SSE framing, auth behavior, and default local behavior.
- Operational risk is opt-in: tenant/audit mode, external workers, and disabled in-process workers require explicit env or Make target selection.
- Migration risk is additive and revert-safe: `operational_audit_events` is append-only and has no job foreign key, so retention/deletion behavior for existing job state is unchanged.
- Selector/contract stability is preserved for frontdoor and orchestrator surfaces; the route factory now passes `Request` internally without changing public path/query semantics.