### PR TITLE
fix(pilot): enforce tenant-scoped dispatch paths

### DIFF
--- a/app.py
+++ b/app.py
@@ -58,7 +58,13 @@ from transformation_portal.api.v1 import (
     ReadyResponse,
     UploadStagingEnvelope,
 )
-from transformation_portal.core.security.tenant import TenantContext, TenantError, TenantManager, TenantPolicy
+from transformation_portal.core.security.tenant import (
+    TenantAwareFSGuard,
+    TenantContext,
+    TenantError,
+    TenantManager,
+    TenantPolicy,
+)
 from transformation_portal.determinism.trace import get_or_create_trace_context
 from transformation_portal.ingest.upload_staging import (
     DEFAULT_CAPTURE_METADATA_CONFIG_PATH,
@@ -1375,13 +1381,42 @@ async def _pilot_enforce_job_tenant(
     )
 
 
+def _pilot_tenant_fs_guard(tenant: TenantContext) -> TenantAwareFSGuard:
+    guard = TenantAwareFSGuard(_pilot_tenant_manager())
+    guard.set_tenant(tenant)
+    return guard
+
+
+def _pilot_enforce_dispatch_filesystem_tenant(
+    tenant: Optional[TenantContext],
+    filesystem: DispatchFilesystemPreflight,
+    *,
+    pipeline: str,
+) -> None:
+    if tenant is None or not PILOT_CONTROL_PLANE_ENABLED:
+        return
+    guard = _pilot_tenant_fs_guard(tenant)
+    for field, path in (
+        ("input_dir", filesystem.input_dir),
+        ("output_dir", filesystem.output_dir),
+    ):
+        if path is None:
+            continue
+        try:
+            guard.enforce_path(path)
+        except TenantError:
+            raise JobPreflightError(
+                "tenant_path_outside_workspace",
+                field=field,
+                message="Tenant dispatch paths must stay within the tenant workspace or CAS root.",
+                status_code=403,
+                extra={"pipeline": pipeline, "tenant_id": tenant.tenant_id},
+            ) from None
+
+
 async def _pilot_active_job_count_for_tenant(repo: JobRepository, tenant_id: str) -> int:
     records, _total = await repo.list(limit=None)
-    return sum(
-        1
-        for record in records
-        if record.state in ACTIVE_JOB_STATES and _record_tenant_id(record) == tenant_id
-    )
+    return sum(1 for record in records if record.state in ACTIVE_JOB_STATES and _record_tenant_id(record) == tenant_id)
 
 
 def _record_from_job(job: Job) -> JobRecord:
@@ -1755,6 +1790,7 @@ PORTAL_SAFE_ERROR_MESSAGES = {
     "bag_dir_required": "A bag directory is required before dispatch.",
     "input_dir_required": "An existing input directory is required before dispatch.",
     "output_dir_unwritable": "The output directory or its parent is not writable.",
+    "tenant_path_outside_workspace": "Tenant dispatch paths must stay within the tenant workspace or CAS root.",
     "invalid_depth_device": "The selected compute device is not supported.",
     "invalid_preset": "The selected preset is not supported.",
     "invalid_run_card_version": "The selected run card version is not supported.",
@@ -2052,6 +2088,12 @@ class JobPreflightError(RuntimeError):
             details["field"] = self.field
         details.update(self.extra)
         return details
+
+
+@dataclass(frozen=True)
+class DispatchFilesystemPreflight:
+    input_dir: Optional[Path] = None
+    output_dir: Optional[Path] = None
 
 
 def _now() -> float:
@@ -2868,13 +2910,14 @@ def _enforce_dispatch_value_preflight(
 def _enforce_dispatch_filesystem_preflight(
     pipeline: str,
     execution_args: Dict[str, Any],
-) -> Optional[Path]:
+) -> DispatchFilesystemPreflight:
     """Read-only validation of dispatch filesystem inputs.
 
-    Verifies that ``input_dir`` exists inside an allowed root and returns the
-    trusted ``output_dir`` Path that the caller should ``mkdir`` *after* the
-    job admission gate succeeds (so a 429 reject does not leave behind empty
-    directories under load). Each path component is walked via
+    Verifies that ``input_dir`` exists inside an allowed root, validates the
+    requested ``output_dir`` root, and returns trusted paths. The caller should
+    ``mkdir`` ``output_dir`` *after* the job admission gate succeeds (so a 429
+    reject does not leave behind empty directories under load). Each path
+    component is walked via
     :func:`_trusted_existing_dir` / :func:`_trusted_creatable_dir`, which
     iterate ``Path.iterdir()`` rather than passing user-controlled strings to
     filesystem APIs — this also satisfies the CodeQL ``py/path-injection``
@@ -2883,6 +2926,7 @@ def _enforce_dispatch_filesystem_preflight(
     Raises :class:`JobPreflightError` with a portal-safe reason on failure.
     """
 
+    input_dir_trusted: Optional[Path] = None
     input_dir_raw = str(_pick(execution_args, "input_dir", "inputDir", default="")).strip()
     if input_dir_raw:
         input_dir_trusted = _trusted_existing_dir(input_dir_raw, ALLOWED_INPUT_ROOTS)
@@ -2897,7 +2941,7 @@ def _enforce_dispatch_filesystem_preflight(
 
     output_dir_raw = str(_pick(execution_args, "output_dir", "outputDir", default="")).strip()
     if not output_dir_raw:
-        return None
+        return DispatchFilesystemPreflight(input_dir=input_dir_trusted, output_dir=None)
 
     output_dir_trusted = _trusted_creatable_dir(output_dir_raw, ALLOWED_OUTPUT_ROOTS)
     if output_dir_trusted is None:
@@ -2924,7 +2968,7 @@ def _enforce_dispatch_filesystem_preflight(
             status_code=400,
             extra={"pipeline": pipeline},
         )
-    return output_dir_trusted
+    return DispatchFilesystemPreflight(input_dir=input_dir_trusted, output_dir=output_dir_trusted)
 
 
 def _materialize_dispatch_output_dir(
@@ -9832,8 +9876,15 @@ async def _create_job(
 
     try:
         # Read-only filesystem preflight: validates paths and returns the
-        # trusted output_dir to materialise *after* admission succeeds.
-        trusted_output_dir = _enforce_dispatch_filesystem_preflight(pipeline, execution_args)
+        # trusted dispatch paths. Materialise output_dir *after* admission
+        # succeeds so tenant/admission rejects never leave empty directories.
+        filesystem_preflight = _enforce_dispatch_filesystem_preflight(pipeline, execution_args)
+        _pilot_enforce_dispatch_filesystem_tenant(
+            pilot_tenant,
+            filesystem_preflight,
+            pipeline=pipeline,
+        )
+        trusted_output_dir = filesystem_preflight.output_dir
     except JobPreflightError as exc:
         status_code = int(exc.status_code)
         field = str(exc.field or "payload")

--- a/docs/deployment/paid_pilot_services.md
+++ b/docs/deployment/paid_pilot_services.md
@@ -142,7 +142,9 @@ TP_PILOT_MAX_ACTIVE_JOBS_PER_TENANT=2
 When enabled, job admission and config preview require the tenant header. Job
 list/detail/events/artifact/cancel surfaces are tenant-filtered, artifact store
 keys are prefixed with the tenant id, active-job quota is enforced per tenant,
-and pipeline entitlement uses `TenantPolicy.allowed_node_types`.
+pipeline entitlement uses `TenantPolicy.allowed_node_types`, and dispatch
+`input_dir` / `output_dir` paths must remain inside the tenant workspace or
+tenant CAS roots.
 
 Audit v1 writes append-only operational events to the same Postgres database as
 job state. Run `make db-upgrade` before enabling tenant/audit mode so the

--- a/src/transformation_portal/core/security/tenant.py
+++ b/src/transformation_portal/core/security/tenant.py
@@ -344,6 +344,10 @@ class TenantAwareFSGuard(FSGuard):
                 path,
             )
 
+    def enforce_path(self, path: Path) -> None:
+        """Validate that a path stays within the current tenant's scope."""
+        self._enforce_tenant(path)
+
     def read_text(self, path: Path, encoding: str = "utf-8") -> str:
         """Read with tenant check."""
         self._enforce_tenant(path)

--- a/tests/orchestrator/test_pilot_control_plane_contract.py
+++ b/tests/orchestrator/test_pilot_control_plane_contract.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import importlib
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -110,3 +111,42 @@ def test_pilot_artifact_storage_job_id_uses_tenant_prefix() -> None:
     )
 
     assert orchestrator_app._artifact_storage_job_id(job) == "tenant_a__job_artifacts"
+
+
+def test_pilot_dispatch_filesystem_preflight_requires_tenant_scoped_paths(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(orchestrator_app, "PILOT_CONTROL_PLANE_ENABLED", True)
+    monkeypatch.setattr(orchestrator_app, "PILOT_TENANT_WORKSPACE_ROOT", tmp_path / "workspaces")
+    monkeypatch.setattr(orchestrator_app, "PILOT_TENANT_CAS_ROOT", tmp_path / "cas")
+    monkeypatch.setattr(orchestrator_app, "_PILOT_TENANT_MANAGER", None)
+
+    tenant = orchestrator_app._pilot_tenant_manager().create_tenant(
+        "tenant_a",
+        policy=orchestrator_app._pilot_tenant_policy(),
+    )
+    input_dir = tenant.tenant_workspace / "input"
+    input_dir.mkdir(parents=True)
+    output_dir = tenant.tenant_workspace / "output"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+
+    orchestrator_app._pilot_enforce_dispatch_filesystem_tenant(
+        tenant,
+        orchestrator_app.DispatchFilesystemPreflight(input_dir=input_dir, output_dir=output_dir),
+        pipeline="lux-depth-v3",
+    )
+
+    with pytest.raises(orchestrator_app.JobPreflightError) as exc_info:
+        orchestrator_app._pilot_enforce_dispatch_filesystem_tenant(
+            tenant,
+            orchestrator_app.DispatchFilesystemPreflight(input_dir=outside, output_dir=output_dir),
+            pipeline="lux-depth-v3",
+        )
+
+    exc = exc_info.value
+    assert exc.reason == "tenant_path_outside_workspace"
+    assert exc.field == "input_dir"
+    assert exc.status_code == 403
+    assert exc.extra == {"pipeline": "lux-depth-v3", "tenant_id": "tenant_a"}

--- a/tests/security/test_tenant_isolation_helpers.py
+++ b/tests/security/test_tenant_isolation_helpers.py
@@ -123,10 +123,14 @@ def test_tenant_aware_fs_guard_enforces_current_tenant(monkeypatch: pytest.Monke
     )
     monkeypatch.setattr(FSGuard, "delete", lambda self, path, missing_ok=True: calls.append(("delete", path)) or True)
 
+    guard.enforce_path(inside)
     assert guard.read_text(inside) == "payload"
     guard.write_text(inside, "data")
     assert guard.delete(inside) is True
     assert calls == [("read", inside), ("write", inside), ("delete", inside)]
+
+    with pytest.raises(TenantError, match="Cross-tenant access denied"):
+        guard.enforce_path(outside)
 
     with pytest.raises(TenantError, match="Cross-tenant access denied"):
         guard.read_text(outside)


### PR DESCRIPTION
## Summary
- Pilot tenant mode accepted dispatch paths after generic root preflight, but did not prove the trusted input/output paths were inside the selected tenant roots.
- This adds a narrow TenantAwareFSGuard admission check while preserving the default single-tenant path.

## Changes
- Added `TenantAwareFSGuard.enforce_path` for explicit path-only tenant checks.
- Return trusted input/output paths from dispatch filesystem preflight and reject tenant-mode job admission when either path escapes the tenant workspace/CAS roots.
- Documented tenant-mode dispatch path boundaries.
- Added focused tenant helper and pilot control-plane contract coverage.

## Validation
Proven green:
- `./.venv/bin/pytest -q tests/security/test_tenant_isolation_helpers.py tests/orchestrator/test_pilot_control_plane_contract.py -m unit`
- `./.venv/bin/pytest -q tests/test_app_orchestrator_contract_http.py -m unit`
- `./.venv/bin/pytest -q tests/orchestrator/test_paid_pilot_services_contract.py -m unit` (1 passed, 1 skipped)
- `./.venv/bin/pytest -q tests/validation/test_cloudflare_worker_root_shim_contract.py -m unit`
- `make check-doc-heading-links`
- `make ci-quick`
- `make validate-ci`
- `git diff --check`
- `npm ci`
- `npm run worker:dry-run`

Still failing:
- The merged `3d1157a` Cloudflare Workers external check failed in the provider dashboard, but the PR head and squash commit have identical tree hashes and local Worker install/dry-run passes. GitHub exposes no inline provider log.

## Risk
- Compatibility risk is bounded to opt-in `TP_PILOT_CONTROL_PLANE_ENABLED` tenant mode; tenant-less/default behavior keeps returning trusted output paths and materializing after admission.
- Governance risk is reduced by failing closed on tenant path escapes with a sanitized `INVALID_ARGUMENT` response.
- The change is revert-safe because it is additive around tenant-mode admission and does not rename routes, selectors, envelopes, CLI flags, or backend selectors.