### PR TITLE
fix(worker): preserve provider vars on deploy

### DIFF
--- a/cloudflare/transformationportal-worker/package.json
+++ b/cloudflare/transformationportal-worker/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "typecheck": "tsc --noEmit",
     "dev": "wrangler dev",
-    "deploy": "wrangler deploy",
+    "deploy": "wrangler deploy --keep-vars",
     "dry-run": "wrangler deploy --dry-run"
   },
   "engines": {

--- a/docs/governance/REPO_ORGANIZATION.md
+++ b/docs/governance/REPO_ORGANIZATION.md
@@ -171,7 +171,9 @@ The root Cloudflare Workers files are not a general JavaScript application
 root. They are a minimal Workers Builds deploy shim for
 `cloudflare/transformationportal-worker`; keep scripts, Node engine metadata,
 Wrangler version, and the delegated entrypoint aligned with that governed
-worker package. The contract is enforced by
+worker package. Production deploy scripts must preserve dashboard-managed
+provider vars such as `FRONTDOOR_ORIGIN` with `--keep-vars`. The contract is
+enforced by
 `tests/validation/test_cloudflare_worker_root_shim_contract.py`.
 
 ### Root Directory Limits

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "worker:dry-run": "wrangler deploy --dry-run",
-    "worker:deploy": "wrangler deploy"
+    "worker:deploy": "wrangler deploy --keep-vars"
   },
   "engines": {
     "node": ">=22 <23"

--- a/tests/validation/test_cloudflare_worker_root_shim_contract.py
+++ b/tests/validation/test_cloudflare_worker_root_shim_contract.py
@@ -26,6 +26,7 @@ def test_root_worker_build_package_is_minimal_deploy_shim() -> None:
         "worker:dry-run": worker_package["scripts"]["dry-run"],
         "worker:deploy": worker_package["scripts"]["deploy"],
     }
+    assert root_package["scripts"]["worker:deploy"].endswith(" --keep-vars")
     assert root_package["engines"] == worker_package["engines"]
     assert root_package["packageManager"] == worker_package["packageManager"]
     assert root_package["devDependencies"] == {


### PR DESCRIPTION
## Summary
- The post-merge `main` check failed only in the external Cloudflare `Workers Builds: transformationportal` production build.
- GitHub exposed no provider annotations or log text, but the Worker source packages locally and Wrangler documents that deploys remove dashboard-managed vars unless `--keep-vars` is set.
- This keeps the Cloudflare production deploy command from dropping provider-managed vars such as `FRONTDOOR_ORIGIN`.

## Changes
- Add `--keep-vars` to the root Workers Builds deploy shim.
- Align the governed `cloudflare/transformationportal-worker` deploy script with the root shim.
- Pin the behavior in `test_cloudflare_worker_root_shim_contract`.
- Document that production Worker deploy scripts must preserve provider vars.

## Validation
Proven green:
- `PATH=/Users/richardcheetham/.nvm/versions/node/v22.22.2/bin:$PATH npm run worker:dry-run`
- `PATH=/Users/richardcheetham/.nvm/versions/node/v22.22.2/bin:$PATH npm run worker:deploy -- --dry-run`
- `PATH=/Users/richardcheetham/.nvm/versions/node/v22.22.2/bin:$PATH npm run typecheck` in `cloudflare/transformationportal-worker`
- `PATH=/Users/richardcheetham/.nvm/versions/node/v22.22.2/bin:$PATH npm run deploy -- --dry-run` in `cloudflare/transformationportal-worker`
- `./.venv/bin/pytest -q tests/validation/test_cloudflare_worker_root_shim_contract.py -m unit`
- `make check-doc-heading-links`
- `make ci-quick`
- `git diff --check`

Still failing:
- Current `main` commit `9638f49f48a7fe3052b30cb894aa59379df68d6d` has a failed external Cloudflare Workers build `3cde2277-59ae-49b0-afb9-15032a0ad61c`. GitHub exposes no inline Cloudflare annotations.
- Several GitHub Actions checks on that same `main` push were still in progress during triage, not failed.

Risk
- Bounded to Cloudflare Worker deploy commands; no route, API, selector, or backend contract changes.
- `--keep-vars` preserves existing provider-managed runtime variables and is revert-safe if Cloudflare production config is later moved fully into `wrangler.jsonc`.