### PR TITLE
perf(pipelines): add unified luxury batch io benchmark

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ PHASE6_SMOKE_TESTS := \
 	tests/test_lux_render_pipeline_smoke.py \
 	tests/lux_depth_v3/test_orchestrator_smoke.py
 
-.PHONY: help test-fast test-novideo test-full test-integration test-structure test-utils test-orchestrator-contract test-orchestrator-http-contract test-artifact-s3-contract test-orchestrator-postgres-contract test-orchestrator-postgres-app-contract test-worker-redis-contract test-frontdoor-redis-contract test-paid-pilot-services-contract run-managed-paid-pilot-gate run-orchestrator-worker test-portal-contract test-frontdoor-contract test-archive-gate-contract db-upgrade db-revision seed-frontdoor-user run-frontdoor-local run-backend-local run-backend-local-noreload dev-write-env dev-start dev-stop check-vercel-env validate-orchestrator-http validate-portal-lux-materials-live validate-portal-fastvlm-captioning-live validate-portal-css-layer-parity validate-portal-browser validate-frontdoor-browser validate-frontdoor-deployment-gate audit-pipeline-readiness coverage-fast-scope coverage-report coverage-diff coverage-package venv repair-core-venv setup clean \
+.PHONY: help test-fast test-novideo test-full test-integration test-structure test-utils test-orchestrator-contract test-orchestrator-http-contract test-artifact-s3-contract test-orchestrator-postgres-contract test-orchestrator-postgres-app-contract test-worker-redis-contract test-frontdoor-redis-contract test-paid-pilot-services-contract run-managed-paid-pilot-gate run-orchestrator-worker test-portal-contract test-frontdoor-contract test-archive-gate-contract db-upgrade db-revision seed-frontdoor-user run-frontdoor-local run-backend-local run-backend-local-noreload dev-write-env dev-start dev-stop check-vercel-env validate-orchestrator-http validate-portal-lux-materials-live validate-portal-fastvlm-captioning-live validate-portal-css-layer-parity validate-portal-browser validate-frontdoor-browser validate-frontdoor-deployment-gate audit-pipeline-readiness benchmark-unified-luxury-batch-io coverage-fast-scope coverage-report coverage-diff coverage-package venv repair-core-venv setup clean \
         lint lint-parity ci ci-full pre-commit install-hooks quality-check fix-quality check-quality validate-ci organize-docs check-json-serialization check-piptools-cache \
         check-python-headers check-yaml-governance check-stale-docs check-doc-heading-links lock lock-prod lock-ci lock-dev install-core install-ml install-ml-core install-ml-raw install-ml-sam2 install-ml-coreml install-fastvlm-runtime check-fastvlm-runtime docs docs-clean \
         check check-test-markers check-ci-sync check-todo-governance check-environment check-portal-asset-budgets check-dependency-pinning validate-full validate-quick clean-frontdoor clean-all check-worktree \
@@ -77,6 +77,7 @@ help:
 	@echo "  validate-portal-browser  Run the live browser smoke audit with an isolated local backend"
 	@echo "  validate-frontdoor-browser  Run the live browser smoke audit with isolated local backend/frontdoor runtimes"
 	@echo "  validate-frontdoor-deployment-gate  Run the manual shared-deployment frontdoor posture gate"
+	@echo "  benchmark-unified-luxury-batch-io  Compare Unified Luxury serial vs parallel batch I/O"
 	@echo "  validate-full      Run the full validation suite (all checks + browser smokes)"
 	@echo "  validate-quick     Run quick validation (skip browser smokes)"
 	@echo "  audit-pipeline-readiness  Run the local four-pipeline readiness audit"
@@ -280,6 +281,10 @@ test-structure:
 test-utils:
 	@echo "Running utility tests..."
 	@"$(PY)" -m pytest -v tests/test_performance_utils.py tests/test_error_handling.py
+
+benchmark-unified-luxury-batch-io:
+	@echo "Benchmarking Unified Luxury Pipeline batch I/O..."
+	@"$(PY)" tools/benchmark_unified_luxury_batch_io.py $(UNIFIED_LUXURY_BATCH_IO_BENCHMARK_ARGS)
 
 test-orchestrator-contract:
 	@echo "Running portal orchestrator contract suite..."

--- a/docs/analysis/PERFORMANCE_OPTIMIZATION_PLAN.md
+++ b/docs/analysis/PERFORMANCE_OPTIMIZATION_PLAN.md
@@ -3,7 +3,9 @@
 ## Status
 
 Phase 1 is partially implemented as a bounded parallel I/O primitive and an
-explicit opt-in path for the compatibility Unified Luxury Pipeline.
+explicit opt-in path for the compatibility Unified Luxury Pipeline. Phase 1.B
+adds the dedicated advisory benchmark harness needed to evaluate whether that
+opt-in path should ever become the default.
 
 Implemented:
 
@@ -18,12 +20,16 @@ Implemented:
   - `io_saver_workers`
 - focused unit coverage for ordering, failure isolation, and background-save
   overlap
+- `tools/benchmark_unified_luxury_batch_io.py`
+- `make benchmark-unified-luxury-batch-io`
+- advisory benchmark documentation at
+  `docs/performance/unified_luxury_batch_io_benchmark.md`
 
 Not implemented:
 
 - a new public `--parallel-io` CLI flag
 - default-on behavior for existing batch callers
-- benchmark gate changes
+- benchmark gate changes or committed performance baselines
 - GPU/backend acceleration changes
 - memory-mapped TIFF loading
 
@@ -151,28 +157,66 @@ Any future performance claim should include:
 - peak RSS
 - output quality/hash comparison when deterministic output is expected
 - benchmark artifact path and schema verification
+- whether the benchmark input set was explicitly marked representative with
+  `--representative-input-set`
 
 Minimum local measurement command shape:
 
 ```bash
-.venv/bin/python -m pytest tests/test_parallel_io.py tests/test_unified_luxury_pipeline.py -q
+.venv/bin/python -m pytest tests/test_parallel_io.py tests/test_unified_luxury_pipeline.py tests/test_unified_luxury_batch_io_benchmark.py -q
 ```
 
-For real throughput measurement, add or reuse a benchmark that writes a non-empty
-artifact with a schema that the consuming workflow validates. Do not treat a
-green workflow as performance evidence unless the artifact contains real
-measurements.
+For real throughput measurement, use the dedicated harness:
 
-## Remaining Work
+```bash
+UNIFIED_LUXURY_BATCH_IO_BENCHMARK_ARGS="\
+  --input-dir /path/to/representative/tiffs \
+  --output-json /tmp/unified-luxury-batch-io.json \
+  --runs 5 \
+  --warmup-runs 1 \
+  --output-formats master \
+  --memory-limit-mib 4096 \
+  --representative-input-set" \
+make benchmark-unified-luxury-batch-io
+```
 
-1. Add a dedicated benchmark harness for Unified Luxury Pipeline batch I/O.
-2. Evaluate whether `parallel_io=True` should become the default after measured
-   evidence and memory limits are understood.
-3. Reassess the recipe pipeline and TIFF batch processor for shared reuse of
-   `ParallelIOPipeline`; both already have existing parallel execution controls,
-   so changes should be evidence-driven.
-4. Keep GPU/backend acceleration work separate from I/O scheduling; it has
-   different dependencies, hardware assumptions, and failure modes.
+Do not treat a green workflow as performance evidence unless the artifact
+contains real measurements under schema
+`tp.unified_luxury.batch_io_benchmark.v1`.
+
+## Current Evaluation
+
+The default remains `parallel_io=False`.
+
+Local fixture evidence from
+`tests/fixtures/pipelines/750_picacho_lane/input` exercises two 800x600 TIFF
+files, `output_formats=master`, `runs=3`, `warmup_runs=1`, and
+`--memory-limit-mib 4096`. That run produced a non-empty
+`tp.unified_luxury.batch_io_benchmark.v1` artifact with:
+
+- serial mean wall time: 0.0209056663s
+- `parallel_io=True` mean wall time: 0.0132810000s
+- measured mean speedup: 1.5741033222x
+- `parallel_io=True` peak RSS: 92.703125 MiB
+- failures: 0
+
+This is useful smoke evidence, but it is not enough to change the default
+because the input set is only two small fixtures and was not marked
+representative. A default flip still requires a larger production-sized batch,
+an operator-approved memory limit for the target host class, and review of the
+resulting benchmark artifact.
+
+The recipe pipeline and TIFF batch processor should not be switched to
+`ParallelIOPipeline` by default. The recipe pipeline already exposes
+`parallel=True` through isolated `ThreadPoolExecutor` worker pipeline instances,
+and the TIFF batch processor already exposes `--workers` through
+`ProcessPoolExecutor`. Shared reuse should be revisited only after separate
+benchmarks prove load/save overlap beats those existing execution controls
+without changing recipe/RAG semantics or TIFF processing isolation.
+
+GPU/backend acceleration remains out of scope for this I/O scheduling lane. It
+belongs in backend-specific benchmark work because dependencies, hardware
+assumptions, memory pressure, and failure modes differ from load/save overlap.
 
 ## Validation
 
@@ -180,6 +224,8 @@ Focused validation for this phase:
 
 ```bash
 .venv/bin/pytest tests/test_parallel_io.py tests/test_unified_luxury_pipeline.py -q
+.venv/bin/pytest tests/test_unified_luxury_batch_io_benchmark.py -q
+make benchmark-unified-luxury-batch-io
 git diff --check
 ```
 

--- a/docs/governance/DOCUMENTATION_MAP.md
+++ b/docs/governance/DOCUMENTATION_MAP.md
@@ -75,6 +75,7 @@ operator guidance unless they are linked here as canonical documents.
 | Repo-wide audit baseline | [Portal Repo-Wide Audit - 2026-05-18](PORTAL_AUDIT_REPO_WIDE_2026-05-18.md) | Static repo-wide audit baseline as of 2026-05-18 covering CI/typing/coverage enforcement, ML runtime hotspots (SAM2, Gaussian rasterizer, segmentation cache hashing), container and plugin isolation, dependency/security governance, and software/model licensing |
 | Repo-wide audit backlog | [Portal Audit Backlog - 2026-05-18](audit/PORTAL_AUDIT_2026-05-18_backlog.md) | Companion remediation backlog for the 2026-05-18 audit: 12 actionable items across immediate / near-term / medium-term / long-term tiers with file targets and acceptance criteria |
 | Performance gate policy | [Performance Gate Policy](../performance/GATE_POLICY.md) | Maintained authority for PR-blocking, nightly-blocking, and advisory performance signals |
+| Unified Luxury batch I/O benchmark | [Unified Luxury Batch I/O Benchmark](../performance/unified_luxury_batch_io_benchmark.md) | Maintained advisory harness for measuring serial versus `parallel_io=True` batch I/O before any default or reuse decision |
 | Test marker policy | [ADR-044 Test Marker Enforcement](../architecture/ADR-044-test-marker-enforcement.md) | Maintained |
 | Security hardening report | [security_best_practices_report.md](security_best_practices_report.md) | Maintained status record |
 

--- a/docs/guides/UNIFIED_LUXURY_PIPELINE.md
+++ b/docs/guides/UNIFIED_LUXURY_PIPELINE.md
@@ -118,7 +118,10 @@ print(f"Processed {len(results)} images")
 `parallel_io` is opt-in for compatibility. It overlaps input loading and output
 writing for batch runs while preserving result ordering and per-image failure
 isolation. Keep it disabled when comparing against older timing baselines or
-when debugging per-stage behavior.
+when debugging per-stage behavior. Use
+[Unified Luxury Batch I/O Benchmark](../performance/unified_luxury_batch_io_benchmark.md)
+to collect measured serial vs `parallel_io=True` evidence before considering a
+default change.
 
 ## Configuration Guide
 

--- a/docs/performance/README.md
+++ b/docs/performance/README.md
@@ -9,6 +9,9 @@ The Transformation Portal performance ledger provides regression detection for p
 
 Current gate authority: [Performance Gate Policy](GATE_POLICY.md).
 
+Unified Luxury batch I/O scheduling has a dedicated advisory harness:
+[Unified Luxury Batch I/O Benchmark](unified_luxury_batch_io_benchmark.md).
+
 ---
 
 ## Quick Start

--- a/docs/performance/unified_luxury_batch_io_benchmark.md
+++ b/docs/performance/unified_luxury_batch_io_benchmark.md
@@ -1,0 +1,89 @@
+# Unified Luxury Batch I/O Benchmark
+
+This benchmark measures the Unified Luxury Pipeline batch I/O scheduler:
+
+- serial batch processing with `parallel_io=False`
+- overlapped input load and output save with `parallel_io=True`
+
+It is intentionally CPU-only by default. GPU/backend acceleration work must stay
+in separate benchmark lanes because it has different dependencies, hardware
+assumptions, and failure modes.
+
+## Run
+
+Use the Make target:
+
+```bash
+make benchmark-unified-luxury-batch-io
+```
+
+Pass harness arguments through `UNIFIED_LUXURY_BATCH_IO_BENCHMARK_ARGS`:
+
+```bash
+UNIFIED_LUXURY_BATCH_IO_BENCHMARK_ARGS="\
+  --input-dir /path/to/representative/tiffs \
+  --output-json /tmp/unified-luxury-batch-io.json \
+  --runs 5 \
+  --warmup-runs 1 \
+  --output-formats master \
+  --io-prefetch-size 2 \
+  --io-saver-workers 2 \
+  --memory-limit-mib 4096" \
+make benchmark-unified-luxury-batch-io
+```
+
+When `--input-dir` is omitted, the harness creates deterministic synthetic
+fixtures. Synthetic runs are useful for smoke checks, but they are not enough to
+change defaults.
+
+The harness writes a JSON report with schema
+`tp.unified_luxury.batch_io_benchmark.v1`. The report includes per-trial wall
+time, summary percentiles, peak RSS when `psutil` is installed, the default
+candidate decision, and reuse notes for adjacent pipelines.
+
+## Default Policy
+
+Keep `UnifiedPipelineConfig.parallel_io` defaulted to `False` until measured
+evidence proves a default flip is safe for representative production batches.
+
+Minimum evidence for a default flip:
+
+- serial and `parallel_io=True` runs use the same input set and output formats
+- representative images include production-sized TIFFs, not only synthetic
+  fixtures
+- mean speedup is at least the configured `--min-speedup` threshold
+- p95 wall time does not regress materially
+- `--memory-limit-mib` is set to the operator limit for the target host class
+- peak RSS with `parallel_io=True` stays below that memory limit
+- no per-image failures, ordering changes, or output-count changes occur
+
+If any item is missing, the report should keep the decision at `keep_false`.
+If all items pass, treat `candidate_after_representative_runs` as review
+evidence, not an automatic code change.
+
+## Adjacent Pipelines
+
+Do not automatically reuse `ParallelIOPipeline` in the recipe pipeline or TIFF
+batch processor.
+
+The recipe pipeline already supports `parallel=True` through isolated
+`ThreadPoolExecutor` worker pipeline instances. That model overlaps whole-image
+work and has recipe/RAG indexing semantics that differ from load/save overlap.
+Reassess it only with a dedicated benchmark proving lower wall time and stable
+recipe state.
+
+The TIFF batch processor already supports `--workers` through
+`ProcessPoolExecutor`. That model isolates per-image TIFF processing and has a
+different memory profile from threaded save workers. Reassess it only with
+TIFF-specific measurements against representative source files.
+
+## Out Of Scope
+
+This harness does not evaluate:
+
+- depth backend selection
+- GPU, MPS, CUDA, CoreML, or TensorRT acceleration
+- model download, warmup, or inference scheduling
+- quality metric changes
+
+Those concerns should remain in backend-specific benchmark lanes.

--- a/docs/performance/unified_luxury_batch_io_benchmark.md
+++ b/docs/performance/unified_luxury_batch_io_benchmark.md
@@ -28,7 +28,8 @@ UNIFIED_LUXURY_BATCH_IO_BENCHMARK_ARGS="\
   --output-formats master \
   --io-prefetch-size 2 \
   --io-saver-workers 2 \
-  --memory-limit-mib 4096" \
+  --memory-limit-mib 4096 \
+  --representative-input-set" \
 make benchmark-unified-luxury-batch-io
 ```
 
@@ -54,12 +55,14 @@ Minimum evidence for a default flip:
 - mean speedup is at least the configured `--min-speedup` threshold
 - p95 wall time does not regress materially
 - `--memory-limit-mib` is set to the operator limit for the target host class
+- `--representative-input-set` is passed only after the input set is large and
+  varied enough to represent the target production workload
 - peak RSS with `parallel_io=True` stays below that memory limit
 - no per-image failures, ordering changes, or output-count changes occur
 
-If any item is missing, the report should keep the decision at `keep_false`.
-If all items pass, treat `candidate_after_representative_runs` as review
-evidence, not an automatic code change.
+If any item is missing, the report keeps the decision at `keep_false`. If all
+items pass, treat `candidate_after_representative_runs` as review evidence, not
+an automatic code change.
 
 ## Adjacent Pipelines
 

--- a/tests/test_unified_luxury_batch_io_benchmark.py
+++ b/tests/test_unified_luxury_batch_io_benchmark.py
@@ -54,16 +54,27 @@ def test_default_candidate_requires_memory_limit_and_speedup() -> None:
         parallel_summary=parallel,
         min_speedup=1.10,
         memory_limit_mib=None,
+        representative_input_set=True,
+    )
+    not_representative = harness.evaluate_parallel_io_default(
+        serial_summary=serial,
+        parallel_summary=parallel,
+        min_speedup=1.10,
+        memory_limit_mib=256.0,
+        representative_input_set=False,
     )
     accepted = harness.evaluate_parallel_io_default(
         serial_summary=serial,
         parallel_summary=parallel,
         min_speedup=1.10,
         memory_limit_mib=256.0,
+        representative_input_set=True,
     )
 
     assert missing_limit["decision"] == "keep_false"
     assert "no memory limit supplied" in missing_limit["reason"]
+    assert not_representative["decision"] == "keep_false"
+    assert "not marked representative" in not_representative["reason"]
     assert accepted["decision"] == "candidate_after_representative_runs"
     assert accepted["parallel_io_default_candidate"] is True
 

--- a/tests/test_unified_luxury_batch_io_benchmark.py
+++ b/tests/test_unified_luxury_batch_io_benchmark.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "tools" / "benchmark_unified_luxury_batch_io.py"
+
+
+def _load_harness() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("benchmark_unified_luxury_batch_io", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_generate_synthetic_inputs_are_deterministic_tiffs(tmp_path: Path) -> None:
+    harness = _load_harness()
+
+    first_dir = tmp_path / "first"
+    second_dir = tmp_path / "second"
+    first = harness.generate_synthetic_inputs(first_dir, count=2, width=16, height=12, image_format="tif")
+    second = harness.generate_synthetic_inputs(second_dir, count=2, width=16, height=12, image_format="tif")
+
+    assert [path.name for path in first] == ["synthetic_0000.tif", "synthetic_0001.tif"]
+    assert [path.read_bytes() for path in first] == [path.read_bytes() for path in second]
+
+
+def test_default_candidate_requires_memory_limit_and_speedup() -> None:
+    harness = _load_harness()
+    serial = {
+        "wall_time_s": {"mean": 10.0},
+        "peak_rss_mib": {"max": 100.0},
+        "images_failed": 0,
+    }
+    parallel = {
+        "wall_time_s": {"mean": 5.0},
+        "peak_rss_mib": {"max": 120.0},
+        "images_failed": 0,
+    }
+
+    missing_limit = harness.evaluate_parallel_io_default(
+        serial_summary=serial,
+        parallel_summary=parallel,
+        min_speedup=1.10,
+        memory_limit_mib=None,
+    )
+    accepted = harness.evaluate_parallel_io_default(
+        serial_summary=serial,
+        parallel_summary=parallel,
+        min_speedup=1.10,
+        memory_limit_mib=256.0,
+    )
+
+    assert missing_limit["decision"] == "keep_false"
+    assert "no memory limit supplied" in missing_limit["reason"]
+    assert accepted["decision"] == "candidate_after_representative_runs"
+    assert accepted["parallel_io_default_candidate"] is True
+
+
+def test_reuse_assessment_keeps_adjacent_pipeline_changes_evidence_driven() -> None:
+    harness = _load_harness()
+
+    assessment = harness.reuse_assessment()
+
+    assert "ThreadPoolExecutor" in assessment["recipe_pipeline"]["current_control"]
+    assert "ProcessPoolExecutor" in assessment["tiff_batch_processor"]["current_control"]
+    assert "GPU/backend acceleration is out of scope" in assessment["acceleration_scope"]
+
+
+def test_harness_emits_batch_io_report(tmp_path: Path) -> None:
+    harness = _load_harness()
+    output_json = tmp_path / "report.json"
+    work_dir = tmp_path / "work"
+    args = harness.build_parser().parse_args(
+        [
+            "--work-dir",
+            str(work_dir),
+            "--output-json",
+            str(output_json),
+            "--runs",
+            "1",
+            "--warmup-runs",
+            "0",
+            "--image-count",
+            "2",
+            "--width",
+            "32",
+            "--height",
+            "24",
+            "--input-format",
+            "jpg",
+            "--output-formats",
+            "social",
+        ]
+    )
+
+    written = harness.run_from_args(args)
+    report = json.loads(output_json.read_text(encoding="utf-8"))
+
+    assert written == output_json
+    assert report["schema"] == harness.SCHEMA
+    assert report["summary"]["serial"]["runs"] == 1
+    assert report["summary"]["parallel_io"]["runs"] == 1
+    assert report["trials"]["serial"][0]["images_succeeded"] == 2
+    assert report["trials"]["parallel_io"][0]["images_succeeded"] == 2
+    assert report["comparison"]["decision"] == "keep_false"

--- a/tests/test_unified_luxury_batch_io_benchmark.py
+++ b/tests/test_unified_luxury_batch_io_benchmark.py
@@ -39,14 +39,16 @@ def test_generate_synthetic_inputs_are_deterministic_tiffs(tmp_path: Path) -> No
 def test_default_candidate_requires_memory_limit_and_speedup() -> None:
     harness = _load_harness()
     serial = {
-        "wall_time_s": {"mean": 10.0},
+        "wall_time_s": {"mean": 10.0, "p95": 10.5},
         "peak_rss_mib": {"max": 100.0},
         "images_failed": 0,
+        "output_files": 12,
     }
     parallel = {
-        "wall_time_s": {"mean": 5.0},
+        "wall_time_s": {"mean": 5.0, "p95": 8.0},
         "peak_rss_mib": {"max": 120.0},
         "images_failed": 0,
+        "output_files": 12,
     }
 
     missing_limit = harness.evaluate_parallel_io_default(
@@ -77,6 +79,60 @@ def test_default_candidate_requires_memory_limit_and_speedup() -> None:
     assert "not marked representative" in not_representative["reason"]
     assert accepted["decision"] == "candidate_after_representative_runs"
     assert accepted["parallel_io_default_candidate"] is True
+
+
+def test_default_candidate_rejects_output_count_changes() -> None:
+    harness = _load_harness()
+    serial = {
+        "wall_time_s": {"mean": 10.0, "p95": 10.5},
+        "peak_rss_mib": {"max": 100.0},
+        "images_failed": 0,
+        "output_files": 12,
+    }
+    parallel = {
+        "wall_time_s": {"mean": 5.0, "p95": 8.0},
+        "peak_rss_mib": {"max": 120.0},
+        "images_failed": 0,
+        "output_files": 10,
+    }
+
+    result = harness.evaluate_parallel_io_default(
+        serial_summary=serial,
+        parallel_summary=parallel,
+        min_speedup=1.10,
+        memory_limit_mib=256.0,
+        representative_input_set=True,
+    )
+
+    assert result["decision"] == "keep_false"
+    assert "output file count changed: serial=12, parallel_io=10" in result["reason"]
+
+
+def test_default_candidate_rejects_p95_regression() -> None:
+    harness = _load_harness()
+    serial = {
+        "wall_time_s": {"mean": 10.0, "p95": 10.5},
+        "peak_rss_mib": {"max": 100.0},
+        "images_failed": 0,
+        "output_files": 12,
+    }
+    parallel = {
+        "wall_time_s": {"mean": 5.0, "p95": 11.0},
+        "peak_rss_mib": {"max": 120.0},
+        "images_failed": 0,
+        "output_files": 12,
+    }
+
+    result = harness.evaluate_parallel_io_default(
+        serial_summary=serial,
+        parallel_summary=parallel,
+        min_speedup=1.10,
+        memory_limit_mib=256.0,
+        representative_input_set=True,
+    )
+
+    assert result["decision"] == "keep_false"
+    assert "parallel_io p95 11.000s regressed versus serial p95 10.500s" in result["reason"]
 
 
 def test_reuse_assessment_keeps_adjacent_pipeline_changes_evidence_driven() -> None:

--- a/tools/benchmark_unified_luxury_batch_io.py
+++ b/tools/benchmark_unified_luxury_batch_io.py
@@ -264,6 +264,10 @@ def evaluate_parallel_io_default(
 
     serial_mean = float(serial_summary["wall_time_s"]["mean"])
     parallel_mean = float(parallel_summary["wall_time_s"]["mean"])
+    serial_p95 = float(serial_summary["wall_time_s"]["p95"])
+    parallel_p95 = float(parallel_summary["wall_time_s"]["p95"])
+    serial_outputs = int(serial_summary["output_files"])
+    parallel_outputs = int(parallel_summary["output_files"])
     speedup = serial_mean / parallel_mean if parallel_mean > 0 else 0.0
     parallel_peak = parallel_summary["peak_rss_mib"]["max"]
     failures = int(serial_summary["images_failed"]) + int(parallel_summary["images_failed"])
@@ -271,6 +275,10 @@ def evaluate_parallel_io_default(
     reasons: list[str] = []
     if failures:
         reasons.append("one or more benchmark images failed")
+    if serial_outputs != parallel_outputs:
+        reasons.append(f"output file count changed: serial={serial_outputs}, parallel_io={parallel_outputs}")
+    if parallel_p95 > serial_p95:
+        reasons.append(f"parallel_io p95 {parallel_p95:.3f}s regressed versus serial p95 {serial_p95:.3f}s")
     if not representative_input_set:
         reasons.append("input set was not marked representative")
     if speedup < min_speedup:

--- a/tools/benchmark_unified_luxury_batch_io.py
+++ b/tools/benchmark_unified_luxury_batch_io.py
@@ -11,7 +11,6 @@ hardware, and failure profiles.
 from __future__ import annotations
 
 import argparse
-import contextlib
 import tempfile
 import threading
 import time
@@ -65,6 +64,7 @@ class BenchmarkOptions:
     io_saver_workers: int
     min_speedup: float
     memory_limit_mib: float | None
+    representative_input_set: bool
 
 
 class PeakRSSMonitor:
@@ -258,6 +258,7 @@ def evaluate_parallel_io_default(
     parallel_summary: dict[str, Any],
     min_speedup: float,
     memory_limit_mib: float | None,
+    representative_input_set: bool,
 ) -> dict[str, Any]:
     """Evaluate whether results are strong enough to consider a default flip."""
 
@@ -270,6 +271,8 @@ def evaluate_parallel_io_default(
     reasons: list[str] = []
     if failures:
         reasons.append("one or more benchmark images failed")
+    if not representative_input_set:
+        reasons.append("input set was not marked representative")
     if speedup < min_speedup:
         reasons.append(f"mean speedup {speedup:.3f}x is below required {min_speedup:.3f}x")
     if memory_limit_mib is None:
@@ -469,6 +472,7 @@ def build_report(
             parallel_summary=parallel_summary,
             min_speedup=options.min_speedup,
             memory_limit_mib=options.memory_limit_mib,
+            representative_input_set=options.representative_input_set,
         ),
         "reuse_assessment": reuse_assessment(),
     }
@@ -517,6 +521,11 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--io-saver-workers", type=_positive_int, default=2)
     parser.add_argument("--min-speedup", type=float, default=1.10)
     parser.add_argument("--memory-limit-mib", type=float, default=None)
+    parser.add_argument(
+        "--representative-input-set",
+        action="store_true",
+        help="Assert the input set is representative enough for default-candidate review evidence.",
+    )
     parser.add_argument("--keep-work-dir", action="store_true", help="Keep generated fixtures and outputs after the run.")
     return parser
 
@@ -532,60 +541,58 @@ def _input_paths_from_dir(input_dir: Path) -> list[Path]:
     return deduped
 
 
+def _run_with_work_dir(args: argparse.Namespace, work_dir: Path) -> Path:
+    """Execute the benchmark with an already-created work directory."""
+
+    work_dir.mkdir(parents=True, exist_ok=True)
+    if args.input_dir is None:
+        input_paths = generate_synthetic_inputs(
+            work_dir / "inputs",
+            count=args.image_count,
+            width=args.width,
+            height=args.height,
+            image_format=args.input_format,
+        )
+        image_count = args.image_count
+    else:
+        input_paths = _input_paths_from_dir(args.input_dir)
+        image_count = len(input_paths)
+
+    output_formats = tuple(args.output_formats)
+    options = BenchmarkOptions(
+        runs=args.runs,
+        warmup_runs=args.warmup_runs,
+        image_count=image_count,
+        width=args.width,
+        height=args.height,
+        input_format=args.input_format,
+        output_formats=tuple(fmt.value for fmt in output_formats),
+        io_prefetch_size=args.io_prefetch_size,
+        io_saver_workers=args.io_saver_workers,
+        min_speedup=args.min_speedup,
+        memory_limit_mib=args.memory_limit_mib,
+        representative_input_set=args.representative_input_set,
+    )
+    report = build_report(
+        input_paths=input_paths,
+        work_dir=work_dir / "runs",
+        options=options,
+        output_formats=output_formats,
+    )
+    output_json = args.output_json or (Path(tempfile.gettempdir()) / "tp-unified-luxury-batch-io-benchmark.json")
+    write_report(output_json, report)
+    return output_json
+
+
 def run_from_args(args: argparse.Namespace) -> Path:
     """Execute the benchmark from parsed CLI args and return the report path."""
 
-    temp_ctx: contextlib.AbstractContextManager[str] | None = None
-    if args.work_dir is None:
-        if args.keep_work_dir:
-            work_dir = Path(tempfile.mkdtemp(prefix="tp-unified-luxury-batch-io-"))
-        else:
-            temp_ctx = tempfile.TemporaryDirectory(prefix="tp-unified-luxury-batch-io-")
-            work_dir = Path(temp_ctx.__enter__())
-    else:
-        work_dir = args.work_dir
-        work_dir.mkdir(parents=True, exist_ok=True)
-
-    try:
-        if args.input_dir is None:
-            input_paths = generate_synthetic_inputs(
-                work_dir / "inputs",
-                count=args.image_count,
-                width=args.width,
-                height=args.height,
-                image_format=args.input_format,
-            )
-            image_count = args.image_count
-        else:
-            input_paths = _input_paths_from_dir(args.input_dir)
-            image_count = len(input_paths)
-
-        output_formats = tuple(args.output_formats)
-        options = BenchmarkOptions(
-            runs=args.runs,
-            warmup_runs=args.warmup_runs,
-            image_count=image_count,
-            width=args.width,
-            height=args.height,
-            input_format=args.input_format,
-            output_formats=tuple(fmt.value for fmt in output_formats),
-            io_prefetch_size=args.io_prefetch_size,
-            io_saver_workers=args.io_saver_workers,
-            min_speedup=args.min_speedup,
-            memory_limit_mib=args.memory_limit_mib,
-        )
-        report = build_report(
-            input_paths=input_paths,
-            work_dir=work_dir / "runs",
-            options=options,
-            output_formats=output_formats,
-        )
-        output_json = args.output_json or (Path(tempfile.gettempdir()) / "tp-unified-luxury-batch-io-benchmark.json")
-        write_report(output_json, report)
-        return output_json
-    finally:
-        if temp_ctx is not None and not args.keep_work_dir:
-            temp_ctx.__exit__(None, None, None)
+    if args.work_dir is not None:
+        return _run_with_work_dir(args, args.work_dir)
+    if args.keep_work_dir:
+        return _run_with_work_dir(args, Path(tempfile.mkdtemp(prefix="tp-unified-luxury-batch-io-")))
+    with tempfile.TemporaryDirectory(prefix="tp-unified-luxury-batch-io-") as temp_dir:
+        return _run_with_work_dir(args, Path(temp_dir))
 
 
 def main(argv: Iterable[str] | None = None) -> int:

--- a/tools/benchmark_unified_luxury_batch_io.py
+++ b/tools/benchmark_unified_luxury_batch_io.py
@@ -1,0 +1,603 @@
+#!/usr/bin/env python3
+"""Benchmark Unified Luxury Pipeline batch I/O scheduling.
+
+This harness compares the current serial batch path with the opt-in
+``parallel_io=True`` path using deterministic CPU-only image fixtures. It is
+intentionally scoped to load/save scheduling. GPU and backend acceleration
+benchmarks belong in separate harnesses because they have different dependency,
+hardware, and failure profiles.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import tempfile
+import threading
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+import numpy as np
+from PIL import Image
+
+from transformation_portal.ingest.canonical_json import dump_json
+from transformation_portal.pipelines.unified_luxury_pipeline import (
+    OutputFormat,
+    ProcessingProfile,
+    SceneType,
+    UnifiedLuxuryPipeline,
+    UnifiedPipelineConfig,
+)
+
+SCHEMA = "tp.unified_luxury.batch_io_benchmark.v1"
+DEFAULT_OUTPUT_FORMATS = (OutputFormat.MASTER_TIFF,)
+
+
+@dataclass(frozen=True)
+class TrialMetrics:
+    """One measured batch run."""
+
+    mode: str
+    run_index: int
+    wall_time_s: float
+    images_total: int
+    images_succeeded: int
+    images_failed: int
+    output_files: int
+    peak_rss_mib: float | None
+    peak_rss_delta_mib: float | None
+
+
+@dataclass(frozen=True)
+class BenchmarkOptions:
+    """Configuration captured in the benchmark report."""
+
+    runs: int
+    warmup_runs: int
+    image_count: int
+    width: int
+    height: int
+    input_format: str
+    output_formats: tuple[str, ...]
+    io_prefetch_size: int
+    io_saver_workers: int
+    min_speedup: float
+    memory_limit_mib: float | None
+
+
+class PeakRSSMonitor:
+    """Poll process RSS during a run without making psutil mandatory."""
+
+    def __init__(self, *, interval_s: float = 0.005) -> None:
+        self.interval_s = interval_s
+        self.available = False
+        self.baseline_rss_bytes: int | None = None
+        self.peak_rss_bytes: int | None = None
+        self.samples = 0
+        self._process: Any = None
+        self._thread: threading.Thread | None = None
+        self._stop = threading.Event()
+        self._ready = threading.Event()
+
+    def __enter__(self) -> "PeakRSSMonitor":
+        try:
+            import psutil  # type: ignore
+        except ImportError:
+            return self
+
+        self._process = psutil.Process()
+        self.available = True
+        self._stop.clear()
+        self._ready.clear()
+        self.baseline_rss_bytes = int(self._process.memory_info().rss)
+        self.peak_rss_bytes = self.baseline_rss_bytes
+        self.samples = 0
+        self._thread = threading.Thread(target=self._poll, name="batch-io-rss", daemon=True)
+        self._thread.start()
+        if not self._ready.wait(timeout=max(0.05, self.interval_s * 10)):
+            self._stop.set()
+            self._thread.join(timeout=1.0)
+            raise RuntimeError("PeakRSSMonitor first-sample barrier timed out")
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> bool:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=1.0)
+        if self.available:
+            self._sample()
+        return False
+
+    @property
+    def peak_rss_mib(self) -> float | None:
+        if self.peak_rss_bytes is None:
+            return None
+        return self.peak_rss_bytes / (1024 * 1024)
+
+    @property
+    def peak_rss_delta_mib(self) -> float | None:
+        if self.peak_rss_bytes is None or self.baseline_rss_bytes is None:
+            return None
+        return max(0.0, (self.peak_rss_bytes - self.baseline_rss_bytes) / (1024 * 1024))
+
+    def _poll(self) -> None:
+        self._sample()
+        self._ready.set()
+        while not self._stop.wait(self.interval_s):
+            self._sample()
+
+    def _sample(self) -> None:
+        if self._process is None:
+            return
+        rss = int(self._process.memory_info().rss)
+        self.samples += 1
+        if self.peak_rss_bytes is None or rss > self.peak_rss_bytes:
+            self.peak_rss_bytes = rss
+
+
+def parse_output_formats(raw: str) -> tuple[OutputFormat, ...]:
+    """Parse comma-separated OutputFormat values or enum names."""
+
+    aliases: dict[str, OutputFormat] = {}
+    for fmt in OutputFormat:
+        aliases[fmt.value.lower()] = fmt
+        aliases[fmt.name.lower()] = fmt
+
+    parsed = []
+    for item in raw.split(","):
+        key = item.strip().lower()
+        if not key:
+            continue
+        if key not in aliases:
+            allowed = ", ".join(sorted(aliases))
+            raise argparse.ArgumentTypeError(f"unknown output format {item!r}; allowed: {allowed}")
+        parsed.append(aliases[key])
+
+    if not parsed:
+        raise argparse.ArgumentTypeError("--output-formats must include at least one format")
+    return tuple(parsed)
+
+
+def generate_synthetic_inputs(
+    input_dir: Path,
+    *,
+    count: int,
+    width: int,
+    height: int,
+    image_format: str,
+    seed: int = 1337,
+) -> list[Path]:
+    """Create deterministic synthetic RGB fixtures for the benchmark."""
+
+    if count < 1:
+        raise ValueError("count must be >= 1")
+    if width < 1 or height < 1:
+        raise ValueError("width and height must be >= 1")
+
+    normalized_format = image_format.lower().lstrip(".")
+    extension = {
+        "jpg": ".jpg",
+        "jpeg": ".jpg",
+        "png": ".png",
+        "tif": ".tif",
+        "tiff": ".tif",
+    }.get(normalized_format)
+    if extension is None:
+        raise ValueError("image_format must be one of jpg, jpeg, png, tif, tiff")
+
+    input_dir.mkdir(parents=True, exist_ok=True)
+    rng = np.random.default_rng(seed)
+    x_coords = np.linspace(0, 255, width, dtype=np.float32)
+    y_coords = np.linspace(0, 255, height, dtype=np.float32)
+    xx, yy = np.meshgrid(x_coords, y_coords)
+
+    paths: list[Path] = []
+    for index in range(count):
+        noise = rng.integers(0, 24, size=(height, width), dtype=np.uint8)
+        red = ((xx + index * 17) % 256).astype(np.uint8)
+        green = ((yy + index * 11) % 256).astype(np.uint8)
+        blue = (((xx + yy) / 2 + noise + index * 7) % 256).astype(np.uint8)
+        image = Image.fromarray(np.stack([red, green, blue], axis=2), mode="RGB")
+        path = input_dir / f"synthetic_{index:04d}{extension}"
+        if extension == ".jpg":
+            image.save(path, quality=95, subsampling=0)
+        elif extension == ".png":
+            image.save(path, compress_level=3)
+        else:
+            image.save(path, compression="tiff_lzw")
+        paths.append(path)
+    return paths
+
+
+def percentile(values: Sequence[float], q: float) -> float:
+    """Return an interpolated percentile for a non-empty sequence."""
+
+    if not values:
+        return 0.0
+    ordered = sorted(float(value) for value in values)
+    if len(ordered) == 1:
+        return ordered[0]
+    rank = (len(ordered) - 1) * (q / 100.0)
+    lower = int(rank)
+    upper = min(lower + 1, len(ordered) - 1)
+    fraction = rank - lower
+    return ordered[lower] + (ordered[upper] - ordered[lower]) * fraction
+
+
+def summarize_trials(trials: Sequence[TrialMetrics]) -> dict[str, Any]:
+    """Build stable summary metrics from measured trials."""
+
+    wall_times = [trial.wall_time_s for trial in trials]
+    peak_rss = [trial.peak_rss_mib for trial in trials if trial.peak_rss_mib is not None]
+    peak_delta = [trial.peak_rss_delta_mib for trial in trials if trial.peak_rss_delta_mib is not None]
+    failures = sum(trial.images_failed for trial in trials)
+    outputs = sum(trial.output_files for trial in trials)
+    return {
+        "runs": len(trials),
+        "wall_time_s": {
+            "min": min(wall_times) if wall_times else 0.0,
+            "mean": sum(wall_times) / len(wall_times) if wall_times else 0.0,
+            "p50": percentile(wall_times, 50),
+            "p95": percentile(wall_times, 95),
+            "max": max(wall_times) if wall_times else 0.0,
+        },
+        "peak_rss_mib": {
+            "max": max(peak_rss) if peak_rss else None,
+            "delta_max": max(peak_delta) if peak_delta else None,
+        },
+        "images_failed": failures,
+        "output_files": outputs,
+    }
+
+
+def evaluate_parallel_io_default(
+    *,
+    serial_summary: dict[str, Any],
+    parallel_summary: dict[str, Any],
+    min_speedup: float,
+    memory_limit_mib: float | None,
+) -> dict[str, Any]:
+    """Evaluate whether results are strong enough to consider a default flip."""
+
+    serial_mean = float(serial_summary["wall_time_s"]["mean"])
+    parallel_mean = float(parallel_summary["wall_time_s"]["mean"])
+    speedup = serial_mean / parallel_mean if parallel_mean > 0 else 0.0
+    parallel_peak = parallel_summary["peak_rss_mib"]["max"]
+    failures = int(serial_summary["images_failed"]) + int(parallel_summary["images_failed"])
+
+    reasons: list[str] = []
+    if failures:
+        reasons.append("one or more benchmark images failed")
+    if speedup < min_speedup:
+        reasons.append(f"mean speedup {speedup:.3f}x is below required {min_speedup:.3f}x")
+    if memory_limit_mib is None:
+        reasons.append("no memory limit supplied")
+    elif parallel_peak is None:
+        reasons.append("peak RSS was unavailable; install psutil to capture memory")
+    elif float(parallel_peak) > memory_limit_mib:
+        reasons.append(f"parallel peak RSS {parallel_peak:.1f} MiB exceeds limit {memory_limit_mib:.1f} MiB")
+
+    candidate = not reasons
+    return {
+        "mean_speedup": speedup,
+        "parallel_io_default_candidate": candidate,
+        "decision": "candidate_after_representative_runs" if candidate else "keep_false",
+        "reason": "measured speedup and memory stayed within thresholds" if candidate else "; ".join(reasons),
+        "policy": (
+            "Do not change UnifiedPipelineConfig.parallel_io default from False until representative "
+            "production-sized batches meet the speedup threshold and a documented memory limit."
+        ),
+    }
+
+
+def reuse_assessment() -> dict[str, Any]:
+    """Document adjacent pipeline reuse boundaries for this benchmark."""
+
+    return {
+        "recipe_pipeline": {
+            "surface": "src/transformation_portal/pipeline_unified.py",
+            "current_control": "parallel=True uses ThreadPoolExecutor with isolated worker pipeline instances",
+            "recommendation": (
+                "defer ParallelIOPipeline reuse until a separate benchmark shows load/save overlap "
+                "beats whole-image worker parallelism without changing recipe state or RAG indexing semantics"
+            ),
+        },
+        "tiff_batch_processor": {
+            "surface": "src/luxury_tiff_batch_processor",
+            "current_control": "--workers uses ProcessPoolExecutor for per-image TIFF processing",
+            "recommendation": (
+                "defer ParallelIOPipeline reuse until TIFF-specific measurements show lower wall time "
+                "and acceptable RSS versus process-based parallel execution"
+            ),
+        },
+        "acceleration_scope": (
+            "GPU/backend acceleration is out of scope for this I/O benchmark and should stay in "
+            "hardware-specific benchmark lanes."
+        ),
+    }
+
+
+def _run_single_trial(
+    *,
+    mode: str,
+    run_index: int,
+    input_paths: Sequence[Path],
+    output_dir: Path,
+    output_formats: Sequence[OutputFormat],
+    parallel_io: bool,
+    io_prefetch_size: int,
+    io_saver_workers: int,
+) -> TrialMetrics:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    config = UnifiedPipelineConfig(
+        scene_type=SceneType.INTERIOR,
+        profile=ProcessingProfile.PERFORMANCE,
+        output_formats=list(output_formats),
+        output_dir=output_dir,
+        enable_depth=False,
+        enable_material_response=False,
+        enable_vfx=False,
+        enable_color_grading=False,
+        preserve_metadata=False,
+        parallel_outputs=False,
+        parallel_io=parallel_io,
+        io_prefetch_size=io_prefetch_size,
+        io_saver_workers=io_saver_workers,
+        device="cpu",
+    )
+    pipeline = UnifiedLuxuryPipeline(config)
+    start = time.perf_counter()
+    with PeakRSSMonitor() as rss:
+        results = pipeline.batch_process(list(input_paths), show_progress=False)
+    wall_time_s = time.perf_counter() - start
+    succeeded = sum(1 for outputs in results.values() if outputs)
+    output_files = sum(len(outputs) for outputs in results.values())
+    return TrialMetrics(
+        mode=mode,
+        run_index=run_index,
+        wall_time_s=wall_time_s,
+        images_total=len(input_paths),
+        images_succeeded=succeeded,
+        images_failed=len(input_paths) - succeeded,
+        output_files=output_files,
+        peak_rss_mib=rss.peak_rss_mib,
+        peak_rss_delta_mib=rss.peak_rss_delta_mib,
+    )
+
+
+def run_mode_trials(
+    *,
+    mode: str,
+    input_paths: Sequence[Path],
+    work_dir: Path,
+    output_formats: Sequence[OutputFormat],
+    parallel_io: bool,
+    runs: int,
+    warmup_runs: int,
+    io_prefetch_size: int,
+    io_saver_workers: int,
+) -> list[TrialMetrics]:
+    """Run warmup and measured trials for one mode."""
+
+    if runs < 1:
+        raise ValueError("runs must be >= 1")
+    if warmup_runs < 0:
+        raise ValueError("warmup_runs must be >= 0")
+
+    for warmup_index in range(warmup_runs):
+        _run_single_trial(
+            mode=f"{mode}_warmup",
+            run_index=warmup_index,
+            input_paths=input_paths,
+            output_dir=work_dir / f"{mode}_warmup_{warmup_index}",
+            output_formats=output_formats,
+            parallel_io=parallel_io,
+            io_prefetch_size=io_prefetch_size,
+            io_saver_workers=io_saver_workers,
+        )
+
+    trials: list[TrialMetrics] = []
+    for run_index in range(runs):
+        trials.append(
+            _run_single_trial(
+                mode=mode,
+                run_index=run_index,
+                input_paths=input_paths,
+                output_dir=work_dir / f"{mode}_{run_index}",
+                output_formats=output_formats,
+                parallel_io=parallel_io,
+                io_prefetch_size=io_prefetch_size,
+                io_saver_workers=io_saver_workers,
+            )
+        )
+    return trials
+
+
+def build_report(
+    *,
+    input_paths: Sequence[Path],
+    work_dir: Path,
+    options: BenchmarkOptions,
+    output_formats: Sequence[OutputFormat],
+) -> dict[str, Any]:
+    """Run the benchmark and return a JSON-serializable report."""
+
+    serial_trials = run_mode_trials(
+        mode="serial",
+        input_paths=input_paths,
+        work_dir=work_dir,
+        output_formats=output_formats,
+        parallel_io=False,
+        runs=options.runs,
+        warmup_runs=options.warmup_runs,
+        io_prefetch_size=options.io_prefetch_size,
+        io_saver_workers=options.io_saver_workers,
+    )
+    parallel_trials = run_mode_trials(
+        mode="parallel_io",
+        input_paths=input_paths,
+        work_dir=work_dir,
+        output_formats=output_formats,
+        parallel_io=True,
+        runs=options.runs,
+        warmup_runs=options.warmup_runs,
+        io_prefetch_size=options.io_prefetch_size,
+        io_saver_workers=options.io_saver_workers,
+    )
+    serial_summary = summarize_trials(serial_trials)
+    parallel_summary = summarize_trials(parallel_trials)
+    return {
+        "schema": SCHEMA,
+        "created_at": time.time(),
+        "options": asdict(options),
+        "inputs": {
+            "count": len(input_paths),
+            "paths": [str(path) for path in input_paths],
+        },
+        "trials": {
+            "serial": [asdict(trial) for trial in serial_trials],
+            "parallel_io": [asdict(trial) for trial in parallel_trials],
+        },
+        "summary": {
+            "serial": serial_summary,
+            "parallel_io": parallel_summary,
+        },
+        "comparison": evaluate_parallel_io_default(
+            serial_summary=serial_summary,
+            parallel_summary=parallel_summary,
+            min_speedup=options.min_speedup,
+            memory_limit_mib=options.memory_limit_mib,
+        ),
+        "reuse_assessment": reuse_assessment(),
+    }
+
+
+def write_report(path: Path, report: dict[str, Any]) -> None:
+    """Persist a deterministic JSON benchmark report."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        dump_json(report, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+
+def _positive_int(raw: str) -> int:
+    value = int(raw)
+    if value < 1:
+        raise argparse.ArgumentTypeError("value must be >= 1")
+    return value
+
+
+def _non_negative_int(raw: str) -> int:
+    value = int(raw)
+    if value < 0:
+        raise argparse.ArgumentTypeError("value must be >= 0")
+    return value
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the CLI parser."""
+
+    parser = argparse.ArgumentParser(description="Benchmark Unified Luxury Pipeline batch I/O scheduling.")
+    parser.add_argument(
+        "--input-dir", type=Path, help="Existing input directory. If omitted, synthetic fixtures are generated."
+    )
+    parser.add_argument("--work-dir", type=Path, help="Directory for generated inputs and per-trial outputs.")
+    parser.add_argument("--output-json", type=Path, help="Path to write the benchmark JSON report.")
+    parser.add_argument("--runs", type=_positive_int, default=3)
+    parser.add_argument("--warmup-runs", type=_non_negative_int, default=1)
+    parser.add_argument("--image-count", type=_positive_int, default=6)
+    parser.add_argument("--width", type=_positive_int, default=512)
+    parser.add_argument("--height", type=_positive_int, default=384)
+    parser.add_argument("--input-format", choices=("jpg", "jpeg", "png", "tif", "tiff"), default="tif")
+    parser.add_argument("--output-formats", type=parse_output_formats, default=DEFAULT_OUTPUT_FORMATS)
+    parser.add_argument("--io-prefetch-size", type=_positive_int, default=2)
+    parser.add_argument("--io-saver-workers", type=_positive_int, default=2)
+    parser.add_argument("--min-speedup", type=float, default=1.10)
+    parser.add_argument("--memory-limit-mib", type=float, default=None)
+    parser.add_argument("--keep-work-dir", action="store_true", help="Keep generated fixtures and outputs after the run.")
+    return parser
+
+
+def _input_paths_from_dir(input_dir: Path) -> list[Path]:
+    patterns = ("*.jpg", "*.jpeg", "*.png", "*.tif", "*.tiff", "*.JPG", "*.JPEG", "*.PNG", "*.TIF", "*.TIFF")
+    paths: list[Path] = []
+    for pattern in patterns:
+        paths.extend(sorted(path for path in input_dir.glob(pattern) if path.is_file()))
+    deduped = sorted(set(paths))
+    if not deduped:
+        raise ValueError(f"no supported image files found in {input_dir}")
+    return deduped
+
+
+def run_from_args(args: argparse.Namespace) -> Path:
+    """Execute the benchmark from parsed CLI args and return the report path."""
+
+    temp_ctx: contextlib.AbstractContextManager[str] | None = None
+    if args.work_dir is None:
+        if args.keep_work_dir:
+            work_dir = Path(tempfile.mkdtemp(prefix="tp-unified-luxury-batch-io-"))
+        else:
+            temp_ctx = tempfile.TemporaryDirectory(prefix="tp-unified-luxury-batch-io-")
+            work_dir = Path(temp_ctx.__enter__())
+    else:
+        work_dir = args.work_dir
+        work_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        if args.input_dir is None:
+            input_paths = generate_synthetic_inputs(
+                work_dir / "inputs",
+                count=args.image_count,
+                width=args.width,
+                height=args.height,
+                image_format=args.input_format,
+            )
+            image_count = args.image_count
+        else:
+            input_paths = _input_paths_from_dir(args.input_dir)
+            image_count = len(input_paths)
+
+        output_formats = tuple(args.output_formats)
+        options = BenchmarkOptions(
+            runs=args.runs,
+            warmup_runs=args.warmup_runs,
+            image_count=image_count,
+            width=args.width,
+            height=args.height,
+            input_format=args.input_format,
+            output_formats=tuple(fmt.value for fmt in output_formats),
+            io_prefetch_size=args.io_prefetch_size,
+            io_saver_workers=args.io_saver_workers,
+            min_speedup=args.min_speedup,
+            memory_limit_mib=args.memory_limit_mib,
+        )
+        report = build_report(
+            input_paths=input_paths,
+            work_dir=work_dir / "runs",
+            options=options,
+            output_formats=output_formats,
+        )
+        output_json = args.output_json or (Path(tempfile.gettempdir()) / "tp-unified-luxury-batch-io-benchmark.json")
+        write_report(output_json, report)
+        return output_json
+    finally:
+        if temp_ctx is not None and not args.keep_work_dir:
+            temp_ctx.__exit__(None, None, None)
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    try:
+        output_json = run_from_args(args)
+    except (OSError, ValueError, RuntimeError) as exc:
+        parser.exit(2, f"benchmark error: {exc}\n")
+    print(output_json)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Adds a dedicated benchmark harness for Unified Luxury Pipeline batch I/O so serial and `parallel_io=True` behavior can be measured with wall-time and memory evidence.
- Keeps `parallel_io` opt-in by default and makes any default flip depend on representative measured batches plus an explicit memory limit and no evidence regressions.

## Changes
- Added `tools/benchmark_unified_luxury_batch_io.py` to generate deterministic fixtures or consume an input directory, run serial and parallel-I/O trials, track peak RSS when `psutil` is available, and emit a JSON report with schema `tp.unified_luxury.batch_io_benchmark.v1`.
- Added `make benchmark-unified-luxury-batch-io` with pass-through `UNIFIED_LUXURY_BATCH_IO_BENCHMARK_ARGS`.
- Added `--representative-input-set`; reports keep `decision=keep_false` unless the caller explicitly marks the input set representative enough for default-candidate review.
- Tightened the default-candidate gate so it also rejects output-file count changes and p95 wall-time regressions before emitting `candidate_after_representative_runs`.
- Added unit coverage for deterministic fixtures, report emission, default-decision guardrails, output-count drift, p95 regression, and adjacent-pipeline reuse boundaries.
- Updated `docs/analysis/PERFORMANCE_OPTIMIZATION_PLAN.md` so the old Remaining Work list no longer claims the harness is missing; it now records the local fixture evidence and remaining default-flip requirements.
- Documented the default policy, memory requirements, recipe-pipeline/TIFF-batch reuse reassessment rules, and GPU/backend acceleration separation.
- No `parallel_io` default change, route change, selector change, or production pipeline behavior change.

## Validation
Proven green:
- `./.venv/bin/pytest -q tests/test_unified_luxury_batch_io_benchmark.py -m unit`
- `./.venv/bin/pytest -q tests/test_unified_luxury_pipeline.py tests/test_parallel_io.py -m unit`
- `./.venv/bin/python tools/benchmark_unified_luxury_batch_io.py --work-dir /tmp/tp-unified-luxury-batch-io-smoke --output-json /tmp/tp-unified-luxury-batch-io-smoke.json --runs 1 --warmup-runs 0 --image-count 2 --width 32 --height 24 --input-format jpg --output-formats social`
- `make benchmark-unified-luxury-batch-io UNIFIED_LUXURY_BATCH_IO_BENCHMARK_ARGS="--work-dir /tmp/tp-unified-luxury-batch-io-make-smoke --output-json /tmp/tp-unified-luxury-batch-io-make-smoke.json --runs 1 --warmup-runs 0 --image-count 2 --width 32 --height 24 --input-format jpg --output-formats social"`
- `./.venv/bin/python tools/benchmark_unified_luxury_batch_io.py --input-dir tests/fixtures/pipelines/750_picacho_lane/input --work-dir /tmp/tp-unified-luxury-batch-io-fixtures-v3 --output-json /tmp/tp-unified-luxury-batch-io-fixtures-v3.json --runs 3 --warmup-runs 1 --output-formats master --memory-limit-mib 4096`
- `./.venv/bin/python -m json.tool /tmp/tp-unified-luxury-batch-io-smoke.json`
- `./.venv/bin/python -m black --check tools/benchmark_unified_luxury_batch_io.py tests/test_unified_luxury_batch_io_benchmark.py`
- `make check-doc-heading-links`
- `make check-stale-docs`
- `make ci-quick`
- `make validate-ci`
- `make check-python-headers`
- `git diff --check`
- `git diff --cached --check`

Measured fixture evidence:
- Two 800x600 TIFF fixtures, 3 measured runs, 1 warmup, `output_formats=master`, `--memory-limit-mib 4096`.
- Report schema: `tp.unified_luxury.batch_io_benchmark.v1`.
- Decision: `keep_false` because the input set was not marked representative.
- Observed mean speedup: 1.5741033222x; `parallel_io=True` peak RSS: 92.703125 MiB; failures: 0.

Still failing:
- None in the local validation above.

Notes:
- The smoke and fixture runs prove harness wiring and report shape; they are not representative evidence for changing the default.

## Risk
- Bounded to advisory tooling, docs, and tests; production defaults remain unchanged.
- `psutil` is optional, so environments without it still get timing evidence and an explicit memory-unavailable decision.
- Revert-safe because the Make target and tool are additive and no existing runtime contract changes.