### PR TITLE
fix(pilot): sequence managed paid-pilot gate steps

### DIFF
--- a/docs/deployment/managed_paid_pilot_staging_runbook.md
+++ b/docs/deployment/managed_paid_pilot_staging_runbook.md
@@ -219,12 +219,14 @@ make run-managed-paid-pilot-gate
 ```
 
 The launcher runs `make db-upgrade` against staging `TP_DATABASE_URL`, not
-`TP_TEST_POSTGRES_URL`, before invoking `make test-paid-pilot-services-contract`.
-Do not point `TP_DATABASE_URL` at the disposable test database.
+`TP_TEST_POSTGRES_URL`, then runs each component gate before the integrated
+paid-pilot smoke. Do not point `TP_DATABASE_URL` at the disposable test
+database.
 
 Add `--evidence-out /tmp/tp-managed-paid-pilot-acceptance.md` through
 `MANAGED_PAID_PILOT_GATE_ARGS` when a redacted acceptance note is needed. The
-output must live outside the repository. Use
+output must live outside the repository and records each launcher step with a
+redacted command, result, and exit code. Use
 [`managed_provider_acceptance_note_template.md`](managed_provider_acceptance_note_template.md)
 as the manual review template before promoting evidence into docs.
 
@@ -244,7 +246,7 @@ Record the following in the staging acceptance note or release record:
 - Clean env preflight result.
 - `make db-upgrade` result.
 - Each component gate result.
-- `make test-paid-pilot-services-contract` result.
+- Integrated paid-pilot smoke result.
 - Any skipped lane and the reason.
 - Artifact bucket, Redis, and Postgres validation resource cleanup result.
 

--- a/docs/deployment/managed_provider_acceptance_note_template.md
+++ b/docs/deployment/managed_provider_acceptance_note_template.md
@@ -34,7 +34,7 @@ bucket names. Use provider/environment labels instead.
 - `make test-worker-redis-contract`:
 - `make test-artifact-s3-contract`:
 - `make test-frontdoor-redis-contract`:
-- `make test-paid-pilot-services-contract`:
+- Integrated paid-pilot smoke:
 
 The integrated gate must prove `/v1/jobs` creation through Redis broker
 enqueue, worker completion, terminal state from Postgres after

--- a/docs/deployment/paid_pilot_services.md
+++ b/docs/deployment/paid_pilot_services.md
@@ -98,6 +98,11 @@ TP_MANAGED_PAID_PILOT_ENV_FILE=/tmp/tp-managed-staging.env \
 make run-managed-paid-pilot-gate
 ```
 
+The clean launcher runs `make db-upgrade`, the component gates above, and then
+the integrated paid-pilot smoke. When `--evidence-out` is supplied through
+`MANAGED_PAID_PILOT_GATE_ARGS`, the generated redacted note records each step,
+result, and exit code.
+
 The integrated smoke submits a real `/v1/jobs` request, enqueues through
 Redis, executes through the in-process worker pool with a tiny generated
 subprocess, persists terminal state in Postgres, mirrors artifacts to

--- a/scripts/validation/run_managed_paid_pilot_gate.sh
+++ b/scripts/validation/run_managed_paid_pilot_gate.sh
@@ -16,6 +16,7 @@ ENV_FILE="${DEFAULT_ENV_FILE}"
 EVIDENCE_OUT=""
 PREFLIGHT_ONLY=0
 CLEAN_PROCESS=0
+STEP_LOG=""
 
 usage() {
     cat <<'EOF'
@@ -36,6 +37,22 @@ EOF
 die() {
     printf 'ERROR: %s\n' "$*" >&2
     exit 1
+}
+
+cleanup_step_log() {
+    [[ -z "${STEP_LOG}" ]] || rm -f "${STEP_LOG}"
+}
+
+init_step_log() {
+    if [[ -z "${STEP_LOG}" ]]; then
+        STEP_LOG="$(mktemp "${TMPDIR:-/tmp}/tp-managed-paid-pilot-steps.XXXXXX")"
+        trap cleanup_step_log EXIT
+    fi
+}
+
+record_step() {
+    init_step_log
+    printf '%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" >>"${STEP_LOG}"
 }
 
 while (($#)); do
@@ -148,11 +165,36 @@ set -a
 . "${ENV_FILE}"
 set +a
 
-write_evidence_note() {
+validate_evidence_out() {
     [[ -n "${EVIDENCE_OUT}" ]] || return 0
-    "${PYTHON_BIN}" - "${EVIDENCE_OUT}" "$1" <<'PY'
+    "${PYTHON_BIN}" - "${EVIDENCE_OUT}" <<'PY'
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
+evidence_path = Path(sys.argv[1])
+repo_root = Path.cwd().resolve()
+
+resolved = evidence_path.expanduser().resolve()
+try:
+    resolved.relative_to(repo_root)
+except ValueError:
+    pass
+else:
+    print("ERROR: managed paid-pilot evidence output must live outside the repository", file=sys.stderr)
+    raise SystemExit(1)
+
+resolved.parent.mkdir(parents=True, exist_ok=True)
+PY
+}
+
+write_evidence_note() {
+    [[ -n "${EVIDENCE_OUT}" ]] || return 0
+    "${PYTHON_BIN}" - "${EVIDENCE_OUT}" "$1" "${STEP_LOG}" <<'PY'
+from __future__ import annotations
+
+from collections import OrderedDict
 import datetime as _dt
 import os
 import subprocess
@@ -162,6 +204,7 @@ from urllib.parse import urlsplit
 
 evidence_path = Path(sys.argv[1])
 gate_status = sys.argv[2]
+step_log_path = Path(sys.argv[3]) if len(sys.argv) > 3 and sys.argv[3] else None
 repo_root = Path.cwd().resolve()
 
 resolved = evidence_path.expanduser().resolve()
@@ -195,12 +238,45 @@ def _url_summary(name: str) -> str:
 def _set_summary(name: str) -> str:
     return "set" if os.getenv(name, "").strip() else "unset"
 
+def _markdown_cell(value: str) -> str:
+    return value.replace("|", "\\|").replace("\n", " ")
+
+def _load_steps(path: Path | None) -> list[dict[str, str]]:
+    if path is None or not path.exists():
+        return []
+
+    steps: OrderedDict[str, dict[str, str]] = OrderedDict()
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        if not raw_line.strip():
+            continue
+        try:
+            label, command, status, exit_code = raw_line.split("\t", 3)
+        except ValueError:
+            continue
+        if label not in steps:
+            steps[label] = {
+                "label": label,
+                "command": command,
+                "status": status,
+                "exit_code": exit_code,
+            }
+        else:
+            steps[label].update(
+                {
+                    "command": command,
+                    "status": status,
+                    "exit_code": exit_code,
+                }
+            )
+    return list(steps.values())
+
 try:
     commit = subprocess.check_output(["git", "rev-parse", "--verify", "HEAD"], text=True).strip()
 except Exception:
     commit = "unknown"
 
 generated_at = _dt.datetime.now(_dt.timezone.utc).replace(microsecond=0).isoformat()
+steps = _load_steps(step_log_path)
 lines = [
     "# Managed Provider Paid-Pilot Acceptance Note",
     "",
@@ -230,12 +306,35 @@ lines.extend(
         f"- `TP_TEST_S3_BUCKET`: `{_set_summary('TP_TEST_S3_BUCKET')}`",
         f"- `TP_ARTIFACT_REGION`: `{_set_summary('TP_ARTIFACT_REGION')}`",
         "",
+        "## Gate Step Results",
+        "",
+    ]
+)
+if steps:
+    lines.extend(
+        [
+            "| Step | Command | Result | Exit code |",
+            "| --- | --- | --- | --- |",
+        ]
+    )
+    for step in steps:
+        exit_code = step["exit_code"] or "-"
+        lines.append(
+            "| "
+            f"{_markdown_cell(step['label'])} | "
+            f"`{_markdown_cell(step['command'])}` | "
+            f"`{_markdown_cell(step['status'])}` | "
+            f"`{_markdown_cell(exit_code)}` |"
+        )
+else:
+    lines.append("- No gate steps recorded.")
+
+lines.extend(
+    [
+        "",
         "## Evidence Checklist",
         "",
-        "- Clean env preflight: captured by this note status.",
-        "- `make db-upgrade`: record exact result for full gate runs.",
-        "- Component gates: record exact result for full gate runs.",
-        "- `make test-paid-pilot-services-contract`: record exact result for full gate runs.",
+        "- Confirm every gate step above passed before opening paid-pilot admission.",
         "- Cleanup result: record validation Postgres/Redis/S3 cleanup confirmation.",
         "",
         "Do not add secrets, private hostnames, customer identifiers, real usernames, or bucket names to this note.",
@@ -337,12 +436,52 @@ print("unsafe managed/test overlap:", unsafe_overlap)
 raise SystemExit(1 if missing or placeholder or wrong or leaked or unsafe_overlap else 0)
 PY
 
+validate_evidence_out
+record_step "Clean env preflight" "managed provider env validation" "passed" "0"
+
 if [[ "${PREFLIGHT_ONLY}" == "1" ]]; then
     write_evidence_note "preflight_passed"
     printf '%s\n' "Managed paid-pilot clean-env preflight passed."
     exit 0
 fi
 
-make db-upgrade
-make test-paid-pilot-services-contract
+initialize_gate_plan() {
+    record_step "Database migrations" "make db-upgrade" "not_run" ""
+    record_step "Orchestrator Postgres contract" "TP_ORCHESTRATOR_STATE_BACKEND=memory TP_ORCHESTRATOR_QUEUE_BACKEND=memory TP_ARTIFACT_STORE=local make test-orchestrator-postgres-contract" "not_run" ""
+    record_step "Orchestrator Postgres app contract" "TP_ORCHESTRATOR_STATE_BACKEND=memory TP_ORCHESTRATOR_QUEUE_BACKEND=memory TP_ARTIFACT_STORE=local make test-orchestrator-postgres-app-contract" "not_run" ""
+    record_step "Worker Redis contract" "TP_ORCHESTRATOR_STATE_BACKEND=memory TP_ORCHESTRATOR_QUEUE_BACKEND=memory TP_ARTIFACT_STORE=local make test-worker-redis-contract" "not_run" ""
+    record_step "Artifact S3 contract" "make test-artifact-s3-contract" "not_run" ""
+    record_step "Frontdoor Redis contract" "make test-frontdoor-redis-contract" "not_run" ""
+    record_step "Integrated paid-pilot smoke" "TP_RUN_PAID_PILOT_SERVICES_CONTRACT=1 python -m pytest -q tests/orchestrator/test_paid_pilot_services_contract.py -m unit" "not_run" ""
+}
+
+run_gate_step() {
+    local label="$1"
+    local command_display="$2"
+    shift 2
+
+    printf 'Running managed paid-pilot gate step: %s\n' "${label}"
+    set +e
+    "$@"
+    local exit_code=$?
+    set -e
+
+    if [[ "${exit_code}" == "0" ]]; then
+        record_step "${label}" "${command_display}" "passed" "${exit_code}"
+        return 0
+    fi
+
+    record_step "${label}" "${command_display}" "failed" "${exit_code}"
+    write_evidence_note "gate_failed" || true
+    exit "${exit_code}"
+}
+
+initialize_gate_plan
+run_gate_step "Database migrations" "make db-upgrade" make db-upgrade
+run_gate_step "Orchestrator Postgres contract" "TP_ORCHESTRATOR_STATE_BACKEND=memory TP_ORCHESTRATOR_QUEUE_BACKEND=memory TP_ARTIFACT_STORE=local make test-orchestrator-postgres-contract" env TP_ORCHESTRATOR_STATE_BACKEND=memory TP_ORCHESTRATOR_QUEUE_BACKEND=memory TP_ARTIFACT_STORE=local make test-orchestrator-postgres-contract
+run_gate_step "Orchestrator Postgres app contract" "TP_ORCHESTRATOR_STATE_BACKEND=memory TP_ORCHESTRATOR_QUEUE_BACKEND=memory TP_ARTIFACT_STORE=local make test-orchestrator-postgres-app-contract" env TP_ORCHESTRATOR_STATE_BACKEND=memory TP_ORCHESTRATOR_QUEUE_BACKEND=memory TP_ARTIFACT_STORE=local make test-orchestrator-postgres-app-contract
+run_gate_step "Worker Redis contract" "TP_ORCHESTRATOR_STATE_BACKEND=memory TP_ORCHESTRATOR_QUEUE_BACKEND=memory TP_ARTIFACT_STORE=local make test-worker-redis-contract" env TP_ORCHESTRATOR_STATE_BACKEND=memory TP_ORCHESTRATOR_QUEUE_BACKEND=memory TP_ARTIFACT_STORE=local make test-worker-redis-contract
+run_gate_step "Artifact S3 contract" "make test-artifact-s3-contract" make test-artifact-s3-contract
+run_gate_step "Frontdoor Redis contract" "make test-frontdoor-redis-contract" make test-frontdoor-redis-contract
+run_gate_step "Integrated paid-pilot smoke" "TP_RUN_PAID_PILOT_SERVICES_CONTRACT=1 python -m pytest -q tests/orchestrator/test_paid_pilot_services_contract.py -m unit" env TP_RUN_PAID_PILOT_SERVICES_CONTRACT=1 "${PYTHON_BIN}" -m pytest -q tests/orchestrator/test_paid_pilot_services_contract.py -m unit
 write_evidence_note "gate_passed"

--- a/tests/validation/test_managed_paid_pilot_gate_script.py
+++ b/tests/validation/test_managed_paid_pilot_gate_script.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import os
+import shlex
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -71,6 +73,101 @@ def _run_preflight(
     )
 
 
+def _write_executable(path: Path, content: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+    return path
+
+
+def _write_fake_gate_repo(tmp_path: Path) -> tuple[Path, Path, Path]:
+    fake_repo = tmp_path / "fake-repo"
+    gate_script = fake_repo / "scripts" / "validation" / "run_managed_paid_pilot_gate.sh"
+    _write_executable(gate_script, SCRIPT_PATH.read_text(encoding="utf-8"))
+
+    real_python = shlex.quote(sys.executable)
+    _write_executable(
+        fake_repo / "scripts" / "setup" / "resolve_python_311.sh",
+        f"#!/bin/sh\nprintf '%s\\n' {real_python}\n",
+    )
+    _write_executable(
+        fake_repo / "scripts" / "setup" / "ensure_node_version.sh",
+        "#!/bin/sh\nexit 0\n",
+    )
+
+    venv_bin = fake_repo / ".venv" / "bin"
+    _write_executable(
+        venv_bin / "activate",
+        f"export PATH={shlex.quote(str(venv_bin))}:$PATH\n",
+    )
+    _write_executable(
+        venv_bin / "python",
+        "\n".join(
+            [
+                "#!/bin/sh",
+                'if [ "$1" = "-m" ] && [ "$2" = "pytest" ] && [ "$4" = "tests/orchestrator/test_paid_pilot_services_contract.py" ]; then',
+                '    printf "%s\\n" "integrated:$*" >> "$GATE_TEST_LOG"',
+                '    exit "${GATE_INTEGRATED_EXIT:-0}"',
+                "fi",
+                f'exec {real_python} "$@"',
+                "",
+            ]
+        ),
+    )
+
+    fake_bin = tmp_path / "fake-bin"
+    _write_executable(fake_bin / "node", "#!/bin/sh\nprintf '%s\\n' 'v22.22.2'\n")
+    _write_executable(
+        fake_bin / "make",
+        "\n".join(
+            [
+                "#!/bin/sh",
+                'target="$1"',
+                'printf "%s\\n" "make:$target" >> "$GATE_TEST_LOG"',
+                'if [ "${GATE_FAIL_TARGET:-}" = "$target" ]; then',
+                '    exit "${GATE_FAIL_EXIT:-42}"',
+                "fi",
+                "exit 0",
+                "",
+            ]
+        ),
+    )
+    return gate_script, fake_bin, tmp_path / "gate-steps.log"
+
+
+def _run_fake_full_gate(
+    tmp_path: Path,
+    *,
+    make_fail_target: str = "",
+    integrated_exit: int = 0,
+) -> tuple[subprocess.CompletedProcess[str], Path, Path]:
+    gate_script, fake_bin, step_log = _write_fake_gate_repo(tmp_path)
+    env_file = _write_env_file(
+        tmp_path / "managed.env",
+        extra="\n".join(
+            [
+                f"GATE_TEST_LOG={shlex.quote(str(step_log))}",
+                f"GATE_FAIL_TARGET={shlex.quote(make_fail_target)}",
+                "GATE_FAIL_EXIT=42",
+                f"GATE_INTEGRATED_EXIT={integrated_exit}",
+            ]
+        ),
+    )
+    evidence_out = tmp_path / "acceptance-note.md"
+
+    run_env = dict(os.environ)
+    run_env["PATH"] = f"{fake_bin}{os.pathsep}{run_env.get('PATH', '')}"
+    result = subprocess.run(
+        ["bash", str(gate_script), "--env-file", str(env_file), "--evidence-out", str(evidence_out)],
+        cwd=gate_script.parents[2],
+        env=run_env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    return result, evidence_out, step_log
+
+
 def test_managed_paid_pilot_preflight_runs_from_clean_env(tmp_path: Path) -> None:
     env_file = _write_env_file(tmp_path / "managed.env")
     contaminated_env = dict(os.environ)
@@ -105,6 +202,8 @@ def test_managed_paid_pilot_preflight_writes_redacted_evidence_note(tmp_path: Pa
     assert "gate_status: `preflight_passed`" in note
     assert "`TP_ORCHESTRATOR_STATE_BACKEND`: `postgres`" in note
     assert "`TP_DATABASE_URL`: `scheme=postgresql+asyncpg; tls=no; path=set`" in note
+    assert "## Gate Step Results" in note
+    assert "| Clean env preflight | `managed provider env validation` | `passed` | `0` |" in note
     assert "staging_user" not in note
     assert "staging-db.example.test" not in note
     assert "tp-staging-artifacts" not in note
@@ -192,3 +291,75 @@ def test_managed_paid_pilot_preflight_rejects_same_postgres_database_with_differ
     assert result.returncode == 1
     assert "TP_TEST_POSTGRES_URL" in result.stdout
     assert "same Postgres host/port/database" in result.stdout
+
+
+def test_managed_paid_pilot_full_gate_runs_components_before_integrated_smoke(
+    tmp_path: Path,
+) -> None:
+    result, evidence_out, step_log = _run_fake_full_gate(tmp_path)
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert step_log.read_text(encoding="utf-8").splitlines() == [
+        "make:db-upgrade",
+        "make:test-orchestrator-postgres-contract",
+        "make:test-orchestrator-postgres-app-contract",
+        "make:test-worker-redis-contract",
+        "make:test-artifact-s3-contract",
+        "make:test-frontdoor-redis-contract",
+        "integrated:-m pytest -q tests/orchestrator/test_paid_pilot_services_contract.py -m unit",
+    ]
+
+    note = evidence_out.read_text(encoding="utf-8")
+    assert "gate_status: `gate_passed`" in note
+    assert "| Database migrations | `make db-upgrade` | `passed` | `0` |" in note
+    assert (
+        "| Orchestrator Postgres contract | "
+        "`TP_ORCHESTRATOR_STATE_BACKEND=memory TP_ORCHESTRATOR_QUEUE_BACKEND=memory "
+        "TP_ARTIFACT_STORE=local make test-orchestrator-postgres-contract` | "
+        "`passed` | `0` |"
+    ) in note
+    assert "| Frontdoor Redis contract | `make test-frontdoor-redis-contract` | `passed` | `0` |" in note
+    assert (
+        "| Integrated paid-pilot smoke | "
+        "`TP_RUN_PAID_PILOT_SERVICES_CONTRACT=1 python -m pytest -q "
+        "tests/orchestrator/test_paid_pilot_services_contract.py -m unit` | "
+        "`passed` | `0` |"
+    ) in note
+    assert note.index("Orchestrator Postgres contract") < note.index("Integrated paid-pilot smoke")
+    assert "staging_user" not in note
+    assert "staging-db.example.test" not in note
+    assert "tp-staging-artifacts" not in note
+    assert "test-secret-value" not in note
+
+
+def test_managed_paid_pilot_full_gate_records_failed_component_and_stops(
+    tmp_path: Path,
+) -> None:
+    result, evidence_out, step_log = _run_fake_full_gate(
+        tmp_path,
+        make_fail_target="test-worker-redis-contract",
+    )
+
+    assert result.returncode == 42, result.stderr + result.stdout
+    assert step_log.read_text(encoding="utf-8").splitlines() == [
+        "make:db-upgrade",
+        "make:test-orchestrator-postgres-contract",
+        "make:test-orchestrator-postgres-app-contract",
+        "make:test-worker-redis-contract",
+    ]
+
+    note = evidence_out.read_text(encoding="utf-8")
+    assert "gate_status: `gate_failed`" in note
+    assert (
+        "| Worker Redis contract | "
+        "`TP_ORCHESTRATOR_STATE_BACKEND=memory TP_ORCHESTRATOR_QUEUE_BACKEND=memory "
+        "TP_ARTIFACT_STORE=local make test-worker-redis-contract` | "
+        "`failed` | `42` |"
+    ) in note
+    assert "| Artifact S3 contract | `make test-artifact-s3-contract` | `not_run` | `-` |" in note
+    assert (
+        "| Integrated paid-pilot smoke | "
+        "`TP_RUN_PAID_PILOT_SERVICES_CONTRACT=1 python -m pytest -q "
+        "tests/orchestrator/test_paid_pilot_services_contract.py -m unit` | "
+        "`not_run` | `-` |"
+    ) in note


### PR DESCRIPTION
## Summary
- The managed paid-pilot launcher previously delegated the provider-backed validation to the aggregate paid-pilot target, which made component gate ordering and per-step evidence opaque.
- This change makes the launcher run migrations, each component gate, and then the integrated smoke explicitly while preserving the clean-env preflight and redacted evidence output.

## Changes
- Add a temporary step ledger to `run_managed_paid_pilot_gate.sh` so the generated acceptance note records each launcher step, result, and exit code without including provider secrets.
- Run component gates before the integrated smoke in full launcher mode:
  - `make db-upgrade`
  - `make test-orchestrator-postgres-contract`
  - `make test-orchestrator-postgres-app-contract`
  - `make test-worker-redis-contract`
  - `make test-artifact-s3-contract`
  - `make test-frontdoor-redis-contract`
  - integrated paid-pilot pytest smoke
- Write `gate_failed` evidence with remaining planned steps marked `not_run` when a component gate fails.
- Extend launcher tests with a fake-repo harness that proves full ordering, redacted note content, and failure stop behavior.
- Align paid-pilot operator docs and the acceptance-note template with the new launcher evidence flow.

## Validation
Proven green:
- `bash -n scripts/validation/run_managed_paid_pilot_gate.sh`
- `.venv/bin/pytest tests/validation/test_managed_paid_pilot_gate_script.py -v`
- `make ci-quick`
- `make test-fast`
- `make pre-commit`
- `make check-doc-heading-links`
- `git diff --check -- scripts/validation/run_managed_paid_pilot_gate.sh tests/validation/test_managed_paid_pilot_gate_script.py docs/deployment/managed_paid_pilot_staging_runbook.md docs/deployment/paid_pilot_services.md docs/deployment/managed_provider_acceptance_note_template.md`

Still failing:
- None on the committed branch.

Not run:
- Real provider-backed `make run-managed-paid-pilot-gate`; no managed staging env file or provider Postgres/Redis/S3 services were supplied locally.

Failure classification:
- Provider-backed gate not run is an environment/service availability gap, not a product failure.

## Risk
- Behavior is bounded to the managed paid-pilot launcher and its generated acceptance note.
- The clean-process `env -i` reexec and provider env fail-closed checks remain intact before any service-backed command runs.
- The integrated smoke still runs the same paid-pilot pytest used by the aggregate Make target, after the launcher-owned component gates have passed.
