### PR TITLE
fix(apex): pin da3 metric model in matrix runner

### DIFF
--- a/scripts/apex_matrix_runner.py
+++ b/scripts/apex_matrix_runner.py
@@ -49,6 +49,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import List, Optional
 
+from transformation_portal.lux_depth_v3._backend_contract import normalize_backend_id
 from transformation_portal.metrics.aggregator import (
     compute_global_stats,
     compute_per_zone_stats,
@@ -233,7 +234,7 @@ def check_ml_dependencies(backend_id: str) -> tuple[bool, list[str]]:
 
 def _model_key_for_backend(backend_id: str) -> Optional[str]:
     """Return governed model selectors that the matrix runner must pin."""
-    if backend_id == "da3":
+    if normalize_backend_id(backend_id, warn=False) == "da3":
         return APEX_DA3_MODEL_KEY
     return None
 

--- a/scripts/apex_matrix_runner.py
+++ b/scripts/apex_matrix_runner.py
@@ -60,6 +60,8 @@ from transformation_portal.metrics.performance_capsule import PerformanceCapsule
 
 __version__ = "1.0.0"
 
+APEX_DA3_MODEL_KEY = "da3-metric"
+
 
 class ApexConfigError(ValueError):
     """Configuration error (invalid flags, unknown backend_id, etc.).
@@ -229,6 +231,13 @@ def check_ml_dependencies(backend_id: str) -> tuple[bool, list[str]]:
     return all_available, missing
 
 
+def _model_key_for_backend(backend_id: str) -> Optional[str]:
+    """Return governed model selectors that the matrix runner must pin."""
+    if backend_id == "da3":
+        return APEX_DA3_MODEL_KEY
+    return None
+
+
 def run_apex_for_config(
     run_spec: RunSpec,
     zone: str,
@@ -338,6 +347,7 @@ def run_apex_for_config(
 
     config = EnhanceConfig(
         model_variant=ModelVariant.METRIC_LARGE,
+        model_key=_model_key_for_backend(run_spec.backend_id),
         depth_device=run_spec.device,
         v2_device=run_spec.device,
         depth_backend=run_spec.backend_id,

--- a/tests/test_apex_matrix_runner.py
+++ b/tests/test_apex_matrix_runner.py
@@ -1,0 +1,85 @@
+"""Focused regression tests for the APEX matrix runner."""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+class _StopAfterConfig(Exception):
+    """Raised by the fake orchestrator once it captures runner config."""
+
+
+def test_real_da3_run_uses_governed_metric_model_key(monkeypatch, tmp_path):
+    """The scheduled real DA3 lane must not fall back to the research selector."""
+    from scripts import apex_matrix_runner
+    from transformation_portal.metrics.contracts import RunSpec
+
+    captured = {}
+    input_dir = tmp_path / "inputs"
+    input_dir.mkdir()
+
+    monkeypatch.setattr(
+        apex_matrix_runner,
+        "check_ml_dependencies",
+        lambda backend_id: (True, []),
+    )
+
+    discovery_module = types.ModuleType("transformation_portal.lux_depth_v3.input_discovery")
+
+    class DiscoveryConfig:
+        def __init__(self, *, strict_mode: bool) -> None:
+            self.strict_mode = strict_mode
+
+    discovery_module.DiscoveryConfig = DiscoveryConfig
+    discovery_module.discover_images = lambda input_dir, _config, _extensions: [Path(input_dir) / "sample.jpg"]
+
+    raw_loader_module = types.ModuleType("transformation_portal.lux_depth_v3.raw_loader")
+    raw_loader_module.RAW_EXTENSIONS = frozenset()
+
+    orchestrator_module = types.ModuleType("transformation_portal.lux_depth_v3.orchestrator")
+
+    class CapturingOrchestrator:
+        def __init__(self, *, config, output_root, verify_outputs) -> None:
+            captured["config"] = config
+            captured["output_root"] = output_root
+            captured["verify_outputs"] = verify_outputs
+            raise _StopAfterConfig
+
+    orchestrator_module.EnhanceOrchestrator = CapturingOrchestrator
+
+    monkeypatch.setitem(sys.modules, discovery_module.__name__, discovery_module)
+    monkeypatch.setitem(sys.modules, raw_loader_module.__name__, raw_loader_module)
+    monkeypatch.setitem(sys.modules, orchestrator_module.__name__, orchestrator_module)
+
+    run_spec = RunSpec(
+        run_id="scheduled-run",
+        commit_sha="abc123",
+        workflow_version="v1",
+        zones=["local"],
+        device="cpu",
+        backend_id="da3",
+        timestamp="2026-06-04T00:00:00+00:00",
+    )
+
+    with pytest.raises(_StopAfterConfig):
+        apex_matrix_runner.run_apex_for_config(
+            run_spec=run_spec,
+            zone="local",
+            output_dir=tmp_path / "results",
+            dry_run=False,
+            synthetic=False,
+            input_dir=input_dir,
+            sample_size=1,
+        )
+
+    config = captured["config"]
+    assert config.depth_backend == "da3"
+    assert config.model_key == "da3-metric"
+    assert config.non_commercial_ok is False
+    assert captured["verify_outputs"] is False

--- a/tests/test_apex_matrix_runner.py
+++ b/tests/test_apex_matrix_runner.py
@@ -8,6 +8,8 @@ from pathlib import Path
 
 import pytest
 
+import scripts.apex_matrix_runner as apex_matrix_runner  # pylint: disable=consider-using-from-import
+
 pytestmark = pytest.mark.unit
 
 
@@ -15,9 +17,9 @@ class _StopAfterConfig(Exception):
     """Raised by the fake orchestrator once it captures runner config."""
 
 
-def test_real_da3_run_uses_governed_metric_model_key(monkeypatch, tmp_path):
+@pytest.mark.parametrize("backend_id", ["da3", "depth-anything-v3", "depth_anything_v3"])
+def test_real_da3_run_uses_governed_metric_model_key(monkeypatch, tmp_path, backend_id):
     """The scheduled real DA3 lane must not fall back to the research selector."""
-    from scripts import apex_matrix_runner
     from transformation_portal.metrics.contracts import RunSpec
 
     captured = {}
@@ -30,7 +32,8 @@ def test_real_da3_run_uses_governed_metric_model_key(monkeypatch, tmp_path):
         lambda backend_id: (True, []),
     )
 
-    discovery_module = types.ModuleType("transformation_portal.lux_depth_v3.input_discovery")
+    discovery_module_name = "transformation_portal.lux_depth_v3.input_discovery"
+    discovery_module = types.ModuleType(discovery_module_name)
 
     class DiscoveryConfig:
         def __init__(self, *, strict_mode: bool) -> None:
@@ -39,10 +42,12 @@ def test_real_da3_run_uses_governed_metric_model_key(monkeypatch, tmp_path):
     discovery_module.DiscoveryConfig = DiscoveryConfig
     discovery_module.discover_images = lambda input_dir, _config, _extensions: [Path(input_dir) / "sample.jpg"]
 
-    raw_loader_module = types.ModuleType("transformation_portal.lux_depth_v3.raw_loader")
+    raw_loader_module_name = "transformation_portal.lux_depth_v3.raw_loader"
+    raw_loader_module = types.ModuleType(raw_loader_module_name)
     raw_loader_module.RAW_EXTENSIONS = frozenset()
 
-    orchestrator_module = types.ModuleType("transformation_portal.lux_depth_v3.orchestrator")
+    orchestrator_module_name = "transformation_portal.lux_depth_v3.orchestrator"
+    orchestrator_module = types.ModuleType(orchestrator_module_name)
 
     class CapturingOrchestrator:
         def __init__(self, *, config, output_root, verify_outputs) -> None:
@@ -53,9 +58,9 @@ def test_real_da3_run_uses_governed_metric_model_key(monkeypatch, tmp_path):
 
     orchestrator_module.EnhanceOrchestrator = CapturingOrchestrator
 
-    monkeypatch.setitem(sys.modules, discovery_module.__name__, discovery_module)
-    monkeypatch.setitem(sys.modules, raw_loader_module.__name__, raw_loader_module)
-    monkeypatch.setitem(sys.modules, orchestrator_module.__name__, orchestrator_module)
+    monkeypatch.setitem(sys.modules, discovery_module_name, discovery_module)
+    monkeypatch.setitem(sys.modules, raw_loader_module_name, raw_loader_module)
+    monkeypatch.setitem(sys.modules, orchestrator_module_name, orchestrator_module)
 
     run_spec = RunSpec(
         run_id="scheduled-run",
@@ -63,7 +68,7 @@ def test_real_da3_run_uses_governed_metric_model_key(monkeypatch, tmp_path):
         workflow_version="v1",
         zones=["local"],
         device="cpu",
-        backend_id="da3",
+        backend_id=backend_id,
         timestamp="2026-06-04T00:00:00+00:00",
     )
 


### PR DESCRIPTION
## Summary
- Scheduled APEX real runs with backend_id=da3 were constructing EnhanceConfig without an explicit model_key, allowing the legacy ModelVariant.METRIC_LARGE selector to resolve to the research DA3 model.
- Pin the runner's da3 config to da3-metric and cover real-run config construction with a focused regression test.

## Changes
- Added an APEX_DA3_MODEL_KEY constant and backend-scoped selector helper in scripts/apex_matrix_runner.py.
- Plumbed model_key into EnhanceConfig for backend_id=da3 while leaving non-da3 backends unset.
- Added tests/test_apex_matrix_runner.py to assert real da3 runs pass model_key=da3-metric before orchestration.
- No route, API, selector, CLI flag, or schema contract changes.

## Validation
Proven green:
- .venv/bin/pytest tests/test_apex_matrix_runner.py tests/test_apex_backend_deps.py tests/test_apex_contract_verification.py::TestExecutionModeEnforcement -v
- Commit hooks: Auto-format staged Python files, Black, isort, script topology, ML isolation, unsafe torch.load, gitleaks, and other configured pre-commit checks

Still failing:
- None observed in the narrow local gate.

Failure classification:
- No product, stale-test, or environment/tooling failures observed.

## Risk
- Low operational risk: the change is scoped to APEX matrix runner config construction for backend_id=da3.
- Revert-safe: removing the helper and model_key assignment restores prior behavior; no migrations or public contracts changed.