### PR TITLE
fix(frontdoor): validate worker deployments and redis sessions

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -70,9 +70,9 @@ checked-in layered dependency contract.
 **Purpose:** Manual predeploy validation for any shared frontdoor rollout that is about to become internet-reachable.
 **Triggers:** `workflow_dispatch` only.
 **Features:**
-- Targets the Cloudflare-in-front-of-Vercel posture for the managed front door.
+- Targets Cloudflare Worker frontdoor rollouts and the legacy Cloudflare-in-front-of-Vercel posture for the managed front door.
 - Verifies the public hostname is Cloudflare Access protected and not serving the real DNA shell unauthenticated.
-- Verifies the Vercel deployment or preview URL is protected and not serving the real DNA shell unauthenticated.
+- Verifies the Cloudflare Worker or Vercel deployment URL is protected and not serving the real DNA shell unauthenticated.
 - Verifies FastAPI is either non-public by explicit operator attestation or does not expose healthy unauthenticated `/ready` or `/healthz`.
 - Runs `make test-frontdoor-contract`, `tests/validation/test_frontdoor_deployment_gate.py`, and `make test-orchestrator-contract` before the live posture probe.
 - Uses GitHub environments `frontdoor-staging` and `frontdoor-production` for reviewer-gated rollout approval.

--- a/.github/workflows/frontdoor-deployment-gate.yml
+++ b/.github/workflows/frontdoor-deployment-gate.yml
@@ -18,9 +18,21 @@ on:
         description: Cloudflare Access team domain
         required: true
         type: string
+      deployment_target:
+        description: Deployment surface to validate
+        required: false
+        default: cloudflare-worker
+        type: choice
+        options:
+          - cloudflare-worker
+          - vercel
+      deployment_url:
+        description: Cloudflare Worker or Vercel deployment URL
+        required: false
+        type: string
       vercel_deployment_url:
-        description: Vercel deployment or preview URL
-        required: true
+        description: Legacy Vercel deployment or preview URL alias
+        required: false
         type: string
       fastapi_public_url:
         description: Public FastAPI base URL (leave blank when none exists)
@@ -107,6 +119,8 @@ jobs:
           TP_FRONTDOOR_GATE_ENVIRONMENT: ${{ github.event.inputs.environment }}
           TP_FRONTDOOR_GATE_FRONTDOOR_URL: ${{ github.event.inputs.frontdoor_url }}
           TP_FRONTDOOR_GATE_CF_ACCESS_TEAM_DOMAIN: ${{ github.event.inputs.cf_access_team_domain }}
+          TP_FRONTDOOR_GATE_DEPLOYMENT_TARGET: ${{ github.event.inputs.deployment_target }}
+          TP_FRONTDOOR_GATE_DEPLOYMENT_URL: ${{ github.event.inputs.deployment_url }}
           TP_FRONTDOOR_GATE_VERCEL_DEPLOYMENT_URL: ${{ github.event.inputs.vercel_deployment_url }}
           TP_FRONTDOOR_GATE_FASTAPI_PUBLIC_URL: ${{ github.event.inputs.fastapi_public_url }}
           TP_FRONTDOOR_GATE_CONFIRM_FASTAPI_NON_PUBLIC: ${{ github.event.inputs.confirm_fastapi_non_public && '1' || '' }}

--- a/Makefile
+++ b/Makefile
@@ -532,11 +532,20 @@ validate-frontdoor-browser:
 validate-frontdoor-deployment-gate:
 	@echo "Running shared-deployment frontdoor posture gate..."
 	@set -eu; \
+	deployment_url="$${TP_FRONTDOOR_GATE_DEPLOYMENT_URL:-$${TP_FRONTDOOR_GATE_VERCEL_DEPLOYMENT_URL:-}}"; \
+	deployment_target="$${TP_FRONTDOOR_GATE_DEPLOYMENT_TARGET:-}"; \
+	if [ -n "$${TP_FRONTDOOR_GATE_VERCEL_DEPLOYMENT_URL:-}" ] && [ -z "$${TP_FRONTDOOR_GATE_DEPLOYMENT_URL:-}" ]; then \
+		deployment_target="vercel"; \
+	fi; \
+	if [ -z "$${deployment_target}" ]; then \
+		deployment_target="cloudflare-worker"; \
+	fi; \
 	set -- "$(PY)" scripts/validation/check_frontdoor_deployment_gate.py \
 		--environment "$${TP_FRONTDOOR_GATE_ENVIRONMENT:-}" \
 		--frontdoor-url "$${TP_FRONTDOOR_GATE_FRONTDOOR_URL:-}" \
 		--cf-access-team-domain "$${TP_FRONTDOOR_GATE_CF_ACCESS_TEAM_DOMAIN:-}" \
-		--vercel-deployment-url "$${TP_FRONTDOOR_GATE_VERCEL_DEPLOYMENT_URL:-}"; \
+		--deployment-target "$${deployment_target}" \
+		--deployment-url "$${deployment_url}"; \
 	if [ -n "$${TP_FRONTDOOR_GATE_FASTAPI_PUBLIC_URL:-}" ]; then \
 		set -- "$$@" --fastapi-public-url "$${TP_FRONTDOOR_GATE_FASTAPI_PUBLIC_URL}"; \
 	fi; \

--- a/docs/architecture/PORTAL_EDGE_HARDENING_IMPLEMENTATION_STANDARD.md
+++ b/docs/architecture/PORTAL_EDGE_HARDENING_IMPLEMENTATION_STANDARD.md
@@ -124,8 +124,9 @@ Current-state auth is unchanged:
   the explicit local development bypass is active.
 - Authenticated managed surfaces: `/portal`, `/portal/bootstrap`, and `/v1/*`
   require a current verified Access context and fail closed on auth failure.
-- Browser session: SQLite-backed frontdoor session with CSRF-bound unsafe
-  requests.
+- Browser session: server-side frontdoor session with CSRF-bound unsafe
+  requests. SQLite is the single-instance local/default store; Redis is the
+  supported hosted external store.
 - API proxy: the frontdoor injects the backend secret server-to-server; browser
   code does not receive the backend API key in managed mode.
 - Local bypass: allowed only in explicit development flows described below.
@@ -160,7 +161,7 @@ Local development exception:
 
 ### Session And Cookie Contract
 
-The browser session is SQLite-backed and server-side. The cookie and timeout
+The browser session is server-side. The cookie, store, scaling, and timeout
 contract is environment-aware.
 
 Cookie naming and transport:
@@ -205,8 +206,9 @@ deployment documentation in the same change.
   build, and start.
 - FastAPI request limits and path or root allowlists remain enforced in
   `app.py`.
-- Do not weaken the current session-scaling guardrails: the shipped posture is
-  still single-instance SQLite unless an external session store is introduced.
+- Do not weaken the current session-scaling guardrails: SQLite is limited to
+  single-instance posture, while hosted `multi_instance` and
+  `ephemeral_runtime` posture require the Redis session store.
 
 ### Direct-Origin Denial
 
@@ -218,7 +220,8 @@ Required posture:
 - Treat direct FastAPI exposure as an exception that requires compensating
   controls and explicit documentation.
 - Preserve the deployment gate that checks protected frontdoor posture,
-  protected deployment URL posture, and the non-public FastAPI assumption.
+  protected Worker or Vercel deployment URL posture, and the non-public FastAPI
+  assumption.
 
 ## SSRF And Outbound Fetch Policy
 

--- a/docs/guides/PORTAL_SECURE_FRONTDOOR_QUICKSTART.md
+++ b/docs/guides/PORTAL_SECURE_FRONTDOOR_QUICKSTART.md
@@ -14,7 +14,11 @@ The secure front door is a separate Node app in `web/secure-landing/`.
 - The front door serves `GET /` directly; FastAPI remains the backend system of record for `GET /ready` and `/v1/*`.
 - `GET /healthz` is the managed front-door health contract; FastAPI `GET /ready` remains the backend readiness contract and is not mirrored under `/api/*` by default.
 
-In production, place the front door behind Cloudflare Tunnel + Access and keep the FastAPI origin off the public browser path.
+In production, place the front door behind Cloudflare Access and keep the
+FastAPI origin off the public browser path. The current hosted rollout can use
+the frontdoor-only Cloudflare Worker as the public edge proxy; its
+`FRONTDOOR_ORIGIN` points at the managed Next frontdoor origin and must stay out
+of normal browser traffic.
 
 ## Required Environment
 
@@ -39,7 +43,8 @@ Notes:
 - `TP_FRONTDOOR_USERS_JSON` remains available only as a local-dev and test fallback when a file is not supplied.
 - `TP_CF_ACCESS_TEAM_DOMAIN` must point at the Cloudflare Access team domain used to mint `Cf-Access-Jwt-Assertion`.
 - `TP_CF_ACCESS_AUD` must match the Access application audience tag for this front door.
-- `TP_FRONTDOOR_SESSION_SCALING_MODE` should stay `single_instance` for the current SQLite-backed front door. Declaring `multi_instance` or `ephemeral_runtime` intentionally fails readiness until a real external session store exists.
+- `TP_FRONTDOOR_SESSION_SCALING_MODE=single_instance` uses SQLite and is only appropriate for single-instance runtime posture.
+- Hosted multi-instance or ephemeral runtime posture requires `TP_FRONTDOOR_SESSION_STORE=redis` plus `TP_FRONTDOOR_REDIS_URL=redis://...` or `rediss://...`; unsupported store selectors and unsupported scaling modes intentionally fail readiness.
 - `TP_ALLOW_LOCAL_ACCESS_BYPASS=1` is for local development only and is honored only when `NODE_ENV=development`.
 - Production login expects a valid `Cf-Access-Jwt-Assertion`, a matching username/password pair, and issuer/audience validation against the configured Access team domain and audience tag.
 - Development uses an HTTP-safe `tp_session` cookie. Production uses `__Host-tp_session` with `Secure`.
@@ -255,10 +260,12 @@ originRequest:
 - Keep app-side JWT verification enabled even when Tunnel origin enforcement is active.
 - Do not route normal browser traffic directly to FastAPI.
 - If the front door is hosted on Vercel, Cloudflare must still front the user-facing hostname, the app must continue to verify the Access JWT, and deployment or preview URLs must be protected with equivalent controls such as Vercel Deployment Protection.
-- Vercel deployment or preview-URL protection is distinct from production-domain coverage. Configure the appropriate Vercel Deployment Protection scope for the environment you are validating; protecting only preview URLs is not sufficient for a production-domain rollout.
+- If the front door is published through the Cloudflare Worker edge proxy, the Worker deployment URL must also be Access-protected and must not serve the real homepage or login shell unauthenticated.
+- Deployment URL protection is distinct from production-domain coverage. Configure the appropriate Cloudflare Access or Vercel Deployment Protection scope for the environment you are validating; protecting only one URL is not sufficient for a production-domain rollout.
 - Treat this posture as a predeploy requirement before any internet-reachable staging or production environment, not as a post-launch hardening task.
-- The v1 session store remains SQLite-backed and currently supports only `TP_FRONTDOOR_SESSION_SCALING_MODE=single_instance`.
-- If your deployment target requires `multi_instance` or `ephemeral_runtime`, treat that as a blocked requirement until a dedicated external session store is introduced; the front door now fails `/healthz` under those modes on purpose.
+- SQLite sessions support only `TP_FRONTDOOR_SESSION_SCALING_MODE=single_instance`.
+- Redis-backed frontdoor sessions support `single_instance`, `multi_instance`, and `ephemeral_runtime` when `TP_FRONTDOOR_SESSION_STORE=redis` and `TP_FRONTDOOR_REDIS_URL` are configured.
+- Unsupported session store selectors, missing Redis URLs, and invalid scaling modes still fail `/healthz` on purpose.
 
 ## Validation
 
@@ -323,7 +330,8 @@ Manual shared-deployment posture gate:
 TP_FRONTDOOR_GATE_ENVIRONMENT="staging" \
 TP_FRONTDOOR_GATE_FRONTDOOR_URL="https://portal.example.com" \
 TP_FRONTDOOR_GATE_CF_ACCESS_TEAM_DOMAIN="https://your-team.cloudflareaccess.com" \
-TP_FRONTDOOR_GATE_VERCEL_DEPLOYMENT_URL="https://portal-preview.vercel.app" \
+TP_FRONTDOOR_GATE_DEPLOYMENT_TARGET="cloudflare-worker" \
+TP_FRONTDOOR_GATE_DEPLOYMENT_URL="https://transformationportal.<account>.workers.dev" \
 TP_FRONTDOOR_GATE_CONFIRM_FASTAPI_NON_PUBLIC=1 \
 make validate-frontdoor-deployment-gate
 ```
@@ -331,8 +339,9 @@ make validate-frontdoor-deployment-gate
 Notes:
 - This gate is a manual predeploy control. It does not reconfigure Cloudflare or Vercel for you.
 - The gate validates edge posture at rollout time. It does not replace app-side Cloudflare Access JWT verification.
+- Use `TP_FRONTDOOR_GATE_DEPLOYMENT_TARGET=vercel` with `TP_FRONTDOOR_GATE_DEPLOYMENT_URL=https://<deployment>.vercel.app` for Vercel deployment protection checks. The legacy `TP_FRONTDOOR_GATE_VERCEL_DEPLOYMENT_URL` variable still maps to the Vercel target.
 - If FastAPI has a public URL, set `TP_FRONTDOOR_GATE_FASTAPI_PUBLIC_URL` instead of `TP_FRONTDOOR_GATE_CONFIRM_FASTAPI_NON_PUBLIC=1`.
-- The gate fails closed for ambiguous frontdoor or Vercel responses; only clearly protected responses pass.
+- The gate fails closed for ambiguous frontdoor, Worker, or Vercel responses; only clearly protected responses pass.
 
 Browser smoke with isolated local backend + managed front door:
 

--- a/docs/operations/frontdoor_vercel_env.md
+++ b/docs/operations/frontdoor_vercel_env.md
@@ -1,6 +1,6 @@
-# Vercel Frontdoor Environment Checklist
+# Frontdoor Environment Checklist
 
-The managed frontdoor (`web/secure-landing/`) deployed on Vercel reads its
+The managed frontdoor (`web/secure-landing/`) in hosted rollout environments reads its
 configuration entirely from environment variables. When any of the variables
 below are missing or stale, `/healthz` returns `503` with a structured `reason`
 field that names the offender. This checklist enumerates every variable, how to
@@ -18,8 +18,10 @@ two values as one secret, set them together, rotate them together.
 | `TP_FASTAPI_ORIGIN` | all envs | URL of the FastAPI origin used by `/healthz` and the v1 proxy. This is the runtime source of truth; `TP_BACKEND_ORIGIN` is not consumed by the managed frontdoor. | `backend_unreachable` |
 | `TP_BACKEND_API_KEY` | all envs | API key the frontdoor presents to the backend. **Must equal backend `TP_API_KEY`.** | `missing_backend_api_key` (when empty) / `backend_auth_mismatch` (when wrong) |
 | `TP_FRONTDOOR_USERS_JSON` *or* `TP_FRONTDOOR_USERS_FILE` | all envs | At least one configured user. JSON form is `[{"username":"…","password_hash":"…","access_email":"…","role":"admin"}]`. | `no_configured_users` |
-| `TP_FRONTDOOR_SESSION_SCALING_MODE` | all envs | Must be `single_instance` for the current SQLite-backed frontdoor. Multi-instance declarations intentionally fail until an external session-store implementation exists. | `multi_instance_requires_external_session_store` / `invalid_session_scaling_mode` |
-| `TP_FRONTDOOR_SESSION_DB` | when `single_instance` | Path to the SQLite session DB. On Vercel, prefer an external store. | `session_store_unavailable` |
+| `TP_FRONTDOOR_SESSION_SCALING_MODE` | all envs | `single_instance` for SQLite. `multi_instance` or `ephemeral_runtime` only passes when Redis-backed sessions are explicitly configured. | `multi_instance_requires_external_session_store` / `ephemeral_runtime_requires_external_session_store` / `invalid_session_scaling_mode` |
+| `TP_FRONTDOOR_SESSION_STORE` | when using Redis-backed sessions | `redis` for external session storage. Omit or set `sqlite` only for single-instance SQLite sessions. Unsupported values fail readiness. | `invalid_session_store_backend` |
+| `TP_FRONTDOOR_REDIS_URL` | when `TP_FRONTDOOR_SESSION_STORE=redis` | `redis://` or `rediss://` URL for the frontdoor session Redis. Required for `multi_instance` and `ephemeral_runtime` rollout modes. | `missing_frontdoor_redis_url` / `session_store_unavailable` |
+| `TP_FRONTDOOR_SESSION_DB` | when using SQLite sessions | Path to the SQLite session DB. Do not use SQLite for multi-instance hosted deployments. | `session_store_unavailable` |
 | `TP_CF_ACCESS_TEAM_DOMAIN` | production | Cloudflare Access team domain (`https://<team>.cloudflareaccess.com`). Validated by the preflight; required when `TP_ALLOW_LOCAL_ACCESS_BYPASS` is unset. | `missing_access_team_domain` |
 | `TP_CF_ACCESS_AUD` | production | Cloudflare Access JWT audience for the protected application. | `missing_access_audience` |
 
@@ -56,6 +58,12 @@ deployment-local path to exist on the reviewer's machine. Add
 `--validate-user-file` when checking a local runtime env where the file should
 be readable and contain at least one valid user.
 
+For Redis-backed hosted sessions, the checker requires
+`TP_FRONTDOOR_SESSION_STORE=redis` and an absolute `redis://` or `rediss://`
+`TP_FRONTDOOR_REDIS_URL` before accepting `multi_instance` or
+`ephemeral_runtime` scaling. Unsupported session store selectors and unsupported
+scaling modes remain fail-closed.
+
 Expected shape when healthy:
 
 ```
@@ -73,8 +81,8 @@ Expected shape when healthy:
     },
     "access_config": { "ok": true, "mode": "cloudflare_access", "teamDomainConfigured": true, "audienceConfigured": true },
     "user_source":   { "ok": true, "userCount": <n> },
-    "session_store": { "ok": true, "configured": true },
-    "session_scaling": { "ok": true }
+    "session_store": { "ok": true, "configured": true, "backend": "redis" },
+    "session_scaling": { "ok": true, "backend": "redis", "mode": "multi_instance" }
   }
 }
 ```

--- a/scripts/validation/check_frontdoor_deployment_gate.py
+++ b/scripts/validation/check_frontdoor_deployment_gate.py
@@ -19,6 +19,7 @@ DEFAULT_USER_AGENT = "TransformationPortalFrontdoorDeploymentGate/1.0"
 MAX_BODY_BYTES = 64 * 1024
 HTML_ACCEPT = "text/html,application/xhtml+xml"
 JSON_ACCEPT = "application/json"
+DEPLOYMENT_TARGETS = ("cloudflare-worker", "vercel")
 FRONTDOOR_PATHS = ("/", "/login")
 FASTAPI_PATHS = ("/ready", "/healthz")
 
@@ -102,7 +103,16 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--environment", choices=("staging", "production"), required=True)
     parser.add_argument("--frontdoor-url", required=True)
     parser.add_argument("--cf-access-team-domain", required=True)
-    parser.add_argument("--vercel-deployment-url", required=True)
+    parser.add_argument(
+        "--deployment-target",
+        choices=DEPLOYMENT_TARGETS + ("cloudflare_worker",),
+        help="Deployment surface to validate. Use cloudflare-worker for the current Worker frontdoor rollout.",
+    )
+    parser.add_argument("--deployment-url", help="Cloudflare Worker or Vercel deployment base URL.")
+    parser.add_argument(
+        "--vercel-deployment-url",
+        help="Deprecated alias for --deployment-url with --deployment-target=vercel.",
+    )
     parser.add_argument("--fastapi-public-url")
     parser.add_argument("--confirm-fastapi-non-public", action="store_true")
     parser.add_argument("--timeout-seconds", type=float, default=DEFAULT_TIMEOUT_SECONDS)
@@ -470,6 +480,58 @@ def _probe_vercel_deployment(
     )
 
 
+def _probe_worker_deployment(
+    *,
+    worker_url: str,
+    access_team_domain: str,
+    timeout_seconds: float,
+    user_agent: str,
+) -> SurfaceVerdict:
+    outcomes = [
+        _classify_frontdoor_probe(
+            _perform_request(
+                base_url=worker_url,
+                path=path,
+                accept=HTML_ACCEPT,
+                timeout_seconds=timeout_seconds,
+                user_agent=user_agent,
+            ),
+            access_team_domain=access_team_domain,
+        )
+        for path in FRONTDOOR_PATHS
+    ]
+    return _surface_verdict_from_path_outcomes(
+        surface="worker_deployment",
+        outcomes=outcomes,
+        preferred_success_code="cf_access_redirect",
+        fallback_success_code="cf_access_interstitial",
+    )
+
+
+def _probe_deployment_target(
+    *,
+    deployment_target: str,
+    deployment_url: str,
+    access_team_domain: str,
+    timeout_seconds: float,
+    user_agent: str,
+) -> SurfaceVerdict:
+    if deployment_target == "vercel":
+        return _probe_vercel_deployment(
+            vercel_url=deployment_url,
+            timeout_seconds=timeout_seconds,
+            user_agent=user_agent,
+        )
+    if deployment_target == "cloudflare-worker":
+        return _probe_worker_deployment(
+            worker_url=deployment_url,
+            access_team_domain=access_team_domain,
+            timeout_seconds=timeout_seconds,
+            user_agent=user_agent,
+        )
+    raise ValueError(f"Unsupported deployment target: {deployment_target}")
+
+
 def _healthy_json_payload(probe: ProbeResponse) -> bool:
     if probe.status is None or not (200 <= probe.status < 300):
         return False
@@ -553,12 +615,25 @@ def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
     args = parser.parse_args(argv)
     if args.confirm_fastapi_non_public and args.fastapi_public_url:
         parser.error("Use either --fastapi-public-url or --confirm-fastapi-non-public, not both.")
+    if args.deployment_target:
+        args.deployment_target = args.deployment_target.replace("_", "-")
+    if args.deployment_url and args.vercel_deployment_url:
+        parser.error("Use either --deployment-url or --vercel-deployment-url, not both.")
+    if args.vercel_deployment_url:
+        if args.deployment_target and args.deployment_target != "vercel":
+            parser.error("--vercel-deployment-url requires --deployment-target=vercel.")
+        args.deployment_target = "vercel"
+        args.deployment_url = args.vercel_deployment_url
+    if not args.deployment_url:
+        parser.error("Supply --deployment-url, or the legacy --vercel-deployment-url alias.")
+    if not args.deployment_target:
+        parser.error("--deployment-target is required when --deployment-url is used.")
     try:
         args.frontdoor_url = _normalize_base_url(args.frontdoor_url, require_https=True, label="frontdoor URL")
-        args.vercel_deployment_url = _normalize_base_url(
-            args.vercel_deployment_url,
+        args.deployment_url = _normalize_base_url(
+            args.deployment_url,
             require_https=True,
-            label="Vercel deployment URL",
+            label=f"{args.deployment_target} deployment URL",
         )
         if args.fastapi_public_url:
             args.fastapi_public_url = _normalize_base_url(
@@ -583,8 +658,10 @@ def run_validation(argv: Sequence[str] | None = None) -> list[SurfaceVerdict]:
             timeout_seconds=args.timeout_seconds,
             user_agent=args.user_agent,
         ),
-        _probe_vercel_deployment(
-            vercel_url=args.vercel_deployment_url,
+        _probe_deployment_target(
+            deployment_target=args.deployment_target,
+            deployment_url=args.deployment_url,
+            access_team_domain=args.cf_access_team_domain,
             timeout_seconds=args.timeout_seconds,
             user_agent=args.user_agent,
         ),

--- a/scripts/validation/check_frontdoor_vercel_env.py
+++ b/scripts/validation/check_frontdoor_vercel_env.py
@@ -17,6 +17,7 @@ import argparse
 import json
 import os
 import sys
+import urllib.parse
 from dataclasses import dataclass
 from typing import Iterable, List, Literal, Optional
 
@@ -36,6 +37,8 @@ VARIABLES: tuple[Variable, ...] = (
     Variable("TP_BACKEND_API_KEY", "all", "Frontdoor-presented API key (must equal backend TP_API_KEY)"),
     Variable("TP_FRONTDOOR_USERS_JSON|TP_FRONTDOOR_USERS_FILE", "all", "User source (JSON array or file path)"),
     Variable("TP_FRONTDOOR_SESSION_SCALING_MODE", "all", "single_instance or external-store-backed mode"),
+    Variable("TP_FRONTDOOR_SESSION_STORE", "optional", "sqlite default or redis for external session storage"),
+    Variable("TP_FRONTDOOR_REDIS_URL", "optional", "Redis URL required when TP_FRONTDOOR_SESSION_STORE=redis"),
     Variable("TP_CF_ACCESS_TEAM_DOMAIN", "production", "Cloudflare Access team domain"),
     Variable("TP_CF_ACCESS_AUD", "production", "Cloudflare Access JWT audience"),
     Variable("TP_PORTAL_RUM_ENABLED", "optional", "Shared portal/frontdoor RUM kill switch"),
@@ -45,6 +48,9 @@ VARIABLES: tuple[Variable, ...] = (
 )
 
 SUPPORTED_SESSION_SCALING_MODES = frozenset({"single_instance"})
+EXTERNAL_SESSION_SCALING_MODES = frozenset({"multi_instance", "ephemeral_runtime"})
+SUPPORTED_SESSION_STORE_BACKENDS = frozenset({"sqlite", "redis"})
+SUPPORTED_REDIS_URL_SCHEMES = frozenset({"redis", "rediss"})
 
 
 def _resolve(value_or_alias: str, env: dict[str, str]) -> Optional[str]:
@@ -101,6 +107,49 @@ def _normalize_session_scaling_mode(value: str) -> str:
     return value.strip().lower().replace("-", "_")
 
 
+def _normalize_session_store_backend(value: str) -> str:
+    return value.strip().lower() if value.strip() else "sqlite"
+
+
+def _validate_redis_url(value: str) -> tuple[bool, str]:
+    raw = value.strip()
+    if not raw:
+        return False, "TP_FRONTDOOR_REDIS_URL is required for Redis-backed sessions"
+    parsed = urllib.parse.urlparse(raw)
+    if parsed.scheme.lower() not in SUPPORTED_REDIS_URL_SCHEMES or not parsed.netloc:
+        return False, "TP_FRONTDOOR_REDIS_URL must be an absolute redis:// or rediss:// URL"
+    return True, "set via TP_FRONTDOOR_REDIS_URL"
+
+
+def _evaluate_session_store_backend(env: dict[str, str]) -> tuple[bool, str]:
+    raw = env.get("TP_FRONTDOOR_SESSION_STORE", "").strip()
+    backend = _normalize_session_store_backend(raw)
+    if backend not in SUPPORTED_SESSION_STORE_BACKENDS:
+        return False, f"unsupported session store backend: {backend}"
+    if backend == "redis":
+        redis_url = env.get("TP_FRONTDOOR_REDIS_URL", "")
+        redis_ok, redis_detail = _validate_redis_url(redis_url)
+        if not redis_ok:
+            if not redis_url.strip():
+                return False, "TP_FRONTDOOR_SESSION_STORE=redis requires TP_FRONTDOOR_REDIS_URL"
+            return False, redis_detail
+        return True, "set via TP_FRONTDOOR_SESSION_STORE (redis)"
+    if raw:
+        return True, "set via TP_FRONTDOOR_SESSION_STORE (sqlite)"
+    return True, "default sqlite session store"
+
+
+def _evaluate_redis_url(env: dict[str, str]) -> tuple[bool, str, bool]:
+    scaling_mode = _normalize_session_scaling_mode(env.get("TP_FRONTDOOR_SESSION_SCALING_MODE", ""))
+    backend = _normalize_session_store_backend(env.get("TP_FRONTDOOR_SESSION_STORE", ""))
+    required = backend == "redis" or scaling_mode in EXTERNAL_SESSION_SCALING_MODES
+    raw = env.get("TP_FRONTDOOR_REDIS_URL", "").strip()
+    if not raw and not required:
+        return True, "only required when TP_FRONTDOOR_SESSION_STORE=redis", False
+    valid, detail = _validate_redis_url(raw)
+    return valid, detail, bool(raw)
+
+
 def _evaluate_session_scaling_mode(env: dict[str, str]) -> tuple[bool, str]:
     raw = env.get("TP_FRONTDOOR_SESSION_SCALING_MODE", "").strip()
     if not raw:
@@ -108,8 +157,17 @@ def _evaluate_session_scaling_mode(env: dict[str, str]) -> tuple[bool, str]:
     mode = _normalize_session_scaling_mode(raw)
     if mode in SUPPORTED_SESSION_SCALING_MODES:
         return True, f"set via TP_FRONTDOOR_SESSION_SCALING_MODE ({mode})"
-    if mode in {"multi_instance", "ephemeral_runtime"}:
-        return False, f"{mode} requires an external session-store implementation"
+    if mode in EXTERNAL_SESSION_SCALING_MODES:
+        backend = _normalize_session_store_backend(env.get("TP_FRONTDOOR_SESSION_STORE", ""))
+        if backend != "redis":
+            return False, f"{mode} requires TP_FRONTDOOR_SESSION_STORE=redis"
+        redis_url = env.get("TP_FRONTDOOR_REDIS_URL", "")
+        redis_ok, redis_detail = _validate_redis_url(redis_url)
+        if not redis_ok:
+            if not redis_url.strip():
+                return False, f"{mode} requires TP_FRONTDOOR_REDIS_URL"
+            return False, f"{mode} requires {redis_detail}"
+        return True, f"set via TP_FRONTDOOR_SESSION_SCALING_MODE ({mode}) with Redis session store"
     return False, f"unsupported session scaling mode: {mode}"
 
 
@@ -166,6 +224,24 @@ def _evaluate(
                 rows.append(("missing", var.name, detail))
             else:
                 rows.append(("optional", var.name, detail))
+            continue
+        if var.name == "TP_FRONTDOOR_SESSION_STORE":
+            valid, detail = _evaluate_session_store_backend(env)
+            if valid:
+                rows.append(("ok", var.name, detail))
+            else:
+                ok = False
+                rows.append(("missing", var.name, detail))
+            continue
+        if var.name == "TP_FRONTDOOR_REDIS_URL":
+            valid, detail, configured = _evaluate_redis_url(env)
+            if valid and configured:
+                rows.append(("ok", var.name, detail))
+            elif valid:
+                rows.append(("optional", var.name, detail))
+            else:
+                ok = False
+                rows.append(("missing", var.name, detail))
             continue
         resolved = _resolve(var.name, env)
         if resolved:

--- a/tests/validation/test_check_frontdoor_vercel_env.py
+++ b/tests/validation/test_check_frontdoor_vercel_env.py
@@ -146,3 +146,117 @@ def test_vercel_env_rejects_runtime_unsupported_session_scaling_mode() -> None:
 
     assert ok is False
     assert ("missing", "TP_FRONTDOOR_SESSION_SCALING_MODE", "unsupported session scaling mode: planet_scale") in rows
+
+
+@pytest.mark.unit
+def test_vercel_env_accepts_redis_backed_multi_instance_sessions() -> None:
+    module = _load_module()
+    ok, rows = module._evaluate(
+        {
+            "TP_FASTAPI_ORIGIN": "https://fastapi.example.com",
+            "TP_BACKEND_API_KEY": "secret",
+            "TP_FRONTDOOR_USERS_JSON": _valid_user_json(),
+            "TP_FRONTDOOR_SESSION_SCALING_MODE": "multi-instance",
+            "TP_FRONTDOOR_SESSION_STORE": "redis",
+            "TP_FRONTDOOR_REDIS_URL": "rediss://session.example.com:6380/0",
+        },
+        production=False,
+    )
+
+    assert ok is True
+    assert (
+        "ok",
+        "TP_FRONTDOOR_SESSION_SCALING_MODE",
+        "set via TP_FRONTDOOR_SESSION_SCALING_MODE (multi_instance) with Redis session store",
+    ) in rows
+    assert ("ok", "TP_FRONTDOOR_SESSION_STORE", "set via TP_FRONTDOOR_SESSION_STORE (redis)") in rows
+    assert ("ok", "TP_FRONTDOOR_REDIS_URL", "set via TP_FRONTDOOR_REDIS_URL") in rows
+
+
+@pytest.mark.unit
+def test_vercel_env_rejects_external_scaling_without_redis_store() -> None:
+    module = _load_module()
+    ok, rows = module._evaluate(
+        {
+            "TP_FASTAPI_ORIGIN": "https://fastapi.example.com",
+            "TP_BACKEND_API_KEY": "secret",
+            "TP_FRONTDOOR_USERS_JSON": _valid_user_json(),
+            "TP_FRONTDOOR_SESSION_SCALING_MODE": "ephemeral_runtime",
+        },
+        production=False,
+    )
+
+    assert ok is False
+    assert (
+        "missing",
+        "TP_FRONTDOOR_SESSION_SCALING_MODE",
+        "ephemeral_runtime requires TP_FRONTDOOR_SESSION_STORE=redis",
+    ) in rows
+
+
+@pytest.mark.unit
+def test_vercel_env_rejects_redis_store_without_redis_url() -> None:
+    module = _load_module()
+    ok, rows = module._evaluate(
+        {
+            "TP_FASTAPI_ORIGIN": "https://fastapi.example.com",
+            "TP_BACKEND_API_KEY": "secret",
+            "TP_FRONTDOOR_USERS_JSON": _valid_user_json(),
+            "TP_FRONTDOOR_SESSION_SCALING_MODE": "single_instance",
+            "TP_FRONTDOOR_SESSION_STORE": "redis",
+        },
+        production=False,
+    )
+
+    assert ok is False
+    assert (
+        "missing",
+        "TP_FRONTDOOR_SESSION_STORE",
+        "TP_FRONTDOOR_SESSION_STORE=redis requires TP_FRONTDOOR_REDIS_URL",
+    ) in rows
+    assert (
+        "missing",
+        "TP_FRONTDOOR_REDIS_URL",
+        "TP_FRONTDOOR_REDIS_URL is required for Redis-backed sessions",
+    ) in rows
+
+
+@pytest.mark.unit
+def test_vercel_env_rejects_invalid_redis_url_scheme() -> None:
+    module = _load_module()
+    ok, rows = module._evaluate(
+        {
+            "TP_FASTAPI_ORIGIN": "https://fastapi.example.com",
+            "TP_BACKEND_API_KEY": "secret",
+            "TP_FRONTDOOR_USERS_JSON": _valid_user_json(),
+            "TP_FRONTDOOR_SESSION_SCALING_MODE": "multi_instance",
+            "TP_FRONTDOOR_SESSION_STORE": "redis",
+            "TP_FRONTDOOR_REDIS_URL": "https://session.example.com",
+        },
+        production=False,
+    )
+
+    assert ok is False
+    assert (
+        "missing",
+        "TP_FRONTDOOR_REDIS_URL",
+        "TP_FRONTDOOR_REDIS_URL must be an absolute redis:// or rediss:// URL",
+    ) in rows
+
+
+@pytest.mark.unit
+def test_vercel_env_rejects_unsupported_session_store_backend() -> None:
+    module = _load_module()
+    ok, rows = module._evaluate(
+        {
+            "TP_FASTAPI_ORIGIN": "https://fastapi.example.com",
+            "TP_BACKEND_API_KEY": "secret",
+            "TP_FRONTDOOR_USERS_JSON": _valid_user_json(),
+            "TP_FRONTDOOR_SESSION_SCALING_MODE": "single_instance",
+            "TP_FRONTDOOR_SESSION_STORE": "memcached",
+        },
+        production=False,
+    )
+
+    assert ok is False
+    assert ("missing", "TP_FRONTDOOR_SESSION_STORE", "unsupported session store backend: memcached") in rows

--- a/tests/validation/test_frontdoor_deployment_gate.py
+++ b/tests/validation/test_frontdoor_deployment_gate.py
@@ -669,3 +669,123 @@ def test_ambiguous_fastapi_2xx_non_health_response_fails(monkeypatch: pytest.Mon
     output = capsys.readouterr().out
     assert exit_code == 1
     assert "surface=fastapi_public_probe verdict=FAIL code=fastapi_probe_unclassified" in output
+
+
+def test_cloudflare_worker_deployment_url_passes_when_access_protected(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+):
+    module = _load_module("tests_frontdoor_gate_worker_protected")
+    mapping = {
+        ("https://portal.example.com", "/"): _probe(
+            module, path="/", status=403, headers={"Server": "cloudflare"}, body="cloudflare access"
+        ),
+        ("https://portal.example.com", "/login"): _probe(
+            module, path="/login", status=403, headers={"Server": "cloudflare"}, body="cloudflare access"
+        ),
+        ("https://transformationportal.example.workers.dev", "/"): _probe(
+            module,
+            path="/",
+            status=302,
+            headers={"Location": "https://team.cloudflareaccess.com/cdn-cgi/access/login/worker"},
+            location="https://team.cloudflareaccess.com/cdn-cgi/access/login/worker",
+        ),
+        ("https://transformationportal.example.workers.dev", "/login"): _probe(
+            module,
+            path="/login",
+            status=302,
+            headers={"Location": "https://team.cloudflareaccess.com/cdn-cgi/access/login/worker"},
+            location="https://team.cloudflareaccess.com/cdn-cgi/access/login/worker",
+        ),
+    }
+    monkeypatch.setattr(module, "_perform_request", _fake_request_factory(module, mapping))
+
+    exit_code = module.main(
+        [
+            "--environment",
+            "production",
+            "--frontdoor-url",
+            "https://portal.example.com",
+            "--cf-access-team-domain",
+            "https://team.cloudflareaccess.com",
+            "--deployment-target",
+            "cloudflare-worker",
+            "--deployment-url",
+            "https://transformationportal.example.workers.dev",
+            "--confirm-fastapi-non-public",
+        ]
+    )
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "surface=worker_deployment verdict=PASS code=cf_access_redirect" in output
+    assert "overall=PASS" in output
+
+
+def test_cloudflare_worker_deployment_serving_real_shell_fails(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+):
+    module = _load_module("tests_frontdoor_gate_worker_shell_exposed")
+    mapping = {
+        ("https://portal.example.com", "/"): _probe(
+            module, path="/", status=403, headers={"Server": "cloudflare"}, body="cloudflare access"
+        ),
+        ("https://portal.example.com", "/login"): _probe(
+            module, path="/login", status=403, headers={"Server": "cloudflare"}, body="cloudflare access"
+        ),
+        ("https://transformationportal.example.workers.dev", "/"): _probe(
+            module,
+            path="/",
+            status=200,
+            headers={"Server": "cloudflare"},
+            body='<title>Dynamic Neural Access</title><body data-ui="homepage-shell"><h1 data-ui="homepage-hero-title"></h1>',
+        ),
+        ("https://transformationportal.example.workers.dev", "/login"): _probe(
+            module,
+            path="/login",
+            status=302,
+            headers={"Location": "https://team.cloudflareaccess.com/cdn-cgi/access/login/worker"},
+            location="https://team.cloudflareaccess.com/cdn-cgi/access/login/worker",
+        ),
+    }
+    monkeypatch.setattr(module, "_perform_request", _fake_request_factory(module, mapping))
+
+    exit_code = module.main(
+        [
+            "--environment",
+            "production",
+            "--frontdoor-url",
+            "https://portal.example.com",
+            "--cf-access-team-domain",
+            "https://team.cloudflareaccess.com",
+            "--deployment-target",
+            "cloudflare_worker",
+            "--deployment-url",
+            "https://transformationportal.example.workers.dev",
+            "--confirm-fastapi-non-public",
+        ]
+    )
+
+    output = capsys.readouterr().out
+    assert exit_code == 1
+    assert "surface=worker_deployment verdict=FAIL code=frontdoor_app_shell_exposed" in output
+
+
+def test_generic_deployment_url_requires_explicit_target(capsys: pytest.CaptureFixture[str]):
+    module = _load_module("tests_frontdoor_gate_generic_deployment_target_required")
+
+    with pytest.raises(SystemExit):
+        module._parse_args(
+            [
+                "--environment",
+                "staging",
+                "--frontdoor-url",
+                "https://portal.example.com",
+                "--cf-access-team-domain",
+                "https://team.cloudflareaccess.com",
+                "--deployment-url",
+                "https://transformationportal.example.workers.dev",
+                "--confirm-fastapi-non-public",
+            ]
+        )
+
+    assert "--deployment-target is required" in capsys.readouterr().err

--- a/web/secure-landing/app/healthz/route.js
+++ b/web/secure-landing/app/healthz/route.js
@@ -3,9 +3,26 @@ import { NextResponse } from "next/server.js";
 import { getConfig } from "../../lib/config.js";
 import { getDb } from "../../lib/db.js";
 import { applySecurityHeaders } from "../../lib/http.js";
-import { evaluateSessionScaling } from "../../lib/session-scaling.js";
+import { getSessionStore } from "../../lib/session-store/index.js";
+import { evaluateSessionScaling, SESSION_STORE_BACKEND } from "../../lib/session-scaling.js";
 
 export const runtime = "nodejs";
+
+const SESSION_STORE_HEALTH_TIMEOUT_MS = 1000;
+
+async function withTimeout(promise, timeoutMs) {
+  let timeoutHandle;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise((_, reject) => {
+        timeoutHandle = setTimeout(() => reject(new Error("timeout")), timeoutMs);
+      })
+    ]);
+  } finally {
+    clearTimeout(timeoutHandle);
+  }
+}
 
 function evaluateAccessConfig(config) {
   const required = !config.allowLocalAccessBypass;
@@ -37,7 +54,56 @@ function evaluateUserSource(config) {
   };
 }
 
-function evaluateSessionStore(config) {
+function normalizeSessionStoreBackend(config) {
+  return String(config.sessionStoreBackend || SESSION_STORE_BACKEND.SQLITE).trim().toLowerCase();
+}
+
+async function evaluateSessionStore(config) {
+  const backend = normalizeSessionStoreBackend(config);
+  if (backend === SESSION_STORE_BACKEND.REDIS) {
+    if (!config.sessionStoreRedisUrl) {
+      return {
+        ok: false,
+        required: true,
+        configured: false,
+        backend,
+        reason: "missing_frontdoor_redis_url"
+      };
+    }
+    try {
+      const store = getSessionStore();
+      if (typeof store.ping !== "function") {
+        throw new Error("Redis session store does not expose a health check");
+      }
+      await withTimeout(store.ping(), SESSION_STORE_HEALTH_TIMEOUT_MS);
+      return {
+        ok: true,
+        required: true,
+        configured: true,
+        backend,
+        reason: null
+      };
+    } catch {
+      return {
+        ok: false,
+        required: true,
+        configured: true,
+        backend,
+        reason: "session_store_unavailable"
+      };
+    }
+  }
+
+  if (backend !== SESSION_STORE_BACKEND.SQLITE) {
+    return {
+      ok: false,
+      required: true,
+      configured: false,
+      backend,
+      reason: "invalid_session_store_backend"
+    };
+  }
+
   try {
     const db = getDb(config.sessionDbPath);
     db.prepare("SELECT 1 AS ok").get();
@@ -45,6 +111,7 @@ function evaluateSessionStore(config) {
       ok: true,
       required: true,
       configured: Boolean(config.sessionDbPath),
+      backend,
       reason: null
     };
   } catch {
@@ -52,6 +119,7 @@ function evaluateSessionStore(config) {
       ok: false,
       required: true,
       configured: Boolean(config.sessionDbPath),
+      backend,
       reason: "session_store_unavailable"
     };
   }
@@ -171,11 +239,12 @@ async function evaluateBackend(config) {
 export async function GET() {
   const config = getConfig();
   const backend = await evaluateBackend(config);
+  const sessionStore = await evaluateSessionStore(config);
   const checks = {
     backend,
     access_config: evaluateAccessConfig(config),
     user_source: evaluateUserSource(config),
-    session_store: evaluateSessionStore(config),
+    session_store: sessionStore,
     session_scaling: evaluateSessionScaling(config)
   };
   const ok = Object.values(checks).every((check) => !check.required || check.ok);

--- a/web/secure-landing/lib/session-store/redis-store.js
+++ b/web/secure-landing/lib/session-store/redis-store.js
@@ -10,11 +10,10 @@
  * with the timestamp as score, so the throttle-window count is a
  * ``ZCOUNT`` against ``(now - window, now)``.
  *
- * The module uses ``ioredis`` lazily so the bundle still ships when the
- * dependency is not yet installed in a given environment — single-instance
- * sqlite deployments do not need redis on disk. If the import fails the
- * factory in ``./index.js`` falls back to sqlite with a warning so the
- * frontdoor still serves traffic.
+ * The module uses ``ioredis`` lazily so the bundle still ships before a Redis
+ * connection is needed. When Redis is explicitly selected, a missing package or
+ * unreachable Redis endpoint fails the session path instead of silently
+ * downgrading a hosted deployment to local SQLite.
  *
  * Schema invariants:
  *
@@ -29,6 +28,7 @@
  */
 
 let _Redis = null;
+const DEFAULT_REDIS_CONNECT_TIMEOUT_MS = 1000;
 
 async function loadRedisClient() {
   if (_Redis !== null) return _Redis;
@@ -47,7 +47,14 @@ async function loadRedisClient() {
 }
 
 export class RedisSessionStore {
-  constructor({ redisUrl, keyPrefix, idleTimeoutMs, absoluteTimeoutMs, client = null } = {}) {
+  constructor({
+    redisUrl,
+    keyPrefix,
+    idleTimeoutMs,
+    absoluteTimeoutMs,
+    client = null,
+    connectTimeoutMs = DEFAULT_REDIS_CONNECT_TIMEOUT_MS
+  } = {}) {
     if (!redisUrl) {
       throw new Error("RedisSessionStore requires a non-empty redisUrl (TP_FRONTDOOR_REDIS_URL).");
     }
@@ -55,6 +62,7 @@ export class RedisSessionStore {
     this._keyPrefix = keyPrefix || "tp:frontdoor:";
     this._idleTimeoutMs = idleTimeoutMs;
     this._absoluteTimeoutMs = absoluteTimeoutMs;
+    this._connectTimeoutMs = connectTimeoutMs;
     this._client = client;
     this._clientPromise = null;
   }
@@ -68,11 +76,20 @@ export class RedisSessionStore {
     if (!this._clientPromise) {
       this._clientPromise = (async () => {
         const Redis = await loadRedisClient();
-        this._client = new Redis(this._redisUrl, { lazyConnect: false });
+        this._client = new Redis(this._redisUrl, {
+          lazyConnect: false,
+          connectTimeout: this._connectTimeoutMs,
+          maxRetriesPerRequest: 1
+        });
         return this._client;
       })();
     }
     return this._clientPromise;
+  }
+
+  async ping() {
+    const client = await this._client_();
+    return client.ping();
   }
 
   _sessionKey(sessionId) {
@@ -179,6 +196,7 @@ export class RedisSessionStore {
   }
 
   async close() {
+    this._clientPromise = null;
     if (this._client) {
       await this._client.quit().catch(() => undefined);
       this._client = null;

--- a/web/secure-landing/tests/routes.test.mjs
+++ b/web/secure-landing/tests/routes.test.mjs
@@ -21,6 +21,9 @@ const ENV_KEYS = [
   "TP_FRONTDOOR_USERS_JSON",
   "TP_FRONTDOOR_SESSION_DB",
   "TP_FRONTDOOR_SESSION_SCALING_MODE",
+  "TP_FRONTDOOR_SESSION_STORE",
+  "TP_FRONTDOOR_REDIS_URL",
+  "TP_FRONTDOOR_REDIS_KEY_PREFIX",
   "TP_CF_ACCESS_TEAM_DOMAIN",
   "TP_CF_ACCESS_AUD",
   "TP_ALLOW_LOCAL_ACCESS_BYPASS",
@@ -106,6 +109,24 @@ function withTempEnvironment(overrides = {}) {
     process.env.TP_FRONTDOOR_SESSION_SCALING_MODE = overrides.TP_FRONTDOOR_SESSION_SCALING_MODE;
   } else {
     delete process.env.TP_FRONTDOOR_SESSION_SCALING_MODE;
+  }
+
+  if (typeof overrides.TP_FRONTDOOR_SESSION_STORE === "string") {
+    process.env.TP_FRONTDOOR_SESSION_STORE = overrides.TP_FRONTDOOR_SESSION_STORE;
+  } else {
+    delete process.env.TP_FRONTDOOR_SESSION_STORE;
+  }
+
+  if (typeof overrides.TP_FRONTDOOR_REDIS_URL === "string") {
+    process.env.TP_FRONTDOOR_REDIS_URL = overrides.TP_FRONTDOOR_REDIS_URL;
+  } else {
+    delete process.env.TP_FRONTDOOR_REDIS_URL;
+  }
+
+  if (typeof overrides.TP_FRONTDOOR_REDIS_KEY_PREFIX === "string") {
+    process.env.TP_FRONTDOOR_REDIS_KEY_PREFIX = overrides.TP_FRONTDOOR_REDIS_KEY_PREFIX;
+  } else {
+    delete process.env.TP_FRONTDOOR_REDIS_KEY_PREFIX;
   }
 
   if (typeof overrides.TP_ALLOW_LOCAL_ACCESS_BYPASS === "string") {
@@ -3687,6 +3708,196 @@ test("healthz rejects multi-instance session scaling until an external session s
         body.checks.session_scaling.reason,
         "multi_instance_requires_external_session_store"
       );
+    } finally {
+      global.fetch = originalFetch;
+    }
+  } finally {
+    env.cleanup();
+  }
+});
+
+test("healthz accepts Redis-backed multi-instance session readiness", async () => {
+  const env = withTempEnvironment({
+    TP_FRONTDOOR_SESSION_SCALING_MODE: "multi_instance",
+    TP_FRONTDOOR_SESSION_STORE: "redis",
+    TP_FRONTDOOR_REDIS_URL: "rediss://redis.example.com:6380/0",
+    usersFileEntries: [
+      {
+        username: "admin",
+        password_hash: "hash",
+        access_email: "admin@example.com",
+        role: "admin"
+      }
+    ]
+  });
+  const sessionStoreModule = await import("../lib/session-store/index.js");
+
+  try {
+    sessionStoreModule.__setSessionStoreForTesting(
+      {
+        backend: "redis",
+        ping: async () => "PONG"
+      },
+      "redis"
+    );
+    const { GET } = await importFresh("../app/healthz/route.js");
+    const originalFetch = global.fetch;
+    global.fetch = async () =>
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: {
+          "content-type": "application/json"
+        }
+      });
+
+    try {
+      const response = await GET();
+      const body = await response.json();
+
+      assert.equal(response.status, 200);
+      assert.equal(body.ok, true);
+      assert.equal(body.checks.session_store.ok, true);
+      assert.equal(body.checks.session_store.backend, "redis");
+      assert.equal(body.checks.session_scaling.ok, true);
+      assert.equal(body.checks.session_scaling.backend, "redis");
+      assert.equal(body.checks.session_scaling.mode, "multi_instance");
+    } finally {
+      global.fetch = originalFetch;
+    }
+  } finally {
+    sessionStoreModule.resetSessionStoreSingleton();
+    env.cleanup();
+  }
+});
+
+test("healthz bounds Redis session readiness probes", async () => {
+  const env = withTempEnvironment({
+    TP_FRONTDOOR_SESSION_SCALING_MODE: "multi_instance",
+    TP_FRONTDOOR_SESSION_STORE: "redis",
+    TP_FRONTDOOR_REDIS_URL: "rediss://redis.example.com:6380/0",
+    usersFileEntries: [
+      {
+        username: "admin",
+        password_hash: "hash",
+        access_email: "admin@example.com",
+        role: "admin"
+      }
+    ]
+  });
+  const sessionStoreModule = await import("../lib/session-store/index.js");
+
+  try {
+    sessionStoreModule.__setSessionStoreForTesting(
+      {
+        backend: "redis",
+        ping: async () => new Promise(() => {})
+      },
+      "redis"
+    );
+    const { GET } = await importFresh("../app/healthz/route.js");
+    const originalFetch = global.fetch;
+    global.fetch = async () =>
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: {
+          "content-type": "application/json"
+        }
+      });
+
+    try {
+      const startedAt = Date.now();
+      const response = await GET();
+      const elapsedMs = Date.now() - startedAt;
+      const body = await response.json();
+
+      assert.equal(response.status, 503);
+      assert.equal(body.checks.session_store.ok, false);
+      assert.equal(body.checks.session_store.backend, "redis");
+      assert.equal(body.checks.session_store.reason, "session_store_unavailable");
+      assert.ok(elapsedMs < 1800, `Redis health probe should be timeout-bounded, took ${elapsedMs}ms`);
+    } finally {
+      global.fetch = originalFetch;
+    }
+  } finally {
+    sessionStoreModule.resetSessionStoreSingleton();
+    env.cleanup();
+  }
+});
+
+test("healthz fails closed when Redis session store lacks a URL", async () => {
+  const env = withTempEnvironment({
+    TP_FRONTDOOR_SESSION_SCALING_MODE: "multi_instance",
+    TP_FRONTDOOR_SESSION_STORE: "redis",
+    TP_FRONTDOOR_REDIS_URL: "",
+    usersFileEntries: [
+      {
+        username: "admin",
+        password_hash: "hash",
+        access_email: "admin@example.com",
+        role: "admin"
+      }
+    ]
+  });
+
+  try {
+    const { GET } = await importFresh("../app/healthz/route.js");
+    const originalFetch = global.fetch;
+    global.fetch = async () =>
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: {
+          "content-type": "application/json"
+        }
+      });
+
+    try {
+      const response = await GET();
+      const body = await response.json();
+
+      assert.equal(response.status, 503);
+      assert.equal(body.checks.session_store.ok, false);
+      assert.equal(body.checks.session_store.backend, "redis");
+      assert.equal(body.checks.session_store.reason, "missing_frontdoor_redis_url");
+    } finally {
+      global.fetch = originalFetch;
+    }
+  } finally {
+    env.cleanup();
+  }
+});
+
+test("healthz fails closed for unsupported session store backends", async () => {
+  const env = withTempEnvironment({
+    TP_FRONTDOOR_SESSION_STORE: "memcached",
+    usersFileEntries: [
+      {
+        username: "admin",
+        password_hash: "hash",
+        access_email: "admin@example.com",
+        role: "admin"
+      }
+    ]
+  });
+
+  try {
+    const { GET } = await importFresh("../app/healthz/route.js");
+    const originalFetch = global.fetch;
+    global.fetch = async () =>
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: {
+          "content-type": "application/json"
+        }
+      });
+
+    try {
+      const response = await GET();
+      const body = await response.json();
+
+      assert.equal(response.status, 503);
+      assert.equal(body.checks.session_store.ok, false);
+      assert.equal(body.checks.session_store.backend, "memcached");
+      assert.equal(body.checks.session_store.reason, "invalid_session_store_backend");
     } finally {
       global.fetch = originalFetch;
     }


### PR DESCRIPTION
## Summary
- Current rollout posture on `main` supports Cloudflare Worker frontdoor deployments and Redis-backed frontdoor sessions, but the deployment/env validation contracts still assumed Vercel-only and SQLite-only posture.
- Add explicit Worker deployment validation and Redis session env/readiness validation while keeping unsupported configs fail-closed.

## Changes
- Add `--deployment-target` / `--deployment-url` to `check_frontdoor_deployment_gate.py`, with `--vercel-deployment-url` retained as a legacy alias.
- Validate Cloudflare Worker deployment URLs using the same Cloudflare Access protected-response classification as the public frontdoor.
- Update `check_frontdoor_vercel_env.py` so `multi_instance` and `ephemeral_runtime` pass only with `TP_FRONTDOOR_SESSION_STORE=redis` and an absolute `redis://` or `rediss://` URL.
- Make `/healthz` report Redis session store readiness and fail closed for missing Redis URLs or unsupported session store backends.
- Update focused tests, Make/workflow inputs, and live operator docs for Worker deployment targets and Redis-backed sessions.
- No route or selector changes; `/healthz` keeps the existing envelope and extends `checks.session_store` with backend detail.

## Validation
Proven green:
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest -q tests/validation/test_frontdoor_deployment_gate.py tests/validation/test_check_frontdoor_vercel_env.py`
- `PATH=/Users/richardcheetham/.nvm/versions/node/v22.22.2/bin:$PATH node --experimental-specifier-resolution=node --test --test-name-pattern "healthz|session scaling|RedisSessionStore" tests/routes.test.mjs tests/session-scaling.test.mjs tests/session-store.test.mjs` from `web/secure-landing`
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m py_compile scripts/validation/check_frontdoor_deployment_gate.py scripts/validation/check_frontdoor_vercel_env.py`
- Redis env-check sample with `TP_FRONTDOOR_SESSION_STORE=redis` and `TP_FRONTDOOR_SESSION_SCALING_MODE=multi_instance`
- `PATH=/Users/richardcheetham/.nvm/versions/node/v22.22.2/bin:$PATH make test-frontdoor-contract`
- `git diff --check` on touched files
- Commit hooks: Python formatting/import checks, script topology, root placement, test markers, gitleaks, and related pre-commit checks passed during commit

Still failing:
- No product or stale-test failures observed.
- A non-canonical system `python3 -m py_compile ...` attempt failed because macOS Python tried to write bytecode under `~/Library/Caches` outside the sandbox. Repo Python with bytecode disabled passed.

## Risk
- Compatibility risk is bounded: legacy Vercel deployment URL input and `TP_FRONTDOOR_GATE_VERCEL_DEPLOYMENT_URL` remain supported.
- Operational risk is intentional fail-closed behavior: Worker/Vercel deployment URLs must classify as clearly protected, and Redis-backed session modes fail readiness when Redis config or reachability is missing.
- Revert-safe because the change is limited to validation contracts, health readiness reporting, focused tests, and operator docs; no public route shapes or UI selectors are changed.