### PR TITLE
fix(worker): preserve dashboard vars in wrangler config

### DIFF
--- a/cloudflare/transformationportal-worker/wrangler.jsonc
+++ b/cloudflare/transformationportal-worker/wrangler.jsonc
@@ -3,6 +3,7 @@
   "name": "transformationportal",
   "main": "src/index.ts",
   "compatibility_date": "2026-05-03",
+  "keep_vars": true,
   "observability": {
     "enabled": true,
     "head_sampling_rate": 0.1

--- a/tests/validation/test_cloudflare_worker_root_shim_contract.py
+++ b/tests/validation/test_cloudflare_worker_root_shim_contract.py
@@ -70,6 +70,7 @@ def test_root_wrangler_config_points_to_governed_worker_entrypoint() -> None:
     assert root_config["main"] == expected_root_main
     assert worker_entrypoint.is_file()
     assert root_config["compatibility_date"] == worker_config["compatibility_date"]
+    assert root_config["keep_vars"] is worker_config["keep_vars"] is True
     assert root_config["observability"] == worker_config["observability"]
     assert root_config["observability"]["enabled"] is True
     assert 0 < root_config["observability"]["head_sampling_rate"] <= 1

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -3,6 +3,7 @@
   "name": "transformationportal",
   "main": "cloudflare/transformationportal-worker/src/index.ts",
   "compatibility_date": "2026-05-03",
+  "keep_vars": true,
   "observability": {
     "enabled": true,
     "head_sampling_rate": 0.1


### PR DESCRIPTION
## Summary
- Main post-merge had a failing external Cloudflare Workers Builds check while GitHub Actions were still running.
- The Worker source and root shim build locally, but Cloudflare production builds can run the default deploy command instead of the repo script that passes --keep-vars.
- Add the Wrangler top-level keep_vars guard so dashboard-managed provider vars are preserved regardless of whether the deploy uses the script flag or default Wrangler config.

## Changes
- Set keep_vars: true in the root Cloudflare Workers build shim wrangler.jsonc.
- Set keep_vars: true in the governed cloudflare/transformationportal-worker/wrangler.jsonc.
- Extend the Cloudflare worker root-shim contract test to require both configs to keep provider vars.

## Validation
Proven green:
- ./.venv/bin/pytest tests/validation/test_cloudflare_worker_root_shim_contract.py -q
- PATH=/Users/richardcheetham/.nvm/versions/node/v22.22.2/bin:$PATH npm run worker:dry-run
- PATH=/Users/richardcheetham/.nvm/versions/node/v22.22.2/bin:$PATH npm run dry-run (from cloudflare/transformationportal-worker)
- PATH=/Users/richardcheetham/.nvm/versions/node/v22.22.2/bin:$PATH npm run typecheck (from cloudflare/transformationportal-worker)
- git diff --check on touched files
- commit hooks

Still failing:
- The original main Cloudflare check remains red on commit cdcbbdcdac4e138b83901e49c4d2c769dfde5704 until this PR lands and triggers a new provider build.

Failure classification:
- Product source locally validates; the observed failure is most consistent with deployment configuration/provider command behavior around dashboard-managed vars.

## Risk
- Bounded to Cloudflare Worker deploy configuration and its root-shim contract.
- Revert-safe: removing keep_vars restores prior deploy behavior without touching worker request handling, routes, bindings, or frontend/backend contracts.