### PR TITLE
test(coverage): floor app.py + orchestrator durable-state backends

### DIFF
--- a/docs/testing/COLD_ZONE_COVERAGE_PROGRAM.md
+++ b/docs/testing/COLD_ZONE_COVERAGE_PROGRAM.md
@@ -692,3 +692,39 @@ the new floor took effect in §17.3 below.
    code paths that assume `transformation_portal.vlm.LLaVAProcessor` is
    importable without instantiation)? Audit during PR 0; surface affected
    call sites in the PR description.
+
+---
+
+## 19. Floor additions — 2026-06-06 (app.py + orchestrator durable-state)
+
+A coverage audit on 2026-06-06 found two governed surfaces that were already
+*measured* by the core-tier coverage step (`.github/workflows/build.yml` runs
+`--cov=app`) but had **no enforced floor**, so they could silently regress:
+
+1. **`app.py`** — the FastAPI origin holding the most security-critical
+   hardening (allowed-root validation, API-key / trusted-host enforcement,
+   request size / concurrency / rate limits, pipeline allowlists).
+2. **The paid-pilot durable-state backends** —
+   `orchestrator/storage/`, `orchestrator/queue/`, `orchestrator/artifact_store/`
+   (the `JobRepository` / `QueueBroker` / `ArtifactStore` Protocol surfaces).
+   Their Postgres/Redis/S3 paths only get full exercise behind the opt-in
+   live-service contract gates, so the core-lane rollup leans on the
+   in-memory/local implementations — which is exactly the contract coverage a
+   floor protects.
+
+Floors were set conservatively below a 2026-06-06 core-lane snapshot
+(`(unit or security or regression or golden or integration) and not ml and not
+slow and not benchmark`) to absorb cross-lane variance, per the
+"conservative starter, ratchet upward after a confirming CI run" discipline.
+
+| Prefix | Measured line | Line floor | Measured branch | Branch floor |
+|---|---:|---:|---:|---:|
+| `app.py` | 83.8% | 76.0% | 75.3% | 66.0% |
+| `orchestrator/storage/` | 68.0% | 60.0% | 51.4% | 44.0% |
+| `orchestrator/queue/` | 67.6% | 58.0% | 43.8% | 36.0% |
+| `orchestrator/artifact_store/` | 65.9% | 58.0% | 54.7% | 46.0% |
+
+Line floors live in `scripts/ci/check_per_package_coverage.py`; branch floors
+in `scripts/ci/check_per_package_branch_coverage.py`. Ratchet upward once the
+live-service lanes (Postgres/Redis/S3 contract gates) are folded into the
+floor-bearing coverage run.

--- a/scripts/ci/check_per_package_branch_coverage.py
+++ b/scripts/ci/check_per_package_branch_coverage.py
@@ -41,6 +41,16 @@ BRANCH_FLOORS: tuple[BranchFloor, ...] = (
     BranchFloor("src/transformation_portal/depth/", 42.0),
     BranchFloor("src/transformation_portal/streaming/", 29.0),
     BranchFloor("src/transformation_portal/spatial_ai/reconstruction/", 47.0),
+    # FastAPI origin + governed paid-pilot durable-state backends. Measured in
+    # the 2026-06-06 core-lane snapshot at app.py 75.3%, orchestrator/storage/
+    # 51.4%, orchestrator/queue/ 43.8%, orchestrator/artifact_store/ 54.7%
+    # branch coverage. Conservative starters below those values; ratchet upward
+    # after a confirming required-CI run. See check_per_package_coverage.py for
+    # the matching line-coverage floors and rationale.
+    BranchFloor("app.py", 66.0),
+    BranchFloor("src/transformation_portal/orchestrator/storage/", 44.0),
+    BranchFloor("src/transformation_portal/orchestrator/queue/", 36.0),
+    BranchFloor("src/transformation_portal/orchestrator/artifact_store/", 46.0),
 )
 
 # If a future branch temporarily clears floors, dry-run mode still reports the
@@ -52,6 +62,10 @@ DRY_RUN_BRANCH_PREFIXES: tuple[str, ...] = (
     "src/transformation_portal/depth/",
     "src/transformation_portal/streaming/",
     "src/transformation_portal/spatial_ai/reconstruction/",
+    "app.py",
+    "src/transformation_portal/orchestrator/storage/",
+    "src/transformation_portal/orchestrator/queue/",
+    "src/transformation_portal/orchestrator/artifact_store/",
 )
 
 

--- a/scripts/ci/check_per_package_coverage.py
+++ b/scripts/ci/check_per_package_coverage.py
@@ -90,6 +90,25 @@ PACKAGE_FLOORS: tuple[PackageFloor, ...] = (
     PackageFloor("src/transformation_portal/depth/", 57.0),
     PackageFloor("src/transformation_portal/streaming/", 53.0),
     PackageFloor("src/transformation_portal/spatial_ai/reconstruction/", 42.0),
+    # FastAPI origin. app.py is already measured in the core-tier coverage step
+    # (build.yml runs `--cov=app`), and a 2026-06-06 core-lane snapshot put it at
+    # ~83.8% line coverage, but until now nothing FLOORED it — the most
+    # security-critical hardening surface (allowed-root validation, API-key /
+    # trusted-host enforcement, request limits, pipeline allowlists) could
+    # silently regress. Conservative starter well below the measured value to
+    # absorb cross-lane variance; ratchet upward after a confirming CI run.
+    PackageFloor("app.py", 76.0),
+    # Governed paid-pilot durable-state backends. These three packages are the
+    # first-class JobRepository / QueueBroker / ArtifactStore Protocol surfaces
+    # (memory + Postgres/Redis/S3 implementations). The Postgres/Redis/S3 paths
+    # only get full exercise behind the opt-in live-service contract gates, so
+    # the core-lane rollup leans on the in-memory/local implementations. Floors
+    # set below the 2026-06-06 core-lane snapshot (storage 68.0%, queue 67.6%,
+    # artifact_store 65.9%) so the in-memory/local contract coverage cannot
+    # silently regress; raise once the live-service lanes are folded in.
+    PackageFloor("src/transformation_portal/orchestrator/storage/", 60.0),
+    PackageFloor("src/transformation_portal/orchestrator/queue/", 58.0),
+    PackageFloor("src/transformation_portal/orchestrator/artifact_store/", 58.0),
 )
 
 

--- a/tests/test_check_per_package_branch_coverage.py
+++ b/tests/test_check_per_package_branch_coverage.py
@@ -142,7 +142,7 @@ def test_missing_coverage_xml_returns_2(script_module, tmp_path: Path):
     assert script_module.main([str(tmp_path / "missing.xml"), "--dry-run"]) == 2
 
 
-def test_default_branch_floors_cover_cold_zone_prefixes(script_module):
+def test_default_branch_floors_cover_cold_zone_and_durable_state_prefixes(script_module):
     assert tuple((floor.prefix, floor.floor) for floor in script_module.BRANCH_FLOORS) == (
         ("src/transformation_portal/plugins/", 36.0),
         ("src/transformation_portal/stage_graph/", 63.0),
@@ -150,6 +150,10 @@ def test_default_branch_floors_cover_cold_zone_prefixes(script_module):
         ("src/transformation_portal/depth/", 42.0),
         ("src/transformation_portal/streaming/", 29.0),
         ("src/transformation_portal/spatial_ai/reconstruction/", 47.0),
+        ("app.py", 66.0),
+        ("src/transformation_portal/orchestrator/storage/", 44.0),
+        ("src/transformation_portal/orchestrator/queue/", 36.0),
+        ("src/transformation_portal/orchestrator/artifact_store/", 46.0),
     )
 
 


### PR DESCRIPTION
The core-tier coverage step already measures app.py (build.yml runs
`--cov=app`), but nothing FLOORED it — so the FastAPI origin's
security-critical hardening could silently regress. The paid-pilot
durable-state backends (JobRepository / QueueBroker / ArtifactStore)
were likewise unfloored.

Add conservative per-package line- and branch-coverage floors, set below
a 2026-06-06 core-lane snapshot to absorb cross-lane variance:

  prefix                              line(meas/floor)  branch(meas/floor)
  app.py                                 83.8 / 76.0       75.3 / 66.0
  orchestrator/storage/                  68.0 / 60.0       51.4 / 44.0
  orchestrator/queue/                    67.6 / 58.0       43.8 / 36.0
  orchestrator/artifact_store/           65.9 / 58.0       54.7 / 46.0

Both floor scripts pass end-to-end against a full CI-lane coverage.xml
with no regression to existing floors. Documented in §19 of the
cold-zone coverage program. Ratchet upward once the live-service
(Postgres/Redis/S3) contract lanes are folded into the floor-bearing run.

https://claude.ai/code/session_01M6t48Ftq36XX3tyRdjaYJ2