### PR TITLE
chore(requirements): bump hypothesis lock pin

### DIFF
--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -103,7 +103,7 @@ httpcore==1.0.9
     # via httpx
 httpx==0.28.1
     # via -r dev.in
-hypothesis==6.152.1
+hypothesis==6.155.2
     # via -r dev.in
 id==1.6.1
     # via twine

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -107,7 +107,7 @@ httpx==0.28.1
     # via
     #   -c all.txt
     #   -r dev.in
-hypothesis==6.152.1
+hypothesis==6.155.2
     # via
     #   -c all.txt
     #   -r dev.in


### PR DESCRIPTION
## Summary
- Recreates the failing Hypothesis Dependabot update from PR #1897 with the narrow lock change only.
- Preserves the generic lock contract, including the non-Linux opencv-python marker pin.

## Changes
- Bumps hypothesis from 6.152.1 to 6.155.2 in requirements/all.txt.
- Bumps hypothesis from 6.152.1 to 6.155.2 in requirements/dev.txt.

## Validation
- Proven green: bash scripts/validate_dependency_constraints.sh --verbose
- Proven green: ./.venv/bin/python scripts/validation/check_requirements_lock_contract.py
- Proven green: ./.venv/bin/pytest tests/validation/test_validate_dependency_constraints_script.py tests/test_check_requirements_lock_contract.py -v
- Proven green: git diff --check
- Proven green: commit hooks run by git commit

## Risk
- Bounded to two generated generic lock pins.
- Revert-safe as a single dependency-only commit.

Supersedes #1897.