### PR TITLE
chore(deps): consolidate remaining dependency updates

### DIFF
--- a/cloudflare/transformationportal-worker/package-lock.json
+++ b/cloudflare/transformationportal-worker/package-lock.json
@@ -6,9 +6,9 @@
     "": {
       "name": "transformationportal-worker",
       "devDependencies": {
-        "@cloudflare/workers-types": "4.20260603.1",
+        "@cloudflare/workers-types": "4.20260609.1",
         "typescript": "6.0.3",
-        "wrangler": "4.97.0"
+        "wrangler": "4.98.0"
       },
       "engines": {
         "node": ">=22 <23"
@@ -41,9 +41,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260601.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260601.1.tgz",
-      "integrity": "sha512-iXZBVuRbvuVqQ/63wul01hHCv/3R8G5S8zbkjfoHvyPZFynmlKTV59Hk+H8whyGwFAZuB71UJGLr+G5mJKfjWA==",
+      "version": "1.20260603.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260603.1.tgz",
+      "integrity": "sha512-cEXDWu6V3ZrpmwWkM4OJE9AeXjdAgOY5rh8EHhcBVCuP5rxnzUbPzLtrVOHx0UUUAcCrFq0Xsa6mZKL1VUZsKQ==",
       "cpu": [
         "x64"
       ],
@@ -58,9 +58,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260601.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260601.1.tgz",
-      "integrity": "sha512-veGpZQGBw07Twt+Y4z3oyo+/obKHt0iWUwvDV5GOiDAYjC/zW+YGstgVzg4SHq+k1sLH3ElqL2TXx20I5WBv3Q==",
+      "version": "1.20260603.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260603.1.tgz",
+      "integrity": "sha512-uBPK4LaWJNbbCYwPnUAehlHbbVulhVZPZsdcAhBPfZhHb3QAuAEPAQepO/P67R3V6Cni4YGx1fLbL8A5wwoaNA==",
       "cpu": [
         "arm64"
       ],
@@ -75,9 +75,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260601.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260601.1.tgz",
-      "integrity": "sha512-n/9hDz7fPGpYF0J684+Xr5zgjcS2jdmY2Of5m6e+eQ/M9+RfR+UaU8Ee/tkA1dDC0LYQB13hfPafZG66Ff1CsA==",
+      "version": "1.20260603.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260603.1.tgz",
+      "integrity": "sha512-ht9l6/8Tk7Rp6kA4S9oFZ4X8u0VjnnFdmU/6B3fnABYKREYTKh2RdOqXqXxcp5eNJseireKnWik/hQOPK1CutQ==",
       "cpu": [
         "x64"
       ],
@@ -92,9 +92,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260601.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260601.1.tgz",
-      "integrity": "sha512-VHRZZbexATS+n+1j3x/CZaYbIJEye0J3iIHgG0Wp+l+NrZCKQ8qi8Lq1uTV0dLJQ67FuZtJtWdQ95mm9F7Fc+A==",
+      "version": "1.20260603.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260603.1.tgz",
+      "integrity": "sha512-LJZ6x00rAjSrobV4m0ZW0TpH5ilBbKcWBzlH+y+KOUsIE/CpTuhAzKV43TbSnFLRX5+jrWKiz2v0hO91lPXy6A==",
       "cpu": [
         "arm64"
       ],
@@ -109,9 +109,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260601.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260601.1.tgz",
-      "integrity": "sha512-ye0C7MFLkeH16iTo8Tcjv2KiFmp23+sZGvUzSQa4xhP0QMe6EoJ+H/4SqqvnZ5nfN54slqKvx2VnXceENWe2CQ==",
+      "version": "1.20260603.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260603.1.tgz",
+      "integrity": "sha512-DvwqkXMAJRPoDN4PxapAwhlz/6ouD+6R1ttbAEK3cWD/QBvFF5STx7Ds/9Irf+rBly3np3uHWkeX+wZnNFEuzA==",
       "cpu": [
         "x64"
       ],
@@ -126,9 +126,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "4.20260603.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260603.1.tgz",
-      "integrity": "sha512-TLeVHoBbcYv35S5TdRWUoj3IJ56BhHtrsuci+O7ithU8yz7ttNdCk6rAl1QUSGNVEWSIp54bWOuV/xmX1zu79g==",
+      "version": "4.20260609.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260609.1.tgz",
+      "integrity": "sha512-krGHtwSApCFBjTe1NTx/TFQ0P5i/bHGQOqCPnCLssb8rOKaAG4JkPFJZsossr0z/ZTMnpP2Tid5jWju+/i0hCA==",
       "dev": true,
       "license": "MIT OR Apache-2.0"
     },
@@ -146,9 +146,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.0.tgz",
+      "integrity": "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -696,6 +696,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -713,6 +716,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -730,6 +736,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -747,6 +756,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -764,6 +776,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -781,6 +796,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -798,6 +816,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -815,6 +836,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -832,6 +856,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -855,6 +882,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -878,6 +908,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -901,6 +934,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -924,6 +960,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -947,6 +986,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -970,6 +1012,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -993,6 +1038,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1159,9 +1207,9 @@
       }
     },
     "node_modules/@speed-highlight/core": {
-      "version": "1.2.15",
-      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.15.tgz",
-      "integrity": "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==",
+      "version": "1.2.16",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.16.tgz",
+      "integrity": "sha512-yNm/fYEcnpRjYduLMaddTK9XKYil6xB88+qFg79ZdZhHu1PadfoQmFW7pVTx7FZqMBNcUuThiAhxhENgtAO2/w==",
       "dev": true,
       "license": "CC0-1.0"
     },
@@ -1274,16 +1322,16 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "4.20260601.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260601.0.tgz",
-      "integrity": "sha512-56TFiulSEQu43cYxdXgCiA3U3i+Ls0NoXwJXd6DmpNsx8yl/1Il2T3DQ4CMXjR6yfE7CSvC5MuXaqcSAMREjgw==",
+      "version": "4.20260603.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260603.0.tgz",
+      "integrity": "sha512-+kMQYB82gC8MPOuojHur3icQsUeZUEJ+Sphuo5rVC3Ri9txBLAW/mH33b9OVrpmkogQeaaqPS4tPtugJZhk5Kw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
         "sharp": "0.34.5",
         "undici": "7.24.8",
-        "workerd": "1.20260601.1",
+        "workerd": "1.20260603.1",
         "ws": "8.20.1",
         "youch": "4.1.0-beta.10"
       },
@@ -1309,9 +1357,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
-      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.3.tgz",
+      "integrity": "sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -1422,9 +1470,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20260601.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260601.1.tgz",
-      "integrity": "sha512-Bg4+HF3B8TW0urAv8chiz25HSQ/aJxMBjgheUzu/nB1NQa+CaKGrUPv+Z3bf0np/WxLHYW1kcseVEtzZVPbX4g==",
+      "version": "1.20260603.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260603.1.tgz",
+      "integrity": "sha512-NPcbhI1++CS+fnELyXtsIR52en+5kwr/OrKeiQeYXGy10HxmPdsQBv9N+DU7hJIOOmBHhOGAAsoGDjyiQ2YCaA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -1435,17 +1483,17 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260601.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260601.1",
-        "@cloudflare/workerd-linux-64": "1.20260601.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260601.1",
-        "@cloudflare/workerd-windows-64": "1.20260601.1"
+        "@cloudflare/workerd-darwin-64": "1.20260603.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260603.1",
+        "@cloudflare/workerd-linux-64": "1.20260603.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260603.1",
+        "@cloudflare/workerd-windows-64": "1.20260603.1"
       }
     },
     "node_modules/wrangler": {
-      "version": "4.97.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.97.0.tgz",
-      "integrity": "sha512-jzW/aNvjerV+4TmwbvwGY6lpcuBk7EFUTonMDNfci45wSmMTj2/OJN+83cc/CeepKdb+6ZjGJw9NRjmcQoxqRg==",
+      "version": "4.98.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.98.0.tgz",
+      "integrity": "sha512-cXfFUuF4rMIvE0hiMnXjEAB27ERryaCgquBJdUoPIjFzYYE1rbRdMUkEdQ18qDPUtsPvhJdqxLntixT9OfSzQw==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
@@ -1453,10 +1501,10 @@
         "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.27.3",
-        "miniflare": "4.20260601.0",
+        "miniflare": "4.20260603.0",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260601.1"
+        "workerd": "1.20260603.1"
       },
       "bin": {
         "wrangler": "bin/wrangler.js",
@@ -1469,7 +1517,7 @@
         "fsevents": "2.3.3"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20260601.1"
+        "@cloudflare/workers-types": "^4.20260603.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {

--- a/cloudflare/transformationportal-worker/package.json
+++ b/cloudflare/transformationportal-worker/package.json
@@ -13,8 +13,8 @@
   },
   "packageManager": "npm@11.12.1",
   "devDependencies": {
-    "@cloudflare/workers-types": "4.20260603.1",
+    "@cloudflare/workers-types": "4.20260609.1",
     "typescript": "6.0.3",
-    "wrangler": "4.97.0"
+    "wrangler": "4.98.0"
   }
 }

--- a/config/fastvlm_runtime_requirements.txt
+++ b/config/fastvlm_runtime_requirements.txt
@@ -1,4 +1,4 @@
-pip==26.1.1
+pip==26.1.2
 aiohappyeyeballs==2.6.2
 aiohttp==3.14.0
 aiosignal==1.4.0
@@ -45,11 +45,11 @@ packaging==26.2
 pandas==3.0.2
 pillow==12.2.0
 propcache==0.4.1
-protobuf==7.34.1
+protobuf==7.35.0
 pyaml==26.2.1
 pyarrow==24.0.0
 pydantic==2.13.4
-pydantic_core==2.46.4
+pydantic_core==2.47.0
 pydub==0.25.1
 Pygments==2.20.0
 python-dateutil==2.9.0.post0
@@ -60,7 +60,7 @@ regex==2026.4.4
 requests==2.34.2
 rich==15.0.0
 safehttpx==0.1.7
-safetensors==0.7.0
+safetensors==0.8.0
 scipy==1.13.1
 semantic-version==2.10.0
 shellingham==1.5.4

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "transformation-portal-worker-build",
       "devDependencies": {
-        "wrangler": "4.97.0"
+        "wrangler": "4.98.0"
       },
       "engines": {
         "node": ">=22 <23"
@@ -39,9 +39,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260601.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260601.1.tgz",
-      "integrity": "sha512-iXZBVuRbvuVqQ/63wul01hHCv/3R8G5S8zbkjfoHvyPZFynmlKTV59Hk+H8whyGwFAZuB71UJGLr+G5mJKfjWA==",
+      "version": "1.20260603.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260603.1.tgz",
+      "integrity": "sha512-cEXDWu6V3ZrpmwWkM4OJE9AeXjdAgOY5rh8EHhcBVCuP5rxnzUbPzLtrVOHx0UUUAcCrFq0Xsa6mZKL1VUZsKQ==",
       "cpu": [
         "x64"
       ],
@@ -56,9 +56,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260601.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260601.1.tgz",
-      "integrity": "sha512-veGpZQGBw07Twt+Y4z3oyo+/obKHt0iWUwvDV5GOiDAYjC/zW+YGstgVzg4SHq+k1sLH3ElqL2TXx20I5WBv3Q==",
+      "version": "1.20260603.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260603.1.tgz",
+      "integrity": "sha512-uBPK4LaWJNbbCYwPnUAehlHbbVulhVZPZsdcAhBPfZhHb3QAuAEPAQepO/P67R3V6Cni4YGx1fLbL8A5wwoaNA==",
       "cpu": [
         "arm64"
       ],
@@ -73,9 +73,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260601.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260601.1.tgz",
-      "integrity": "sha512-n/9hDz7fPGpYF0J684+Xr5zgjcS2jdmY2Of5m6e+eQ/M9+RfR+UaU8Ee/tkA1dDC0LYQB13hfPafZG66Ff1CsA==",
+      "version": "1.20260603.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260603.1.tgz",
+      "integrity": "sha512-ht9l6/8Tk7Rp6kA4S9oFZ4X8u0VjnnFdmU/6B3fnABYKREYTKh2RdOqXqXxcp5eNJseireKnWik/hQOPK1CutQ==",
       "cpu": [
         "x64"
       ],
@@ -90,9 +90,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260601.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260601.1.tgz",
-      "integrity": "sha512-VHRZZbexATS+n+1j3x/CZaYbIJEye0J3iIHgG0Wp+l+NrZCKQ8qi8Lq1uTV0dLJQ67FuZtJtWdQ95mm9F7Fc+A==",
+      "version": "1.20260603.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260603.1.tgz",
+      "integrity": "sha512-LJZ6x00rAjSrobV4m0ZW0TpH5ilBbKcWBzlH+y+KOUsIE/CpTuhAzKV43TbSnFLRX5+jrWKiz2v0hO91lPXy6A==",
       "cpu": [
         "arm64"
       ],
@@ -107,9 +107,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260601.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260601.1.tgz",
-      "integrity": "sha512-ye0C7MFLkeH16iTo8Tcjv2KiFmp23+sZGvUzSQa4xhP0QMe6EoJ+H/4SqqvnZ5nfN54slqKvx2VnXceENWe2CQ==",
+      "version": "1.20260603.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260603.1.tgz",
+      "integrity": "sha512-DvwqkXMAJRPoDN4PxapAwhlz/6ouD+6R1ttbAEK3cWD/QBvFF5STx7Ds/9Irf+rBly3np3uHWkeX+wZnNFEuzA==",
       "cpu": [
         "x64"
       ],
@@ -137,9 +137,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.0.tgz",
+      "integrity": "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -687,6 +687,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -704,6 +707,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -721,6 +727,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -738,6 +747,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -755,6 +767,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -772,6 +787,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -789,6 +807,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -806,6 +827,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -823,6 +847,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -846,6 +873,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -869,6 +899,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -892,6 +925,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -915,6 +951,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -938,6 +977,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -961,6 +1003,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -984,6 +1029,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1150,9 +1198,9 @@
       }
     },
     "node_modules/@speed-highlight/core": {
-      "version": "1.2.15",
-      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.15.tgz",
-      "integrity": "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==",
+      "version": "1.2.16",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.16.tgz",
+      "integrity": "sha512-yNm/fYEcnpRjYduLMaddTK9XKYil6xB88+qFg79ZdZhHu1PadfoQmFW7pVTx7FZqMBNcUuThiAhxhENgtAO2/w==",
       "dev": true,
       "license": "CC0-1.0"
     },
@@ -1265,16 +1313,16 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "4.20260601.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260601.0.tgz",
-      "integrity": "sha512-56TFiulSEQu43cYxdXgCiA3U3i+Ls0NoXwJXd6DmpNsx8yl/1Il2T3DQ4CMXjR6yfE7CSvC5MuXaqcSAMREjgw==",
+      "version": "4.20260603.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260603.0.tgz",
+      "integrity": "sha512-+kMQYB82gC8MPOuojHur3icQsUeZUEJ+Sphuo5rVC3Ri9txBLAW/mH33b9OVrpmkogQeaaqPS4tPtugJZhk5Kw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
         "sharp": "0.34.5",
         "undici": "7.24.8",
-        "workerd": "1.20260601.1",
+        "workerd": "1.20260603.1",
         "ws": "8.20.1",
         "youch": "4.1.0-beta.10"
       },
@@ -1300,9 +1348,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
-      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.3.tgz",
+      "integrity": "sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -1399,9 +1447,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20260601.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260601.1.tgz",
-      "integrity": "sha512-Bg4+HF3B8TW0urAv8chiz25HSQ/aJxMBjgheUzu/nB1NQa+CaKGrUPv+Z3bf0np/WxLHYW1kcseVEtzZVPbX4g==",
+      "version": "1.20260603.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260603.1.tgz",
+      "integrity": "sha512-NPcbhI1++CS+fnELyXtsIR52en+5kwr/OrKeiQeYXGy10HxmPdsQBv9N+DU7hJIOOmBHhOGAAsoGDjyiQ2YCaA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -1412,17 +1460,17 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260601.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260601.1",
-        "@cloudflare/workerd-linux-64": "1.20260601.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260601.1",
-        "@cloudflare/workerd-windows-64": "1.20260601.1"
+        "@cloudflare/workerd-darwin-64": "1.20260603.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260603.1",
+        "@cloudflare/workerd-linux-64": "1.20260603.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260603.1",
+        "@cloudflare/workerd-windows-64": "1.20260603.1"
       }
     },
     "node_modules/wrangler": {
-      "version": "4.97.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.97.0.tgz",
-      "integrity": "sha512-jzW/aNvjerV+4TmwbvwGY6lpcuBk7EFUTonMDNfci45wSmMTj2/OJN+83cc/CeepKdb+6ZjGJw9NRjmcQoxqRg==",
+      "version": "4.98.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.98.0.tgz",
+      "integrity": "sha512-cXfFUuF4rMIvE0hiMnXjEAB27ERryaCgquBJdUoPIjFzYYE1rbRdMUkEdQ18qDPUtsPvhJdqxLntixT9OfSzQw==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
@@ -1430,10 +1478,10 @@
         "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.27.3",
-        "miniflare": "4.20260601.0",
+        "miniflare": "4.20260603.0",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260601.1"
+        "workerd": "1.20260603.1"
       },
       "bin": {
         "wrangler": "bin/wrangler.js",
@@ -1446,7 +1494,7 @@
         "fsevents": "2.3.3"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20260601.1"
+        "@cloudflare/workers-types": "^4.20260603.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
   },
   "packageManager": "npm@11.12.1",
   "devDependencies": {
-    "wrangler": "4.97.0"
+    "wrangler": "4.98.0"
   }
 }

--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -103,7 +103,7 @@ httpcore==1.0.9
     # via httpx
 httpx==0.28.1
     # via -r dev.in
-hypothesis==6.152.1
+hypothesis==6.155.2
     # via -r dev.in
 id==1.6.1
     # via twine

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -107,7 +107,7 @@ httpx==0.28.1
     # via
     #   -c all.txt
     #   -r dev.in
-hypothesis==6.152.1
+hypothesis==6.155.2
     # via
     #   -c all.txt
     #   -r dev.in

--- a/web/secure-landing/package-lock.json
+++ b/web/secure-landing/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "argon2": "^0.44.0",
         "better-sqlite3": "^12.10.0",
-        "ioredis": "^5.11.0",
+        "ioredis": "^5.11.1",
         "next": "16.2.7",
         "react": "^19.2.7",
         "react-dom": "^19.2.7"
@@ -20,7 +20,7 @@
         "@playwright/test": "1.60.0",
         "esbuild": "^0.28.0",
         "postcss": "8.5.15",
-        "stylelint": "^17.12.0"
+        "stylelint": "^17.13.0"
       },
       "engines": {
         "node": ">=22 <23"
@@ -76,9 +76,9 @@
       }
     },
     "node_modules/@csstools/css-calc": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
-      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
       "dev": true,
       "funding": [
         {
@@ -123,9 +123,9 @@
       }
     },
     "node_modules/@csstools/css-syntax-patches-for-csstree": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
-      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.5.tgz",
+      "integrity": "sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==",
       "dev": true,
       "funding": [
         {
@@ -2272,9 +2272,9 @@
       "license": "ISC"
     },
     "node_modules/ioredis": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.11.0.tgz",
-      "integrity": "sha512-EZBErytyVovD8f6pDfG3Kb37N6Y3lmDA9NNj+4+IP13CzzHGeX+OyeRM2Um13khRzoBSzzL+5lVnCX8V2RLeMg==",
+      "version": "5.11.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.11.1.tgz",
+      "integrity": "sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==",
       "license": "MIT",
       "dependencies": {
         "@ioredis/commands": "1.10.0",
@@ -3301,9 +3301,9 @@
       }
     },
     "node_modules/stylelint": {
-      "version": "17.12.0",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-17.12.0.tgz",
-      "integrity": "sha512-KIlzWXMHUvgfPUR0R7TK3H80yCIi0uoivUwf+6Az4yrHJD1Q3c1qIkh/H5Z0i/K3QXgtq/UMEkWyBUSUwnpnOg==",
+      "version": "17.13.0",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-17.13.0.tgz",
+      "integrity": "sha512-G1WYzMerp7ihOaIe9VJCHLt12MoAD2QLf1AFerYP37+BCRBUK5UCpq8e/mN+zCIaJPKQcaxhE4WlPmqdiOx/gw==",
       "dev": true,
       "funding": [
         {
@@ -3317,9 +3317,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-calc": "^3.2.1",
         "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.4",
         "@csstools/css-tokenizer": "^4.0.0",
         "@csstools/media-query-list-parser": "^5.0.0",
         "@csstools/selector-resolve-nested": "^4.0.0",
@@ -3343,7 +3343,7 @@
         "micromatch": "^4.0.8",
         "normalize-path": "^3.0.0",
         "picocolors": "^1.1.1",
-        "postcss": "^8.5.14",
+        "postcss": "^8.5.15",
         "postcss-safe-parser": "^7.0.1",
         "postcss-selector-parser": "^7.1.1",
         "postcss-value-parser": "^4.2.0",

--- a/web/secure-landing/package.json
+++ b/web/secure-landing/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "argon2": "^0.44.0",
     "better-sqlite3": "^12.10.0",
-    "ioredis": "^5.11.0",
+    "ioredis": "^5.11.1",
     "next": "16.2.7",
     "react": "^19.2.7",
     "react-dom": "^19.2.7"
@@ -39,6 +39,6 @@
     "@playwright/test": "1.60.0",
     "esbuild": "^0.28.0",
     "postcss": "8.5.15",
-    "stylelint": "^17.12.0"
+    "stylelint": "^17.13.0"
   }
 }


### PR DESCRIPTION
## Summary
- Recreates the remaining safe open dependency PRs as one current-base batch to avoid strict required-check churn after each single merge.
- Keeps the already-reviewed dependency-only changes while preserving lock and Worker shim contracts.

## Changes
- Bumps frontdoor ioredis to 5.11.1 and stylelint to 17.13.0.
- Bumps FastVLM runtime pins: pip 26.1.2, protobuf 7.35.0, pydantic_core 2.47.0, safetensors 0.8.0.
- Bumps root and governed Worker Wrangler to 4.98.0 and governed Worker @cloudflare/workers-types to 4.20260609.1.
- Bumps generic lock Hypothesis pin to 6.155.2 without dropping the non-Linux opencv-python marker pin.
- Updates corresponding npm lockfiles.

## Validation
- Proven green: ./.venv/bin/pytest tests/validation/test_cloudflare_worker_root_shim_contract.py -v
- Proven green: bash scripts/validate_dependency_constraints.sh --verbose
- Proven green: ./.venv/bin/python scripts/validation/check_requirements_lock_contract.py
- Proven green: ./.venv/bin/pytest tests/validation/test_validate_dependency_constraints_script.py tests/test_check_requirements_lock_contract.py tests/vlm_captioning/test_fastvlm_runtime.py tests/vlm_captioning/test_fastvlm_runtime_manifest.py -v
- Proven green: PATH=/Users/richardcheetham/.nvm/versions/node/v22.22.2/bin:$PATH npm --prefix web/secure-landing run check:utility-ownership
- Proven green: PATH=/Users/richardcheetham/.nvm/versions/node/v22.22.2/bin:$PATH npm --prefix web/secure-landing run build:portal
- Proven green: git diff --cached --check
- Proven green: commit hooks run by git commit

## Risk
- Bounded to dependency manifests, lockfiles, and runtime requirement pins.
- Revert-safe as one dependency-only commit.
- Does not include the broad automated dependency sweep from #1896, which needs separate regeneration because it lacks repo CI and alters lock provenance.

Supersedes #1908, #1907, #1906, #1905, #1904, #1901, #1900, #1899, #1898, and #1897.