### PR TITLE
fix(comfyui): stabilize declarative workflow contracts

### DIFF
--- a/docs/ci/COMFYUI_WORKFLOW_INTEGRATION.md
+++ b/docs/ci/COMFYUI_WORKFLOW_INTEGRATION.md
@@ -1,67 +1,66 @@
-
-
 # ComfyUI Workflow Integration
 
-**Node-based visual pipeline orchestration for luxury real estate enhancement**
+The ComfyUI integration currently provides a declarative workflow construction
+layer for Transformation Portal enhancement graphs. `WorkflowBuilder` and
+`WorkflowTemplates` are safe to import in the core environment and can serialize
+workflow JSON without optional ML dependencies.
 
-## Overview
+Full programmatic execution is intentionally limited. `WorkflowExecutor` fails
+fast for unsupported node types instead of silently passing inputs through an
+unimplemented runtime path.
 
-The ComfyUI integration provides a powerful, visual workflow system for orchestrating complex enhancement pipelines. It combines all Transformation Portal components (FLUX, SkyGAN, VLM, segmentation, neuroaesthetics) into reusable, shareable workflows.
+## Current Contract
 
-### Key Benefits
+- Package-level `transformation_portal.comfyui` imports expose pure workflow
+  builder and template primitives eagerly.
+- Runtime custom nodes and `WorkflowExecutor` are lazy imports because they may
+  require optional ML or image-processing dependencies.
+- `WorkflowTemplates` are build and serialization contracts, not proof that
+  every emitted node has an executable runtime implementation.
+- Unsupported executor nodes raise a clear `NotImplementedError`.
 
-- **Visual Pipeline Design**: Drag-and-drop workflow composition
-- **Modular Architecture**: Mix and match enhancement components
-- **Reproducible Results**: Version-controlled workflow definitions
-- **Batch Processing**: Execute workflows programmatically
-- **Rapid Iteration**: Quick parameter experimentation
-- **Client Collaboration**: Share workflows for consistent results
+## Components
 
----
-
-## Architecture
-
-### Components
-
-```
+```text
 comfyui/
-├── __init__.py                    # Module exports
-├── workflow_builder.py            # Programmatic workflow construction
-├── workflow_templates.py          # Pre-built workflows
-├── custom_nodes.py                # Node implementations
-└── executor.py                    # Programmatic execution engine
+├── __init__.py                    # Pure exports plus lazy runtime access
+├── workflow_builder.py            # Declarative workflow construction
+├── workflow_templates.py          # Pre-built declarative workflows
+├── custom_nodes.py                # Implemented runtime custom nodes
+└── executor.py                    # Programmatic execution dispatcher
 ```
 
-### Available Nodes
+## Implemented Runtime Nodes
 
-#### Analysis Nodes
-- **SceneAnalysisNode**: VLM-powered scene understanding
-- **MaterialSegmentationNode**: SAM+CLIP material segmentation
+These custom nodes are registered in `custom_nodes.py`:
 
-#### Enhancement Nodes
-- **FluxEnhancementNode**: FLUX diffusion enhancement
-- **NeuroaestheticsNode**: Computational neuroaesthetics optimization
+- `FluxEnhancementNode`
+- `SkyGANNode`
+- `SceneAnalysisNode`
 
-#### Atmospheric Nodes
-- **SkyGANNode**: Location-specific sky generation
-- **AtmosphericModelNode**: Aerial perspective and marine layer
+They are runtime-oriented and may require optional dependencies when imported
+or executed. Keep imports lazy from package entry points.
 
-#### Validation Nodes
-- **QualityValidationNode**: AI-powered quality assessment
+## Declarative Workflow Node Types
 
----
+The builder can emit JSON for the following planned node types, but runtime
+implementations are not complete yet:
 
-## Quick Start
+- `MaterialSegmentationNode`
+- `NeuroaestheticsNode`
+- `AtmosphericModelNode`
+- `QualityValidationNode`
 
-### 1. Build a Workflow Programmatically
+These nodes are safe for workflow serialization tests but must not be treated
+as executable until their custom node and executor implementations are added.
+
+## Building Workflows
 
 ```python
 from transformation_portal.comfyui import WorkflowBuilder
 
-# Create workflow
-builder = WorkflowBuilder(name="Luxury Estate Enhancement")
-
-workflow = (builder
+workflow = (
+    WorkflowBuilder(name="Luxury Estate Enhancement")
     .add_input("estate.jpg")
     .add_scene_analysis(detailed=True)
     .add_flux_enhancement(strength=0.45, num_steps=4)
@@ -71,935 +70,66 @@ workflow = (builder
     .build()
 )
 
-# Save for use in ComfyUI
-workflow.save("my_workflow.json")
+workflow.save("luxury_estate_enhancement.json")
 ```
 
-### 2. Use Pre-Built Templates
+`add_scene_analysis()` is a sidecar builder operation: it reads the current
+image, but the image chain remains attached to the previous image-producing
+node so downstream image operations do not consume the analysis report.
+`add_quality_validation()` follows the same sidecar rule so `SaveImage` nodes
+continue to receive images rather than validation reports.
+
+## Template Coverage
+
+The current template factories are expected to build and serialize:
+
+- `full_luxury_estate_pipeline`
+- `quick_iterative_enhancement`
+- `material_specific_enhancement`
+- `location_specific_atmospheric`
+- `coastal_property_golden_hour`
+- `multi_variant_generation`
+
+`multi_variant_generation()` rejects `num_variants < 1` and rejects empty
+`emotional_targets` or `flux_strengths` lists when those lists are provided.
+
+## Execution Posture
+
+Use `WorkflowExecutor` only for node types with explicit executor support. It
+does not provide a pass-through fallback for unknown or planned node types:
 
 ```python
-from transformation_portal.comfyui import WorkflowTemplates
+from transformation_portal.comfyui import WorkflowExecutor, WorkflowTemplates
 
-# Full enhancement pipeline
-workflow = WorkflowTemplates.full_luxury_estate_pipeline(
-    input_path="estate.jpg",
-    output_path="enhanced.jpg",
-    location="montecito",
-    time_of_day="golden_hour",
-    emotional_target="luxury"
-)
+workflow = WorkflowTemplates.quick_iterative_enhancement("input.jpg", "output.jpg")
+result = WorkflowExecutor(cache_models=False).execute(workflow)
 
-# Quick iterative enhancement
-quick_workflow = WorkflowTemplates.quick_iterative_enhancement(
-    input_path="estate.jpg",
-    output_path="quick_test.jpg",
-    flux_strength=0.35
-)
-
-# Material-specific enhancement
-material_workflow = WorkflowTemplates.material_specific_enhancement(
-    input_path="kitchen.jpg",
-    output_path="enhanced_kitchen.jpg",
-    target_materials=["marble", "wood", "metal"]
-)
+assert result["success"] is False
+assert "No executor implementation" in result["errors"][0]
 ```
 
-### 3. Execute Workflows Programmatically
+This fail-fast behavior is intentional. It prevents declarative workflow JSON
+from being mistaken for completed FLUX, SkyGAN, segmentation,
+neuroaesthetics, or quality-validation execution.
 
-```python
-from transformation_portal.comfyui import WorkflowExecutor
+## Validation
 
-# Initialize executor
-executor = WorkflowExecutor(verbose=True)
+Core declarative checks:
 
-# Execute workflow
-results = executor.execute(workflow)
-
-if results["success"]:
-    print(f"Enhancement completed in {results['execution_time']:.2f}s")
-    print(f"Output saved to: {results['node_outputs']['output_path']}")
-else:
-    print(f"Errors: {results['errors']}")
+```bash
+python -S -c 'import sys; sys.path.insert(0, "src"); import transformation_portal.comfyui as c; print(c.WorkflowBuilder)'
+python -m pytest -q tests/comfyui/test_workflow_templates_contract.py
 ```
 
----
+Runtime custom-node checks remain ML/runtime scoped:
 
-## Workflow Templates
-
-### Full Luxury Estate Pipeline
-
-Complete enhancement with all components:
-
-```python
-workflow = WorkflowTemplates.full_luxury_estate_pipeline(
-    input_path="montecito_estate.jpg",
-    output_path="enhanced_estate.jpg",
-    location="montecito",
-    season="summer",
-    time_of_day="golden_hour",
-    emotional_target="luxury",
-    flux_variant="dev",
-    flux_strength=0.45,
-    quality_threshold=7.0
-)
+```bash
+python -m pytest -q tests/test_comfyui.py
 ```
 
-**Pipeline Steps:**
-1. Scene analysis (VLM)
-2. Material segmentation (SAM+CLIP)
-3. FLUX enhancement with ControlNet
-4. SkyGAN atmospheric rendering
-5. Neuroaesthetics optimization
-6. Quality validation
+Broader closeout for changes in this area:
 
-**Best for:**
-- Final client deliverables
-- High-quality showcase images
-- Portfolio pieces
-
-**Execution time:** ~2-3 minutes (GPU: RTX 4090)
-
----
-
-### Quick Iterative Enhancement
-
-Fast enhancement for client feedback:
-
-```python
-workflow = WorkflowTemplates.quick_iterative_enhancement(
-    input_path="test.jpg",
-    output_path="quick_test.jpg",
-    flux_strength=0.35,
-    quality_threshold=6.0
-)
+```bash
+make test-fast
+make coverage-package
 ```
-
-**Pipeline Steps:**
-1. FLUX schnell enhancement (1-4 steps)
-2. Quick quality validation
-
-**Best for:**
-- Rapid client iterations
-- A/B testing parameters
-- Preview generation
-
-**Execution time:** ~30-45 seconds
-
----
-
-### Material-Specific Enhancement
-
-Material-aware processing:
-
-```python
-workflow = WorkflowTemplates.material_specific_enhancement(
-    input_path="luxury_kitchen.jpg",
-    output_path="enhanced_kitchen.jpg",
-    target_materials=["marble", "wood", "stainless_steel"],
-    flux_strength=0.40
-)
-```
-
-**Pipeline Steps:**
-1. Material segmentation
-2. Material-aware FLUX enhancement with ControlNet
-3. Material consistency validation
-
-**Best for:**
-- Kitchens with mixed materials
-- Bathrooms (marble, tile, glass)
-- Architectural details
-
-**Execution time:** ~1.5-2 minutes
-
----
-
-### Location-Specific Atmospheric
-
-Authentic atmospheric rendering:
-
-```python
-workflow = WorkflowTemplates.location_specific_atmospheric(
-    input_path="coastal_view.jpg",
-    output_path="atmospheric_view.jpg",
-    location="montecito",
-    season="summer",
-    time_of_day="golden_hour",
-    marine_layer=True,
-    cloud_coverage=0.3
-)
-```
-
-**Pipeline Steps:**
-1. Scene analysis
-2. SkyGAN sky replacement
-3. Atmospheric modeling (aerial perspective, marine layer)
-4. Color harmony optimization
-
-**Best for:**
-- Properties with prominent sky views
-- Coastal estates
-- Ocean-view properties
-
-**Execution time:** ~1-1.5 minutes
-
----
-
-### Coastal Property Golden Hour
-
-Specialized coastal enhancement:
-
-```python
-workflow = WorkflowTemplates.coastal_property_golden_hour(
-    input_path="ocean_view_estate.jpg",
-    output_path="golden_hour_estate.jpg",
-    location="montecito",
-    season="summer",
-    include_marine_layer=False
-)
-```
-
-**Pipeline Steps:**
-1. Scene analysis and material segmentation
-2. FLUX enhancement with depth+canny ControlNet
-3. Golden hour sky (sun at 10-15° elevation)
-4. Atmospheric modeling with extended distance
-5. Aspiration-targeted neuroaesthetics
-6. High-quality validation (7.5+ threshold)
-
-**Best for:**
-- Montecito/Santa Barbara coastal estates
-- Properties with ocean views
-- Sunset-facing properties
-
-**Execution time:** ~2.5-3 minutes
-**Output quality:** 98 (maximum)
-
----
-
-### Multi-Variant Generation
-
-A/B testing with multiple emotional targets:
-
-```python
-workflows = WorkflowTemplates.multi_variant_generation(
-    input_path="estate.jpg",
-    output_dir="variants",
-    num_variants=3,
-    emotional_targets=["luxury", "aspiration", "comfort"],
-    flux_strengths=[0.35, 0.45, 0.55]
-)
-
-# Execute all variants
-executor = WorkflowExecutor()
-for i, workflow in enumerate(workflows):
-    print(f"Generating variant {i+1}...")
-    executor.execute(workflow)
-```
-
-**Generates:**
-- variant_1_luxury.jpg (strength 0.35)
-- variant_2_aspiration.jpg (strength 0.45)
-- variant_3_comfort.jpg (strength 0.55)
-
-**Best for:**
-- Client A/B testing
-- Finding optimal enhancement strength
-- Exploring emotional directions
-
-**Execution time:** ~2-3 minutes per variant
-
----
-
-## Custom Workflow Building
-
-### Basic Workflow
-
-```python
-from transformation_portal.comfyui import WorkflowBuilder
-
-builder = WorkflowBuilder(name="My Custom Workflow")
-
-workflow = (builder
-    .add_input("input.jpg")
-    .add_flux_enhancement(strength=0.45)
-    .add_output("output.jpg")
-    .build()
-)
-```
-
-### Advanced Workflow with Multiple Enhancements
-
-```python
-workflow = (builder
-    .add_input("estate.jpg")
-
-    # Analysis phase
-    .add_scene_analysis(detailed=True)
-    .add_material_segmentation(materials=["marble", "wood", "glass"])
-
-    # Enhancement phase
-    .add_flux_enhancement(
-        strength=0.45,
-        num_steps=4,
-        variant="dev",
-        use_controlnet=True,
-        controlnet_types=["depth", "canny"]
-    )
-
-    # Atmospheric rendering
-    .add_skygan_sky(
-        location="montecito",
-        season="fall",
-        time_of_day="golden_hour",
-        cloud_coverage=0.2,
-        update_reflections=True
-    )
-
-    # Depth-based atmospheric effects
-    .add_atmospheric_model(
-        apply_aerial_perspective=True,
-        marine_layer=True,
-        max_distance=1500.0
-    )
-
-    # Aesthetic optimization
-    .add_neuroaesthetics_optimization(
-        emotional_target="aspiration",
-        optimize_composition=True,
-        optimize_color_harmony=True,
-        optimize_spatial_frequency=True
-    )
-
-    # Quality validation
-    .add_quality_validation(
-        pass_threshold=7.5,
-        warning_threshold=6.0,
-        check_realism=True,
-        check_structural_accuracy=True,
-        check_material_consistency=True
-    )
-
-    .add_output("enhanced_estate.jpg", quality=98)
-
-    .build()
-)
-```
-
----
-
-## Node Reference
-
-### FluxEnhancementNode
-
-FLUX diffusion enhancement with optional ControlNet.
-
-**Inputs:**
-- `image` (IMAGE): Input image
-- `strength` (FLOAT): Enhancement strength (0.0-1.0, default: 0.45)
-- `num_steps` (INT): Diffusion steps (1-50, default: 4)
-- `guidance_scale` (FLOAT): CFG scale (1.0-20.0, default: 3.5)
-- `variant` (CHOICE): FLUX variant ["dev", "schnell"]
-- `prompt` (STRING, optional): Enhancement prompt
-- `negative_prompt` (STRING, optional): Negative prompt
-- `seed` (INT, optional): Random seed (-1 for random)
-- `use_controlnet` (BOOLEAN): Enable ControlNet
-
-**Outputs:**
-- `IMAGE`: Enhanced image
-
-**Example:**
-```python
-.add_flux_enhancement(
-    strength=0.45,
-    num_steps=4,
-    variant="dev",
-    use_controlnet=True,
-    controlnet_types=["depth", "canny"]
-)
-```
-
----
-
-### SkyGANNode
-
-Location-specific atmospheric sky generation.
-
-**Inputs:**
-- `image` (IMAGE): Input image
-- `location` (CHOICE): ["montecito", "santa_barbara", "hope_ranch", "riviera"]
-- `season` (CHOICE): ["spring", "summer", "fall", "winter"]
-- `time_of_day` (CHOICE): ["sunrise", "morning", "midday", "golden_hour", "sunset", "twilight"]
-- `cloud_coverage` (FLOAT): Cloud amount (0.0-1.0, default: 0.3)
-- `sun_azimuth` (FLOAT, optional): Sun azimuth override
-- `sun_elevation` (FLOAT, optional): Sun elevation override
-- `turbidity` (FLOAT, optional): Atmospheric turbidity override
-- `update_reflections` (BOOLEAN): Update water/glass reflections
-
-**Outputs:**
-- `IMAGE`: Enhanced image with new sky
-- `IMAGE`: Sky mask
-
-**Example:**
-```python
-.add_skygan_sky(
-    location="montecito",
-    season="summer",
-    time_of_day="golden_hour",
-    cloud_coverage=0.2,
-    update_reflections=True
-)
-```
-
----
-
-### SceneAnalysisNode
-
-VLM-powered scene understanding.
-
-**Inputs:**
-- `image` (IMAGE): Input image
-- `detailed` (BOOLEAN): Perform detailed analysis
-
-**Outputs:**
-- `SCENE_ANALYSIS`: Analysis object (dict)
-- `STRING`: JSON representation
-
-**Example:**
-```python
-.add_scene_analysis(detailed=True)
-```
-
----
-
-### MaterialSegmentationNode
-
-SAM+CLIP material-aware segmentation.
-
-**Inputs:**
-- `image` (IMAGE): Input image
-- `filter_by_area` (BOOLEAN): Filter small segments
-- `min_area` (INT): Minimum segment area (100-10000, default: 500)
-
-**Outputs:**
-- `SEGMENTATION`: Segmentation data (list of dicts)
-- `IMAGE`: Visualization
-
-**Example:**
-```python
-.add_material_segmentation(
-    filter_by_area=True,
-    min_area=500
-)
-```
-
----
-
-### NeuroaestheticsNode
-
-Computational neuroaesthetics optimization.
-
-**Inputs:**
-- `image` (IMAGE): Input image
-- `emotional_target` (CHOICE): ["luxury", "aspiration", "desire", "nostalgia", "comfort", "serenity", "energy"]
-- `optimize_composition` (BOOLEAN): Golden ratio optimization
-- `optimize_color_harmony` (BOOLEAN): Color harmony optimization
-- `optimize_spatial_frequency` (BOOLEAN): Spatial frequency optimization
-
-**Outputs:**
-- `IMAGE`: Optimized image
-- `STRING`: Analysis report (JSON)
-
-**Example:**
-```python
-.add_neuroaesthetics_optimization(
-    emotional_target="luxury",
-    optimize_composition=True,
-    optimize_color_harmony=True,
-    optimize_spatial_frequency=True
-)
-```
-
----
-
-### QualityValidationNode
-
-AI-powered quality assessment.
-
-**Inputs:**
-- `image` (IMAGE): Input image
-- `pass_threshold` (FLOAT): Minimum pass score (0.0-10.0, default: 7.0)
-- `warning_threshold` (FLOAT): Warning threshold (0.0-10.0, default: 5.0)
-- `reference_image` (IMAGE, optional): Reference for comparison
-
-**Outputs:**
-- `BOOLEAN`: Validation passed
-- `STRING`: Validation report (JSON)
-- `FLOAT`: Overall quality score
-
-**Example:**
-```python
-.add_quality_validation(
-    pass_threshold=7.5,
-    warning_threshold=6.0
-)
-```
-
----
-
-## Batch Processing
-
-### Process Multiple Images
-
-```python
-from transformation_portal.comfyui import WorkflowTemplates, WorkflowExecutor
-from pathlib import Path
-
-# Get all images
-input_dir = Path("raw_images")
-output_dir = Path("enhanced_images")
-output_dir.mkdir(exist_ok=True)
-
-# Create executor
-executor = WorkflowExecutor(cache_models=True, verbose=True)
-
-# Process each image
-for image_path in input_dir.glob("*.jpg"):
-    print(f"Processing: {image_path.name}")
-
-    # Create workflow for this image
-    workflow = WorkflowTemplates.full_luxury_estate_pipeline(
-        input_path=str(image_path),
-        output_path=str(output_dir / f"enhanced_{image_path.name}"),
-        location="montecito",
-        time_of_day="golden_hour"
-    )
-
-    # Execute
-    results = executor.execute(workflow)
-
-    if results["success"]:
-        print(f"  ✓ Completed in {results['execution_time']:.1f}s")
-    else:
-        print(f"  ✗ Failed: {results['errors']}")
-
-# Print stats
-stats = executor.get_stats()
-print(f"\nProcessed {stats['total_executions']} images")
-print(f"Total time: {stats['total_time']:.1f}s")
-print(f"Average time: {stats['average_time']:.1f}s per image")
-```
-
----
-
-## Performance Optimization
-
-### Model Caching
-
-Cache models between executions to avoid reloading:
-
-```python
-executor = WorkflowExecutor(cache_models=True)
-
-# First execution loads models
-results1 = executor.execute(workflow1)  # ~10s loading + 2min processing
-
-# Subsequent executions reuse cached models
-results2 = executor.execute(workflow2)  # ~2min processing (no loading)
-results3 = executor.execute(workflow3)  # ~2min processing (no loading)
-
-# Clear cache when done
-executor.clear_cache()
-```
-
-**Memory savings:** ~15-20GB VRAM kept between executions
-
----
-
-### GPU Memory Management
-
-For limited VRAM, use CPU offload:
-
-```python
-# In custom_nodes.py node implementations
-from transformation_portal.diffusion import FLUXPipeline
-
-pipeline = FLUXPipeline(
-    variant="dev",
-    enable_cpu_offload=True,  # Offload to CPU when not in use
-    enable_attention_slicing=True  # Reduce VRAM usage
-)
-```
-
-**VRAM requirements:**
-- Without optimization: ~24GB
-- With CPU offload: ~16GB
-- With attention slicing: ~12GB
-
----
-
-## Workflow Export/Import
-
-### Save Workflows
-
-```python
-# Save individual workflow
-workflow.save("workflows/luxury_estate.json")
-
-# Save all templates
-WorkflowTemplates.save_all_templates("workflows/templates")
-```
-
-### Load Workflows
-
-```python
-from transformation_portal.comfyui import Workflow
-
-# Load from file
-workflow = Workflow.load("workflows/luxury_estate.json")
-
-# Execute
-executor = WorkflowExecutor()
-results = executor.execute(workflow)
-```
-
-### Share Workflows
-
-Workflow JSON files are portable and can be:
-- Version controlled in git
-- Shared with team members
-- Loaded in ComfyUI interface (when custom nodes installed)
-- Modified manually for fine-tuning
-
----
-
-## Integration with Existing Tools
-
-### Use with FLUX Pipeline
-
-```python
-from transformation_portal.diffusion import FLUXPipeline
-from transformation_portal.comfyui import WorkflowBuilder
-
-# Standalone FLUX
-pipeline = FLUXPipeline(variant="dev")
-enhanced = pipeline.enhance("image.jpg", strength=0.45)
-
-# FLUX in workflow
-workflow = (WorkflowBuilder()
-    .add_input("image.jpg")
-    .add_flux_enhancement(strength=0.45, variant="dev")
-    .add_output("enhanced.jpg")
-    .build()
-)
-```
-
-### Use with SkyGAN
-
-```python
-from transformation_portal.atmosphere import SkyGANGenerator
-from transformation_portal.comfyui import WorkflowBuilder
-
-# Standalone SkyGAN
-generator = SkyGANGenerator()
-sky = generator.generate_sky(sun_azimuth=270, sun_elevation=15)
-
-# SkyGAN in workflow
-workflow = (WorkflowBuilder()
-    .add_input("image.jpg")
-    .add_skygan_sky(location="montecito", time_of_day="golden_hour")
-    .add_output("enhanced.jpg")
-    .build()
-)
-```
-
----
-
-## Troubleshooting
-
-### Workflow Execution Fails
-
-```python
-results = executor.execute(workflow)
-
-if not results["success"]:
-    print("Errors occurred:")
-    for error in results["errors"]:
-        print(f"  - {error}")
-
-    print("\nNode execution times:")
-    for node_id, exec_time in results["execution_times"].items():
-        print(f"  {node_id}: {exec_time:.2f}s")
-```
-
-### Memory Issues
-
-```
-RuntimeError: CUDA out of memory
-```
-
-**Solutions:**
-1. Enable CPU offload in FLUX nodes
-2. Clear model cache between executions
-3. Reduce batch size
-4. Use "schnell" variant instead of "dev"
-
-```python
-# Clear cache manually
-executor.clear_cache()
-
-# Use schnell for lower VRAM
-.add_flux_enhancement(variant="schnell")
-```
-
-### Quality Validation Fails
-
-```
-Quality validation failed: Overall score 6.2 < threshold 7.0
-```
-
-**Solutions:**
-1. Increase enhancement strength
-2. Enable ControlNet for structural preservation
-3. Review validation report for specific issues
-4. Lower threshold for iterative work
-
-```python
-# Check validation details
-if not results["node_outputs"]["quality_validation"]["passed"]:
-    report = results["node_outputs"]["quality_validation"]["report"]
-    print(report)  # See specific aspect scores
-```
-
----
-
-## Best Practices
-
-### 1. Template Selection
-
-- **Client deliverables**: Use `full_luxury_estate_pipeline`
-- **Quick previews**: Use `quick_iterative_enhancement`
-- **Material focus**: Use `material_specific_enhancement`
-- **Sky replacement**: Use `location_specific_atmospheric`
-- **A/B testing**: Use `multi_variant_generation`
-
-### 2. Parameter Tuning
-
-Start conservative and iterate:
-
-```python
-# Conservative (subtle enhancement)
-strength=0.35, quality_threshold=6.5
-
-# Balanced (recommended)
-strength=0.45, quality_threshold=7.0
-
-# Aggressive (maximum enhancement)
-strength=0.55, quality_threshold=7.5
-```
-
-### 3. Quality Gates
-
-Always validate important deliverables:
-
-```python
-.add_quality_validation(
-    pass_threshold=7.5,  # High bar for final work
-    warning_threshold=6.0,
-    check_realism=True,
-    check_structural_accuracy=True,
-    check_material_consistency=True
-)
-```
-
-### 4. Workflow Organization
-
-```
-workflows/
-├── templates/              # Pre-built templates
-│   ├── full_pipeline.json
-│   ├── quick_enhancement.json
-│   └── coastal_golden_hour.json
-├── custom/                 # Project-specific workflows
-│   ├── montecito_estates.json
-│   └── hope_ranch_villas.json
-└── experiments/            # Testing workflows
-    ├── strength_test.json
-    └── emotional_variants.json
-```
-
----
-
-## API Reference
-
-### WorkflowBuilder
-
-```python
-class WorkflowBuilder:
-    def __init__(name: str = "Transformation Portal Workflow")
-    def add_input(image_path: str, node_id: Optional[str] = None) -> WorkflowBuilder
-    def add_scene_analysis(detailed: bool = True) -> WorkflowBuilder
-    def add_material_segmentation(materials: Optional[List[str]] = None) -> WorkflowBuilder
-    def add_flux_enhancement(...) -> WorkflowBuilder
-    def add_skygan_sky(...) -> WorkflowBuilder
-    def add_neuroaesthetics_optimization(...) -> WorkflowBuilder
-    def add_quality_validation(...) -> WorkflowBuilder
-    def add_atmospheric_model(...) -> WorkflowBuilder
-    def add_output(output_path: str, format: str = "jpg", quality: int = 95) -> WorkflowBuilder
-    def build() -> Workflow
-```
-
-### WorkflowTemplates
-
-```python
-class WorkflowTemplates:
-    @staticmethod
-    def full_luxury_estate_pipeline(...) -> Workflow
-
-    @staticmethod
-    def quick_iterative_enhancement(...) -> Workflow
-
-    @staticmethod
-    def material_specific_enhancement(...) -> Workflow
-
-    @staticmethod
-    def location_specific_atmospheric(...) -> Workflow
-
-    @staticmethod
-    def multi_variant_generation(...) -> List[Workflow]
-
-    @staticmethod
-    def coastal_property_golden_hour(...) -> Workflow
-
-    @staticmethod
-    def save_all_templates(output_dir: str) -> None
-```
-
-### WorkflowExecutor
-
-```python
-class WorkflowExecutor:
-    def __init__(cache_models: bool = True, verbose: bool = False)
-    def execute(workflow: Workflow, output_dir: Optional[Path] = None) -> Dict[str, Any]
-    def get_stats() -> Dict[str, Any]
-    def clear_cache() -> None
-```
-
-### Workflow
-
-```python
-class Workflow:
-    def to_comfyui_format() -> Dict[str, Any]
-    def save(path: Union[str, Path]) -> None
-
-    @classmethod
-    def load(path: Union[str, Path]) -> Workflow
-```
-
----
-
-## Examples
-
-### Example 1: Simple Enhancement
-
-```python
-from transformation_portal.comfyui import WorkflowBuilder, WorkflowExecutor
-
-# Build
-builder = WorkflowBuilder("Simple Enhancement")
-workflow = (builder
-    .add_input("estate.jpg")
-    .add_flux_enhancement(strength=0.45, num_steps=4)
-    .add_output("enhanced.jpg")
-    .build()
-)
-
-# Execute
-executor = WorkflowExecutor()
-results = executor.execute(workflow)
-print(f"Done in {results['execution_time']:.1f}s")
-```
-
-### Example 2: Full Pipeline with Validation
-
-```python
-from transformation_portal.comfyui import WorkflowTemplates, WorkflowExecutor
-
-# Use template
-workflow = WorkflowTemplates.full_luxury_estate_pipeline(
-    input_path="montecito_estate.jpg",
-    output_path="enhanced_estate.jpg",
-    location="montecito",
-    time_of_day="golden_hour",
-    quality_threshold=7.5
-)
-
-# Execute
-executor = WorkflowExecutor(verbose=True)
-results = executor.execute(workflow)
-
-# Check results
-if results["success"]:
-    validation = results["node_outputs"]["quality_validation"]
-    print(f"Quality score: {validation['overall_score']:.1f}/10")
-    print(f"Validation: {'PASSED' if validation['passed'] else 'FAILED'}")
-else:
-    print(f"Errors: {results['errors']}")
-```
-
-### Example 3: Batch Processing with Progress
-
-```python
-from transformation_portal.comfyui import WorkflowTemplates, WorkflowExecutor
-from pathlib import Path
-
-input_dir = Path("raw_images")
-output_dir = Path("enhanced")
-output_dir.mkdir(exist_ok=True)
-
-images = list(input_dir.glob("*.jpg"))
-executor = WorkflowExecutor(cache_models=True)
-
-for i, image_path in enumerate(images, 1):
-    print(f"[{i}/{len(images)}] Processing {image_path.name}...")
-
-    workflow = WorkflowTemplates.quick_iterative_enhancement(
-        input_path=str(image_path),
-        output_path=str(output_dir / f"enhanced_{image_path.name}")
-    )
-
-    results = executor.execute(workflow)
-    status = "✓" if results["success"] else "✗"
-    print(f"  {status} {results['execution_time']:.1f}s")
-
-print(f"\nCompleted {len(images)} images")
-```
-
----
-
-## Performance Benchmarks
-
-Hardware: NVIDIA RTX 4090 (24GB), AMD Ryzen 9 7950X
-
-| Workflow | Execution Time | VRAM Usage | Output Quality |
-|----------|---------------|------------|----------------|
-| Full Luxury Estate Pipeline | 2m 15s | 22GB | 9.2/10 |
-| Quick Iterative Enhancement | 38s | 18GB | 7.8/10 |
-| Material-Specific Enhancement | 1m 52s | 20GB | 8.9/10 |
-| Location Atmospheric | 1m 18s | 16GB | 8.5/10 |
-| Coastal Golden Hour | 2m 42s | 23GB | 9.4/10 |
-| Multi-Variant (3x) | 6m 10s | 22GB | 8.7/10 avg |
-
----
-
-## Conclusion
-
-ComfyUI workflow integration provides a powerful, flexible system for luxury real estate enhancement. Whether you need quick previews or final deliverables, the combination of visual workflow design and programmatic execution enables efficient, reproducible, high-quality results.
-
-**Next Steps:**
-1. Explore pre-built templates
-2. Create custom workflows for your properties
-3. Set up batch processing pipelines
-4. Integrate with your existing tools
-
-For questions or support, consult the main AI Enhancement Guide or individual component documentation.

--- a/src/transformation_portal/comfyui/__init__.py
+++ b/src/transformation_portal/comfyui/__init__.py
@@ -1,50 +1,46 @@
-"""ComfyUI workflow integration for visual pipeline orchestration.
+"""ComfyUI declarative workflow integration.
 
-ComfyUI provides node-based workflow design for complex enhancement pipelines,
-enabling:
-- Visual pipeline composition
-- Modular component integration
-- Parameter experimentation
-- Reproducible enhancement workflows
-
-Integrates all Transformation Portal components:
-- FLUX diffusion for AI enhancement
-- SkyGAN for atmospheric rendering
-- VLM for scene analysis and quality validation
-- Semantic segmentation for material-aware processing
-- Neuroaesthetics optimization
-- Quality metrics (LPIPS, FID)
-
-Example Workflows:
-- Full luxury estate enhancement pipeline
-- Quick iterative enhancement with quality gates
-- Material-specific processing with segmentation
-- Location-specific atmospheric rendering
-- Multi-variant generation with emotional targeting
+The package-level import intentionally exposes only pure workflow construction
+primitives. Runtime custom nodes and the executor are loaded lazily because they
+depend on optional ML/runtime packages that are not part of the core install.
 """
 
-from transformation_portal.comfyui.custom_nodes import (
-    CustomNodeRegistry,
-    FluxEnhancementNode,
-    MaterialSegmentationNode,
-    NeuroaestheticsNode,
-    QualityValidationNode,
-    SceneAnalysisNode,
-    SkyGANNode,
-)
-from transformation_portal.comfyui.executor import WorkflowExecutor
-from transformation_portal.comfyui.workflow_builder import WorkflowBuilder
+from typing import Any
+
+from transformation_portal.comfyui.workflow_builder import Node, NodeConnection, NodeType, Workflow, WorkflowBuilder
 from transformation_portal.comfyui.workflow_templates import WorkflowTemplates
 
 __all__ = [
+    "Node",
+    "NodeConnection",
+    "NodeType",
+    "Workflow",
     "WorkflowBuilder",
     "WorkflowTemplates",
     "WorkflowExecutor",
     "CustomNodeRegistry",
+    "BaseNode",
     "FluxEnhancementNode",
     "SkyGANNode",
     "SceneAnalysisNode",
-    "MaterialSegmentationNode",
-    "NeuroaestheticsNode",
-    "QualityValidationNode",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    if name == "WorkflowExecutor":
+        from transformation_portal.comfyui.executor import WorkflowExecutor
+
+        return WorkflowExecutor
+
+    if name in {
+        "CustomNodeRegistry",
+        "BaseNode",
+        "FluxEnhancementNode",
+        "SkyGANNode",
+        "SceneAnalysisNode",
+    }:
+        from transformation_portal.comfyui import custom_nodes
+
+        return getattr(custom_nodes, name)
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/transformation_portal/comfyui/executor.py
+++ b/src/transformation_portal/comfyui/executor.py
@@ -127,21 +127,20 @@ class WorkflowExecutor:
 
         inputs = self._get_node_inputs(node, workflow, context)
 
-        # Dispatch table
         method_name = f"_execute_{node.node_type.name.lower()}_node"
-        if hasattr(self, method_name):
-            outputs = getattr(self, method_name)(node, inputs)
-        else:
-            # Fallback mappings for specific types mentioned in your code
-            if node.node_type == NodeType.SKYGAN_SKY:
-                outputs = self._execute_skygan_node(node, inputs)
-            elif node.node_type == NodeType.ATMOSPHERIC_MODEL:
-                outputs = self._execute_atmospheric_model_node(node, inputs)
-            elif node.node_type == NodeType.FLUX_ENHANCEMENT:
-                outputs = self._execute_flux_node(node, inputs)
-            # ... add other mappings ...
-            else:
-                outputs = inputs  # Pass-through fallback
+        handler = getattr(self, method_name, None)
+
+        if handler is None and node.node_type == NodeType.SKYGAN_SKY:
+            handler = self._execute_skygan_node
+        elif handler is None and node.node_type == NodeType.ATMOSPHERIC_MODEL:
+            handler = self._execute_atmospheric_model_node
+
+        if handler is None:
+            raise NotImplementedError(
+                f"No executor implementation for node type {node.node_type.name} " f"({node.node_type.value})"
+            )
+
+        outputs = handler(node, inputs)
 
         context.set_output(node.node_id, outputs)
 

--- a/src/transformation_portal/comfyui/workflow_builder.py
+++ b/src/transformation_portal/comfyui/workflow_builder.py
@@ -241,17 +241,20 @@ class WorkflowBuilder:
         return self
 
     def add_scene_analysis(self, detailed: bool = True) -> "WorkflowBuilder":
+        previous_node_id = self._last_node_id
+        previous_output = self._last_output
+
         self._add_node(
             NodeType.SCENE_ANALYSIS,
             parameters={"detailed": detailed},
         )
-        # Note: Analysis node outputs STRING (json), not IMAGE.
-        # This breaks the chain for image processing unless we handle branching.
-        # For simplicity in linear builder, we assume analysis is a sidecar
-        # but the builder continues from the previous image node?
-        # A true builder would need to support branching.
-        # For this salvage, we will assume analysis acts as a pass-through or ends chain.
-        self._last_output = "STRING"
+
+        # Scene analysis reads the current image as a sidecar. Preserve the
+        # image chain so downstream image-processing nodes do not consume the
+        # analysis report as their input image.
+        self._last_node_id = previous_node_id
+        self._last_output = previous_output
+
         logger.info("Added scene analysis node")
         return self
 
@@ -263,6 +266,7 @@ class WorkflowBuilder:
         guidance_scale: float = 3.5,
         variant: str = "dev",
         use_controlnet: bool = False,
+        controlnet_types: Optional[List[str]] = None,
     ) -> "WorkflowBuilder":
         params = {
             "strength": strength,
@@ -273,8 +277,27 @@ class WorkflowBuilder:
         }
         if prompt:
             params["prompt"] = prompt
+        if controlnet_types is not None:
+            params["controlnet_types"] = controlnet_types
 
         self._add_node(NodeType.FLUX_ENHANCEMENT, parameters=params)
+        self._last_output = "IMAGE"
+        return self
+
+    def add_material_segmentation(
+        self,
+        materials: Optional[List[str]] = None,
+        filter_by_area: bool = True,
+        min_area: int = 500,
+    ) -> "WorkflowBuilder":
+        params: Dict[str, Any] = {
+            "filter_by_area": filter_by_area,
+            "min_area": min_area,
+        }
+        if materials is not None:
+            params["materials"] = materials
+
+        self._add_node(NodeType.MATERIAL_SEGMENTATION, parameters=params)
         self._last_output = "IMAGE"
         return self
 
@@ -286,6 +309,7 @@ class WorkflowBuilder:
         cloud_coverage: float = 0.3,
         auto_correct: bool = True,
         strict_physics: bool = False,
+        update_reflections: bool = True,
         sun_azimuth: Optional[float] = None,
         sun_elevation: Optional[float] = None,
         turbidity: Optional[float] = None,
@@ -301,6 +325,7 @@ class WorkflowBuilder:
             "cloud_coverage": cloud_coverage,
             "auto_correct": auto_correct,
             "strict_physics": strict_physics,
+            "update_reflections": update_reflections,
         }
 
         if sun_azimuth is not None:
@@ -315,17 +340,67 @@ class WorkflowBuilder:
         logger.info(f"Added SkyGAN node (location={location}, auto_correct={auto_correct})")
         return self
 
+    def add_neuroaesthetics_optimization(
+        self,
+        emotional_target: str = "luxury",
+        optimize_composition: bool = True,
+        optimize_color_harmony: bool = True,
+        optimize_spatial_frequency: bool = True,
+    ) -> "WorkflowBuilder":
+        self._add_node(
+            NodeType.NEUROAESTHETICS,
+            parameters={
+                "emotional_target": emotional_target,
+                "optimize_composition": optimize_composition,
+                "optimize_color_harmony": optimize_color_harmony,
+                "optimize_spatial_frequency": optimize_spatial_frequency,
+            },
+        )
+        self._last_output = "IMAGE"
+        return self
+
+    def add_atmospheric_model(
+        self,
+        apply_aerial_perspective: bool = True,
+        marine_layer: bool = False,
+        max_distance: float = 1000.0,
+    ) -> "WorkflowBuilder":
+        self._add_node(
+            NodeType.ATMOSPHERIC_MODEL,
+            parameters={
+                "apply_aerial_perspective": apply_aerial_perspective,
+                "marine_layer": marine_layer,
+                "max_distance": max_distance,
+            },
+        )
+        self._last_output = "IMAGE"
+        return self
+
     def add_quality_validation(
         self,
         pass_threshold: float = 7.0,
         warning_threshold: float = 5.0,
+        check_realism: bool = True,
+        check_structural_accuracy: bool = True,
+        check_material_consistency: bool = False,
     ) -> "WorkflowBuilder":
+        previous_node_id = self._last_node_id
+        previous_output = self._last_output
+
         params = {
             "pass_threshold": pass_threshold,
             "warning_threshold": warning_threshold,
+            "check_realism": check_realism,
+            "check_structural_accuracy": check_structural_accuracy,
+            "check_material_consistency": check_material_consistency,
         }
         self._add_node(NodeType.QUALITY_VALIDATION, parameters=params)
-        self._last_output = "STRING"  # Output is report
+
+        # Quality validation emits a report, but downstream image nodes should
+        # keep consuming the image that was validated.
+        self._last_node_id = previous_node_id
+        self._last_output = previous_output
+
         return self
 
     def add_output(self, output_path: str, format: str = "jpg", quality: int = 95) -> "WorkflowBuilder":

--- a/src/transformation_portal/comfyui/workflow_templates.py
+++ b/src/transformation_portal/comfyui/workflow_templates.py
@@ -190,6 +190,13 @@ class WorkflowTemplates:
         """Generate multiple enhancement variants."""
         logger.info(f"Creating multi-variant generation workflows ({num_variants} variants)")
 
+        if num_variants < 1:
+            raise ValueError("num_variants must be >= 1")
+        if emotional_targets is not None and not emotional_targets:
+            raise ValueError("emotional_targets must not be empty when provided")
+        if flux_strengths is not None and not flux_strengths:
+            raise ValueError("flux_strengths must not be empty when provided")
+
         # Default emotional targets
         if emotional_targets is None:
             emotional_targets = ["luxury", "aspiration", "comfort"][:num_variants]
@@ -314,7 +321,7 @@ class WorkflowTemplates:
         for i, variant in enumerate(variants):
             variant.save(output_path / f"multi_variant_{i+1}.json")
 
-        logger.info(f"Saved {6 + len(variants)} workflow templates")
+        logger.info(f"Saved {5 + len(variants)} workflow templates")
 
 
 # Export

--- a/tests/comfyui/test_workflow_templates_contract.py
+++ b/tests/comfyui/test_workflow_templates_contract.py
@@ -1,0 +1,144 @@
+"""Pure ComfyUI workflow construction contracts."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from transformation_portal.comfyui.workflow_builder import NodeType, WorkflowBuilder
+from transformation_portal.comfyui.workflow_templates import WorkflowTemplates
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_comfyui_package_imports_without_site_packages():
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(REPO_ROOT / "src")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-S",
+            "-c",
+            "import transformation_portal.comfyui as c; print(c.WorkflowBuilder)",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        lambda: WorkflowTemplates.full_luxury_estate_pipeline("input.jpg", "output.jpg"),
+        lambda: WorkflowTemplates.quick_iterative_enhancement("input.jpg", "output.jpg"),
+        lambda: WorkflowTemplates.material_specific_enhancement("input.jpg", "output.jpg"),
+        lambda: WorkflowTemplates.location_specific_atmospheric("input.jpg", "output.jpg"),
+        lambda: WorkflowTemplates.coastal_property_golden_hour("input.jpg", "output.jpg"),
+    ],
+)
+def test_single_workflow_templates_build(factory):
+    workflow = factory()
+
+    assert workflow.nodes
+    assert workflow.metadata["name"]
+    assert workflow.to_comfyui_format()
+
+
+def test_multi_variant_generation_builds_expected_count():
+    workflows = WorkflowTemplates.multi_variant_generation(
+        input_path="input.jpg",
+        output_dir="variants",
+        num_variants=4,
+    )
+
+    assert len(workflows) == 4
+    assert all(workflow.nodes for workflow in workflows)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"num_variants": 0}, "num_variants must be >= 1"),
+        ({"emotional_targets": []}, "emotional_targets must not be empty"),
+        ({"flux_strengths": []}, "flux_strengths must not be empty"),
+    ],
+)
+def test_multi_variant_generation_rejects_invalid_inputs(kwargs, match):
+    with pytest.raises(ValueError, match=match):
+        WorkflowTemplates.multi_variant_generation(
+            input_path="input.jpg",
+            output_dir="variants",
+            **kwargs,
+        )
+
+
+def test_save_all_templates_writes_expected_files(tmp_path):
+    WorkflowTemplates.save_all_templates(str(tmp_path))
+
+    expected = {
+        "full_luxury_estate_pipeline.json",
+        "quick_iterative_enhancement.json",
+        "material_specific_enhancement.json",
+        "location_specific_atmospheric.json",
+        "coastal_property_golden_hour.json",
+        "multi_variant_1.json",
+        "multi_variant_2.json",
+        "multi_variant_3.json",
+    }
+
+    assert expected <= {path.name for path in tmp_path.iterdir()}
+
+
+def test_scene_analysis_is_sidecar_not_image_chain_head():
+    workflow = WorkflowBuilder().add_input("input.jpg").add_scene_analysis(detailed=True).add_flux_enhancement().build()
+
+    flux_node_id = next(node_id for node_id, node in workflow.nodes.items() if node.node_type == NodeType.FLUX_ENHANCEMENT)
+
+    flux_input_connection = next(conn for conn in workflow.connections if conn.target_node_id == flux_node_id)
+
+    source_node = workflow.nodes[flux_input_connection.source_node_id]
+    assert source_node.node_type == NodeType.INPUT
+    assert flux_input_connection.source_output == "IMAGE"
+
+
+def test_quality_validation_is_sidecar_not_output_image_source():
+    workflow = (
+        WorkflowBuilder()
+        .add_input("input.jpg")
+        .add_flux_enhancement()
+        .add_quality_validation(pass_threshold=7.0)
+        .add_output("output.jpg")
+        .build()
+    )
+
+    output_node_id = next(node_id for node_id, node in workflow.nodes.items() if node.node_type == NodeType.OUTPUT)
+
+    output_input_connection = next(conn for conn in workflow.connections if conn.target_node_id == output_node_id)
+
+    source_node = workflow.nodes[output_input_connection.source_node_id]
+    assert source_node.node_type == NodeType.FLUX_ENHANCEMENT
+    assert output_input_connection.source_output == "IMAGE"
+
+
+def test_executor_fails_fast_for_unsupported_nodes():
+    from transformation_portal.comfyui.executor import WorkflowExecutor
+
+    workflow = WorkflowTemplates.quick_iterative_enhancement("input.jpg", "output.jpg")
+    executor = WorkflowExecutor(cache_models=False)
+
+    result = executor.execute(workflow)
+
+    assert result["success"] is False
+    assert "No executor implementation" in result["errors"][0]


### PR DESCRIPTION
## Summary
- Root cause: ComfyUI package imports and templates advertised runtime completeness while the core surface still depended on optional runtime nodes and missing builder methods.
- Smallest safe change: keep the package import and template path declarative, lazy-load runtime pieces, and fail fast for unsupported executor nodes.

## Changes
- Export pure workflow builder/template primitives eagerly from transformation_portal.comfyui and lazy-load runtime custom nodes or executor access.
- Add declarative builder methods and kwargs used by existing templates: material segmentation, neuroaesthetics, atmospheric model, ControlNet types, SkyGAN reflection updates, and validation flags.
- Preserve image-chain semantics for scene analysis and quality validation sidecar nodes.
- Add multi-variant input validation and correct save_all_templates logging.
- Replace unsupported executor pass-through behavior with a clear NotImplementedError.
- Replace stale ComfyUI CI docs with current declarative/runtime contract guidance.
- Add pure ComfyUI workflow-template contract tests with unit markers.

## Validation
Proven green:
- .venv/bin/python -m pytest -q tests/comfyui/test_workflow_templates_contract.py tests/test_comfyui.py
- make ci-quick
- make check-worktree
- git diff --cached --check
- Commit pre-commit hooks from git commit -m "fix(comfyui): stabilize declarative workflow contracts"

Still failing:
- None observed.

Failure classification:
- No product logic, stale test, or environment/tooling failures observed. make ci-quick reports the existing TODO/FIXME warning and exits successfully.

## Risk
- Runtime behavior is intentionally bounded: unsupported executor nodes now fail closed instead of silently passing inputs through.
- Public workflow JSON shape remains declarative and additive for planned node types.
- Package import compatibility improves for core environments by removing eager optional ML/runtime imports.
- Revert-safe: changes are limited to ComfyUI builder/import/executor/docs/tests and do not alter external routes, selectors, auth, or deployment contracts.