### PR TITLE
test(comfyui): ratchet workflow template coverage

### DIFF
--- a/docs/testing/COLD_ZONE_COVERAGE_PROGRAM.md
+++ b/docs/testing/COLD_ZONE_COVERAGE_PROGRAM.md
@@ -738,6 +738,7 @@ deterministic behavioral tests and pinned with file-level floors:
 |---|---:|---|---:|---|
 | `metrics/ledger.py` | ~30% line | 98.8% / 93% | 90% / 82% | `tests/test_metrics_ledger.py` |
 | `comfyui/workflow_builder.py` | 0% line | 100% / 100% | 90% / 80% | `tests/test_comfyui_workflow_builder.py` |
+| `comfyui/workflow_templates.py` | 98.0% / 88.9% | 100% / 100% | 95% / 90% | `tests/comfyui/test_workflow_templates_contract.py` |
 | `hardening/` (`universal.py`) | 81% / 67% | 98% / 100% | 90% / 85% | `tests/security/test_universal_hardening.py` |
 | `storage/cas_store.py` | 78.5% / 59% | 96% / 89% | 88% / 80% | `tests/storage/test_cas_store_lifecycle.py` |
 | `orchestrator/worker.py` | 76% / 71% | 100% / 100% | 90% / 85% | `tests/orchestrator/test_worker_runner_unit.py` |

--- a/scripts/ci/check_per_package_branch_coverage.py
+++ b/scripts/ci/check_per_package_branch_coverage.py
@@ -58,6 +58,10 @@ BRANCH_FLOORS: tuple[BranchFloor, ...] = (
     # ComfyUI workflow builder — branch coverage reached 100% on 2026-06-06 via
     # tests/test_comfyui_workflow_builder.py. Conservative floor locks it in.
     BranchFloor("src/transformation_portal/comfyui/workflow_builder.py", 80.0),
+    # ComfyUI workflow templates — pure declarative builders and serialization
+    # only. Custom variant-list tests cover the non-default target/strength
+    # branches; no executor, torch, ML, or network runtime path is invoked.
+    BranchFloor("src/transformation_portal/comfyui/workflow_templates.py", 90.0),
     # Universal hardening wrapper — branch coverage reached 100% on 2026-06-06
     # via the input-validation path tests. Conservative package floor.
     BranchFloor("src/transformation_portal/hardening/", 85.0),
@@ -84,6 +88,7 @@ DRY_RUN_BRANCH_PREFIXES: tuple[str, ...] = (
     "src/transformation_portal/orchestrator/artifact_store/",
     "src/transformation_portal/metrics/ledger.py",
     "src/transformation_portal/comfyui/workflow_builder.py",
+    "src/transformation_portal/comfyui/workflow_templates.py",
     "src/transformation_portal/hardening/",
     "src/transformation_portal/storage/cas_store.py",
     "src/transformation_portal/orchestrator/worker.py",

--- a/scripts/ci/check_per_package_coverage.py
+++ b/scripts/ci/check_per_package_coverage.py
@@ -121,6 +121,12 @@ PACKAGE_FLOORS: tuple[PackageFloor, ...] = (
     # comfyui/ stays unfloored — custom_nodes/executor are torch/atmosphere
     # bound and only run in the ML lane).
     PackageFloor("src/transformation_portal/comfyui/workflow_builder.py", 90.0),
+    # Pure-Python ComfyUI workflow templates. Behavioral tests exercise the
+    # declarative template factories, custom variant target/strength expansion,
+    # and JSON serialization without invoking executor, torch, ML, or network
+    # runtime paths. A 2026-06-10 core-lane audit measured 100% line coverage
+    # after the branch fill; this conservative file floor locks it in.
+    PackageFloor("src/transformation_portal/comfyui/workflow_templates.py", 95.0),
     # Universal hardening wrapper — a governed cold-zone surface (CLAUDE.md).
     # Input-validation path tests in tests/security/test_universal_hardening.py
     # took universal.py from 81% to ~98% line on 2026-06-06. Package floor

--- a/tests/comfyui/test_workflow_templates_contract.py
+++ b/tests/comfyui/test_workflow_templates_contract.py
@@ -67,6 +67,34 @@ def test_multi_variant_generation_builds_expected_count():
     assert all(workflow.nodes for workflow in workflows)
 
 
+def test_multi_variant_generation_preserves_custom_targets_and_strengths():
+    workflows = WorkflowTemplates.multi_variant_generation(
+        input_path="input.jpg",
+        output_dir="variants",
+        num_variants=3,
+        emotional_targets=["serenity"],
+        flux_strengths=[0.25, 0.65],
+    )
+
+    assert [workflow.metadata["name"] for workflow in workflows] == [
+        "Variant 1 - Serenity",
+        "Variant 2 - Serenity",
+        "Variant 3 - Serenity",
+    ]
+
+    for index, workflow in enumerate(workflows):
+        neuro_node = next(node for node in workflow.nodes.values() if node.node_type == NodeType.NEUROAESTHETICS)
+        output_node = next(node for node in workflow.nodes.values() if node.node_type == NodeType.OUTPUT)
+
+        assert neuro_node.parameters["emotional_target"] == "serenity"
+        assert output_node.parameters["filename"] == f"variants/variant_{index + 1}_serenity.jpg"
+
+    assert [
+        next(node for node in workflow.nodes.values() if node.node_type == NodeType.FLUX_ENHANCEMENT).parameters["strength"]
+        for workflow in workflows
+    ] == [0.25, 0.65, 0.45]
+
+
 @pytest.mark.parametrize(
     ("kwargs", "match"),
     [

--- a/tests/test_check_per_package_branch_coverage.py
+++ b/tests/test_check_per_package_branch_coverage.py
@@ -156,6 +156,7 @@ def test_default_branch_floors_cover_cold_zone_and_durable_state_prefixes(script
         ("src/transformation_portal/orchestrator/artifact_store/", 46.0),
         ("src/transformation_portal/metrics/ledger.py", 82.0),
         ("src/transformation_portal/comfyui/workflow_builder.py", 80.0),
+        ("src/transformation_portal/comfyui/workflow_templates.py", 90.0),
         ("src/transformation_portal/hardening/", 85.0),
         ("src/transformation_portal/storage/cas_store.py", 80.0),
         ("src/transformation_portal/orchestrator/worker.py", 85.0),

--- a/tests/test_check_per_package_coverage.py
+++ b/tests/test_check_per_package_coverage.py
@@ -405,6 +405,7 @@ class TestDefaultFloors:
             "src/transformation_portal/depth/": 57.0,
             "src/transformation_portal/streaming/": 53.0,
             "src/transformation_portal/spatial_ai/reconstruction/": 42.0,
+            "src/transformation_portal/comfyui/workflow_templates.py": 95.0,
         }
 
         assert {prefix: floors[prefix] for prefix in expected_floors} == expected_floors


### PR DESCRIPTION
## Summary
- Fresh main@23839915 coverage audit showed `comfyui/workflow_templates.py` was already line-covered but still had uncovered custom-list branch exits.
- Added the smallest behavioral test for declarative multi-variant template construction and pinned conservative file-level floors.

## Changes
- Add a pure-Python contract test for custom `emotional_targets` and `flux_strengths` expansion in `WorkflowTemplates.multi_variant_generation`.
- Add `workflow_templates.py` line and branch coverage floors: 95% line, 90% branch.
- Add the new file-level ratchet to the cold-zone coverage ledger.
- Update floor-config tests for the new line and branch floor entries.

## Validation
Proven green:
- `make coverage-package` (`11122 passed, 48 skipped, 932 deselected`)
- `.venv/bin/python scripts/ci/check_per_package_branch_coverage.py coverage.xml` on the fresh coverage-package report
- `.venv/bin/python -m pytest -q tests/comfyui/test_workflow_templates_contract.py tests/test_check_per_package_coverage.py tests/test_check_per_package_branch_coverage.py` (`47 passed`)
- `.venv/bin/python -m pytest -q tests/comfyui/test_workflow_templates_contract.py --cov=transformation_portal.comfyui.workflow_templates --cov-branch --cov-report=term-missing --cov-report=xml:/tmp/workflow_templates_coverage.xml --cov-config=pyproject.toml` (`workflow_templates.py` 100% line / 100% branch)
- `.venv/bin/python -m pytest tests/ -m "not ml and not slow and not benchmark and not stress" --cov=src/transformation_portal --cov=src/tp --cov=app --cov-branch --cov-report=xml:coverage.xml --cov-config=pyproject.toml -q` (`11124 passed, 47 skipped, 932 deselected`)
- `.venv/bin/python scripts/ci/check_per_package_coverage.py coverage.xml`
- `.venv/bin/python scripts/ci/check_per_package_branch_coverage.py coverage.xml`
- `make ci-quick`
- `make pre-commit`
- `make test-fast` (`77 passed`)
- `git diff --check -- docs/testing/COLD_ZONE_COVERAGE_PROGRAM.md scripts/ci/check_per_package_coverage.py scripts/ci/check_per_package_branch_coverage.py tests/comfyui/test_workflow_templates_contract.py tests/test_check_per_package_coverage.py tests/test_check_per_package_branch_coverage.py`

Still failing:
- None.

Audit note:
- `make coverage-package` generates `coverage.xml` without `src/tp`, so the line-floor checker reports `src/tp/` as `0/0` if run directly against that target's XML. The enforcing line-floor validation above used the full coverage command with `--cov=src/tp`, matching the floor checker input requirements. Branch floors do not include `src/tp` and passed on both reports.

## Risk
- Runtime risk is low: no product code or executor behavior changed.
- The change is bounded to deterministic tests, coverage ratchet configuration, and documentation.
- Revert-safe: removing this commit removes only the new test and conservative `workflow_templates.py` floor entries.