### PR TITLE
test(dashboard): cover node_api + experiment_api routers, pin floors

### DIFF
--- a/docs/testing/COLD_ZONE_COVERAGE_PROGRAM.md
+++ b/docs/testing/COLD_ZONE_COVERAGE_PROGRAM.md
@@ -748,24 +748,37 @@ deterministic behavioral tests and pinned with file-level floors:
 | `dashboard/studio_inspector.py` | ~0% (unfloored) | 88.9% / 100% | 82% / 80% | `tests/dashboard/test_studio_inspector.py` |
 | `dashboard/node_api.py` | ~0% (unfloored) | 98.2% / 100% | 92% / 90% | `tests/dashboard/test_node_api.py` |
 | `dashboard/experiment_api.py` | ~0% (unfloored) | 98.2% / 100% | 92% / 90% | `tests/dashboard/test_experiment_api.py` |
+| `dashboard/server.py` | ~0% (unfloored) | 84.0% / 75.0% | 78% / 66% | `tests/dashboard/test_server.py` |
+| `dashboard/gpu_api.py` | ~0% (unfloored) | 61.1% / 42.9% | 55% / 36% | `tests/dashboard/test_gpu_api.py` |
+| `dashboard/dag_api.py` | ~0% (unfloored) | 95.6% / 100% | 88% / 90% | `tests/dashboard/test_dag_api.py` |
+| `dashboard/artifact_api.py` | ~0% (unfloored) | 86.6% / 85.4% | 80% / 76% | `tests/dashboard/test_artifact_api.py` |
+| `dashboard/artifact_preview.py` | ~0% (unfloored) | 95.9% / 94.1% | 88% / 85% | `tests/dashboard/test_artifact_preview.py` |
+| `dashboard/optimization_api.py` | ~0% (unfloored) | 72.1% / 83.3% | 65% / 72% | `tests/dashboard/test_optimization_api.py` |
+| `dashboard/rl_api.py` | ~0% (unfloored) | 87.9% / 75.0% | 80% / 65% | `tests/dashboard/test_rl_api.py` |
+| `dashboard/dag_editor_api.py` | ~0% (unfloored) | 84.1% / 77.3% | 76% / 68% | `tests/dashboard/test_dag_editor_api.py` |
+| `dashboard/execution_api.py` | ~0% (unfloored) | 94.0% / 81.2% | 86% / 72% | `tests/dashboard/test_execution_api.py` |
+| `dashboard/` (package) | ~0% (unfloored) | 89.4% / 87.4% | 80% / 75% | (all `tests/dashboard/`) |
 
-The six `dashboard/` rows (2026-06-11) open coverage on the previously
+The `dashboard/` rows (2026-06-11) open coverage on the previously
 unfloored dashboard package (~9.6k LOC, pure-Python FastAPI/pydantic/sqlite,
-no ML — the largest offline-testable surface outside this program). They are
-file-level floors against the most self-contained seams: a pure per-node state
-store, the async execution manager's lifecycle/cancellation state machine, the
-SQLite-backed experiment-tracking API, and the FastAPI routers (`time_travel`,
-`studio_inspector`, `node_api`) driven via `TestClient`. The remaining
-dashboard modules stay unfloored pending further behavioral fills. Notes:
-`execution_manager.py`'s residual misses are the
-legacy inline-trim fallback and post-loop cancellation edge branches;
-`studio_inspector.py` is ~1.4k LOC but coverage.py sees only ~25 executable
-statements (the bulk is HTML string literals), and the router modules'
-(`time_travel`, `studio_inspector`, `node_api`, `experiment_api`) only residual
-miss is the module-level `except ImportError` FastAPI guard (unreachable while
-FastAPI — a core dependency — is installed). Percentages are from an isolated
-`tests/dashboard/` run; confirm against the first green core-lane
-`coverage.xml` before any upward ratchet.
+no ML — the largest offline-testable surface outside this program). All 15
+modules now carry file-level floors, driven by `TestClient` route tests plus
+direct unit tests for the pure helpers/state machines. **A package-level floor
+`dashboard/` (line 80 / branch 75) now sits on top of the per-file floors** —
+the whole-package aggregate measured 89.4% line / 87.4% branch. The package
+floor is intentionally redundant with the per-file floors for the existing
+modules; its job is to catch *future* unfloored additions to the package that
+would otherwise silently drag the aggregate down. Notes on inherent offline
+ceilings: `gpu_api.py` (61%) cannot reach the NVML-present stats branches
+without a GPU; `optimization_api.py` (72%) stubs the heavy eval-backed
+optimizer; `server.py` (84%) leaves the blocking `uvicorn.run` helpers and one
+asyncio-loop dispatch branch uncovered; `execution_manager.py`'s residual
+misses are the legacy inline-trim fallback and post-loop cancellation edge
+branches; `studio_inspector.py` is ~1.4k LOC but coverage.py sees only ~25
+executable statements (the bulk is HTML string literals); and the FastAPI-guard
+`except ImportError` blocks are unreachable while FastAPI — a core dependency —
+is installed. Percentages are from an isolated `tests/dashboard/` run; confirm
+against the first green core-lane `coverage.xml` before any upward ratchet.
 
 `comfyui/workflow_builder.py` required a precondition: `comfyui/__init__.py`
 eagerly imported `custom_nodes` (top-level `import torch`), so the pure builder

--- a/docs/testing/COLD_ZONE_COVERAGE_PROGRAM.md
+++ b/docs/testing/COLD_ZONE_COVERAGE_PROGRAM.md
@@ -746,18 +746,22 @@ deterministic behavioral tests and pinned with file-level floors:
 | `dashboard/execution_manager.py` | ~0% (unfloored) | 90.9% / 81.8% | 85% / 75% | `tests/dashboard/test_execution_manager.py` |
 | `dashboard/time_travel.py` | ~0% (unfloored) | 96.0% / 100% | 90% / 90% | `tests/dashboard/test_time_travel.py` |
 | `dashboard/studio_inspector.py` | ~0% (unfloored) | 88.9% / 100% | 82% / 80% | `tests/dashboard/test_studio_inspector.py` |
+| `dashboard/node_api.py` | ~0% (unfloored) | 98.2% / 100% | 92% / 90% | `tests/dashboard/test_node_api.py` |
+| `dashboard/experiment_api.py` | ~0% (unfloored) | 98.2% / 100% | 92% / 90% | `tests/dashboard/test_experiment_api.py` |
 
-The four `dashboard/` rows (2026-06-11) open coverage on the previously
+The six `dashboard/` rows (2026-06-11) open coverage on the previously
 unfloored dashboard package (~9.6k LOC, pure-Python FastAPI/pydantic/sqlite,
 no ML — the largest offline-testable surface outside this program). They are
 file-level floors against the most self-contained seams: a pure per-node state
-store, the async execution manager's lifecycle/cancellation state machine, and
-the two FastAPI routers (`time_travel`, `studio_inspector`) driven via
-`TestClient`. The remaining dashboard modules stay unfloored pending further
-behavioral fills. Notes: `execution_manager.py`'s residual misses are the
+store, the async execution manager's lifecycle/cancellation state machine, the
+SQLite-backed experiment-tracking API, and the FastAPI routers (`time_travel`,
+`studio_inspector`, `node_api`) driven via `TestClient`. The remaining
+dashboard modules stay unfloored pending further behavioral fills. Notes:
+`execution_manager.py`'s residual misses are the
 legacy inline-trim fallback and post-loop cancellation edge branches;
 `studio_inspector.py` is ~1.4k LOC but coverage.py sees only ~25 executable
-statements (the bulk is HTML string literals), and both routers' only residual
+statements (the bulk is HTML string literals), and the router modules'
+(`time_travel`, `studio_inspector`, `node_api`, `experiment_api`) only residual
 miss is the module-level `except ImportError` FastAPI guard (unreachable while
 FastAPI — a core dependency — is installed). Percentages are from an isolated
 `tests/dashboard/` run; confirm against the first green core-lane

--- a/scripts/ci/check_per_package_branch_coverage.py
+++ b/scripts/ci/check_per_package_branch_coverage.py
@@ -84,6 +84,12 @@ BRANCH_FLOORS: tuple[BranchFloor, ...] = (
     # Dashboard studio inspector — branch coverage reached 100% on 2026-06-11
     # (only two branches; the rest is HTML). Conservative floor.
     BranchFloor("src/transformation_portal/dashboard/studio_inspector.py", 80.0),
+    # Dashboard node-inspection router — branch coverage reached 100% on
+    # 2026-06-11 via the TestClient route tests. Conservative floor.
+    BranchFloor("src/transformation_portal/dashboard/node_api.py", 90.0),
+    # Dashboard experiment API — branch coverage reached 100% on 2026-06-11
+    # via the Python-API + router tests. Conservative floor.
+    BranchFloor("src/transformation_portal/dashboard/experiment_api.py", 90.0),
 )
 
 # If a future branch temporarily clears floors, dry-run mode still reports the
@@ -109,6 +115,8 @@ DRY_RUN_BRANCH_PREFIXES: tuple[str, ...] = (
     "src/transformation_portal/dashboard/execution_manager.py",
     "src/transformation_portal/dashboard/time_travel.py",
     "src/transformation_portal/dashboard/studio_inspector.py",
+    "src/transformation_portal/dashboard/node_api.py",
+    "src/transformation_portal/dashboard/experiment_api.py",
 )
 
 

--- a/scripts/ci/check_per_package_branch_coverage.py
+++ b/scripts/ci/check_per_package_branch_coverage.py
@@ -90,6 +90,22 @@ BRANCH_FLOORS: tuple[BranchFloor, ...] = (
     # Dashboard experiment API — branch coverage reached 100% on 2026-06-11
     # via the Python-API + router tests. Conservative floor.
     BranchFloor("src/transformation_portal/dashboard/experiment_api.py", 90.0),
+    # Remaining dashboard routers + server, covered 2026-06-11. Branch floors
+    # are conservative below the measured offline branch coverage; gpu_api and
+    # optimization_api carry inherent offline ceilings (no GPU / stubbed
+    # optimizer), so their floors are set accordingly.
+    BranchFloor("src/transformation_portal/dashboard/server.py", 66.0),
+    BranchFloor("src/transformation_portal/dashboard/gpu_api.py", 36.0),
+    BranchFloor("src/transformation_portal/dashboard/dag_api.py", 90.0),
+    BranchFloor("src/transformation_portal/dashboard/artifact_api.py", 76.0),
+    BranchFloor("src/transformation_portal/dashboard/artifact_preview.py", 85.0),
+    BranchFloor("src/transformation_portal/dashboard/optimization_api.py", 72.0),
+    BranchFloor("src/transformation_portal/dashboard/rl_api.py", 65.0),
+    BranchFloor("src/transformation_portal/dashboard/dag_editor_api.py", 68.0),
+    BranchFloor("src/transformation_portal/dashboard/execution_api.py", 72.0),
+    # Package-level branch floor for the whole dashboard package (~87% measured
+    # 2026-06-11); guards future unfloored additions.
+    BranchFloor("src/transformation_portal/dashboard/", 75.0),
 )
 
 # If a future branch temporarily clears floors, dry-run mode still reports the
@@ -117,6 +133,16 @@ DRY_RUN_BRANCH_PREFIXES: tuple[str, ...] = (
     "src/transformation_portal/dashboard/studio_inspector.py",
     "src/transformation_portal/dashboard/node_api.py",
     "src/transformation_portal/dashboard/experiment_api.py",
+    "src/transformation_portal/dashboard/server.py",
+    "src/transformation_portal/dashboard/gpu_api.py",
+    "src/transformation_portal/dashboard/dag_api.py",
+    "src/transformation_portal/dashboard/artifact_api.py",
+    "src/transformation_portal/dashboard/artifact_preview.py",
+    "src/transformation_portal/dashboard/optimization_api.py",
+    "src/transformation_portal/dashboard/rl_api.py",
+    "src/transformation_portal/dashboard/dag_editor_api.py",
+    "src/transformation_portal/dashboard/execution_api.py",
+    "src/transformation_portal/dashboard/",
 )
 
 

--- a/scripts/ci/check_per_package_coverage.py
+++ b/scripts/ci/check_per_package_coverage.py
@@ -187,6 +187,45 @@ PACKAGE_FLOORS: tuple[PackageFloor, ...] = (
     # covers experiment/run CRUD, metric merge, and the router 400/404 paths:
     # ~98% line on 2026-06-11 (residual miss is the import guard).
     PackageFloor("src/transformation_portal/dashboard/experiment_api.py", 92.0),
+    # Dashboard server (app factory, event broadcast, history, WebSocket).
+    # tests/dashboard/test_server.py covers the routes, broadcast fan-out, and
+    # DashboardServer construction: ~84% line on 2026-06-11 (residual misses are
+    # the asyncio-loop dispatch branches and the blocking uvicorn.run helpers).
+    PackageFloor("src/transformation_portal/dashboard/server.py", 78.0),
+    # Dashboard GPU monitor. NVML/pynvml is absent on core CI hosts, so the
+    # NVML-present stats branches are unreachable offline; tests pin the
+    # degraded paths + router + stream error frame: ~61% line on 2026-06-11.
+    PackageFloor("src/transformation_portal/dashboard/gpu_api.py", 55.0),
+    # Dashboard DAG/Merkle visualization router. tests/dashboard/test_dag_api.py
+    # drives both configured and not-configured branches: ~96% line on 2026-06-11.
+    PackageFloor("src/transformation_portal/dashboard/dag_api.py", 88.0),
+    # Dashboard CAS artifact browser (list/get/preview/stats + _human_size).
+    # tests/dashboard/test_artifact_api.py uses a tmp_path objects tree: ~87%
+    # line on 2026-06-11.
+    PackageFloor("src/transformation_portal/dashboard/artifact_api.py", 80.0),
+    # Dashboard artifact preview (detect_content_type + meta/raw/thumbnail/text).
+    # tests/dashboard/test_artifact_preview.py covers the type matrix and Pillow
+    # thumbnailing: ~96% line on 2026-06-11.
+    PackageFloor("src/transformation_portal/dashboard/artifact_preview.py", 88.0),
+    # Dashboard optimization API. The background optimizer pulls heavy eval deps
+    # and is stubbed; tests cover the manager + router status/history/stop/list:
+    # ~72% line on 2026-06-11.
+    PackageFloor("src/transformation_portal/dashboard/optimization_api.py", 65.0),
+    # Dashboard RL API. The training task needs torch (absent on core CI); tests
+    # cover the torch-free actions/policy endpoints + handshake: ~88% line.
+    PackageFloor("src/transformation_portal/dashboard/rl_api.py", 80.0),
+    # Dashboard pipeline editor (FSGuard-backed CRUD with name validation).
+    # tests/dashboard/test_dag_editor_api.py covers the round-trip + rejection
+    # paths against a tmp_path pipelines dir: ~84% line on 2026-06-11.
+    PackageFloor("src/transformation_portal/dashboard/dag_editor_api.py", 76.0),
+    # Dashboard execution router (run/list/cancel + WebSocket). Driven via
+    # TestClient against an injected ExecutionManager: ~94% line on 2026-06-11.
+    PackageFloor("src/transformation_portal/dashboard/execution_api.py", 86.0),
+    # Package-level floor for the whole dashboard package. With all modules now
+    # behaviorally covered the aggregate measured ~89% line on 2026-06-11; this
+    # conservative package floor sits on top of the per-file floors and guards
+    # against future *unfloored* additions silently dragging the package down.
+    PackageFloor("src/transformation_portal/dashboard/", 80.0),
 )
 
 

--- a/scripts/ci/check_per_package_coverage.py
+++ b/scripts/ci/check_per_package_coverage.py
@@ -176,6 +176,17 @@ PACKAGE_FLOORS: tuple[PackageFloor, ...] = (
     # wiring, FastAPI guard, and HTML structural contracts: ~89% line on
     # 2026-06-11 (residual miss is the import guard, as above).
     PackageFloor("src/transformation_portal/dashboard/studio_inspector.py", 82.0),
+    # Dashboard node-inspection router (per-node detail/inputs/outputs/artifacts/
+    # logs, run summary, CAS artifact info/preview/download). TestClient route
+    # tests in tests/dashboard/test_node_api.py exercise the 404/503 paths and
+    # the preview content-type matrix against a fake CAS: ~98% line on
+    # 2026-06-11 (residual miss is the import guard).
+    PackageFloor("src/transformation_portal/dashboard/node_api.py", 92.0),
+    # Dashboard experiment-tracking API (SQLite-backed Python API + router).
+    # tests/dashboard/test_experiment_api.py points the DB at a tmp file and
+    # covers experiment/run CRUD, metric merge, and the router 400/404 paths:
+    # ~98% line on 2026-06-11 (residual miss is the import guard).
+    PackageFloor("src/transformation_portal/dashboard/experiment_api.py", 92.0),
 )
 
 

--- a/tests/dashboard/test_artifact_api.py
+++ b/tests/dashboard/test_artifact_api.py
@@ -1,0 +1,217 @@
+"""Behavioral coverage for ``dashboard.artifact_api``.
+
+Drives the CAS artifact-browser router via ``TestClient`` against a fake
+``ArtifactStore`` whose ``objects_dir`` is a real ``tmp_path`` tree, so the
+filesystem-walking list/stats endpoints and the get/preview endpoints are
+exercised offline. Also covers the ``_human_size`` helper directly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from transformation_portal.dashboard import artifact_api
+
+
+@dataclass
+class _CASObject:
+    sha256: str
+    path: Path
+    size_bytes: int
+
+
+class _FakeCAS:
+    def __init__(self, objects_dir: Path) -> None:
+        self.objects_dir = objects_dir
+
+    def _path_for(self, sha256: str) -> Path:
+        return self.objects_dir / sha256[:2] / sha256
+
+    def put(self, sha256: str, data: bytes) -> None:
+        p = self._path_for(sha256)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_bytes(data)
+
+    def get_object(self, sha256: str) -> Optional[_CASObject]:
+        p = self._path_for(sha256)
+        if not p.exists():
+            return None
+        return _CASObject(sha256=sha256, path=p, size_bytes=p.stat().st_size)
+
+
+class _MerkleNode:
+    def __init__(self, node_type: str, outputs: dict) -> None:
+        self.node_type = node_type
+        self.outputs = outputs
+
+
+class _FakeMerkle:
+    def __init__(self) -> None:
+        self.nodes: dict = {}
+
+
+@pytest.fixture
+def cas(tmp_path) -> _FakeCAS:
+    return _FakeCAS(tmp_path / "objects")
+
+
+@pytest.fixture
+def restore_globals():
+    orig_c, orig_m = artifact_api._global_cas, artifact_api._global_merkle_dag
+    yield
+    artifact_api.set_artifact_store(orig_c)  # type: ignore[arg-type]
+    artifact_api.set_merkle_dag(orig_m)  # type: ignore[arg-type]
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    app.include_router(artifact_api.create_artifact_router())
+    return TestClient(app)
+
+
+# --------------------------------------------------------------------------- #
+# _human_size helper
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("size", "expected"),
+    [(512, "512.0 B"), (2048, "2.0 KB"), (5 * 1024 * 1024, "5.0 MB")],
+)
+def test_human_size(size: int, expected: str) -> None:
+    assert artifact_api._human_size(size) == expected
+
+
+def test_human_size_petabyte_overflow() -> None:
+    assert artifact_api._human_size(1024**5).endswith("PB")
+
+
+# --------------------------------------------------------------------------- #
+# list
+# --------------------------------------------------------------------------- #
+
+
+def test_list_without_cas_returns_error(restore_globals) -> None:
+    artifact_api.set_artifact_store(None)  # type: ignore[arg-type]
+    body = _client().get("/api/artifacts/").json()
+    assert body["artifacts"] == [] and body["total"] == 0 and "error" in body
+
+
+def test_list_artifacts_with_prefix_and_pagination(restore_globals, cas: _FakeCAS) -> None:
+    cas.put("aa" + "0" * 62, b"x")
+    cas.put("aa" + "1" * 62, b"yy")
+    cas.put("bb" + "2" * 62, b"zzz")
+    artifact_api.set_artifact_store(cas)  # type: ignore[arg-type]
+    client = _client()
+
+    # Prefix filter keeps only the "aa..." objects.
+    body = client.get("/api/artifacts/", params={"prefix": "aa"}).json()
+    assert body["total"] == 2
+    assert all(a["hash"].startswith("aa") for a in body["artifacts"])
+
+    # Pagination: limit caps the returned slice, total still counts all.
+    paged = client.get("/api/artifacts/", params={"prefix": "aa", "limit": 1}).json()
+    assert paged["total"] == 2
+    assert len(paged["artifacts"]) == 1
+
+
+# --------------------------------------------------------------------------- #
+# get
+# --------------------------------------------------------------------------- #
+
+
+def test_get_artifact_404_without_cas(restore_globals) -> None:
+    artifact_api.set_artifact_store(None)  # type: ignore[arg-type]
+    assert _client().get("/api/artifacts/somehash").status_code == 404
+
+
+def test_get_artifact_404_when_missing(restore_globals, cas: _FakeCAS) -> None:
+    artifact_api.set_artifact_store(cas)  # type: ignore[arg-type]
+    assert _client().get("/api/artifacts/absent").status_code == 404
+
+
+def test_get_artifact_with_related_merkle_nodes(restore_globals, cas: _FakeCAS) -> None:
+    cas.put("h" * 64, b"data")
+    merkle = _FakeMerkle()
+    merkle.nodes["mn1"] = _MerkleNode("compute", {"content_hash": "h" * 64})
+    merkle.nodes["mn2"] = _MerkleNode("compute", {"content_hash": "other"})
+    artifact_api.set_artifact_store(cas)  # type: ignore[arg-type]
+    artifact_api.set_merkle_dag(merkle)  # type: ignore[arg-type]
+
+    body = _client().get(f"/api/artifacts/{'h' * 64}").json()
+    assert body["size_bytes"] == 4
+    assert [n["node_hash"] for n in body["related_merkle_nodes"]] == ["mn1"]
+
+
+# --------------------------------------------------------------------------- #
+# preview
+# --------------------------------------------------------------------------- #
+
+
+def test_preview_text(restore_globals, cas: _FakeCAS) -> None:
+    cas.put("t" * 64, b"hello world")
+    artifact_api.set_artifact_store(cas)  # type: ignore[arg-type]
+    body = _client().get(f"/api/artifacts/{'t' * 64}/preview").json()
+    assert body["type"] == "text"
+    assert body["preview"] == "hello world"
+
+
+def test_preview_binary_returns_hex(restore_globals, cas: _FakeCAS) -> None:
+    cas.put("b" * 64, b"\x00\x01\xff\xfe")
+    artifact_api.set_artifact_store(cas)  # type: ignore[arg-type]
+    body = _client().get(f"/api/artifacts/{'b' * 64}/preview").json()
+    assert body["type"] == "binary"
+    assert body["preview"] == "0001fffe"
+
+
+def test_preview_404s_and_500(restore_globals, cas: _FakeCAS, tmp_path) -> None:
+    artifact_api.set_artifact_store(None)  # type: ignore[arg-type]
+    assert _client().get("/api/artifacts/x/preview").status_code == 404  # no CAS
+
+    artifact_api.set_artifact_store(cas)  # type: ignore[arg-type]
+    assert _client().get("/api/artifacts/absent/preview").status_code == 404  # unknown
+
+    # Object known to CAS but the file vanished -> open() raises -> 500. We
+    # build a CAS whose get_object returns an object for a non-existent path.
+    class _GhostCAS(_FakeCAS):
+        def get_object(self, sha256: str):
+            return _CASObject(sha256=sha256, path=tmp_path / "gone.bin", size_bytes=10)
+
+    artifact_api.set_artifact_store(_GhostCAS(tmp_path / "objects"))  # type: ignore[arg-type]
+    assert _client().get("/api/artifacts/ghost/preview").status_code == 500
+
+
+# --------------------------------------------------------------------------- #
+# stats
+# --------------------------------------------------------------------------- #
+
+
+def test_stats_without_cas_returns_error(restore_globals) -> None:
+    artifact_api.set_artifact_store(None)  # type: ignore[arg-type]
+    assert "error" in _client().get("/api/artifacts/stats/summary").json()
+
+
+def test_stats_size_distribution(restore_globals, cas: _FakeCAS) -> None:
+    cas.put("aa" + "0" * 62, b"x")  # <1KB
+    cas.put("bb" + "1" * 62, b"y" * 2048)  # 1KB-1MB
+    artifact_api.set_artifact_store(cas)  # type: ignore[arg-type]
+
+    body = _client().get("/api/artifacts/stats/summary").json()
+    assert body["total_objects"] == 2
+    assert body["size_distribution"]["<1KB"] == 1
+    assert body["size_distribution"]["1KB-1MB"] == 1
+
+
+def test_create_router_requires_fastapi(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(artifact_api, "FASTAPI_AVAILABLE", False)
+    with pytest.raises(ImportError, match="FastAPI is required"):
+        artifact_api.create_artifact_router()

--- a/tests/dashboard/test_artifact_preview.py
+++ b/tests/dashboard/test_artifact_preview.py
@@ -1,0 +1,218 @@
+"""Behavioral coverage for ``dashboard.artifact_preview``.
+
+Covers the pure ``detect_content_type`` (extension map, mimetypes fallback,
+and magic-byte sniffing) plus the preview router (meta/raw/thumbnail/text)
+driven via ``TestClient`` against a fake CAS whose objects are real
+``tmp_path`` files. Thumbnail generation uses Pillow (a core dependency).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Optional
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from transformation_portal.dashboard import artifact_preview
+from transformation_portal.dashboard.artifact_preview import detect_content_type
+
+
+class _FakeCAS:
+    def __init__(self) -> None:
+        self._paths: dict[str, Path] = {}
+
+    def put(self, hash: str, path: Path) -> None:
+        self._paths[hash] = path
+
+    def get_object(self, hash: str):
+        path = self._paths.get(hash)
+        return SimpleNamespace(path=path) if path is not None else None
+
+
+@pytest.fixture
+def cas() -> _FakeCAS:
+    return _FakeCAS()
+
+
+@pytest.fixture
+def client(cas: _FakeCAS):
+    original = artifact_preview._global_cas
+    artifact_preview.set_preview_cas(cas)  # type: ignore[arg-type]
+    app = FastAPI()
+    app.include_router(artifact_preview.create_preview_router())
+    try:
+        yield TestClient(app)
+    finally:
+        artifact_preview.set_preview_cas(original)  # type: ignore[arg-type]
+
+
+def _png_bytes() -> bytes:
+    import io
+
+    from PIL import Image
+
+    buf = io.BytesIO()
+    Image.new("RGB", (4, 4), (10, 20, 30)).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+# --------------------------------------------------------------------------- #
+# detect_content_type
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("a.png", "image/png"),
+        ("a.glb", "model/gltf-binary"),
+        ("a.json", "application/json"),
+        ("a.bin", "application/octet-stream"),
+    ],
+)
+def test_detect_by_extension(name: str, expected: str) -> None:
+    assert detect_content_type(Path(name)) == expected
+
+
+def test_detect_by_mimetypes_fallback() -> None:
+    # ".html" is not in MIME_EXTENSIONS, so mimetypes resolves it.
+    assert detect_content_type(Path("page.html")) == "text/html"
+
+
+@pytest.mark.parametrize(
+    ("data", "expected"),
+    [
+        (b"\x89PNG\r\n\x1a\n", "image/png"),
+        (b"\xff\xd8\xff", "image/jpeg"),
+        (b"GIF89a", "image/gif"),
+        (b"RIFF\x00\x00\x00\x00WEBP", "image/webp"),
+        (b"glTF\x02\x00", "model/gltf-binary"),
+        (b'{"k":1}', "application/json"),
+        (b"\x00\x01\x02\x03", "application/octet-stream"),
+    ],
+)
+def test_detect_by_magic_bytes(data: bytes, expected: str) -> None:
+    # Unknown extension forces the magic-byte path.
+    assert detect_content_type(Path("blob.dat"), data) == expected
+
+
+def test_detect_json_leading_but_undecodable_falls_back(tmp_path) -> None:
+    assert detect_content_type(Path("blob.dat"), b"{\xff\xfe") == "application/octet-stream"
+
+
+# --------------------------------------------------------------------------- #
+# meta
+# --------------------------------------------------------------------------- #
+
+
+def test_meta_404_when_unknown(client: TestClient) -> None:
+    assert client.get("/api/preview/artifact/ghost/meta").status_code == 404
+
+
+def test_meta_404_when_file_missing(client: TestClient, cas: _FakeCAS, tmp_path) -> None:
+    cas.put("h", tmp_path / "missing.png")
+    assert client.get("/api/preview/artifact/h/meta").status_code == 404
+
+
+def test_meta_for_image(client: TestClient, cas: _FakeCAS, tmp_path) -> None:
+    f = tmp_path / "img.png"
+    f.write_bytes(_png_bytes())
+    cas.put("img", f)
+    body = client.get("/api/preview/artifact/img/meta").json()
+    assert body["content_type"] == "image/png"
+    assert body["is_image"] is True
+    assert body["previewable"] is True
+    assert body["is_3d"] is False
+
+
+def test_meta_for_text(client: TestClient, cas: _FakeCAS, tmp_path) -> None:
+    f = tmp_path / "notes.txt"
+    f.write_text("hi")
+    cas.put("txt", f)
+    body = client.get("/api/preview/artifact/txt/meta").json()
+    assert body["is_text"] is True
+
+
+# --------------------------------------------------------------------------- #
+# raw / thumbnail / text
+# --------------------------------------------------------------------------- #
+
+
+def test_raw_streams_file(client: TestClient, cas: _FakeCAS, tmp_path) -> None:
+    f = tmp_path / "data.bin"
+    f.write_bytes(b"payload")
+    cas.put("raw", f)
+    resp = client.get("/api/preview/artifact/raw/raw")
+    assert resp.status_code == 200
+    assert resp.content == b"payload"
+
+
+def test_raw_404_when_unknown(client: TestClient) -> None:
+    assert client.get("/api/preview/artifact/ghost/raw").status_code == 404
+
+
+def test_thumbnail_success_for_image(client: TestClient, cas: _FakeCAS, tmp_path) -> None:
+    f = tmp_path / "img.png"
+    f.write_bytes(_png_bytes())
+    cas.put("img", f)
+    resp = client.get("/api/preview/artifact/img/thumbnail", params={"size": 8})
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "image/png"
+
+
+def test_thumbnail_rejects_non_image(client: TestClient, cas: _FakeCAS, tmp_path) -> None:
+    f = tmp_path / "notes.txt"
+    f.write_text("hi")
+    cas.put("txt", f)
+    assert client.get("/api/preview/artifact/txt/thumbnail").status_code == 400
+
+
+def test_thumbnail_corrupt_image_returns_500(client: TestClient, cas: _FakeCAS, tmp_path) -> None:
+    # .png extension routes into the image branch, but the bytes are not a
+    # valid image, so PIL raises -> 500.
+    f = tmp_path / "broken.png"
+    f.write_bytes(b"not really a png")
+    cas.put("broken", f)
+    assert client.get("/api/preview/artifact/broken/thumbnail").status_code == 500
+
+
+def test_thumbnail_404_when_unknown(client: TestClient) -> None:
+    assert client.get("/api/preview/artifact/ghost/thumbnail").status_code == 404
+
+
+def test_text_success(client: TestClient, cas: _FakeCAS, tmp_path) -> None:
+    f = tmp_path / "notes.txt"
+    f.write_text("line one")
+    cas.put("txt", f)
+    body = client.get("/api/preview/artifact/txt/text").json()
+    assert body["content"] == "line one"
+    assert body["truncated"] is False
+
+
+def test_text_rejects_binary(client: TestClient, cas: _FakeCAS, tmp_path) -> None:
+    f = tmp_path / "blob.bin"
+    f.write_bytes(b"\xff\xfe\x00\x01")
+    cas.put("blob", f)
+    assert client.get("/api/preview/artifact/blob/text").status_code == 400
+
+
+def test_text_404_when_unknown(client: TestClient) -> None:
+    assert client.get("/api/preview/artifact/ghost/text").status_code == 404
+
+
+def test_preview_viewer_serves_html(client: TestClient) -> None:
+    resp = client.get("/api/preview/")
+    assert resp.status_code == 200
+    assert "<html" in resp.text.lower()
+
+
+def test_create_router_requires_fastapi(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(artifact_preview, "FASTAPI_AVAILABLE", False)
+    with pytest.raises(ImportError, match="FastAPI is required"):
+        artifact_preview.create_preview_router()

--- a/tests/dashboard/test_dag_api.py
+++ b/tests/dashboard/test_dag_api.py
@@ -1,0 +1,174 @@
+"""Behavioral coverage for ``dashboard.dag_api``.
+
+Drives the DAG/Merkle visualization router via ``TestClient`` against fake
+scheduler and Merkle DAG stand-ins (injected through the module setters) so
+both the configured and not-configured branches of every route are exercised
+offline.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from transformation_portal.dashboard import dag_api
+
+
+class _FakeScheduler:
+    def __init__(self) -> None:
+        self.nodes: dict = {}
+        self.results: dict = {}
+
+    def add(self, node_id, *, priority=0, deps=(), gpu=False, gpu_memory_mb=0):
+        self.nodes[node_id] = SimpleNamespace(
+            priority=priority,
+            deps=list(deps),
+            resources=SimpleNamespace(gpu=gpu, gpu_memory_mb=gpu_memory_mb),
+        )
+
+    def get_execution_order(self):
+        return list(self.nodes)
+
+
+class _MerkleNode:
+    def __init__(self, h, *, inputs=(), outputs=None, metadata=None, node_type="compute", timestamp="t0"):
+        self.hash = h
+        self.node_type = node_type
+        self.inputs = list(inputs)
+        self.outputs = outputs or {}
+        self.metadata = metadata or {}
+        self.timestamp = timestamp
+
+
+class _FakeMerkle:
+    def __init__(self) -> None:
+        self.nodes: dict = {}
+
+    def get_node(self, h):
+        return self.nodes.get(h)
+
+    def get_lineage(self, h, max_depth=10):
+        node = self.nodes.get(h)
+        return [node] if node else []
+
+    def summary(self):
+        return {"node_count": len(self.nodes)}
+
+
+@pytest.fixture
+def restore_globals():
+    orig_s, orig_m = dag_api._global_scheduler, dag_api._global_merkle_dag
+    yield
+    dag_api.set_scheduler(orig_s)  # type: ignore[arg-type]
+    dag_api.set_merkle_dag(orig_m)  # type: ignore[arg-type]
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    app.include_router(dag_api.create_dag_router())
+    return TestClient(app)
+
+
+# --------------------------------------------------------------------------- #
+# /graph
+# --------------------------------------------------------------------------- #
+
+
+def test_graph_without_scheduler_returns_error(restore_globals) -> None:
+    dag_api.set_scheduler(None)  # type: ignore[arg-type]
+    body = _client().get("/api/dag/graph").json()
+    assert body["nodes"] == [] and body["edges"] == []
+    assert "error" in body
+
+
+def test_graph_with_scheduler(restore_globals) -> None:
+    sched = _FakeScheduler()
+    sched.add("a", priority=-3, deps=[], gpu=False)
+    sched.add("b", priority=-1, deps=["a"], gpu=True, gpu_memory_mb=2048)
+    sched.results = {"a": {"score": 0.7}}
+    dag_api.set_scheduler(sched)  # type: ignore[arg-type]
+
+    body = _client().get("/api/dag/graph").json()
+    ids = {n["id"]: n for n in body["nodes"]}
+    assert ids["a"]["status"] == "completed"  # in results
+    assert ids["a"]["priority"] == 3  # negated back to original
+    assert ids["a"]["score"] == 0.7
+    assert ids["b"]["status"] == "pending"
+    assert ids["b"]["resources"]["gpu"] is True
+    assert {"source": "a", "target": "b"} in body["edges"]
+    assert body["execution_order"] == ["a", "b"]
+
+
+# --------------------------------------------------------------------------- #
+# /merkle
+# --------------------------------------------------------------------------- #
+
+
+def test_merkle_graph_without_dag_returns_error(restore_globals) -> None:
+    dag_api.set_merkle_dag(None)  # type: ignore[arg-type]
+    body = _client().get("/api/dag/merkle").json()
+    assert body["nodes"] == [] and "error" in body
+
+
+def test_merkle_graph_with_dag(restore_globals) -> None:
+    merkle = _FakeMerkle()
+    merkle.nodes["h1"] = _MerkleNode("h1")
+    merkle.nodes["h2"] = _MerkleNode("h2", inputs=["h1"])
+    dag_api.set_merkle_dag(merkle)  # type: ignore[arg-type]
+
+    body = _client().get("/api/dag/merkle").json()
+    assert {n["id"] for n in body["nodes"]} == {"h1", "h2"}
+    assert {"source": "h1", "target": "h2"} in body["edges"]
+    assert body["summary"] == {"node_count": 2}
+
+
+def test_merkle_node_detail_and_404s(restore_globals) -> None:
+    merkle = _FakeMerkle()
+    merkle.nodes["h1"] = _MerkleNode("h1", inputs=["seed"], outputs={"x": 1})
+    dag_api.set_merkle_dag(merkle)  # type: ignore[arg-type]
+    client = _client()
+
+    found = client.get("/api/dag/merkle/h1").json()
+    assert found["hash"] == "h1"
+    assert found["inputs"] == ["seed"]
+
+    assert client.get("/api/dag/merkle/ghost").status_code == 404
+
+    dag_api.set_merkle_dag(None)  # type: ignore[arg-type]
+    assert _client().get("/api/dag/merkle/h1").status_code == 404
+
+
+def test_merkle_lineage_and_404s(restore_globals) -> None:
+    merkle = _FakeMerkle()
+    merkle.nodes["h1"] = _MerkleNode("h1")
+    dag_api.set_merkle_dag(merkle)  # type: ignore[arg-type]
+    client = _client()
+
+    body = client.get("/api/dag/merkle/h1/lineage").json()
+    assert body["target"] == "h1"
+    assert body["depth"] == 1
+
+    assert client.get("/api/dag/merkle/ghost/lineage").status_code == 404  # empty lineage
+
+    dag_api.set_merkle_dag(None)  # type: ignore[arg-type]
+    assert _client().get("/api/dag/merkle/h1/lineage").status_code == 404
+
+
+def test_setters_mutate_globals(restore_globals) -> None:
+    s, m = _FakeScheduler(), _FakeMerkle()
+    dag_api.set_scheduler(s)  # type: ignore[arg-type]
+    dag_api.set_merkle_dag(m)  # type: ignore[arg-type]
+    assert dag_api._global_scheduler is s
+    assert dag_api._global_merkle_dag is m
+
+
+def test_create_router_requires_fastapi(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(dag_api, "FASTAPI_AVAILABLE", False)
+    with pytest.raises(ImportError, match="FastAPI is required"):
+        dag_api.create_dag_router()

--- a/tests/dashboard/test_dag_editor_api.py
+++ b/tests/dashboard/test_dag_editor_api.py
@@ -1,0 +1,98 @@
+"""Behavioral coverage for ``dashboard.dag_editor_api``.
+
+Drives the pipeline-editor CRUD router via ``TestClient`` against a
+``tmp_path`` pipelines directory (set with ``set_pipelines_dir``). Covers the
+save/get/list/delete round-trip, pydantic node/edge coercion, the node-types
+catalog, and the security-relevant name-validation rejection path.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from transformation_portal.dashboard import dag_editor_api
+
+
+@pytest.fixture
+def client(tmp_path):
+    original = dag_editor_api._pipelines_dir
+    dag_editor_api.set_pipelines_dir(tmp_path / "pipelines")
+    app = FastAPI()
+    app.include_router(dag_editor_api.create_dag_editor_router())
+    try:
+        yield TestClient(app)
+    finally:
+        dag_editor_api.set_pipelines_dir(original)
+
+
+def _pipeline_payload() -> dict:
+    return {
+        "nodes": [{"id": "n1", "label": "Ingest", "type": "ingest", "position": {"x": 0.0, "y": 0.0}}],
+        "edges": [{"id": "e1", "source": "n1", "target": "n2"}],
+        "metadata": {"author": "test"},
+    }
+
+
+def test_save_get_list_delete_roundtrip(client: TestClient) -> None:
+    # Save
+    save = client.post("/api/editor/pipelines/demo", json=_pipeline_payload())
+    assert save.status_code == 200
+    assert save.json() == {"status": "ok", "name": "demo"}
+
+    # Get returns the persisted definition with name overridden from the URL.
+    got = client.get("/api/editor/pipelines/demo").json()
+    assert got["name"] == "demo"
+    assert len(got["nodes"]) == 1
+    assert got["nodes"][0]["id"] == "n1"
+
+    # List reflects the saved pipeline with computed counts.
+    listing = client.get("/api/editor/pipelines").json()["pipelines"]
+    entry = next(p for p in listing if p["name"] == "demo")
+    assert entry["node_count"] == 1
+    assert entry["edge_count"] == 1
+
+    # Delete then 404 on subsequent fetch.
+    assert client.delete("/api/editor/pipelines/demo").json() == {"status": "ok"}
+    assert client.get("/api/editor/pipelines/demo").status_code == 404
+
+
+def test_get_unknown_pipeline_404(client: TestClient) -> None:
+    assert client.get("/api/editor/pipelines/nope").status_code == 404
+
+
+def test_delete_unknown_pipeline_404(client: TestClient) -> None:
+    assert client.delete("/api/editor/pipelines/nope").status_code == 404
+
+
+def test_list_empty(client: TestClient) -> None:
+    assert client.get("/api/editor/pipelines").json() == {"pipelines": []}
+
+
+def test_node_types_catalog(client: TestClient) -> None:
+    body = client.get("/api/editor/node-types").json()
+    types = {nt["type"] for nt in body["node_types"]}
+    assert "ingest" in types
+
+
+def test_invalid_pipeline_name_rejected(client: TestClient) -> None:
+    # A traversal-style name must be rejected by validation, not written.
+    resp = client.get("/api/editor/pipelines/..%2F..%2Fetc")
+    assert resp.status_code in (400, 404)  # 400 from validation; 404 if router declines the path
+
+
+def test_save_rejects_invalid_name(client: TestClient) -> None:
+    resp = client.post("/api/editor/pipelines/bad name!", json=_pipeline_payload())
+    assert resp.status_code == 400
+
+
+def test_save_coerces_empty_node_and_edge_lists(client: TestClient) -> None:
+    resp = client.post("/api/editor/pipelines/empty", json={"nodes": [], "edges": []})
+    assert resp.status_code == 200
+    got = client.get("/api/editor/pipelines/empty").json()
+    assert got["nodes"] == []
+    assert got["edges"] == []

--- a/tests/dashboard/test_execution_api.py
+++ b/tests/dashboard/test_execution_api.py
@@ -1,0 +1,169 @@
+"""Behavioral coverage for ``dashboard.execution_api``.
+
+Drives the execution router via ``TestClient`` against an injected
+``ExecutionManager`` (set with ``set_manager``). Run state is created directly
+through ``prepare_run`` so the run/list/cancel endpoints are exercised without
+spinning real background tasks; the run endpoint's launch is stubbed for the
+success path and forced to fail for the 500 path. Also covers ``broadcast``
+fan-out, the manager accessor, and the WebSocket ping/pong.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from transformation_portal.dashboard import execution_api
+from transformation_portal.dashboard.execution_manager import ExecutionManager, RunStatus
+
+
+@pytest.fixture(autouse=True)
+def reset_clients():
+    execution_api._websocket_clients.clear()
+    yield
+    execution_api._websocket_clients.clear()
+
+
+@pytest.fixture
+def manager() -> ExecutionManager:
+    mgr = ExecutionManager()
+    execution_api.set_manager(mgr)
+    return mgr
+
+
+@pytest.fixture
+def client(manager: ExecutionManager) -> TestClient:
+    app = FastAPI()
+    app.include_router(execution_api.create_execution_router())
+    return TestClient(app)
+
+
+def _pipeline() -> Dict[str, Any]:
+    return {"nodes": [{"id": "a", "type": "passthrough"}], "edges": []}
+
+
+# --------------------------------------------------------------------------- #
+# manager accessor + broadcast
+# --------------------------------------------------------------------------- #
+
+
+def test_get_manager_lazily_creates_then_set_overrides() -> None:
+    execution_api.set_manager(None)  # type: ignore[arg-type]
+    created = execution_api.get_manager()
+    assert isinstance(created, ExecutionManager)
+    assert execution_api.get_manager() is created  # stable
+
+    replacement = ExecutionManager()
+    execution_api.set_manager(replacement)
+    assert execution_api.get_manager() is replacement
+
+
+async def test_broadcast_prunes_disconnected_clients() -> None:
+    sent: List[Dict[str, Any]] = []
+
+    class _Good:
+        async def send_json(self, msg):
+            sent.append(msg)
+
+    class _Bad:
+        async def send_json(self, msg):
+            raise RuntimeError("closed")
+
+    good, bad = _Good(), _Bad()
+    execution_api._websocket_clients.extend([good, bad])
+    await execution_api.broadcast({"type": "tick"})
+
+    assert sent == [{"type": "tick"}]
+    assert bad not in execution_api._websocket_clients
+    assert good in execution_api._websocket_clients
+
+
+# --------------------------------------------------------------------------- #
+# /run
+# --------------------------------------------------------------------------- #
+
+
+def test_run_accepts_and_returns_run_id(client: TestClient, manager: ExecutionManager, monkeypatch) -> None:
+    class _FakeTask:
+        def get_name(self) -> str:
+            return "fake-task"
+
+    monkeypatch.setattr(manager, "start_pipeline_background", lambda *a, **k: _FakeTask())
+
+    resp = client.post("/api/exec/run", json=_pipeline())
+    assert resp.status_code == 202
+    body = resp.json()
+    assert body["status"] == "accepted"
+    assert isinstance(body["run_id"], str) and body["run_id"]
+
+
+def test_run_launch_failure_returns_500(client: TestClient, manager: ExecutionManager, monkeypatch) -> None:
+    def _boom(*a, **k):
+        raise RuntimeError("cannot start")
+
+    monkeypatch.setattr(manager, "start_pipeline_background", _boom)
+    assert client.post("/api/exec/run", json=_pipeline()).status_code == 500
+
+
+# --------------------------------------------------------------------------- #
+# /runs + /runs/{id} + cancel
+# --------------------------------------------------------------------------- #
+
+
+def test_list_runs(client: TestClient, manager: ExecutionManager) -> None:
+    manager.prepare_run("r1", _pipeline())
+    runs = client.get("/api/exec/runs").json()["runs"]
+    assert any(r["run_id"] == "r1" for r in runs)
+
+
+def test_get_run_detail_and_404(client: TestClient, manager: ExecutionManager) -> None:
+    manager.prepare_run("r1", _pipeline())
+    body = client.get("/api/exec/runs/r1").json()
+    assert body["run_id"] == "r1"
+    assert body["status"] == RunStatus.PENDING.value
+    assert "a" in body["nodes"]
+
+    assert client.get("/api/exec/runs/ghost").status_code == 404
+
+
+def test_cancel_pending_run_returns_202(client: TestClient, manager: ExecutionManager) -> None:
+    manager.prepare_run("r1", _pipeline())
+    resp = client.post("/api/exec/runs/r1/cancel")
+    assert resp.status_code == 202
+    assert resp.json()["status"] == "cancelling"
+
+
+def test_cancel_terminal_run_returns_200(client: TestClient, manager: ExecutionManager) -> None:
+    manager.prepare_run("r1", _pipeline())
+    manager.get_run_state("r1").status = RunStatus.COMPLETE
+    resp = client.post("/api/exec/runs/r1/cancel")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "complete"
+
+
+def test_cancel_unknown_run_404(client: TestClient) -> None:
+    assert client.post("/api/exec/runs/ghost/cancel").status_code == 404
+
+
+# --------------------------------------------------------------------------- #
+# UI + WebSocket
+# --------------------------------------------------------------------------- #
+
+
+def test_execution_ui_serves_html(client: TestClient) -> None:
+    resp = client.get("/api/exec/")
+    assert resp.status_code == 200
+    assert "<html" in resp.text.lower()
+
+
+def test_websocket_ping_pong(client: TestClient) -> None:
+    with client.websocket_connect("/api/exec/ws") as ws:
+        ws.send_text("ping")
+        assert ws.receive_text() == "pong"
+    assert len(execution_api._websocket_clients) == 0

--- a/tests/dashboard/test_experiment_api.py
+++ b/tests/dashboard/test_experiment_api.py
@@ -1,0 +1,216 @@
+"""Behavioral coverage for ``dashboard.experiment_api``.
+
+The experiment-tracking module pairs a pure SQLite-backed Python API
+(create/get/list experiments and runs, log metrics, complete runs) with a
+FastAPI router over it. These tests point the module-global DB path at a
+``tmp_path`` file and exercise both layers offline:
+
+- Python API: experiment + run CRUD, metric merge-on-update, the
+  missing-row metrics branch, and ``get_experiment`` miss
+- Router: list/create (incl. duplicate-name ``IntegrityError`` -> 400),
+  experiment detail + 404, run create/list + unknown-experiment 404,
+  metric logging + unknown-run 404, run completion + 404, the HTML UI route,
+  and the FastAPI-availability guard
+
+The DB path is restored after each test so no ``experiments.db`` leaks into
+the repo and tests stay isolated.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from transformation_portal.dashboard import experiment_api
+
+
+@pytest.fixture
+def db(tmp_path):
+    """Point the module DB at a tmp file with schema initialized."""
+    original = experiment_api._db_path
+    experiment_api.set_db_path(tmp_path / "exp.db")
+    experiment_api.init_db()
+    try:
+        yield
+    finally:
+        experiment_api.set_db_path(original)
+
+
+@pytest.fixture
+def client(db):
+    app = FastAPI()
+    app.include_router(experiment_api.create_experiment_router())
+    return TestClient(app)
+
+
+# --------------------------------------------------------------------------- #
+# Python API
+# --------------------------------------------------------------------------- #
+
+
+def test_create_get_and_list_experiments(db) -> None:
+    exp_id = experiment_api.create_experiment("alpha", description="first", tags=["t1", "t2"])
+    assert isinstance(exp_id, int)
+
+    exp = experiment_api.get_experiment(exp_id)
+    assert exp is not None
+    assert exp.name == "alpha"
+    assert exp.description == "first"
+    assert exp.tags == ["t1", "t2"]
+
+    experiment_api.create_experiment("beta")
+    names = {e.name for e in experiment_api.list_experiments()}
+    assert names == {"alpha", "beta"}
+
+
+def test_get_experiment_miss_returns_none(db) -> None:
+    assert experiment_api.get_experiment(9999) is None
+
+
+def test_run_lifecycle_create_metrics_complete(db) -> None:
+    exp_id = experiment_api.create_experiment("exp")
+    run_id = experiment_api.create_run(exp_id, name="r1", config={"lr": 0.1}, params={"seed": 7})
+
+    run = experiment_api.get_run(run_id)
+    assert run is not None
+    assert run.status == "running"
+    assert run.config == {"lr": 0.1}
+    assert run.params == {"seed": 7}
+    assert run.start_time is not None
+
+    experiment_api.log_metrics(run_id, {"acc": 0.5})
+    experiment_api.log_metrics(run_id, {"loss": 1.2})  # merges, not replaces
+    assert experiment_api.get_run(run_id).metrics == {"acc": 0.5, "loss": 1.2}
+
+    experiment_api.complete_run(run_id, status="failed")
+    completed = experiment_api.get_run(run_id)
+    assert completed.status == "failed"
+    assert completed.end_time is not None
+
+
+def test_list_runs_orders_and_scopes_by_experiment(db) -> None:
+    exp_a = experiment_api.create_experiment("a")
+    exp_b = experiment_api.create_experiment("b")
+    experiment_api.create_run(exp_a, name="a1")
+    experiment_api.create_run(exp_a, name="a2")
+    experiment_api.create_run(exp_b, name="b1")
+
+    a_runs = experiment_api.list_runs(exp_a)
+    assert {r.name for r in a_runs} == {"a1", "a2"}
+    assert [r.name for r in experiment_api.list_runs(exp_b)] == ["b1"]
+
+
+def test_get_run_miss_returns_none(db) -> None:
+    assert experiment_api.get_run(4242) is None
+
+
+def test_log_metrics_on_missing_run_is_noop(db) -> None:
+    # No row exists; the function must not raise (existing defaults to {}).
+    experiment_api.log_metrics(123, {"x": 1})
+    assert experiment_api.get_run(123) is None
+
+
+# --------------------------------------------------------------------------- #
+# Router
+# --------------------------------------------------------------------------- #
+
+
+def test_api_list_experiments_empty_then_populated(client: TestClient) -> None:
+    assert client.get("/api/experiments/").json() == {"experiments": []}
+
+    client.post("/api/experiments/", params={"name": "alpha"})
+    body = client.get("/api/experiments/").json()
+    assert [e["name"] for e in body["experiments"]] == ["alpha"]
+
+
+def test_api_create_experiment_duplicate_returns_400(client: TestClient) -> None:
+    first = client.post("/api/experiments/", params={"name": "dup"})
+    assert first.status_code == 200
+    second = client.post("/api/experiments/", params={"name": "dup"})
+    assert second.status_code == 400
+    assert "already exists" in second.json()["detail"]
+
+
+def test_api_get_experiment_detail_and_404(client: TestClient) -> None:
+    exp_id = client.post("/api/experiments/", params={"name": "withruns"}).json()["id"]
+    client.post(f"/api/experiments/{exp_id}/runs", json={"config": {}, "params": {}})
+
+    detail = client.get(f"/api/experiments/{exp_id}").json()
+    assert detail["name"] == "withruns"
+    assert detail["run_count"] == 1
+    assert len(detail["runs"]) == 1
+
+    assert client.get("/api/experiments/9999").status_code == 404
+
+
+def test_api_create_run_unknown_experiment_404(client: TestClient) -> None:
+    resp = client.post("/api/experiments/777/runs", json={"config": {}, "params": {}})
+    assert resp.status_code == 404
+
+
+def test_api_list_runs(client: TestClient) -> None:
+    exp_id = client.post("/api/experiments/", params={"name": "e"}).json()["id"]
+    client.post(f"/api/experiments/{exp_id}/runs", json={})
+    runs = client.get(f"/api/experiments/{exp_id}/runs").json()["runs"]
+    assert len(runs) == 1
+    assert runs[0]["status"] == "running"
+
+
+def test_api_log_metrics_success_and_404(client: TestClient) -> None:
+    exp_id = client.post("/api/experiments/", params={"name": "m"}).json()["id"]
+    run_id = client.post(f"/api/experiments/{exp_id}/runs", json={}).json()["id"]
+
+    ok = client.post(f"/api/experiments/runs/{run_id}/metrics", json={"acc": 0.9})
+    assert ok.status_code == 200
+    assert experiment_api.get_run(run_id).metrics == {"acc": 0.9}
+
+    assert client.post("/api/experiments/runs/999/metrics", json={"acc": 1}).status_code == 404
+
+
+def test_api_complete_run_success_and_404(client: TestClient) -> None:
+    exp_id = client.post("/api/experiments/", params={"name": "c"}).json()["id"]
+    run_id = client.post(f"/api/experiments/{exp_id}/runs", json={}).json()["id"]
+
+    ok = client.post(f"/api/experiments/runs/{run_id}/complete", params={"status": "completed"})
+    assert ok.status_code == 200
+    assert experiment_api.get_run(run_id).status == "completed"
+
+    assert client.post("/api/experiments/runs/999/complete").status_code == 404
+
+
+def test_router_startup_event_initializes_db(db) -> None:
+    # Driving the app through its lifespan context fires the router startup
+    # handler (init_db); the endpoint then responds without error.
+    app = FastAPI()
+    app.include_router(experiment_api.create_experiment_router())
+    with TestClient(app) as ctx_client:
+        assert ctx_client.get("/api/experiments/").status_code == 200
+
+
+def test_experiments_ui_serves_html(client: TestClient) -> None:
+    resp = client.get("/api/experiments/ui")
+    assert resp.status_code == 200
+    assert "text/html" in resp.headers["content-type"]
+    assert "<html" in resp.text.lower()
+
+
+def test_set_db_path_mutates_global(tmp_path) -> None:
+    original = experiment_api._db_path
+    target = tmp_path / "custom.db"
+    try:
+        experiment_api.set_db_path(target)
+        assert experiment_api._db_path == target
+    finally:
+        experiment_api.set_db_path(original)
+
+
+def test_create_router_requires_fastapi(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(experiment_api, "FASTAPI_AVAILABLE", False)
+    with pytest.raises(ImportError, match="FastAPI is required"):
+        experiment_api.create_experiment_router()

--- a/tests/dashboard/test_gpu_api.py
+++ b/tests/dashboard/test_gpu_api.py
@@ -1,0 +1,66 @@
+"""Behavioral coverage for ``dashboard.gpu_api``.
+
+In the core lane NVML/pynvml is unavailable, so these tests pin the
+NVML-absent behavior (the production default on non-GPU CI hosts): the
+stats helpers degrade to ``None``/empty, the status route reports
+unavailability, the stream emits the error frame, and the HTML/guard paths
+hold. GPU-present branches require real hardware and stay out of scope.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from transformation_portal.dashboard import gpu_api
+
+
+@pytest.fixture
+def client() -> TestClient:
+    app = FastAPI()
+    app.include_router(gpu_api.create_gpu_router())
+    return TestClient(app)
+
+
+def test_get_gpu_stats_none_when_nvml_unavailable() -> None:
+    # NVML is not initialized in core CI.
+    assert gpu_api.NVML_AVAILABLE is False
+    assert gpu_api.get_gpu_stats(0) is None
+
+
+def test_get_all_gpu_stats_empty_without_gpus() -> None:
+    assert gpu_api.get_all_gpu_stats() == []
+
+
+def test_status_reports_unavailable(client: TestClient) -> None:
+    body = client.get("/api/gpu/status").json()
+    assert body["available"] is False
+    assert "NVML" in body["message"]
+
+
+def test_stream_emits_error_frame_without_nvml(client: TestClient) -> None:
+    with client.websocket_connect("/api/gpu/stream") as ws:
+        frame = ws.receive_json()
+        assert frame == {"error": "NVML not available"}
+
+
+def test_gpu_dashboard_serves_html(client: TestClient) -> None:
+    resp = client.get("/api/gpu/")
+    assert resp.status_code == 200
+    assert "<html" in resp.text.lower()
+
+
+def test_gpu_dashboard_html_has_stream_wiring() -> None:
+    html = gpu_api.get_gpu_dashboard_html()
+    assert "/api/gpu/stream" in html
+    assert "websocket" in html.lower()
+
+
+def test_create_router_requires_fastapi(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(gpu_api, "FASTAPI_AVAILABLE", False)
+    with pytest.raises(ImportError, match="FastAPI is required"):
+        gpu_api.create_gpu_router()

--- a/tests/dashboard/test_node_api.py
+++ b/tests/dashboard/test_node_api.py
@@ -214,9 +214,7 @@ def test_artifact_info_success(client: TestClient, tmp_path: Path) -> None:
         (b"\x00\x01\x02\xff\xfe", "binary"),
     ],
 )
-def test_artifact_preview_content_type_matrix(
-    client: TestClient, tmp_path: Path, data: bytes, expected_type: str
-) -> None:
+def test_artifact_preview_content_type_matrix(client: TestClient, tmp_path: Path, data: bytes, expected_type: str) -> None:
     f = tmp_path / "blob"
     f.write_bytes(data)
     cas = _FakeCAS()
@@ -228,9 +226,7 @@ def test_artifact_preview_content_type_matrix(
     assert body["truncated"] is False
 
 
-def test_artifact_preview_json_leading_but_undecodable_falls_back_to_binary(
-    client: TestClient, tmp_path: Path
-) -> None:
+def test_artifact_preview_json_leading_but_undecodable_falls_back_to_binary(client: TestClient, tmp_path: Path) -> None:
     # Leading "{" routes into the JSON branch, but invalid UTF-8 makes the
     # decode raise -> the except: pass leaves it as binary with no preview.
     f = tmp_path / "bad.json"

--- a/tests/dashboard/test_node_api.py
+++ b/tests/dashboard/test_node_api.py
@@ -1,0 +1,320 @@
+"""Behavioral coverage for ``dashboard.node_api``.
+
+The node-inspection router exposes per-node detail/inputs/outputs/artifacts/logs,
+run summaries, and CAS-backed artifact info/preview/download. These tests drive
+it via ``TestClient`` against a real in-memory ``NodeStateStore`` (injected with
+``set_store``) and a fake ``ArtifactStore`` (injected with ``set_cas``), so every
+branch is exercised offline:
+
+- 404s when a node/run is absent on each detail endpoint
+- artifact listing with and without CAS metadata
+- log ``tail`` truncation
+- artifact info/preview/download: CAS-not-configured 503, missing-object 404,
+  missing-file 404, and the content-type sniffing matrix (PNG/JPEG/WEBP/JSON/
+  text/binary-hex) plus the read-failure 500 path
+- the HTML UI route and the FastAPI-availability guard
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from transformation_portal.dashboard import node_api
+from transformation_portal.dashboard.node_state_store import NodeStateStore, set_store
+
+
+@dataclass
+class _FakeCASObject:
+    sha256: str
+    path: Path
+    size_bytes: int
+
+
+class _FakeCAS:
+    """Minimal ArtifactStore stand-in exposing ``get_object``."""
+
+    def __init__(self) -> None:
+        self._objs: dict[str, _FakeCASObject] = {}
+
+    def add(self, sha256: str, path: Path, *, size_bytes: Optional[int] = None) -> None:
+        size = size_bytes if size_bytes is not None else (path.stat().st_size if path.exists() else 0)
+        self._objs[sha256] = _FakeCASObject(sha256=sha256, path=path, size_bytes=size)
+
+    def get_object(self, sha256: str) -> Optional[_FakeCASObject]:
+        return self._objs.get(sha256)
+
+
+@pytest.fixture
+def populated_store() -> NodeStateStore:
+    store = NodeStateStore()
+    store.init_run("run_1", ["ingest"])
+    store.set_status("run_1", "ingest", "complete")
+    store.update_inputs("run_1", "ingest", {"image": "in.png"})
+    store.update_outputs("run_1", "ingest", {"rgb": [1, 2, 3]})
+    store.add_log("run_1", "ingest", "loaded")
+    return store
+
+
+@pytest.fixture
+def client(populated_store: NodeStateStore):
+    """TestClient wired to a populated store; CAS reset to None per test."""
+    original_store = node_api.get_store()
+    original_cas = node_api._global_cas
+    set_store(populated_store)
+    node_api.set_cas(None)  # type: ignore[arg-type]
+
+    app = FastAPI()
+    app.include_router(node_api.create_node_inspection_router())
+    try:
+        yield TestClient(app)
+    finally:
+        set_store(original_store)
+        node_api.set_cas(original_cas)  # type: ignore[arg-type]
+
+
+# --------------------------------------------------------------------------- #
+# node detail endpoints
+# --------------------------------------------------------------------------- #
+
+
+def test_node_details_success(client: TestClient) -> None:
+    resp = client.get("/api/inspect/runs/run_1/nodes/ingest")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["node_id"] == "ingest"
+    assert body["status"] == "complete"
+    assert body["inputs"] == {"image": "in.png"}
+
+
+@pytest.mark.parametrize(
+    "suffix",
+    ["", "/inputs", "/outputs", "/artifacts", "/logs"],
+)
+def test_node_endpoints_404_for_unknown_node(client: TestClient, suffix: str) -> None:
+    resp = client.get(f"/api/inspect/runs/run_1/nodes/ghost{suffix}")
+    assert resp.status_code == 404
+
+
+def test_node_inputs_and_outputs(client: TestClient) -> None:
+    inputs = client.get("/api/inspect/runs/run_1/nodes/ingest/inputs").json()
+    assert inputs == {"node_id": "ingest", "inputs": {"image": "in.png"}}
+    outputs = client.get("/api/inspect/runs/run_1/nodes/ingest/outputs").json()
+    assert outputs == {"node_id": "ingest", "outputs": {"rgb": [1, 2, 3]}}
+
+
+def test_node_logs_respects_tail(client: TestClient) -> None:
+    store = node_api.get_store()
+    for i in range(5):
+        store.add_log("run_1", "ingest", f"line-{i}")
+    body = client.get("/api/inspect/runs/run_1/nodes/ingest/logs", params={"tail": 2}).json()
+    assert body["total_logs"] == 6  # 1 from fixture + 5
+    assert len(body["logs"]) == 2
+    assert body["logs"][-1].endswith("line-4")
+
+
+# --------------------------------------------------------------------------- #
+# artifacts (with / without CAS)
+# --------------------------------------------------------------------------- #
+
+
+def test_artifacts_without_cas_returns_bare_entries(client: TestClient) -> None:
+    node_api.get_store().add_artifact("run_1", "ingest", "depth", "sha-d")
+    body = client.get("/api/inspect/runs/run_1/nodes/ingest/artifacts").json()
+    assert body["artifacts"] == [{"name": "depth", "hash": "sha-d"}]
+
+
+def test_artifacts_with_cas_but_unknown_hash_stays_bare(client: TestClient) -> None:
+    # CAS is configured, but the artifact hash is not in it -> get_object None,
+    # so the entry is not enriched (exercises the `if obj:` false branch).
+    node_api.set_cas(_FakeCAS())  # type: ignore[arg-type]
+    node_api.get_store().add_artifact("run_1", "ingest", "depth", "sha-unknown")
+    body = client.get("/api/inspect/runs/run_1/nodes/ingest/artifacts").json()
+    assert body["artifacts"] == [{"name": "depth", "hash": "sha-unknown"}]
+
+
+def test_artifacts_with_cas_enriches_metadata(client: TestClient, tmp_path: Path) -> None:
+    artifact_file = tmp_path / "depth.bin"
+    artifact_file.write_bytes(b"xyz")
+    cas = _FakeCAS()
+    cas.add("sha-d", artifact_file)
+    node_api.set_cas(cas)  # type: ignore[arg-type]
+    node_api.get_store().add_artifact("run_1", "ingest", "depth", "sha-d")
+
+    entry = client.get("/api/inspect/runs/run_1/nodes/ingest/artifacts").json()["artifacts"][0]
+    assert entry["name"] == "depth"
+    assert entry["size_bytes"] == 3
+    assert entry["exists"] is True
+    assert entry["path"].endswith("depth.bin")
+
+
+# --------------------------------------------------------------------------- #
+# run summary
+# --------------------------------------------------------------------------- #
+
+
+def test_run_summary_success(client: TestClient) -> None:
+    body = client.get("/api/inspect/runs/run_1/summary").json()
+    assert body["run_id"] == "run_1"
+    node = body["nodes"]["ingest"]
+    assert node["has_inputs"] is True
+    assert node["has_outputs"] is True
+    assert node["log_count"] >= 1
+
+
+def test_run_summary_404_for_unknown_run(client: TestClient) -> None:
+    assert client.get("/api/inspect/runs/ghost/summary").status_code == 404
+
+
+# --------------------------------------------------------------------------- #
+# artifact info / preview / download
+# --------------------------------------------------------------------------- #
+
+
+def test_artifact_info_503_without_cas(client: TestClient) -> None:
+    resp = client.get("/api/inspect/artifact/sha-x")
+    assert resp.status_code == 503
+    assert resp.json()["detail"] == "CAS not configured"
+
+
+def test_artifact_info_404_when_missing(client: TestClient) -> None:
+    node_api.set_cas(_FakeCAS())  # type: ignore[arg-type]
+    assert client.get("/api/inspect/artifact/absent").status_code == 404
+
+
+def test_artifact_info_success(client: TestClient, tmp_path: Path) -> None:
+    f = tmp_path / "a.bin"
+    f.write_bytes(b"hello")
+    cas = _FakeCAS()
+    cas.add("sha-a", f)
+    node_api.set_cas(cas)  # type: ignore[arg-type]
+
+    body = client.get("/api/inspect/artifact/sha-a").json()
+    assert body["hash"] == "sha-a"
+    assert body["size_bytes"] == 5
+    assert body["exists"] is True
+
+
+@pytest.mark.parametrize(
+    ("data", "expected_type"),
+    [
+        (b"\x89PNG\r\n\x1a\n" + b"rest", "image/png"),
+        (b"\xff\xd8\xff\xe0" + b"jfif", "image/jpeg"),
+        (b"RIFF\x00\x00\x00\x00WEBPxxxx", "image/webp"),
+        (b'{"k": 1}', "application/json"),
+        (b"plain text body", "text/plain"),
+        (b"\x00\x01\x02\xff\xfe", "binary"),
+    ],
+)
+def test_artifact_preview_content_type_matrix(
+    client: TestClient, tmp_path: Path, data: bytes, expected_type: str
+) -> None:
+    f = tmp_path / "blob"
+    f.write_bytes(data)
+    cas = _FakeCAS()
+    cas.add("sha-blob", f)
+    node_api.set_cas(cas)  # type: ignore[arg-type]
+
+    body = client.get("/api/inspect/artifact/sha-blob/preview").json()
+    assert body["content_type"] == expected_type
+    assert body["truncated"] is False
+
+
+def test_artifact_preview_json_leading_but_undecodable_falls_back_to_binary(
+    client: TestClient, tmp_path: Path
+) -> None:
+    # Leading "{" routes into the JSON branch, but invalid UTF-8 makes the
+    # decode raise -> the except: pass leaves it as binary with no preview.
+    f = tmp_path / "bad.json"
+    f.write_bytes(b"{\xff\xfe\x00")
+    cas = _FakeCAS()
+    cas.add("sha-badjson", f)
+    node_api.set_cas(cas)  # type: ignore[arg-type]
+
+    body = client.get("/api/inspect/artifact/sha-badjson/preview").json()
+    assert body["content_type"] == "binary"
+    assert body["preview"] is None
+
+
+def test_artifact_preview_truncated_flag(client: TestClient, tmp_path: Path) -> None:
+    f = tmp_path / "big.txt"
+    f.write_bytes(b"a" * 100)
+    cas = _FakeCAS()
+    cas.add("sha-big", f)
+    node_api.set_cas(cas)  # type: ignore[arg-type]
+
+    body = client.get("/api/inspect/artifact/sha-big/preview", params={"max_bytes": 10}).json()
+    assert body["truncated"] is True
+
+
+def test_artifact_preview_503_and_404(client: TestClient) -> None:
+    assert client.get("/api/inspect/artifact/x/preview").status_code == 503  # no CAS
+    node_api.set_cas(_FakeCAS())  # type: ignore[arg-type]
+    assert client.get("/api/inspect/artifact/absent/preview").status_code == 404
+
+
+def test_artifact_preview_read_failure_returns_500(client: TestClient, tmp_path: Path) -> None:
+    cas = _FakeCAS()
+    # Object exists in CAS, but the backing file does not -> open() raises.
+    cas.add("sha-missing", tmp_path / "does_not_exist.bin", size_bytes=10)
+    node_api.set_cas(cas)  # type: ignore[arg-type]
+    assert client.get("/api/inspect/artifact/sha-missing/preview").status_code == 500
+
+
+def test_artifact_download_success(client: TestClient, tmp_path: Path) -> None:
+    f = tmp_path / "dl.bin"
+    f.write_bytes(b"payload")
+    cas = _FakeCAS()
+    cas.add("sha-dl", f)
+    node_api.set_cas(cas)  # type: ignore[arg-type]
+
+    resp = client.get("/api/inspect/artifact/sha-dl/download")
+    assert resp.status_code == 200
+    assert resp.content == b"payload"
+
+
+def test_artifact_download_503_404_and_missing_file(client: TestClient, tmp_path: Path) -> None:
+    assert client.get("/api/inspect/artifact/x/download").status_code == 503  # no CAS
+
+    cas = _FakeCAS()
+    node_api.set_cas(cas)  # type: ignore[arg-type]
+    assert client.get("/api/inspect/artifact/absent/download").status_code == 404  # unknown hash
+
+    cas.add("sha-gone", tmp_path / "gone.bin", size_bytes=5)  # object known, file absent
+    assert client.get("/api/inspect/artifact/sha-gone/download").status_code == 404
+
+
+# --------------------------------------------------------------------------- #
+# UI route + guards
+# --------------------------------------------------------------------------- #
+
+
+def test_inspection_ui_serves_html(client: TestClient) -> None:
+    resp = client.get("/api/inspect/")
+    assert resp.status_code == 200
+    assert "text/html" in resp.headers["content-type"]
+    assert "<html" in resp.text.lower()
+
+
+def test_set_cas_mutates_global() -> None:
+    original = node_api._global_cas
+    sentinel = _FakeCAS()
+    try:
+        node_api.set_cas(sentinel)  # type: ignore[arg-type]
+        assert node_api._global_cas is sentinel
+    finally:
+        node_api.set_cas(original)  # type: ignore[arg-type]
+
+
+def test_create_router_requires_fastapi(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(node_api, "FASTAPI_AVAILABLE", False)
+    with pytest.raises(ImportError, match="FastAPI is required"):
+        node_api.create_node_inspection_router()

--- a/tests/dashboard/test_optimization_api.py
+++ b/tests/dashboard/test_optimization_api.py
@@ -1,0 +1,119 @@
+"""Behavioral coverage for ``dashboard.optimization_api``.
+
+Covers the in-memory ``OptimizationJobManager`` (job create/get, broadcast
+wiring) and the optimization router's status/history/stop/list endpoints plus
+the start endpoint with the background optimizer stubbed out (the real
+optimizer pulls heavy eval dependencies and is out of scope here).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from transformation_portal.dashboard import optimization_api
+from transformation_portal.dashboard.optimization_api import OptimizationJobManager
+
+
+@pytest.fixture(autouse=True)
+def clear_jobs():
+    optimization_api.optimization_manager.jobs.clear()
+    yield
+    optimization_api.optimization_manager.jobs.clear()
+
+
+@pytest.fixture
+def client() -> TestClient:
+    app = FastAPI()
+    app.include_router(optimization_api.create_optimization_router())
+    return TestClient(app)
+
+
+# --------------------------------------------------------------------------- #
+# OptimizationJobManager
+# --------------------------------------------------------------------------- #
+
+
+def test_create_and_get_job() -> None:
+    mgr = OptimizationJobManager()
+    job = mgr.create_job("j1", max_iterations=5)
+    assert job.job_id == "j1"
+    assert job.max_iterations == 5
+    assert mgr.get_job("j1") is job
+    assert mgr.get_job("absent") is None
+
+
+async def test_broadcast_invokes_fn_when_set() -> None:
+    received = []
+    mgr = OptimizationJobManager()
+
+    async def sink(evt):
+        received.append(evt)
+
+    mgr.set_broadcast(sink)
+    await mgr._broadcast({"type": "x"})
+    assert received[-1] == {"type": "x"}
+
+
+async def test_broadcast_noop_without_fn() -> None:
+    mgr = OptimizationJobManager()
+    await mgr._broadcast({"type": "x"})  # must not raise
+
+
+# --------------------------------------------------------------------------- #
+# Router
+# --------------------------------------------------------------------------- #
+
+
+def test_start_optimization_creates_job(client: TestClient, monkeypatch) -> None:
+    # Stub the background optimizer so no heavy eval work runs.
+    async def _stub_run(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(optimization_api.optimization_manager, "run_optimization", _stub_run)
+
+    resp = client.post("/optimize/start", json={"max_iterations": 3})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "started"
+    assert body["job_id"] in optimization_api.optimization_manager.jobs
+
+
+def test_status_found_and_not_found(client: TestClient) -> None:
+    optimization_api.optimization_manager.create_job("known", max_iterations=2)
+    ok = client.get("/optimize/status/known").json()
+    assert ok["job_id"] == "known"
+    assert ok["max_iterations"] == 2
+
+    assert client.get("/optimize/status/ghost").json() == {"error": "Job not found"}
+
+
+def test_history_found_and_not_found(client: TestClient) -> None:
+    optimization_api.optimization_manager.create_job("known")
+    assert client.get("/optimize/history/known").json() == {"job_id": "known", "history": []}
+    assert client.get("/optimize/history/ghost").json() == {"error": "Job not found"}
+
+
+def test_stop_found_and_not_found(client: TestClient) -> None:
+    optimization_api.optimization_manager.create_job("known")
+    body = client.post("/optimize/stop/known").json()
+    assert body == {"job_id": "known", "status": "stopped"}
+    assert optimization_api.optimization_manager.get_job("known").status == "stopped"
+
+    assert client.post("/optimize/stop/ghost").json() == {"error": "Job not found"}
+
+
+def test_list_jobs(client: TestClient) -> None:
+    optimization_api.optimization_manager.create_job("a")
+    optimization_api.optimization_manager.create_job("b")
+    jobs = client.get("/optimize/jobs").json()["jobs"]
+    assert {j["job_id"] for j in jobs} == {"a", "b"}
+
+
+def test_create_router_returns_none_without_fastapi(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(optimization_api, "FASTAPI_AVAILABLE", False)
+    assert optimization_api.create_optimization_router() is None

--- a/tests/dashboard/test_rl_api.py
+++ b/tests/dashboard/test_rl_api.py
@@ -1,0 +1,59 @@
+"""Behavioral coverage for ``dashboard.rl_api``.
+
+Covers the torch-free surface of the RL optimization router: the
+action-listing and policy-config endpoints (backed by the pure
+``transformation_portal.rl.action_space`` / ``policy_guard`` modules), the
+job-start handshake, the unknown-job status path, and the FastAPI guard.
+The actual RL training that the start endpoint schedules requires torch and
+is intentionally not asserted here.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from transformation_portal.dashboard import rl_api
+
+
+@pytest.fixture
+def client() -> TestClient:
+    app = FastAPI()
+    app.include_router(rl_api.create_rl_api_router())
+    return TestClient(app)
+
+
+def test_list_actions(client: TestClient) -> None:
+    body = client.get("/rl/actions").json()
+    assert body["count"] > 0
+    first = body["actions"][0]
+    assert {"index", "node", "action_type", "params"} <= set(first)
+
+
+def test_get_policy_config(client: TestClient) -> None:
+    body = client.get("/rl/policy").json()
+    assert {"safe_actions", "risky_actions", "blocked_actions"} <= set(body)
+    assert isinstance(body["safe_actions"], list)
+
+
+def test_status_unknown_job(client: TestClient) -> None:
+    assert client.get("/rl/status/ghost").json() == {"error": "Job not found"}
+
+
+def test_optimize_returns_job_handshake(client: TestClient) -> None:
+    # The scheduled background task needs torch (absent in the core lane) and
+    # will fail closed; we only assert the synchronous handshake here.
+    resp = client.post("/rl/optimize", json={"max_iterations": 1})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "started"
+    assert isinstance(body["job_id"], str) and body["job_id"]
+
+
+def test_create_router_returns_none_without_fastapi(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(rl_api, "FASTAPI_AVAILABLE", False)
+    assert rl_api.create_rl_api_router() is None

--- a/tests/dashboard/test_server.py
+++ b/tests/dashboard/test_server.py
@@ -1,0 +1,171 @@
+"""Behavioral coverage for ``dashboard.server``.
+
+Covers the dashboard app factory and its event plumbing offline:
+
+- ``DashboardEvent.to_dict`` shape
+- ``broadcast_event`` history append + trim, with the no-event-loop path
+- ``_broadcast_to_clients`` fan-out and disconnected-client pruning
+- ``create_app`` routes: index HTML, ``/api/status``, ``/api/history`` limit,
+  ``/api/event`` POST, and the ``/ws`` WebSocket ping/pong + history-on-connect
+- ``DashboardServer`` construction + ``stop`` and the FastAPI guards
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+from fastapi.testclient import TestClient
+
+from transformation_portal.dashboard import server
+
+
+@pytest.fixture(autouse=True)
+def reset_state():
+    """Reset module-global client/history lists around each test."""
+    server._connected_clients.clear()
+    server._event_history.clear()
+    original_max = server._max_history
+    yield
+    server._connected_clients.clear()
+    server._event_history.clear()
+    server._max_history = original_max
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(server.create_app())
+
+
+# --------------------------------------------------------------------------- #
+# DashboardEvent + broadcast_event
+# --------------------------------------------------------------------------- #
+
+
+def test_dashboard_event_to_dict() -> None:
+    evt = server.DashboardEvent(event_type="eval", data={"score": 1}, source="node")
+    d = evt.to_dict()
+    assert d == {"type": "eval", "data": {"score": 1}, "timestamp": evt.timestamp, "source": "node"}
+
+
+def test_broadcast_event_appends_history() -> None:
+    server.broadcast_event("eval", {"score": 0.9}, source="q")
+    assert len(server._event_history) == 1
+    assert server._event_history[0].event_type == "eval"
+
+
+def test_broadcast_event_trims_history() -> None:
+    server._max_history = 3
+    for i in range(5):
+        server.broadcast_event("eval", {"i": i})
+    assert len(server._event_history) == 3
+    # Oldest entries dropped; the most recent survive.
+    assert [e.data["i"] for e in server._event_history] == [2, 3, 4]
+
+
+async def test_broadcast_to_clients_prunes_disconnected() -> None:
+    sent: List[str] = []
+
+    class _Good:
+        async def send_text(self, msg: str) -> None:
+            sent.append(msg)
+
+    class _Bad:
+        async def send_text(self, msg: str) -> None:
+            raise RuntimeError("closed")
+
+    good, bad = _Good(), _Bad()
+    server._connected_clients.extend([good, bad])
+
+    await server._broadcast_to_clients(server.DashboardEvent(event_type="x", data={}))
+
+    assert len(sent) == 1  # good client received
+    assert bad not in server._connected_clients  # failing client pruned
+    assert good in server._connected_clients
+
+
+async def test_broadcast_to_clients_noop_without_clients() -> None:
+    # No clients -> returns immediately without error.
+    await server._broadcast_to_clients(server.DashboardEvent(event_type="x", data={}))
+
+
+# --------------------------------------------------------------------------- #
+# HTTP routes
+# --------------------------------------------------------------------------- #
+
+
+def test_index_serves_html(client: TestClient) -> None:
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert "<html" in resp.text.lower()
+
+
+def test_status_endpoint(client: TestClient) -> None:
+    body = client.get("/api/status").json()
+    assert body["status"] == "running"
+    assert body["connected_clients"] == 0
+    assert body["event_history_size"] == 0
+
+
+def test_history_endpoint_respects_limit(client: TestClient) -> None:
+    for i in range(5):
+        server.broadcast_event("eval", {"i": i})
+    body = client.get("/api/history", params={"limit": 2}).json()
+    assert body["count"] == 2
+    assert [e["data"]["i"] for e in body["events"]] == [3, 4]
+
+
+def test_post_event_endpoint(client: TestClient) -> None:
+    resp = client.post("/api/event", params={"event_type": "progress"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert body["event"]["type"] == "progress"
+    assert len(server._event_history) == 1
+
+
+# --------------------------------------------------------------------------- #
+# WebSocket
+# --------------------------------------------------------------------------- #
+
+
+def test_websocket_ping_pong_and_history(client: TestClient) -> None:
+    # Seed one history event; it is replayed on connect.
+    server.broadcast_event("eval", {"score": 1})
+
+    with client.websocket_connect("/ws") as ws:
+        first = ws.receive_text()  # history replay
+        assert "eval" in first
+        ws.send_text("ping")
+        assert ws.receive_text() == "pong"
+    # After the context exits the client is pruned from the connection list.
+    assert len(server._connected_clients) == 0
+
+
+# --------------------------------------------------------------------------- #
+# DashboardServer + guards
+# --------------------------------------------------------------------------- #
+
+
+def test_dashboard_server_construct_and_stop() -> None:
+    srv = server.DashboardServer()
+    assert srv.app is not None
+    srv._server_thread = object()  # type: ignore[assignment]
+    srv.stop()
+    assert srv._should_stop is True
+    assert srv._server_thread is None
+
+
+def test_create_app_requires_fastapi(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(server, "FASTAPI_AVAILABLE", False)
+    with pytest.raises(ImportError, match="FastAPI is required"):
+        server.create_app()
+
+
+def test_dashboard_server_requires_fastapi(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(server, "FASTAPI_AVAILABLE", False)
+    with pytest.raises(ImportError, match="FastAPI is required"):
+        server.DashboardServer()

--- a/tests/test_check_per_package_branch_coverage.py
+++ b/tests/test_check_per_package_branch_coverage.py
@@ -164,6 +164,8 @@ def test_default_branch_floors_cover_cold_zone_and_durable_state_prefixes(script
         ("src/transformation_portal/dashboard/execution_manager.py", 75.0),
         ("src/transformation_portal/dashboard/time_travel.py", 90.0),
         ("src/transformation_portal/dashboard/studio_inspector.py", 80.0),
+        ("src/transformation_portal/dashboard/node_api.py", 90.0),
+        ("src/transformation_portal/dashboard/experiment_api.py", 90.0),
     )
 
 

--- a/tests/test_check_per_package_branch_coverage.py
+++ b/tests/test_check_per_package_branch_coverage.py
@@ -166,6 +166,16 @@ def test_default_branch_floors_cover_cold_zone_and_durable_state_prefixes(script
         ("src/transformation_portal/dashboard/studio_inspector.py", 80.0),
         ("src/transformation_portal/dashboard/node_api.py", 90.0),
         ("src/transformation_portal/dashboard/experiment_api.py", 90.0),
+        ("src/transformation_portal/dashboard/server.py", 66.0),
+        ("src/transformation_portal/dashboard/gpu_api.py", 36.0),
+        ("src/transformation_portal/dashboard/dag_api.py", 90.0),
+        ("src/transformation_portal/dashboard/artifact_api.py", 76.0),
+        ("src/transformation_portal/dashboard/artifact_preview.py", 85.0),
+        ("src/transformation_portal/dashboard/optimization_api.py", 72.0),
+        ("src/transformation_portal/dashboard/rl_api.py", 65.0),
+        ("src/transformation_portal/dashboard/dag_editor_api.py", 68.0),
+        ("src/transformation_portal/dashboard/execution_api.py", 72.0),
+        ("src/transformation_portal/dashboard/", 75.0),
     )
 
 

--- a/tests/test_check_per_package_coverage.py
+++ b/tests/test_check_per_package_coverage.py
@@ -424,6 +424,16 @@ class TestDefaultFloors:
             "src/transformation_portal/dashboard/studio_inspector.py": 82.0,
             "src/transformation_portal/dashboard/node_api.py": 92.0,
             "src/transformation_portal/dashboard/experiment_api.py": 92.0,
+            "src/transformation_portal/dashboard/server.py": 78.0,
+            "src/transformation_portal/dashboard/gpu_api.py": 55.0,
+            "src/transformation_portal/dashboard/dag_api.py": 88.0,
+            "src/transformation_portal/dashboard/artifact_api.py": 80.0,
+            "src/transformation_portal/dashboard/artifact_preview.py": 88.0,
+            "src/transformation_portal/dashboard/optimization_api.py": 65.0,
+            "src/transformation_portal/dashboard/rl_api.py": 80.0,
+            "src/transformation_portal/dashboard/dag_editor_api.py": 76.0,
+            "src/transformation_portal/dashboard/execution_api.py": 86.0,
+            "src/transformation_portal/dashboard/": 80.0,
         }
 
         assert floors == expected_floors

--- a/tests/test_check_per_package_coverage.py
+++ b/tests/test_check_per_package_coverage.py
@@ -422,6 +422,8 @@ class TestDefaultFloors:
             "src/transformation_portal/dashboard/execution_manager.py": 85.0,
             "src/transformation_portal/dashboard/time_travel.py": 90.0,
             "src/transformation_portal/dashboard/studio_inspector.py": 82.0,
+            "src/transformation_portal/dashboard/node_api.py": 92.0,
+            "src/transformation_portal/dashboard/experiment_api.py": 92.0,
         }
 
         assert floors == expected_floors


### PR DESCRIPTION
Extend the dashboard cold-zone fills to the two highest-value remaining route
modules, both driven through FastAPI TestClient with no app bootstrap, network,
or ML:

- node_api.py: per-node detail/inputs/outputs/artifacts/logs, run summary, and
  CAS-backed artifact info/preview/download. Tests use a real in-memory
  NodeStateStore (set_store) and a fake ArtifactStore (set_cas) to exercise the
  404/503 paths, log-tail truncation, and the full preview content-type matrix
  (PNG/JPEG/WEBP/JSON/text/binary-hex + read-failure 500). 98% line / 100%
  branch.
- experiment_api.py: SQLite-backed Python API (experiment/run CRUD, metric
  merge, completion) plus its router. Tests point the module DB path at a
  tmp_path file and cover the router 400 (duplicate name) / 404 paths and the
  startup hook. 98% line / 100% branch.

Adds 48 tests (114 total in tests/dashboard/, ~3s). File-level line floors land
in check_per_package_coverage.py, branch floors + dry-run prefixes in
check_per_package_branch_coverage.py, and the exact-list assertions in both
floor-script test suites are updated to match. COLD_ZONE_COVERAGE_PROGRAM.md
§19.1 gains two rows (now six dashboard files floored). Percentages are from an
isolated tests/dashboard/ run; confirm against the first green core-lane
coverage.xml before any upward ratchet.

https://claude.ai/code/session_01WgNjD1kzJFh4x1DtX6YbH3