### PR TITLE
ci(coverage): raise core global floor to 30

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -729,8 +729,8 @@ jobs:
             COV_FLAGS="--no-cov"
             echo "ML tier: coverage disabled for faster PR feedback"
           else
-            COV_FLAGS="--cov=src/transformation_portal --cov=src/tp --cov=lux_depth_v3 --cov=app --cov-report=term-missing --cov-report=xml --cov-report=html --cov-fail-under=25"
-            echo "Core tier: enforcing 25% minimum global coverage"
+            COV_FLAGS="--cov=src/transformation_portal --cov=src/tp --cov=lux_depth_v3 --cov=app --cov-report=term-missing --cov-report=xml --cov-report=html --cov-fail-under=30"
+            echo "Core tier: enforcing 30% minimum global coverage"
           fi
 
           # ML tier: add duration profiling for triage of slow tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -219,7 +219,8 @@ All pull requests must pass these automated gates before merge:
 ### 4. Coverage Gates and Targets
 
 #### Global Minimum
-- Combined coverage must stay **≥25%** (enforced via `coverage report --fail-under=25`)
+- Combined coverage must stay **≥30%** (enforced by the core `build.yml`
+  test leg via `--cov-fail-under=30`)
 - Coverage ratchet targets and current baseline evidence live in
   [`docs/testing/test_coverage_improvement_plan.md`](docs/testing/test_coverage_improvement_plan.md)
   and [`docs/testing/COLD_ZONE_COVERAGE_PROGRAM.md`](docs/testing/COLD_ZONE_COVERAGE_PROGRAM.md).
@@ -228,7 +229,7 @@ All pull requests must pass these automated gates before merge:
 - **New/changed lines should target 85%+ covered**
 - This is the primary local quality ratchet and PR-review signal.
 - Check it with `make coverage-diff`; required PR CI currently enforces the
-  global 25% floor and package/cold-zone checks in `build.yml`, not `diff-cover`.
+  global 30% floor and package/cold-zone checks in `build.yml`, not `diff-cover`.
 
 #### Critical Module Floors
 Future enforcement (not yet active):
@@ -304,7 +305,7 @@ pytest -v tests/ -m "not slow" \
   --cov-report=html
 
 # Check coverage threshold
-coverage report --fail-under=25
+coverage report --fail-under=30
 
 # Build package
 .venv/bin/python -m build

--- a/docs/governance/audit/PORTAL_AUDIT_2026-05-18_backlog.md
+++ b/docs/governance/audit/PORTAL_AUDIT_2026-05-18_backlog.md
@@ -69,7 +69,7 @@ Each item carries severity, effort, the files to touch, observable acceptance cr
 
 ## Tier 2 — Near term (target window: 2026-05-26 → 2026-06-16)
 
-> **Tier 2 status (2026-05-27):** all three items merged. One open follow-up remains on N-2 — flip `--cov-fail-under=25 → 30` once the cold-zone trigger in `docs/testing/COLD_ZONE_COVERAGE_PROGRAM.md` §17.2 is met (two consecutive main-branch core runs ≥ 35% combined coverage + clean `coverage-ml-sampled-*` artifact + no regressing PRs).
+> **Tier 2 status (2026-06-11):** all three items merged, and the N-2 follow-up is complete. `--cov-fail-under` is ratcheted from `25` to `30` after the cold-zone trigger in `docs/testing/COLD_ZONE_COVERAGE_PROGRAM.md` §17.2 was met (two consecutive main-branch core runs ≥ 35% combined coverage + clean `coverage-ml-sampled-*` artifact + no regressing PRs).
 
 ### N-1. Expand mypy whitelist by tranche
 
@@ -83,9 +83,9 @@ Each item carries severity, effort, the files to touch, observable acceptance cr
 - Each newly typed module passes `mypy --config-file=mypy.ini <path>` cleanly per the in-comment policy at `build.yml:565`.
 - `docs/ci/TYPE_CHECKING_POLICY.md` (referenced from the workflow comment) is updated with the new tranche and remaining backlog.
 
-### N-2. Add lightweight ML sampled coverage and raise the 25% core floor
+### N-2. Add lightweight ML sampled coverage and raise the core floor to 30%
 
-**Status:** Instrumentation landed in PR #1835 (`37a73dc7`) on 2026-05-25 — ML PR lane runs sampled `--cov` on `vlm` + `spatial_ai/segmentation`, uploaded as the `coverage-ml-sampled-*` artifact, non-blocking. The global `--cov-fail-under` ratchet from 25 → 30 is deferred until the trigger in `docs/testing/COLD_ZONE_COVERAGE_PROGRAM.md` §17.2 is met (two consecutive main-branch core runs ≥ 35% combined coverage + clean ML sampled artifact + no regressing PRs). A follow-up PR will flip the floor when evidence is in hand.
+**Status:** Done — instrumentation landed in PR #1835 (`37a73dc7`) on 2026-05-25, and the global `--cov-fail-under` ratchet from 25 → 30 landed on 2026-06-11 after the trigger in `docs/testing/COLD_ZONE_COVERAGE_PROGRAM.md` §17.2 was met. The ML PR lane runs sampled `--cov` on `vlm` + `spatial_ai/segmentation`, uploaded as the `coverage-ml-sampled-*` artifact, non-blocking.
 
 **Severity / Effort:** Medium / M
 **Tracks finding:** [#2](../PORTAL_AUDIT_REPO_WIDE_2026-05-18.md#61-code-quality-typing-and-test-enforcement) — fragmented coverage

--- a/docs/guides/coverage-improvement-plan.md
+++ b/docs/guides/coverage-improvement-plan.md
@@ -1,16 +1,16 @@
 # Coverage Improvement Plan
 
-**Current Status (as of 2026-02-04)**
+**Current Status (baseline captured 2026-02-04; gate ratcheted 2026-06-11)**
 - **Combined Coverage**: 25.44%
 - **Total Statements**: 24,820
 - **Covered Statements**: ~6,314 (24,820 × 0.2544)
-- **Baseline Gate**: 25% (prevents regression below this floor)
+- **Current Required PR Gate**: 30% (prevents regression below this floor)
 
 ## Historical Context
 
 The coverage baseline was previously set at 33% but this was aspirational rather than actual. After PR #832 fixed coverage artifact consolidation, we now have accurate combined coverage data from both core and ML test suites.
 
-**Why 25.44%?**
+**Why was the 2026-02-04 baseline 25.44%?**
 - Core tests focus on depth processing, material response, and rendering pipelines
 - ML tests cover model backends and inference paths
 - Many modules (plugins, streaming, style transfer, VLM) have 0% coverage
@@ -86,7 +86,7 @@ Low-priority modules (can defer):
 4. **Mock expensive operations**: File I/O, model inference, FFmpeg calls
 
 ### CI Integration
-- **Baseline gate** (`--fail-under=25`): Prevents regression
+- **Baseline gate** (`--cov-fail-under=30`): Prevents regression
 - **Diff coverage target** (`make coverage-diff`): Local PR-review signal for new code;
   not a required PR CI gate until `build.yml` wires in `diff-cover`
 - **Ratchet mechanism**: As coverage improves, baseline gate increases
@@ -142,7 +142,7 @@ make coverage-fast-scope
 
 **Q: What are the coverage targets?**
 - **Diff coverage**: 85% on new/changed lines (local target / future PR gate)
-- **Global floor**: 25% (required PR gate; prevents regression)
+- **Global floor**: 30% (required PR gate; prevents regression)
 - **Long-horizon target**: 70% overall
 
 See `docs/testing/test_coverage_improvement_plan.md` for the full phased plan.

--- a/docs/testing/COLD_ZONE_COVERAGE_PROGRAM.md
+++ b/docs/testing/COLD_ZONE_COVERAGE_PROGRAM.md
@@ -652,31 +652,31 @@ benchmark"` over the two test trees only — keeps the sample focused on
 the cold packages without re-running the full ML suite under tracing
 overhead.
 
-### 17.2 Global `--cov-fail-under` ratchet (deferred)
+### 17.2 Global `--cov-fail-under` ratchet (completed)
 
-The build.yml core lane currently sets `--cov-fail-under=25`. The
-audit's acceptance criterion is to ratchet that to `30` once the
-cold-zone baseline shows stable margin on the affected packages.
+The build.yml core lane now sets `--cov-fail-under=30`. The audit's
+acceptance criterion was to ratchet the floor from `25` to `30` once the
+cold-zone baseline showed stable margin on the affected packages.
 
-**Ratchet trigger (must hold before flipping):**
+**Ratchet trigger evidence (confirmed 2026-06-11 before flipping):**
 
-1. Two consecutive main-branch core CI runs report combined line
-   coverage ≥ 35% (a five-point margin over the new 30 floor).
-2. The `coverage-ml-sampled-*` artifact from a main-branch run shows
-   the ML-lane sampled packages above their existing per-package
-   floors (`vlm ≥ 69%` per §12.1, no regression on
-   `spatial_ai/segmentation`).
-3. No open PR is reducing the core lane's combined coverage.
-
-When all three hold, a follow-up PR flips
-`COV_FLAGS="... --cov-fail-under=30"` in build.yml and records the date
-the new floor took effect in §17.3 below.
+1. Two consecutive main-branch core CI runs reported combined line
+   coverage ≥ 35%: run `27345386028` at commit `0e384ba00` reported
+   `68.16%`, and run `27341933253` at commit `d47c24220` reported
+   `67.98%`.
+2. The `coverage-ml-sampled-*` artifact was generated successfully on
+   both sampled runs. VLM stayed above its floor (`78.7-79.2%` line
+   coverage against the `69%` floor), and
+   `spatial_ai/segmentation` was stable (`35.2-35.5%` line coverage).
+3. No open PR was reducing the core lane's combined coverage at the
+   verification point.
 
 ### 17.3 Ratchet history
 
 | Date | Floor before | Floor after | Trigger evidence |
 |---|---:|---:|---|
 | 2026-05-25 | 25 | 25 | N-2 instrumentation landed; ratchet awaiting two consecutive ≥35% main runs (see §17.2). |
+| 2026-06-11 | 25 | 30 | Runs `27345386028` (`0e384ba00`, 68.16%) and `27341933253` (`d47c24220`, 67.98%) met the two-run core margin; ML sampled artifacts generated successfully with VLM above floor and segmentation stable; no open regressing PRs. |
 
 ---
 

--- a/docs/testing/STRATEGY.md
+++ b/docs/testing/STRATEGY.md
@@ -29,7 +29,7 @@ This document defines the testing strategy for the Transformation Portal reposit
 | **CI Selection** | `(unit or security or regression or golden or integration) and not ml and not slow and not benchmark` |
 | **Duration** | < 2 minutes |
 | **Dependencies** | Standard library, numpy, PIL, pyyaml |
-| **Coverage Target** | 25% minimum for core modules |
+| **Coverage Target** | 30% minimum for core modules |
 
 **Note:** Per ADR-044, all tests must have a category marker. CI uses **positive marker selection** to explicitly select core test categories.
 
@@ -328,7 +328,7 @@ TP_RUN_BENCHMARKS=1 pytest -v tests/benchmarks/ -m "benchmark"
 
 | Tier | Minimum | Notes |
 |------|---------|-------|
-| Core tests | 20% | `--cov-fail-under=20` in build.yml |
+| Core tests | 30% | `--cov-fail-under=30` in build.yml |
 | ML tests | — | Coverage disabled for faster PR feedback |
 
 **Aspirational Per-Module Targets (Not Yet Enforced):**

--- a/docs/testing/test_coverage_improvement_plan.md
+++ b/docs/testing/test_coverage_improvement_plan.md
@@ -25,7 +25,7 @@ The repository has substantial test volume, but high-risk areas remain under-cov
 | Offline integration tests | pytest | Pass |
 | Contract tests | pytest | Pass |
 | Security boundary tests | pytest | Pass |
-| **Global floor** | coverage | ≥25% |
+| **Global floor** | coverage | ≥30% |
 
 ### Local / Review Targets (non-blocking today)
 
@@ -66,7 +66,7 @@ its `app.py` milestone targets below are actually enforced, not aspirational.
 
 ```bash
 # Enforced in required PR CI today
-coverage report --fail-under=25
+pytest ... --cov-fail-under=30
 
 # Local target / intended future PR gate
 make coverage-diff

--- a/tests/test_codebase_structure.py
+++ b/tests/test_codebase_structure.py
@@ -707,7 +707,7 @@ class TestRootGovernanceMetadata:
         testing_plan = (_repo_root / "docs" / "testing" / "test_coverage_improvement_plan.md").read_text()
         guide_plan = (_repo_root / "docs" / "guides" / "coverage-improvement-plan.md").read_text()
 
-        assert "coverage report --fail-under=25" in contributing
+        assert "--cov-fail-under=30" in contributing
         assert "**New/changed lines should target 85%+ covered**" in contributing
         assert "required PR CI currently enforces the" in contributing
         assert "`build.yml`, not `diff-cover`" in contributing


### PR DESCRIPTION
## Summary
- Completes the cold-zone N-2 capstone by raising the canonical `build.yml` core coverage floor from 25% to 30%.
- Records the two green main-branch core coverage runs and ML sampled evidence that satisfied the §17.2 trigger.

## Changes
- Updates the core `build.yml` pytest coverage flags to `--cov-fail-under=30` and aligns the emitted log text.
- Updates live contributor, testing, coverage-program, and audit guidance from the old 25% required PR floor to the new 30% floor.
- Updates the root governance metadata test assertion so docs keep tracking the active gate.

## Validation
Proven green:
- `./.venv/bin/pytest tests/test_validate_ci_config.py tests/test_codebase_structure.py -q`
- `./.venv/bin/pytest tests/test_check_per_package_coverage.py tests/test_check_per_package_branch_coverage.py -q`
- `make validate-ci`
- `make check-doc-heading-links`
- `git diff --check`
- `make ci-quick`
- `make pre-commit`

Still pending:
- Hosted `build.yml` on this PR must pass, since this change raises the canonical CI floor.

## Risk
- Bounded to the core coverage threshold and docs/tests that describe it; no package floors, selectors, routes, schemas, or ML-lane contracts change.
- Revert-safe: reverting restores the prior 25% floor and accompanying documentation text.