### PR TITLE
ci: add dedicated dependency-pinning-check workflow (TODO_INVENTORY §5.7)

### DIFF
--- a/.github/workflows/dependency-pinning-check.yml
+++ b/.github/workflows/dependency-pinning-check.yml
@@ -1,0 +1,46 @@
+name: Dependency Pinning Check
+
+# Dedicated, isolated signal for TODO_INVENTORY.md §5.7 (Dependency Pinning
+# Validation). The same check runs transitively inside `make ci`, but a
+# standalone workflow gives a focused pass/fail status that is independent of
+# the broader CI matrix and surfaces supply-chain drift quickly on PRs.
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - 'requirements/**'
+      - 'scripts/validation/check_dependency_pinning.py'
+      - '.github/workflows/dependency-pinning-check.yml'
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'requirements/**'
+      - 'scripts/validation/check_dependency_pinning.py'
+      - '.github/workflows/dependency-pinning-check.yml'
+
+# Cancel superseded runs on the same branch/PR to save CI minutes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-pinning:
+    name: Verify Exact (==) Version Pins
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          fetch-depth: 1
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: '3.11'
+
+      # The checker is standard-library only, so no dependency install is
+      # required — keep this job lean and fast.
+      - name: Verify requirements lockfiles use exact (==) pins
+        run: python scripts/validation/check_dependency_pinning.py

--- a/docs/analysis/TODO_INVENTORY.md
+++ b/docs/analysis/TODO_INVENTORY.md
@@ -1138,7 +1138,7 @@ GitHub UI → Settings → Branches → Branch protection rules → main
 
 ### 5.7 NEW: Dependency Pinning Validation
 
-**Status:** 🟡 **PARTIALLY IMPLEMENTED** (script + Make target landed 2026-05-03; CI workflow still TBD)
+**Status:** ✅ **IMPLEMENTED** (script + Make target landed 2026-05-03; dedicated CI workflow landed 2026-06-11)
 **Priority:** P2 (Medium)
 **Effort:** 4 hours (script: ~1h done; remaining: dedicated workflow)
 **Impact:** Supply chain security, reproducibility
@@ -1150,14 +1150,14 @@ GitHub UI → Settings → Branches → Branch protection rules → main
   (`constraints.txt` is exempt — it intentionally uses `>=` for banned packages)
 - ✅ Wired into `make ci` and exposed as `make check-dependency-pinning`
 - ✅ Tests in `tests/validation/test_check_dependency_pinning.py`
-- ❌ Standalone GitHub Actions workflow not yet created (covered transitively
-  by `make ci` jobs that already invoke the lock contract suite)
+- ✅ Standalone GitHub Actions workflow `dependency-pinning-check.yml` provides
+  an isolated PR/push signal (in addition to the transitive `make ci` coverage)
 
 **Proposed Implementation:**
 - [x] Validate all `requirements/*.txt` use `==` pinning (not `>=`, `~=`)
   via `scripts/validation/check_dependency_pinning.py`
 - [x] Wire into `make ci` so PR lanes catch drift
-- [ ] Create `.github/workflows/dependency-pinning-check.yml` for an isolated
+- [x] Create `.github/workflows/dependency-pinning-check.yml` for an isolated
   signal independent of the broader CI matrix
 - [ ] Validate constraints.txt matches installed versions
 - [ ] Check for floating transitive dependencies (separate analysis)
@@ -1172,11 +1172,13 @@ GitHub UI → Settings → Branches → Branch protection rules → main
 - `scripts/validation/check_dependency_pinning.py` (new)
 - `tests/validation/test_check_dependency_pinning.py` (new)
 - `Makefile` (`check-dependency-pinning` target + wired into `ci`)
-- `.github/workflows/dependency-pinning-check.yml` (still pending)
+- `.github/workflows/dependency-pinning-check.yml` (landed 2026-06-11)
 
-**Architect Recommendation:** Local enforcement landed for v2.2.x; isolated
-workflow can ride into v2.3.0 once we choose between extending an existing
-governance workflow vs. a dedicated one.
+**Architect Recommendation:** Local enforcement landed for v2.2.x; the isolated
+workflow now ships as a dedicated `dependency-pinning-check.yml` (chosen over
+overloading an existing governance workflow so the supply-chain signal stays
+focused and independently observable). The constraints-vs-installed audit and
+floating-transitive analysis remain the open follow-ups under this item.
 
 ---
 

--- a/scripts/validation/check_dependency_pinning.py
+++ b/scripts/validation/check_dependency_pinning.py
@@ -18,8 +18,10 @@ header metadata and security baselines) by enforcing the broader supply-chain
 invariant that no transitive dependency drifts onto a floating range.
 
 Implements the core local-enforcement piece of TODO_INVENTORY.md §5.7
-(Dependency Pinning Validation). The standalone GitHub Actions workflow
-and the constraints-vs-installed audit listed there remain follow-ups.
+(Dependency Pinning Validation). A dedicated GitHub Actions workflow
+(``.github/workflows/dependency-pinning-check.yml``) runs this same check as an
+isolated PR/push signal; the constraints-vs-installed audit listed in §5.7
+remains a follow-up.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Completes the remaining net-new piece of TODO_INVENTORY.md §5.7 (Dependency
Pinning Validation). The enforcement script
(scripts/validation/check_dependency_pinning.py) and its Make target / tests
already shipped; the only documented follow-up was a standalone GitHub Actions
workflow for an isolated, independently-observable supply-chain signal.

- Add .github/workflows/dependency-pinning-check.yml: SHA-pinned actions
  (matching the repo convention enforced by scripts/ci/verify_action_pins.py),
  concurrency cancellation, least-privilege contents:read, and path filters
  scoped to requirements/ + the checker itself. The checker is stdlib-only, so
  the job needs no dependency install.
- Update the script docstring and TODO_INVENTORY.md §5.7 to mark the workflow
  landed and record the dedicated-vs-extend-existing decision; the
  constraints-vs-installed audit remains the open follow-up.

Verified: check_dependency_pinning.py (exit 0), verify_action_pins.py (all
pinned), scan_todo_inventory.py --check-governance (exit 0), and
check_doc_heading_links.py (OK).