### PR TITLE
docs(agents): document core coverage floor ratchet

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,10 @@ actionable; use the linked docs and `Makefile` for exhaustive inventories.
   `python3 scripts/ci/check_per_package_coverage.py coverage.xml`,
   `python3 scripts/ci/check_per_package_branch_coverage.py coverage.xml`, and
   `python3 scripts/ci/check_cold_zone_touched_files.py coverage.xml --compare-ref origin/main`.
+  For floor ratchets, first reproduce the CI core-tier snapshot:
+  `./.venv/bin/pytest -v tests/ -ra -m "(unit or security or regression or golden or integration) and not ml and not slow and not benchmark" --cov=src/transformation_portal --cov=src/tp --cov=lux_depth_v3 --cov=app --cov-branch --cov-report=term-missing --cov-report=xml:coverage.xml --cov-report=html --cov-fail-under=30 --cov-config=pyproject.toml`.
+  Keep floor changes below measured baselines, and do not assume live-service
+  Postgres/Redis/S3 coverage from this core lane.
 - ML sampled coverage evidence:
   `TRANSFORMERS_OFFLINE=1 HF_HOME=/tmp/hf_home_cov TRANSFORMERS_CACHE=/tmp/transformers_cache_cov OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 ./.venv/bin/pytest -v tests/vlm tests/spatial_ai/segmentation -ra -m "ml and not slow and not integration and not benchmark" --cov=src/transformation_portal/vlm --cov=src/transformation_portal/spatial_ai/segmentation --cov-report=term --cov-report=xml:coverage-ml-sampled.xml`.
   Treat this as cold-zone ratchet evidence, not a blocking local gate.


### PR DESCRIPTION
## Summary
- The core coverage floor was raised to 30%, but the coding-agent maintainer guide did not yet carry the exact local reproduction command for that workflow.
- This PR adds the smallest docs-only update to `AGENTS.md` so floor ratchets reproduce the CI core-tier snapshot before changing gates.

## Changes
- Adds the core-tier pytest coverage command under the Coverage/cold-zone validation ladder.
- Includes the current `--cov-fail-under=30` gate and HTML/XML coverage outputs used by CI.
- Calls out that live-service Postgres, Redis, and S3 coverage must not be assumed from the core lane.
- No route, selector, API envelope, CLI flag, Make target, or test contract changes.

## Validation
Proven green:
- `git diff --check -- AGENTS.md`
- `make check-doc-heading-links`
- Commit-time pre-commit hooks: passed for the staged docs change

Still failing:
- None observed.

Failure classification:
- No product logic, stale test logic, or environment/tooling failures observed.

## Risk
- Low docs-only risk; this updates operator guidance without changing runtime behavior.
- Revert-safe and bounded to `AGENTS.md`.