### PR TITLE
fix(deps): audit constraints against installed versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ help:
 	@echo "  check-python-headers  Fail on invalid encoding-cookie-like text in Python header lines 1-2"
 	@echo "  check-yaml-governance  Fail on raw yaml.safe_load outside approved preset/exempt boundaries"
 	@echo "  check-piptools-cache  Fail if requirements/.pip-tools-cache is tracked in git"
-	@echo "  check-dependency-pinning  Fail if requirements/*.txt lockfiles use unpinned operators (TODO §5.7)"
+	@echo "  check-dependency-pinning  Fail on unpinned requirements locks or constraints/env version drift (TODO §5.7)"
 	@echo "  compile-ml-darwin-arm64  Compile target-owned Darwin arm64 ML lock via requirements/"
 	@echo "  update-ml-darwin-arm64   Update target-owned Darwin arm64 ML lock via requirements/"
 	@echo "  check-ml-darwin-arm64    Verify target-owned Darwin arm64 ML lock via requirements/"
@@ -758,7 +758,7 @@ check-requirements-lock-contract:
 	@"$(PY)" scripts/validation/check_requirements_lock_contract.py
 
 check-dependency-pinning:
-	@echo "Checking that requirements lockfiles use exact (==) version pins..."
+	@echo "Checking requirements locks and constraints/env version alignment..."
 	@"$(PY)" scripts/validation/check_dependency_pinning.py
 
 check:

--- a/docs/analysis/TODO_INVENTORY.md
+++ b/docs/analysis/TODO_INVENTORY.md
@@ -1159,7 +1159,7 @@ GitHub UI → Settings → Branches → Branch protection rules → main
 - [x] Wire into `make ci` so PR lanes catch drift
 - [x] Create `.github/workflows/dependency-pinning-check.yml` for an isolated
   signal independent of the broader CI matrix
-- [ ] Validate constraints.txt matches installed versions
+- [x] Validate constraints.txt matches installed versions
 - [ ] Check for floating transitive dependencies (separate analysis)
 
 **Example Check (now codified in script):**
@@ -1177,8 +1177,9 @@ GitHub UI → Settings → Branches → Branch protection rules → main
 **Architect Recommendation:** Local enforcement landed for v2.2.x; the isolated
 workflow now ships as a dedicated `dependency-pinning-check.yml` (chosen over
 overloading an existing governance workflow so the supply-chain signal stays
-focused and independently observable). The constraints-vs-installed audit and
-floating-transitive analysis remain the open follow-ups under this item.
+focused and independently observable). The constraints-vs-installed audit is
+wired into `check_dependency_pinning.py`; floating-transitive analysis remains
+the open follow-up under this item.
 
 ---
 

--- a/scripts/validation/check_dependency_pinning.py
+++ b/scripts/validation/check_dependency_pinning.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python3
-"""Validate that compiled requirements lockfiles use exact (==) version pins.
+"""Validate governed dependency pinning contracts.
 
 Policy:
 - Every requirement line in ``requirements/*.txt`` must specify an exact
   ``==`` version pin (``package==version``) so installations are reproducible.
   PEP 440 arbitrary-equality (``===``) and any range/inequality operator
   (``>=``, ``<=``, ``~=``, ``!=``, ``>``, ``<``) are rejected.
-- ``constraints.txt`` is always exempt — both when scanning the default
-  ``requirements/`` directory and when callers pass it explicitly via the
-  CLI (e.g. ``check_dependency_pinning.py requirements/*.txt``). The file
-  intentionally uses ``>=9999.0.0`` to hard-block banned packages.
+- ``constraints.txt`` is exempt from the lockfile ``==`` policy because it
+  intentionally uses ``>=9999.0.0`` to hard-block banned packages. Any normal
+  ``constraints.txt`` pin must use exact ``==`` syntax and match the version
+  installed in the governed Python environment.
 - Hashes, comments, blank lines, options (``-r``, ``-c``, ``--hash``, etc.),
   and pip-compile continuation lines are ignored.
 
@@ -20,17 +20,17 @@ invariant that no transitive dependency drifts onto a floating range.
 Implements the core local-enforcement piece of TODO_INVENTORY.md §5.7
 (Dependency Pinning Validation). A dedicated GitHub Actions workflow
 (``.github/workflows/dependency-pinning-check.yml``) runs this same check as an
-isolated PR/push signal; the constraints-vs-installed audit listed in §5.7
-remains a follow-up.
+isolated PR/push signal.
 """
 
 from __future__ import annotations
 
 import argparse
+import importlib.metadata as importlib_metadata
 import re
 import sys
 from pathlib import Path
-from typing import Iterable, Iterator
+from typing import Callable, Iterable, Iterator
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 REQUIREMENTS_DIR = PROJECT_ROOT / "requirements"
@@ -41,6 +41,8 @@ EXEMPT_FILES = frozenset({"constraints.txt"})
 # range/inequality operator. The ``(?!=)`` lookahead is the trip-wire that
 # stops ``pkg===1.2.3`` from masquerading as a ``==`` pin.
 PINNED_LINE_PATTERN = re.compile(r"^([A-Za-z0-9_.\-]+)(?:\[[A-Za-z0-9_.,\-\s]+\])?==(?!=)[^\s;#]+")
+CONSTRAINT_PIN_PATTERN = re.compile(r"^(?P<name>[A-Za-z0-9_.\-]+)(?:\[[A-Za-z0-9_.,\-\s]+\])?==(?!=)(?P<version>[^\s;#]+)$")
+HARD_BLOCK_CONSTRAINT_PATTERN = re.compile(r">=\s*9999(?:\.0\.0)?\b")
 # Order matters: longer operators must precede shorter ones so substring
 # detection reports ``===`` rather than the empty-string match it contains.
 UNPINNED_OPERATORS = ("===", ">=", "<=", "~=", "!=", ">", "<")
@@ -81,6 +83,21 @@ def _is_skippable(line: str) -> bool:
 def _is_hash_continuation(line: str) -> bool:
     """Return True for ``--hash=...`` continuation fragments on a wrapped line."""
     return line.lstrip().startswith("--hash=")
+
+
+def _requirement_head(line: str) -> str:
+    """Return the requirement segment before comments or environment markers."""
+    return re.split(r"[;#]", line, maxsplit=1)[0].strip()
+
+
+def _collapsed_requirement_head(line: str) -> str:
+    """Return a whitespace-normalized requirement segment for policy matching."""
+    return re.sub(r"\s+", "", _requirement_head(line))
+
+
+def _is_hard_block_constraint(line: str) -> bool:
+    """Return True when a constraints entry intentionally blocks a package."""
+    return bool(HARD_BLOCK_CONSTRAINT_PATTERN.search(_requirement_head(line)))
 
 
 def _iter_logical_lines(text: str) -> Iterator[tuple[int, str]]:
@@ -149,7 +166,7 @@ def find_violations(paths: Iterable[Path]) -> list[str]:
 
             # Strip inline environment markers / comments so we focus on the
             # ``package<op>version`` segment.
-            head = re.split(r"[;#]", line, maxsplit=1)[0].strip()
+            head = _requirement_head(line)
             if not head:
                 continue
             # Stray fragments without a leading package name (the bracket
@@ -161,7 +178,7 @@ def find_violations(paths: Iterable[Path]) -> list[str]:
             # Collapse internal whitespace so ``pkg[a, b]==1.0.0`` (joined
             # from a wrapped extras list) is matched the same way pip would
             # canonicalise it.
-            collapsed = re.sub(r"\s+", "", head)
+            collapsed = _collapsed_requirement_head(line)
 
             if PINNED_LINE_PATTERN.match(collapsed):
                 continue
@@ -177,6 +194,70 @@ def find_violations(paths: Iterable[Path]) -> list[str]:
                 f"{path}:{line_number}: requirement {head!r} uses unpinned operator "
                 f"{offending_op!r}; lockfiles must use '==' pins"
             )
+    return violations
+
+
+def find_constraint_install_violations(
+    constraints_path: Path,
+    *,
+    version_lookup: Callable[[str], str] = importlib_metadata.version,
+) -> list[str]:
+    """Return violations for normal constraints that drift from installed packages.
+
+    ``constraints.txt`` also carries intentional hard-blocks such as
+    ``realesrgan>=9999.0.0``. Those entries are supply-chain bans, not install
+    pins, so they are skipped here and enforced by the banned-dependencies
+    validator.
+    """
+    violations: list[str] = []
+    try:
+        text = constraints_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return [f"{constraints_path}: could not read file ({exc})"]
+
+    for line_number, logical_line in _iter_logical_lines(text):
+        if _is_skippable(logical_line) or _is_hash_continuation(logical_line):
+            continue
+        if _is_hard_block_constraint(logical_line):
+            continue
+
+        head = _requirement_head(logical_line)
+        if not head:
+            continue
+        if not re.match(r"^[A-Za-z0-9_.\-]", head):
+            continue
+
+        collapsed = _collapsed_requirement_head(logical_line)
+        match = CONSTRAINT_PIN_PATTERN.match(collapsed)
+        if match is None:
+            offending_op = next((op for op in UNPINNED_OPERATORS if op in collapsed), None)
+            if offending_op is None:
+                violations.append(f"{constraints_path}:{line_number}: constraint {head!r} has no exact (==) pin")
+            else:
+                violations.append(
+                    f"{constraints_path}:{line_number}: constraint {head!r} uses operator "
+                    f"{offending_op!r}; constraints must either hard-block with '>=9999.0.0' "
+                    "or use an exact installed-version '==' pin"
+                )
+            continue
+
+        name = match.group("name")
+        expected = match.group("version")
+        try:
+            installed = version_lookup(name)
+        except importlib_metadata.PackageNotFoundError:
+            violations.append(
+                f"{constraints_path}:{line_number}: constraint pins {name}=={expected} "
+                "but that distribution is not installed in the governed environment"
+            )
+            continue
+
+        if installed != expected:
+            violations.append(
+                f"{constraints_path}:{line_number}: constraint pins {name}=={expected} "
+                f"but the governed environment has {name}=={installed}"
+            )
+
     return violations
 
 
@@ -199,28 +280,25 @@ def main() -> int:
     else:
         raw_paths = iter_lockfiles()
 
-    paths, exempt = _partition_exempt(raw_paths)
-    for skipped in exempt:
+    paths, constraints_paths = _partition_exempt(raw_paths)
+    for skipped in constraints_paths:
         # ``constraints.txt`` intentionally uses ``>=9999.0.0`` to ban
         # packages, so it can never satisfy the ``==`` policy. Make the
         # exemption visible rather than silent so callers passing globs
         # like ``requirements/*.txt`` understand why it isn't scanned.
-        print(f"NOTE: skipping exempt file {skipped}", file=sys.stderr)
+        print(f"NOTE: skipping constraints lockfile pin scan for {skipped}", file=sys.stderr)
 
-    if not paths:
+    if not explicit:
+        constraints_paths = [REQUIREMENTS_DIR / "constraints.txt"]
+
+    if not paths and not constraints_paths:
         # Distinguish "default scan turned up nothing" from "every explicit
         # path was exempt" so the message describes the actual input mode.
         if explicit:
-            if exempt:
-                print(
-                    "WARNING: every supplied path was exempt; nothing to scan.",
-                    file=sys.stderr,
-                )
-            else:
-                print(
-                    "WARNING: no lockfiles supplied to scan.",
-                    file=sys.stderr,
-                )
+            print(
+                "WARNING: no lockfiles supplied to scan.",
+                file=sys.stderr,
+            )
         else:
             print(
                 f"WARNING: no lockfiles found under {REQUIREMENTS_DIR}",
@@ -229,14 +307,22 @@ def main() -> int:
         return 0
 
     violations = find_violations(paths)
+    for constraints_path in constraints_paths:
+        violations.extend(find_constraint_install_violations(constraints_path))
+
     if violations:
         print("ERROR: dependency pinning validation failed:", file=sys.stderr)
         for violation in violations:
             print(f"  - {violation}", file=sys.stderr)
         return 1
 
-    scanned = ", ".join(path.name for path in paths)
-    print(f"dependency pinning passed: {len(paths)} lockfile(s) verified ({scanned})")
+    scanned = ", ".join(path.name for path in paths) if paths else "none"
+    audited = ", ".join(path.name for path in constraints_paths) if constraints_paths else "none"
+    print(
+        "dependency pinning passed: "
+        f"{len(paths)} lockfile(s) verified ({scanned}); "
+        f"{len(constraints_paths)} constraints file(s) audited ({audited})"
+    )
     return 0
 
 

--- a/tests/validation/test_check_dependency_pinning.py
+++ b/tests/validation/test_check_dependency_pinning.py
@@ -152,13 +152,13 @@ def test_cli_skips_constraints_when_passed_explicitly(tmp_path: Path, capsys) ->
 
     captured = capsys.readouterr()
     assert exit_code == 0
-    assert "skipping exempt file" in captured.err
+    assert "skipping constraints lockfile pin scan" in captured.err
     assert "constraints.txt" in captured.err
     assert "base.txt" in captured.out
 
 
-def test_cli_warns_about_all_exempt_inputs(tmp_path: Path, capsys) -> None:
-    """When every explicit path is exempt the message must reflect that, not the default dir."""
+def test_cli_audits_all_constraints_inputs(tmp_path: Path, capsys) -> None:
+    """When every explicit path is constraints.txt, the constraints audit still runs."""
     module = _load_module()
     constraints = tmp_path / "constraints.txt"
     constraints.write_text("realesrgan>=9999.0.0\n", encoding="utf-8")
@@ -174,9 +174,88 @@ def test_cli_warns_about_all_exempt_inputs(tmp_path: Path, capsys) -> None:
 
     captured = capsys.readouterr()
     assert exit_code == 0
-    assert "every supplied path was exempt" in captured.err
+    assert "skipping constraints lockfile pin scan" in captured.err
+    assert "1 constraints file(s) audited" in captured.out
     # The default-scan wording must not surface for explicit-args input.
     assert "no lockfiles found under" not in captured.err
+
+
+def test_constraint_hard_blocks_do_not_require_installed_package(tmp_path: Path) -> None:
+    module = _load_module()
+    constraints = tmp_path / "constraints.txt"
+    constraints.write_text("realesrgan>=9999.0.0\n", encoding="utf-8")
+
+    def missing_distribution(name: str) -> str:
+        raise module.importlib_metadata.PackageNotFoundError(name)
+
+    assert (
+        module.find_constraint_install_violations(
+            constraints,
+            version_lookup=missing_distribution,
+        )
+        == []
+    )
+
+
+def test_constraint_exact_pin_must_match_installed_version(tmp_path: Path) -> None:
+    module = _load_module()
+    constraints = tmp_path / "constraints.txt"
+    constraints.write_text("packaging==26.2\n", encoding="utf-8")
+
+    assert (
+        module.find_constraint_install_violations(
+            constraints,
+            version_lookup=lambda name: "26.2",
+        )
+        == []
+    )
+
+
+def test_constraint_version_drift_is_rejected(tmp_path: Path) -> None:
+    module = _load_module()
+    constraints = tmp_path / "constraints.txt"
+    constraints.write_text("packaging==26.2\n", encoding="utf-8")
+
+    violations = module.find_constraint_install_violations(
+        constraints,
+        version_lookup=lambda name: "26.1",
+    )
+
+    assert len(violations) == 1
+    assert "packaging==26.2" in violations[0]
+    assert "packaging==26.1" in violations[0]
+
+
+def test_constraint_missing_distribution_is_rejected(tmp_path: Path) -> None:
+    module = _load_module()
+    constraints = tmp_path / "constraints.txt"
+    constraints.write_text("packaging==26.2\n", encoding="utf-8")
+
+    def missing_distribution(name: str) -> str:
+        raise module.importlib_metadata.PackageNotFoundError(name)
+
+    violations = module.find_constraint_install_violations(
+        constraints,
+        version_lookup=missing_distribution,
+    )
+
+    assert len(violations) == 1
+    assert "not installed in the governed environment" in violations[0]
+
+
+def test_non_hard_block_constraint_range_is_rejected(tmp_path: Path) -> None:
+    module = _load_module()
+    constraints = tmp_path / "constraints.txt"
+    constraints.write_text("packaging>=26.2\n", encoding="utf-8")
+
+    violations = module.find_constraint_install_violations(
+        constraints,
+        version_lookup=lambda name: "26.2",
+    )
+
+    assert len(violations) == 1
+    assert ">=9999.0.0" in violations[0]
+    assert "==" in violations[0]
 
 
 def test_wrapped_extras_pinned_with_equals_is_accepted(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- TODO §5.7 left the constraints-vs-installed audit open after exact lockfile pinning and the dedicated dependency-pinning workflow landed.
- Extend the existing dependency-pinning validator so normal `requirements/constraints.txt` pins are checked against the governed installed Python environment while intentional hard-block bans remain exempt.

## Changes
- Add constraints audit logic to `scripts/validation/check_dependency_pinning.py` using `importlib.metadata.version` for installed distribution versions.
- Preserve the existing `>=9999.0.0` hard-block behavior for banned dependencies in `constraints.txt`.
- Keep the existing `make check-dependency-pinning` validation path and update its operator-facing wording.
- Add focused tests for hard-block exemptions, exact installed-version matches, version drift, missing distributions, and non-hard-block range operators.
- Mark the TODO §5.7 constraints-vs-installed follow-up complete while leaving floating-transitive analysis open.

## Validation
Proven green:
- `.venv/bin/pytest tests/validation/test_check_dependency_pinning.py -v`
- `make check-dependency-pinning`
- `make check-todo-governance`
- `make check-requirements-lock-contract`
- `.venv/bin/python -m black --check scripts/validation/check_dependency_pinning.py tests/validation/test_check_dependency_pinning.py`
- `git diff --check -- scripts/validation/check_dependency_pinning.py tests/validation/test_check_dependency_pinning.py Makefile docs/analysis/TODO_INVENTORY.md`

Still failing:
- None observed.

Failure classification:
- No product, stale-test, or environment/tooling failures observed in the focused validation path.

## Risk
- Validation-only change; no dependency versions, install commands, routes, selectors, or runtime behavior changed.
- Banned-dependency hard-block constraints remain exempt and continue to be enforced by the existing banned-dependencies validator, so the change is bounded and revert-safe.