### PR TITLE
fix(ci): restore main security and torch-boundary gates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -709,10 +709,10 @@ Certain packages require minimum versions due to CVEs:
 
 | Package                 | Minimum Version | Reason                              |
 |-------------------------|-----------------|-------------------------------------|
-| `cryptography`          | >=47.0.0        | Governed lock baseline includes the CVE-2026-26007 / GHSA-r6ph-v2qm-q3c2 fix |
+| `cryptography`          | >=48.0.1        | Governed lock baseline includes the OpenSSL wheel security fix |
 | `sentence-transformers` | >=3.1.0         | CVE-73169 (arbitrary code execution) |
 | `Pillow`                | >=10.3.0        | CVE-2024-28219 and multiple 9.x CVEs |
-| `starlette`             | >=1.0.1         | CVE-2026-48710 / PYSEC-2026-161      |
+| `starlette`             | >=1.3.1         | CVE-2026-48710 / PYSEC-2026-161 plus 2026 web-stack advisories |
 
 ### Approved Exceptions
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -117,10 +117,10 @@ Given our image/video processing nature, special attention is required for:
     - **Disposition**: Managed inference paths do not use `transformers.Trainer`, `Seq2SeqTrainer`, `TrainingArguments`, `_load_rng_state`, or training-resume flows
     - **Action**: Dependabot alerts are dismissed as `not_used` with repo search evidence instead of forcing a `transformers` 5.x pre-release upgrade into inference stacks
   - **Pillow>=10.3.0** - Fixed CVE-2024-28219 (buffer overflow vulnerability)
-  - **cryptography==47.0.0** - Current governed lock; includes the CVE-2026-26007 / GHSA-r6ph-v2qm-q3c2 SECT subgroup validation fix from 46.0.5
+  - **cryptography==48.0.1** - Current governed lock; includes the OpenSSL wheel security baseline fix from 47.0.0
   - **black==26.3.1** - Fixed arbitrary file writes from unsanitized cache names
   - **Pygments==2.20.0** - Fixed CVE-2026-4539; the temporary pip-audit exception is retired
-  - **Starlette==1.0.1** - Fixed CVE-2026-48710 / PYSEC-2026-161 BadHost request URL construction weakness
+  - **Starlette==1.3.1** - Fixed CVE-2026-48710 / PYSEC-2026-161 plus 2026 StaticFiles, HTTPEndpoint, and form parsing advisories
 
   **January 2026**:
   - **protobuf 6.34.0** - Fixed CVE-2026-0994 / GHSA-7gcm-g887-7qv7 (Dependabot #69)

--- a/config/fastvlm_runtime_requirements.txt
+++ b/config/fastvlm_runtime_requirements.txt
@@ -65,7 +65,7 @@ scipy==1.13.1
 semantic-version==2.10.0
 shellingham==1.5.4
 six==1.17.0
-starlette==1.0.1
+starlette==1.3.1
 sympy==1.14.0
 timm==1.0.26
 tokenizers==0.22.2

--- a/docs/governance/DEPENDABOT_PR_GOVERNANCE.md
+++ b/docs/governance/DEPENDABOT_PR_GOVERNANCE.md
@@ -83,7 +83,7 @@ The following dependencies are **exact-pinned** in `requirements/base.in` for AP
 
 ```
 fastapi==0.136.1
-starlette==1.0.1
+starlette==1.3.1
 uvicorn==0.48.0
 aiofiles==25.1.0
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     # Web stack ranges track the patched baseline in requirements/base.in.
     # Exact versions are enforced in compiled lockfiles.
     "fastapi>=0.136.1,<0.137",
-    "starlette>=1.0.1,<1.1",  # direct runtime import + BadHost/PYSEC patched Starlette 1.x baseline
+    "starlette>=1.3.1,<1.4",  # direct runtime import + patched Starlette 1.x baseline
     "uvicorn>=0.48.0,<0.49",
     "aiofiles>=25.1.0,<26",
     "tifffile>=2023.7.18,<2027",
@@ -119,7 +119,7 @@ spatial-ai = [
 ]
 # Optional detached signing support for archive attestation CLIs
 archive-signing = [
-    "cryptography>=47.0.0,<48",
+    "cryptography>=48.0.1,<49",
 ]
 # Development tools - see requirements/dev.in for pinned versions
 dev = [
@@ -133,7 +133,7 @@ dev = [
     "httpx>=0.28,<1",  # required for FastAPI/Starlette TestClient in HTTP contract tests
     "hypothesis>=6.0,<7",
     "jsonschema>=4.21.0,<5",  # required for machine-mode contract schema validation tests
-    "cryptography>=47.0.0,<48",  # required for Phase 3.1 signing CLI tests
+    "cryptography>=48.0.1,<49",  # required for Phase 3.1 signing CLI tests
     "moto[s3]>=5.0,<6",  # required for moto-backed S3 ArtifactStore contract tests
     "mypy>=1.10",
     "flake8>=7.0",

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -32,4 +32,4 @@ opencv-python-headless>=4.8.0,<5 ; platform_system == "Linux"
 opencv-python>=4.8.0,<5 ; platform_system != "Linux"
 
 # Required for detached Merkle signing/verification CLI tests
-cryptography>=47.0.0,<48
+cryptography>=48.0.1,<49

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,7 +17,7 @@ jsonschema>=4.21.0,<5
 httpx>=0.28,<1
 
 # Optional Phase 3.1 detached signing support (tools + tests)
-cryptography>=47.0.0,<48
+cryptography>=48.0.1,<49
 
 # S3 mock for the Phase 4.A ArtifactStore contract tests
 moto[s3]>=5.0,<6

--- a/requirements/README.md
+++ b/requirements/README.md
@@ -124,10 +124,10 @@ The repository's governed web stack currently resolves to:
 | Dependency | Source of Truth | Current Version |
 |-----------|-----------------|-----------------|
 | FastAPI | `requirements/base.in` | `0.136.1` |
-| Starlette | `requirements/base.in` + `pyproject.toml` bound | `1.0.1` |
+| Starlette | `requirements/base.in` + `pyproject.toml` bound | `1.3.1` |
 | Uvicorn | `requirements/base.in` + `pyproject.toml` bound | `0.48.0` |
 
-This baseline was validated and merged via the curated compatibility path, most recently on 2026-05-26 for the Uvicorn `0.48.0` runtime patch after the Starlette `PYSEC-2026-161` patch. Do not treat future updates to these exact pins as routine dependency bumps; use the governance flow documented in `docs/governance/DEPENDABOT_PR_GOVERNANCE.md`.
+This baseline was validated and merged via the curated compatibility path, most recently on 2026-06-20 for the Starlette `1.3.1` security patch and earlier on 2026-05-26 for the Uvicorn `0.48.0` runtime patch. Do not treat future updates to these exact pins as routine dependency bumps; use the governance flow documented in `docs/governance/DEPENDABOT_PR_GOVERNANCE.md`.
 
 ### Layered ML Strategy
 

--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -70,7 +70,7 @@ colorama==0.4.6
     # via tox
 coverage[toml]==7.14.1
     # via pytest-cov
-cryptography==47.0.0
+cryptography==48.0.1
     # via
     #   -r dev.in
     #   moto
@@ -346,7 +346,7 @@ sqlalchemy[asyncio]==2.0.50
     #   -r base.in
     #   alembic
     #   sqlalchemy
-starlette==1.0.1
+starlette==1.3.1
     # via
     #   -r base.in
     #   fastapi

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -15,10 +15,10 @@ typer>=0.10.0,<1           # CLI framework
 tqdm>=4.66,<5              # progress bar utility
 
 # Web orchestration service stack (exact pins for API/UI parity)
-# Security: keep FastAPI + Starlette on patched baseline for CVE-2025-62727
-# and PYSEC-2026-161.
+# Security: keep FastAPI + Starlette on patched baseline for CVE-2025-62727,
+# PYSEC-2026-161, and the 2026 StaticFiles/HTTPEndpoint/form parsing fixes.
 fastapi==0.136.1           # orchestrator API framework (validated against curated Starlette 1.x upgrade)
-starlette==1.0.1           # direct runtime import + curated Starlette 1.x validation target
+starlette==1.3.1           # direct runtime import + curated Starlette 1.x validation target
 uvicorn==0.48.0            # ASGI server runtime pin
 aiofiles==25.1.0           # async file I/O support for FastAPI file responses
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -185,7 +185,7 @@ sqlalchemy[asyncio]==2.0.50
     #   -r base.in
     #   alembic
     #   sqlalchemy
-starlette==1.0.1
+starlette==1.3.1
     # via
     #   -c all.txt
     #   -r base.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -36,7 +36,7 @@ colorama==0.4.6
     # via
     #   -c all.txt
     #   tox
-cryptography==47.0.0
+cryptography==48.0.1
     # via
     #   -c all.txt
     #   secretstorage

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -14,7 +14,7 @@ diff-cover>=10.2.1,<11  # diff coverage for PR validation (Phase 0 coverage infr
 httpx>=0.28,<1  # required for FastAPI/Starlette TestClient in HTTP contract tests
 hypothesis>=6.0,<7
 jsonschema>=4.21.0,<5  # required for machine-mode contract schema validation tests
-cryptography==47.0.0  # CAS determinism + Security: CVE-2024-0727 / GHSA-9v9h-cgj8-h64p fixed
+cryptography==48.0.1  # CAS determinism + Security: OpenSSL wheel baseline fixed
 moto[s3]>=5.0,<6  # S3 mock for the Phase 4.A S3ArtifactStore contract test branch
 
 # Type checking and linting

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -69,7 +69,7 @@ coverage[toml]==7.14.1
     # via
     #   -c all.txt
     #   pytest-cov
-cryptography==47.0.0
+cryptography==48.0.1
     # via
     #   -c all.txt
     #   -r dev.in

--- a/requirements/tools-archive.in
+++ b/requirements/tools-archive.in
@@ -5,6 +5,6 @@
 numpy>=2.2,<2.5
 pandas>=2.2,<3.1
 jsonschema>=4.23,<5
-cryptography>=47.0.0,<48
+cryptography>=48.0.1,<49
 bagit>=1.8,<2
 pyyaml>=6.0,<7

--- a/requirements/tools-archive.txt
+++ b/requirements/tools-archive.txt
@@ -15,7 +15,7 @@ cffi==2.0.0
     # via
     #   -c all.txt
     #   cryptography
-cryptography==47.0.0
+cryptography==48.0.1
     # via
     #   -c all.txt
     #   -r tools-archive.in

--- a/scripts/setup/install_da3_runtime.sh
+++ b/scripts/setup/install_da3_runtime.sh
@@ -220,7 +220,7 @@ BASE_DEPS=(
     "torch==2.12.0"
     "torchvision==0.27.0"
     "transformers==5.5.0"
-    "cryptography==47.0.0"
+    "cryptography==48.0.1"
     "moviepy==1.0.3"
     "einops==0.8.2"
     "huggingface_hub==1.9.0"

--- a/scripts/validation/validate_dependency_constraints.sh
+++ b/scripts/validation/validate_dependency_constraints.sh
@@ -121,7 +121,7 @@ get_security_minimum() {
             return 0
             ;;
         "starlette")
-            echo "1.0.1|CVE-2026-48710 / PYSEC-2026-161 (BadHost request URL construction weakness)"
+            echo "1.3.1|CVE-2026-48710 / PYSEC-2026-161 plus 2026 StaticFiles/HTTPEndpoint/form parsing fixes"
             return 0
             ;;
     esac

--- a/tests/enforcement/test_ml_fast_collection_contract.py
+++ b/tests/enforcement/test_ml_fast_collection_contract.py
@@ -127,7 +127,7 @@ def _write_torch_blocker(sitecustomize_path: Path) -> None:
         "class TorchBlocker(importlib.abc.MetaPathFinder):\n"
         "    def find_spec(self, fullname, path=None, target=None):\n"
         "        if fullname == 'torch' or fullname.startswith('torch.'):\n"
-        f"            raise ImportError('{TORCH_BLOCK_MESSAGE}: ' + fullname)\n"
+        f"            raise ModuleNotFoundError('{TORCH_BLOCK_MESSAGE}: ' + fullname)\n"
         "        return None\n"
         "\n"
         "sys.meta_path.insert(0, TorchBlocker())\n",

--- a/tests/test_codebase_structure.py
+++ b/tests/test_codebase_structure.py
@@ -591,21 +591,21 @@ class TestRootGovernanceMetadata:
         requirements_lint = (_repo_root / "requirements-lint.txt").read_text()
         contributing = (_repo_root / "CONTRIBUTING.md").read_text()
 
-        assert "cryptography==47.0.0" in (_repo_root / "requirements/ci.txt").read_text()
-        assert "cryptography==47.0.0" in (_repo_root / "requirements/dev.txt").read_text()
-        assert "cryptography==47.0.0" in (_repo_root / "requirements/all.txt").read_text()
+        assert "cryptography==48.0.1" in (_repo_root / "requirements/ci.txt").read_text()
+        assert "cryptography==48.0.1" in (_repo_root / "requirements/dev.txt").read_text()
+        assert "cryptography==48.0.1" in (_repo_root / "requirements/all.txt").read_text()
         assert "pillow==12.2.0" in (_repo_root / "requirements/base.txt").read_text()
 
-        assert "**cryptography==47.0.0**" in security_policy
+        assert "**cryptography==48.0.1**" in security_policy
         assert "**cryptography==46.0.5**" not in security_policy
-        assert "cryptography>=47.0.0,<48" in requirements_ci
-        assert "cryptography>=47.0.0,<48" in requirements_dev
+        assert "cryptography>=48.0.1,<49" in requirements_ci
+        assert "cryptography>=48.0.1,<49" in requirements_dev
         assert "cryptography>=46.0,<48" not in requirements_ci
         assert "cryptography>=46.0,<48" not in requirements_dev
-        assert "`cryptography`          | >=47.0.0" in contributing
+        assert "`cryptography`          | >=48.0.1" in contributing
         assert "`cryptography`          | >=46.0.5" not in contributing
-        assert "`starlette`             | >=1.0.1" in contributing
-        assert "Starlette==1.0.1" in security_policy
+        assert "`starlette`             | >=1.3.1" in contributing
+        assert "Starlette==1.3.1" in security_policy
         assert "current governed lock baseline is pillow==12.2.0" in requirements_lint
         assert "allows pillow==12.1.1 in lockfiles" not in requirements_lint
 
@@ -617,12 +617,12 @@ class TestRootGovernanceMetadata:
         tools_archive_lock = (_repo_root / "requirements" / "tools-archive.txt").read_text()
 
         for extra_name in ("archive-signing", "dev"):
-            assert "cryptography>=47.0.0,<48" in optional_dependencies[extra_name]
+            assert "cryptography>=48.0.1,<49" in optional_dependencies[extra_name]
             assert "cryptography>=46.0,<48" not in optional_dependencies[extra_name]
 
-        assert "cryptography>=47.0.0,<48" in tools_archive_in
+        assert "cryptography>=48.0.1,<49" in tools_archive_in
         assert "cryptography>=46.0,<48" not in tools_archive_in
-        assert "cryptography==47.0.0" in tools_archive_lock
+        assert "cryptography==48.0.1" in tools_archive_lock
 
     def test_pyproject_core_dependencies_track_governed_base_requirements(self):
         """Installable package metadata should not trail the governed core dependency surface."""
@@ -634,7 +634,7 @@ class TestRootGovernanceMetadata:
             "Pillow>=10.3.0,<13",
             "scikit-learn>=1.8.0,<2",
             "fastapi>=0.136.1,<0.137",
-            "starlette>=1.0.1,<1.1",
+            "starlette>=1.3.1,<1.4",
             "uvicorn>=0.48.0,<0.49",
             "aiofiles>=25.1.0,<26",
             "SQLAlchemy[asyncio]>=2.0.50,<2.2",

--- a/tests/test_secure_install_pilot_workflow.py
+++ b/tests/test_secure_install_pilot_workflow.py
@@ -104,9 +104,9 @@ def test_requirements_readme_records_current_curated_web_runtime_baseline() -> N
     readme = REQUIREMENTS_README_PATH.read_text(encoding="utf-8")
 
     assert "| FastAPI | `requirements/base.in` | `0.136.1` |" in readme
-    assert "| Starlette | `requirements/base.in` + `pyproject.toml` bound | `1.0.1` |" in readme
+    assert "| Starlette | `requirements/base.in` + `pyproject.toml` bound | `1.3.1` |" in readme
     assert "| Uvicorn | `requirements/base.in` + `pyproject.toml` bound | `0.48.0` |" in readme
-    assert "Starlette `PYSEC-2026-161` patch" in readme
+    assert "Starlette `1.3.1` security patch" in readme
 
 
 def test_dependabot_governance_doc_includes_dep_pin_changed_checklist() -> None:

--- a/tests/validation/test_python_bootstrap_scripts.py
+++ b/tests/validation/test_python_bootstrap_scripts.py
@@ -560,7 +560,7 @@ def test_install_da3_runtime_baseline_profile_omits_optional_deps(tmp_path: Path
     assert result.returncode == 0, result.stdout + result.stderr
     pip_install_lines = "\n".join(_dry_run_pip_install_lines(result.stdout))
     assert "DA3 NumPy spec: numpy>=2.0,<3" in result.stdout
-    assert "cryptography==47.0.0" in pip_install_lines
+    assert "cryptography==48.0.1" in pip_install_lines
     assert "cryptography==46.0.6" not in pip_install_lines
     assert "numpy==1.26.4" not in pip_install_lines
     assert "pycolmap==" not in pip_install_lines

--- a/tests/validation/test_validate_dependency_constraints_script.py
+++ b/tests/validation/test_validate_dependency_constraints_script.py
@@ -164,7 +164,7 @@ def test_generic_stale_warning_preserves_make_compile_guidance(tmp_path: Path) -
     ("constraint", "minimum", "reason"),
     (
         ("Pillow>=10.0.0,<13  # stale security floor", "10.3.0", "CVE-2024-28219"),
-        ("starlette==1.0.0  # stale Starlette pin", "1.0.1", "CVE-2026-48710"),
+        ("starlette==1.0.0  # stale Starlette pin", "1.3.1", "CVE-2026-48710"),
     ),
 )
 def test_security_minimums_reject_stale_constraints(
@@ -395,7 +395,7 @@ def test_validator_uses_repo_resolved_python_instead_of_path_python3(tmp_path: P
         "\n".join(
             [
                 "Pillow>=10.3.0,<13  # Security regression coverage",
-                "starlette==1.0.1  # direct runtime import + curated Starlette 1.x validation target",
+                "starlette==1.3.1  # direct runtime import + curated Starlette 1.x validation target",
             ]
         )
         + "\n",


### PR DESCRIPTION
## Summary
- Main push CI was failing on the fast-ML torch-boundary collect check and pip-audit security gates.
- This patch keeps guarded `pytest.importorskip("torch")` collection compatible with the blocker and bumps the governed Starlette/cryptography baselines to audited fixed versions.

## Changes
- Change the fast-ML torch blocker to raise `ModuleNotFoundError`, preserving failures for unguarded torch imports while allowing importorskip guards to skip.
- Bump Starlette to 1.3.1 and cryptography to 48.0.1 across source requirements, generated locks, pyproject extras, runtime installer/config pins, docs, and contract tests.
- Preserve Python 3.11 lock provenance and platform-marked OpenCV/keyring-chain lock entries.

## Validation
Proven green:
- `/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin/pytest tests/enforcement/test_ml_fast_collection_contract.py -q`
- `/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin/python scripts/validation/check_requirements_lock_contract.py`
- `PATH=/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin:$PATH bash scripts/validate_dependency_constraints.sh --verbose`
- `/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin/python scripts/validation/check_ci_dep_sync.py`
- `/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin/python scripts/validation/check_dependency_pinning.py`
- `PATH=/private/tmp/tp-py311-piptools/bin:$PATH make -C requirements check LOCK_PYTHON_VERSION=3.11`
- `XDG_CACHE_HOME=/private/tmp/tp-pip-audit-cache PATH=/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin:$PATH pip-audit --desc -r requirements-ci.txt`
- `/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin/pytest tests/test_codebase_structure.py::TestRootGovernanceMetadata::test_security_baseline_versions_match_current_locks tests/test_codebase_structure.py::TestRootGovernanceMetadata::test_pyproject_security_extras_track_current_cryptography_floor tests/test_codebase_structure.py::TestRootGovernanceMetadata::test_pyproject_core_dependencies_track_governed_base_requirements -q`
- `/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin/pytest tests/validation/test_validate_dependency_constraints_script.py -q`
- `/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin/pytest tests/validation/test_python_bootstrap_scripts.py::test_install_da3_runtime_baseline_profile_omits_optional_deps tests/validation/test_python_bootstrap_scripts.py::test_install_da3_runtime_optional_profiles_add_requested_deps -q`
- `XDG_CACHE_HOME=/private/tmp/tp-pip-cache /Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin/python -m pip install --dry-run -r requirements-ci.txt`
- `PATH=/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin:$PATH PYTHONPATH=/private/tmp/tp-ci-main-fix/src:/private/tmp/tp-ci-main-fix git commit -m "fix(ci): restore main security and torch-boundary gates"` pre-commit hooks

Still failing:
- Broad local core marker run reached 4024 passed, 18 skipped, and 932 deselected before failing at `tests/spatial_ai/ingest/test_phase2_camera_native_linear.py::test_ingest_phase2_rejects_invalid_subprocess_tensor_shape` because the temp worktree lacks compiled extension `transformation_portal.determinism._fpstate`.
- The earlier torch-boundary collection failure did not recur in that broad run.
- The desktop checkout has pre-existing `AGENTS.md` dirt, untouched.

Environment/tooling:
- `make -C requirements check` must use the Python 3.11 pip-tools lane; the Python 3.12 desktop venv produces host-sensitive generic lock drift.

## Risk
- Dependency changes are bounded to governed web/security baselines; pip-audit and resolver dry-run confirm the CI install surface.
- Torch-boundary change narrows only the synthetic blocker error type and still fails unguarded imports.
- Revert-safe: restore the prior dependency pins and blocker exception type.