### PR TITLE
chore(deps): refresh generic requirements locks

### DIFF
--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -14,7 +14,7 @@ annotated-doc==0.0.4
     #   typer
 annotated-types==0.7.0
     # via pydantic
-anyio==4.13.0
+anyio==4.14.0
     # via
     #   httpx
     #   starlette
@@ -36,11 +36,11 @@ bandit==1.9.4
     # via -r ci.in
 black==26.3.1
     # via -r dev.in
-boto3==1.43.24
+boto3==1.43.34
     # via
     #   -r base.in
     #   moto
-botocore==1.43.24
+botocore==1.43.34
     # via
     #   boto3
     #   moto
@@ -49,7 +49,7 @@ build==1.5.0
     # via -r ci.in
 cachetools==7.1.4
     # via tox
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   httpcore
     #   httpx
@@ -68,7 +68,7 @@ click==8.4.1
     #   uvicorn
 colorama==0.4.6
     # via tox
-coverage[toml]==7.14.1
+coverage[toml]==7.14.2
     # via pytest-cov
 cryptography==48.0.1
     # via
@@ -79,7 +79,7 @@ diff-cover==10.3.0
     # via -r dev.in
 dill==0.4.1
     # via pylint
-distlib==0.4.1
+distlib==0.4.3
     # via virtualenv
 docutils==0.23
     # via readme-renderer
@@ -87,14 +87,14 @@ execnet==2.1.2
     # via pytest-xdist
 fastapi==0.136.1
     # via -r base.in
-filelock==3.29.1
+filelock==3.29.4
     # via
     #   python-discovery
     #   tox
     #   virtualenv
 flake8==7.3.0
     # via -r dev.in
-greenlet==3.5.1
+greenlet==3.5.2
     # via sqlalchemy
 h11==0.16.0
     # via
@@ -104,7 +104,7 @@ httpcore==1.0.9
     # via httpx
 httpx==0.28.1
     # via -r dev.in
-hypothesis==6.155.2
+hypothesis==6.155.6
     # via -r dev.in
 id==1.6.1
     # via twine
@@ -192,7 +192,7 @@ numpy==2.4.6
     # via
     #   -r base.in
     #   imagecodecs
-    #   opencv-python-headless
+    #   opencv-python
     #   scikit-learn
     #   scipy
     #   tifffile
@@ -252,7 +252,7 @@ pygments==2.20.0
     #   pytest
     #   readme-renderer
     #   rich
-pylint==4.0.5
+pylint==4.0.6
     # via -r dev.in
 pypdf==6.13.3
     # via -r ci.in
@@ -260,7 +260,7 @@ pyproject-api==1.10.1
     # via tox
 pyproject-hooks==1.2.0
     # via build
-pytest==9.0.3
+pytest==9.1.1
     # via
     #   -r dev.in
     #   pytest-asyncio
@@ -283,7 +283,7 @@ pytest-xdist==3.8.0
     # via -r dev.in
 python-dateutil==2.9.0.post0
     # via botocore
-python-discovery==1.4.0
+python-discovery==1.4.2
     # via
     #   tox
     #   virtualenv
@@ -296,7 +296,7 @@ pyyaml==6.0.3
     #   moto
     #   pre-commit
     #   responses
-readme-renderer==44.0
+readme-renderer==45.0
     # via twine
 redis==6.4.0
     # via -r base.in
@@ -325,7 +325,7 @@ rpds-py==2026.5.1
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.18.0
+s3transfer==0.19.0
     # via boto3
 scikit-learn==1.9.0
     # via -r base.in
@@ -341,7 +341,7 @@ six==1.17.0
     # via python-dateutil
 sortedcontainers==2.4.0
     # via hypothesis
-sqlalchemy[asyncio]==2.0.50
+sqlalchemy[asyncio]==2.0.51
     # via
     #   -r base.in
     #   alembic
@@ -362,7 +362,7 @@ tomlkit==0.15.0
     # via pylint
 tox==4.55.1
     # via -r ci.in
-tqdm==4.68.1
+tqdm==4.68.3
     # via -r base.in
 twine==6.2.0
     # via -r ci.in
@@ -396,7 +396,7 @@ urllib3==2.7.0
     #   twine
 uvicorn==0.48.0
     # via -r base.in
-virtualenv==21.4.2
+virtualenv==21.5.1
     # via
     #   pre-commit
     #   tox

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -21,7 +21,7 @@ annotated-types==0.7.0
     # via
     #   -c all.txt
     #   pydantic
-anyio==4.13.0
+anyio==4.14.0
     # via
     #   -c all.txt
     #   starlette
@@ -34,11 +34,11 @@ attrs==26.1.0
     #   -c all.txt
     #   jsonschema
     #   referencing
-boto3==1.43.24
+boto3==1.43.34
     # via
     #   -c all.txt
     #   -r base.in
-botocore==1.43.24
+botocore==1.43.34
     # via
     #   -c all.txt
     #   boto3
@@ -51,7 +51,7 @@ fastapi==0.136.1
     # via
     #   -c all.txt
     #   -r base.in
-greenlet==3.5.1
+greenlet==3.5.2
     # via
     #   -c all.txt
     #   sqlalchemy
@@ -109,12 +109,14 @@ numpy==2.4.6
     #   -c all.txt
     #   -r base.in
     #   imagecodecs
-    #   opencv-python-headless
+    #   opencv-python
     #   scikit-learn
     #   scipy
     #   tifffile
 opencv-python==4.13.0.92 ; platform_system != "Linux"
-    # via -r base.in
+    # via
+    #   -c all.txt
+    #   -r base.in
 opencv-python-headless==4.13.0.92 ; platform_system == "Linux"
     # via
     #   -c all.txt
@@ -158,7 +160,7 @@ rpds-py==2026.5.1
     #   -c all.txt
     #   jsonschema
     #   referencing
-s3transfer==0.18.0
+s3transfer==0.19.0
     # via
     #   -c all.txt
     #   boto3
@@ -179,7 +181,7 @@ six==1.17.0
     # via
     #   -c all.txt
     #   python-dateutil
-sqlalchemy[asyncio]==2.0.50
+sqlalchemy[asyncio]==2.0.51
     # via
     #   -c all.txt
     #   -r base.in
@@ -198,7 +200,7 @@ tifffile==2026.3.3
     # via
     #   -c all.txt
     #   -r base.in
-tqdm==4.68.1
+tqdm==4.68.3
     # via
     #   -c all.txt
     #   -r base.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -20,7 +20,7 @@ cachetools==7.1.4
     # via
     #   -c all.txt
     #   tox
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   -c all.txt
     #   requests
@@ -40,7 +40,7 @@ cryptography==48.0.1
     # via
     #   -c all.txt
     #   secretstorage
-distlib==0.4.1
+distlib==0.4.3
     # via
     #   -c all.txt
     #   virtualenv
@@ -48,7 +48,7 @@ docutils==0.23
     # via
     #   -c all.txt
     #   readme-renderer
-filelock==3.29.1
+filelock==3.29.4
     # via
     #   -c all.txt
     #   python-discovery
@@ -142,7 +142,7 @@ pyproject-hooks==1.2.0
     # via
     #   -c all.txt
     #   build
-python-discovery==1.4.0
+python-discovery==1.4.2
     # via
     #   -c all.txt
     #   tox
@@ -151,7 +151,7 @@ pyyaml==6.0.3
     # via
     #   -c all.txt
     #   bandit
-readme-renderer==44.0
+readme-renderer==45.0
     # via
     #   -c all.txt
     #   twine
@@ -199,7 +199,7 @@ urllib3==2.7.0
     #   id
     #   requests
     #   twine
-virtualenv==21.4.2
+virtualenv==21.5.1
     # via
     #   -c all.txt
     #   tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --constraint=all.txt --output-file=dev.txt dev.in
 #
-anyio==4.13.0
+anyio==4.14.0
     # via
     #   -c all.txt
     #   httpx
@@ -29,17 +29,17 @@ black==26.3.1
     # via
     #   -c all.txt
     #   -r dev.in
-boto3==1.43.24
+boto3==1.43.34
     # via
     #   -c all.txt
     #   moto
-botocore==1.43.24
+botocore==1.43.34
     # via
     #   -c all.txt
     #   boto3
     #   moto
     #   s3transfer
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   -c all.txt
     #   httpcore
@@ -65,7 +65,7 @@ click==8.4.1
     # via
     #   -c all.txt
     #   black
-coverage[toml]==7.14.1
+coverage[toml]==7.14.2
     # via
     #   -c all.txt
     #   pytest-cov
@@ -82,7 +82,7 @@ dill==0.4.1
     # via
     #   -c all.txt
     #   pylint
-distlib==0.4.1
+distlib==0.4.3
     # via
     #   -c all.txt
     #   virtualenv
@@ -90,7 +90,7 @@ execnet==2.1.2
     # via
     #   -c all.txt
     #   pytest-xdist
-filelock==3.29.1
+filelock==3.29.4
     # via
     #   -c all.txt
     #   python-discovery
@@ -111,7 +111,7 @@ httpx==0.28.1
     # via
     #   -c all.txt
     #   -r dev.in
-hypothesis==6.155.2
+hypothesis==6.155.6
     # via
     #   -c all.txt
     #   -r dev.in
@@ -236,11 +236,11 @@ pygments==2.20.0
     #   -c all.txt
     #   diff-cover
     #   pytest
-pylint==4.0.5
+pylint==4.0.6
     # via
     #   -c all.txt
     #   -r dev.in
-pytest==9.0.3
+pytest==9.1.1
     # via
     #   -c all.txt
     #   -r dev.in
@@ -278,7 +278,7 @@ python-dateutil==2.9.0.post0
     # via
     #   -c all.txt
     #   botocore
-python-discovery==1.4.0
+python-discovery==1.4.2
     # via
     #   -c all.txt
     #   virtualenv
@@ -312,7 +312,7 @@ rpds-py==2026.5.1
     #   -c all.txt
     #   jsonschema
     #   referencing
-s3transfer==0.18.0
+s3transfer==0.19.0
     # via
     #   -c all.txt
     #   boto3
@@ -345,7 +345,7 @@ urllib3==2.7.0
     #   botocore
     #   requests
     #   responses
-virtualenv==21.4.2
+virtualenv==21.5.1
     # via
     #   -c all.txt
     #   pre-commit

--- a/requirements/security.txt
+++ b/requirements/security.txt
@@ -12,15 +12,15 @@ cachecontrol[filecache]==0.14.4
     # via
     #   cachecontrol
     #   pip-audit
-certifi==2026.5.20
+certifi==2026.6.17
     # via requests
 charset-normalizer==3.4.7
     # via requests
-cyclonedx-python-lib==11.9.0
+cyclonedx-python-lib==11.11.0
     # via pip-audit
 defusedxml==0.7.1
     # via py-serializable
-filelock==3.29.1
+filelock==3.29.4
     # via cachecontrol
 idna==3.18
     # via requests
@@ -42,7 +42,7 @@ packaging==26.2
     #   pip-requirements-parser
 pip-api==0.0.34
     # via pip-audit
-pip-audit==2.10.0
+pip-audit==2.10.1
     # via -r security.in
 pip-requirements-parser==32.0.1
     # via pip-audit


### PR DESCRIPTION
## Summary
- PR #1926 was stale and unmergeable against current main, with only deployment checks and stale lock output.
- Regenerate the generic Python requirements locks from current origin/main using the repo-governed Python 3.11 pip-tools lane.

## Changes
- Refresh requirements/all.txt, requirements/base.txt, requirements/ci.txt, requirements/dev.txt, and requirements/security.txt.
- Preserve the explicit Linux keyring-chain pins required by the lock contract after macOS resolution.
- No route, API, selector, CLI, schema, or runtime contract changes.

## Validation
Proven green:
- make -C requirements update-generic LOCK_PYTHON_VERSION=3.11 PIP_COMPILE_BIN=/private/tmp/tp-py311-piptools/bin/pip-compile
- git diff --check -- requirements/all.txt requirements/base.txt requirements/ci.txt requirements/dev.txt requirements/security.txt
- make check-requirements-lock-contract
- make -C requirements check-generic LOCK_PYTHON_VERSION=3.11 PIP_COMPILE_BIN=/private/tmp/tp-py311-piptools/bin/pip-compile
- make check-dependency-pinning
- make check-piptools-cache
- PATH=/private/tmp/tp-py311-piptools/bin:$PATH ./scripts/validate_dependency_constraints.sh --verbose
- pre-commit hooks run by git commit, including Validate Dependency Constraints and gitleaks

Still failing:
- None in the focused local validation.

Failure classification:
- The initial commit attempt failed because the temp worktree resolved to a Python interpreter without packaging; rerunning with the Python 3.11 pip-tools venv made the same dependency constraint hook pass.

## Risk
- Bounded to generated generic requirements locks.
- Revert-safe as a single lockfile refresh commit.
- Cross-platform lock risk is bounded by preserving the Linux keyring-chain pins and passing the lock-contract guard.