### PR TITLE
docs(agents): document governance baseline refresh commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,17 @@ actionable; use the linked docs and `Makefile` for exhaustive inventories.
   `./scripts/setup/run_repo_python.sh scripts/governance/check_script_topology.py`
   and
   `./scripts/setup/run_repo_python.sh scripts/validation/check_gitleaks_workflow_contract.py`.
+  For scoped dependency drift checks, the dedicated
+  `.github/workflows/dependency-pinning-check.yml` workflow runs
+  `python scripts/validation/check_dependency_pinning.py`; it enforces exact
+  requirement pins and audits normal `constraints.txt` pins against the
+  governed environment. When TODO or workflow baselines change, refresh
+  committed docs from live repo state:
+  `python3 scripts/validation/scan_todo_inventory.py --write-snapshot` updates
+  `docs/analysis/todo_scanner_snapshot.json`, and
+  `docs/ci/WORKFLOW_MATRIX.md` must match live `.github/workflows/*.yml`
+  inventory counts plus per-workflow line estimates. Treat workflow-matrix
+  recommendations as proposals until matching workflow YAML changes land.
 - Root metadata contract tests:
   `./.venv/bin/pytest tests/validation/test_cloudflare_worker_root_shim_contract.py tests/validation/test_git_blame_ignore_revs_contract.py tests/validation/test_gitattributes_contract.py tests/validation/test_pylint_config_contract.py -v`.
 - Coverage/cold-zone:


### PR DESCRIPTION
## Summary
- Document the current dependency-pinning and docs-baseline refresh commands in `AGENTS.md`.
- Keep the guidance to the existing governance/docs gate surface with a single minimal docs-only insertion.

## Changes
- Note that `.github/workflows/dependency-pinning-check.yml` runs `python scripts/validation/check_dependency_pinning.py`.
- Point baseline refreshes at `python3 scripts/validation/scan_todo_inventory.py --write-snapshot`.
- Clarify that `docs/ci/WORKFLOW_MATRIX.md` must stay aligned with live `.github/workflows/*.yml` inventory counts and line estimates, and that matrix recommendations remain proposals until workflow YAML changes land.
- No route, selector, API, CLI flag, schema, or runtime contract changes.

## Validation
Proven green:
- `make check-dependency-pinning`
- `make check-todo-governance`
- `make check-doc-heading-links`
- `git diff --check -- AGENTS.md`
- `wc -l .github/workflows/*.yml` -> 31 workflow files, 7,843 total lines, matching `docs/ci/WORKFLOW_MATRIX.md`
- Commit hook suite passed during `git commit`

Still failing:
- None observed.

Failure classification:
- No product logic, stale test logic, or environment/tooling failures observed.

## Risk
- Docs-only operator guidance in `AGENTS.md`; no runtime behavior change.
- Revert-safe single-file patch.