### PR TITLE
fix(ci): suppress summary fallback PR comments

### DIFF
--- a/.github/workflows/AI_WORKFLOWS_HARDENING_STATUS.md
+++ b/.github/workflows/AI_WORKFLOWS_HARDENING_STATUS.md
@@ -75,7 +75,7 @@ All three AI advisory workflows have been hardened according to the technical re
 AI API Failure Path:
 ┌────────────────────────────────────────────┐
 │ OpenAI API call                            │
-│ └─ Retry logic (6 attempts, exp backoff)  │
+│ └─ Retry logic (workflow-specific bound)  │
 │    └─ All retries exhausted                │
 │       └─ Exception caught in Python        │
 │          └─ print("::warning::...")        │  ← Visible in UI
@@ -112,7 +112,7 @@ All three workflows implement a shared hardening baseline:
 - ✅ Python: `print("::warning::...(non-blocking)...")`
 - ✅ Shell: `echo "::warning::...failed (non-blocking)..."`
 - ✅ Terminal: `if: always()` summary step
-- ℹ️ Retry/backoff is currently implemented in `ai-code-review.yml` and `smart-issue-management.yml` only
+- ℹ️ Retry/backoff is implemented in all three workflows; `summary.yml` uses a shorter 3-attempt bound
 
 ---
 
@@ -126,7 +126,7 @@ All three workflows implement a shared hardening baseline:
 | Failure visibility | ✅ | `::warning::` in Python + Shell |
 | Syntax validation | ✅ | `make validate-ci` passes |
 | Consistent implementation | ✅ | Shared advisory hardening baseline across all three workflows |
-| Retry logic coverage | ✅ | Backoff retries in code review + triage; summary uses single-attempt fallback path |
+| Retry logic coverage | ✅ | Backoff retries in code review + triage; summary uses a 3-attempt fallback path |
 | Error messages clear | ✅ | Indicate non-blocking nature |
 
 ---
@@ -135,7 +135,7 @@ All three workflows implement a shared hardening baseline:
 
 ### Scenario 1: OpenAI Rate Limit (429)
 **Expected Behavior:**
-1. Retry logic attempts 6 times with backoff
+1. Retry logic uses the workflow-specific retry bound with backoff
 2. If all fail, Python emits `::warning::`
 3. Script exits 0 (non-blocking)
 4. `if: always()` summary step runs

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -105,8 +105,9 @@ The repository includes three AI-powered advisory workflows that provide intelli
 **Features:**
 - Triggered on `issues`, `pull_request`, and `issue_comment` events.
 - Uses OpenAI `gpt-4o-mini` model to generate neutral, concise summaries.
-- Posts the summary as a comment on the issue or pull request.
-- Graceful handling when API key is missing (posts diagnostic message once).
+- Retries HTTP 429, transient HTTP 5xx, and network errors up to 3 total attempts.
+- Posts successful AI-generated summaries as comments on the issue or pull request.
+- Graceful handling when API key is missing or AI calls fail; diagnostic fallbacks stay in logs.
 - Non-blocking: continues even if AI service fails.
 - Timeout-bounded: 4-minute step timeout, 10-minute job timeout.
 - Requires `OPENAI_API_KEY` in repository secrets.
@@ -130,7 +131,7 @@ All three workflows implement a hardened pattern with:
 - **Non-blocking behavior**: `continue-on-error: true`; expected AI/service failures emit warnings and typically exit 0, while hard infrastructure errors may still exit non-zero
 - **Timeout bounds**: 4-minute step timeout for AI calls, 10-minute job timeout
 - **Failure visibility**: `::warning::` emission in Python exception handlers and shell failure steps
-- **Retry logic (where implemented)**: up to 6 attempts with exponential backoff in `ai-code-review.yml` and `smart-issue-management.yml`; `summary.yml` currently uses a single-attempt call with graceful fallback
+- **Retry logic**: up to 6 attempts with exponential backoff in `ai-code-review.yml` and `smart-issue-management.yml`; up to 3 attempts with bounded backoff in `summary.yml`
 - **Concurrency control**: Cancel outdated runs to reduce CI costs
 
 ---

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -33,7 +33,7 @@ jobs:
       ISSUE_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number || '' }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       GH_TOKEN: ${{ github.token }}
-      # Marker used to deduplicate fallback diagnostic comments.
+      # Marker used to identify fallback diagnostics that should stay log-only.
       DIAGNOSTIC_MARKER: "<!-- ai-summarizer-diagnostic -->"
       DIAGNOSTIC_MSG_MISSING_KEY: |
         AI summarizer skipped: OPENAI_API_KEY is not configured in CI.
@@ -233,11 +233,10 @@ jobs:
           echo "First 5 lines of RESPONSE_FILE:"
           head -n 5 "$RESPONSE_FILE" || true
 
-      - name: Post comment only if present and not previously posted
+      - name: Post successful summary comment only
         env:
           RESPONSE_FILE: ${{ runner.temp }}/issue_summary.txt
           GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
           ISSUE_NUMBER: ${{ env.ISSUE_NUMBER }}
           MARKER: ${{ env.DIAGNOSTIC_MARKER }}
         run: |
@@ -253,14 +252,10 @@ jobs:
             exit 0
           fi
 
-          # Only deduplicate when the current comment is a diagnostic fallback.
+          # Fallback diagnostics are visible in CI logs but should not add PR noise.
           if grep -Fq "$MARKER" "$RESPONSE_FILE"; then
-            echo "Checking existing comments for diagnostic marker..."
-            EXISTING=$(gh api "repos/$REPO/issues/$ISSUE_NUMBER/comments" --jq '.[].body' 2>/dev/null || echo "")
-            if echo "$EXISTING" | grep -Fq "$MARKER"; then
-              echo "A diagnostic comment has already been posted; skipping duplicate diagnostic."
-              exit 0
-            fi
+            echo "Diagnostic fallback response is log-only; skipping PR comment post."
+            exit 0
           fi
 
           # Post the comment using --body-file to avoid quoting issues.

--- a/docs/ci/WORKFLOW_MATRIX.md
+++ b/docs/ci/WORKFLOW_MATRIX.md
@@ -2,13 +2,13 @@
 
 **Purpose**: Canonical reference for all GitHub Actions workflows. Tracks the full inventory and the consolidation roadmap.
 **Owner**: Transformation Portal Architect
-**Last Updated**: 2026-06-11
+**Last Updated**: 2026-06-22
 
 ---
 
 ## Status Snapshot
 
-- **Workflow files**: 31 (`.github/workflows/*.yml`), 7,843 lines total
+- **Workflow files**: 31 (`.github/workflows/*.yml`), 7,838 lines total
 - **Required PR check**: `build.yml` → `CI Gate` (single aggregated check)
 - **Consolidation target**: 31 → ~19 workflows via phased incremental PRs (see [Consolidation Roadmap](#consolidation-roadmap))
 - **Prior matrix doc** (2026-03-25) listed 12 workflows — this revision corrects the omission of 18 that exist on disk.
@@ -49,7 +49,7 @@ Every `.github/workflows/*.yml` file, current as of the timestamp above. The **R
 | 26 | `submit-pypi.yml` | Submit to PyPI | push (tag), manual | Release | 139 | **Keep** — release pipeline. |
 | 27 | `tag_retention_prune_preservation_tags.yml` | Tag Retention (Preservation Tags) | schedule, manual | ❌ No | 40 | **Keep** — periodic cleanup. |
 | 28 | `ai-code-review.yml` | AI Code Review | PR | ❌ No | 316 | **Investigate → Consolidate or retire** — frequent rate-limit failures on recent PRs (#1558 saw 4/4 calls error out). Either fold into `ai-advisory.yml` (proposed) or accept the noise. |
-| 29 | `summary.yml` | Issue Summarizer | issue_comment, PR, issues | ❌ No | 279 | **Investigate → Consolidate or retire** — same rate-limit story as ai-code-review. |
+| 29 | `summary.yml` | Issue Summarizer | issue_comment, PR, issues | ❌ No | 274 | **Investigate → Consolidate or retire** — same rate-limit story as ai-code-review. |
 | 30 | `smart-issue-management.yml` | Smart Issue Management | issues, pull_request_target | ❌ No | 347 | **Investigate → Consolidate or retire** — same. |
 | 31 | `issue_printer.yml` | Print Issue Info | issues | ❌ No | 24 | **Retire** — 24 lines that print title/body to job logs. No artifact, no enforcement. Pure noise. |
 
@@ -99,7 +99,7 @@ Aggregated reduction: **5 fewer workflows** (4 contract validators → 1 = net �
 
 These need maintainer judgment, not mechanical merging.
 
-7. **Three AI advisory workflows** (`ai-code-review.yml`, `summary.yml`, `smart-issue-management.yml`, total 942 lines). They share a hardening baseline (per `AI_WORKFLOWS_HARDENING_STATUS.md`) and currently fail with rate-limit errors on most PRs. Options:
+7. **Three AI advisory workflows** (`ai-code-review.yml`, `summary.yml`, `smart-issue-management.yml`, total 937 lines). They share a hardening baseline (per `AI_WORKFLOWS_HARDENING_STATUS.md`) and currently fail with rate-limit errors on most PRs. Options:
    - **Consolidate** into one `ai-advisory.yml` with three jobs sharing setup (saves ~200 LOC)
    - **Retire** if the value-to-noise ratio is unfavorable (recent PR #1558: 4 of 4 AI calls errored)
    - **Keep separate** if isolation is desirable for independent ownership

--- a/docs/ci_cd/AI_RATE_LIMIT_MITIGATION.md
+++ b/docs/ci_cd/AI_RATE_LIMIT_MITIGATION.md
@@ -2,7 +2,7 @@
 
 **Issue:** GitHub Actions workflows using AI services (OpenAI) have experienced rate-limit errors (HTTP 429) during PR reviews and issue summarization, causing workflow failures or degraded experience.
 
-**Current State:** AI code review is non-blocking, retries transient OpenAI 429 responses, treats `insufficient_quota` as terminal, and keeps fallback diagnostics in CI logs instead of posting fallback PR comments.
+**Current State:** AI advisory workflows are non-blocking. AI code review retries transient OpenAI 429 responses, treats `insufficient_quota` as terminal, and keeps fallback diagnostics in CI logs instead of posting fallback PR comments. The issue summarizer retries bounded transient OpenAI failures and posts only successful AI summaries; fallback diagnostics stay in CI logs.
 
 ---
 
@@ -32,10 +32,15 @@
 
 ### Issue Summarizer Workflow (`.github/workflows/summary.yml`)
 
-⚠️ **Partial mitigation:**
+✅ **Has bounded retry logic and quiet fallback behavior:**
 - Has concurrency control
 - Skips gracefully if key missing
-- **No retry logic** - single attempt only
+- Retries OpenAI HTTP 429 responses up to 3 total attempts
+- Retries transient HTTP 5xx and network errors up to 3 total attempts
+- Honors `Retry-After` when present, capped at 30 seconds
+- Otherwise uses exponential backoff with jitter, capped at 20 seconds
+- Writes fallback diagnostics to the workflow output/logs without posting PR comments
+- Posts only successful AI-generated summaries as issue/PR comments
 
 ---
 
@@ -59,43 +64,23 @@ jobs:
 - Rate limits and quota exhaustion must not block PR merges when code is correct
 - Human review is the authoritative gate; AI is advisory
 
-### 2. Add Retry Logic to Issue Summarizer (Medium Priority)
+### 2. Keep Issue Summarizer Retry Bounded (Implemented)
 
-**Change:** Add same retry/backoff pattern used in AI code review.
+**Contract:** `.github/workflows/summary.yml` keeps retries short enough for its 4-minute step timeout and 10-minute job timeout.
 
 **Implementation:**
-```python
-def call_openai_with_retries(client, messages, model="gpt-4o-mini", max_retries=6, **kwargs):
-    for attempt in range(1, max_retries + 1):
-        try:
-            return client.chat.completions.create(
-                model=model,
-                messages=messages,
-                max_tokens=1000,
-                temperature=0.3,
-                **kwargs
-            )
-        except Exception as e:
-            err_str = str(e)
-            status_is_429 = False
-            status = getattr(e, "status_code", None) or getattr(e, "http_status", None)
-            if status == 429 or "429" in err_str or "Rate limit" in err_str:
-                status_is_429 = True
-
-            if status_is_429 and attempt < max_retries:
-                base_wait = min(60, 2 ** attempt)
-                jitter = random.uniform(0.5, 1.5)
-                wait = base_wait * jitter
-                print(f"⚠️ Rate limited (attempt {attempt}/{max_retries}). Waiting {wait:.1f}s...")
-                time.sleep(wait)
-                continue
-            raise
-```
+- Calls OpenAI with `max_retries=3`
+- Retries HTTP 429, transient HTTP 5xx, and network errors
+- Honors `Retry-After` for 429/5xx responses, capped at 30 seconds
+- Falls back to exponential backoff plus jitter when `Retry-After` is absent, capped at 20 seconds
+- Treats other HTTP 4xx responses as terminal for the current run
+- Emits workflow warnings and exits non-blocking after exhausted retries
+- Keeps diagnostic fallback bodies log-only by skipping comment posting when the `<!-- ai-summarizer-diagnostic -->` marker is present
 
 **Rationale:**
-- Consistent error handling across AI workflows
-- Transient rate limits should not cause permanent failures
-- Terminal quota errors such as `insufficient_quota` should be logged once and not retried
+- Transient rate limits should get a bounded retry window
+- PRs should not accumulate comments for service-unavailable diagnostics
+- Human review and normal CI remain authoritative when AI services are unavailable
 
 ### 3. Add Rate-Limit Budget Monitoring (Medium Priority)
 
@@ -155,7 +140,7 @@ check-quota:
 | Priority | Change | Impact | Effort | Recommended Timeline |
 |----------|--------|--------|--------|---------------------|
 | **Done** | Keep AI workflows non-blocking | Prevents PR merge blockage | Low (1 line change) | Implemented |
-| **Medium** | Add retry to issue summarizer | Improves reliability | Medium (30 mins) | Next sprint |
+| **Done** | Keep issue summarizer retries bounded and fallback comments suppressed | Improves reliability without PR noise | Low | Implemented |
 | **Medium** | Add rate-limit budget monitoring | Proactive management | Medium (1-2 hours) | Next sprint |
 | **Low** | Add degraded mode fallback | Better job-summary UX when limited | High (2-3 hours) | Future consideration |
 | **Low** | Alternative AI providers | Risk diversification | High (4-6 hours) | Future consideration |
@@ -190,7 +175,7 @@ jobs:
 2. Trigger AI review workflow
 3. Verify that even if AI fails, PR can still merge
 4. Verify that AI comments still post when successful
-5. Verify that `insufficient_quota` logs a warning without repeated retries or a fallback PR comment
+5. Verify that rate-limit fallback diagnostics log a warning without posting a fallback PR comment
 
 ---
 
@@ -200,7 +185,7 @@ jobs:
 
 1. **GitHub Actions logs:** Search for "Rate limited", "429", or `insufficient_quota` in workflow runs
 2. **OpenAI dashboard:** Monitor API usage and quota consumption
-3. **GitHub Issues:** Track rate-limit failures as incidents
+3. **GitHub Issues:** Track rate-limit failures as maintainer-created incidents when logs show sustained failures
 
 **Alert thresholds:**
 - **Warning:** >10 rate-limit errors per day
@@ -218,9 +203,9 @@ jobs:
 
 ## Status
 
-**Current:** AI code review retries transient 429s, treats `insufficient_quota` as terminal, stays non-blocking, and avoids fallback PR comments.
+**Current:** AI code review retries transient 429s, treats `insufficient_quota` as terminal, stays non-blocking, and avoids fallback PR comments. The issue summarizer retries 429/5xx/network failures up to 3 total attempts, keeps fallback diagnostics log-only, and posts successful AI summaries.
 
-**Proposed:** Add retry classification parity to issue summarizer and consider optional quota monitoring.
+**Proposed:** Consider optional quota monitoring if logs show sustained OpenAI rate-limit pressure.
 
 **Owner:** Repository maintainers (requires workflow permission to modify).
 

--- a/tests/test_summary_workflow.py
+++ b/tests/test_summary_workflow.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SUMMARY_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "summary.yml"
+DIAGNOSTIC_MARKER = "<!-- ai-summarizer-diagnostic -->"
+
+
+def _workflow_text() -> str:
+    return SUMMARY_WORKFLOW_PATH.read_text(encoding="utf-8")
+
+
+def _load_workflow() -> dict:
+    return yaml.load(_workflow_text(), Loader=yaml.BaseLoader)
+
+
+def _post_comment_step() -> dict:
+    workflow = _load_workflow()
+    steps = workflow["jobs"]["summarize"]["steps"]
+    return next(step for step in steps if step.get("name") == "Post successful summary comment only")
+
+
+def _run_post_comment_step(tmp_path: Path, response_body: str) -> tuple[subprocess.CompletedProcess[str], str]:
+    response_file = tmp_path / "issue_summary.txt"
+    response_file.write_text(response_body, encoding="utf-8")
+
+    calls_file = tmp_path / "gh-calls.txt"
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    gh_path = bin_dir / "gh"
+    gh_script = "\n".join(
+        [
+            "#!/usr/bin/env bash",
+            'printf "%s\\n" "$*" >> "$GH_CALLS_FILE"',
+            "exit 0",
+            "",
+        ]
+    )
+    gh_path.write_text(
+        gh_script,
+        encoding="utf-8",
+    )
+    gh_path.chmod(gh_path.stat().st_mode | stat.S_IXUSR)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "GH_CALLS_FILE": str(calls_file),
+            "GH_TOKEN": "test-token",
+            "ISSUE_NUMBER": "1947",
+            "MARKER": DIAGNOSTIC_MARKER,
+            "PATH": f"{bin_dir}:{env.get('PATH', '')}",
+            "RESPONSE_FILE": str(response_file),
+        }
+    )
+
+    result = subprocess.run(
+        ["bash", "-c", _post_comment_step()["run"]],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    calls = calls_file.read_text(encoding="utf-8") if calls_file.exists() else ""
+    return result, calls
+
+
+def test_summary_workflow_remains_advisory_and_timeout_bounded() -> None:
+    workflow = _load_workflow()
+    job = workflow["jobs"]["summarize"]
+    run_step = next(step for step in job["steps"] if step.get("name") == "Run summarizer (safe Option B)")
+
+    assert job["continue-on-error"] == "true"
+    assert job["timeout-minutes"] == "10"
+    assert run_step["timeout-minutes"] == "4"
+
+
+def test_summary_workflow_suppresses_pr_1947_rate_limit_diagnostic_comment(tmp_path: Path) -> None:
+    diagnostic_body = (
+        "AI summarizer skipped after bounded retries due to OpenAI rate limiting.\n"
+        "This is non-blocking and intentionally does not fail CI.\n"
+        f"{DIAGNOSTIC_MARKER}\n"
+    )
+
+    result, gh_calls = _run_post_comment_step(tmp_path, diagnostic_body)
+
+    assert result.returncode == 0, result.stderr
+    assert gh_calls == ""
+    assert "Diagnostic fallback response is log-only; skipping PR comment post." in result.stdout
+    assert "Posting comment to issue/PR #1947" not in result.stdout
+
+
+def test_summary_workflow_still_posts_successful_ai_summary(tmp_path: Path) -> None:
+    result, gh_calls = _run_post_comment_step(tmp_path, "This PR updates workflow guidance.\n")
+
+    assert result.returncode == 0, result.stderr
+    assert "Posting comment to issue/PR #1947" in result.stdout
+    assert gh_calls.startswith("issue comment 1947 --body-file ")


### PR DESCRIPTION
## Summary
- `.github/workflows/summary.yml` posted rate-limit fallback diagnostics as PR comments whenever OpenAI retries exhausted.
- This keeps successful AI summaries posting while making marker-bearing fallback diagnostics log-only.

## Changes
- Renamed the summary post step to reflect that only successful summaries should be commented.
- Skips `gh issue comment` when `RESPONSE_FILE` contains `<!-- ai-summarizer-diagnostic -->`.
- Added focused workflow tests for the PR #1947 rate-limit reproducer and the successful-summary posting path.
- Updated AI workflow docs to describe the real 3-attempt retry behavior and quiet fallback contract.

## Validation
Proven green:
- `.venv/bin/pytest tests/test_summary_workflow.py tests/test_ai_code_review_workflow.py tests/test_smart_issue_management_workflow.py -q`
- `make validate-ci`
- `make check-doc-heading-links`
- `git diff --check -- .github/workflows/summary.yml tests/test_summary_workflow.py docs/ci_cd/AI_RATE_LIMIT_MITIGATION.md .github/workflows/README.md .github/workflows/AI_WORKFLOWS_HARDENING_STATUS.md`

Still failing:
- None in the focused validation path.

Failure classification:
- No product, stale-test, or environment/tooling failures observed.

## Risk
- Low operational risk: the change only suppresses marker-bearing fallback comments and leaves marker-free successful AI summary comments on the existing post path.
- Failure remains non-blocking and visible in CI logs.
- Revert-safe because it is isolated to the advisory summary workflow and its docs/tests.