### PR TITLE
chore(deps): refresh governed Python locks

### DIFF
--- a/docs/governance/DEPENDABOT_PR_GOVERNANCE.md
+++ b/docs/governance/DEPENDABOT_PR_GOVERNANCE.md
@@ -100,7 +100,7 @@ compatibility changes.
 The following dependencies are **exact-pinned** in `requirements/base.in` for API/UI parity and security baseline:
 
 ```
-fastapi==0.136.1
+fastapi==0.138.0
 starlette==1.3.1
 uvicorn==0.48.0
 aiofiles==25.1.0

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -4,7 +4,7 @@
 
 # Core dependencies that are actually imported in linted files
 numpy>=1.24,<2.5.0
-Pillow>=10.3.0,<13  # Security: CVE-2024-28219 fixed in 10.3.0; current governed lock baseline is pillow==12.2.0
+Pillow>=10.3.0,<13  # Security: CVE-2024-28219 fixed in 10.3.0; current governed lock baseline is pillow==12.3.0
 PyYAML>=6.0,<7
 tqdm>=4.66,<5
 

--- a/requirements/README.md
+++ b/requirements/README.md
@@ -123,7 +123,7 @@ The repository's governed web stack currently resolves to:
 
 | Dependency | Source of Truth | Current Version |
 |-----------|-----------------|-----------------|
-| FastAPI | `requirements/base.in` | `0.136.1` |
+| FastAPI | `requirements/base.in` | `0.138.0` |
 | Starlette | `requirements/base.in` + `pyproject.toml` bound | `1.3.1` |
 | Uvicorn | `requirements/base.in` + `pyproject.toml` bound | `0.48.0` |
 

--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -6,19 +6,19 @@
 #
 aiofiles==25.1.0
     # via -r base.in
-alembic==1.18.4
+alembic==1.18.5
     # via -r base.in
-annotated-doc==0.0.4
+annotated-doc==0.0.5
     # via
     #   fastapi
     #   typer
-annotated-types==0.7.0
+annotated-types==0.8.0
     # via pydantic
-anyio==4.14.0
+anyio==4.14.2
     # via
     #   httpx
     #   starlette
-ast-serialize==0.5.0
+ast-serialize==0.6.0
     # via mypy
 astroid==4.0.4
     # via pylint
@@ -36,46 +36,46 @@ bandit==1.9.4
     # via -r ci.in
 black==26.3.1
     # via -r dev.in
-boto3==1.43.34
+boto3==1.43.62
     # via
     #   -r base.in
     #   moto
-botocore==1.43.34
+botocore==1.43.62
     # via
     #   boto3
     #   moto
     #   s3transfer
 build==1.5.0
     # via -r ci.in
-cachetools==7.1.4
+cachetools==7.1.7
     # via tox
-certifi==2026.6.17
+certifi==2026.7.22
     # via
     #   httpcore
     #   httpx
     #   requests
-cffi==2.0.0
+cffi==2.1.0
     # via cryptography
 cfgv==3.5.0
     # via pre-commit
 chardet==7.4.3
     # via diff-cover
-charset-normalizer==3.4.7
+charset-normalizer==3.4.9
     # via requests
-click==8.4.1
+click==8.4.2
     # via
     #   black
     #   uvicorn
 colorama==0.4.6
     # via tox
-coverage[toml]==7.14.2
+coverage[toml]==7.15.3
     # via pytest-cov
 cryptography==48.0.1
     # via
     #   -r dev.in
     #   moto
     #   secretstorage
-diff-cover==10.3.0
+diff-cover==10.4.1
     # via -r dev.in
 dill==0.4.1
     # via pylint
@@ -85,16 +85,16 @@ docutils==0.23
     # via readme-renderer
 execnet==2.1.2
     # via pytest-xdist
-fastapi==0.136.1
+fastapi==0.138.0
     # via -r base.in
-filelock==3.29.4
+filelock==3.32.2
     # via
     #   python-discovery
     #   tox
     #   virtualenv
 flake8==7.3.0
     # via -r dev.in
-greenlet==3.5.2
+greenlet==3.5.4
     # via sqlalchemy
 h11==0.16.0
     # via
@@ -104,7 +104,7 @@ httpcore==1.0.9
     # via httpx
 httpx==0.28.1
     # via -r dev.in
-hypothesis==6.155.6
+hypothesis==6.165.0
     # via -r dev.in
 id==1.6.1
     # via twine
@@ -129,7 +129,7 @@ jaraco-classes==3.4.0
     # via keyring
 jaraco-context==6.1.2
     # via keyring
-jaraco-functools==4.5.0
+jaraco-functools==4.6.0
     # via keyring
 jeepney==0.9.0
     # via
@@ -151,9 +151,9 @@ jsonschema-specifications==2025.9.1
     # via jsonschema
 keyring==25.7.0
     # via twine
-libcst==1.8.6
+libcst==1.9.0
     # via -r dev.in
-librt==0.11.0
+librt==0.13.0
     # via mypy
 mako==1.3.12
     # via alembic
@@ -176,15 +176,15 @@ more-itertools==11.1.0
     #   jaraco-functools
 moto[s3]==5.2.2
     # via -r dev.in
-mypy==2.1.0
+mypy==2.3.0
     # via -r dev.in
 mypy-extensions==1.1.0
     # via
     #   black
     #   mypy
-narwhals==2.22.1
+narwhals==2.24.0
     # via scikit-learn
-nh3==0.3.5
+nh3==0.3.6
     # via readme-renderer
 nodeenv==1.10.0
     # via pre-commit
@@ -192,13 +192,13 @@ numpy==2.4.6
     # via
     #   -r base.in
     #   imagecodecs
-    #   opencv-python
+    #   opencv-python-headless
     #   scikit-learn
     #   scipy
     #   tifffile
-opencv-python==4.13.0.92 ; platform_system != "Linux"
+opencv-python==4.14.0.94 ; platform_system != "Linux"
     # via -r base.in
-opencv-python-headless==4.13.0.92 ; platform_system == "Linux"
+opencv-python-headless==4.14.0.94 ; platform_system == "Linux"
     # via -r base.in
 packaging==26.2
     # via
@@ -213,13 +213,12 @@ pathspec==1.1.1
     # via
     #   black
     #   mypy
-pillow==12.2.0
+pillow==12.3.0
     # via -r base.in
-platformdirs==4.10.0
+platformdirs==4.11.0
     # via
     #   black
     #   pylint
-    #   python-discovery
     #   tox
     #   virtualenv
 pluggy==1.6.0
@@ -228,7 +227,7 @@ pluggy==1.6.0
     #   pytest
     #   pytest-cov
     #   tox
-pre-commit==4.6.0
+pre-commit==4.6.1
     # via -r dev.in
 py-partiql-parser==0.6.3
     # via moto
@@ -256,7 +255,7 @@ pylint==4.0.6
     # via -r dev.in
 pypdf==6.14.2
     # via -r ci.in
-pyproject-api==1.10.1
+pyproject-api==1.11.0
     # via tox
 pyproject-hooks==1.2.0
     # via build
@@ -277,13 +276,13 @@ pytest-json-report==1.5.0
     # via -r dev.in
 pytest-metadata==3.1.1
     # via pytest-json-report
-pytest-rerunfailures==16.3
+pytest-rerunfailures==16.4
     # via -r dev.in
 pytest-xdist==3.8.0
     # via -r dev.in
 python-dateutil==2.9.0.post0
     # via botocore
-python-discovery==1.4.2
+python-discovery==1.5.1
     # via
     #   tox
     #   virtualenv
@@ -312,7 +311,7 @@ requests==2.34.2
     #   twine
 requests-toolbelt==1.0.0
     # via twine
-responses==0.26.1
+responses==0.26.2
     # via moto
 rfc3986==2.0.0
     # via twine
@@ -321,11 +320,11 @@ rich==15.0.0
     #   bandit
     #   twine
     #   typer
-rpds-py==2026.5.1
+rpds-py==2026.6.3
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.19.0
+s3transfer==0.19.2
     # via boto3
 scikit-learn==1.9.0
     # via -r base.in
@@ -350,7 +349,7 @@ starlette==1.3.1
     # via
     #   -r base.in
     #   fastapi
-stevedore==5.8.0
+stevedore==5.9.0
     # via bandit
 threadpoolctl==3.6.0
     # via scikit-learn
@@ -358,19 +357,19 @@ tifffile==2026.3.3
     # via -r base.in
 tomli-w==1.2.0
     # via tox
-tomlkit==0.15.0
+tomlkit==0.15.1
     # via pylint
-tox==4.55.1
+tox==4.58.0
     # via -r ci.in
-tqdm==4.68.3
+tqdm==4.70.0
     # via -r base.in
 twine==6.2.0
     # via -r ci.in
-typer==0.26.7
+typer==0.27.0
     # via -r base.in
-types-pyyaml==6.0.12.20260518
+types-pyyaml==6.0.12.20260724
     # via -r dev.in
-typing-extensions==4.15.0
+typing-extensions==4.16.0
     # via
     #   alembic
     #   anyio
@@ -396,7 +395,7 @@ urllib3==2.7.0
     #   twine
 uvicorn==0.48.0
     # via -r base.in
-virtualenv==21.5.1
+virtualenv==21.7.1
     # via
     #   pre-commit
     #   tox

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -4,7 +4,7 @@
 
 # Core array and image processing
 numpy>=1.24,<2.5.0         # upper bound for OpenCV compatibility; see ADR-032
-Pillow>=10.3.0,<13         # Security: CVE-2024-28219 fixed in 10.3.0; current governed lock baseline is pillow==12.2.0
+Pillow>=10.3.0,<13         # Security: CVE-2024-28219 fixed in 10.3.0; current governed lock baseline is pillow==12.3.0
 scipy>=1.15,<2
 scikit-learn>=1.8.0,<2       # classical ML (used in core features)
 opencv-python-headless>=4.8.0,<5 ; platform_system == "Linux"      # required for depth_writer (core pipeline)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,20 +8,20 @@ aiofiles==25.1.0
     # via
     #   -c all.txt
     #   -r base.in
-alembic==1.18.4
+alembic==1.18.5
     # via
     #   -c all.txt
     #   -r base.in
-annotated-doc==0.0.4
+annotated-doc==0.0.5
     # via
     #   -c all.txt
     #   fastapi
     #   typer
-annotated-types==0.7.0
+annotated-types==0.8.0
     # via
     #   -c all.txt
     #   pydantic
-anyio==4.14.0
+anyio==4.14.2
     # via
     #   -c all.txt
     #   starlette
@@ -34,24 +34,24 @@ attrs==26.1.0
     #   -c all.txt
     #   jsonschema
     #   referencing
-boto3==1.43.34
+boto3==1.43.62
     # via
     #   -c all.txt
     #   -r base.in
-botocore==1.43.34
+botocore==1.43.62
     # via
     #   -c all.txt
     #   boto3
     #   s3transfer
-click==8.4.1
+click==8.4.2
     # via
     #   -c all.txt
     #   uvicorn
-fastapi==0.136.1
+fastapi==0.138.0
     # via
     #   -c all.txt
     #   -r base.in
-greenlet==3.5.2
+greenlet==3.5.4
     # via
     #   -c all.txt
     #   sqlalchemy
@@ -100,7 +100,7 @@ mdurl==0.1.2
     # via
     #   -c all.txt
     #   markdown-it-py
-narwhals==2.22.1
+narwhals==2.24.0
     # via
     #   -c all.txt
     #   scikit-learn
@@ -109,19 +109,19 @@ numpy==2.4.6
     #   -c all.txt
     #   -r base.in
     #   imagecodecs
-    #   opencv-python
+    #   opencv-python-headless
     #   scikit-learn
     #   scipy
     #   tifffile
-opencv-python==4.13.0.92 ; platform_system != "Linux"
+opencv-python==4.14.0.94 ; platform_system != "Linux"
     # via
     #   -c all.txt
     #   -r base.in
-opencv-python-headless==4.13.0.92 ; platform_system == "Linux"
+opencv-python-headless==4.14.0.94 ; platform_system == "Linux"
     # via
     #   -c all.txt
     #   -r base.in
-pillow==12.2.0
+pillow==12.3.0
     # via
     #   -c all.txt
     #   -r base.in
@@ -155,12 +155,12 @@ rich==15.0.0
     # via
     #   -c all.txt
     #   typer
-rpds-py==2026.5.1
+rpds-py==2026.6.3
     # via
     #   -c all.txt
     #   jsonschema
     #   referencing
-s3transfer==0.19.0
+s3transfer==0.19.2
     # via
     #   -c all.txt
     #   boto3
@@ -200,15 +200,15 @@ tifffile==2026.3.3
     # via
     #   -c all.txt
     #   -r base.in
-tqdm==4.68.3
+tqdm==4.70.0
     # via
     #   -c all.txt
     #   -r base.in
-typer==0.26.7
+typer==0.27.0
     # via
     #   -c all.txt
     #   -r base.in
-typing-extensions==4.15.0
+typing-extensions==4.16.0
     # via
     #   -c all.txt
     #   alembic

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -16,19 +16,19 @@ build==1.5.0
     # via
     #   -c all.txt
     #   -r ci.in
-cachetools==7.1.4
+cachetools==7.1.7
     # via
     #   -c all.txt
     #   tox
-certifi==2026.6.17
+certifi==2026.7.22
     # via
     #   -c all.txt
     #   requests
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   -c all.txt
     #   cryptography
-charset-normalizer==3.4.7
+charset-normalizer==3.4.9
     # via
     #   -c all.txt
     #   requests
@@ -48,7 +48,7 @@ docutils==0.23
     # via
     #   -c all.txt
     #   readme-renderer
-filelock==3.29.4
+filelock==3.32.2
     # via
     #   -c all.txt
     #   python-discovery
@@ -74,7 +74,7 @@ jaraco-context==6.1.2
     # via
     #   -c all.txt
     #   keyring
-jaraco-functools==4.5.0
+jaraco-functools==4.6.0
     # via
     #   -c all.txt
     #   keyring
@@ -100,7 +100,7 @@ more-itertools==11.1.0
     #   -c all.txt
     #   jaraco-classes
     #   jaraco-functools
-nh3==0.3.5
+nh3==0.3.6
     # via
     #   -c all.txt
     #   readme-renderer
@@ -111,10 +111,9 @@ packaging==26.2
     #   pyproject-api
     #   tox
     #   twine
-platformdirs==4.10.0
+platformdirs==4.11.0
     # via
     #   -c all.txt
-    #   python-discovery
     #   tox
     #   virtualenv
 pluggy==1.6.0
@@ -134,7 +133,7 @@ pypdf==6.14.2
     # via
     #   -c all.txt
     #   -r ci.in
-pyproject-api==1.10.1
+pyproject-api==1.11.0
     # via
     #   -c all.txt
     #   tox
@@ -142,7 +141,7 @@ pyproject-hooks==1.2.0
     # via
     #   -c all.txt
     #   build
-python-discovery==1.4.2
+python-discovery==1.5.1
     # via
     #   -c all.txt
     #   tox
@@ -177,7 +176,7 @@ secretstorage==3.5.0
     # via
     #   -c all.txt
     #   keyring
-stevedore==5.8.0
+stevedore==5.9.0
     # via
     #   -c all.txt
     #   bandit
@@ -185,7 +184,7 @@ tomli-w==1.2.0
     # via
     #   -c all.txt
     #   tox
-tox==4.55.1
+tox==4.58.0
     # via
     #   -c all.txt
     #   -r ci.in
@@ -199,7 +198,7 @@ urllib3==2.7.0
     #   id
     #   requests
     #   twine
-virtualenv==21.5.1
+virtualenv==21.7.1
     # via
     #   -c all.txt
     #   tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,11 +4,11 @@
 #
 #    pip-compile --constraint=all.txt --output-file=dev.txt dev.in
 #
-anyio==4.14.0
+anyio==4.14.2
     # via
     #   -c all.txt
     #   httpx
-ast-serialize==0.5.0
+ast-serialize==0.6.0
     # via
     #   -c all.txt
     #   mypy
@@ -29,23 +29,23 @@ black==26.3.1
     # via
     #   -c all.txt
     #   -r dev.in
-boto3==1.43.34
+boto3==1.43.62
     # via
     #   -c all.txt
     #   moto
-botocore==1.43.34
+botocore==1.43.62
     # via
     #   -c all.txt
     #   boto3
     #   moto
     #   s3transfer
-certifi==2026.6.17
+certifi==2026.7.22
     # via
     #   -c all.txt
     #   httpcore
     #   httpx
     #   requests
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   -c all.txt
     #   cryptography
@@ -57,15 +57,15 @@ chardet==7.4.3
     # via
     #   -c all.txt
     #   diff-cover
-charset-normalizer==3.4.7
+charset-normalizer==3.4.9
     # via
     #   -c all.txt
     #   requests
-click==8.4.1
+click==8.4.2
     # via
     #   -c all.txt
     #   black
-coverage[toml]==7.14.2
+coverage[toml]==7.15.3
     # via
     #   -c all.txt
     #   pytest-cov
@@ -74,7 +74,7 @@ cryptography==48.0.1
     #   -c all.txt
     #   -r dev.in
     #   moto
-diff-cover==10.3.0
+diff-cover==10.4.1
     # via
     #   -c all.txt
     #   -r dev.in
@@ -90,7 +90,7 @@ execnet==2.1.2
     # via
     #   -c all.txt
     #   pytest-xdist
-filelock==3.29.4
+filelock==3.32.2
     # via
     #   -c all.txt
     #   python-discovery
@@ -111,7 +111,7 @@ httpx==0.28.1
     # via
     #   -c all.txt
     #   -r dev.in
-hypothesis==6.155.6
+hypothesis==6.165.0
     # via
     #   -c all.txt
     #   -r dev.in
@@ -151,11 +151,11 @@ jsonschema-specifications==2025.9.1
     # via
     #   -c all.txt
     #   jsonschema
-libcst==1.8.6
+libcst==1.9.0
     # via
     #   -c all.txt
     #   -r dev.in
-librt==0.11.0
+librt==0.13.0
     # via
     #   -c all.txt
     #   mypy
@@ -173,7 +173,7 @@ moto[s3]==5.2.2
     # via
     #   -c all.txt
     #   -r dev.in
-mypy==2.1.0
+mypy==2.3.0
     # via
     #   -c all.txt
     #   -r dev.in
@@ -197,12 +197,11 @@ pathspec==1.1.1
     #   -c all.txt
     #   black
     #   mypy
-platformdirs==4.10.0
+platformdirs==4.11.0
     # via
     #   -c all.txt
     #   black
     #   pylint
-    #   python-discovery
     #   virtualenv
 pluggy==1.6.0
     # via
@@ -210,7 +209,7 @@ pluggy==1.6.0
     #   diff-cover
     #   pytest
     #   pytest-cov
-pre-commit==4.6.0
+pre-commit==4.6.1
     # via
     #   -c all.txt
     #   -r dev.in
@@ -266,7 +265,7 @@ pytest-metadata==3.1.1
     # via
     #   -c all.txt
     #   pytest-json-report
-pytest-rerunfailures==16.3
+pytest-rerunfailures==16.4
     # via
     #   -c all.txt
     #   -r dev.in
@@ -278,7 +277,7 @@ python-dateutil==2.9.0.post0
     # via
     #   -c all.txt
     #   botocore
-python-discovery==1.4.2
+python-discovery==1.5.1
     # via
     #   -c all.txt
     #   virtualenv
@@ -303,16 +302,16 @@ requests==2.34.2
     #   -c all.txt
     #   moto
     #   responses
-responses==0.26.1
+responses==0.26.2
     # via
     #   -c all.txt
     #   moto
-rpds-py==2026.5.1
+rpds-py==2026.6.3
     # via
     #   -c all.txt
     #   jsonschema
     #   referencing
-s3transfer==0.19.0
+s3transfer==0.19.2
     # via
     #   -c all.txt
     #   boto3
@@ -324,15 +323,15 @@ sortedcontainers==2.4.0
     # via
     #   -c all.txt
     #   hypothesis
-tomlkit==0.15.0
+tomlkit==0.15.1
     # via
     #   -c all.txt
     #   pylint
-types-pyyaml==6.0.12.20260518
+types-pyyaml==6.0.12.20260724
     # via
     #   -c all.txt
     #   -r dev.in
-typing-extensions==4.15.0
+typing-extensions==4.16.0
     # via
     #   -c all.txt
     #   anyio
@@ -345,7 +344,7 @@ urllib3==2.7.0
     #   botocore
     #   requests
     #   responses
-virtualenv==21.5.1
+virtualenv==21.7.1
     # via
     #   -c all.txt
     #   pre-commit

--- a/requirements/security.txt
+++ b/requirements/security.txt
@@ -12,15 +12,15 @@ cachecontrol[filecache]==0.14.4
     # via
     #   cachecontrol
     #   pip-audit
-certifi==2026.6.17
+certifi==2026.7.22
     # via requests
-charset-normalizer==3.4.7
+charset-normalizer==3.4.9
     # via requests
 cyclonedx-python-lib==11.11.0
     # via pip-audit
 defusedxml==0.7.1
     # via py-serializable
-filelock==3.29.4
+filelock==3.32.2
     # via cachecontrol
 idna==3.18
     # via requests
@@ -46,7 +46,7 @@ pip-audit==2.10.1
     # via -r security.in
 pip-requirements-parser==32.0.1
     # via pip-audit
-platformdirs==4.10.0
+platformdirs==4.11.0
     # via pip-audit
 py-serializable==2.1.0
     # via cyclonedx-python-lib
@@ -66,13 +66,13 @@ rich==15.0.0
     #   pip-audit
 sortedcontainers==2.4.0
     # via cyclonedx-python-lib
-stevedore==5.8.0
+stevedore==5.9.0
     # via bandit
 tomli==2.4.1
     # via pip-audit
 tomli-w==1.2.0
     # via pip-audit
-typing-extensions==4.15.0
+typing-extensions==4.16.0
     # via cyclonedx-python-lib
 urllib3==2.7.0
     # via requests

--- a/requirements/tools-archive.txt
+++ b/requirements/tools-archive.txt
@@ -11,7 +11,7 @@ attrs==26.1.0
     #   referencing
 bagit==1.9.0
     # via -r tools-archive.in
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   -c all.txt
     #   cryptography
@@ -32,7 +32,7 @@ numpy==2.4.6
     #   -c all.txt
     #   -r tools-archive.in
     #   pandas
-pandas==3.0.3
+pandas==3.0.5
     # via -r tools-archive.in
 pycparser==3.0
     # via
@@ -51,7 +51,7 @@ referencing==0.37.0
     #   -c all.txt
     #   jsonschema
     #   jsonschema-specifications
-rpds-py==2026.5.1
+rpds-py==2026.6.3
     # via
     #   -c all.txt
     #   jsonschema
@@ -60,7 +60,7 @@ six==1.17.0
     # via
     #   -c all.txt
     #   python-dateutil
-typing-extensions==4.15.0
+typing-extensions==4.16.0
     # via
     #   -c all.txt
     #   referencing

--- a/tests/api/test_jobs_router_factory.py
+++ b/tests/api/test_jobs_router_factory.py
@@ -116,28 +116,21 @@ def test_jobs_router_default_factory_call_uses_portal_list_limit_contract() -> N
 def test_jobs_router_pins_paths_methods_endpoint_names_and_response_models() -> None:
     _client, _recording, test_app = _build_test_app()
 
-    tracked: dict[tuple[str, str], tuple[str, type[Any] | None]] = {}
-    for route in test_app.routes:
-        methods = getattr(route, "methods", None)
-        path = getattr(route, "path", None)
-        if not methods or not path:
-            continue
-        for method in methods:
-            if method in {"GET", "POST", "DELETE"}:
-                tracked[(method, path)] = (
-                    getattr(route, "name"),
-                    getattr(route, "response_model", None),
-                )
-
-    assert tracked == {
+    schema_refs = {
+        JobEnvelope: {"$ref": "#/components/schemas/ApiEnvelope_JobBriefData_"},
+        JobsListEnvelope: {"$ref": "#/components/schemas/ApiEnvelope_JobsListData_"},
+        JobStatusEnvelope: {"$ref": "#/components/schemas/ApiEnvelope_JobStatusData_"},
+        None: {},
+    }
+    expected = {
         ("POST", "/v1/jobs"): ("create_job_http", JobEnvelope),
         ("POST", "/v2/jobs"): ("create_job_v2_http", JobEnvelope),
         ("GET", "/v1/jobs"): ("list_jobs", JobsListEnvelope),
         ("GET", "/v2/jobs"): ("list_jobs_v2", JobsListEnvelope),
         ("GET", "/v1/jobs/{job_id}"): ("get_job", JobStatusEnvelope),
         ("GET", "/v2/jobs/{job_id}"): ("get_job_v2", JobStatusEnvelope),
-        ("GET", "/v1/jobs/{job_id}/artifacts/{artifact_path:path}"): ("get_job_artifact", None),
-        ("GET", "/v2/jobs/{job_id}/artifacts/{artifact_path:path}"): ("get_job_artifact_v2", None),
+        ("GET", "/v1/jobs/{job_id}/artifacts/{artifact_path}"): ("get_job_artifact", None),
+        ("GET", "/v2/jobs/{job_id}/artifacts/{artifact_path}"): ("get_job_artifact_v2", None),
         ("DELETE", "/v1/jobs/{job_id}/artifacts"): ("delete_job_artifacts", JobStatusEnvelope),
         ("DELETE", "/v2/jobs/{job_id}/artifacts"): ("delete_job_artifacts_v2", JobStatusEnvelope),
         ("POST", "/v1/jobs/{job_id}/cancel"): ("cancel_job", JobEnvelope),
@@ -145,6 +138,23 @@ def test_jobs_router_pins_paths_methods_endpoint_names_and_response_models() -> 
         ("GET", "/v1/jobs/{job_id}/events"): ("job_events", None),
         ("GET", "/v2/jobs/{job_id}/events"): ("job_events_v2", None),
     }
+
+    openapi_paths = test_app.openapi()["paths"]
+    tracked = {
+        (method.upper(), path): operation
+        for path, path_item in openapi_paths.items()
+        for method, operation in path_item.items()
+        if method.upper() in {"GET", "POST", "DELETE"}
+    }
+    assert set(tracked) == set(expected)
+    for route, (_endpoint_name, response_model) in expected.items():
+        assert tracked[route]["responses"]["200"]["content"]["application/json"]["schema"] == schema_refs[response_model]
+
+    for (method, path), (endpoint_name, _response_model) in expected.items():
+        values = {"job_id": "job-1", "artifact_path": "nested/report.json"}
+        expected_path = path.format(**values)
+        route_values = {name: value for name, value in values.items() if "{" + name + "}" in path}
+        assert str(test_app.url_path_for(endpoint_name, **route_values)) == expected_path
 
 
 def test_jobs_router_delegates_list_limits_to_the_injected_handlers() -> None:

--- a/tests/test_app_orchestrator_contract_http.py
+++ b/tests/test_app_orchestrator_contract_http.py
@@ -4276,16 +4276,15 @@ def test_delete_job_artifacts_requires_api_key_before_store_access(
 
 
 def test_delete_job_artifacts_routes_use_job_status_response_model() -> None:
-    route_models = {}
-    for route in orchestrator_app.app.routes:
-        path = getattr(route, "path", None)
-        methods = getattr(route, "methods", set()) or set()
-        if path in {"/v1/jobs/{job_id}/artifacts", "/v2/jobs/{job_id}/artifacts"} and "DELETE" in methods:
-            route_models[path] = getattr(route, "response_model", None)
+    openapi_paths = orchestrator_app.app.openapi()["paths"]
+    route_models = {
+        path: openapi_paths[path]["delete"]["responses"]["200"]["content"]["application/json"]["schema"]
+        for path in {"/v1/jobs/{job_id}/artifacts", "/v2/jobs/{job_id}/artifacts"}
+    }
 
     assert route_models == {
-        "/v1/jobs/{job_id}/artifacts": orchestrator_app.JobStatusEnvelope,
-        "/v2/jobs/{job_id}/artifacts": orchestrator_app.JobStatusEnvelope,
+        "/v1/jobs/{job_id}/artifacts": {"$ref": "#/components/schemas/ApiEnvelope_JobStatusData_"},
+        "/v2/jobs/{job_id}/artifacts": {"$ref": "#/components/schemas/ApiEnvelope_JobStatusData_"},
     }
 
 

--- a/tests/test_app_route_inventory.py
+++ b/tests/test_app_route_inventory.py
@@ -5,8 +5,8 @@ of FastAPI routes. The two large contract suites
 (``test_app_orchestrator_runtime.py``, ``test_app_orchestrator_contract_http.py``)
 exercise most behaviour, but new routes can land without anyone noticing
 that no contract test was ever written for them. This file is the
-*inventory* gate — it walks ``app.routes`` and asserts every method+path
-pair appears in an explicit registry tagged with a coarse family.
+*inventory* gate — it reads the generated OpenAPI paths and asserts every
+method+path pair appears in an explicit registry tagged with a coarse family.
 
 What this file enforces (the cheap, statically-verifiable invariants):
 
@@ -33,6 +33,7 @@ What this file deliberately does NOT enforce:
 from __future__ import annotations
 
 import importlib
+import re
 from typing import Iterable
 
 import pytest
@@ -100,19 +101,19 @@ ROUTE_REGISTRY: dict[tuple[str, str], str] = {
 }
 
 
+def _normalize_path(path: str) -> str:
+    """Normalize Starlette path converters to their public OpenAPI form."""
+    return re.sub(r"\{([^}:]+):[^}]+\}", r"{\1}", path)
+
+
 def _iter_app_routes() -> Iterable[tuple[str, str]]:
-    """Yield ``(method, path)`` tuples for every concrete HTTP route on ``app``."""
+    """Yield ``(method, path)`` tuples from the app's public OpenAPI contract."""
     orchestrator_app = importlib.import_module("app").app
-    for route in orchestrator_app.routes:
-        # Starlette also tracks Mount objects, lifespan handlers, etc;
-        # we only care about HTTP-level concrete routes that have ``methods``.
-        methods = getattr(route, "methods", None)
-        path = getattr(route, "path", None)
-        if not methods or not path:
-            continue
-        for method in methods:
-            if method in _TRACKED_METHODS:
-                yield (method, path)
+    for path, path_item in orchestrator_app.openapi()["paths"].items():
+        for method in path_item:
+            normalized_method = method.upper()
+            if normalized_method in _TRACKED_METHODS:
+                yield (normalized_method, _normalize_path(path))
 
 
 @pytest.fixture(scope="module")
@@ -123,7 +124,7 @@ def discovered_routes() -> set[tuple[str, str]]:
 class TestRouteInventory:
     def test_every_live_route_is_registered(self, discovered_routes):
         # New route landed in app.py? Add it to ROUTE_REGISTRY.
-        registered = set(ROUTE_REGISTRY)
+        registered = {(method, _normalize_path(path)) for method, path in ROUTE_REGISTRY}
         unexpected = sorted(discovered_routes - registered)
         assert not unexpected, (
             "The following live routes are NOT in ROUTE_REGISTRY:\n  "
@@ -136,7 +137,7 @@ class TestRouteInventory:
 
     def test_every_registered_route_is_live(self, discovered_routes):
         # Route was removed/renamed? Remove the registry entry too.
-        registered = set(ROUTE_REGISTRY)
+        registered = {(method, _normalize_path(path)) for method, path in ROUTE_REGISTRY}
         stale = sorted(registered - discovered_routes)
         assert not stale, (
             "The following ROUTE_REGISTRY entries no longer match a live "

--- a/tests/test_codebase_structure.py
+++ b/tests/test_codebase_structure.py
@@ -594,7 +594,7 @@ class TestRootGovernanceMetadata:
         assert "cryptography==48.0.1" in (_repo_root / "requirements/ci.txt").read_text()
         assert "cryptography==48.0.1" in (_repo_root / "requirements/dev.txt").read_text()
         assert "cryptography==48.0.1" in (_repo_root / "requirements/all.txt").read_text()
-        assert "pillow==12.2.0" in (_repo_root / "requirements/base.txt").read_text()
+        assert "pillow==12.3.0" in (_repo_root / "requirements/base.txt").read_text()
 
         assert "**cryptography==48.0.1**" in security_policy
         assert "**cryptography==46.0.5**" not in security_policy
@@ -606,7 +606,7 @@ class TestRootGovernanceMetadata:
         assert "`cryptography`          | >=46.0.5" not in contributing
         assert "`starlette`             | >=1.3.1" in contributing
         assert "Starlette==1.3.1" in security_policy
-        assert "current governed lock baseline is pillow==12.2.0" in requirements_lint
+        assert "current governed lock baseline is pillow==12.3.0" in requirements_lint
         assert "allows pillow==12.1.1 in lockfiles" not in requirements_lint
 
     def test_pyproject_security_extras_track_current_cryptography_floor(self):

--- a/tests/test_secure_install_pilot_workflow.py
+++ b/tests/test_secure_install_pilot_workflow.py
@@ -103,7 +103,7 @@ def test_secure_install_pilot_readme_records_explicit_hash_policy() -> None:
 def test_requirements_readme_records_current_curated_web_runtime_baseline() -> None:
     readme = REQUIREMENTS_README_PATH.read_text(encoding="utf-8")
 
-    assert "| FastAPI | `requirements/base.in` | `0.136.1` |" in readme
+    assert "| FastAPI | `requirements/base.in` | `0.138.0` |" in readme
     assert "| Starlette | `requirements/base.in` + `pyproject.toml` bound | `1.3.1` |" in readme
     assert "| Uvicorn | `requirements/base.in` + `pyproject.toml` bound | `0.48.0` |" in readme
     assert "Starlette `1.3.1` security patch" in readme


### PR DESCRIPTION
## Summary
- Refresh the six governed generic Python lock outputs from the audited dependency-update snapshot.
- Adapt three stale FastAPI route-introspection contracts to FastAPI 0.138's router tree without changing public routes, response envelopes, endpoint names, or HTTP behavior.

## Changes
- Update `requirements/{all,base,ci,dev,security,tools-archive}.txt`, including FastAPI 0.138.0, Pillow 12.3.0, tqdm 4.70.0, and tox 4.58.0.
- Keep `requirements/base.in` and the Pillow minimum unchanged; do not import Darwin, CUDA, or target-owned ML lock churn.
- Verify route inventory and response schemas through OpenAPI plus `url_path_for` instead of assuming `app.routes` is flat.
- Synchronize the documented and tested curated FastAPI baseline to 0.138.0.

## Validation
### Proven green
- `make -C requirements check-generic LOCK_PYTHON_VERSION=3.11 PIP_TOOLS_CACHE_DIR=/private/tmp/tp-python-locks-pip-cache`
- `make check-requirements-lock-contract`
- `make check-dependency-pinning`
- `.venv/bin/pytest tests/api/test_jobs_router_factory.py tests/test_app_route_inventory.py tests/test_app_orchestrator_contract_http.py::test_delete_job_artifacts_routes_use_job_status_response_model -q` (29 passed)
- `.venv/bin/pytest tests/test_app_orchestrator_contract_http.py -q` (272 passed)
- `make test-orchestrator-contract` (891 passed, 9 skipped)
- `make test-orchestrator-http-contract` (272 passed)
- `.venv/bin/pytest tests/test_secure_install_pilot_workflow.py -q` (9 passed)
- `make ci-quick` (27 passed)
- `make test-fast` (77 passed)
- `make pre-commit`
- `PATH=/Users/richardcheetham/.nvm/versions/node/v22.22.2/bin:/usr/bin:/bin:/usr/sbin:/sbin make ci`

### Still failing
- No repo-owned failures.
- The first lock check used pip 26 and failed because pip-tools 7.5.2 references a removed pip API; rerunning with the CI contract `pip<26` passed.
- The first full-CI attempts used ambient Node 25 or lacked clean-worktree native npm packages; Node 22.22.2 plus npm 11.12.1 installation passed the complete canonical gate.

## Risk
- Compatibility risk is bounded to dependency resolution and internal test introspection; route paths, endpoint names, response schemas, auth behavior, selectors, CLI flags, and public envelopes are unchanged.
- No source dependency minima or target-owned ML locks change, so the patch is revert-safe and does not broaden runtime contracts.