### PR TITLE
chore(fastvlm): refresh compatible runtime pins

### DIFF
--- a/config/fastvlm_runtime_requirements.txt
+++ b/config/fastvlm_runtime_requirements.txt
@@ -1,6 +1,6 @@
 pip==26.1.2
 aiohappyeyeballs==2.6.2
-aiohttp==3.14.1
+aiohttp==3.14.3
 aiosignal==1.4.0
 annotated-doc==0.0.4
 annotated-types==0.7.0
@@ -23,7 +23,7 @@ gradio_client==2.5.0
 groovy==0.1.2
 h11==0.16.0
 hf-gradio==0.4.1
-hf-xet==1.5.0
+hf-xet==1.5.2
 httpcore==1.0.9
 httpx==0.28.1
 huggingface_hub==1.13.0
@@ -43,7 +43,7 @@ opencv-python==4.10.0.84
 orjson==3.11.9
 packaging==26.2
 pandas==3.0.2
-pillow==12.2.0
+pillow==12.3.0
 propcache==0.4.1
 protobuf==7.35.0
 pyaml==26.2.1
@@ -72,7 +72,7 @@ tokenizers==0.22.2
 tomlkit==0.14.0
 torch==2.12.1
 torchvision==0.27.1
-tqdm==4.67.3
+tqdm==4.70.0
 transformers==5.8.0
 typer==0.25.1
 typing-inspection==0.4.2


### PR DESCRIPTION
## Summary
- Refresh four compatible pins in the isolated FastVLM runtime snapshot.
- Preserve the governed datasets/fsspec and torch/torchvision pairs because the standalone bot upgrades are unsatisfiable.

## Changes
- Update aiohttp from 3.14.1 to 3.14.3.
- Update hf-xet from 1.5.0 to 1.5.2.
- Update Pillow from 12.2.0 to 12.3.0.
- Update tqdm from 4.67.3 to 4.70.0.
- Retain `datasets==4.8.5` with `fsspec==2026.2.0` and `torch==2.12.1` with `torchvision==0.27.1`.

This successor incorporates or supersedes #1977, #1979, #1986, #1993, #1999, #2002, and #2003 after merge.

## Validation

### Proven green
- Complete disposable Python 3.11 snapshot: all 83 pins matched, imports succeeded, and `pip check` reported no broken requirements
- FastVLM parser/runtime/manifest suite (34 passed)
- FastVLM portal smoke tests (5 passed)
- `./scripts/setup/install_fastvlm_runtime.sh --dry-run --models smoke,default`
- `make ci-quick`
- `make test-fast` (77 passed)
- `make pre-commit`
- `git diff --check`

### Still failing
- `make check-fastvlm-runtime` cannot run live inference in the clean worktree because the pinned source checkouts, isolated runtime venv, and smoke/default model checkpoints are not installed. This is an environment/assets blocker, not a manifest or product-logic failure.
- `pip-audit` reports retained Torch 2.12.1 and setuptools 81.0.0 advisories. Torch 2.13 conflicts with torchvision 0.27.1, and Torch constrains setuptools below the available fixed release; both require a separately scoped coupled runtime migration.

## Risk
- This changes only the isolated advisory FastVLM snapshot; routes, response envelopes, selectors, auth, schemas, installers, and model manifests are unchanged.
- `datasets==4.8.5` caps fsspec at 2026.2.0, while torchvision 0.27.1 requires torch 2.12.1 exactly. Keeping those pairs avoids resolver breakage.
- The four selected releases support Python 3.11 and the full pinned graph passes dependency resolution.
- The change is four-line and revert-safe.
