### PR TITLE
chore(frontdoor): refresh secured runtime dependencies

### DIFF
--- a/tests/fixtures/portal-css/layer-parity-baseline.json
+++ b/tests/fixtures/portal-css/layer-parity-baseline.json
@@ -394,7 +394,7 @@
       "rect": {
         "height": 185.89,
         "left": 41,
-        "top": 2717.95,
+        "top": 5246.52,
         "width": 674
       },
       "transform": "none",
@@ -442,7 +442,7 @@
       "rect": {
         "height": 334.16,
         "left": 41,
-        "top": 2371.8,
+        "top": 4900.36,
         "width": 674
       },
       "transform": "none",
@@ -490,7 +490,7 @@
       "rect": {
         "height": 783.83,
         "left": 24,
-        "top": 2137.02,
+        "top": 4665.58,
         "width": 708
       },
       "transform": "none",
@@ -663,7 +663,7 @@
       "grid-column": "auto",
       "grid-template-areas": "none",
       "grid-template-columns": "708px",
-      "height": "1649.89px",
+      "height": "4178.45px",
       "justify-content": "normal",
       "line-height": "24px",
       "margin": "0px 0px 24px",
@@ -680,7 +680,7 @@
       "position": "static",
       "present": true,
       "rect": {
-        "height": 1649.89,
+        "height": 4178.45,
         "left": 24,
         "top": 243.64,
         "width": 708
@@ -1037,7 +1037,7 @@
       "contain-intrinsic-size": "none",
       "content-visibility": "visible",
       "cursor": "auto",
-      "display": "none",
+      "display": "block",
       "flex": "0 1 auto",
       "flex-direction": "row",
       "flex-wrap": "nowrap",
@@ -1114,7 +1114,7 @@
       "rect": {
         "height": 169.48,
         "left": 293,
-        "top": 1930.53,
+        "top": 4459.09,
         "width": 98.7
       },
       "transform": "none",
@@ -1162,7 +1162,7 @@
       "rect": {
         "height": 195.48,
         "left": 24,
-        "top": 1917.53,
+        "top": 4446.09,
         "width": 708
       },
       "transform": "none",
@@ -1191,7 +1191,7 @@
       "grid-column": "auto",
       "grid-template-areas": "none",
       "grid-template-columns": "none",
-      "height": "2968.84px",
+      "height": "5497.41px",
       "justify-content": "normal",
       "line-height": "24px",
       "margin": "8px",
@@ -1208,7 +1208,7 @@
       "position": "static",
       "present": true,
       "rect": {
-        "height": 2968.84,
+        "height": 5497.41,
         "left": 8,
         "top": 8,
         "width": 740

--- a/web/secure-landing/package-lock.json
+++ b/web/secure-landing/package-lock.json
@@ -9,31 +9,31 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
-        "argon2": "^0.44.0",
+        "argon2": "^0.45.1",
         "better-sqlite3": "^12.11.1",
         "ioredis": "^5.11.1",
-        "next": "16.2.9",
-        "react": "^19.2.7",
-        "react-dom": "^19.2.7"
+        "next": "16.2.12",
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8"
       },
       "devDependencies": {
-        "@playwright/test": "1.61.0",
+        "@playwright/test": "1.62.1",
         "esbuild": "^0.28.1",
-        "postcss": "8.5.15",
-        "stylelint": "^17.13.0"
+        "postcss": "8.5.25",
+        "stylelint": "^17.14.1"
       },
       "engines": {
         "node": ">=22 <23"
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -42,9 +42,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -52,22 +52,22 @@
       }
     },
     "node_modules/@cacheable/memory": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.9.tgz",
-      "integrity": "sha512-HdMx6DoGywB30vacDbBsITbIX4pgFqj1zsrV58jZBUw3klzkNoXhj7qOqAgledhxG7YZI5rBSJg7Zp8/VG0DuA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.2.0.tgz",
+      "integrity": "sha512-CTLKqLItRCEixEAewD3/j9DB3/o96gpTPD4eJ1v+DGOlxZRZncRQkGYqqnAGCscYd6RNeXfGeiuCphsPtqyIfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cacheable/utils": "^2.4.1",
+        "@cacheable/utils": "^2.5.0",
         "@keyv/bigmap": "^1.3.1",
         "hookified": "^1.15.1",
         "keyv": "^5.6.0"
       }
     },
     "node_modules/@cacheable/utils": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.4.1.tgz",
-      "integrity": "sha512-eiFgzCbIneyMlLOmNG4g9xzF7Hv3Mga4LjxjcSC/ues6VYq2+gUbQI8JqNuw/ZM8tJIeIaBGpswAsqV2V7ApgA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.5.0.tgz",
+      "integrity": "sha512-buipgOVDkkPXNR5+xBpDw7Zk2n1EvU7qBJCNUcL7rhQ//kfpOXPAvQ511Os0vpLYJ1pZnvudNytkQt2hst3wqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -123,9 +123,9 @@
       }
     },
     "node_modules/@csstools/css-syntax-patches-for-csstree": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.5.tgz",
-      "integrity": "sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+      "integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
       "dev": true,
       "funding": [
         {
@@ -1192,15 +1192,15 @@
       "license": "MIT"
     },
     "node_modules/@next/env": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.9.tgz",
-      "integrity": "sha512-ki5VxxXfzD/9TDe13wyeTKIjQTAwBVpnr8KhRDUr8ltMUq1/NBpWNT5tiPoxiGl+PHM4X2ahSOiPk6iAimIzPg==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.12.tgz",
+      "integrity": "sha512-d0Z5Bc13Fa4nR8pFAKx2jay2yhJM16vlfHbTzYnUQAxlNb6B6lmn4hjt69lYNt4kRtyYP6gEM49lPRHNbIyneg==",
       "license": "MIT"
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.9.tgz",
-      "integrity": "sha512-HkfxNYUCmcct0Xsqib5KxqMSHV4AHJq857BNRchyBDs4YS19aHzVfn1kDuBYKqLLQBjXgnkIsjV2Kd4d2wzYhw==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.12.tgz",
+      "integrity": "sha512-0W1R0teHWJrqKX0FH20IzzIWAOuGtBxPGuObrxy1lE8hQvCFj49KE8a3WUg0D7sq6rn6zkM4c7YGUnhudBS6oA==",
       "cpu": [
         "arm64"
       ],
@@ -1214,9 +1214,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.9.tgz",
-      "integrity": "sha512-7IAtK4MeybpqRV9GRABWEhJ62mOS+rzWOzOTFie4cSEtm12xsoOMJRcECoZx3FHPzFAqN/IJtHqWAFOLfl152w==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.12.tgz",
+      "integrity": "sha512-Hy5Ls099+aFUmOLmIgPfLqNi6iCwhL3uQCssz5rWk+5Nkc6TUKCE83DY5BbNylfm3+mfwcSFnLRfrZDJhVxdtw==",
       "cpu": [
         "x64"
       ],
@@ -1230,9 +1230,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.9.tgz",
-      "integrity": "sha512-hBD75iWpUtkL9SmQmcRhmLomn9jgkPzCEkbOcLgHymPEKzv+6ONy13RRiIEz/iEObjkS2Jlb5gYS2XGoS3X4rw==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.12.tgz",
+      "integrity": "sha512-+YqU2h1cQkHsGfvjAsrSmst8UIFBibBGm5x3Xgel8NLMiDQtNOM4sM2GOEMvG5YiOBNeN/Ykk8cQC2S0Xrqljg==",
       "cpu": [
         "arm64"
       ],
@@ -1249,9 +1249,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.9.tgz",
-      "integrity": "sha512-qZTI3pf9SGc/obr8NkQAekBxmp1QK+kVm+VAf3BALLfFAj+1kUhkTxmrWpVos9R/UYIA8AWX2p6cGI5WdwzVUA==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.12.tgz",
+      "integrity": "sha512-0qjhiYBaKAqF63LA1ZWAAnKTzFUguAaZiRa5etMLGGPj/B6uEVjtIZldIzFEp3wHlB0koK6aTzqPtSdplTCjoA==",
       "cpu": [
         "arm64"
       ],
@@ -1268,9 +1268,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.9.tgz",
-      "integrity": "sha512-xm0HfRNX+UkH4R3c18ynswjj5o5uEj/7iI9p9omdtTSIsRCzQqkGMA+10nzJ4EHnYC3as65IMhbbl5fWRUWHYg==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.12.tgz",
+      "integrity": "sha512-7A3q26W+h7gnA15uqBToNuDqBEFZZcqh0mW2mn4AJh/G5pdg2RVE3n4slzLEliASZFG3NmsbEzng/x2Sh09mBg==",
       "cpu": [
         "x64"
       ],
@@ -1287,9 +1287,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.9.tgz",
-      "integrity": "sha512-QumimHkGEG6vM3PfEDWKyKen03NcqLOkeKB1EfcPe7VxzmEiCa4jNnMyBn/US5zcd/VE1CI+O8Ovb3lfjVHfGw==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.12.tgz",
+      "integrity": "sha512-qSjL/uppm+cbh21s72Ss8gkiOhQ4dExWHNGOWy6eZV7STj5WsKehgxT61beSsOj+YYQuTplL376lOCdMQU5T8w==",
       "cpu": [
         "x64"
       ],
@@ -1306,9 +1306,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.9.tgz",
-      "integrity": "sha512-hzQpKZvw8rAwI6A2uQh6SacCSvNAXaIkPNsWwzqqfRiIMiXMfH936skDhz1OO6KpvdKkJrgHHtqQOq5PIXOvdQ==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.12.tgz",
+      "integrity": "sha512-X6hzsOUJac/e7AWSbn9gQ9nzHld1xWP5iyjHpYWvud8pufB679O1xg4JDyKr8Xd69Jvd+kM2Der6uftiZCmjYA==",
       "cpu": [
         "arm64"
       ],
@@ -1322,9 +1322,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.9.tgz",
-      "integrity": "sha512-qr2VL3Ce5QrwgO2yh1ujSBawrimjVKX8FGF/cOynmdYKJY0BdHpGVNIRK1tqONB10Vkm25Ub1BD2bkjWs4+96w==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.12.tgz",
+      "integrity": "sha512-F6fakeHuFTLOPt0bslQJdf+xtT+WIP9DVn/m4y1w1mRnVPyh3D/cNvzlRkxM444xfm+IvvYNSOrKiA2CDJ0Uxw==",
       "cpu": [
         "x64"
       ],
@@ -1385,19 +1385,19 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.61.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
-      "integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.61.0"
+        "playwright": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@sindresorhus/merge-streams": {
@@ -1469,15 +1469,15 @@
       }
     },
     "node_modules/argon2": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/argon2/-/argon2-0.44.0.tgz",
-      "integrity": "sha512-zHPGN3S55sihSQo0dBbK0A5qpi2R31z7HZDZnry3ifOyj8bZZnpZND2gpmhnRGO1V/d555RwBqIK5W4Mrmv3ig==",
+      "version": "0.45.1",
+      "resolved": "https://registry.npmjs.org/argon2/-/argon2-0.45.1.tgz",
+      "integrity": "sha512-skm+/WCjkGqCQxF7FG1LuZXM5yvbFjgbfiCGsud2oLgaDhh6b6dbH0b1EkghbM+xx4Bj8Ape+KKgixoIlWZicQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@phc/format": "^1.0.0",
-        "cross-env": "^10.0.0",
-        "node-addon-api": "^8.5.0",
+        "cross-env": "^10.1.0",
+        "node-addon-api": "^8.9.0",
         "node-gyp-build": "^4.8.4"
       },
       "engines": {
@@ -1605,14 +1605,14 @@
       }
     },
     "node_modules/cacheable": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.3.5.tgz",
-      "integrity": "sha512-EQfaKe09tl615iNvq/TBRWTFf1AKJNXYQSsMx0Z3EI0nA+pVsVPS8wJhnRlkbdacKPh1d0qVIhwTc2zsQNFEEg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.5.0.tgz",
+      "integrity": "sha512-60cyAOytib/OzBw1JNSoSV/boK1AtHryDIjvVBk7XbN4ugfkM3+Sry7fEjNgPMGgOjuaZPAp8ruZ0Cxafwyq9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cacheable/memory": "^2.0.8",
-        "@cacheable/utils": "^2.4.1",
+        "@cacheable/memory": "^2.2.0",
+        "@cacheable/utils": "^2.5.0",
         "hookified": "^1.15.0",
         "keyv": "^5.6.0",
         "qified": "^0.10.1"
@@ -1697,9 +1697,9 @@
       "license": "MIT"
     },
     "node_modules/cosmiconfig": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
-      "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.2.tgz",
+      "integrity": "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1962,9 +1962,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -1999,13 +1999,13 @@
       }
     },
     "node_modules/file-entry-cache": {
-      "version": "11.1.3",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.3.tgz",
-      "integrity": "sha512-oMbq0PD6VIiIwMF6LIa7MEwd/l9huKwmqRKXqmrkqIZv8CvRbfowL+L0ryAl8h//HfAS0zS+4SbYoRyAoA6BJA==",
+      "version": "11.1.5",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.5.tgz",
+      "integrity": "sha512-+PFTHITI08JIGhnNpGNI8T8inUpgZfk3GNEqfT9R2zZV2iFXg3CvqzSl/uEhs7TSGujYRELEANyDvS8Fj7+S7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "flat-cache": "^6.1.22"
+        "flat-cache": "^6.1.23"
       }
     },
     "node_modules/file-uri-to-path": {
@@ -2028,21 +2028,21 @@
       }
     },
     "node_modules/flat-cache": {
-      "version": "6.1.22",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.22.tgz",
-      "integrity": "sha512-N2dnzVJIphnNsjHcrxGW7DePckJ6haPrSFqpsBUhHYgwtKGVq4JrBGielEGD2fCVnsGm1zlBVZ8wGhkyuetgug==",
+      "version": "6.1.23",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.23.tgz",
+      "integrity": "sha512-f++BY9pTk+983xK1FLzlLpmM0i0z+jHmx3QESGkURMXujQZz1k5wzwX6hjnQ8goaD0B+sYnDK1yZ6MTyZfUaqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cacheable": "^2.3.4",
+        "cacheable": "^2.5.0",
         "flatted": "^3.4.2",
         "hookified": "^1.15.0"
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
-      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+      "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
       "dev": true,
       "license": "ISC"
     },
@@ -2140,9 +2140,9 @@
       }
     },
     "node_modules/globby": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-16.2.0.tgz",
-      "integrity": "sha512-QrJia2qDf5BB/V6HYlDTs0I0lBahyjLzpGQg3KT7FnCdTonAyPy2RtY802m2k4ALx6Dp752f82WsOczEVr3l6Q==",
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-16.2.2.tgz",
+      "integrity": "sha512-NLvV9ubZ6NDsJaOpKPy3cQeJpKi9DcWiyCiFUpJPA0YihRqiE6RWaLUmgNNPr8MgPpLZjnBjSmou7uZBRJv9wA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2234,9 +2234,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2541,9 +2541,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "funding": [
         {
           "type": "github",
@@ -2565,12 +2565,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.9.tgz",
-      "integrity": "sha512-MEOJiq/UvuezAdqVSceHbqDgZt1kDw2tpGVOlsdIoJsQdbN2JY2hpVG4xnXGkbdJUOEWhnRfiu/O4Hpc9Juwww==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.12.tgz",
+      "integrity": "sha512-iD59eYQWmbFcEbX7v/acG5DRym9iw1DdaPoD0WTA920naWsE25wShzJW4+UvAs8MK9EC2kBfIH6vtto1H1PHGw==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.9",
+        "@next/env": "16.2.12",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
@@ -2584,14 +2584,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.9",
-        "@next/swc-darwin-x64": "16.2.9",
-        "@next/swc-linux-arm64-gnu": "16.2.9",
-        "@next/swc-linux-arm64-musl": "16.2.9",
-        "@next/swc-linux-x64-gnu": "16.2.9",
-        "@next/swc-linux-x64-musl": "16.2.9",
-        "@next/swc-win32-arm64-msvc": "16.2.9",
-        "@next/swc-win32-x64-msvc": "16.2.9",
+        "@next/swc-darwin-arm64": "16.2.12",
+        "@next/swc-darwin-x64": "16.2.12",
+        "@next/swc-linux-arm64-gnu": "16.2.12",
+        "@next/swc-linux-arm64-musl": "16.2.12",
+        "@next/swc-linux-x64-gnu": "16.2.12",
+        "@next/swc-linux-x64-musl": "16.2.12",
+        "@next/swc-win32-arm64-msvc": "16.2.12",
+        "@next/swc-win32-x64-msvc": "16.2.12",
         "sharp": "^0.34.5"
       },
       "peerDependencies": {
@@ -2630,9 +2630,9 @@
       }
     },
     "node_modules/node-addon-api": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.7.0.tgz",
-      "integrity": "sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==",
+      "version": "8.9.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.1.tgz",
+      "integrity": "sha512-4eUQWVPCUUUiBjLnHS3cXWeC6ryoPUc0U3rP7IuzapoGbzMqd/r6KKO0clr0b+snQhsrueFEhCZDdK+LK7hxKg==",
       "license": "MIT",
       "engines": {
         "node": "^18 || ^20 || >= 21"
@@ -2729,41 +2729,41 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.61.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
-      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.61.0"
+        "playwright-core": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.61.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
-      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "funding": [
         {
           "type": "opencollective",
@@ -2780,7 +2780,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -2816,9 +2816,9 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
+      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2930,24 +2930,24 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
-      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
-      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.7"
+        "react": "^19.2.8"
       }
     },
     "node_modules/readable-stream": {
@@ -3323,9 +3323,9 @@
       }
     },
     "node_modules/stylelint": {
-      "version": "17.13.0",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-17.13.0.tgz",
-      "integrity": "sha512-G1WYzMerp7ihOaIe9VJCHLt12MoAD2QLf1AFerYP37+BCRBUK5UCpq8e/mN+zCIaJPKQcaxhE4WlPmqdiOx/gw==",
+      "version": "17.14.1",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-17.14.1.tgz",
+      "integrity": "sha512-xVQwyiuxALUBNB2fBe0tmNemg9KqLtdj3T64mioFDar79B2cU8LIyz+3KL6LdiHs9NkeNfwxpKSaIVOY8f112g==",
       "dev": true,
       "funding": [
         {
@@ -3341,21 +3341,21 @@
       "dependencies": {
         "@csstools/css-calc": "^3.2.1",
         "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-syntax-patches-for-csstree": "^1.1.4",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.6",
         "@csstools/css-tokenizer": "^4.0.0",
         "@csstools/media-query-list-parser": "^5.0.0",
         "@csstools/selector-resolve-nested": "^4.0.0",
         "@csstools/selector-specificity": "^6.0.0",
         "colord": "^2.9.3",
-        "cosmiconfig": "^9.0.1",
+        "cosmiconfig": "^9.0.2",
         "css-functions-list": "^3.3.3",
         "css-tree": "^3.2.1",
         "debug": "^4.4.3",
         "fast-glob": "^3.3.3",
         "fastest-levenshtein": "^1.0.16",
-        "file-entry-cache": "^11.1.3",
+        "file-entry-cache": "^11.1.5",
         "global-modules": "^2.0.0",
-        "globby": "^16.2.0",
+        "globby": "^16.2.1",
         "globjoin": "^0.1.4",
         "html-tags": "^5.1.0",
         "ignore": "^7.0.5",
@@ -3365,12 +3365,12 @@
         "micromatch": "^4.0.8",
         "normalize-path": "^3.0.0",
         "picocolors": "^1.1.1",
-        "postcss": "^8.5.15",
+        "postcss": "^8.5.16",
         "postcss-safe-parser": "^7.0.1",
-        "postcss-selector-parser": "^7.1.1",
+        "postcss-selector-parser": "^7.1.4",
         "postcss-value-parser": "^4.2.0",
         "string-width": "^8.2.1",
-        "supports-hyperlinks": "^4.4.0",
+        "supports-hyperlinks": "^4.5.0",
         "svg-tags": "^1.0.0",
         "table": "^6.9.0",
         "write-file-atomic": "^7.0.1"
@@ -3396,9 +3396,9 @@
       }
     },
     "node_modules/supports-hyperlinks": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-4.4.0.tgz",
-      "integrity": "sha512-UKbpT93hN5Nr9go5UY7bopIB9YQlMz9nm/ct4IXt/irb5YRkn9WaqrOBJGZ5Pwvsd5FQzSVeYlGdXoCAPQZrPg==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-4.5.0.tgz",
+      "integrity": "sha512-ZW2OvfeCXrNTbLakPUzjQG922EeGCOteFSVoek5DKStTh898wf7zgtuFlzQN8HfZCxC3Eh02yJVrRW51hADf+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/web/secure-landing/package.json
+++ b/web/secure-landing/package.json
@@ -25,21 +25,21 @@
   },
   "packageManager": "npm@11.12.1",
   "dependencies": {
-    "argon2": "^0.44.0",
+    "argon2": "^0.45.1",
     "better-sqlite3": "^12.11.1",
     "ioredis": "^5.11.1",
-    "next": "16.2.9",
-    "react": "^19.2.7",
-    "react-dom": "^19.2.7"
+    "next": "16.2.12",
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8"
   },
   "overrides": {
     "js-yaml": "4.2.0",
-    "postcss": "8.5.15"
+    "postcss": "8.5.25"
   },
   "devDependencies": {
-    "@playwright/test": "1.61.0",
+    "@playwright/test": "1.62.1",
     "esbuild": "^0.28.1",
-    "postcss": "8.5.15",
-    "stylelint": "^17.13.0"
+    "postcss": "8.5.25",
+    "stylelint": "^17.14.1"
   }
 }


### PR DESCRIPTION
## Summary
- Reconcile the overlapping frontdoor dependency updates into one Node 22-compatible graph.
- Keep the change bounded to the planned runtime/tooling versions and refresh the stale CSS parity snapshot for the already-landed supported-but-gated staged-upload UI.

## Changes
- Update argon2 to `^0.45.1`, Next to `16.2.12`, React/React DOM to `^19.2.8`, Playwright to `1.62.1`, PostCSS and its override to `8.5.25`, and Stylelint to `^17.14.1`.
- Resolve transitive-only `fast-uri` to `3.1.5`; it is not added as a direct dependency.
- Preserve Node `>=22 <23`, npm `11.12.1`, route shapes, managed-auth behavior, selectors, and existing range styles.
- Refresh 10 computed-style baseline values so the parity fixture matches the May 31 supported-but-gated staged-upload contract (`display: block` with the corresponding deterministic geometry).

## Validation

### Proven green
- `npm ci`
- Exact `npm ls` dependency-tree verification and native argon2 hash/verify
- `npm test` (259 passed)
- `npm run test:coverage`
- `npm run lint:css`
- `npm run build`
- `npm run check:utility-ownership`
- `PLAYWRIGHT_BROWSERS_PATH=/private/tmp/tp-playwright-1.62.1 npm run test:browser` (11 passed)
- `make test-frontdoor-contract`
- `make validate-portal-css-layer-parity` plus a second direct parity run (24 selectors, 39 properties, 359 runtime utility classes)
- `make validate-frontdoor-browser`
- `make ci-quick`
- `make test-fast`
- repo pre-commit hooks over all files and again on the staged diff
- `make ci` (including 891 orchestrator contracts, 259 frontdoor tests, governance checks, asset budgets, and the production Next build)
- `git diff --check`

### Still failing / blocked
- `make validate-portal-browser` reaches the live shell and preview path, then fails closed because the local environment lacks the repo-local DA3 runtime. The reported blocker is `The selected DA3 backend requires the repo-local DA3 runtime`; this is an environment/runtime dependency, not frontend product logic.
- `npm audit` reports two residual high-severity advisory families: Stylelint/Cosmiconfig through the retained `js-yaml@4.2.0` override (fix requires js-yaml 4.3.0), and Next 16.2.12 through optional `sharp@0.34.5` (fix requires Next 16.3/sharp 0.35). Both require migrations outside this planned graph. `fast-uri@3.1.5` has no residual advisory.

## Risk
- Compatibility risk is bounded by retaining Node 22, npm 11.12.1, package range styles, routes, selectors, auth contracts, and transitive ownership.
- The CSS fixture update records existing intended UI behavior only; no CSS, JavaScript, route, selector, or runtime behavior changes.
- The change is revert-safe as a three-file dependency/snapshot update.
