### PR TITLE
fix(deps): update cryptography security baseline

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -709,7 +709,7 @@ Certain packages require minimum versions due to CVEs:
 
 | Package                 | Minimum Version | Reason                              |
 |-------------------------|-----------------|-------------------------------------|
-| `cryptography`          | >=48.0.1        | Governed lock baseline includes the OpenSSL wheel security fix |
+| `cryptography`          | >=50.0.0        | Governed lock baseline includes the CVE-2026-69247 security fix |
 | `sentence-transformers` | >=3.1.0         | CVE-73169 (arbitrary code execution) |
 | `msgpack`               | >=1.2.1         | GHSA-6v7p-g79w-8964 |
 | `Pillow`                | >=10.3.0        | CVE-2024-28219 and multiple 9.x CVEs |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -117,7 +117,7 @@ Given our image/video processing nature, special attention is required for:
     - **Disposition**: Managed inference paths do not use `transformers.Trainer`, `Seq2SeqTrainer`, `TrainingArguments`, `_load_rng_state`, or training-resume flows
     - **Action**: Dependabot alerts are dismissed as `not_used` with repo search evidence instead of forcing a `transformers` 5.x pre-release upgrade into inference stacks
   - **Pillow>=10.3.0** - Fixed CVE-2024-28219 (buffer overflow vulnerability)
-  - **cryptography==48.0.1** - Current governed lock; includes the OpenSSL wheel security baseline fix from 47.0.0
+  - **cryptography==50.0.0** - Current governed lock; includes the CVE-2026-69247 security fix
   - **black==26.3.1** - Fixed arbitrary file writes from unsanitized cache names
   - **Pygments==2.20.0** - Fixed CVE-2026-4539; the temporary pip-audit exception is retired
   - **Starlette==1.3.1** - Fixed CVE-2026-48710 / PYSEC-2026-161 plus 2026 StaticFiles, HTTPEndpoint, and form parsing advisories

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,7 @@ spatial-ai = [
 ]
 # Optional detached signing support for archive attestation CLIs
 archive-signing = [
-    "cryptography>=48.0.1,<49",
+    "cryptography>=50.0.0,<51",
 ]
 # Development tools - see requirements/dev.in for pinned versions
 dev = [
@@ -133,7 +133,7 @@ dev = [
     "httpx>=0.28,<1",  # required for FastAPI/Starlette TestClient in HTTP contract tests
     "hypothesis>=6.0,<7",
     "jsonschema>=4.21.0,<5",  # required for machine-mode contract schema validation tests
-    "cryptography>=48.0.1,<49",  # required for Phase 3.1 signing CLI tests
+    "cryptography>=50.0.0,<51",  # required for Phase 3.1 signing CLI tests
     "moto[s3]>=5.0,<6",  # required for moto-backed S3 ArtifactStore contract tests
     "mypy>=1.10",
     "flake8>=7.0",

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -32,4 +32,4 @@ opencv-python-headless>=4.8.0,<5 ; platform_system == "Linux"
 opencv-python>=4.8.0,<5 ; platform_system != "Linux"
 
 # Required for detached Merkle signing/verification CLI tests
-cryptography>=48.0.1,<49
+cryptography>=50.0.0,<51

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,7 +17,7 @@ jsonschema>=4.21.0,<5
 httpx>=0.28,<1
 
 # Optional Phase 3.1 detached signing support (tools + tests)
-cryptography>=48.0.1,<49
+cryptography>=50.0.0,<51
 
 # S3 mock for the Phase 4.A ArtifactStore contract tests
 moto[s3]>=5.0,<6

--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -70,7 +70,7 @@ colorama==0.4.6
     # via tox
 coverage[toml]==7.15.3
     # via pytest-cov
-cryptography==48.0.1
+cryptography==50.0.0
     # via
     #   -r dev.in
     #   moto

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -36,7 +36,7 @@ colorama==0.4.6
     # via
     #   -c all.txt
     #   tox
-cryptography==48.0.1
+cryptography==50.0.0
     # via
     #   -c all.txt
     #   secretstorage

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -14,7 +14,7 @@ diff-cover>=10.2.1,<11  # diff coverage for PR validation (Phase 0 coverage infr
 httpx>=0.28,<1  # required for FastAPI/Starlette TestClient in HTTP contract tests
 hypothesis>=6.0,<7
 jsonschema>=4.21.0,<5  # required for machine-mode contract schema validation tests
-cryptography==48.0.1  # CAS determinism + Security: OpenSSL wheel baseline fixed
+cryptography==50.0.0  # CAS determinism + Security: CVE-2026-69247 baseline fixed
 moto[s3]>=5.0,<6  # S3 mock for the Phase 4.A S3ArtifactStore contract test branch
 
 # Type checking and linting

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -69,7 +69,7 @@ coverage[toml]==7.15.3
     # via
     #   -c all.txt
     #   pytest-cov
-cryptography==48.0.1
+cryptography==50.0.0
     # via
     #   -c all.txt
     #   -r dev.in

--- a/requirements/tools-archive.in
+++ b/requirements/tools-archive.in
@@ -5,6 +5,6 @@
 numpy>=2.2,<2.5
 pandas>=2.2,<3.1
 jsonschema>=4.23,<5
-cryptography>=48.0.1,<49
+cryptography>=50.0.0,<51
 bagit>=1.8,<2
 pyyaml>=6.0,<7

--- a/requirements/tools-archive.txt
+++ b/requirements/tools-archive.txt
@@ -15,7 +15,7 @@ cffi==2.1.0
     # via
     #   -c all.txt
     #   cryptography
-cryptography==48.0.1
+cryptography==50.0.0
     # via
     #   -c all.txt
     #   -r tools-archive.in

--- a/scripts/setup/install_da3_runtime.sh
+++ b/scripts/setup/install_da3_runtime.sh
@@ -220,7 +220,7 @@ BASE_DEPS=(
     "torch==2.12.0"
     "torchvision==0.27.0"
     "transformers==5.5.0"
-    "cryptography==48.0.1"
+    "cryptography==50.0.0"
     "moviepy==1.0.3"
     "einops==0.8.2"
     "huggingface_hub==1.9.0"

--- a/tests/test_codebase_structure.py
+++ b/tests/test_codebase_structure.py
@@ -591,19 +591,19 @@ class TestRootGovernanceMetadata:
         requirements_lint = (_repo_root / "requirements-lint.txt").read_text()
         contributing = (_repo_root / "CONTRIBUTING.md").read_text()
 
-        assert "cryptography==48.0.1" in (_repo_root / "requirements/ci.txt").read_text()
-        assert "cryptography==48.0.1" in (_repo_root / "requirements/dev.txt").read_text()
-        assert "cryptography==48.0.1" in (_repo_root / "requirements/all.txt").read_text()
+        assert "cryptography==50.0.0" in (_repo_root / "requirements/ci.txt").read_text()
+        assert "cryptography==50.0.0" in (_repo_root / "requirements/dev.txt").read_text()
+        assert "cryptography==50.0.0" in (_repo_root / "requirements/all.txt").read_text()
         assert "pillow==12.3.0" in (_repo_root / "requirements/base.txt").read_text()
 
-        assert "**cryptography==48.0.1**" in security_policy
-        assert "**cryptography==46.0.5**" not in security_policy
-        assert "cryptography>=48.0.1,<49" in requirements_ci
-        assert "cryptography>=48.0.1,<49" in requirements_dev
-        assert "cryptography>=46.0,<48" not in requirements_ci
-        assert "cryptography>=46.0,<48" not in requirements_dev
-        assert "`cryptography`          | >=48.0.1" in contributing
-        assert "`cryptography`          | >=46.0.5" not in contributing
+        assert "**cryptography==50.0.0**" in security_policy
+        assert "**cryptography==48.0.1**" not in security_policy
+        assert "cryptography>=50.0.0,<51" in requirements_ci
+        assert "cryptography>=50.0.0,<51" in requirements_dev
+        assert "cryptography>=48.0.1,<49" not in requirements_ci
+        assert "cryptography>=48.0.1,<49" not in requirements_dev
+        assert "`cryptography`          | >=50.0.0" in contributing
+        assert "`cryptography`          | >=48.0.1" not in contributing
         assert "`starlette`             | >=1.3.1" in contributing
         assert "Starlette==1.3.1" in security_policy
         assert "current governed lock baseline is pillow==12.3.0" in requirements_lint
@@ -617,12 +617,12 @@ class TestRootGovernanceMetadata:
         tools_archive_lock = (_repo_root / "requirements" / "tools-archive.txt").read_text()
 
         for extra_name in ("archive-signing", "dev"):
-            assert "cryptography>=48.0.1,<49" in optional_dependencies[extra_name]
-            assert "cryptography>=46.0,<48" not in optional_dependencies[extra_name]
+            assert "cryptography>=50.0.0,<51" in optional_dependencies[extra_name]
+            assert "cryptography>=48.0.1,<49" not in optional_dependencies[extra_name]
 
-        assert "cryptography>=48.0.1,<49" in tools_archive_in
-        assert "cryptography>=46.0,<48" not in tools_archive_in
-        assert "cryptography==48.0.1" in tools_archive_lock
+        assert "cryptography>=50.0.0,<51" in tools_archive_in
+        assert "cryptography>=48.0.1,<49" not in tools_archive_in
+        assert "cryptography==50.0.0" in tools_archive_lock
 
     def test_pyproject_core_dependencies_track_governed_base_requirements(self):
         """Installable package metadata should not trail the governed core dependency surface."""

--- a/tests/validation/test_python_bootstrap_scripts.py
+++ b/tests/validation/test_python_bootstrap_scripts.py
@@ -560,8 +560,8 @@ def test_install_da3_runtime_baseline_profile_omits_optional_deps(tmp_path: Path
     assert result.returncode == 0, result.stdout + result.stderr
     pip_install_lines = "\n".join(_dry_run_pip_install_lines(result.stdout))
     assert "DA3 NumPy spec: numpy>=2.0,<3" in result.stdout
-    assert "cryptography==48.0.1" in pip_install_lines
-    assert "cryptography==46.0.6" not in pip_install_lines
+    assert "cryptography==50.0.0" in pip_install_lines
+    assert "cryptography==48.0.1" not in pip_install_lines
     assert "numpy==1.26.4" not in pip_install_lines
     assert "pycolmap==" not in pip_install_lines
     assert "xformers" not in pip_install_lines


### PR DESCRIPTION
## Summary
- Raise the governed cryptography baseline from 48.0.1 to 50.0.0 so the repository no longer permits the CVE-2026-69247-affected line.
- Keep the change bounded to dependency policy, generated generic locks, the DA3 bootstrap snapshot, security guidance, and matching contract assertions.

## Changes
- Set public/dev/archive cryptography ranges to `>=50.0.0,<51` and exact governed pins to `50.0.0`.
- Regenerate the Python 3.11 generic lock contract without moving any unrelated package; only `all.txt`, `ci.txt`, `dev.txt`, and `tools-archive.txt` change their cryptography pin.
- Update the DA3 baseline installer and repository security guidance to the same exact baseline.
- Ratchet structure/bootstrap tests so the retired 48.x range cannot return.
- Preserve all routes, response envelopes, selectors, auth behavior, CLI flags, schemas, and platform-owned ML locks.

## Validation

### Proven green
- `make -C requirements check-generic LOCK_PYTHON_VERSION=3.11 PIP_COMPILE_BIN=/private/tmp/tp-crypto50-tools.pQAWbA/venv/bin/pip-compile PIP_TOOLS_CACHE_DIR=/private/tmp/tp-crypto50-pip-cache`
- `make check-requirements-lock-contract`
- `make check-dependency-pinning`
- `make check-ci-sync`
- Focused governance/bootstrap/signing tests: 35 passed.
- Disposable Python 3.11 install of `requirements/all.txt` plus `requirements/tools-archive.txt`; `pip check` passed and cryptography reported `50.0.0`.
- Cryptography 50 signing/TLS/Merkle suite in that disposable environment: 32 passed.
- `pip-audit --desc -r requirements-ci.txt`: no known vulnerabilities.
- `pip-audit --desc -r requirements/all.txt`: no known vulnerabilities.
- `pip-audit --desc -r requirements/tools-archive.txt`: no known vulnerabilities.
- `./scripts/setup/install_da3_runtime.sh --dry-run --skip-verify`
- `make ci-quick`: 27 passed.
- `make test-fast`: 77 passed.
- `make pre-commit`: every hook passed.
- `make ci`: 77 fast tests, 891 orchestrator tests (9 skipped), 259 frontdoor tests, and the production frontdoor build passed.
- `git diff --check`

### Still failing
- None.
- Resolved environment-only seams: the default user npm cache was not writable, and the first generated lint virtualenv had a broken pip bootstrap. Isolated task caches/toolchains passed without source changes.

## Risk
- Cryptography 50 can reject malformed certificate/DER inputs more strictly; the repository signing, TLS helper, task-signing, and Merkle CLI suites passed against the installed 50.0.0 wheel.
- The range is capped below 51, `cffi==2.1.0` remains unchanged and compatible, and no runtime/API contract changes are included.
- The patch is revert-safe: reverting restores the prior ranges, four exact lock pins, bootstrap pin, docs, and assertions as one atomic change.
