### PR TITLE
fix(security): close residual pypdf and CAS alerts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -713,7 +713,7 @@ Certain packages require minimum versions due to CVEs:
 | `sentence-transformers` | >=3.1.0         | CVE-73169 (arbitrary code execution) |
 | `msgpack`               | >=1.2.1         | GHSA-6v7p-g79w-8964 |
 | `Pillow`                | >=10.3.0        | CVE-2024-28219 and multiple 9.x CVEs |
-| `pypdf`                 | >=6.13.3        | GHSA-jm82-fx9c-mx94 |
+| `pypdf`                 | >=6.15.0        | GHSA-fwg2-594c-jp42 and GHSA-fp3f-mc75-235c |
 | `starlette`             | >=1.3.1         | CVE-2026-48710 / PYSEC-2026-161 plus 2026 web-stack advisories |
 
 ### Approved Exceptions

--- a/docs/architecture/ADR-032-dependency-pinning-strategy.md
+++ b/docs/architecture/ADR-032-dependency-pinning-strategy.md
@@ -207,7 +207,7 @@ Exceptions to pinning rules require explicit approval via one of:
 | `psutil`      | ml.in   | `>=5.9.0`       | System utilities: OS compatibility layer   |
 | `memory-profiler` | ml.in | `>=0.61.0`  | Dev/profiling tool in optional deps        |
 | `types-PyYAML` | dev.in | `>=6.0.12`     | Type stubs: must track PyYAML version      |
-| `pypdf`       | ci.in   | `>=6.13.3`      | PDF utilities: backward-compatible 6.x security floor |
+| `pypdf`       | ci.in   | `>=6.15.0`      | PDF utilities: backward-compatible 6.x security floor |
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,7 +152,7 @@ ci = [
     "build>=1.0,<2",
     "twine>=4.0,<7",
     "tox>=4.5,<5",
-    "pypdf>=6.13.3",
+    "pypdf>=6.15.0",
 ]
 # All dependencies combined (minimal pointer, not full graph)
 # For production, use lockfiles: requirements/all.txt

--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -253,7 +253,7 @@ pygments==2.20.0
     #   rich
 pylint==4.0.6
     # via -r dev.in
-pypdf==6.14.2
+pypdf==6.15.0
     # via -r ci.in
 pyproject-api==1.11.0
     # via tox

--- a/requirements/ci.in
+++ b/requirements/ci.in
@@ -19,4 +19,4 @@ twine>=4.0,<7          # upload distributions to PyPI
 tox>=4.5,<5            # test runner for multiple envs (future compatibility)
 
 # Additional CI utilities
-pypdf>=6.13.3          # PDF processing for reports; security floor for GHSA-jm82-fx9c-mx94
+pypdf>=6.15.0          # PDF reports; security floor for GHSA-fwg2-594c-jp42 and GHSA-fp3f-mc75-235c

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -129,7 +129,7 @@ pygments==2.20.0
     #   -c all.txt
     #   readme-renderer
     #   rich
-pypdf==6.14.2
+pypdf==6.15.0
     # via
     #   -c all.txt
     #   -r ci.in

--- a/src/transformation_portal/core/security/path_safety.py
+++ b/src/transformation_portal/core/security/path_safety.py
@@ -13,7 +13,7 @@ NOT:
 Key guarantees:
 - Pre-sanitization before path construction
 - Whitelist-based validation (not blocklist)
-- No reliance on .resolve() or .relative_to() as security boundaries
+- Normalized containment checks before filesystem access where symlinks matter
 - CodeQL-compliant patterns
 
 Usage:
@@ -31,6 +31,7 @@ Usage:
 from __future__ import annotations
 
 import logging
+import os
 import re
 from pathlib import Path
 from typing import List
@@ -225,9 +226,15 @@ def safe_cas_path(
     """
     safe_sha = validate_sha256(sha256)
 
-    # Standard 2-char prefix sharding
-    prefix = safe_sha[:2]
-    filepath = objects_dir / prefix / safe_sha
+    # Normalize before the containment check so both runtime enforcement and
+    # static analysis can prove that filesystem access stays under the CAS
+    # objects directory, including when a shard is replaced by a symlink.
+    normalized_root = os.path.realpath(os.fspath(objects_dir))
+    filepath = os.path.realpath(os.path.join(normalized_root, safe_sha[:2], safe_sha))
+    root_prefix = normalized_root if normalized_root.endswith(os.sep) else normalized_root + os.sep
+    if not filepath.startswith(root_prefix):
+        logger.warning("Path safety: rejected CAS path outside objects directory")
+        raise PathSafetyError("CAS path escapes objects directory")
 
     logger.debug("Path safety: constructed CAS path %s", filepath)
-    return filepath
+    return Path(filepath)

--- a/tests/security/test_ci_bootstrap_security_baselines.py
+++ b/tests/security/test_ci_bootstrap_security_baselines.py
@@ -8,6 +8,8 @@ pytestmark = [pytest.mark.unit, pytest.mark.security]
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SAFE_DETERMINISM_TOOLCHAIN = 'python -m pip install --upgrade "pip==26.1.2" ' '"setuptools==83.0.0" "wheel==0.46.2"'
+PYPDF_SECURITY_FLOOR = "pypdf>=6.15.0"
+PYPDF_LOCK_PIN = "pypdf==6.15.0"
 
 
 @pytest.mark.parametrize(
@@ -47,3 +49,25 @@ def test_lock_generation_workflows_use_pip_tools_with_pip_26_support(
     assert '"pip-tools==7.6.0"' in workflow
     assert '"pip-tools==7.5.3"' not in workflow
     assert '"pip-tools==7.5.2"' not in workflow
+
+
+def test_pypdf_governed_surfaces_require_non_vulnerable_release() -> None:
+    ci_input = (REPO_ROOT / "requirements/ci.in").read_text(encoding="utf-8")
+    pyproject = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    all_lock = (REPO_ROOT / "requirements/all.txt").read_text(encoding="utf-8")
+    ci_lock = (REPO_ROOT / "requirements/ci.txt").read_text(encoding="utf-8")
+    contributing = (REPO_ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8")
+    dependency_adr = (REPO_ROOT / "docs/architecture/ADR-032-dependency-pinning-strategy.md").read_text(encoding="utf-8")
+
+    assert PYPDF_SECURITY_FLOOR in ci_input
+    assert f'"{PYPDF_SECURITY_FLOOR}"' in pyproject
+    assert PYPDF_LOCK_PIN in all_lock
+    assert PYPDF_LOCK_PIN in ci_lock
+    assert ">=6.15.0" in contributing
+    assert "GHSA-fwg2-594c-jp42" in contributing
+    assert "GHSA-fp3f-mc75-235c" in contributing
+    assert "`>=6.15.0`" in dependency_adr
+
+    governed_surfaces = "\n".join((ci_input, pyproject, all_lock, ci_lock, contributing, dependency_adr))
+    assert "pypdf>=6.13.3" not in governed_surfaces
+    assert "pypdf==6.14.2" not in governed_surfaces

--- a/tests/security/test_path_safety_global.py
+++ b/tests/security/test_path_safety_global.py
@@ -226,6 +226,15 @@ class TestSafeCasPath:
         with pytest.raises(PathSafetyError):
             safe_cas_path(tmp_path, "../" + "a" * 61)
 
+    def test_symlinked_shard_cannot_escape_objects_directory(self, tmp_path: Path) -> None:
+        """A shard symlink cannot redirect CAS access outside its root."""
+        outside_dir = tmp_path.parent / f"{tmp_path.name}-outside"
+        outside_dir.mkdir()
+        (tmp_path / "aa").symlink_to(outside_dir, target_is_directory=True)
+
+        with pytest.raises(PathSafetyError, match="escapes objects directory"):
+            safe_cas_path(tmp_path, "a" * 64)
+
 
 @pytest.mark.security
 class TestPathSafetyIntegration:


### PR DESCRIPTION
## Summary
- Default-branch recomputation after #2011 exposed eight new pypdf advisories and two residual CodeQL path-injection alerts in CAS object lookup.
- Raise only the governed pypdf security floor/pins and make CAS path normalization plus containment explicit before filesystem access.

## Changes
- Raise pypdf from 6.14.2 to 6.15.0 in the aggregate/CI locks and from >=6.13.3 to >=6.15.0 in the CI input, package metadata, and governance docs.
- Normalize CAS object paths with realpath and reject candidates outside the separator-bounded CAS root before exists/stat access.
- Add regression coverage for governed pypdf surfaces and symlinked CAS shard escapes.
- Preserve existing dashboard routes, response envelopes, 404 behavior, and selectors.

## Validation
### Proven green
- `PYTHONPATH=src /Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin/pytest tests/security/test_ci_bootstrap_security_baselines.py tests/test_codebase_structure.py tests/test_check_requirements_lock_contract.py tests/test_requirements_lock_lane_makefile.py tests/validation/test_check_ci_dep_sync.py tests/validation/test_validate_dependency_constraints_script.py tests/security/test_path_safety_global.py tests/storage/test_cas_store_hash_mismatch.py tests/dashboard/test_artifact_api.py tests/dashboard/test_artifact_preview.py tests/dashboard/test_node_api.py -q` — 349 passed.
- Focused CAS/dashboard/security rerun — 181 passed.
- `make -C requirements check-generic LOCK_PYTHON_VERSION=3.11 PIP_COMPILE_BIN=/tmp/tp-pip-toolchain-audit/bin/pip-compile PIP_TOOLS_CACHE_DIR=/tmp/tp-pypdf-pip-tools-cache` — locks up to date.
- `pip-audit --strict` for `requirements/all.txt` and `requirements/ci.txt` — no known vulnerabilities.
- `make ci-quick` — passed, including 27 quick tests.
- `make test-fast` — 77 passed.
- `make pre-commit` — all hooks passed, including dependency constraints and gitleaks.
- `git diff --check` — passed.

### Still failing
- None. Hosted CodeQL remains the required definitive closure proof for the two interprocedural alerts.

## Risk
- Low and bounded: pypdf is a patch-level security update with no new required Python 3.11 dependency.
- CAS lookup now returns the normalized absolute path already documented by `CASObject.path`; valid SHA-256 sharding and uppercase normalization remain unchanged.
- The change is additive/fail-closed and revert-safe; no route, auth, selector, CLI, schema, or deployment contract changes.