### PR TITLE
test(coverage): cover manifest and pip-tools guardrails

### DIFF
--- a/tests/runtime/test_execution_manifest.py
+++ b/tests/runtime/test_execution_manifest.py
@@ -1,0 +1,233 @@
+"""Behavioral coverage for run-level execution manifests."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from transformation_portal.runtime import execution_manifest as manifest_module
+from transformation_portal.runtime.execution_manifest import (
+    EnvironmentInfo,
+    ExecutionManifest,
+    ManifestBuilder,
+    _hash_dict,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def environment() -> EnvironmentInfo:
+    """Return stable environment metadata for serialization tests."""
+    return EnvironmentInfo(
+        python_version="3.12.test",
+        platform="test-platform",
+        hostname="test-host",
+        user="test-user",
+        cwd="/workspace",
+    )
+
+
+def _manifest(environment: EnvironmentInfo) -> ExecutionManifest:
+    node_hashes = ["node-b", "node-a"]
+    return ExecutionManifest(
+        run_id="run-test",
+        node_hashes=node_hashes,
+        root_hash=_hash_dict({"nodes": sorted(node_hashes)}),
+        created_at="2026-08-08T12:00:00+00:00",
+        duration_seconds=2.5,
+        environment=environment,
+        metadata={"preset": "audit"},
+    )
+
+
+def test_hash_dict_is_canonical_and_content_sensitive() -> None:
+    """Dictionary insertion order does not affect the manifest digest."""
+    first = _hash_dict({"outer": {"b": 2, "a": 1}, "items": [3, 2, 1]})
+    reordered = _hash_dict({"items": [3, 2, 1], "outer": {"a": 1, "b": 2}})
+    changed = _hash_dict({"outer": {"b": 2, "a": 1}, "items": [1, 2, 3]})
+
+    assert first == "0df0f9efb0df20f199431be3cd3b7f366e4454c6993d504e57bd157aac938935"
+    assert first == reordered
+    assert first != changed
+    assert len(first) == 64
+
+
+@pytest.mark.parametrize(
+    ("user", "username", "expected_user"),
+    [
+        ("primary-user", "fallback-user", "primary-user"),
+        (None, "windows-user", "windows-user"),
+        (None, None, "unknown"),
+    ],
+)
+def test_environment_capture_records_platform_and_user_fallbacks(
+    monkeypatch: pytest.MonkeyPatch,
+    user: str | None,
+    username: str | None,
+    expected_user: str,
+) -> None:
+    """Environment capture is explicit and supports Unix and Windows user names."""
+    monkeypatch.setattr(manifest_module.sys, "version", "3.12.test")
+    monkeypatch.setattr(manifest_module.platform, "platform", lambda: "test-platform")
+    monkeypatch.setattr(manifest_module.platform, "node", lambda: "test-host")
+    monkeypatch.setattr(manifest_module.os, "getcwd", lambda: "/test/workspace")
+
+    for name, value in (("USER", user), ("USERNAME", username)):
+        if value is None:
+            monkeypatch.delenv(name, raising=False)
+        else:
+            monkeypatch.setenv(name, value)
+
+    assert EnvironmentInfo.capture() == EnvironmentInfo(
+        python_version="3.12.test",
+        platform="test-platform",
+        hostname="test-host",
+        user=expected_user,
+        cwd="/test/workspace",
+    )
+
+
+def test_manifest_serialization_supports_pretty_and_compact_json(environment: EnvironmentInfo) -> None:
+    """The portable manifest payload remains stable across JSON formatting modes."""
+    manifest = _manifest(environment)
+
+    payload = manifest.to_dict()
+    pretty = manifest.to_json()
+    compact = manifest.to_json(pretty=False)
+
+    assert payload == {
+        "version": "1.0",
+        "run_id": "run-test",
+        "node_hashes": ["node-b", "node-a"],
+        "root_hash": manifest.root_hash,
+        "created_at": "2026-08-08T12:00:00+00:00",
+        "duration_seconds": 2.5,
+        "environment": {
+            "python_version": "3.12.test",
+            "platform": "test-platform",
+            "hostname": "test-host",
+            "user": "test-user",
+            "cwd": "/workspace",
+        },
+        "metadata": {"preset": "audit"},
+    }
+    assert "\n" in pretty
+    assert "\n" not in compact
+    assert json.loads(pretty) == payload
+    assert json.loads(compact) == payload
+
+
+def test_manifest_save_load_and_root_hash_tamper_detection(
+    tmp_path: Path,
+    environment: EnvironmentInfo,
+) -> None:
+    """A saved manifest round-trips and detects altered node provenance."""
+    manifest = _manifest(environment)
+    path = tmp_path / "execution-manifest.json"
+
+    manifest.save(path)
+    loaded = ExecutionManifest.load(path)
+
+    assert path.read_text() == manifest.to_json()
+    assert loaded == manifest
+    assert loaded.verify_root_hash() is True
+
+    loaded.node_hashes.append("tampered-node")
+    assert loaded.verify_root_hash() is False
+
+
+def test_manifest_load_supplies_backward_compatible_optional_defaults(
+    tmp_path: Path,
+    environment: EnvironmentInfo,
+) -> None:
+    """Older payloads without optional metadata still load deterministically."""
+    payload = _manifest(environment).to_dict()
+    payload.pop("duration_seconds")
+    payload.pop("metadata")
+    payload["environment"] = {"python_version": "legacy-python"}
+    path = tmp_path / "legacy-manifest.json"
+    path.write_text(json.dumps(payload))
+
+    loaded = ExecutionManifest.load(path)
+
+    assert loaded.duration_seconds == 0
+    assert loaded.metadata == {}
+    assert loaded.environment == EnvironmentInfo(
+        python_version="legacy-python",
+        platform="",
+        hostname="",
+        user="",
+        cwd="",
+    )
+
+
+def test_manifest_builder_tracks_run_duration_and_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    environment: EnvironmentInfo,
+) -> None:
+    """A started builder uses the tracked run ID and elapsed duration."""
+    timestamps = iter((100.0, 103.25))
+    monkeypatch.setattr(manifest_module.time, "time", lambda: next(timestamps))
+    monkeypatch.setattr(manifest_module.EnvironmentInfo, "capture", lambda: environment)
+    builder = ManifestBuilder()
+
+    builder.start("tracked-run")
+    manifest = builder.build(["node-z", "node-a"], metadata={"quality": "golden"})
+
+    assert manifest.run_id == "tracked-run"
+    assert manifest.node_hashes == ["node-z", "node-a"]
+    assert manifest.duration_seconds == pytest.approx(3.25)
+    assert manifest.environment == environment
+    assert manifest.metadata == {"quality": "golden"}
+    assert datetime.fromisoformat(manifest.created_at).tzinfo is not None
+    assert manifest.verify_root_hash() is True
+
+
+def test_manifest_builder_supports_explicit_and_generated_run_ids(
+    monkeypatch: pytest.MonkeyPatch,
+    environment: EnvironmentInfo,
+) -> None:
+    """Callers may override the run ID or rely on the timestamp fallback."""
+    monkeypatch.setattr(manifest_module.time, "time", lambda: 1234.9)
+    monkeypatch.setattr(manifest_module.EnvironmentInfo, "capture", lambda: environment)
+    builder = ManifestBuilder()
+    builder.start("tracked-run")
+
+    explicit = builder.build([], run_id="explicit-run", metadata={})
+    generated = ManifestBuilder().build([])
+
+    assert explicit.run_id == "explicit-run"
+    assert explicit.duration_seconds == 0.0
+    assert explicit.metadata == {}
+    assert generated.run_id == "run_1234"
+    assert generated.duration_seconds == 0.0
+    assert generated.metadata == {}
+    assert explicit.root_hash == generated.root_hash
+
+
+def test_manifest_builder_builds_from_dag_and_rejects_missing_dag(
+    monkeypatch: pytest.MonkeyPatch,
+    environment: EnvironmentInfo,
+) -> None:
+    """DAG manifests use every node key and fail clearly without a DAG."""
+
+    class FakeDAG:
+        nodes = {"node-b": object(), "node-a": object()}
+
+    monkeypatch.setattr(manifest_module.EnvironmentInfo, "capture", lambda: environment)
+    manifest = ManifestBuilder(FakeDAG()).build_from_dag(
+        run_id="dag-run",
+        metadata={"source": "dag"},
+    )
+
+    assert manifest.run_id == "dag-run"
+    assert manifest.node_hashes == ["node-b", "node-a"]
+    assert manifest.metadata == {"source": "dag"}
+    assert manifest.verify_root_hash() is True
+
+    with pytest.raises(ValueError, match="No DAG provided to ManifestBuilder"):
+        ManifestBuilder().build_from_dag()

--- a/tests/validation/test_check_piptools_cache_tracked.py
+++ b/tests/validation/test_check_piptools_cache_tracked.py
@@ -1,0 +1,157 @@
+"""Tests for the pip-tools cache tracking guardrail."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _load_guard_module() -> ModuleType:
+    """Load the validation script without crossing the scripts import boundary."""
+    repo_root = Path(__file__).resolve().parents[2]
+    module_path = repo_root / "scripts" / "validation" / "check_piptools_cache_tracked.py"
+    spec = importlib.util.spec_from_file_location("check_piptools_cache_tracked_under_test", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Failed to load module from {module_path}")
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def guard_module() -> ModuleType:
+    """Return the dynamically loaded guard module."""
+    return _load_guard_module()
+
+
+def test_tracked_cache_files_uses_exact_pathspec_and_sorts_nul_output(
+    monkeypatch: pytest.MonkeyPatch,
+    guard_module: ModuleType,
+) -> None:
+    """The git query is bounded to the cache path and returns stable ordering."""
+    observed: dict[str, object] = {}
+
+    def fake_run(
+        args: list[str],
+        *,
+        check: bool,
+        capture_output: bool,
+        text: bool,
+    ) -> subprocess.CompletedProcess[str]:
+        observed.update(
+            args=args,
+            check=check,
+            capture_output=capture_output,
+            text=text,
+        )
+        return subprocess.CompletedProcess(
+            args,
+            0,
+            stdout="requirements/.pip-tools-cache/z.json\0requirements/.pip-tools-cache/a.json\0\0",
+            stderr="",
+        )
+
+    monkeypatch.setattr(guard_module.subprocess, "run", fake_run)
+
+    assert guard_module.tracked_cache_files() == [
+        "requirements/.pip-tools-cache/a.json",
+        "requirements/.pip-tools-cache/z.json",
+    ]
+    assert observed == {
+        "args": ["git", "ls-files", "-z", "--", "requirements/.pip-tools-cache"],
+        "check": False,
+        "capture_output": True,
+        "text": True,
+    }
+
+
+def test_tracked_cache_files_fails_closed_when_git_query_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    guard_module: ModuleType,
+) -> None:
+    """A broken git query cannot be mistaken for an empty tracked-file set."""
+    failed = subprocess.CompletedProcess(
+        ["git", "ls-files"],
+        128,
+        stdout="",
+        stderr="  fatal: not a git repository  \n",
+    )
+    monkeypatch.setattr(guard_module.subprocess, "run", lambda *_args, **_kwargs: failed)
+
+    with pytest.raises(RuntimeError, match=r"git ls-files failed \(128\): fatal: not a git repository"):
+        guard_module.tracked_cache_files()
+
+
+def test_main_reports_clean_repository(
+    monkeypatch: pytest.MonkeyPatch,
+    guard_module: ModuleType,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """No tracked cache artifacts is the successful CLI outcome."""
+    monkeypatch.setattr(guard_module, "tracked_cache_files", lambda: [])
+
+    assert guard_module.main() == 0
+
+    captured = capsys.readouterr()
+    assert captured.out == "pip-tools cache guardrail passed: no tracked files under requirements/.pip-tools-cache.\n"
+    assert captured.err == ""
+
+
+def test_main_lists_tracked_cache_files_and_remediation(
+    monkeypatch: pytest.MonkeyPatch,
+    guard_module: ModuleType,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Policy failures list every tracked artifact and the recovery command."""
+    tracked = [
+        "requirements/.pip-tools-cache/a.json",
+        "requirements/.pip-tools-cache/nested/b.json",
+    ]
+    monkeypatch.setattr(guard_module, "tracked_cache_files", lambda: tracked)
+
+    assert guard_module.main() == 1
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err.splitlines() == [
+        "ERROR: tracked pip-tools cache files detected:",
+        "  - requirements/.pip-tools-cache/a.json",
+        "  - requirements/.pip-tools-cache/nested/b.json",
+        "Remediation: remove cache artifacts from git tracking "
+        "(for example: git rm --cached -r requirements/.pip-tools-cache).",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("error", "expected_message"),
+    [
+        (FileNotFoundError(), "ERROR: git executable not found"),
+        (RuntimeError("git ls-files failed (3): broken worktree"), "ERROR: git ls-files failed (3): broken worktree"),
+    ],
+)
+def test_main_reports_operational_errors_separately_from_policy_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    guard_module: ModuleType,
+    capsys: pytest.CaptureFixture[str],
+    error: Exception,
+    expected_message: str,
+) -> None:
+    """Missing or broken git returns the distinct operational exit code."""
+
+    def fail() -> list[str]:
+        raise error
+
+    monkeypatch.setattr(guard_module, "tracked_cache_files", fail)
+
+    assert guard_module.main() == 2
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == f"{expected_message}\n"


### PR DESCRIPTION
## Summary
- Close two confirmed coverage gaps: run-level execution manifests and the pip-tools cache tracking guardrail.
- Add focused behavioral tests only; production code and existing public contracts are unchanged.

## Changes
- Cover canonical SHA-256 hashing, environment capture fallbacks, JSON serialization, save/load compatibility, root-hash tamper detection, run timing and ID precedence, and DAG manifest construction.
- Cover the cache guard's exact git pathspec, sorted NUL-delimited parsing, fail-closed git errors, clean and policy-failure output, remediation guidance, and distinct operational exit status.
- Pin the manifest digest with a known vector and prove explicit run IDs override tracked IDs following independent review.

## Validation

### Proven green
- `PYTHONPATH=src /Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin/pytest tests/runtime/test_execution_manifest.py tests/validation/test_check_piptools_cache_tracked.py -q` — 16 passed.
- `PATH=/Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin:/Users/richardcheetham/.nvm/versions/node/v22.22.2/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin PYTHONPATH=src /Users/richardcheetham/Desktop/Transformation_Portal/.venv/bin/pre-commit run --files tests/runtime/test_execution_manifest.py tests/validation/test_check_piptools_cache_tracked.py` — all applicable hooks passed.
- `make test-fast` — 77 passed.
- `make ci-quick` — 27 passed.
- Runtime suite — 180 passed.
- Validation suite — 412 passed, 4 skipped because Node 22 was not present on that invocation's PATH.
- `make coverage-report` — 11,423 passed, 63 skipped, 932 deselected; total branch-aware coverage 68.20%, with both newly covered modules at 100%.
- Per-package line floors, per-package branch floors, and the touched-source cold-zone check passed.

### Still failing
- None in the touched surface.
- An initial commit-hook invocation in the temporary worktree lacked `PYTHONPATH=src`; rerunning with the repository source path supplied passed every hook. This was an environment/tooling issue, not a product or test regression.

## Risk
- Tests only: no route, response, selector, auth, CLI, schema, or runtime behavior changes.
- The added assertions codify existing behavior and are bounded and revert-safe.
