### PR TITLE
docs: refresh AGENTS workflow guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,7 +118,8 @@ actionable; use the linked docs and `Makefile` for exhaustive inventories.
   `make validate-ci`,
   `make check-stale-docs`, `make check-doc-heading-links`,
   `make check-todo-governance`, `make check-ci-sync`,
-  `make check-requirements-lock-contract`, `make check-dependency-pinning`,
+  `make check-piptools-cache`, `make check-requirements-lock-contract`,
+  `make check-dependency-pinning`,
   `make check-json-serialization`, `make check-yaml-governance`,
   `make check-python-headers`, and
   `python3 scripts/governance/check_docs_structure.py --all`. For direct
@@ -137,6 +138,24 @@ actionable; use the linked docs and `Makefile` for exhaustive inventories.
   `docs/ci/WORKFLOW_MATRIX.md` must match live `.github/workflows/*.yml`
   inventory counts plus per-workflow line estimates. Treat workflow-matrix
   recommendations as proposals until matching workflow YAML changes land.
+- AI advisory workflow contracts:
+  `./.venv/bin/pytest tests/test_summary_workflow.py tests/test_ai_code_review_workflow.py tests/test_smart_issue_management_workflow.py -q`.
+  Issue summarizer fallback diagnostics carrying
+  `<!-- ai-summarizer-diagnostic -->` stay log-only; only marker-free
+  successful summaries should post PR comments.
+- Secure-install hash pilot:
+  from `requirements/`, run
+  `make compile-hash-pilot LOCK_PYTHON_VERSION=3.11` then
+  `make check-hash-pilot LOCK_PYTHON_VERSION=3.11`; use
+  `HASH_PILOT_OUT_DIR=/tmp/tp-hash-pilot` to keep pilot artifacts disposable.
+  Match CI with `python -m pip install --upgrade "pip==26.1.2"` and
+  `python -m pip install "pip-tools==7.6.0"`. Use the same toolchain for the
+  decisive generic-lock freshness check:
+  `make -C requirements check-generic LOCK_PYTHON_VERSION=3.11`. Validate
+  contract changes with
+  `./.venv/bin/pytest tests/test_requirements_makefile_hash_pilot.py tests/test_secure_install_pilot_workflow.py -q`.
+  This pilot is advisory and does not replace the standard checked-in lock or
+  install flows.
 - Root metadata contract tests:
   `./.venv/bin/pytest tests/validation/test_cloudflare_worker_root_shim_contract.py tests/validation/test_git_blame_ignore_revs_contract.py tests/validation/test_gitattributes_contract.py tests/validation/test_pylint_config_contract.py -v`.
 - Coverage/cold-zone:


### PR DESCRIPTION
## Summary

- add the pip-tools cache guardrail to the governance command surface
- document the focused AI advisory workflow contract tests and diagnostic-marker behavior
- align the secure-install pilot with `pip==26.1.2` and `pip-tools==7.6.0`
- document the separate generic-lock freshness check

## Why

`AGENTS.md` lagged the repository’s current dependency and advisory-workflow contracts. In particular, it still named the superseded pip-tools 7.5.2 baseline and omitted the generic lock freshness and cache guardrail commands.

## Impact

Documentation only. No production behavior, public contracts, dependencies, or generated files change.

## Validation

- `git diff --check -- AGENTS.md`
- `./scripts/setup/run_repo_python.sh scripts/validation/check_unicode_controls.py AGENTS.md`
- `python3 scripts/governance/check_docs_structure.py --all`
- `make check-doc-heading-links`
- `make check-docs`
- `make check-stale-docs`
- `make check-piptools-cache`
- `make check-requirements-lock-contract`
- `make check-dependency-pinning`
- focused hash-pilot/cache pytest bundle: 19 passed
- generic lock freshness passed in a disposable Python 3.11 environment using `pip==26.1.2` and `pip-tools==7.6.0`
